### PR TITLE
Fixed Developer Toolset undefined window error

### DIFF
--- a/electron-react/src/electron-starter.js
+++ b/electron-react/src/electron-starter.js
@@ -332,7 +332,7 @@ function getMenuTemplate() {
                 process.platform === "darwin"
                   ? "Alt+Command+I"
                   : "Ctrl+Shift+I",
-              click: () => windows.main.toggleDevTools(),
+              click: () => mainWindow.toggleDevTools(),
             },
           ],
         },


### PR DESCRIPTION
Master branch, a revision from 2 days ago, Ubuntu 18.04 LTS: 

When the Chromium Developer Toolset menu item is clicked, the following JS error appears:

'Uncaught Exception: ReferenceError: windows is not defined at click (/.../chia-blockchain/electron-react/src/electron-starter.js:335:41) at MenuItem.click(electron/js2c/browser_init.js:1549:9) at Function.executeCommand (electron/js2c/browser_init.js:1810:13)"