### PR TITLE
Don't reuse public keys, generate puzzles for all wallets

### DIFF
--- a/src/wallet/cc_wallet/cc_wallet_puzzles.py
+++ b/src/wallet/cc_wallet/cc_wallet_puzzles.py
@@ -99,7 +99,7 @@ def get_innerpuzzle_from_puzzle(puzzle: str):
 def create_spend_for_ephemeral(parent_of_e, auditor_coin, spend_amount):
     puzstring = f"(r (r (c (q 0x{auditor_coin.name()}) (c (q {spend_amount}) (q ())))))"
     puzzle = Program(binutils.assemble(puzstring))
-    coin = Coin(parent_of_e.name(), puzzle.get_tree_hash(), 0)
+    coin = Coin(parent_of_e.name(), puzzle.get_tree_hash(), uint64(0))
     solution = Program(binutils.assemble("()"))
     coinsol = CoinSolution(coin, clvm.to_sexp_f([puzzle, solution]))
     return coinsol
@@ -109,7 +109,7 @@ def create_spend_for_ephemeral(parent_of_e, auditor_coin, spend_amount):
 def create_spend_for_auditor(parent_of_a, auditee):
     puzstring = f"(r (c (q 0x{auditee.name()}) (q ())))"
     puzzle = Program(binutils.assemble(puzstring))
-    coin = Coin(parent_of_a.name(), puzzle.get_tree_hash(), 0)
+    coin = Coin(parent_of_a.name(), puzzle.get_tree_hash(), uint64(0))
     solution = Program(binutils.assemble("()"))
     coinsol = CoinSolution(coin, clvm.to_sexp_f([puzzle, solution]))
     return coinsol
@@ -119,7 +119,7 @@ def cc_generate_eve_spend(coin: Coin, full_puzzle: Program):
     solution = cc_make_eve_solution(
         coin.parent_coin_info, coin.puzzle_hash, coin.amount
     )
-    list_of_solutions = [CoinSolution(coin, clvm.to_sexp_f([full_puzzle, solution, ]), )]
+    list_of_solutions = [CoinSolution(coin, clvm.to_sexp_f([full_puzzle, solution]),)]
     aggsig = BLSSignature.aggregate([])
     spend_bundle = SpendBundle(list_of_solutions, aggsig)
     return spend_bundle

--- a/src/wallet/trade_manager.py
+++ b/src/wallet/trade_manager.py
@@ -59,9 +59,9 @@ class TradeManager:
                             to_exclude: List[Coin] = []
                         else:
                             to_exclude = spend_bundle.removals()
-                        zero_spend_bundle: Optional[SpendBundle] = await wallet.generate_zero_val_coin(
-                            False, to_exclude
-                        )
+                        zero_spend_bundle: Optional[
+                            SpendBundle
+                        ] = await wallet.generate_zero_val_coin(False, to_exclude)
 
                         if zero_spend_bundle is None:
                             raise ValueError(
@@ -290,7 +290,7 @@ class TradeManager:
                 )
             else:
                 if chia_spend_bundle is None:
