### PR TITLE
Peer gossip bugfix.

### DIFF
--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -539,6 +539,8 @@ class AddressManager:
             rand_pos = randrange(len(self.random_pos) - n) + n
             self.swap_random_(n, rand_pos)
             info = self.map_info[self.random_pos[n]]
+            if not info.peer_info.is_valid():
+                continue
             if not info.is_terrible():
                 cur_peer_info = TimestampedPeerInfo(
                     info.peer_info.host,

--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -284,6 +284,8 @@ class AddressManager:
     def mark_good_(self, addr: PeerInfo, test_before_evict: bool, timestamp: int):
         self.last_good = timestamp
         (info, node_id) = self.find_(addr)
+        if not addr.is_valid():
+            return
         if info is None:
             return
         if node_id is None:
@@ -354,6 +356,8 @@ class AddressManager:
             addr.host,
             addr.port,
         )
+        if not peer_info.is_valid():
+            return False
         (info, node_id) = self.find_(peer_info)
         if (
             info is not None

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -207,8 +207,11 @@ class PeerConnections:
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get("http://checkip.amazonaws.com/") as resp:
-                    ip = str(await resp.text())
-                    ip = ip.rstrip()
+                    if resp.status == 200:
+                        ip = str(await resp.text())
+                        ip = ip.rstrip()
+                    else:
+                        ip = None
         except Exception:
             ip = None
         if ip is None:

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -213,7 +213,10 @@ class PeerConnections:
             ip = None
         if ip is None:
             return None
-        return PeerInfo(ip, uint16(port))
+        peer = PeerInfo(ip, uint16(port))
+        if not peer.is_valid():
+            return None
+        return peer
 
     def get_connections(self):
         return self._all_connections

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -206,7 +206,7 @@ class PeerConnections:
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get("http://checkip.amazonaws.com/") as resp:
+                async with session.get("https://checkip.amazonaws.com/") as resp:
                     if resp.status == 200:
                         ip = str(await resp.text())
                         ip = ip.rstrip()

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -242,7 +242,9 @@ class FullNodeDiscovery:
                         time.time() - last_timestamp_local_info > 1800
                         or local_peerinfo is None
                     ):
-                        local_peerinfo = await self.global_connections.get_local_peerinfo()
+                        local_peerinfo = (
+                            await self.global_connections.get_local_peerinfo()
+                        )
                         last_timestamp_local_info = uint64(int(time.time()))
                     if local_peerinfo is not None and addr == local_peerinfo:
                         continue

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -108,7 +108,7 @@ class FullNodeDiscovery:
                     await self.address_manager.add_to_new_table(
                         [timestamped_peer_info], peer_info, 0
                     )
-                    await self.address_manager.mark_good(peer_info, True)
+                    # await self.address_manager.mark_good(peer_info, True)
                     if self.relay_queue is not None:
                         self.relay_queue.put_nowait((timestamped_peer_info, 1))
             except Exception as e:
@@ -447,6 +447,9 @@ class FullNodePeers(FullNodeDiscovery):
         while not self.is_closed:
             try:
                 relay_peer, num_peers = await self.relay_queue.get()
+                relay_peer_info = PeerInfo(relay_peer.host, relay_peer.port)
+                if not relay_peer_info.is_valid():
+                    continue
                 # https://en.bitcoin.it/wiki/Satoshi_Client_Node_Discovery#Address_Relay
                 connections = self.global_connections.get_full_node_connections()
                 hashes = []

--- a/src/server/pipeline.py
+++ b/src/server/pipeline.py
@@ -246,7 +246,7 @@ async def perform_handshake(
         async for conn in global_connections.successful_handshake(connection):
             yield conn, global_connections
     except Exception as e:
-        connection.log.warning(f"{e}, handshake not completed. Connection not created.")
+        connection.log.info(f"{e}, handshake not completed. Connection not created.")
         global_connections.failed_handshake(connection, e)
         # Make sure to close the connection even if it's not in global connections
         connection.close()

--- a/src/types/peer_info.py
+++ b/src/types/peer_info.py
@@ -12,6 +12,23 @@ class PeerInfo(Streamable):
     host: str
     port: uint16
 
+    def is_valid(self):
+        ip = None
+        try:
+            ip = ipaddress.IPv6Address(self.host)
+        except ValueError:
+            ip = None
+        if ip is not None:
+            return True
+
+        try:
+            ip = ipaddress.IPv4Address(self.host)
+        except ValueError:
+            ip = None
+        if ip is not None:
+            return True
+        return False
+
     # Functions related to peer bucketing in new/tried tables.
     def get_key(self):
         try:

--- a/tests/full_node/test_address_manager.py
+++ b/tests/full_node/test_address_manager.py
@@ -288,8 +288,8 @@ class TestPeerManager:
         assert len(peers2) == 2
 
         # Test: Ensure GetPeers works with new and tried addresses.
-        await addrman.mark_good(peer1)
-        await addrman.mark_good(peer2)
+        await addrman.mark_good(PeerInfo(peer1.host, peer1.port))
+        await addrman.mark_good(PeerInfo(peer2.host, peer2.port))
         peers3 = await addrman.get_peers()
         assert len(peers3) == 2
 
@@ -302,7 +302,7 @@ class TestPeerManager:
             )
             await addrman.add_to_new_table([peer])
             if i % 8 == 0:
-                await addrman.mark_good(peer)
+                await addrman.mark_good(PeerInfo(peer.host, peer.port))
 
         peers4 = await addrman.get_peers()
         percent = await addrman.size()


### PR DESCRIPTION
Try to make peer gossip work better by:

- Checking for invalid IP addresses and never store them into new/tried table, never gossip/relay them.
- Catch exceptions in create outbound connections task, which should guarantee we are still discovering peers even if something bad happens.
- Be more cautious self advertisement produces a good IP.
