### PR TITLE
Rename processes

### DIFF
--- a/scripts/chia-restart-harvester
+++ b/scripts/chia-restart-harvester
@@ -5,7 +5,7 @@ _restart_harvester_servers() {
     echo "Shutting down harvesters"
     echo "$PROCS" | xargs -L1 kill
     echo "Restarting harvesters"
-    _run_bg_cmd python -m src.server.start_harvester
+    _run_bg_cmd chia_harvester
   else
     echo "No running harvesters found"
   fi

--- a/scripts/chia-start-all
+++ b/scripts/chia-start-all
@@ -2,10 +2,10 @@
 
 # Starts a harvester, farmer, timelord, and full node
 
-_run_bg_cmd python -m src.server.start_harvester
-_run_bg_cmd python -m src.server.start_timelord
-_run_bg_cmd python -m src.timelord_launcher
-_run_bg_cmd python -m src.server.start_farmer
-_run_bg_cmd python -m src.server.start_full_node --port=8444 --connect_to_farmer=True --connect_to_timelord=True --rpc_port=8555
+_run_bg_cmd chia_harvester
+_run_bg_cmd chia_timelord
+_run_bg_cmd chia_timelord_launcher
+_run_bg_cmd chia_farmer
+_run_bg_cmd chia_full_node --port=8444 --connect_to_farmer=True --connect_to_timelord=True --rpc_port=8555
 
 wait

--- a/scripts/chia-start-farmer
+++ b/scripts/chia-start-farmer
@@ -2,8 +2,8 @@
 
 # Starts a harvester, farmer, and full node.
 
-_run_bg_cmd python -m src.server.start_harvester
-_run_bg_cmd python -m src.server.start_farmer
-_run_bg_cmd python -m src.server.start_full_node --port=8444 --connect_to_farmer=True --rpc_port=8555
+_run_bg_cmd chia_harvester
+_run_bg_cmd chia_farmer
+_run_bg_cmd chia_full_node --port=8444 --connect_to_farmer=True --rpc_port=8555
 
 wait

--- a/scripts/chia-start-introducer
+++ b/scripts/chia-start-introducer
@@ -2,6 +2,6 @@
 
 # Starts an introducer
 
-_run_bg_cmd python -m src.server.start_introducer
+_run_bg_cmd chia_introducer
 
 wait

--- a/scripts/chia-start-node
+++ b/scripts/chia-start-node
@@ -1,6 +1,6 @@
 . _chia-common
 
 # Starts a full node
-_run_bg_cmd python -m src.server.start_full_node --port=8444 --connect_to_farmer=True --connect_to_timelord=True --rpc_port=8555
+_run_bg_cmd chia_full_node --port=8444 --connect_to_farmer=True --connect_to_timelord=True --rpc_port=8555
 
 wait

--- a/scripts/chia-start-sim
+++ b/scripts/chia-start-sim
@@ -6,12 +6,12 @@ echo "Note that this simulation will not work if connected to external nodes."
 # Starts a harvester, farmer, timelord, introducer, and 3 full nodes, locally.
 # Please note that the simulation is meant to be run locally and not connected to external nodes.
 
-_run_bg_cmd python -m src.server.start_harvester --logging.log_stdout=True
-_run_bg_cmd python -m src.server.start_timelord --logging.log_stdout=True
-_run_bg_cmd python -m src.timelord_launcher --logging.log_stdout=True
-_run_bg_cmd python -m src.server.start_farmer --logging.log_stdout=True
-_run_bg_cmd python -m src.server.start_introducer --logging.log_stdout=True
-_run_bg_cmd python -m src.server.start_full_node --port=8444 --database_path="simulation_1.db" --connect_to_farmer=True --connect_to_timelord=True --rpc_port=8555 --introducer_peer.host="127.0.0.1" --introducer_peer.port=8445 --logging.log_stdout=True
-_run_bg_cmd python -m src.server.start_full_node --port=8002 --database_path="simulation_2.db" --rpc_port=8556 --introducer_peer.host="127.0.0.1" --introducer_peer.port=8445 --logging.log_stdout=True
+_run_bg_cmd chia_harvester --logging.log_stdout=True
+_run_bg_cmd chia_timelord --logging.log_stdout=True
+_run_bg_cmd chia_timelord_launcher --logging.log_stdout=True
+_run_bg_cmd chia_farmer --logging.log_stdout=True
+_run_bg_cmd chia_introducer --logging.log_stdout=True
+_run_bg_cmd chia_full_node --port=8444 --database_path="simulation_1.db" --connect_to_farmer=True --connect_to_timelord=True --rpc_port=8555 --introducer_peer.host="127.0.0.1" --introducer_peer.port=8445 --logging.log_stdout=True
+_run_bg_cmd chia_full_node --port=8002 --database_path="simulation_2.db" --rpc_port=8556 --introducer_peer.host="127.0.0.1" --introducer_peer.port=8445 --logging.log_stdout=True
 
 wait

--- a/scripts/chia-start-timelord
+++ b/scripts/chia-start-timelord
@@ -2,8 +2,8 @@
 
 # Starts a timelord, and a full node
 
-_run_bg_cmd python -m src.server.start_timelord
-_run_bg_cmd python -m src.timelord_launcher
-_run_bg_cmd python -m src.server.start_full_node --port=8444 --connect_to_timelord=True --rpc_port=8555
+_run_bg_cmd chia_timelord
+_run_bg_cmd chia_timelord_launcher
+_run_bg_cmd chia_full_node --port=8444 --connect_to_timelord=True --rpc_port=8555
 
 wait

--- a/scripts/chia-start-wallet-server
+++ b/scripts/chia-start-wallet-server
@@ -1,4 +1,0 @@
-# Starts a websocket for GUI Wallet
-python -m src.wallet.websocket_server
-
-wait

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ kwargs = dict(
         "scripts/chia-start-sim",
         "scripts/chia-start-timelord",
         "scripts/chia-start-wallet-gui",
-        "scripts/chia-start-wallet-server",
         "scripts/chia-stop-all",
     ],
     entry_points={
@@ -81,7 +80,15 @@ kwargs = dict(
             "chia-check-plots = src.cmds.check_plots:main",
             "chia-create-plots = src.cmds.create_plots:main",
             "chia-generate-keys = src.cmds.generate_keys:main",
-            "chia-websocket-server = src.wallet.websocket_server:main",
+            "chia-start-wallet-server = src.wallet.websocket_server:main",
+            "chia-wallet = src.wallet.websocket_server:main",
+            "chia_full_node = src.server.start_full_node:main",
+            "chia_harvester = src.server.start_harvester:main",
+            "chia_farmer = src.server.start_farmer:main",
+            "chia_introducer = src.server.start_introducer:main",
+            "chia_timelord = src.server.start_timelord:main",
+            "chia_timelord_launcher = src.timelord_launcher:main",
+            "chia_full_node_simulator = src.simulator.start_simulator:main",
         ]
     },
     package_data={

--- a/src/server/start_farmer.py
+++ b/src/server/start_farmer.py
@@ -17,7 +17,7 @@ from src.util.logging import initialize_logging
 from src.util.setproctitle import setproctitle
 
 
-async def main():
+async def async_main():
     root_path = DEFAULT_ROOT_PATH
     net_config = load_config(root_path, "config.yaml")
     config = load_config_cli(root_path, "config.yaml", "farmer")
@@ -61,6 +61,11 @@ async def main():
     log.info("Farmer fully closed.")
 
 
-if uvloop is not None:
-    uvloop.install()
-asyncio.run(main())
+def main():
+    if uvloop is not None:
+        uvloop.install()
+    asyncio.run(async_main())
+
+
+if __name__ == '__main__':
+    main()

--- a/src/server/start_full_node.py
+++ b/src/server/start_full_node.py
@@ -29,7 +29,7 @@ from src.util.pip_import import pip_import
 from src.util.setproctitle import setproctitle
 
 
-async def main():
+async def async_main():
     config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", "full_node")
     net_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     setproctitle("chia_full_node")
@@ -146,6 +146,11 @@ async def main():
     log.info("Node fully closed.")
 
 
-if uvloop is not None:
-    uvloop.install()
-asyncio.run(main())
+def main():
+    if uvloop is not None:
+        uvloop.install()
+    asyncio.run(async_main())
+
+
+if __name__ == '__main__':
+    main()

--- a/src/server/start_harvester.py
+++ b/src/server/start_harvester.py
@@ -17,7 +17,7 @@ from src.util.logging import initialize_logging
 from src.util.setproctitle import setproctitle
 
 
-async def main():
+async def async_main():
     root_path = DEFAULT_ROOT_PATH
     net_config = load_config(root_path, "config.yaml")
     config = load_config_cli(root_path, "config.yaml", "harvester")
@@ -54,6 +54,11 @@ async def main():
     log.info("Harvester fully closed.")
 
 
-if uvloop is not None:
-    uvloop.install()
-asyncio.run(main())
+def main():
+    if uvloop is not None:
+        uvloop.install()
+    asyncio.run(async_main())
+
+
+if __name__ == '__main__':
+    main()

--- a/src/server/start_introducer.py
+++ b/src/server/start_introducer.py
@@ -16,7 +16,7 @@ from src.util.logging import initialize_logging
 from src.util.setproctitle import setproctitle
 
 
-async def main():
+async def async_main():
     root_path = DEFAULT_ROOT_PATH
     net_config = load_config(root_path, "config.yaml")
     config = load_config_cli(root_path, "config.yaml", "introducer")
@@ -42,6 +42,11 @@ async def main():
     log.info("Introducer fully closed.")
 
 
-if uvloop is not None:
-    uvloop.install()
-asyncio.run(main())
+def main():
+    if uvloop is not None:
+        uvloop.install()
+    asyncio.run(async_main())
+
+
+if __name__ == '__main__':
+    main()

--- a/src/server/start_timelord.py
+++ b/src/server/start_timelord.py
@@ -20,7 +20,7 @@ from src.util.logging import initialize_logging
 from src.util.setproctitle import setproctitle
 
 
-async def main():
+async def async_main():
     root_path = DEFAULT_ROOT_PATH
     net_config = load_config(root_path, "config.yaml")
     config = load_config_cli(root_path, "config.yaml", "timelord")
@@ -78,6 +78,11 @@ async def main():
     log.info("Timelord fully closed.")
 
 
-if uvloop is not None:
-    uvloop.install()
-asyncio.run(main())
+def main():
+    if uvloop is not None:
+        uvloop.install()
+    asyncio.run(async_main())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is a non-controversial precursor to removing `setproctitle`. It doesn't actually remove it, but it creates some python commands of the same names that launch the process that we're setting with `setproctitle`.