### PR TITLE
suppress redux extensions when not running in electron

### DIFF
--- a/electron-react/src/modules/store.js
+++ b/electron-react/src/modules/store.js
@@ -8,15 +8,15 @@ import dev_config from "../dev_config";
 const middleware = [reduxThunk, wsMiddleware];
 
 const store =
-  isElectron() && !dev_config.redux_tool
+  ((isElectron() && !dev_config.redux_tool) || !isElectron)
     ? createStore(rootReducer, compose(applyMiddleware(...middleware)))
     : createStore(
-        rootReducer,
-        compose(
-          applyMiddleware(...middleware),
-          window.__REDUX_DEVTOOLS_EXTENSION__ &&
-            window.__REDUX_DEVTOOLS_EXTENSION__()
-        )
-      );
+      rootReducer,
+      compose(
+        applyMiddleware(...middleware),
+        window.__REDUX_DEVTOOLS_EXTENSION__ &&
+        window.__REDUX_DEVTOOLS_EXTENSION__()
+      )
+    );
 
 export default store;


### PR DESCRIPTION
passing the redux devtools extensions to `compose` breaks page load when running in the browser (i.e. sans electron host)