### PR TITLE
Remote UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ electron-react/src/dev_config.js
 electron-react/build
 build_scripts/dist
 build_scripts/*.Dmg
+
+.jshintrc

--- a/electron-react/public/index.html
+++ b/electron-react/public/index.html
@@ -14,7 +14,10 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Chia Blockchain</title>
+    <!--
+      title is set dynamically in code 
+      <title>Chia Blockchain</title> 
+    -->
   </head>
   <body>
     <div id="root"></div>

--- a/electron-react/src/index.js
+++ b/electron-react/src/index.js
@@ -6,26 +6,60 @@ import App from "./App";
 import "./assets/css/App.css";
 import store from "./modules/store";
 import WebSocketConnection from "./hocs/WebsocketConnection";
-import { daemon_rpc_ws } from "./util/config";
 import { exit_and_close } from "./modules/message";
 import isElectron from "is-electron";
 
-const Root = ({ store }) => (
-  <Provider store={store}>
-    <WebSocketConnection host={daemon_rpc_ws}>
-      <Router>
-        <Route path="/" component={App} />
-      </Router>
-    </WebSocketConnection>
-  </Provider>
-);
+const url = require("url");
+const config = require("./util/config");
+const parseArgs = require('minimist');
+
+const Root = ({ store }) => {
+  return (
+    <Provider store={store}>
+      <WebSocketConnection host={getDaemonHost()}>
+        <Router>
+          <Route path="/" component={App} />
+        </Router>
+      </WebSocketConnection>
+    </Provider>
+  )
+};
 
 ReactDOM.render(<Root store={store} />, document.getElementById("root"));
 
 window.onload = () => {
+  var title = "Chia Blockchain"
+  if (!config.isLocalHost()) {
+    title += " - [" + config.getDaemonHost() + "]";
+  }
+  window.document.title = title;
+
   if (isElectron()) {
     window.ipcRenderer.on("exit-daemon", (event, ...args) => {
       store.dispatch(exit_and_close(event));
     });
   }
 };
+
+function getDaemonHost() {
+  if (isElectron()) {
+    // leave this here - it breaks loading if declared at the module level
+    const remote = window.require('electron').remote;
+
+    // see if the Main process got the selfHostName on the command line  
+    // so the Render process can set the correct HTML document title
+    const argv = parseArgs(remote.process.argv.slice(1));
+    if (argv.selfHostName) {
+      config.setSelfHostName(argv.selfHostName);
+    }
+  }
+  else {
+    // if the host name was passed on the url, update the config    
+    var query = url.parse(window.document.URL, true).query;
+    if (query && query.selfHostName) {
+      config.setSelfHostName(query.selfHostName);
+    }
+  }
+
+  return config.getDaemonHost();
+}

--- a/electron-react/src/modules/store.js
+++ b/electron-react/src/modules/store.js
@@ -8,15 +8,16 @@ import dev_config from "../dev_config";
 const middleware = [reduxThunk, wsMiddleware];
 
 const store =
-  isElectron() && !dev_config.redux_tool
+  // when using electron wo redux or wo electron (ie in the browser) don't pass extensions to the composer
+  (isElectron() && !dev_config.redux_tool) || !isElectron()
     ? createStore(rootReducer, compose(applyMiddleware(...middleware)))
     : createStore(
-        rootReducer,
-        compose(
-          applyMiddleware(...middleware),
-          window.__REDUX_DEVTOOLS_EXTENSION__ &&
-            window.__REDUX_DEVTOOLS_EXTENSION__()
-        )
-      );
+      rootReducer,
+      compose(
+        applyMiddleware(...middleware),
+        window.__REDUX_DEVTOOLS_EXTENSION__ &&
+        window.__REDUX_DEVTOOLS_EXTENSION__()
+      )
+    );
 
 export default store;

--- a/electron-react/src/util/config.js
+++ b/electron-react/src/util/config.js
@@ -1,12 +1,20 @@
-const self_hostname = "localhost";
-const daemon_rpc_ws = "ws://" + self_hostname + ":55400";
+var self_hostname = "localhost";
+
 const wallet_rpc_host_and_port = "ws://" + self_hostname + ":9256";
 const full_node_rpc_host = self_hostname;
 const full_node_rpc_port = 8555;
 
 module.exports = {
+  setSelfHostName: (hostname) => {
+    self_hostname = hostname;
+  },
+  isLocalHost: () => {
+    return self_hostname === "localhost";
+  },
+  getDaemonHost: () => {
+    return "ws://" + self_hostname + ":55400";
+  },
   self_hostname,
-  daemon_rpc_ws,
   wallet_rpc_host_and_port,
   full_node_rpc_host,
   full_node_rpc_port


### PR DESCRIPTION
This PR enables the react UI to interact with deamons running on remote machines. This allows the farmer/wallet/full node to be run headless on a pi, but still be graphically managed via the react UI.

With these changes the UI can be run via electron and also as a node module with a browser based UI. In either mode, the UI can interact with a daemon on the `localhost` or remotely (with `localhost` always being the default). Whenever running in the browser, or with a remote daemon, the UI will not attempt to start or stop the daemon. When running via electron, on the same machine as the daemon, it will start and stop along with the UI as it currently does.

To test the node app
````
cd electron-react
npm install
npm start
````
A browser will open at `localhost:3000` to host the UI. To attach the browser UI to a remote daemon, the remote host name can be supplied as a query parameter: `localhost:3000?selfHostName=<remote machine name or ip>`

To run the electron UI against a remote daemon, the remote host name can be passed via the command line: `Chia.exe --selfHostName=<remote machine name or ip>`

In all cases the UI expects the daemon to be listening on port 55400. 

To run the UI from a browser, the _nodejs_ service needs to be running somewhere on the network. Depending on where you run the _nodejs_ service you may need to change the port the daemon listens to:
- If the _nodejs_ service and dameon are not on the same machine, `config.yaml` needs to have the daemon listen on `0.0.0.0` instead of `localhost`. Find the unindented line `self_hostname: localhost` and change it to `self_hostname: 0.0.0.0`. _note:_ doing this intentionally exposes the daemon on the network, so firewall rules should be such that traffic is restricted to only the UI hosts you intend. With `ufw` for instance add a rule like this `ufw allow from <ip of ui machine> to any port 55400 proto tcp`
- Alternatively the _nodejs_ service can run on that same server as the daemon, in which case the service can talk to the daemon on `localhost `but will need setup to be hosted. [pm2](https://pm2.keymetrics.io/docs/usage/quick-start/) is a simple solution to host a nodejs service. It has advantages for simplicity of use and security. (you'd still want to use firewall or webserver rules to control client access as the UI does not authenticate.)

from the electron-react directory
````
npm run build
cd build
pm2 serve . 3000
pm2 startup
pm2 save
````
will build, serve, and daemonize the nodejs service as well as restart it at boot 