### PR TITLE
Sanitizer (dev).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ for setuptools_scm/PEP 440 reasons.
 
 ### Added
 
+- Added a faster VDF process, which generates n-wesolowski proofs very fast, after the VDF result is known.
+This requires a high number of CPUs. To use it, set timelord.fast_algorithm = True in the config file.
+- Added a new type of timelord, which generates compact proofs of time for the existing blocks. This helps
+reducing the database size. Full nodes send 100 random uncompact blocks per hour to timelords, and if
+timelord.sanitizer_mode = True, the timelord will work on those challenges.
+
 ### Changed
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ dependencies = [
     "aiosqlite==0.13.0",  # asyncio wrapper for sqlite, to store blocks
     "aiohttp==3.6.2",  # HTTP server for full node rpc
     "colorlog==4.1.0",  # Adds color to logs
-    "chiavdf==0.12.16",  # timelord and vdf verification
+    "chiavdf==0.3b9",  # timelord and vdf verification
     "chiabip158==0.14",  # bip158-style wallet filters
     "chiapos==0.12.21",  # proof of space
     "sortedcontainers==2.1.0",  # For maintaining sorted mempools

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ dependencies = [
     "aiosqlite==0.13.0",  # asyncio wrapper for sqlite, to store blocks
     "aiohttp==3.6.2",  # HTTP server for full node rpc
     "colorlog==4.1.0",  # Adds color to logs
-    "chiavdf==0.3b9",  # timelord and vdf verification
+    "chiavdf==0.3b11",  # timelord and vdf verification
     "chiabip158==0.14",  # bip158-style wallet filters
     "chiapos==0.12.21",  # proof of space
     "sortedcontainers==2.1.0",  # For maintaining sorted mempools

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -3,6 +3,7 @@ import concurrent
 import logging
 import traceback
 import time
+import random
 from asyncio import Event
 from pathlib import Path
 from typing import AsyncGenerator, Dict, List, Optional, Tuple, Type, Callable

--- a/src/server/start_timelord.py
+++ b/src/server/start_timelord.py
@@ -92,7 +92,11 @@ async def async_main():
 
     vdf_server = asyncio.ensure_future(coro)
 
-    await timelord._manage_discriminant_queue()
+    sanitizer_mode = config["sanitizer_mode"]
+    if not sanitizer_mode:
+        await timelord._manage_discriminant_queue()
+    else:
+        await timelord._manage_discriminant_queue_sanitizer()
 
     log.info("Closed discriminant queue.")
     log.info("Shutdown timelord.")

--- a/src/timelord.py
+++ b/src/timelord.py
@@ -221,16 +221,17 @@ class Timelord:
         disc: int = create_discriminant(
             challenge_hash, self.constants["DISCRIMINANT_SIZE_BITS"]
         )
-        # Tell the client if we're interested in extending the chain
-        # or to produce compact proofs.
+        # Depending on the flags 'fast_algorithm' and 'sanitizer_mode',
+        # the timelord tells the vdf_client what to execute.
         if not self.sanitizer_mode:
             if self.config["fast_algorithm"]:
-                # Run n-wesolowski algorithm.
+                # Run n-wesolowski (fast) algorithm.
                 writer.write(b"N")
             else:
-                # Run two-wesolowski algorithm.
+                # Run two-wesolowski (slow) algorithm.
                 writer.write(b"T")
         else:
+            # Create compact proofs of time.
             writer.write(b"S")
         await writer.drain()
 

--- a/src/timelord.py
+++ b/src/timelord.py
@@ -288,7 +288,7 @@ class Timelord:
             msg = ""
             try:
                 msg = data.decode()
-            except Exception as e:
+            except Exception:
                 pass
 
             if msg == "STOP":

--- a/src/timelord.py
+++ b/src/timelord.py
@@ -14,7 +14,7 @@ from src.types.classgroup import ClassgroupElement
 from src.types.proof_of_time import ProofOfTime
 from src.types.sized_bytes import bytes32
 from src.util.api_decorators import api_request
-from src.util.ints import uint64, int512, uint128
+from src.util.ints import uint8, uint64, int512, uint128
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +49,10 @@ class Timelord:
         self.free_clients: List[Tuple[str, StreamReader, StreamWriter]] = []
         self.server: Optional[ChiaServer] = None
         self._is_shutdown = False
+        self.sanitizer_mode = self.config["sanitizer_mode"]
+        log.info(f"Am I sanitizing? {self.sanitizer_mode}")
+        self.last_time_seen_discriminant: Dict = {}
+        self.max_known_weights: List[uint128] = []
 
     def set_server(self, server: ChiaServer):
         self.server = server
@@ -217,6 +221,18 @@ class Timelord:
         disc: int = create_discriminant(
             challenge_hash, self.constants["DISCRIMINANT_SIZE_BITS"]
         )
+        # Tell the client if we're interested in extending the chain
+        # or to produce compact proofs.
+        if not self.sanitizer_mode:
+            if self.config["fast_algorithm"]:
+                # Run n-wesolowski algorithm.
+                writer.write(b"N")
+            else:
+                # Run two-wesolowski algorithm.
+                writer.write(b"T")
+        else:
+            writer.write(b"S")
+        await writer.drain()
 
         prefix = str(len(str(disc)))
         if len(prefix) == 1:
@@ -231,6 +247,11 @@ class Timelord:
             async with self.lock:
                 if challenge_hash not in self.done_discriminants:
                     self.done_discriminants.append(challenge_hash)
+                if self.sanitizer_mode:
+                    if challenge_hash in self.pending_iters:
+                        del self.pending_iters[challenge_hash]
+                    if challenge_hash in self.submitted_iters:
+                        del self.submitted_iters[challenge_hash]
             return
 
         if ok.decode() != "OK":
@@ -257,13 +278,17 @@ class Timelord:
                         del self.active_discriminants_start_time[challenge_hash]
                     if challenge_hash not in self.done_discriminants:
                         self.done_discriminants.append(challenge_hash)
+                    if self.sanitizer_mode:
+                        if challenge_hash in self.pending_iters:
+                            del self.pending_iters[challenge_hash]
+                        if challenge_hash in self.submitted_iters:
+                            del self.submitted_iters[challenge_hash]
                 break
 
             msg = ""
             try:
                 msg = data.decode()
             except Exception as e:
-                log.error(f"Exception while decoding data {e}")
                 pass
 
             if msg == "STOP":
@@ -293,6 +318,11 @@ class Timelord:
                             del self.active_discriminants_start_time[challenge_hash]
                         if challenge_hash not in self.done_discriminants:
                             self.done_discriminants.append(challenge_hash)
+                        if self.sanitizer_mode:
+                            if challenge_hash in self.pending_iters:
+                                del self.pending_iters[challenge_hash]
+                            if challenge_hash in self.submitted_iters:
+                                del self.submitted_iters[challenge_hash]
                     break
 
                 iterations_needed = uint64(
@@ -303,7 +333,9 @@ class Timelord:
                 y_size = uint64(int.from_bytes(y_size_bytes, "big", signed=True))
 
                 y_bytes = stdout_bytes_io.read(y_size)
-
+                witness_type = uint8(
+                    int.from_bytes(stdout_bytes_io.read(1), "big", signed=True)
+                )
                 proof_bytes: bytes = stdout_bytes_io.read()
 
                 # Verifies our own proof just in case
@@ -316,7 +348,7 @@ class Timelord:
                     challenge_hash,
                     iterations_needed,
                     output,
-                    self.config["n_wesolowski"],
+                    witness_type,
                     proof_bytes,
                 )
 
@@ -336,7 +368,19 @@ class Timelord:
                         )
                     )
 
