### PR TITLE
Update create_plots.py

### DIFF
--- a/scripts/create_plots.py
+++ b/scripts/create_plots.py
@@ -25,6 +25,9 @@ def main():
         "-n", "--num_plots", help="Number of plots", type=int, default=10
     )
     parser.add_argument(
+        "-i", "--index", help="First plot index", type=int, default=0
+    )
+    parser.add_argument(
         "-p", "--pool_pub_key", help="Hex public key of pool", type=str, default=""
     )
     parser.add_argument(
@@ -63,10 +66,10 @@ def main():
         pool_pk = pool_sk.get_public_key()
 
     print(
-        f"Creating {args.num_plots} plots of size {args.size}, sk_seed {sk_seed.hex()} ppk {pool_pk}"
+        f"Creating {args.num_plots} plots, from index {args.index} to {args.index + args.num_plots - 1}, of size {args.size}, sk_seed {sk_seed.hex()} ppk {pool_pk}"
     )
 
-    for i in range(args.num_plots):
+    for i in range(args.index, args.index + args.num_plots):
         # Generate a sk based on the seed, plot size (k), and index
         sk: PrivateKey = PrivateKey.from_seed(
             sk_seed + args.size.to_bytes(1, "big") + i.to_bytes(4, "big")


### PR DESCRIPTION
The proposed change allows to call create_plots.py with an optional index, so ranges of plots can be generated, that don't overlap. For example:
server1: python -m scripts.create_plots -k 30 -i 0 -n 150 -d /data/plots/disk1
server2: python -m scripts.create_plots -k 30 -i 150 -n 150 -d /data/plots/disk2
server3: python -m scripts.create_plots -k 30 -i 300 -n 150 -d /data/plots/disk3
Disks 1 through 3 are USB disks that can be when plotting finished, removed from the servers 1 through 3 and attached to server4. 