### PR TITLE
Install python & wheels

### DIFF
--- a/electron-wix/blockchain/.gitignore
+++ b/electron-wix/blockchain/.gitignore
@@ -1,4 +1,4 @@
 *
 !.gitignore
-!readme.md
+!readme.*
 !install.ps1

--- a/electron-wix/blockchain/.gitignore
+++ b/electron-wix/blockchain/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!readme.md
+!install.ps1

--- a/electron-wix/blockchain/install.ps1
+++ b/electron-wix/blockchain/install.ps1
@@ -1,9 +1,9 @@
 Remove-Item "./venv" -Recurse -Force -ErrorAction Ignore
 
 Start-Process "$env:HOMEDRIVE$env:HOMEPATH\AppData\Local\Programs\Python\Python37\python.exe" -ArgumentList "-m venv venv" -Wait
-if ($LastExitCode) { exit $LastExitCode }
 
 . .\venv\Scripts\activate.ps1
+
 pip3 install --upgrade pip
-pip install -i https://download.chia.net/simple/ miniupnpc==2.1 setproctitle==1.1.10 cbor2==5.1.0
-pip install -e .
+
+.\wheels.ps1

--- a/electron-wix/blockchain/install.ps1
+++ b/electron-wix/blockchain/install.ps1
@@ -1,0 +1,9 @@
+Remove-Item "./venv" -Recurse -Force -ErrorAction Ignore
+
+Start-Process "$env:HOMEDRIVE$env:HOMEPATH\AppData\Local\Programs\Python\Python37\python.exe" -ArgumentList "-m venv venv" -Wait
+if ($LastExitCode) { exit $LastExitCode }
+
+. .\venv\Scripts\activate.ps1
+pip3 install --upgrade pip
+pip install -i https://download.chia.net/simple/ miniupnpc==2.1 setproctitle==1.1.10 cbor2==5.1.0
+pip install -e .

--- a/electron-wix/blockchain/readme.md
+++ b/electron-wix/blockchain/readme.md
@@ -1,0 +1,6 @@
+# Blockchain
+
+Folder layout that the installer will pick up:
+
+- `./` (any files to go in the root installation directory)
+- `./wheels/` (any wheels to drop in the install directory)

--- a/electron-wix/blockchain/readme.txt
+++ b/electron-wix/blockchain/readme.txt
@@ -1,0 +1,2 @@
+To complete the install, open powershell, and navigate to `~\AppData\Local\Programs\Chia Network\Chia Blockchain\`
+Execute the `install.ps1` located in that folder.

--- a/electron-wix/build-blockchain-msi.ps1
+++ b/electron-wix/build-blockchain-msi.ps1
@@ -20,6 +20,15 @@ Copy-Item ".\blockchain\install.ps1" "$blockchainDir" -Force
 Copy-Item ".\blockchain\readme.txt" "$blockchainDir" -Force
 Copy-Item ".\blockchain\*.whl" "$blockchainDir\wheels" -Force
 
+# generate the script that will isntall all the wheels on the target machine
+$text = ""
+Get-ChildItem "$blockchainDir\wheels" -Filter *.whl | 
+Foreach-Object {
+    $text += "pip install .\wheels\$_`n"
+}
+New-Item "$blockchainDir\wheels.ps1" -Force
+Set-Content "$blockchainDir\wheels.ps1" $text
+
 # this generates package-files.wxs from the contents of the electron packager folder
 Write-Host "Creating manifest of python environment files"
 heat dir $blockchainDir -cg ChiaBlockchainFiles -nologo -gg -scom -sreg -sfrag -srd -dr INSTALLDIR -out "$buildDir\$tempName.wxs"

--- a/electron-wix/build-blockchain-msi.ps1
+++ b/electron-wix/build-blockchain-msi.ps1
@@ -8,24 +8,31 @@ catch {
     Write-Host $_    
     exit 1
 }
-$venvDir = "..\venv"
+$blockchainDir = "$buildDir\blockchain"
 
 $tempName = "blockchain-files"
 $packageName = "$env:blockchainProductName-$env:version.msi"
 
