### PR TITLE
Sync changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # chia-blockchain
-Python 3.7 is used for this project. Make sure your python version is >=3.7 by typing python3.
+Python 3.7 is used for this project. Make sure your default python version is >=3.7 by typing python3.
 
 ### Install on Debian/Ubuntu
 
@@ -49,8 +49,8 @@ ssh -p 8222 localhost
 ### Run a farmer + full node
 Farmers are entities in the network who use their hard drive space to try to create
 blocks (like Bitcoin's miners), and earn block rewards. First, you must generate some hard drive plots, which
-can take a long time depending on the size of the plots. Then, run the farmer + full node with
-the following script. A full node is also started on port 8002, which you can ssh into to view the node UI.
+can take a long time depending on the size of the plots (the k variable). Then, run the farmer + full node with
+the following script. A full node is also started, which you can ssh into to view the node UI (previous ssh command).
 ```bash
 python -m scripts.create_plots -k 20 -n 10
 sh ./scripts/run_farming.sh

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -67,6 +67,9 @@ full_node:
   introducer_connect_interval: 120
   # Continue trying to connect to more peers until this number of connections
   target_peer_count: 10
+  # Only connect to peers who we have heard about in the last recent_peer_threshold seconds
+  recent_peer_threshold: 6000
+
 
   farmer_peer:
       host: 127.0.0.1
@@ -84,4 +87,6 @@ introducer:
   host: 127.0.0.1
   port: 8445
   max_peers_to_send: 20
+  # The introducer will only return peers who it has seen in the last
+  # recent_peer_threshold seconds
   recent_peer_threshold: 6000

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -84,3 +84,4 @@ introducer:
   host: 127.0.0.1
   port: 8445
   max_peers_to_send: 20
+  recent_peer_threshold: 6000

--- a/scripts/create_plots.py
+++ b/scripts/create_plots.py
@@ -32,7 +32,7 @@ def main():
     # We need the keys file, to access pool keys (if the exist), and the sk_seed.
     args = parser.parse_args()
     if not os.path.isfile(key_config_filename):
-        raise RuntimeError("Keys not generated. Run ./scripts/regenerate_keys.py.")
+        raise RuntimeError("Keys not generated. Run python3.7 ./scripts/regenerate_keys.py.")
 
     # The seed is what will be used to generate a private key for each plot
     key_config = safe_load(open(key_config_filename, "r"))

--- a/src/consensus/weight_verifier.py
+++ b/src/consensus/weight_verifier.py
@@ -3,14 +3,16 @@ from typing import List
 from src.types.header_block import HeaderBlock
 
 
-def verify_weight(tip: HeaderBlock, proof_blocks: List[HeaderBlock]) -> bool:
+def verify_weight(
+    tip: HeaderBlock, proof_blocks: List[HeaderBlock], fork_point: HeaderBlock
+) -> bool:
     """
     Verifies whether the weight of the tip is valid or not. Naively, looks at every block
     from genesis, verifying proof of space, proof of time, and difficulty resets.
     # TODO: implement
     """
     for height, block in enumerate(proof_blocks):
-        if not block.height == height:
+        if not block.height == height + fork_point.height + 1:
             return False
 
     return True

--- a/src/farmer.py
+++ b/src/farmer.py
@@ -31,7 +31,9 @@ class Farmer:
         config_filename = os.path.join(ROOT_DIR, "config", "config.yaml")
         key_config_filename = os.path.join(ROOT_DIR, "config", "keys.yaml")
         if not os.path.isfile(key_config_filename):
-            raise RuntimeError("Keys not generated. Run ./scripts/regenerate_keys.py.")
+            raise RuntimeError(
+                "Keys not generated. Run python3.7 ./scripts/regenerate_keys.py."
+            )
         self.config = safe_load(open(config_filename, "r"))["farmer"]
         self.key_config = safe_load(open(key_config_filename, "r"))
         self.harvester_responses_header_hash: Dict[bytes32, bytes32] = {}

--- a/src/full_node.py
+++ b/src/full_node.py
@@ -1171,7 +1171,7 @@ class FullNode:
         # Pseudo-message to close the connection
         yield OutboundMessage(NodeType.INTRODUCER, Message("", None), Delivery.CLOSE)
 
-        unconnected = conns.get_unconnected_peers()
+        unconnected = conns.get_unconnected_peers(recent_threshold=self.config["recent_peer_threshold"])
         to_connect = unconnected[: self._num_needed_peers()]
         if not len(to_connect):
             return

--- a/src/full_node.py
+++ b/src/full_node.py
@@ -235,10 +235,44 @@ class FullNode:
         for height in range(0, tip_block.height + 1):
             self.store.set_potential_headers_received(uint32(height), Event())
             self.store.set_potential_blocks_received(uint32(height), Event())
+            self.store.set_potential_hashes_received(Event())
 
-        # Now, we download all of the headers in order to verify the weight, in batches
         timeout = 200
         sleep_interval = 10
+        total_time_slept = 0
+
+        while True:
+            if total_time_slept > timeout:
+                raise TimeoutError("Took too long to fetch header hashes.")
+            if self._shut_down:
+                return
+            # Download all the header hashes and find the fork point
+            request = peer_protocol.RequestAllHeaderHashes(tip_block.header_hash)
+            yield OutboundMessage(
+                NodeType.FULL_NODE,
+                Message("request_all_header_hashes", request),
+                Delivery.RANDOM,
+            )
+            try:
+                await asyncio.wait_for(
+                    self.store.get_potential_hashes_received().wait(),
+                    timeout=sleep_interval,
+                )
+                break
+            except concurrent.futures.TimeoutError:
+                total_time_slept += sleep_interval
+                log.warning("Did not receive desired header hashes")
+
+        # Finding the fork point allows us to only download headers and blocks from the fork point
+        async with self.store.lock:
+            header_hashes = self.store.get_potential_hashes()
+            fork_point_height: HeaderBlock = self.blockchain.find_fork_point(
+                header_hashes
+            )
+            fork_point_hash: bytes32 = header_hashes[fork_point_height]
+        log.info(f"Fork point: {fork_point_hash} at height {fork_point_height}")
+
+        # Now, we download all of the headers in order to verify the weight, in batches
         headers: List[HeaderBlock] = []
 
         # Download headers in batches. We download a few batches ahead in case there are delays or peers
@@ -247,7 +281,7 @@ class FullNode:
         highest_height_requested: uint32 = uint32(0)
         request_made: bool = False
         for height_checkpoint in range(
-            0, tip_height + 1, self.config["max_headers_to_send"]
+            fork_point_height + 1, tip_height + 1, self.config["max_headers_to_send"]
         ):
             end_height = min(
                 height_checkpoint + self.config["max_headers_to_send"], tip_height + 1
@@ -296,6 +330,7 @@ class FullNode:
                             tip_block.header_block.header.get_hash(),
                             [uint32(h) for h in range(batch_start, batch_end)],
                         )
+                        log.info(f"Requesting header blocks {batch_start, batch_end}.")
                         yield OutboundMessage(
                             NodeType.FULL_NODE,
                             Message("request_header_blocks", request),
@@ -311,24 +346,30 @@ class FullNode:
                     (self.store.get_potential_headers_received(uint32(height))).wait()
                     for height in range(height_checkpoint, end_height)
                 ]
+                future = asyncio.gather(*awaitables, return_exceptions=True)
                 try:
-                    await asyncio.wait_for(
-                        asyncio.gather(*awaitables), timeout=sleep_interval
-                    )
+                    await asyncio.wait_for(future, timeout=sleep_interval)
                     break
                 except concurrent.futures.TimeoutError:
+                    try:
+                        await future
+                    except asyncio.CancelledError:
+                        pass
                     total_time_slept += sleep_interval
-                    log.info("Did not receive desired header blocks")
-                    pass
+                    log.info(f"Did not receive desired header blocks")
 
         async with self.store.lock:
-            for h in range(0, tip_height + 1):
+            for h in range(fork_point_height + 1, tip_height + 1):
                 header = self.store.get_potential_header(uint32(h))
                 assert header is not None
                 headers.append(header)
 
         log.error(f"Downloaded headers up to tip height: {tip_height}")
-        if not verify_weight(tip_block.header_block, headers):
+        if not verify_weight(
+            tip_block.header_block,
+            headers,
+            self.blockchain.header_blocks[fork_point_hash],
+        ):
             raise errors.InvalidWeight(
                 f"Weight of {tip_block.header_block.header.get_hash()} not valid."
             )
@@ -336,11 +377,7 @@ class FullNode:
         log.error(
             f"Validated weight of headers. Downloaded {len(headers)} headers, tip height {tip_height}"
         )
-        assert tip_height + 1 == len(headers)
-
-        # Finding the fork point allows us to only download blocks from the fork point
-        async with self.store.lock:
-            fork_point: HeaderBlock = self.blockchain.find_fork_point(headers)
+        assert tip_height == fork_point_height + len(headers)
 
         # Download blocks in batches, and verify them as they come in. We download a few batches ahead,
         # in case there are delays.
@@ -348,7 +385,7 @@ class FullNode:
         highest_height_requested = uint32(0)
         request_made = False
         for height_checkpoint in range(
-            fork_point.height + 1, tip_height + 1, self.config["max_blocks_to_send"]
+            fork_point_height + 1, tip_height + 1, self.config["max_blocks_to_send"]
         ):
             end_height = min(
                 height_checkpoint + self.config["max_blocks_to_send"], tip_height + 1
@@ -417,15 +454,17 @@ class FullNode:
                     (self.store.get_potential_blocks_received(uint32(height))).wait()
                     for height in range(height_checkpoint, end_height)
                 ]
+                future = asyncio.gather(*awaitables, return_exceptions=True)
                 try:
-                    await asyncio.wait_for(
-                        asyncio.gather(*awaitables), timeout=sleep_interval
-                    )
+                    await asyncio.wait_for(future, timeout=sleep_interval)
                     break
                 except concurrent.futures.TimeoutError:
+                    try:
+                        await future
+                    except asyncio.CancelledError:
+                        pass
                     total_time_slept += sleep_interval
                     log.info("Did not receive desired blocks")
-                    pass
 
             # Verifies this batch, which we are guaranteed to have (since we broke from the above loop)
             for height in range(height_checkpoint, end_height):
@@ -480,6 +519,30 @@ class FullNode:
             yield msg
 
     @api_request
+    async def request_all_header_hashes(
+        self, request: peer_protocol.RequestAllHeaderHashes
+    ) -> AsyncGenerator[OutboundMessage, None]:
+        try:
+            header_hashes = self.blockchain.get_header_hashes(request.tip_header_hash)
+            message = Message(
+                "all_header_hashes", peer_protocol.AllHeaderHashes(header_hashes)
+            )
+            yield OutboundMessage(NodeType.FULL_NODE, message, Delivery.RESPOND)
+        except ValueError:
+            log.info("Do not have requested header hashes.")
+
+    @api_request
+    async def all_header_hashes(
+        self, all_header_hashes: peer_protocol.AllHeaderHashes
+    ) -> AsyncGenerator[OutboundMessage, None]:
+        assert len(all_header_hashes.header_hashes) > 0
+        async with self.store.lock:
+            self.store.set_potential_hashes(all_header_hashes.header_hashes)
+            self.store.get_potential_hashes_received().set()
+        for _ in []:  # Yields nothing
+            yield _
+
+    @api_request
     async def request_header_blocks(
         self, request: peer_protocol.RequestHeaderBlocks
     ) -> AsyncGenerator[OutboundMessage, None]:
@@ -516,6 +579,9 @@ class FullNode:
         """
         Receive header blocks from a peer.
         """
+        log.info(
+            f"Received header blocks {request.header_blocks[0].height, request.header_blocks[-1].height}."
+        )
         async with self.store.lock:
             for header_block in request.header_blocks:
                 self.store.add_potential_header(header_block)
@@ -976,19 +1042,8 @@ class FullNode:
                     peer_protocol.RequestBlock(block.block.prev_header_hash),
                 )
                 async with self.store.lock:
-                    # If we have already requested the prev block, don't do so again
-                    if (
-                        await self.store.get_disconnected_block(
-                            block.block.prev_header_hash
-                        )
-                        is not None
-                    ):
-                        log.info(
-                            f"Have already requested block {block.block.prev_header_hash}"
-                        )
-                        return
                     await self.store.add_disconnected_block(block.block)
-                yield OutboundMessage(NodeType.FULL_NODE, msg, Delivery.RANDOM)
+                yield OutboundMessage(NodeType.FULL_NODE, msg, Delivery.RESPOND)
             return
         elif added == ReceiveBlockResult.ADDED_TO_HEAD:
             # Only propagate blocks which extend the blockchain (becomes one of the heads)
@@ -1078,7 +1133,7 @@ class FullNode:
         async with self.store.lock:
             next_block: Optional[
                 FullBlock
-            ] = await self.store.get_disconnected_block(block.block.header_hash)
+            ] = await self.store.get_disconnected_block_by_prev(block.block.header_hash)
         if next_block is not None:
             async for msg in self.block(peer_protocol.Block(next_block)):
                 yield msg
@@ -1110,7 +1165,6 @@ class FullNode:
         self, request: peer_protocol.Peers
     ) -> AsyncGenerator[OutboundMessage, None]:
         conns = self.server.global_connections
-        log.info(f"Received peer list: {request.peer_list}")
         for peer in request.peer_list:
             conns.peers.add(peer)
 

--- a/src/harvester.py
+++ b/src/harvester.py
@@ -25,9 +25,13 @@ class Harvester:
         key_config_filename = os.path.join(ROOT_DIR, "config", "keys.yaml")
 
         if not os.path.isfile(key_config_filename):
-            raise RuntimeError("Keys not generated. Run ./scripts/regenerate_keys.py.")
+            raise RuntimeError(
+                "Keys not generated. Run python3.7 ./scripts/regenerate_keys.py."
+            )
         if not os.path.isfile(plot_config_filename):
-            raise RuntimeError("Plots not generated. Run ./scripts/create_plots.py.")
+            raise RuntimeError(
+                "Plots not generated. Run python3.7 ./scripts/create_plots.py."
+            )
 
         self.config = safe_load(open(config_filename, "r"))["harvester"]
         self.key_config = safe_load(open(key_config_filename, "r"))

--- a/src/introducer.py
+++ b/src/introducer.py
@@ -23,6 +23,8 @@ class Introducer:
         self, request: RequestPeers
     ) -> AsyncGenerator[OutboundMessage, None]:
         max_peers = self.config["max_peers_to_send"]
-        peers = self.server.global_connections.peers.get_peers(max_peers, True)
+        peers = self.server.global_connections.peers.get_peers(
+            max_peers, True, self.config["recent_peer_threshold"]
+        )
         msg = Message("peers", Peers(peers))
         yield OutboundMessage(NodeType.FULL_NODE, msg, Delivery.RESPOND)

--- a/src/protocols/peer_protocol.py
+++ b/src/protocols/peer_protocol.py
@@ -107,6 +107,26 @@ class Peers:
 
 @dataclass(frozen=True)
 @cbor_message
+class RequestAllHeaderHashes:
+    """
+    Request all header hashes of blocks up to the tip header hash.
+    """
+
+    tip_header_hash: bytes32
+
+
+@dataclass(frozen=True)
+@cbor_message
+class AllHeaderHashes:
+    """
+    Responds with all header hashes of blocks up to and including the tip header hash.
+    """
+
+    header_hashes: List[bytes32]
+
+
+@dataclass(frozen=True)
+@cbor_message
 class RequestHeaderBlocks:
     """
     Request headers of blocks that are ancestors of the specified tip.

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -123,9 +123,9 @@ class PeerConnections:
     def get_full_node_peerinfos(self):
         return list(filter(None, map(Connection.get_peer_info, self._all_connections)))
 
-    def get_unconnected_peers(self, max_peers=0):
+    def get_unconnected_peers(self, max_peers=0, recent_threshold=9999999):
         connected = self.get_full_node_peerinfos()
-        peers = self.peers.get_peers()
+        peers = self.peers.get_peers(recent_threshold=recent_threshold)
         unconnected = list(filter(lambda peer: peer not in connected, peers))
         if not max_peers:
             max_peers = len(unconnected)

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -2,12 +2,13 @@ import logging
 import random
 import time
 from asyncio import StreamReader, StreamWriter
-from typing import Any, AsyncGenerator, Callable, List, Optional
+from typing import Any, AsyncGenerator, Callable, List, Optional, Dict
 
 from src.server.outbound_message import Message, NodeType, OutboundMessage
 from src.types.peer_info import PeerInfo
 from src.util import cbor
-from src.util.ints import uint16
+from src.types.sized_bytes import bytes32
+from src.util.ints import uint16, uint64
 
 # Each message is prepended with LENGTH_BYTES bytes specifying the length
 LENGTH_BYTES: int = 4
@@ -99,12 +100,6 @@ class PeerConnections:
         self.peers.add(connection.get_peer_info())
         return True
 
-    def have_connection(self, connection: Connection) -> bool:
-        for c in self._all_connections:
-            if c.node_id == connection.node_id:
-                return True
-        return False
-
     def close(self, connection: Connection, keep_peer: bool = False):
         if connection in self._all_connections:
             info = connection.get_peer_info()
@@ -140,16 +135,19 @@ class PeerConnections:
 class Peers:
     """
     Has the list of known full node peers that are already connected or may be
-    connected to.
+    connected to, and the time that they were last added.
     """
 
     def __init__(self):
         self._peers: List[PeerInfo] = []
+        self.time_added: Dict[bytes32, uint64] = {}
 
     def add(self, peer: Optional[PeerInfo]) -> bool:
-        if peer is None or not peer.port or peer in self._peers:
+        if peer is None or not peer.port:
             return False
-        self._peers.append(peer)
+        if peer not in self._peers:
+            self._peers.append(peer)
+        self.time_added[peer.get_hash()] = uint64(int(time.time()))
         return True
 
     def remove(self, peer: Optional[PeerInfo]) -> bool:
@@ -161,9 +159,16 @@ class Peers:
         except ValueError:
             return False
 
-    def get_peers(self, max_peers: int = 0, randomize: bool = False) -> List[PeerInfo]:
-        if not max_peers or max_peers > len(self._peers):
-            max_peers = len(self._peers)
+    def get_peers(
+        self, max_peers: int = 0, randomize: bool = False, recent_threshold=9999999
+    ) -> List[PeerInfo]:
+        target_peers = [
+            peer
+            for peer in self._peers
+            if time.time() - self.time_added[peer.get_hash()] < recent_threshold
+        ]
+        if not max_peers or max_peers > len(target_peers):
+            max_peers = len(target_peers)
         if randomize:
-            random.shuffle(self._peers)
-        return self._peers[:max_peers]
+            random.shuffle(target_peers)
+        return target_peers[:max_peers]

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -319,10 +319,8 @@ class ChiaServer:
             connection.peer_server_port = int(inbound_handshake.server_port)
             connection.connection_type = inbound_handshake.node_type
 
-            if self.global_connections.have_connection(connection):
+            if not self.global_connections.add(connection):
                 raise InvalidHandshake(f"Duplicate connection to {connection}")
-
-            self.global_connections.add(connection)
 
             # Send Ack message
             await connection.send(Message("handshake_ack", HandshakeAck()))
@@ -379,7 +377,12 @@ class ChiaServer:
             log.warning(
                 f"Connection error by peer {connection.get_peername()}, closing connection."
             )
-        except (concurrent.futures._base.CancelledError, OSError, TimeoutError, asyncio.TimeoutError) as e:
+        except (
+            concurrent.futures._base.CancelledError,
+            OSError,
+            TimeoutError,
+            asyncio.TimeoutError,
+        ) as e:
             log.warning(
                 f"Timeout/OSError {e} in connection with peer {connection.get_peername()}, closing connection."
             )

--- a/src/timelord.py
+++ b/src/timelord.py
@@ -400,9 +400,13 @@ class Timelord:
         many iterations to run for.
         """
         async with self.lock:
-            log.info(f"proof_of_space_info {proof_of_space_info.challenge_hash} {proof_of_space_info.iterations_needed}")
+            log.info(
+                f"proof_of_space_info {proof_of_space_info.challenge_hash} {proof_of_space_info.iterations_needed}"
+            )
             if proof_of_space_info.challenge_hash in self.done_discriminants:
-                log.info(f"proof_of_space_info {proof_of_space_info.challenge_hash} already done, returning")
+                log.info(
+                    f"proof_of_space_info {proof_of_space_info.challenge_hash} already done, returning"
+                )
                 return
 
             if proof_of_space_info.challenge_hash not in self.pending_iters:
@@ -412,7 +416,11 @@ class Timelord:
                 proof_of_space_info.iterations_needed
                 not in self.pending_iters[proof_of_space_info.challenge_hash]
             ):
-                log.info(f"proof_of_space_info {proof_of_space_info.challenge_hash} adding {proof_of_space_info.iterations_needed} to {self.pending_iters[proof_of_space_info.challenge_hash]}")
+                log.info(
+                    f"proof_of_space_info {proof_of_space_info.challenge_hash} adding "
+                    f"{proof_of_space_info.iterations_needed} to "
+                    f"{self.pending_iters[proof_of_space_info.challenge_hash]}"
+                )
                 self.pending_iters[proof_of_space_info.challenge_hash].append(
                     proof_of_space_info.iterations_needed
                 )

--- a/src/ui/prompt_ui.py
+++ b/src/ui/prompt_ui.py
@@ -260,7 +260,9 @@ class FullNodeUI:
             if max_block not in added_blocks:
                 added_blocks.append(max_block)
             heads.remove(max_block)
-            prev: Optional[HeaderBlock] = self.blockchain.header_blocks.get(max_block.prev_header_hash, None)
+            prev: Optional[HeaderBlock] = self.blockchain.header_blocks.get(
+                max_block.prev_header_hash, None
+            )
             if prev is not None:
                 heads.append(prev)
         return added_blocks

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -368,3 +368,18 @@ class TestReorgs:
         for block in reorg:
             await b.receive_block(block)
         assert b.lca_block == blocks[0]
+
+    @pytest.mark.asyncio
+    async def test_get_header_hashes(self):
+        blocks = bt.get_consecutive_blocks(test_constants, 5, [], 9, b"0")
+        store = FullNodeStore("fndb_test")
+        await store._clear_database()
+        b: Blockchain = Blockchain(store, test_constants)
+        await b.initialize()
+        for block in blocks:
+            await b.receive_block(block)
+        header_hashes = b.get_header_hashes(blocks[-1].header_hash)
+        assert len(header_hashes) == 6
+        print(header_hashes)
+        print([block.header_hash for block in blocks])
+        assert header_hashes == [block.header_hash for block in blocks]


### PR DESCRIPTION
 * Added a new API call GetAllHeaderHashes which returns just the header hashes. This is used for finding fork point.
* Only downloads headers and blocks from fork point
* Remove CancelledError logging
* Short sync should now work properly, it will always ask for previous block. There might be some repeated requests.
* Introducer now only returns peers which it has seen recently, and full node only connects to peers which it has heard from recently.