### PR TITLE
Fix warnings

### DIFF
--- a/lib/chiapos/prepare.sh
+++ b/lib/chiapos/prepare.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+git submodule update --init --recursive
+mkdir build -p
+cd build
+cmake ../

--- a/lib/chiapos/src/bits.hpp
+++ b/lib/chiapos/src/bits.hpp
@@ -31,6 +31,8 @@
 
 // A stack vector of length 5, having the functions of std::vector needed for Bits.
 struct SmallVector {
+    typedef uint16_t size_type;
+
     SmallVector() {
         count_ = 0;
     }
@@ -49,24 +51,26 @@ struct SmallVector {
 
     SmallVector& operator = (const SmallVector& other) {
         count_ = other.count_;
-        for (uint16_t i = 0; i < other.count_; i++)
+        for (size_type i = 0; i < other.count_; i++)
             v_[i] = other.v_[i];
         return (*this);
     }
 
-    uint16_t size() const {
+    size_type size() const {
         return count_;
     }
 
  private:
     uint128_t v_[5];
-    uint16_t count_;
+    size_type count_;
 };
 
 
 // A stack vector of length 1024, having the functions of std::vector needed for Bits.
 // The max number of Bits that can be stored is 1024 * 128
 struct ParkVector {
+    typedef uint32_t size_type;
+
     ParkVector() {
         count_ = 0;
     }
@@ -85,18 +89,18 @@ struct ParkVector {
 
     ParkVector& operator = (const ParkVector& other) {
         count_ = other.count_;
-        for (uint32_t i = 0; i < other.count_; i++)
+        for (size_type i = 0; i < other.count_; i++)
             v_[i] = other.v_[i];
         return (*this);
     }
 
-    uint32_t size() const {
+    size_type size() const {
         return count_;
     }
 
  private:
     uint128_t v_[1024];
-    uint32_t count_;
+    size_type count_;
 };
 
 /*
@@ -212,12 +216,12 @@ template <class T> class BitsGeneric {
         }
         BitsGeneric<T> result;
         if (values_.size() > 0) {
-            for (uint32_t i = 0; i < static_cast<uint32_t>(values_.size()) - 1; i++)
+            for (typename T::size_type i = 0; i < values_.size() - 1; i++)
                 result.AppendValue(values_[i], 128);
             result.AppendValue(values_[values_.size() - 1], last_size_);
         }
         if (b.values_.size() > 0) {
-            for (uint32_t i = 0; i < static_cast<uint32_t>(b.values_.size()) - 1; i++)
+            for (typename T::size_type i = 0; i < b.values_.size() - 1; i++)
                 result.AppendValue(b.values_[i], 128);
             result.AppendValue(b.values_[b.values_.size() - 1], b.last_size_);
         }
@@ -228,7 +232,7 @@ template <class T> class BitsGeneric {
     template <class T2>
     BitsGeneric<T>& operator += (const BitsGeneric<T2>& b) {
         if (b.values_.size() > 0) {
-             for (uint32_t i = 0; i < static_cast<uint32_t>(b.values_.size()) - 1; i++)
+             for (typename T2::size_type i = 0; i < b.values_.size() - 1; i++)
                 this->AppendValue(b.values_[i], 128);
             this->AppendValue(b.values_[b.values_.size() - 1], b.last_size_);
         }
@@ -275,6 +279,7 @@ template <class T> class BitsGeneric {
             values_[values_.size() - 1]--;
             return *this;
         }
+        
         if (values_.size() > 1) {
             // Search for the first bucket different than 0.
             for (int16_t i = values_.size() - 2; i >= 0; i--)
@@ -286,7 +291,7 @@ template <class T> class BitsGeneric {
                                       (uint128_t)std::numeric_limits<uint64_t> :: max();
                     // All buckets that were previously 0, now become full of 1s.
                     // (i.e. 1010000 - 1 = 1001111)
-                    for (uint32_t j = i + 1; j < static_cast<uint32_t>(values_.size()) - 1; j++)
+                    for (typename T::size_type j = i + 1; j < values_.size() - 1; j++)
                         values_[j] =  limit;
                     values_[values_.size() - 1] = (last_size_ == 128) ? limit :
                                                    ((static_cast<uint128_t>(1) << last_size_) - 1);
@@ -429,11 +434,11 @@ template <class T> class BitsGeneric {
 
     std::string ToString() const {
         std::string str = "";
-        for (uint32_t i = 0; i < values_.size(); i++) {
+        for (typename T::size_type i = 0; i < values_.size(); i++) {
             uint128_t val = values_[i];
-            uint32_t size = (i == static_cast<uint32_t>(values_.size() - 1)) ? last_size_ : 128;
+            typename T::size_type size = (i == values_.size() - 1) ? last_size_ : 128;
             std::string str_bucket = "";
-            for (uint32_t i = 0; i < size; i++) {
+            for (typename T::size_type i = 0; i < size; i++) {
                 if (val % 2)
                     str_bucket = "1" + str_bucket;
                 else

--- a/lib/chiapos/src/bits.hpp
+++ b/lib/chiapos/src/bits.hpp
@@ -212,12 +212,12 @@ template <class T> class BitsGeneric {
         }
         BitsGeneric<T> result;
         if (values_.size() > 0) {
-            for (uint32_t i = 0; i < values_.size() - 1; i++)
+            for (uint32_t i = 0; i < static_cast<uint32_t>(values_.size()) - 1; i++)
                 result.AppendValue(values_[i], 128);
             result.AppendValue(values_[values_.size() - 1], last_size_);
         }
         if (b.values_.size() > 0) {
-            for (uint32_t i = 0; i < b.values_.size() - 1; i++)
+            for (uint32_t i = 0; i < static_cast<uint32_t>(b.values_.size()) - 1; i++)
                 result.AppendValue(b.values_[i], 128);
             result.AppendValue(b.values_[b.values_.size() - 1], b.last_size_);
         }
@@ -228,12 +228,12 @@ template <class T> class BitsGeneric {
     template <class T2>
     BitsGeneric<T>& operator += (const BitsGeneric<T2>& b) {
         if (b.values_.size() > 0) {
-             for (uint32_t i = 0; i < b.values_.size() - 1; i++)
+             for (uint32_t i = 0; i < static_cast<uint32_t>(b.values_.size()) - 1; i++)
                 this->AppendValue(b.values_[i], 128);
             this->AppendValue(b.values_[b.values_.size() - 1], b.last_size_);
         }
         return *this;
-    }
+    }  
 
     BitsGeneric<T>& operator++() {
         uint128_t limit = ((uint128_t)std::numeric_limits<uint64_t> :: max() << 64) +
@@ -243,12 +243,10 @@ template <class T> class BitsGeneric {
         if (values_[values_.size() - 1] != last_bucket_mask) {
             values_[values_.size() - 1]++;
         } else {
-            bool all_one = true;
             if (values_.size() > 1) {
                 // Otherwise, search for the first bucket that isn't full of 1 bits.
                 for (int16_t i = values_.size() - 2; i >= 0; i--)
                     if (values_[i] != limit) {
-                        all_one = false;
                         // Increment it.
                         values_[i]++;
                         // Buckets that were full of 1 bits turn all to 0 bits.
@@ -288,7 +286,7 @@ template <class T> class BitsGeneric {
                                       (uint128_t)std::numeric_limits<uint64_t> :: max();
                     // All buckets that were previously 0, now become full of 1s.
                     // (i.e. 1010000 - 1 = 1001111)
-                    for (uint32_t j = i + 1; j < values_.size() - 1; j++)
+                    for (uint32_t j = i + 1; j < static_cast<uint32_t>(values_.size()) - 1; j++)
                         values_[j] =  limit;
                     values_[values_.size() - 1] = (last_size_ == 128) ? limit :
                                                    ((static_cast<uint128_t>(1) << last_size_) - 1);
@@ -317,12 +315,12 @@ template <class T> class BitsGeneric {
         return res;
     }
 
-    BitsGeneric<T> Slice(int32_t start_index) const {
+    BitsGeneric<T> Slice(uint32_t start_index) const {
         return Slice(start_index, GetSize());
     }
 
     // Slices the bits from [start_index, end_index)
-    BitsGeneric<T> Slice(int32_t start_index, int32_t end_index) const {
+    BitsGeneric<T> Slice(uint32_t start_index, uint32_t end_index) const {
         if (end_index > GetSize()) {
             end_index = GetSize();
         }
@@ -363,7 +361,7 @@ template <class T> class BitsGeneric {
     }
 
     // Same as 'Slice', but result fits into an uint64_t. Used for memory optimization.
-    uint64_t SliceBitsToInt(int32_t start_index, int32_t end_index) const {
+    uint64_t SliceBitsToInt(uint32_t start_index, uint32_t end_index) const {
         /*if (end_index > GetSize()) {
             end_index = GetSize();
         }
@@ -372,7 +370,7 @@ template <class T> class BitsGeneric {
         } */
         if ((start_index >> 7) == (end_index >> 7)) {
             uint128_t res = values_[start_index >> 7];
-            if (((uint32_t)start_index >> 7) == values_.size() - 1)
+            if ((start_index >> 7) == values_.size() - 1)
                 res = res >> (last_size_ - (end_index & 127));
             else
                 res = res >> (128 - (end_index & 127));
@@ -383,7 +381,7 @@ template <class T> class BitsGeneric {
             uint128_t prefix, suffix;
             SplitNumberByPrefix(values_[(start_index >> 7)], 128, start_index & 127, &prefix, &suffix);
             uint128_t result = suffix;
-            uint8_t bucket_size = (((uint32_t)end_index >> 7) == values_.size() - 1) ? last_size_ : 128;
+            uint8_t bucket_size = ((end_index >> 7) == values_.size() - 1) ? last_size_ : 128;
             SplitNumberByPrefix(values_[(end_index >> 7)], bucket_size, end_index & 127, &prefix, &suffix);
             result = (result << (end_index & 127)) + prefix;
             return result;
@@ -433,9 +431,9 @@ template <class T> class BitsGeneric {
         std::string str = "";
         for (uint32_t i = 0; i < values_.size(); i++) {
             uint128_t val = values_[i];
-            uint32_t size = (i == values_.size() - 1) ? last_size_ : 128;
+            uint32_t size = (i == static_cast<uint32_t>(values_.size() - 1)) ? last_size_ : 128;
             std::string str_bucket = "";
-            for (int i = 0; i < size; i++) {
+            for (uint32_t i = 0; i < size; i++) {
                 if (val % 2)
                     str_bucket = "1" + str_bucket;
                 else


### PR DESCRIPTION
fix compiler warnings in bits.hpp

Most of the warnings are from signedness mismatch between an iteration index and the type of `_values.size()` which can be `uint32_t `or `uint16_t `depending on instantiation.

In order to avoid casting, typedef `size_type `in `SmallVector `and `ParkVector`, much like `std:vector` does.