### PR TITLE
Prevent zombie children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ for setuptools_scm/PEP 440 reasons.
 ### Fixed
 - Proof of space plotting now correctly calculates the total working space used in the `-t` directory.
 - `chia show -w` now displays a message when balances cannot be displayed instead of throwing an error. Thanks to @freddiecoleman for this fix!
+- Fix issue with shutting down full node (full node processes remained open, and caused a spinner when launching Chia)
 - Various code review alerts for comparing to a wider type in chiapos were fixed. Additionally, unused code was removed from chiapos
 - Benchmarking has been re-enabled in bls-signatures.
 - Various node security vulnerabilities were addressed.

--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -16,12 +16,12 @@ except ModuleNotFoundError:
         "Error: Make sure to run . ./activate from the project folder before starting Chia."
     )
     quit()
-from windows_signal import kill
 
 
 import websockets
-from src.cmds.init import chia_init
 
+from src.cmds.init import chia_init
+from src.daemon.windows_signal import kill
 from src.util.ws_message import format_response
 from src.util.json_util import dict_to_json_str
 

--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -431,7 +431,7 @@ def launch_service(root_path, service_command):
 
     # CREATE_NEW_PROCESS_GROUP allows graceful shutdown on windows, by CTRL_BREAK_EVENT signal
     if platform == "win32" or platform == "cygwin":
