### PR TITLE
Add proper about window

### DIFF
--- a/electron-react/package-lock.json
+++ b/electron-react/package-lock.json
@@ -2077,6 +2077,11 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
       "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ=="
     },
+    "about-window": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/about-window/-/about-window-1.13.4.tgz",
+      "integrity": "sha512-Ge7qBRzrmPbVJ2YarUfTrZEaSfhRjeVyFhmH9NqdNDjjgP0dcWwUprH61JWlDgcM3KaDn5zUzimG4YQh6vRocw=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -4876,7 +4881,7 @@
       }
     },
     "electron-osx-sign": {
-      "version": "github:electron/electron-osx-sign#877226b5198f2ed9661129ea56a1ea048c4c55ae",
+      "version": "github:electron/electron-osx-sign#6ba45b2deec3f4f3629010645f92e6506df133ee",
       "from": "github:electron/electron-osx-sign#master",
       "dev": true,
       "requires": {

--- a/electron-react/package.json
+++ b/electron-react/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "about-window": "^1.13.4",
     "is-electron": "^2.2.0",
     "npm-audit-resolver": "^2.2.1",
     "react": "^16.13.1",

--- a/electron-react/package.json
+++ b/electron-react/package.json
@@ -3,6 +3,7 @@
   "author": "Straya Markovic <hello@chia.net> (https://chia.net/)",
   "description": "GUI for Chia Blockchain",
   "productName": "Chia Blockchain",
+  "version": "1.0.0-beta11",
   "private": true,
   "devDependencies": {
     "electron": "^8.5.0",

--- a/electron-react/src/electron-starter.js
+++ b/electron-react/src/electron-starter.js
@@ -141,9 +141,7 @@ const closeDaemon = callback => {
       }
     });
   } catch (e) {
-    clearTimeout(timeout);
-
-    callback(e);
+    clearTimeoutCallback(e);
   }
 };
 

--- a/electron-react/src/electron-starter.js
+++ b/electron-react/src/electron-starter.js
@@ -5,11 +5,10 @@ if (setupEvents.handleSquirrelEvent()) {
   return;
 }
 
-const electron = require("electron");
-const app = electron.app;
-const BrowserWindow = electron.BrowserWindow;
+const { promisify } = require('util');
+const { app, dialog, ipcMain, BrowserWindow, Menu } = require("electron");
+const openAboutWindow = require("about-window").default;
 const path = require("path");
-const ipcMain = require("electron").ipcMain;
 const config = require("./config");
 const dev_config = require("./dev_config");
 const WebSocket = require("ws");
