### PR TITLE
Beta 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
-## [Unreleased]
+## [1.0beta13] aka Beta 1.13 - 2020-09-15
 
 ### Added
 
 ### Changed
+- Long_description_content_type is now set to improve chia-blockchian's Pypi entry. Thanks to @altendky for this pull request.
+- A minor edit was made to clarify that excessive was only related to trolling in the Code of Conduct document.
 
 ### Fixed
+- When starting the GUI from an installer or the command line on Linux, if you had not previously generated a key on your machine, the generate new key GUI would not launch and you would be stuck with a spinnner.
+- Farmer display now correctly displays balance.
 
 ## [1.0beta12] aka Beta 1.12 - 2020-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ for setuptools_scm/PEP 440 reasons.
 - A minor edit was made to clarify that excessive was only related to trolling in the Code of Conduct document.
 
 ### Fixed
-- When starting the GUI from an installer or the command line on Linux, if you had not previously generated a key on your machine, the generate new key GUI would not launch and you would be stuck with a spinnner.
+- When starting the GUI from an installer or the command line on Linux, if you had not previously generated a key on your machine, the generate new key GUI would not launch and you would be stuck with a spinner.
 - Farmer display now correctly displays balance.
 
 ## [1.0beta12] aka Beta 1.12 - 2020-09-14

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
  advances
-* Excessive trolling, insulting/derogatory comments, and personal or political attacks
+* Insulting/derogatory comments, and personal or political attacks, or excessive trolling.
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
  address, without explicit permission

--- a/electron-react/src/pages/Farmer.js
+++ b/electron-react/src/pages/Farmer.js
@@ -650,7 +650,7 @@ const Farmer = props => {
         }
       }
     }
-    if (totalChia !== totalChiaFarmed && !didMount) {
+    if (totalChia !== totalChiaFarmed) {
       setTotalChiaFarmed(totalChia);
       setBiggestHeight(biggestHeight);
     }

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ kwargs = dict(
     },
     use_scm_version={"fallback_version": "unknown-no-.git-directory"},
     long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     zip_safe=False,
 )
 

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -144,7 +144,7 @@ class WalletNode:
     ) -> bool:
         private_key = self.get_key_for_fingerprint(fingerprint)
         if private_key is None:
-            raise RuntimeError("Invalid fingerprint {public_key_fingerprint}")
+            return False
 
         db_path_key_suffix = str(private_key.get_g1().get_fingerprint())
         path = path_from_root(


### PR DESCRIPTION
### Added

### Changed
- Long_description_content_type is now set to improve chia-blockchian's Pypi entry. Thanks to @altendky for this pull request.
- A minor edit was made to clarify that excessive was only related to trolling in the Code of Conduct document.

### Fixed
- When starting the GUI from an installer or the command line on Linux, if you had not previously generated a key on your machine, the generate new key GUI would not launch and you would be stuck with a spinner.
- Farmer display now correctly displays balance.