### PR TITLE
Ping

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,9 @@
 network_id: testnet  # testnet/mainnet
+# Send a ping to all peers after ping_interval seconds
+ping_interval: 10
+# Close the connection if no data is received for timeout_duration seconds.
+# Must be greater than ping_interval
+timeout_duration: 40
 
 harvester:
   # The harvester server (if run) will run on this host and port
@@ -70,7 +75,6 @@ full_node:
   # Only connect to peers who we have heard about in the last recent_peer_threshold seconds
   recent_peer_threshold: 6000
 
-
   farmer_peer:
       host: 127.0.0.1
       port: 8447
@@ -79,10 +83,10 @@ full_node:
       port: 8446
   introducer_peer:
       # To run the simulation, set host to 127.0.0.1 and port to 8445
-      host: 127.0.0.1
-      port: 8445
-      # host: introducer.chia.net  # Chia AWS introducer IPv4/IPv6
-      # port: 8444
+      # host: 127.0.0.1
+      # port: 8445
+      host: introducer.chia.net  # Chia AWS introducer IPv4/IPv6
+      port: 8444
 
 introducer:
   host: 127.0.0.1

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,9 @@
 network_id: testnet  # testnet/mainnet
 # Send a ping to all peers after ping_interval seconds
-ping_interval: 10
+ping_interval: 120
 # Close the connection if no data is received for timeout_duration seconds.
 # Must be greater than ping_interval
-timeout_duration: 40
+timeout_duration: 600
 
 harvester:
   # The harvester server (if run) will run on this host and port

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -79,10 +79,10 @@ full_node:
       port: 8446
   introducer_peer:
       # To run the simulation, set host to 127.0.0.1 and port to 8445
-      # host: 127.0.0.1
-      # port: 8445
-      host: introducer.chia.net  # Chia AWS introducer IPv4/IPv6
-      port: 8444
+      host: 127.0.0.1
+      port: 8445
+      # host: introducer.chia.net  # Chia AWS introducer IPv4/IPv6
+      # port: 8444
 
 introducer:
   host: 127.0.0.1

--- a/scripts/run_farming.sh
+++ b/scripts/run_farming.sh
@@ -5,6 +5,6 @@
 
 _run_bg_cmd python -m src.server.start_harvester
 _run_bg_cmd python -m src.server.start_farmer
-_run_bg_cmd python -m src.server.start_full_node "127.0.0.1" 8444 -id 1 -f -u 8222
+# _run_bg_cmd python -m src.server.start_full_node "127.0.0.1" 8444 -id 1 -f -u 8222
 
 wait

--- a/scripts/run_farming.sh
+++ b/scripts/run_farming.sh
@@ -5,6 +5,6 @@
 
 _run_bg_cmd python -m src.server.start_harvester
 _run_bg_cmd python -m src.server.start_farmer
-# _run_bg_cmd python -m src.server.start_full_node "127.0.0.1" 8444 -id 1 -f -u 8222
+_run_bg_cmd python -m src.server.start_full_node "127.0.0.1" 8444 -id 1 -f -u 8222
 
 wait

--- a/src/full_node.py
+++ b/src/full_node.py
@@ -18,7 +18,11 @@ from src.consensus.constants import constants
 from src.consensus.pot_iterations import calculate_iterations
 from src.consensus.weight_verifier import verify_weight
 from src.database import FullNodeStore
-from src.protocols import farmer_protocol, peer_protocol, timelord_protocol, shared_protocol
+from src.protocols import (
+    farmer_protocol,
+    peer_protocol,
+    timelord_protocol,
+)
 from src.server.outbound_message import Delivery, Message, NodeType, OutboundMessage
 from src.server.server import ChiaServer
 from src.types.body import Body
@@ -187,13 +191,6 @@ class FullNode:
                         continue
                 await asyncio.sleep(self.config["introducer_connect_interval"])
 
-        async def ping():
-            while not self._shut_down:
-                msg = Message("ping", shared_protocol.Ping())
-                self.server.push_message(OutboundMessage(NodeType.FULL_NODE, msg, Delivery.BROADCAST))
-                await asyncio.sleep(10)
-
-        asyncio.create_task(introducer_client())
         asyncio.create_task(introducer_client())
 
     def _shutdown(self):

--- a/src/full_node.py
+++ b/src/full_node.py
@@ -18,7 +18,7 @@ from src.consensus.constants import constants
 from src.consensus.pot_iterations import calculate_iterations
 from src.consensus.weight_verifier import verify_weight
 from src.database import FullNodeStore
-from src.protocols import farmer_protocol, peer_protocol, timelord_protocol
+from src.protocols import farmer_protocol, peer_protocol, timelord_protocol, shared_protocol
 from src.server.outbound_message import Delivery, Message, NodeType, OutboundMessage
 from src.server.server import ChiaServer
 from src.types.body import Body