+# copy blockchain stuff into the build dir
+New-Item -ItemType Directory -Path "$blockchainDir" -Force
+New-Item -ItemType Directory -Path "$blockchainDir\wheels" -Force
+Copy-Item ".\blockchain\install.ps1" "$blockchainDir" -Force
+Copy-Item ".\blockchain\readme.txt" "$blockchainDir" -Force
+Copy-Item ".\blockchain\*.whl" "$blockchainDir\wheels" -Force
+
 # this generates package-files.wxs from the contents of the electron packager folder
 Write-Host "Creating manifest of python environment files"
-heat dir $venvDir -cg ChiaBlockchainFiles -nologo -gg -scom -sreg -sfrag -srd -dr venvDir -out "$buildDir\$tempName.wxs"
+heat dir $blockchainDir -cg ChiaBlockchainFiles -nologo -gg -scom -sreg -sfrag -srd -dr INSTALLDIR -out "$buildDir\$tempName.wxs"
 if ($LastExitCode) { exit $LastExitCode }
 
 # compile the installer
 Write-Host "Compiling $packageName"
-candle "$buildDir\$tempName.wxs" "$sourceDir\blockchain-msi.wxs" -nologo -arch x64 -o "$buildDir\"
+candle "$buildDir\$tempName.wxs" "$sourceDir\blockchain-msi.wxs" -nologo -arch x64 -o "$buildDir\"  -ext WixUtilExtension
 if ($LastExitCode) { exit $LastExitCode }
 
 # link the installer
 Write-Host "Building $packageName"
-light -ext WixUIExtension "$buildDir\$tempName.wixobj" "$buildDir\blockchain-msi.wixobj" -nologo -b $venvDir -o "$buildDir\$packageName"
+light -ext WixUIExtension "$buildDir\$tempName.wixobj" "$buildDir\blockchain-msi.wixobj" -nologo -b $blockchainDir -o "$buildDir\$packageName"  -ext WixUtilExtension
 if ($LastExitCode) { exit $LastExitCode }
 
 Sign-Item "$buildDir\$packageName"