-                await self._update_proofs_count(challenge_weight)
+                if not self.sanitizer_mode:
+                    await self._update_proofs_count(challenge_weight)
+                else:
+                    async with self.lock:
+                        writer.write(b"010")
+                        await writer.drain()
+                        try:
+                            del self.active_discriminants[challenge_hash]
+                            del self.active_discriminants_start_time[challenge_hash]
+                            del self.pending_iters[challenge_hash]
+                            del self.submitted_iters[challenge_hash]
+                        except KeyError:
+                            log.error("Discriminant stopped anormally.")
 
     async def _manage_discriminant_queue(self):
         while not self._is_shutdown:
@@ -437,6 +481,36 @@ class Timelord:
             self.active_discriminants.clear()
             self.active_discriminants_start_time.clear()
 
+    async def _manage_discriminant_queue_sanitizer(self):
+        while not self._is_shutdown:
+            async with self.lock:
+                if len(self.discriminant_queue) > 0:
+                    with_iters = [
+                        (d, w)
+                        for d, w in self.discriminant_queue
+                        if d in self.pending_iters
+                        and len(self.pending_iters[d]) != 0
+                    ]
+                    if (
+                        len(with_iters) > 0
+                        and len(self.free_clients) > 0
+                    ):
+                        disc, weight = with_iters[0]
+                        log.info(f"Creating compact weso proof: weight {weight}.")
+                        ip, sr, sw = self.free_clients[0]
+                        self.free_clients = self.free_clients[1:]
+                        self.discriminant_queue.remove((disc, weight))
+                        asyncio.create_task(
+                            self._do_process_communication(
+                                disc, weight, ip, sr, sw
+                            )
+                        )
+                if len(self.proofs_to_write) > 0:
+                    for msg in self.proofs_to_write:
+                        self.server.push_message(msg)
+                    self.proofs_to_write.clear()
+            await asyncio.sleep(3)
+
     @api_request
     async def challenge_start(self, challenge_start: timelord_protocol.ChallengeStart):
         """
@@ -444,19 +518,37 @@ class Timelord:
         should be started on it. We add the challenge into the queue if it's worth it to have.
         """
         async with self.lock:
-            if challenge_start.challenge_hash in self.seen_discriminants:
-                log.info(
-                    f"Have already seen this challenge hash {challenge_start.challenge_hash}. Ignoring."
+            if not self.sanitizer_mode:
+                if challenge_start.challenge_hash in self.seen_discriminants:
+                    log.info(
+                        f"Have already seen this challenge hash {challenge_start.challenge_hash}. Ignoring."
+                    )
+                    return
+                if challenge_start.weight <= self.best_weight_three_proofs:
+                    log.info("Not starting challenge, already three proofs at that weight")
+                    return
+                self.seen_discriminants.append(challenge_start.challenge_hash)
+                self.discriminant_queue.append(
+                    (challenge_start.challenge_hash, challenge_start.weight)
                 )
-                return
-            if challenge_start.weight <= self.best_weight_three_proofs:
-                log.info("Not starting challenge, already three proofs at that weight")
-                return
-            self.seen_discriminants.append(challenge_start.challenge_hash)
-            self.discriminant_queue.append(
-                (challenge_start.challenge_hash, challenge_start.weight)
-            )
-            log.info("Appended to discriminant queue.")
+                log.info("Appended to discriminant queue.")
+            else:
+                disc_dict = dict(self.discriminant_queue)
+                if challenge_start.challenge_hash in disc_dict:
+                    log.info("Challenge already in discriminant queue. Ignoring.")
+                    return
+                if challenge_start.challenge_hash in self.active_discriminants:
+                    log.info("Challenge currently running. Ignoring.")
+                    return
+
+                self.discriminant_queue.append(
+                    (challenge_start.challenge_hash, challenge_start.weight)
+                )
+                if challenge_start.weight not in self.max_known_weights:
+                    self.max_known_weights.append(challenge_start.weight)
+                    self.max_known_weights.sort()
+                    if len(self.max_known_weights) > 5:
+                        self.max_known_weights = self.max_known_weights[-5:]
 
     @api_request
     async def proof_of_space_info(
@@ -468,14 +560,25 @@ class Timelord:
         many iterations to run for.
         """
         async with self.lock:
-            log.info(
-                f"proof_of_space_info {proof_of_space_info.challenge_hash} {proof_of_space_info.iterations_needed}"
-            )
-            if proof_of_space_info.challenge_hash in self.done_discriminants:
+            if not self.sanitizer_mode:
                 log.info(
-                    f"proof_of_space_info {proof_of_space_info.challenge_hash} already done, returning"
+                    f"proof_of_space_info {proof_of_space_info.challenge_hash} {proof_of_space_info.iterations_needed}"
                 )
-                return
+                if proof_of_space_info.challenge_hash in self.done_discriminants:
+                    log.info(
+                        f"proof_of_space_info {proof_of_space_info.challenge_hash} already done, returning"
+                    )
+                    return
+            else:
+                disc_dict = dict(self.discriminant_queue)
+                if proof_of_space_info.challenge_hash in disc_dict:
+                    challenge_weight = disc_dict[proof_of_space_info.challenge_hash]
+                    if challenge_weight >= min(self.max_known_weights):
+                        log.info("Not storing iter, waiting for more block confirmations.")
+                        return
+                else:
+                    log.info("Not storing iter, challenge inactive.")
+                    return
 
             if proof_of_space_info.challenge_hash not in self.pending_iters:
                 self.pending_iters[proof_of_space_info.challenge_hash] = []

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -78,9 +78,6 @@ timelord_launcher:
 timelord:
   # The timelord server (if run) will run on this port
   port: 8446
-  # How much recursion to use for the wesolowski VDF proof. This increases the size
-  # of the proofs.
-  n_wesolowski: 2
   # Provides a list of VDF clients expected to connect to this timelord.
   # For each client, an IP is provided, together with the estimated iterations per second.
   vdf_clients:
@@ -98,6 +95,12 @@ timelord:
     host: 127.0.0.1
     port: 8000
   logging: *logging
+  # Set 'True' if clients connecting to this timelord have a high number of CPUs.
+  fast_algorithm: False
+  # If set 'True', the timelord will create compact proofs of time, instead of 
+  # extending the chain. The attribute 'fast_algorithm' won't apply if timelord
+  # is running in sanitizer_mode.
+  sanitizer_mode: False
 
   ssl:
     crt: "trusted.crt"
@@ -131,6 +134,11 @@ full_node:
   target_peer_count: 10
   # Only connect to peers who we have heard about in the last recent_peer_threshold seconds
   recent_peer_threshold: 6000
+
+  # Send to the timelords uncompact blocks once every 'send_uncompact_interval' seconds
+  # Set to 0 if you don't use this feature. The recommended value is 
+  # send_uncompact_interval=1800
+  send_uncompact_interval: 1800
 
   connect_to_farmer: False
   connect_to_timelord: False

--- a/tests/rpc/test_farmer_harvester_rpc.py
+++ b/tests/rpc/test_farmer_harvester_rpc.py
@@ -29,7 +29,7 @@ class TestRpc:
     async def test1(self, simulation):
         test_rpc_port = uint16(21522)
         test_rpc_port_2 = uint16(21523)
-        full_node_1, _, harvester, farmer, _, _, _ = simulation
+        full_node_1, _, harvester, farmer, _, _, _, _, _ = simulation
 
         def stop_node_cb():
             pass

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -490,6 +490,6 @@ async def setup_full_system(dic={}):
         PeerInfo("127.0.0.1", uint16(node2_server._port))
     )
 
-    yield (node1, node2, harvester, farmer, introducer, timelord, vdf)
+    yield (node1, node2, harvester, farmer, introducer, timelord, vdf, sanitizer, vdf_sanitizer)
 
     await _teardown_nodes(node_iters)

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -119,7 +119,6 @@ async def setup_full_node(db_name, port, introducer_port=None, dic={}):
     config = load_config(root_path, "config.yaml", "full_node")
     config["database_path"] = db_name
     config["send_uncompact_interval"] = 30
-    config["introducer_connect_interval"] = 60
     if introducer_port is not None:
         config["introducer_peer"]["host"] = "127.0.0.1"
         config["introducer_peer"]["port"] = introducer_port
@@ -144,15 +143,15 @@ async def setup_full_node(db_name, port, introducer_port=None, dic={}):
     )
     _ = await start_server(server_1, full_node_1._on_connect)
     full_node_1._set_server(server_1)
-    introducer = config["introducer_peer"]
-    peer_info = PeerInfo(introducer["host"], introducer["port"])
-    create_periodic_introducer_poll_task(
-        server_1,
-        peer_info,
-        full_node_1.global_connections,
-        config["introducer_connect_interval"],
-        config["target_peer_count"],
-    )
+    if introducer_port is not None:
+        peer_info = PeerInfo("127.0.0.1", introducer_port)
+        create_periodic_introducer_poll_task(
+            server_1,
+            peer_info,
+            full_node_1.global_connections,
+            config["introducer_connect_interval"],
+            config["target_peer_count"],
+        )
     yield (full_node_1, server_1)
 
     # TEARDOWN

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -324,7 +324,10 @@ async def setup_vdf_clients(port):
 
     yield vdf_task
 
-    await kill_processes()
+    try:
+        await kill_processes()
+    except Exception:
+        pass
 
 
 async def setup_timelord(port, sanitizer, dic={}):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -30,7 +30,7 @@ class TestSimulation:
 
     @pytest.mark.asyncio
     async def test_simulation_1(self, simulation):
-        node1, node2, _, _, _, _, _ = simulation
+        node1, node2, _, _, _, _, _, _, _ = simulation
         start = time.time()
         # Use node2 to test node communication, since only node1 extends the chain.
         while time.time() - start < 500:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -5,6 +5,7 @@ from typing import Dict, Any
 from tests.setup_nodes import setup_full_system
 from tests.block_tools import BlockTools
 from src.consensus.constants import constants as consensus_constants
+from src.util.ints import uint32
 
 bt = BlockTools()
 test_constants: Dict[str, Any] = consensus_constants.copy()
@@ -31,8 +32,36 @@ class TestSimulation:
     async def test_simulation_1(self, simulation):
         node1, node2, _, _, _, _, _ = simulation
         start = time.time()
+        # Use node2 to test node communication, since only node1 extends the chain.
         while time.time() - start < 500:
-            if max([h.height for h in node1.blockchain.get_current_tips()]) > 10:
-                return
+            if max([h.height for h in node2.blockchain.get_current_tips()]) > 10:
+                break
             await asyncio.sleep(1)
-        raise Exception("Failed due to timeout")
+        
+        if max([h.height for h in node2.blockchain.get_current_tips()]) <= 10:
+            raise Exception("Failed: could not get 10 blocks.") 
+
+        # Wait additional 2 minutes to get a compact block.
+        while time.time() - start < 620:
+            max_height = node1.blockchain.lca_block.height
+            for h in range(1, max_height):
+                blocks_1: List[FullBlock] = await node1.block_store.get_blocks_at(
+                    [uint32(h)]
+                )
+                blocks_2: List[FullBlock] = await node2.block_store.get_blocks_at(
+                    [uint32(h)]
+                )
+                has_compact_1 = False
+                has_compact_2 = False
+                for block in blocks_1:
+                    if block.proof_of_time.witness_type == 0:
+                        has_compact_1 = True
+                        break
+                for block in blocks_2:
+                    if block.proof_of_time.witness_type == 0:
+                        has_compact_2 = True
+                        break
+                if has_compact_1 and has_compact_2:
+                    return
+            await asyncio.sleep(1)
+        raise Exception("Failed: no block with compact proof of time.")


### PR DESCRIPTION
- Make timelord able to generate compact proofs of time and n-wesolowski proofs of time (by using 'fast_algorithm' and 'sanitizer_mode' flags in config).
- Full node periodically broadcasts non compact proofs of time to timelords.
- Simulation also checks both nodes have at least one compact block at the end.
- Use 'create_periodic_introducer_poll_task' in tests (full_node_setup) to properly connect to the local introducer, if it exists.