-                    to_exclude = []
+                    to_exclude: List = []
                 else:
                     to_exclude = chia_spend_bundle.removals()
                 zero_spend_bundle: SpendBundle = await wallets[

--- a/src/wallet/wallet_puzzle_store.py
+++ b/src/wallet/wallet_puzzle_store.py
@@ -261,47 +261,12 @@ class WalletPuzzleStore:
 
         return None
 
-    async def get_last_derivation_path_for_wallet(
-        self, wallet_id: int
-    ) -> Optional[uint32]:
-        """
-        Returns the last derivation path by derivation_index.
-        """
-
-        cursor = await self.db_connection.execute(
-            f"SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id={wallet_id};"
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
-
-        if row is not None and row[0] is not None:
-            return uint32(row[0])
-
-        return None
-
     async def get_unused_derivation_path(self) -> Optional[uint32]:
         """
         Returns the first unused derivation path by derivation_index.
         """
         cursor = await self.db_connection.execute(
             "SELECT MIN(derivation_index) FROM derivation_paths WHERE used=0;"
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
-
-        if row is not None and row[0] is not None:
-            return uint32(row[0])
-
-        return None
-
-    async def get_unused_derivation_path_for_wallet(
-        self, wallet_id: int
-    ) -> Optional[uint32]:
-        """
-        Returns the first unused derivation path by derivation_index.
-        """
-        cursor = await self.db_connection.execute(
-            f"SELECT MIN(derivation_index) FROM derivation_paths WHERE used=0 and wallet_id={wallet_id};"
         )
         row = await cursor.fetchone()
         await cursor.close()

--- a/src/wallet/wallet_puzzle_store.py
+++ b/src/wallet/wallet_puzzle_store.py
@@ -261,6 +261,24 @@ class WalletPuzzleStore:
 
         return None
 
+    async def get_last_derivation_path_for_wallet(
+        self, wallet_id: int
+    ) -> Optional[uint32]:
+        """
+        Returns the last derivation path by derivation_index.
+        """
+
+        cursor = await self.db_connection.execute(
+            f"SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id={wallet_id};"
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+
+        if row is not None and row[0] is not None:
+            return uint32(row[0])
+
+        return None
+
     async def get_unused_derivation_path(self) -> Optional[uint32]:
         """
         Returns the first unused derivation path by derivation_index.

--- a/src/wallet/wallet_state_manager.py
+++ b/src/wallet/wallet_state_manager.py
@@ -216,7 +216,11 @@ class WalletStateManager:
 
         unused: Optional[uint32] = await self.puzzle_store.get_unused_derivation_path()
         if unused is None:
-            unused = uint32(0)
+            # This handles the case where the database has entries but they have all been used
+            unused = await self.puzzle_store.get_last_derivation_path()
+            if unused is None:
+                # This handles the case where the database is empty
+                unused = uint32(0)
 
         to_generate = 100
 

--- a/src/wallet/websocket_server.py
+++ b/src/wallet/websocket_server.py
@@ -26,6 +26,7 @@ from src.simulator.simulator_constants import test_constants
 from src.simulator.simulator_protocol import FarmNewBlockProtocol
 from src.util.config import load_config_cli, load_config
 from src.util.ints import uint64
+from src.types.sized_bytes import bytes32
 from src.util.logging import initialize_logging
 from src.wallet.util.wallet_types import WalletType
 from src.wallet.rl_wallet.rl_wallet import RLWallet
@@ -224,7 +225,7 @@ class WebSocketServer:
                 response = {"success": True, "type": cc_wallet.wallet_info.type.name}
                 return await websocket.send(format_response(response_api, response))
             elif request["mode"] == "existing":
-                cc_wallet: CCWallet = await CCWallet.create_wallet_for_cc(
+                cc_wallet = await CCWallet.create_wallet_for_cc(
                     wallet_state_manager, main_wallet, request["colour"]
                 )
                 response = {"success": True, "type": cc_wallet.wallet_info.type.name}
@@ -405,7 +406,7 @@ class WebSocketServer:
 
         wallet_id = int(request["wallet_id"])
         wallet: CCWallet = self.wallet_node.wallet_state_manager.wallets[wallet_id]
-        innerpuz: str = await wallet.get_new_inner_hash()
+        innerpuz: bytes32 = await wallet.get_new_inner_hash()
         response = {"innerpuz": innerpuz.hex()}
         return await websocket.send(format_response(response_api, response))
 

--- a/tests/cc_wallet/test_cc_wallet.py
+++ b/tests/cc_wallet/test_cc_wallet.py
@@ -133,6 +133,7 @@ class TestWalletSimulator:
         await self.time_out_assert(15, cc_wallet.get_confirmed_balance, 100)
         await self.time_out_assert(15, cc_wallet.get_unconfirmed_balance, 100)
 
+        assert cc_wallet.cc_info.my_core
         colour = cc_wallet_puzzles.get_genesis_from_core(cc_wallet.cc_info.my_core)
 
         cc_wallet_2: CCWallet = await CCWallet.create_wallet_for_cc(
@@ -232,10 +233,10 @@ class TestWalletSimulator:
         for i in range(1, num_blocks):
             await full_node_1.farm_new_block(FarmNewBlockProtocol(ph))
 
-
         await self.time_out_assert(15, cc_wallet.get_confirmed_balance, 100)
         await self.time_out_assert(15, cc_wallet.get_unconfirmed_balance, 100)
 
+        assert cc_wallet.cc_info.my_core
         colour = cc_wallet_puzzles.get_genesis_from_core(cc_wallet.cc_info.my_core)
 
         cc_wallet_2: CCWallet = await CCWallet.create_wallet_for_cc(
@@ -295,6 +296,7 @@ class TestWalletSimulator:
         await self.time_out_assert(15, cc_wallet.get_confirmed_balance, 100)
         await self.time_out_assert(15, cc_wallet.get_unconfirmed_balance, 100)
 
+        assert cc_wallet.cc_info.my_core
         colour = cc_wallet_puzzles.get_genesis_from_core(cc_wallet.cc_info.my_core)
 
         cc_wallet_2: CCWallet = await CCWallet.create_wallet_for_cc(
@@ -382,6 +384,7 @@ class TestWalletSimulator:
         await self.time_out_assert(15, cc_wallet.get_confirmed_balance, 100)
         await self.time_out_assert(15, cc_wallet.get_unconfirmed_balance, 100)
 
+        assert cc_wallet.cc_info.my_core
         colour = cc_wallet_puzzles.get_genesis_from_core(cc_wallet.cc_info.my_core)
 
         cc_wallet_2: CCWallet = await CCWallet.create_wallet_for_cc(
@@ -395,7 +398,6 @@ class TestWalletSimulator:
 
         for i in range(1, num_blocks):
             await full_node_1.farm_new_block(FarmNewBlockProtocol(ph))
-
 
         await self.time_out_assert(15, cc_wallet.get_confirmed_balance, 40)
         await self.time_out_assert(15, cc_wallet.get_unconfirmed_balance, 40)
@@ -411,7 +413,6 @@ class TestWalletSimulator:
 
         for i in range(0, num_blocks):
             await full_node_1.farm_new_block(FarmNewBlockProtocol(token_bytes()))
-
 
         id = cc_wallet_2.wallet_info.id
         wsm = cc_wallet_2.wallet_state_manager
@@ -457,6 +458,7 @@ class TestWalletSimulator:
         await self.time_out_assert(15, red_wallet.get_confirmed_balance, 100)
         await self.time_out_assert(15, red_wallet.get_unconfirmed_balance, 100)
 
+        assert red_wallet.cc_info.my_core
         red = cc_wallet_puzzles.get_genesis_from_core(red_wallet.cc_info.my_core)
 
         await full_node_1.farm_new_block(FarmNewBlockProtocol(ph2))
@@ -469,6 +471,7 @@ class TestWalletSimulator:
         for i in range(1, num_blocks):
             await full_node_1.farm_new_block(FarmNewBlockProtocol(ph))
 
+        assert blue_wallet_2.cc_info.my_core
         blue = cc_wallet_puzzles.get_genesis_from_core(blue_wallet_2.cc_info.my_core)
 
         red_wallet_2: CCWallet = await CCWallet.create_wallet_for_cc(
@@ -570,11 +573,10 @@ class TestWalletSimulator:
         for i in range(1, num_blocks):
             await full_node_1.farm_new_block(FarmNewBlockProtocol(ph))
 
-
         await self.time_out_assert(15, cc_wallet.get_unconfirmed_balance, 100)
         await self.time_out_assert(15, cc_wallet.get_confirmed_balance, 100)
 
-
+        assert cc_wallet.cc_info.my_core
         colour = cc_wallet_puzzles.get_genesis_from_core(cc_wallet.cc_info.my_core)
 
         cc_wallet_2: CCWallet = await CCWallet.create_wallet_for_cc(
@@ -621,7 +623,6 @@ class TestWalletSimulator:
 
         for i in range(0, num_blocks):
             await full_node_1.farm_new_block(FarmNewBlockProtocol(token_bytes()))
-
 
         await self.time_out_assert(15, cc_wallet_2.get_confirmed_balance, 30)
         await self.time_out_assert(15, cc_wallet_2.get_confirmed_balance, 30)


### PR DESCRIPTION
* Create more puzzle hashes works globally for all wallets.
* Used and last index are global for all wallets, so public keys are not reused within different wallets.
* Linting fixes