### PR TITLE
Move cbor2 to 5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ autoflake==1.3.1
 bitstring==3.1.6
 black==19.10b0
 blspy==0.1.14
-cbor2==4.2.0
+cbor2==5.0.0
 cffi==1.13.2
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
cbor2 deleted their 4.2.0 release and moved up to 5.0.0