--- a/electron-wix/build-bundle.ps1
+++ b/electron-wix/build-bundle.ps1
@@ -11,12 +11,14 @@ catch {
 $packageName = "chia-$env:version.exe"
 
 Write-Host "Compiling $packageName"
-candle "$sourceDir\bundle.wxs" "$sourceDir\msvc2019-package.wxs" "$sourceDir\blockchain-package.wxs" "$sourceDir\wallet-package.wxs" `
+candle "$sourceDir\bundle.wxs" "$sourceDir\python-package.wxs" "$sourceDir\msvc2019-package.wxs" `
+            "$sourceDir\blockchain-package.wxs" "$sourceDir\wallet-package.wxs" `
             -nologo -o "$buildDir\" -ext WixBalExtension -ext WixUtilExtension
 if ($LastExitCode) { exit $LastExitCode }
 
 Write-Host "Building $packageName"
-light "$buildDir\bundle.wixobj" "$buildDir\msvc2019-package.wixobj" "$buildDir\blockchain-package.wixobj" "$buildDir\wallet-package.wixobj" `
+light "$buildDir\bundle.wixobj" "$buildDir\python-package.wixobj" "$buildDir\msvc2019-package.wixobj" `
+            "$buildDir\blockchain-package.wixobj" "$buildDir\wallet-package.wixobj" `
             -nologo -o "$buildDir\$packageName" -sw1133 -ext WixBalExtension -ext WixUtilExtension
 if ($LastExitCode) { exit $LastExitCode }
 

--- a/electron-wix/config.ps1
+++ b/electron-wix/config.ps1
@@ -1,7 +1,7 @@
 # shared variables
 $env:walletProductName = "chia-wallet"
 $env:blockchainProductName = "chia-blockchain"
-$env:version = "0.1.5" # all packages share the same version
+$env:version = "0.1.6" # all packages share the same version
 $env:resourceDir = ".\resources" # bitmaps, icons etc
 $env:prereqDir = ".\prerequisites" # location for any pre-req installers
 

--- a/electron-wix/prerequisites/readme.md
+++ b/electron-wix/prerequisites/readme.md
@@ -3,3 +3,4 @@
 Any prerequisite installers that aren't included in the git repo should be downloaded and placed in this folder
 
 - [MSVC 2019 redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
+- [Python 3.7.7](https://www.python.org/ftp/python/3.7.7/python-3.7.7-amd64.exe)

--- a/electron-wix/src/blockchain-msi.wxs
+++ b/electron-wix/src/blockchain-msi.wxs
@@ -83,17 +83,6 @@
                         <RemoveFolder Id='ChiaNetworkDir' On='uninstall' />
                     </Component>
                     <Directory Id='INSTALLDIR' Name='Chia Blockchain'>
-                        <Directory Id='venvDir' Name='venv'>
-                            <Component Id="dirvenvDir" Guid="5DF86C11-9AAA-4B2A-A9FB-F7555D850E61">
-                                <RemoveFolder Id='venvDir' On='uninstall' />
-                                <RegistryValue Root='HKCU'
-                                    Key='Software\[Manufacturer]\[ProductName]'
-                                    Type='string'
-                                    Name="venvDir"
-                                    Value='venv'
-                                    KeyPath='yes' />
-                            </Component>
-                        </Directory>
                         <Component Id="dirINSTALLDIR" Guid="E645FFCF-0742-4AB1-845E-B3EB8B721059">
                             <RemoveFolder Id='INSTALLDIR' On='uninstall' />
                             <RegistryValue Root='HKCU'
@@ -128,7 +117,6 @@
         <Feature Id='Complete' Level='1'>
             <ComponentRef Id='ProgramMenuDir' />
             <ComponentRef Id='dirINSTALLDIR' />
-            <ComponentRef Id='dirvenvDir' />
             <ComponentRef Id='ManufacturerData' />
             <ComponentGroupRef Id="ChiaBlockchainFiles" /> <!-- this component group is defined in the heat generated wxs file -->
         </Feature>

--- a/electron-wix/src/bundle.wxs
+++ b/electron-wix/src/bundle.wxs
@@ -25,9 +25,11 @@
                 ShowVersion="yes"
                 SuppressOptionsUI="yes"/>
         </BootstrapperApplicationRef>
-        <Chain ParallelCache='yes'>
+        <Chain>
+            <PackageGroupRef Id="PythonPackage" />
             <PackageGroupRef Id="MSVC2019Package" />
             <RollbackBoundary />
+
             <PackageGroupRef Id="BlockchainPackage" />
             <PackageGroupRef Id="WalletPackage" />
         </Chain>

--- a/electron-wix/src/bundle.wxs
+++ b/electron-wix/src/bundle.wxs
@@ -30,8 +30,12 @@
             <PackageGroupRef Id="MSVC2019Package" />
             <RollbackBoundary />
 
-            <PackageGroupRef Id="BlockchainPackage" />
             <PackageGroupRef Id="WalletPackage" />
+            <PackageGroupRef Id="BlockchainPackage" />
         </Chain>
     </Bundle>
 </Wix>
+
+<!--            LaunchArguments="[#readme.txt]"
+                LaunchTarget="notepad.exe"
+                LaunchWorkingFolder="[INSTALLDIR]" -->

--- a/electron-wix/src/python-package.wxs
+++ b/electron-wix/src/python-package.wxs
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!-- This defines the python pre-requisite -->
-<!-- NOT CURRENTLY USED -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" 
     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <?include "config.wxi"?>
@@ -16,11 +15,15 @@
             Result="value"/>
         <PackageGroup Id="PythonPackage">
             <ExePackage Id="PythonExePackage"
-                Description="Python 3.7"
-                SourceFile="python-$(var.pythonVersion)-amd64.exe"
+                Cache="yes"
+                Compressed="yes"            
+                Description="Python 3.7.7"
+                DetectCondition="python37Installed = 1 AND python37Version >= v$(var.pythonVersion)"
                 InstallCommand="/quiet"
-                UninstallCommand="/uninstall"
-                DetectCondition="python37Installed = 0 OR python37Version &lt; v$(var.pythonVersion)"/>
+                PerMachine="no"
+                Permanent="yes"              
+                SourceFile="$(env.prereqDir)\python-$(var.pythonVersion)-amd64.exe"
+                Vital="yes"/>
         </PackageGroup>
     </Fragment>
 </Wix>


### PR DESCRIPTION
adds python as a pre-req and drops all the wheels on the target machine

user needs to execute `install.ps1` to finalize the installation (the venv dir will not be uninstalled because it is created after the fact)