### PR TITLE
Only print error if it is not connection refused

### DIFF
--- a/src/daemon/client.py
+++ b/src/daemon/client.py
@@ -111,5 +111,7 @@ async def connect_to_daemon_and_validate(root_path):
         if r["data"]["value"] == "pong":
             return connection
     except Exception as ex:
-        print(f"Exception {ex}")
-    return None
+        # ConnectionRefusedError means that daemon is not yet running
+        if not isinstance(ex, ConnectionRefusedError):
+            print("Exception connecting to daemon: {ex}")
+        return None


### PR DESCRIPTION
No need for printing to std out if connection refused, it's just that daemon is not running.