### PR TITLE
Fix issue with finalizing blocks while syncing

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -230,7 +230,8 @@ class ChiaServer:
         and nothing is yielded.
         """
         # Send handshake message
-        outbound_handshake = Message("handshake", Handshake(protocol_version, self._node_id, uint16(self._port), self._local_type))
+        outbound_handshake = Message("handshake", Handshake(protocol_version, self._node_id, uint16(self._port),
+                                                            self._local_type))
 
         try:
             await connection.send(outbound_handshake)
@@ -286,7 +287,7 @@ class ChiaServer:
                 # Read one message at a time, forever
                 yield (connection, message)
         except asyncio.IncompleteReadError:
-            log.warning(f"Received EOF from {connection.get_peername()}, closing connection.")
+            log.info(f"Received EOF from {connection.get_peername()}, closing connection.")
         except ConnectionError:
             log.warning(f"Connection error by peer {connection.get_peername()}, closing connection.")
         finally:

--- a/src/server/start_full_node.py
+++ b/src/server/start_full_node.py
@@ -63,6 +63,10 @@ async def main():
 
     full_node._start_bg_tasks()
 
+    log.info("Waiting to connect to some peers...")
+    await asyncio.sleep(3)
+    log.info(f"Connected to {len(server.global_connections.get_connections())} peers.")
+
     if connect_to_farmer and not server_closed:
         peer_info = PeerInfo(full_node.config['farmer_peer']['host'],
                              full_node.config['farmer_peer']['port'])
@@ -73,10 +77,6 @@ async def main():
                              full_node.config['timelord_peer']['port'])
         _ = await server.start_client(peer_info, None)
 
-    log.info("Waiting to connect to some peers...")
-    await asyncio.sleep(3)
-
-    log.info(f"Connected to {len(server.global_connections.get_connections())} peers.")
     if not server_closed:
         try:
             async for msg in full_node._sync():

--- a/src/store/full_node_store.py
+++ b/src/store/full_node_store.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional, Dict, Counter
+from typing import Tuple, Optional, Dict, Counter, List
 import collections
 from asyncio import Lock, Event
 from src.types.proof_of_space import ProofOfSpace
@@ -28,6 +28,8 @@ class FullNodeStore:
         self.potential_blocks: Dict[uint32, FullBlock] = {}
         # Event, which gets set whenever we receive the block at each height. Waited for by sync().
         self.potential_blocks_received: Dict[uint32, Event] = {}
+
+        self.potential_future_blocks: List[FullBlock] = []
 
         # These are the blocks that we created, but don't have the PoS from farmer yet,
         # keyed from the proof of space hash
@@ -62,6 +64,7 @@ class FullNodeStore:
         self.potential_headers.clear()
         self.potential_blocks.clear()
         self.potential_blocks_received.clear()
+        self.potential_future_blocks.clear()
 
     async def add_potential_head(self, header_hash: bytes32):
         self.potential_heads[header_hash] += 1
@@ -92,6 +95,12 @@ class FullNodeStore:
 
     async def get_potential_blocks_received(self, height: uint32) -> Event:
         return self.potential_blocks_received[height]
+
+    async def add_potential_future_block(self, block: FullBlock):
+        self.potential_future_blocks.append(block)
+
+    async def get_potential_future_blocks(self):
+        return self.potential_future_blocks
 
     async def add_candidate_block(self, pos_hash: bytes32, block: Tuple[Body, HeaderData, ProofOfSpace]):
         self.candidate_blocks[pos_hash] = block


### PR DESCRIPTION
OK heres the issue for #1: When we get a new block during sync, we add this as a potential head (actually it should be a potential TIP), this means we potentially want to sync up to this block, if it's good. 

However, when we make our own block (we're connected to timelord, receive a Pot, and the call self.block()), we can't sync up to it, because nobody else has this block yet, we just made it.

The fix adds a new sync mode list: potential_future_blocks. These are blocks that WE finalized, during sync mode. These are added to the blockchain at the end of sync.
