### PR TITLE
Wallet RPC client and server not following standard contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ for setuptools_scm/PEP 440 reasons.
 - Improvements to coloured coin wallet.
 
 ### Fixed
-
+- `chia show -w` now displays a message when balances cannot be displayed instead of throwing an error
 
 ## [1.0beta9] aka Beta 1.9 - 2020-07-27
 

--- a/src/cmds/show.py
+++ b/src/cmds/show.py
@@ -317,13 +317,17 @@ async def show_async(args, parser):
             else:
                 wallet_rpc_port = args.wallet_rpc_port
             wallet_client = await WalletRpcClient.create(self_hostname, wallet_rpc_port)
-            summaries = await wallet_client.get_wallet_summaries()
-            if summaries is None:
-                print("Balances cannot be displayed at this time")
+            summaries_response = await wallet_client.get_wallet_summaries()
+            if "wallet_summaries" not in summaries_response:
+                print("Wallet summary cannot be displayed")
             else:
                 print("Balances")
-                for wallet_id, summary in summaries.items():
-                    balances = await wallet_client.get_wallet_balance(wallet_id)
+                for wallet_id, summary in summaries_response["wallet_summaries"].items():
+                    balances_response = await wallet_client.get_wallet_balance(wallet_id)
+                    if "balances" not in balances_response:
+                        print("Balances cannot be displayed")
+                        continue
+                    balances = balances_response["balances"]
                     if "name" in summary:
                         print(
                             f"Wallet ID {wallet_id} type {summary['type']} {summary['name']}"

--- a/src/cmds/show.py
+++ b/src/cmds/show.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 from time import struct_time, localtime
 
-from typing import List, Optional, Dict
+from typing import List, Optional
 
 from src.server.connection import NodeType
 from src.types.header_block import HeaderBlock

--- a/src/cmds/show.py
+++ b/src/cmds/show.py
@@ -317,7 +317,7 @@ async def show_async(args, parser):
             else:
                 wallet_rpc_port = args.wallet_rpc_port
             wallet_client = await WalletRpcClient.create(self_hostname, wallet_rpc_port)
-            summaries: Dict = await wallet_client.get_wallet_summaries()
+            summaries = await wallet_client.get_wallet_summaries()
             if summaries is None:
                 print("Balances cannot be displayed at this time")
             else:

--- a/src/cmds/show.py
+++ b/src/cmds/show.py
@@ -318,8 +318,10 @@ async def show_async(args, parser):
                 wallet_rpc_port = args.wallet_rpc_port
             wallet_client = await WalletRpcClient.create(self_hostname, wallet_rpc_port)
             summaries: Dict = await wallet_client.get_wallet_summaries()
-            print("Balances")
-            if summaries is not None:
+            if summaries is None:
+                print("Balances cannot be displayed at this time")
+            else:
+                print("Balances")
                 for wallet_id, summary in summaries.items():
                     balances = await wallet_client.get_wallet_balance(wallet_id)
                     if "name" in summary:

--- a/src/cmds/show.py
+++ b/src/cmds/show.py
@@ -319,44 +319,45 @@ async def show_async(args, parser):
             wallet_client = await WalletRpcClient.create(self_hostname, wallet_rpc_port)
             summaries: Dict = await wallet_client.get_wallet_summaries()
             print("Balances")
-            for wallet_id, summary in summaries.items():
-                balances = await wallet_client.get_wallet_balance(wallet_id)
-                if "name" in summary:
-                    print(
-                        f"Wallet ID {wallet_id} type {summary['type']} {summary['name']}"
-                    )
-                    print(
-                        f"   -Confirmed: {balances['confirmed_wallet_balance']/units['colouredcoin']}"
-                    )
-                    print(
-                        f"   -Unconfirmed: {balances['unconfirmed_wallet_balance']/units['colouredcoin']}"
-                    )
-                    print(
-                        f"   -Spendable: {balances['spendable_balance']/units['colouredcoin']}"
-                    )
-                    print(
-                        f"   -Frozen: {balances['frozen_balance']/units['colouredcoin']}"
-                    )
-                    print(
-                        f"   -Pending change: {balances['pending_change']/units['colouredcoin']}"
-                    )
-                else:
-                    print(f"Wallet ID {wallet_id} type {summary['type']}")
-                    print(
-                        f"   -Confirmed: {balances['confirmed_wallet_balance']/units['chia']} TXCH"
-                    )
-                    print(
-                        f"   -Unconfirmed: {balances['unconfirmed_wallet_balance']/units['chia']} TXCH"
-                    )
-                    print(
-                        f"   -Spendable: {balances['spendable_balance']/units['chia']} TXCH"
-                    )
-                    print(
-                        f"   -Frozen: {balances['frozen_balance']/units['chia']} TXCH"
-                    )
-                    print(
-                        f"   -Pending change: {balances['pending_change']/units['chia']} TXCH"
-                    )
+            if summaries is not None:
+                for wallet_id, summary in summaries.items():
+                    balances = await wallet_client.get_wallet_balance(wallet_id)
+                    if "name" in summary:
+                        print(
+                            f"Wallet ID {wallet_id} type {summary['type']} {summary['name']}"
+                        )
+                        print(
+                            f"   -Confirmed: {balances['confirmed_wallet_balance']/units['colouredcoin']}"
+                        )
+                        print(
+                            f"   -Unconfirmed: {balances['unconfirmed_wallet_balance']/units['colouredcoin']}"
+                        )
+                        print(
+                            f"   -Spendable: {balances['spendable_balance']/units['colouredcoin']}"
+                        )
+                        print(
+                            f"   -Frozen: {balances['frozen_balance']/units['colouredcoin']}"
+                        )
+                        print(
+                            f"   -Pending change: {balances['pending_change']/units['colouredcoin']}"
+                        )
+                    else:
+                        print(f"Wallet ID {wallet_id} type {summary['type']}")
+                        print(
+                            f"   -Confirmed: {balances['confirmed_wallet_balance']/units['chia']} TXCH"
+                        )
+                        print(
+                            f"   -Unconfirmed: {balances['unconfirmed_wallet_balance']/units['chia']} TXCH"
+                        )
+                        print(
+                            f"   -Spendable: {balances['spendable_balance']/units['chia']} TXCH"
+                        )
+                        print(
+                            f"   -Frozen: {balances['frozen_balance']/units['chia']} TXCH"
+                        )
+                        print(
+                            f"   -Pending change: {balances['pending_change']/units['chia']} TXCH"
+                        )
             wallet_client.close()
             await wallet_client.await_closed()
 

--- a/src/rpc/wallet_rpc_api.py
+++ b/src/rpc/wallet_rpc_api.py
@@ -275,7 +275,7 @@ class WalletRpcApi:
         else:
             frozen_balance = await wallet.get_frozen_amount()
 
-        balance = {
+        wallet_balance = {
             "wallet_id": wallet_id,
             "confirmed_wallet_balance": balance,
             "unconfirmed_wallet_balance": pending_balance,
@@ -284,7 +284,7 @@ class WalletRpcApi:
             "pending_change": pending_change,
         }
 
-        return {"success": True, "wallet_balance": balance}
+        return {"success": True, "wallet_balance": wallet_balance}
 
     async def get_sync_status(self, request: Dict):
         if self.service.wallet_state_manager is None:

--- a/src/rpc/wallet_rpc_api.py
+++ b/src/rpc/wallet_rpc_api.py
@@ -275,9 +275,8 @@ class WalletRpcApi:
         else:
             frozen_balance = await wallet.get_frozen_amount()
 
-        response = {
+        balance = {
             "wallet_id": wallet_id,
-            "success": True,
             "confirmed_wallet_balance": balance,
             "unconfirmed_wallet_balance": pending_balance,
             "spendable_balance": spendable_balance,
@@ -285,7 +284,7 @@ class WalletRpcApi:
             "pending_change": pending_change,
         }
 
-        return response
+        return {"success": True, "wallet_balance": balance}
 
     async def get_sync_status(self, request: Dict):
         if self.service.wallet_state_manager is None:
@@ -470,7 +469,7 @@ class WalletRpcApi:
     async def get_wallet_summaries(self, request: Dict):
         if self.service.wallet_state_manager is None:
             return {"success": False}
-        response = {}
+        wallet_summaries = {}
         for wallet_id in self.service.wallet_state_manager.wallets:
             wallet = self.service.wallet_state_manager.wallets[wallet_id]
             balance = await wallet.get_confirmed_balance()
@@ -478,15 +477,15 @@ class WalletRpcApi:
             if type == WalletType.COLOURED_COIN.value:
                 name = wallet.cc_info.my_colour_name
                 colour = wallet.get_colour()
-                response[wallet_id] = {
+                wallet_summaries[wallet_id] = {
                     "type": type,
                     "balance": balance,
                     "name": name,
                     "colour": colour,
                 }
             else:
-                response[wallet_id] = {"type": type, "balance": balance}
-        return response
+                wallet_summaries[wallet_id] = {"type": type, "balance": balance}
+        return {"success": True, "wallet_summaries": wallet_summaries}
 
     async def get_discrepancies_for_offer(self, request):
         file_name = request["filename"]

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -15,7 +15,6 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("get_wallet_summaries", {})
         return response["wallet_summaries"]
 
-
     async def get_wallet_balance(self, wallet_id: str) -> Dict:
         response = await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})
         return response["wallet_balance"]

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -12,7 +12,10 @@ class WalletRpcClient(RpcClient):
     """
 
     async def get_wallet_summaries(self) -> Dict:
-        return await self.fetch("get_wallet_summaries", {})
+        response await self.fetch("get_wallet_summaries", {})
+        return response["wallet_summaries"]
+
 
     async def get_wallet_balance(self, wallet_id: str) -> Dict:
-        return await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})
+        response await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})
+        return response["wallet_balance"]

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -12,13 +12,7 @@ class WalletRpcClient(RpcClient):
     """
 
     async def get_wallet_summaries(self) -> Dict:
-        response = await self.fetch("get_wallet_summaries", {})
-        if "wallet_summaries" not in response:
-            return None
-        return response["wallet_summaries"]
+        return await self.fetch("get_wallet_summaries", {})
 
     async def get_wallet_balance(self, wallet_id: str) -> Dict:
-        response = await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})
-        if "wallet_balance" not in response:
-            return None
-        return response["wallet_balance"]
+        return await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -13,8 +13,12 @@ class WalletRpcClient(RpcClient):
 
     async def get_wallet_summaries(self) -> Dict:
         response = await self.fetch("get_wallet_summaries", {})
