### PR TITLE
Always check keys on chia init, and when starting farmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,35 +33,3 @@ Once installed, a
 [Quick Start Guide](https://github.com/Chia-Network/chia-blockchain/wiki/Quick-Start-Guide)
 is available from the repository
 [wiki](https://github.com/Chia-Network/chia-blockchain/wiki).
-
-# Tips
-Ubuntu 18.04 LTS, 19.xx, Amazon Linux 2, and CentOS 7.7 or newer are the
-easiest linux install environments.
-
-UPnP is enabled by default to open port 8444 for incoming connections.
-If this causes issues, you can disable it in config.yaml.
-Some routers may require port forwarding, or enabling UPnP
-in the router's configuration.
-
-Due to the nature of proof of space lookups by the harvester in the current
-release you should limit the number of plots on a physical drive to 50 or less.
-This limit will significantly increase soon.
-
-# uvloop
-
-For potentially increased networking performance on non Windows platforms,
-install uvloop:
-```bash
-pip install -e ".[uvloop]"
-```
-
-# RPC Interface
-
-You can also use the
-[HTTP JSON-RPC](https://github.com/Chia-Network/chia-blockchain/wiki/Networking-and-Serialization#rpc)
-api to access information and control the full node:
-
-```bash
-curl -X POST http://localhost:8555/get_blockchain_state
-curl -d '{"header_hash":"afe223d75d40dd7bd19bf35846d0c9dce608bfc77ee5baa9f9cd6b98436e428b"}' -H "Content-Type: application/json" -X POST http://localhost:8555/get_header
-```

--- a/src/cmds/create_plots.py
+++ b/src/cmds/create_plots.py
@@ -129,7 +129,9 @@ def main():
     try:
         tmp_dir.rmdir()
     except Exception:
-        print(f"warning: did not remove temporary folder {tmp_dir}, it may not be empty.")
+        print(
+            f"warning: did not remove temporary folder {tmp_dir}, it may not be empty."
+        )
 
 
 if __name__ == "__main__":

--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -39,6 +39,24 @@ def dict_add_new_default(
             updated[k] = v
 
 
+def check_keys(new_root):
+    print("\nchecking keys.yaml")
+    keys_config = load_config(new_root, "keys.yaml")
+
+    wallet_sk = ExtendedPrivateKey.from_bytes(bytes.fromhex(keys_config["wallet_sk"]))
+    wallet_target = create_puzzlehash_for_pk(
+        BLSPublicKey(bytes(wallet_sk.public_child(0).get_public_key()))
+    )
+    if (
+        wallet_target.hex() != keys_config["wallet_target"]
+        or wallet_target.hex() != keys_config["pool_target"]
+    ):
+        keys_config["wallet_target"] = wallet_target.hex()
+        keys_config["pool_target"] = wallet_target.hex()
+        print(f"updating wallet target and pool target to {wallet_target.hex()}")
+        save_config(new_root, "keys.yaml", keys_config)
+
+
 def migrate_from(
     old_root: Path, new_root: Path, manifest: List[str], do_not_migrate_keys: List[str]
 ):
@@ -108,21 +126,7 @@ def migrate_from(
         "\nYour plots have not been moved so be careful deleting old preferences folders."
     )
 
-    print("\nmigrating keys.yaml")
-    keys_config = load_config(new_root, "keys.yaml")
-
-    wallet_sk = ExtendedPrivateKey.from_bytes(bytes.fromhex(keys_config["wallet_sk"]))
-    wallet_target = create_puzzlehash_for_pk(
-        BLSPublicKey(bytes(wallet_sk.public_child(0).get_public_key()))
-    )
-    if (
-        wallet_target.hex() != keys_config["wallet_target"]
-        or wallet_target.hex() != keys_config["pool_target"]
-    ):
-        keys_config["wallet_target"] = wallet_target.hex()
-        keys_config["pool_target"] = wallet_target.hex()
-        print(f"updating wallet target and pool target to {wallet_target.hex()}")
-        save_config(new_root, "keys.yaml", keys_config)
+    check_keys(new_root)
 
     print("\nIf you want to move your plot files, you should also modify")
     print(f"{config_path_for_filename(new_root, 'plots.yaml')}")
@@ -145,9 +149,17 @@ def init(args: Namespace, parser: ArgumentParser):
 
 def chia_init(args: Namespace):
     root_path: Path = args.root_path
+
+    if os.environ.get("CHIA_ROOT", None) is not None:
+        print(
+            f"warning, your CHIA_ROOT is set to {os.environ['CHIA_ROOT']}. "
+            f"Please unset the environment variable and run chia init again."
+        )
+
     print(f"migrating to {root_path}")
     if root_path.is_dir():
-        print(f"{root_path} already exists, no action taken")
+        check_keys(root_path)
+        print(f"{root_path} already exists, no migration action taken")
         return -1
 
     # These are the config keys that will not be migrated, and instead the default is used
@@ -167,7 +179,7 @@ def chia_init(args: Namespace):
 
     PATH_MANIFEST_LIST: List[Tuple[Path, List[str]]] = [
         (Path(os.path.expanduser("~/.chia/beta-%s" % _)), MANIFEST)
-        for _ in ["1.0b3", "1.0b2", "1.0b1"]
+        for _ in ["1.0b5.dev0", "1.0b4", "1.0b3", "1.0b2", "1.0b1"]
     ]
 
     for old_path, manifest in PATH_MANIFEST_LIST:

--- a/src/server/start_farmer.py
+++ b/src/server/start_farmer.py
@@ -12,6 +12,7 @@ from src.server.outbound_message import NodeType
 from src.server.server import ChiaServer
 from src.util.config import load_config, load_config_cli
 from src.util.default_root import DEFAULT_ROOT_PATH
+from src.cmds.init import check_keys
 from src.util.logging import initialize_logging
 from src.util.setproctitle import setproctitle
 
@@ -21,9 +22,11 @@ async def async_main():
     net_config = load_config(root_path, "config.yaml")
     config = load_config_cli(root_path, "config.yaml", "farmer")
     try:
+        check_keys(root_path)
         key_config = load_config(root_path, "keys.yaml")
     except FileNotFoundError:
         raise RuntimeError("Keys not generated. Run `chia generate keys`")
+
     initialize_logging("Farmer %(name)-25s", config["logging"], root_path)
     log = logging.getLogger(__name__)
     setproctitle("chia_farmer")


### PR DESCRIPTION
I opted for using the target in keys.yaml (as opposed to the farmer regenerating it on the fly), since technically the farmer should not have access to either the pool_sks or the wallet_sk. 

The fix here is that the farmer just runs check_keys when it starts. Also chia init runs check_keys even when nothing is migrated. Therefore it should be impossible to farm with the wrong keys.

Also there is a warning if CHIA_ROOT is set, and we now migrate from 1.0b4 and 1.0b5.dev0 as well for the next release.