### PR TITLE
Use setuptoools_scm for version numbers.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ pytest==5.2.2
 pytest-asyncio==0.10.0
 PyYAML==5.1.2
 regex==2019.11.1
+setuptools-scm==3.3.3
 six==1.12.0
 toml==0.10.0
 typed-ast==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ dev_dependencies = [
 
 setup(
     name="chiablockchain",
-    version="0.1.2",
     author="Mariano Sorgente",
     author_email="mariano@chia.net",
     description="Chia proof of space plotting, proving, and verifying (wraps C++)",
@@ -22,6 +21,8 @@ setup(
     python_requires=">=3.7, <4",
     keywords="chia blockchain node",
     install_requires=dependencies + dev_dependencies,
+    setup_requires=["setuptools_scm"],
+    use_scm_version=True,
     long_description=open("README.md").read(),
     zip_safe=False,
 )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from setuptools_scm import get_version
+
+__version__ = version = get_version()


### PR DESCRIPTION
I've been doing this for other projects. It creates a version number automatically using git tags, very handy. See also https://github.com/pypa/setuptools_scm/ and https://setuptools.readthedocs.io/en/latest/setuptools.html

We should also consider renaming the "alpha-1.0" tag to "v0.1" or so to make it work better with this.