### PR TITLE
Temporary fix for CI issue

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         eval "$(ssh-agent -s)"
         ssh-add - <<< "${CHIA_MACHINE_SSH_KEY}"
-        apt-get install python3-venv || echo ""
+        sudo apt-get install python3-venv || echo ""
         git submodule update --init --recursive
         brew update && brew install gmp || echo ""
         python3 -m venv .venv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,11 +9,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
         os: [ubuntu-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v1
+    - name: Setup Python environment
+      uses: actions/setup-python@v1.1.1
+      with:
+        python-version: 3.7 # optional, default is 3.x
     - name: Install dependencies
       env:
         CHIA_MACHINE_SSH_KEY: ${{ secrets.CHIA_MACHINE_SSH_KEY }}
@@ -21,7 +24,6 @@ jobs:
       run: |
         eval "$(ssh-agent -s)"
         ssh-add - <<< "${CHIA_MACHINE_SSH_KEY}"
-        sudo apt-get install python3-venv || echo ""
         git submodule update --init --recursive
         brew update && brew install gmp || echo ""
         python3 -m venv .venv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         eval "$(ssh-agent -s)"
         ssh-add - <<< "${CHIA_MACHINE_SSH_KEY}"
+        apt-get install python3-venv || echo ""
         git submodule update --init --recursive
         brew update && brew install gmp || echo ""
         python3 -m venv .venv

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,10 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       env:
         CHIA_MACHINE_SSH_KEY: ${{ secrets.CHIA_MACHINE_SSH_KEY }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ autoflake==1.3.1
 bitstring==3.1.6
 black==19.10b0
 blspy==0.1.14
-cbor2==4.2.0
+cbor2==5.0.0
 cffi==1.13.2
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
The python setup script seems to cause a segfault during the syncing tests. It could be due to conflicting versions of python being installed or due to a bug in a specific version of python. Still exploring, but this fix should keep the tests green.