### PR TITLE
Make rpc server optional for farmer, full_node and harvester

### DIFF
--- a/src/server/start_farmer.py
+++ b/src/server/start_farmer.py
@@ -36,8 +36,9 @@ def service_kwargs_for_farmer(root_path):
         connect_peers=connect_peers,
         auth_connect_peers=False,
         on_connect_callback=api._on_connect,
-        rpc_info=(FarmerRpcApi, config["rpc_port"]),
     )
+    if config["start_rpc_server"]:
+        kwargs["rpc_info"] = (FarmerRpcApi, config["rpc_port"])
     return kwargs
 
 

--- a/src/server/start_full_node.py
+++ b/src/server/start_full_node.py
@@ -53,7 +53,7 @@ def service_kwargs_for_full_node(root_path):
         ),
     )
     if config["start_rpc_server"]:
-        kwards["rpc_info"] = (FullNodeRpcApi, config["rpc_port"])
+        kwargs["rpc_info"] = (FullNodeRpcApi, config["rpc_port"])
     return kwargs
 
 

--- a/src/server/start_full_node.py
+++ b/src/server/start_full_node.py
@@ -46,13 +46,14 @@ def service_kwargs_for_full_node(root_path):
         start_callback=start_callback,
         stop_callback=stop_callback,
         await_closed_callback=await_closed_callback,
-        rpc_info=(FullNodeRpcApi, config["rpc_port"]),
         periodic_introducer_poll=(
             peer_info,
             config["introducer_connect_interval"],
             config["target_peer_count"],
         ),
     )
+    if config["start_rpc_server"]:
+        kwards["rpc_info"] = (FullNodeRpcApi, config["rpc_port"])
     return kwargs
 
 

--- a/src/server/start_harvester.py
+++ b/src/server/start_harvester.py
@@ -47,8 +47,9 @@ def service_kwargs_for_harvester(root_path=DEFAULT_ROOT_PATH):
         start_callback=start_callback,
         stop_callback=stop_callback,
         await_closed_callback=await_closed_callback,
-        rpc_info=(HarvesterRpcApi, config["rpc_port"]),
     )
+    if config["start_rpc_server"]:
+        kwargs["rpc_info"] = (HarvesterRpcApi, config["rpc_port"])
     return kwargs
 
 


### PR DESCRIPTION
Brings back the ability to not start an rpc server when manually handling the lifecycle of processes.