### PR TITLE
Tx trade history 

### DIFF
--- a/electron-ui/cc_wallet/cc_wallet.html
+++ b/electron-ui/cc_wallet/cc_wallet.html
@@ -152,7 +152,7 @@
             </div>
               <div class="wallet-address">
                 <h4>Send Coloured Coins</h4>
-                <p>Receiver Address:</p>
+                <p>Recipient Address:</p>
               <div class="input-group" style="padding-top:0px">
               <input type="text" class="form-control"  id="receiver_puzzle_hash" value="">
               </div>/

--- a/electron-ui/cc_wallet/cc_wallet_renderer.js
+++ b/electron-ui/cc_wallet/cc_wallet_renderer.js
@@ -419,7 +419,7 @@ function get_colour_response(response) {
     wallet_id = response["wallet_id"]
     colour = response["colour"]
     if (wallet_id == g_wallet_id) {
-      colour_textfield.innerHTML = "Colour: " + colour;
+      colour_textfield.innerHTML = "Colour: colour_desc://" + colour;
     }
 }
 
@@ -487,6 +487,13 @@ send.addEventListener('click', () => {
 
     try {
         puzzle_hash = receiver_address.value;
+        if (puzzle_hash.includes("chia_addr") || puzzle_hash.includes("colour_desc")){
+          alert("Error: recipient address is not a coloured wallet address. Please enter a coloured wallet address")
+          return
+        }
+        if (puzzle_hash.substring(0,14) == "colour_addr://"){
+          puzzle_hash = puzzle_hash.substring(14)
+        }
         if (puzzle_hash.startsWith("0x") || puzzle_hash.startsWith("0X")) {
             puzzle_hash = puzzle_hash.substring(2);
         }
@@ -588,7 +595,8 @@ function get_innerpuzzlehash_response(response) {
     /*
     Called when response is received for get_new_puzzle_hash request
     */
-    puzzle_holder.value = response["innerpuz"];
+    puzzle_hash = "colour_addr://"
+    puzzle_holder.value = puzzle_hash.concat(response["innerpuz"]);
     QRCode.toCanvas(canvas, response["innerpuz"], function (error) {
     if (error) console.error(error)
     })

--- a/electron-ui/cc_wallet/cc_wallet_renderer.js
+++ b/electron-ui/cc_wallet/cc_wallet_renderer.js
@@ -252,10 +252,12 @@ function get_wallet_balance_response(response) {
         var confirmed = parseInt(response["confirmed_wallet_balance"])
         var unconfirmed = parseInt(response["unconfirmed_wallet_balance"])
         var pending = confirmed - unconfirmed
-        var wallet_id = response["wallet_id"]
 
+        var wallet_id = response["wallet_id"]
+        console.log("wallet_id = " + wallet_id + "confirmed: " + confirmed + "unconfirmed: " + unconfirmed )
         chia_confirmed = chia_formatter(confirmed, 'mojo').to('chia').toString()
         chia_pending = chia_formatter(pending, 'mojo').to('chia').toString()
+        chia_pending_abs = chia_formatter(Math.abs(pending), 'mojo').to('chia').toString()
 
         wallet_balance_holder = document.querySelector("#" + "balance_wallet_" + wallet_id )
         wallet_pending_holder = document.querySelector("#" + "pending_wallet_" + wallet_id )
@@ -265,7 +267,7 @@ function get_wallet_balance_response(response) {
             if (pending > 0) {
                 pending_textfield.innerHTML = lock + " - " + chia_pending + " CH"
             } else {
-                pending_textfield.innerHTML = lock + " " + chia_pending + " CH"
+                pending_textfield.innerHTML = lock + " " + chia_pending_abs + " CH"
             }
         }
         if (wallet_balance_holder) {
@@ -275,7 +277,7 @@ function get_wallet_balance_response(response) {
             if (pending > 0) {
                 wallet_pending_holder.innerHTML = lock + " - " + chia_pending + " CH"
             } else {
-                wallet_pending_holder.innerHTML = lock + " " + chia_pending + " CH"
+                wallet_pending_holder.innerHTML = lock + " " + chia_pending_abs + " CH"
             }
         }
     }

--- a/electron-ui/cc_wallet/create_cc_wallet.js
+++ b/electron-ui/cc_wallet/create_cc_wallet.js
@@ -90,6 +90,9 @@ function create_wallet_input_colour() {
 
     try {
         colour = input_colour_text.value;
+        if (colour.substring(0,14) == "colour_desc://"){
+          colour = colour.substring(14)
+        }
         if (colour.startsWith("0x") || colour.startsWith("0X")) {
             colour = colour.substring(2);
         }

--- a/electron-ui/renderer.js
+++ b/electron-ui/renderer.js
@@ -323,10 +323,12 @@ function get_wallet_balance_response(response) {
         var confirmed = parseInt(response["confirmed_wallet_balance"])
         var unconfirmed = parseInt(response["unconfirmed_wallet_balance"])
         var pending = confirmed - unconfirmed
-        var wallet_id = response["wallet_id"]
 
+        var wallet_id = response["wallet_id"]
+        console.log("wallet_id = " + wallet_id + "confirmed: " + confirmed + "unconfirmed: " + unconfirmed )
         chia_confirmed = chia_formatter(confirmed, 'mojo').to('chia').toString()
         chia_pending = chia_formatter(pending, 'mojo').to('chia').toString()
+        chia_pending_abs = chia_formatter(Math.abs(pending), 'mojo').to('chia').toString()
 
         wallet_balance_holder = document.querySelector("#" + "balance_wallet_" + wallet_id )
         wallet_pending_holder = document.querySelector("#" + "pending_wallet_" + wallet_id )
@@ -336,7 +338,7 @@ function get_wallet_balance_response(response) {
             if (pending > 0) {
                 pending_textfield.innerHTML = lock + " - " + chia_pending + " CH"
             } else {
-                pending_textfield.innerHTML = lock + " " + chia_pending + " CH"
+                pending_textfield.innerHTML = lock + " " + chia_pending_abs + " CH"
             }
         }
         if (wallet_balance_holder) {
@@ -346,7 +348,7 @@ function get_wallet_balance_response(response) {
             if (pending > 0) {
                 wallet_pending_holder.innerHTML = lock + " - " + chia_pending + " CH"
             } else {
-                wallet_pending_holder.innerHTML = lock + " " + chia_pending + " CH"
+                wallet_pending_holder.innerHTML = lock + " " + chia_pending_abs + " CH"
             }
         }
     }

--- a/electron-ui/renderer.js
+++ b/electron-ui/renderer.js
@@ -169,6 +169,12 @@ send.addEventListener('click', () => {
 
     try {
         puzzle_hash = receiver_address.value;
+        if (puzzle_hash.includes("colour")){
+          dialogs.alert("Error: Cannot send chia to coloured address. Please enter a chia address.")
+          return
+        } else if (puzzle_hash.substring(0, 12) == "chia_addr://") {
+          puzzle_hash = puzzle_hash.substring(12)
+        }
         if (puzzle_hash.startsWith("0x") || puzzle_hash.startsWith("0X")) {
             puzzle_hash = puzzle_hash.substring(2);
         }
@@ -215,7 +221,13 @@ farm_button.addEventListener('click', () => {
         dialogs.alert("Specify puzzle_hash for coinbase reward", ok => {
         })
         return
+    } else if (puzzle_hash.includes("colour")){
+      dialogs.alert("Please enter a chia address for coinbase reward.")
+      return
+    } else if (puzzle_hash.substring(0, 12) == "chia_addr://") {
+      puzzle_hash = puzzle_hash.substring(12)
     }
+
     data = {
         "puzzle_hash": puzzle_hash,
         "wallet_id": g_wallet_id,
@@ -295,7 +307,9 @@ function get_new_puzzlehash_response(response) {
     Called when response is received for get_new_puzzle_hash request
     */
     let puzzle_holder = document.querySelector("#puzzle_holder");
-    puzzle_holder.value = response["puzzlehash"];
+    puzzle_hash = "chia_addr://"
+    puzzle_hash = puzzle_hash.concat(response["puzzlehash"]);
+    puzzle_holder.value = puzzle_hash
     QRCode.toCanvas(canvas, response["puzzlehash"], function (error) {
     if (error) console.error(error)
     })

--- a/electron-ui/trade_renderer.js
+++ b/electron-ui/trade_renderer.js
@@ -220,6 +220,7 @@ function get_wallet_balance_response(response) {
 
         chia_confirmed = chia_formatter(confirmed, 'mojo').to('chia').toString()
         chia_pending = chia_formatter(pending, 'mojo').to('chia').toString()
+        chia_pending_abs = chia_formatter(Math.abs(pending), 'mojo').to('chia').toString()
 
         wallet_balance_holder = document.querySelector("#" + "balance_wallet_" + wallet_id )
         wallet_pending_holder = document.querySelector("#" + "pending_wallet_" + wallet_id )
@@ -231,7 +232,7 @@ function get_wallet_balance_response(response) {
             if (pending > 0) {
                 wallet_pending_holder.innerHTML = lock + " - " + chia_pending + " CH"
             } else {
-                wallet_pending_holder.innerHTML = lock + " " + chia_pending + " CH"
+                wallet_pending_holder.innerHTML = lock + " " + chia_pending_abs + " CH"
             }
         }
     }

--- a/electron-ui/wallet-dark.html
+++ b/electron-ui/wallet-dark.html
@@ -114,7 +114,7 @@
                 </li>
               </ul>
               <div class="wallet-address">
-                <p>Receiver Address:</p>
+                <p>Recipient Address:</p>
               <div class="input-group" style="padding-top:0px">
               <input type="text" class="form-control"  id="receiver_puzzle_hash" value="">
               </div>/

--- a/src/types/spend_bundle.py
+++ b/src/types/spend_bundle.py
@@ -73,3 +73,15 @@ class SpendBundle(Streamable):
             result.append(rem)
 
         return result
+
+    def not_ephemeral_additions(self):
+        all_removals = self.removals()
+        all_additions = self.additions()
+        result: List[Coin] = []
+
+        for add in all_additions:
+            if add in all_removals:
+                continue
+            result.append(add)
+
+        return result

--- a/src/wallet/cc_wallet/cc_wallet.py
+++ b/src/wallet/cc_wallet/cc_wallet.py
@@ -9,7 +9,7 @@ from src.types.BLSSignature import BLSSignature
 from src.types.coin import Coin
 from src.types.coin_solution import CoinSolution
 from src.types.condition_opcodes import ConditionOpcode
-from src.types.program import Program, SExp
+from src.types.program import Program
 from src.types.spend_bundle import SpendBundle
 from src.types.sized_bytes import bytes32
 from src.util.byte_types import hexstr_to_bytes

--- a/src/wallet/trade_manager.py
+++ b/src/wallet/trade_manager.py
@@ -228,7 +228,8 @@ class TradeManager:
                         ] = await self.wallet_state_manager.get_wallet_for_colour(
                             colour
                         )
-                    unspent = await self.wallet_state_manager.get_spendable_coins_for_wallet(wallets[colour].wallet_info.id)
+                    unspent = await self.wallet_state_manager.get_spendable_coins_for_wallet(
+                        wallets[colour].wallet_info.id)
                     if coinsol.coin in [record.coin for record in unspent]:
                         return False, "can't respond to own offer"
                     innerpuzzlereveal = solution.rest().rest().rest().first()

--- a/src/wallet/trade_manager.py
+++ b/src/wallet/trade_manager.py
@@ -228,6 +228,9 @@ class TradeManager:
                         ] = await self.wallet_state_manager.get_wallet_for_colour(
                             colour
                         )
+                    unspent = await self.wallet_state_manager.get_spendable_coins_for_wallet(wallets[colour].wallet_info.id)
+                    if coinsol.coin in [record.coin for record in unspent]:
+                        return False, "can't respond to own offer"
                     innerpuzzlereveal = solution.rest().rest().rest().first()
                     innersol = solution.rest().rest().rest().rest().first()
                     out_amount = cc_wallet_puzzles.get_output_amount_for_puzzle_and_solution(
@@ -267,6 +270,9 @@ class TradeManager:
                     coinsols.append(coinsol)
             else:
                 # standard chia coin
+                unspent = await self.wallet_state_manager.get_spendable_coins_for_wallet(1)
+                if coinsol.coin in [record.coin for record in unspent]:
+                    return False, "can't respond to own offer"
                 if chia_discrepancy is None:
                     chia_discrepancy = cc_wallet_puzzles.get_output_discrepancy_for_puzzle_and_solution(
                         coinsol.coin, puzzle, solution
@@ -309,7 +315,7 @@ class TradeManager:
                         my_cc_spends.add(add)
 
             if my_cc_spends == set() or my_cc_spends is None:
-                return False
+                return False, "insufficient funds"
 
             auditor = my_cc_spends.pop()
             auditor_inner_puzzle = await self.get_inner_puzzle_for_puzzle_hash(
@@ -570,4 +576,4 @@ class TradeManager:
         for tx in my_tx_records:
             await self.wallet_state_manager.add_transaction(tx)
 
-        return True
+        return True, None

--- a/src/wallet/trade_manager.py
+++ b/src/wallet/trade_manager.py
@@ -469,8 +469,6 @@ class TradeManager:
 
             cs_aud = create_spend_for_auditor(auditor, auditor)
             coinsols.append(cs_aud)
-            colour_spend = SpendBundle([cs, cs_eph, cs_aud], aggsig)
-            wallet = wallets[colour]
 
         spend_bundle = SpendBundle(coinsols, aggsig)
         my_tx_records = []
@@ -528,9 +526,9 @@ class TradeManager:
                     incoming=False,
                     confirmed=False,
                     sent=uint32(10),
-                    spend_bundle=chia_spend_bundle,
-                    additions=chia_spend_bundle.additions(),
-                    removals=chia_spend_bundle.removals(),
+                    spend_bundle=spend_bundle,
+                    additions=spend_bundle.additions(),
+                    removals=spend_bundle.removals(),
                     wallet_id=wallet.wallet_info.id,
                     sent_to=[],
                 )
@@ -544,9 +542,9 @@ class TradeManager:
                     incoming=True,
                     confirmed=False,
                     sent=uint32(10),
-                    spend_bundle=chia_spend_bundle,
-                    additions=chia_spend_bundle.additions(),
-                    removals=chia_spend_bundle.removals(),
+                    spend_bundle=spend_bundle,
+                    additions=spend_bundle.additions(),
+                    removals=spend_bundle.removals(),
                     wallet_id=wallet.wallet_info.id,
                     sent_to=[],
                 )

--- a/src/wallet/trade_manager.py
+++ b/src/wallet/trade_manager.py
@@ -99,7 +99,6 @@ class TradeManager:
                     new_spend_bundle = await wallet.create_spend_bundle_relative_chia(
                         amount, to_exclude
                     )
-                    self.log.info("1")
                 else:
                     return False, None
                 if new_spend_bundle.removals() == [] or new_spend_bundle is None:

--- a/src/wallet/trade_manager.py
+++ b/src/wallet/trade_manager.py
@@ -193,10 +193,10 @@ class TradeManager:
 
         return True
 
-    async def respond_to_offer(self, file_path: Path) -> bool:
+    async def respond_to_offer(self, file_path: Path) -> Tuple[bool, Optional[str]]:
         has_wallets = await self.maybe_create_wallets_for_offer(file_path)
         if not has_wallets:
-            return False
+            return False, "Unknown Error"
         trade_offer_hex = file_path.read_text()
         trade_offer = SpendBundle.from_bytes(bytes.fromhex(trade_offer_hex))
 

--- a/src/wallet/transaction_record.py
+++ b/src/wallet/transaction_record.py
@@ -4,6 +4,7 @@ from typing import Optional, List, Tuple
 from src.types.coin import Coin
 from src.types.spend_bundle import SpendBundle
 from src.types.sized_bytes import bytes32
+from src.util.hash import std_hash
 from src.util.streamable import Streamable, streamable
 from src.util.ints import uint32, uint64, uint8
 
@@ -35,4 +36,4 @@ class TransactionRecord(Streamable):
     def name(self) -> bytes32:
         if self.spend_bundle:
             return self.spend_bundle.name()
-        return self.get_hash()
+        return std_hash(bytes(self.to_puzzle_hash) + bytes(self.created_at_time) + bytes(self.amount))

--- a/src/wallet/wallet_transaction_store.py
+++ b/src/wallet/wallet_transaction_store.py
@@ -142,29 +142,29 @@ class WalletTransactionStore:
 
     async def unconfirmed_with_removal_coin(
         self, removal_id: bytes32
-    ) -> Optional[TransactionRecord]:
+    ) -> List[TransactionRecord]:
         """ Returns a record containing removed coin with id: removal_id"""
-
+        result = []
         all_unconfirmed: List[TransactionRecord] = await self.get_all_unconfirmed()
         for record in all_unconfirmed:
             for coin in record.removals:
                 if coin.name() == removal_id:
-                    return record
+                    result.append(record)
 
-        return None
+        return result
 
     async def unconfirmed_with_addition_coin(
         self, removal_id: bytes32
-    ) -> Optional[TransactionRecord]:
+    ) -> List[TransactionRecord]:
         """ Returns a record containing removed coin with id: removal_id"""
-
+        result = []
         all_unconfirmed: List[TransactionRecord] = await self.get_all_unconfirmed()
         for record in all_unconfirmed:
             for coin in record.additions:
                 if coin.name() == removal_id:
-                    return record
+                    result.append(record)
 
-        return None
+        return result
 
     async def increment_sent(
         self,
@@ -237,7 +237,6 @@ class WalletTransactionStore:
         """
         Checks DB and cache for TransactionRecord with id: id and returns it.
         """
-
         if id.hex() in self.tx_record_cache:
             return self.tx_record_cache[id.hex()]
         cursor = await self.db_connection.execute(

--- a/src/wallet/websocket_server.py
+++ b/src/wallet/websocket_server.py
@@ -464,8 +464,11 @@ class WebSocketServer:
 
     async def respond_to_offer(self, websocket, request, response_api):
         file_path = Path(request["filename"])
-        success = await self.trade_manager.respond_to_offer(file_path)
-        response = {"success": success}
+        success, reason = await self.trade_manager.respond_to_offer(file_path)
+        if success:
+            response = {"success": success}
+        else:
+            response = {"success": success, "reason": reason}
         return await websocket.send(format_response(response_api, response))
 
     async def safe_handle(self, websocket, path):

--- a/tests/cc_wallet/test_cc_wallet.py
+++ b/tests/cc_wallet/test_cc_wallet.py
@@ -337,7 +337,7 @@ class TestWalletSimulator:
         assert offer["chia"] == -10
         assert offer[colour] == 30
 
-        success = await trade_manager_2.respond_to_offer(file_path)
+        success, reason = await trade_manager_2.respond_to_offer(file_path)
 
         assert success is True
 
@@ -520,7 +520,7 @@ class TestWalletSimulator:
         assert offer[red] == 30
         assert offer[blue] == -50
 
-        success = await trade_manager_2.respond_to_offer(file_path)
+        success, reason = await trade_manager_2.respond_to_offer(file_path)
 
         assert success is True
         for i in range(0, num_blocks):
@@ -617,7 +617,7 @@ class TestWalletSimulator:
         assert offer["chia"] == 10
         assert offer[colour] == -30
 
-        success = await trade_manager_1.respond_to_offer(file_path)
+        success, reason = await trade_manager_1.respond_to_offer(file_path)
 
         assert success is True
 

--- a/tests/full_node/test_transactions.py
+++ b/tests/full_node/test_transactions.py
@@ -100,20 +100,20 @@ class TestTransactions:
             == funds
         )
 
-        spend_bundle = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
             10, ph1, 0
         )
-        await wallet_0.wallet_state_manager.main_wallet.push_transaction(spend_bundle)
+        await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await asyncio.sleep(3)
 
-        bundle0 = full_node_0.mempool_manager.get_spendbundle(spend_bundle.name())
-        bundle1 = full_node_1.mempool_manager.get_spendbundle(spend_bundle.name())
-        bundle2 = full_node_2.mempool_manager.get_spendbundle(spend_bundle.name())
+        bundle0 = full_node_0.mempool_manager.get_spendbundle(tx.name())
+        bundle1 = full_node_1.mempool_manager.get_spendbundle(tx.name())
+        bundle2 = full_node_2.mempool_manager.get_spendbundle(tx.name())
 
-        assert spend_bundle == bundle0
-        assert spend_bundle == bundle1
-        assert spend_bundle == bundle2
+        assert tx.spend_bundle == bundle0
+        assert tx.spend_bundle == bundle1
+        assert tx.spend_bundle == bundle2
 
         # Farm another block
         for i in range(1, 8):
@@ -178,19 +178,19 @@ class TestTransactions:
             == funds
         )
 
-        spend_bundle = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
             10, token_bytes(), 0
         )
-        await wallet_0.wallet_state_manager.main_wallet.push_transaction(spend_bundle)
+        await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await asyncio.sleep(2)
 
-        bundle0 = full_node_0.mempool_manager.get_spendbundle(spend_bundle.name())
-        bundle1 = full_node_1.mempool_manager.get_spendbundle(spend_bundle.name())
-        bundle2 = full_node_2.mempool_manager.get_spendbundle(spend_bundle.name())
+        bundle0 = full_node_0.mempool_manager.get_spendbundle(tx.name())
+        bundle1 = full_node_1.mempool_manager.get_spendbundle(tx.name())
+        bundle2 = full_node_2.mempool_manager.get_spendbundle(tx.name())
 
-        assert spend_bundle == bundle0
-        assert spend_bundle == bundle1
+        assert tx.spend_bundle == bundle0
+        assert tx.spend_bundle == bundle1
         assert None is bundle2
 
         # make a final connection.
@@ -200,10 +200,10 @@ class TestTransactions:
 
         await asyncio.sleep(2)
 
-        bundle0 = full_node_0.mempool_manager.get_spendbundle(spend_bundle.name())
-        bundle1 = full_node_1.mempool_manager.get_spendbundle(spend_bundle.name())
-        bundle2 = full_node_2.mempool_manager.get_spendbundle(spend_bundle.name())
+        bundle0 = full_node_0.mempool_manager.get_spendbundle(tx.name())
+        bundle1 = full_node_1.mempool_manager.get_spendbundle(tx.name())
+        bundle2 = full_node_2.mempool_manager.get_spendbundle(tx.name())
 
-        assert spend_bundle == bundle0
-        assert spend_bundle == bundle1
-        assert spend_bundle == bundle2
+        assert tx.spend_bundle == bundle0
+        assert tx.spend_bundle == bundle1
+        assert tx.spend_bundle == bundle2

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -93,12 +93,12 @@ class TestWalletSimulator:
         assert await wallet.get_confirmed_balance() == funds
         assert await wallet.get_unconfirmed_balance() == funds
 
-        spend_bundle = await wallet.generate_signed_transaction(
+        tx = await wallet.generate_signed_transaction(
             10,
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             0,
         )
-        await wallet.push_transaction(spend_bundle)
+        await wallet.push_transaction(tx)
 
         await asyncio.sleep(2)
         confirmed_balance = await wallet.get_confirmed_balance()
@@ -205,14 +205,14 @@ class TestWalletSimulator:
             == funds
         )
 
-        spend_bundle = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
             10, token_bytes(), 0
         )
-        await wallet_0.wallet_state_manager.main_wallet.push_transaction(spend_bundle)
+        await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await asyncio.sleep(1)
 
-        bundle0 = full_node_0.mempool_manager.get_spendbundle(spend_bundle.name())
+        bundle0 = full_node_0.mempool_manager.get_spendbundle(tx.name())
         assert bundle0 is not None
 
         # wallet0 <-> sever1
@@ -221,7 +221,7 @@ class TestWalletSimulator:
         )
         await asyncio.sleep(1)
 
-        bundle1 = full_node_1.mempool_manager.get_spendbundle(spend_bundle.name())
+        bundle1 = full_node_1.mempool_manager.get_spendbundle(tx.name())
         assert bundle1 is not None
 
         # wallet0 <-> sever2
@@ -230,7 +230,7 @@ class TestWalletSimulator:
         )
         await asyncio.sleep(1)
 
-        bundle2 = full_node_2.mempool_manager.get_spendbundle(spend_bundle.name())
+        bundle2 = full_node_2.mempool_manager.get_spendbundle(tx.name())
         assert bundle2 is not None
 
     @pytest.mark.asyncio
@@ -267,13 +267,13 @@ class TestWalletSimulator:
         assert await wallet_0.get_confirmed_balance() == funds
         assert await wallet_0.get_unconfirmed_balance() == funds
 
-        spend_bundle = await wallet_0.generate_signed_transaction(
+        tx = await wallet_0.generate_signed_transaction(
             10,
             await wallet_node_1.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             0,
         )
 
-        await wallet_0.push_transaction(spend_bundle)
+        await wallet_0.push_transaction(tx)
 
         await asyncio.sleep(1)
         # Full node height 11, wallet height 9
@@ -304,10 +304,10 @@ class TestWalletSimulator:
         assert unconfirmed_balance == new_funds - 10
         assert wallet_2_confirmed_balance == 10
 
-        spend_bundle = await wallet_1.generate_signed_transaction(
+        tx = await wallet_1.generate_signed_transaction(
             5, await wallet_0.get_new_puzzlehash(), 0
         )
-        await wallet_1.push_transaction(spend_bundle)
+        await wallet_1.push_transaction(tx)
 
         for i in range(0, 7):
             await full_node_0.farm_new_block(FarmNewBlockProtocol(token_bytes()))
@@ -350,16 +350,16 @@ class TestWalletSimulator:
         assert await wallet.get_unconfirmed_balance() == funds
         tx_amount = 32000000000000
         tx_fee = 10
-        spend_bundle = await wallet.generate_signed_transaction(
+        tx = await wallet.generate_signed_transaction(
             tx_amount,
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             tx_fee,
         )
 
-        fees = spend_bundle.fees()
+        fees = tx.spend_bundle.fees()
         assert fees == tx_fee
 
-        await wallet.push_transaction(spend_bundle)
+        await wallet.push_transaction(tx)
 
         await asyncio.sleep(2)
         confirmed_balance = await wallet.get_confirmed_balance()


### PR DESCRIPTION
This moves creation of transaction_record from wsm to where creation was previously been called from.
This allows for more accurate record details and multiple records for a single transaction. (For trades) (sent=10 means it won't be sent multiple times to the full node)

@matt-o-how I wan't sure about which puzzle_hash to use as to_address in trades, can you look at that?