### PR TITLE
Cc wallet missing - remove miniupnpc late install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ kwargs = dict(
         "src.wallet",
         "src.wallet.puzzles",
         "src.wallet.rl_wallet",
-        "src.wallet.cc_wallet"
+        "src.wallet.cc_wallet",
         "src.wallet.util",
         "src.ssl",
     ],

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ kwargs = dict(
         "src.wallet",
         "src.wallet.puzzles",
         "src.wallet.rl_wallet",
+        "src.wallet.cc_wallet"
         "src.wallet.util",
         "src.ssl",
     ],

--- a/src/server/start_full_node.py
+++ b/src/server/start_full_node.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import logging.config
 import signal
+import miniupnpc
 
 import aiosqlite
 
@@ -61,7 +62,6 @@ async def async_main():
     if config["enable_upnp"]:
         log.info(f"Attempting to enable UPnP (open up port {config['port']})")
         try:
-            #miniupnpc = pip_import("miniupnpc", "miniupnpc==2.1") Causing problems on windows
             upnp = miniupnpc.UPnP()
             upnp.discoverdelay = 5
             upnp.discover()

--- a/src/server/start_full_node.py
+++ b/src/server/start_full_node.py
@@ -25,7 +25,6 @@ from src.util.logging import initialize_logging
 from src.util.config import load_config_cli, load_config
 from src.util.default_root import DEFAULT_ROOT_PATH
 from src.util.path import mkdir, path_from_root
-from src.util.pip_import import pip_import
 from src.util.setproctitle import setproctitle
 
 

--- a/src/server/start_full_node.py
+++ b/src/server/start_full_node.py
@@ -61,7 +61,7 @@ async def async_main():
     if config["enable_upnp"]:
         log.info(f"Attempting to enable UPnP (open up port {config['port']})")
         try:
-            miniupnpc = pip_import("miniupnpc", "miniupnpc==2.1")
+            #miniupnpc = pip_import("miniupnpc", "miniupnpc==2.1") Causing problems on windows
             upnp = miniupnpc.UPnP()
             upnp.discoverdelay = 5
             upnp.discover()


### PR DESCRIPTION
@matt-o-how or @Yostra - When you added cc_wallet you also needed to add it in the modules section of setup.py. It worked for ya'll because you had the source on your disk but doesn't work for binary wheel installs like Windows

@richardkiss - I had to revert the pip install miniupnpc logic in start_node as it was causing freezes on Windows.