### PR TITLE
copy outputs to final folder

### DIFF
--- a/electron-wix/.gitignore
+++ b/electron-wix/.gitignore
@@ -1,2 +1,3 @@
 chia-wallet-win32-x64/
 build/
+final/

--- a/electron-wix/clean.ps1
+++ b/electron-wix/clean.ps1
@@ -13,4 +13,5 @@ catch {
 Write-Host "Cleaning any previous outputs"
 Remove-Item $electronpackagerdir -Recurse -Force -ErrorAction Ignore
 Remove-Item "$buildDir" -Recurse -Force -ErrorAction Ignore
-New-Item -ItemType Directory -Path "$buildDir"
+Remove-Item "$finalDir" -Recurse -Force -ErrorAction Ignore
+

--- a/electron-wix/config.ps1
+++ b/electron-wix/config.ps1
@@ -1,11 +1,12 @@
 # shared variables
 $env:walletProductName = "chia-wallet"
 $env:blockchainProductName = "chia-blockchain"
-$env:version = "0.1.6" # all packages share the same version
+$env:version = "0.1.5" # all packages share the same version
 $env:resourceDir = ".\resources" # bitmaps, icons etc
 $env:prereqDir = ".\prerequisites" # location for any pre-req installers
 
 $buildDir = ".\build" # where temp and final build output go
+$finalDir = ".\final" # where temp and final build output go
 $sourceDir = ".\src" # the location of wxs files etc
 $electronPackagerDir = $env:walletProductName + "-win32-x64" # the folder that electron-packager creates
 
@@ -19,7 +20,7 @@ function Sign-Item {
     Param ($packageName)
 
     $timeURL = "http://timestamp.comodoca.com/authenticode"
-    $pfxPath = "$env:HOMEPATH\selfsigncert.pfx"
+    $pfxPath = "$env:HOMEDRIVE\$env:HOMEPATH\selfsigncert.pfx"
     $CERT_PASSWORD = "my_password"
 
     # if a signing cert is specified, sign the package

--- a/electron-wix/rebuild-all.ps1
+++ b/electron-wix/rebuild-all.ps1
@@ -1,5 +1,17 @@
+$ScriptDirectory = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+try {
+    . ("$ScriptDirectory\config.ps1")
+}
+catch {
+    Write-Host "Error while loading supporting PowerShell Scripts" 
+    Write-Host $_    
+    exit 1
+}
+
 # this script cleans and builds all of the packages and bundle
 .\clean.ps1
+
+New-Item -ItemType Directory -Path "$buildDir"
 
 .\build-wallet-msi.ps1
 if ($LastExitCode) { exit $LastExitCode }
@@ -11,3 +23,7 @@ if ($LastExitCode) { exit $LastExitCode }
 if ($LastExitCode) { exit $LastExitCode }
 
 Write-Host "Succesfully built Chia installer for $env:version"
+
+New-Item -ItemType Directory -Path "$finalDir"
+Copy-Item "$buildDir\*.msi" "$finalDir\" -Force
+Copy-Item "$buildDir\*.exe" "$finalDir\" -Force


### PR DESCRIPTION
`rebuild-all.ps1` copies all msi and exe files from `build` to `final` as a last step.