### PR TITLE
Add separate hostname for daemon

### DIFF
--- a/src/daemon/client.py
+++ b/src/daemon/client.py
@@ -96,12 +96,12 @@ class DaemonProxy:
         return await self._get(request)
 
 
-async def connect_to_daemon(self_hostname: str, daemon_port: int):
+async def connect_to_daemon(daemon_hostname: str, daemon_port: int):
     """
     Connect to the local daemon.
     """
 
-    client = DaemonProxy(f"ws://{self_hostname}:{daemon_port}")
+    client = DaemonProxy(f"ws://{daemon_hostname}:{daemon_port}")
     await client.start()
     return client
 
@@ -113,8 +113,9 @@ async def connect_to_daemon_and_validate(root_path):
     """
     try:
         net_config = load_config(root_path, "config.yaml")
+        daemon_hostname = net_config["daemon_hostname"] or net_config["self_hostname"]
         connection = await connect_to_daemon(
-            net_config["self_hostname"], net_config["daemon_port"]
+            daemon_hostname, net_config["daemon_port"]
         )
         r = await connection.ping()
 

--- a/src/rpc/rpc_server.py
+++ b/src/rpc/rpc_server.py
@@ -197,7 +197,7 @@ class RpcServer:
 
         await ws.close()
 
-    async def connect_to_daemon(self, self_hostname: str, daemon_port: uint16):
+    async def connect_to_daemon(self, daemon_hostname: str, daemon_port: uint16):
         while True:
             session = None
             try:
@@ -205,7 +205,7 @@ class RpcServer:
                     break
                 session = aiohttp.ClientSession()
                 async with session.ws_connect(
-                    f"ws://{self_hostname}:{daemon_port}",
+                    f"ws://{daemon_hostname}:{daemon_port}",
                     autoclose=False,
                     autoping=True,
                 ) as ws:
@@ -215,7 +215,7 @@ class RpcServer:
                 await session.close()
             except aiohttp.client_exceptions.ClientConnectorError:
                 self.log.warning(
-                    f"Cannot connect to daemon at ws://{self_hostname}:{daemon_port}"
+                    f"Cannot connect to daemon at ws://{daemon_hostname}:{daemon_port}"
                 )
             except Exception as e:
                 tb = traceback.format_exc()

--- a/src/rpc/rpc_server.py
+++ b/src/rpc/rpc_server.py
@@ -229,6 +229,7 @@ class RpcServer:
 async def start_rpc_server(
     rpc_api: Any,
     self_hostname: str,
+    daemon_hostname: str,
     daemon_port: uint16,
     rpc_port: uint16,
     stop_cb: Callable,
@@ -268,7 +269,7 @@ async def start_rpc_server(
     app.add_routes(routes)
     if connect_to_daemon:
         daemon_connection = asyncio.create_task(
-            rpc_server.connect_to_daemon(self_hostname, daemon_port)
+            rpc_server.connect_to_daemon(daemon_hostname, daemon_port)
         )
     runner = aiohttp.web.AppRunner(app, access_log=None)
     await runner.setup()

--- a/src/server/start_service.py
+++ b/src/server/start_service.py
@@ -94,6 +94,7 @@ class Service:
         ping_interval = net_config.get("ping_interval")
         network_id = net_config.get("network_id")
         self.self_hostname = net_config.get("self_hostname")
+        self.daemon_hostname = net_config.get("daemon_hostname") or self.self_hostname
         self.daemon_port = net_config.get("daemon_port")
         assert ping_interval is not None
         assert network_id is not None
@@ -176,6 +177,7 @@ class Service:
                     start_rpc_server(
                         rpc_api(self._api),
                         self.self_hostname,
+                        self.daemon_hostname,
                         self.daemon_port,
                         rpc_port,
                         self.stop,

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -2,6 +2,7 @@ network_id: testnet  # testnet/mainnet
 # Send a ping to all peers after ping_interval seconds
 ping_interval: 120
 self_hostname: &self_hostname "localhost"
+daemon_hostname: *self_hostname
 daemon_port: 55400
 
 # Controls logging of all servers (harvester, farmer, etc..). Each one can be overriden.

--- a/tests/rpc/test_farmer_harvester_rpc.py
+++ b/tests/rpc/test_farmer_harvester_rpc.py
@@ -45,6 +45,7 @@ class TestRpc:
 
         config = load_config(bt.root_path, "config.yaml")
         hostname = config["self_hostname"]
+        daemon_hostname = config["daemon_hostname"] or hostname
         daemon_port = config["daemon_port"]
 
         farmer_rpc_api = FarmerRpcApi(farmer)
@@ -53,6 +54,7 @@ class TestRpc:
         rpc_cleanup = await start_rpc_server(
             farmer_rpc_api,
             hostname,
+            daemon_hostname,
             daemon_port,
             test_rpc_port,
             stop_node_cb,
@@ -61,6 +63,7 @@ class TestRpc:
         rpc_cleanup_2 = await start_rpc_server(
             harvester_rpc_api,
             hostname,
+            daemon_hostname,
             daemon_port,
             test_rpc_port_2,
             stop_node_cb_2,

--- a/tests/rpc/test_full_node_rpc.py
+++ b/tests/rpc/test_full_node_rpc.py
@@ -49,11 +49,13 @@ class TestRpc:
 
         config = load_config(bt.root_path, "config.yaml")
         hostname = config["self_hostname"]
+        daemon_hostname = config["daemon_hostname"] or hostname
         daemon_port = config["daemon_port"]
 
         rpc_cleanup = await start_rpc_server(
             full_node_rpc_api,
             hostname,
+            daemon_hostname,
             daemon_port,
             test_rpc_port,
             stop_node_cb,


### PR DESCRIPTION
# What

This adds a separate configuration key for the daemon hostname. Currently it uses `self_hostname`.

# Why

At the moment it's assumed that the daemon runs on the same host as the rpc server when attempting to start the rpc server. This is prohibitive when attempting to run all the components separately in their own containers. Allowing the daemon to run on its own host allows all components to be distributed, such as in a docker setup. 

# How

This adds a new `daemon_hostname` field to the configuration that defaults to the `self_hostname` value both in the config and in the code (fallback). It should be a no-op for all existing installations.