-        creationflags = (subprocess.CREATE_NEW_PROCESS_GROUP,)
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         creationflags = 0
     process = subprocess.Popen(

--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -459,7 +459,9 @@ async def kill_service(root_path, services, service_name, delay_before_kill=15) 
 
     if platform == "win32" or platform == "cygwin":
         log.info("sending CTRL_BREAK_EVENT signal to %s", service_name)
+        # pylint: disable=E1101
         kill(process.pid, signal.SIGBREAK)  # type: ignore
+
     else:
         log.info("sending term signal to %s", service_name)
         process.terminate()

--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -432,7 +432,7 @@ def launch_service(root_path, service_command):
     return process, pid_path
 
 
-async def kill_service(root_path, services, service_name, delay_before_kill=10) -> bool:
+async def kill_service(root_path, services, service_name, delay_before_kill=15) -> bool:
     process = services.get(service_name)
     if process is None:
         return False

--- a/src/daemon/windows_signal.py
+++ b/src/daemon/windows_signal.py
@@ -1,0 +1,77 @@
+"""
+Code taken from Stack Overflow Eryk Sun.
+https://stackoverflow.com/questions/35772001/how-to-handle-the-signal-in-python-on-windows-machine
+"""
+
+import os
+import sys
+import time
+import signal
+
+if sys.platform != "win32" and sys.platform != "cygwin":
+    kill = os.kill
+    sleep = time.sleep
+else:
+    # adapt the conflated API on Windows.
+    import threading
+
+    sigmap = {
+        signal.SIGINT: signal.CTRL_C_EVENT,
+        signal.SIGBREAK: signal.CTRL_BREAK_EVENT,
+    }
+
+    def kill(pid, signum):
+        if signum in sigmap and pid == os.getpid():
+            # we don't know if the current process is a
+            # process group leader, so just broadcast
+            # to all processes attached to this console.
+            pid = 0
+        thread = threading.current_thread()
+        handler = signal.getsignal(signum)
+        # work around the synchronization problem when calling
+        # kill from the main thread.
+        if (
+            signum in sigmap
+            and thread.name == "MainThread"
+            and callable(handler)
+            and pid == 0
+        ):
+            event = threading.Event()
+
+            def handler_set_event(signum, frame):
+                event.set()
+                return handler(signum, frame)
+
+            signal.signal(signum, handler_set_event)
+            try:
+                os.kill(pid, sigmap[signum])
+                # busy wait because we can't block in the main
+                # thread, else the signal handler can't execute.
+                while not event.is_set():
+                    pass
+            finally:
+                signal.signal(signum, handler)
+        else:
+            os.kill(pid, sigmap.get(signum, signum))
+
+    if sys.version_info[0] > 2:
+        sleep = time.sleep
+    else:
+        import errno
+
+        # If the signal handler doesn't raise an exception,
+        # time.sleep in Python 2 raises an EINTR IOError, but
+        # Python 3 just resumes the sleep.
+
+        def sleep(interval):
+            """sleep that ignores EINTR in 2.x on Windows"""
+            while True:
+                try:
+                    t = time.time()
+                    time.sleep(interval)
+                except IOError as e:
+                    if e.errno != errno.EINTR:
+                        raise
+                interval -= time.time() - t
+                if interval <= 0:
+                    break

--- a/src/daemon/windows_signal.py
+++ b/src/daemon/windows_signal.py
@@ -16,8 +16,8 @@ else:
     import threading
 
     sigmap = {
-        signal.SIGINT: signal.CTRL_C_EVENT,
-        signal.SIGBREAK: signal.CTRL_BREAK_EVENT,
+        signal.SIGINT: signal.CTRL_C_EVENT,  # pylint: disable=E1101
+        signal.SIGBREAK: signal.CTRL_BREAK_EVENT,  # pylint: disable=E1101
     }
 
     def kill(pid, signum):

--- a/src/daemon/windows_signal.py
+++ b/src/daemon/windows_signal.py
@@ -5,12 +5,10 @@ https://stackoverflow.com/questions/35772001/how-to-handle-the-signal-in-python-
 
 import os
 import sys
-import time
 import signal
 
 if sys.platform != "win32" and sys.platform != "cygwin":
     kill = os.kill
-    sleep = time.sleep
 else:
     # adapt the conflated API on Windows.
     import threading
@@ -53,25 +51,3 @@ else:
                 signal.signal(signum, handler)
         else:
             os.kill(pid, sigmap.get(signum, signum))
-
-    if sys.version_info[0] > 2:
-        sleep = time.sleep
-    else:
-        import errno
-
-        # If the signal handler doesn't raise an exception,
-        # time.sleep in Python 2 raises an EINTR IOError, but
-        # Python 3 just resumes the sleep.
-
-        def sleep(interval):
-            """sleep that ignores EINTR in 2.x on Windows"""
-            while True:
-                try:
-                    t = time.time()
-                    time.sleep(interval)
-                except IOError as e:
-                    if e.errno != errno.EINTR:
-                        raise
-                interval -= time.time() - t
-                if interval <= 0:
-                    break

--- a/src/server/start_service.py
+++ b/src/server/start_service.py
@@ -172,10 +172,6 @@ class Service:
             if self._rpc_info:
                 rpc_api, rpc_port = self._rpc_info
 
-                def rpc_stop():
-                    self._stopped_by_rpc = True
-                    self.stop()
-
                 self._rpc_task = asyncio.create_task(
                     start_rpc_server(
                         rpc_api(self._api),
@@ -208,9 +204,7 @@ class Service:
     async def run(self):
         self.start()
         await self._task
-        while (
-            not stopped_by_signal and not self._stopped_by_rpc and not self._is_stopping
-        ):
+        while not stopped_by_signal and not self._is_stopping:
             await asyncio.sleep(1)
 
         self.stop()

--- a/src/server/start_service.py
+++ b/src/server/start_service.py
@@ -188,13 +188,13 @@ class Service:
                 asyncio.get_running_loop().add_signal_handler(signal.SIGTERM, self.stop)
                 if platform == "win32" or platform == "cygwin":
                     asyncio.get_running_loop().add_signal_handler(
-                        signal.SIGBREAK, self.stop
+                        signal.SIGBREAK, self.stop  # pylint: disable=E1101
                     )
                     asyncio.get_running_loop().add_signal_handler(
-                        signal.CTRL_C_EVENT, self.stop
+                        signal.CTRL_C_EVENT, self.stop  # pylint: disable=E1101
                     )
                     asyncio.get_running_loop().add_signal_handler(
-                        signal.CTRL_BREAK_EVENT, self.stop
+                        signal.CTRL_BREAK_EVENT, self.stop  # pylint: disable=E1101
                     )
             except NotImplementedError:
                 self._log.info("signal handlers unsupported")

--- a/src/server/start_service.py
+++ b/src/server/start_service.py
@@ -3,6 +3,7 @@ import logging
 import logging.config
 import signal
 
+from sys import platform
 from typing import Any, AsyncGenerator, Callable, List, Optional, Tuple
 
 try:
@@ -192,6 +193,9 @@ class Service:
 
             signal.signal(signal.SIGINT, global_signal_handler)
             signal.signal(signal.SIGTERM, global_signal_handler)
+            if platform == "win32" or platform == "cygwin":
+                # pylint: disable=E1101
+                signal.signal(signal.SIGBREAK, global_signal_handler)  # type: ignore
 
         self._task = asyncio.create_task(_run())
 


### PR DESCRIPTION
Tested on Mac and Windows 7.

* Close the full node before closing the servers (since servers might take a long time and never close before the kill). 
* Waiting time increased from 10 to 15 seconds before kill
* Send CTRL_BREAK_EVENT on windows
* Replace loop.add_signal_handler with signal.signal (cross platform)

**Zombie bug explanation**
In the case where server is taking a long time to close, the daemon sends SIGKILL, which means the process gets closed immediately. Any future shutdown logic does not get run. In this case, the full node, and therefore blockchain.py, were not getting closed. Blockchain.py spawns child processes for block verification. These processes were being left open as zombies. Also, the port binding assignment got copied from the parent to the children, so the zombie children were still assigned port 8444 (meaning that a new full node process could not bind to 8444). 

**Solution**
The solution is to close the full node and the RPC server before awaiting the closure of the server, by graceful shutdown catching SIGTERM. To get this graceful signal handling on windows, two things had to be changed. The first is to send a CTRL_BREAK_EVENT as opposed to terminating the process (windows_signal.py). The second is to catch signals with python signal module, as opposed to asyncio loop.add_signal_handler, which has no windows support. Since we catch it outside of asyncio, we need to do an infinite for loop within the event loop and periodically check a global variable.