@@ -187,6 +187,13 @@ class FullNode:
                         continue
                 await asyncio.sleep(self.config["introducer_connect_interval"])
 
+        async def ping():
+            while not self._shut_down:
+                msg = Message("ping", shared_protocol.Ping())
+                self.server.push_message(OutboundMessage(NodeType.FULL_NODE, msg, Delivery.BROADCAST))
+                await asyncio.sleep(10)
+
+        asyncio.create_task(introducer_client())
         asyncio.create_task(introducer_client())
 
     def _shutdown(self):

--- a/src/protocols/shared_protocol.py
+++ b/src/protocols/shared_protocol.py
@@ -31,10 +31,10 @@ class HandshakeAck:
 @dataclass(frozen=True)
 @cbor_message
 class Ping:
-    pass
+    nonce: bytes32
 
 
 @dataclass(frozen=True)
 @cbor_message
 class Pong:
-    pass
+    nonce: bytes32

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -64,6 +64,9 @@ class Connection:
             return None
         return PeerInfo(self.peer_host, uint16(self.peer_server_port))
 
+    def get_last_message_time(self) -> float:
+        return self.last_message_time
+
     async def send(self, message: Message):
         encoded: bytes = cbor.dumps({"f": message.function, "d": message.data})
         assert len(encoded) < (2 ** (LENGTH_BYTES * 8))

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -47,9 +47,11 @@ class Connection:
         self.on_connect = on_connect
 
         # Connection metrics
+        self.handshake_finished = False
         self.creation_type = time.time()
         self.bytes_read = 0
         self.bytes_written = 0
+        self.last_message_time: float = 0
 
     def get_peername(self):
         return self.writer.get_extra_info("peername")
@@ -75,6 +77,7 @@ class Connection:
         full_message: bytes = await self.reader.readexactly(full_message_length)
         full_message_loaded: Any = cbor.loads(full_message)
         self.bytes_read += LENGTH_BYTES + full_message_length
+        self.last_message_time = time.time()
         return Message(full_message_loaded["f"], full_message_loaded["d"])
 
     def close(self):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -194,7 +194,10 @@ class ChiaServer:
                         if (
                             time.time() - connection.get_last_message_time()
                             > config["timeout_duration"]
+                            and connection.connection_type == NodeType.FULL_NODE
+                            and self._local_type == NodeType.FULL_NODE
                         ):
+                            # Only closes down full_node <-> full_node connections, which can be recovered
                             to_close.append(connection)
                 for connection in to_close:
                     log.info(f"Removing connection {connection} due to timeout.")
@@ -381,7 +384,10 @@ class ChiaServer:
         ) as e:
             log.warning(f"{e}, handshake not completed. Connection not created.")
             for established_connection in self.global_connections.get_connections():
-                if connection.node_id == established_connection.node_id and not connection.handshake_finished:
+                if (
+                    connection.node_id == established_connection.node_id
+                    and not connection.handshake_finished
+                ):
                     # Makes sure not to remove a duplicate connection
                     self.global_connections.close(connection)
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -344,7 +344,6 @@ class ChiaServer:
             connection.node_id = inbound_handshake.node_id
             connection.peer_server_port = int(inbound_handshake.server_port)
             connection.connection_type = inbound_handshake.node_type
-
             if not self.global_connections.add(connection):
                 raise InvalidHandshake(f"Duplicate connection to {connection}")
 
@@ -381,7 +380,10 @@ class ChiaServer:
             Exception,
         ) as e:
             log.warning(f"{e}, handshake not completed. Connection not created.")
-            connection.close()
+            for established_connection in self.global_connections.get_connections():
+                if connection.node_id == established_connection.node_id and not connection.handshake_finished:
+                    # Makes sure not to remove a duplicate connection
+                    self.global_connections.close(connection)
 
     async def connection_to_message(
         self, connection: Connection

--- a/src/timelord.py
+++ b/src/timelord.py
@@ -235,7 +235,7 @@ class Timelord:
                         if iter in self.submitted_iters[challenge_hash]:
                             continue
                         self.submitted_iters[challenge_hash].append(iter)
-                        if (len(str(iter)) < 10):
+                        if len(str(iter)) < 10:
                             iter_size = "0" + str(len(str(iter)))
                         else:
                             iter_size = str(len(str(iter)))


### PR DESCRIPTION
This adds a periodic ping message between peers. This fixes a few issues and has some benefits:
* The ping is sent every 120 seconds, and if no message is received from a peer for 600 seconds, connection with it is closed 
* Any node which get's internet connectivity cut off, before did not close its connections, so it would be stuck with zombie connections forever and never recover. 
* If someone closed their laptop and opened it, for example, full node would be disconnected from network, but not realize it, so it won't connect to the introduces nodes. With this change, the pings will not get send and the connection is closed, allowing the node to connect to introduced peers.
* It also fixes a bug where duplicate connections were not removed from list
* This change can help with debugging, to see which peers we're connected to, and how they are responding to network messages