@@ -106,7 +105,12 @@ const createPyProc = () => {
 };
 
 const closeDaemon = callback => {
-  let called_cb = false;
+  const timeout = setTimeout(() => callback(), 20000);
+  const clearTimeoutCallback = err => {
+    clearTimeout(timeout);
+    callback(err);
+  };
+
   try {
     const request_id = crypto.randomBytes(32).toString("hex");
     ws = new WebSocket(daemon_rpc_ws, {
@@ -126,26 +130,21 @@ const closeDaemon = callback => {
     ws.on("message", function incoming(message) {
       message = JSON.parse(message);
       if (message["ack"] === true && message["request_id"] === request_id) {
-        called_cb = true;
-        callback();
+        clearTimeoutCallback();
       }
     });
     ws.on("error", err => {
       if (err.errno === "ECONNREFUSED") {
-        called_cb = true;
-        callback();
+        clearTimeoutCallback();
       } else {
-        console.log("Unexpected websocket error err ", err);
+        clearTimeoutCallback(err);
       }
     });
   } catch (e) {
-    console.log("Error in websocket", e);
+    clearTimeout(timeout);
+
+    callback(e);
   }
-  setTimeout(function() {
-    if (!called_cb) {
-      callback();
-    }
-  }, 20000);
 };
 
 const exitPyProc = e => {};
@@ -209,7 +208,7 @@ const createWindow = () => {
       return;
     }
     e.preventDefault();
-    var choice = require("electron").dialog.showMessageBoxSync({
+    var choice = dialog.showMessageBoxSync({
       type: "question",
       buttons: ["No", "Yes"],
       title: "Confirm",
@@ -228,12 +227,39 @@ const createWindow = () => {
   });
 };
 
-const appReady = () => {
-  closeDaemon(() => {
-    createPyProc();
-    ws.terminate();
-    createWindow();
-  });
+const createMenu = () => {
+  console.log(path.join(__dirname, "assets/chia.png"));
+  const menu = Menu.buildFromTemplate([{
+      label: "Help",
+      submenu: [{
+        label: "About",
+        click: () =>
+          openAboutWindow({
+            homepage: "https://www.chia.net/",
+            bug_report_url: "https://github.com/Chia-Network/chia-blockchain/issues",
+            icon_path: path.join(__dirname, "assets/img/chia_circle.png"),
+            copyright: "Copyright (c) 2020 Chia Network",
+            package_json_dir: __dirname
+          }),
+      }]
+    }
+  ]);
+
+  return menu;
+}
+
+const appReady = async() => {
+  app.applicationMenu = createMenu();
+
+  try {
+    await promisify(closeDaemon)();
+  } catch (err) {
+    console.error("Error in websocket", e);
+  }
+
+  createPyProc();
+  ws.terminate();
+  createWindow();
 };
 
 app.on("ready", appReady);

--- a/electron-react/src/electron-starter.js
+++ b/electron-react/src/electron-starter.js
@@ -228,7 +228,6 @@ const createWindow = () => {
 };
 
 const createMenu = () => {
-  console.log(path.join(__dirname, "assets/chia.png"));
   const menu = Menu.buildFromTemplate([{
       label: "Help",
       submenu: [{

--- a/electron-react/src/electron-starter.js
+++ b/electron-react/src/electron-starter.js
@@ -235,8 +235,7 @@ const createMenu = () => {
             homepage: "https://www.chia.net/",
             bug_report_url: "https://github.com/Chia-Network/chia-blockchain/issues",
             icon_path: path.join(__dirname, "assets/img/chia_circle.png"),
-            copyright: "Copyright (c) 2020 Chia Network",
-            package_json_dir: __dirname
+            copyright: "Copyright (c) 2020 Chia Network"
           }),
       }]
     }

--- a/electron-react/src/electron-starter.js
+++ b/electron-react/src/electron-starter.js
@@ -5,7 +5,7 @@ if (setupEvents.handleSquirrelEvent()) {
   return;
 }
 
-const { promisify } = require('util');
+const { promisify } = require("util");
 const { app, dialog, ipcMain, BrowserWindow, Menu } = require("electron");
 const openAboutWindow = require("about-window").default;
 const path = require("path");

--- a/electron-react/src/electron-starter.js
+++ b/electron-react/src/electron-starter.js
@@ -250,7 +250,7 @@ const appReady = async() => {
 
   try {
     await promisify(closeDaemon)();
-  } catch (err) {
+  } catch (e) {
     console.error("Error in websocket", e);
   }
 


### PR DESCRIPTION
Trello ticket: https://trello.com/c/ljADiDxK/703-add-a-proper-about-window-to-our-electron-app-https-githubcom-rhysd-electron-about-window

Includes some minor refactoring, limited to only code close to the change.

- Added about page in menu
- Tidied up multiple imports from electron
- Minor refactoring around closing daemon on electron ready.
    - Conforms to standard error-first callback style (meaning it can be promisified later 🚀)
    - Clears timeout instead of having it always run with a no-op
    - No longer keeps track of callback being called as this is no longer necessary

### Before change

Generic default menu items can be seen.

![Screenshot 2020-08-19 at 22 46 40](https://user-images.githubusercontent.com/4749434/90692971-efc1f580-e26d-11ea-9c89-b24764abbafd.png)

Default electron about page is displayed.

![Screenshot 2020-08-19 at 22 46 50](https://user-images.githubusercontent.com/4749434/90693017-036d5c00-e26e-11ea-8f99-6778eb671d10.png)


### After change
Single about menu item (title electron in dev mode).

![Screenshot 2020-08-19 at 22 45 50](https://user-images.githubusercontent.com/4749434/90693046-12540e80-e26e-11ea-8954-5e2f88df01c8.png)

Chia specific about window. Clicking on the logo goes to the Chia homepage. Clicking on report issues goes to github issues on the chia-blockchain repo.

![Screenshot 2020-08-19 at 22 46 13](https://user-images.githubusercontent.com/4749434/90693131-36175480-e26e-11ea-95dd-622c97cb3943.png)

And on linux...

![Screenshot from 2020-08-19 23-02-23](https://user-images.githubusercontent.com/4749434/90694607-cf476a80-e270-11ea-91c1-b25eb20424d5.png)

![Screenshot from 2020-08-19 23-03-27](https://user-images.githubusercontent.com/4749434/90694610-d1a9c480-e270-11ea-9a0b-96c36a9862d6.png)


I do not currently have access to a windows machine. This should be tested on windows at some point.