+        if "wallet_summaries" not in response:
+            return None
         return response["wallet_summaries"]
 
     async def get_wallet_balance(self, wallet_id: str) -> Dict:
         response = await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})
+        if "wallet_balance" not in response:
+            return None
         return response["wallet_balance"]

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -12,10 +12,10 @@ class WalletRpcClient(RpcClient):
     """
 
     async def get_wallet_summaries(self) -> Dict:
-        response await self.fetch("get_wallet_summaries", {})
+        response = await self.fetch("get_wallet_summaries", {})
         return response["wallet_summaries"]
 
 
     async def get_wallet_balance(self, wallet_id: str) -> Dict:
-        response await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})
+        response = await self.fetch("get_wallet_balance", {"wallet_id": wallet_id})
         return response["wallet_balance"]


### PR DESCRIPTION
Disclaimer: This is my first ever PR in Python so I might do something obviously silly 😇

This is to address an issue raised here: https://github.com/Chia-Network/chia-blockchain/issues/350

When running `chia show -w` the contract followed by RPC server and client in the rest of the Chia codebase is only provided by the server in the error scenario - the client does not handle it correctly resulting in;

```
Balances
Exception from 'show' argument of type 'bool' is not iterable
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0xffff7e97d490>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0xffff7e93a460>, 145409.858861443)]']
connector: <aiohttp.connector.TCPConnector object at 0xffff7e97d400>
```

As far as I can tell this is not covered by any tests.