### PR TITLE
Beta 15

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -114,7 +114,7 @@ jobs:
         ./venv/bin/py.test tests -s -v --durations 0
 
     - name: Upload MacOS artifacts
-      uses: actions/upload-artifact@v2.1.4
+      uses: actions/upload-artifact@v2.2.0
       with:
         name: Chia-Installer-on-MacOS-10.15-dmg
         path: ${{ github.workspace }}/build_scripts/final_installer/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -94,7 +94,7 @@ jobs:
         venv/bin/python -m pip install -r requirements-dev.txt
 
     - name: Setup Node 12.x
-      uses: actions/setup-node@v2.1.1
+      uses: actions/setup-node@v2.1.2
       with:
         node-version: '12.x'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -78,13 +78,13 @@ jobs:
           .\build_scripts\build_windows.ps1
 
       - name: Upload Windows exe's to artifacts
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v2.2.0
         with:
           name: Windows-Exe
           path: ${{ github.workspace }}\electron-react\Chia-win32-x64\
 
       - name: Upload Installer to artifacts
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v2.2.0
         with:
           name: Windows-Installers
           path: ${{ github.workspace }}\electron-react\release-builds\

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -54,7 +54,7 @@ jobs:
         python -m pep517.build --source --out-dir dist .
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2.1.4
+      uses: actions/upload-artifact@v2.2.0
       with:
         name: dist
         path: ./dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
-## Unreleased
+## [1.0beta15] aka Beta 1.15 - 2020-10-07
 
 ### Changed
+- The development tool WalletTool was refactored out.
+- Update to clvm 0.5.3.
+- As k=30 and k=31 are now ruled out for mainnet, the GUI defaults to a plot size of k=32.
 
 ### Fixed
+- Over time the new peer gossip protocol could slowly disconnect all peers and take your node offline.
+- Sometimes on restart the peer connections database could cause fullnode to crash.
 
 ### Added
+- Choosing a larger k size in the GUI also increases the default memory buffer.
 
 ## [1.0beta14] aka Beta 1.14 - 2020-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## Unreleased
+
+### Changed
+
+### Fixed
+
+### Added
+
 ## [1.0beta14] aka Beta 1.14 - 2020-10-01
 
 ### Added

--- a/electron-react/src/modules/store.js
+++ b/electron-react/src/modules/store.js
@@ -13,9 +13,8 @@ const store =
     : createStore(
         rootReducer,
         compose(
-          applyMiddleware(...middleware),
-          window.__REDUX_DEVTOOLS_EXTENSION__ &&
-            window.__REDUX_DEVTOOLS_EXTENSION__()
+          applyMiddleware(...middleware),  /* preloadedState, */
+          window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__() || compose
         )
       );
 

--- a/electron-react/src/pages/Plotter.js
+++ b/electron-react/src/pages/Plotter.js
@@ -193,18 +193,18 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const plot_size_options = [
-  { label: "600MiB", value: 25, workspace: "1.8GiB" },
-  { label: "1.3GiB", value: 26, workspace: "3.6GiB" },
-  { label: "2.7GiB", value: 27, workspace: "9.2GiB" },
-  { label: "5.6GiB", value: 28, workspace: "19GiB" },
-  { label: "11.5GiB", value: 29, workspace: "38GiB" },
-  { label: "23.8GiB", value: 30, workspace: "83GiB" },
-  { label: "49.1GiB", value: 31, workspace: "165GiB" },
-  { label: "101.4GiB", value: 32, workspace: "331GiB" },
-  { label: "208.8GiB", value: 33, workspace: "660GiB" },
+  { label: "600MiB", value: 25, workspace: "1.8GiB", default_ram: 200 },
+  { label: "1.3GiB", value: 26, workspace: "3.6GiB", default_ram: 200 },
+  { label: "2.7GiB", value: 27, workspace: "9.2GiB", default_ram: 200 },
+  { label: "5.6GiB", value: 28, workspace: "19GiB", default_ram: 200 },
+  { label: "11.5GiB", value: 29, workspace: "38GiB", default_ram: 500 },
+  { label: "23.8GiB", value: 30, workspace: "83GiB", default_ram: 1000  },
+  { label: "49.1GiB", value: 31, workspace: "165GiB", default_ram: 2000  },
+  { label: "101.4GiB", value: 32, workspace: "331GiB", default_ram: 3072 },
+  { label: "208.8GiB", value: 33, workspace: "660GiB", default_ram: 6000  },
   // workspace are guesses using 55.35% - rounded up - past here
-  { label: "429.8GiB", value: 34, workspace: "1300GiB" },
-  { label: "884.1GiB", value: 35, workspace: "2600GiB" }
+  { label: "429.8GiB", value: 34, workspace: "1300GiB", default_ram: 12000  },
+  { label: "884.1GiB", value: 35, workspace: "2600GiB", default_ram: 24000  }
 ];
 
 const WorkLocation = () => {
@@ -329,7 +329,7 @@ const CreatePlot = () => {
   const final_location = useSelector(
     state => state.plot_control.final_location
   );
-  const [plotSize, setPlotSize] = React.useState(25);
+  const [plotSize, setPlotSize] = React.useState(32);
   const [plotCount, setPlotCount] = React.useState(1);
   const [maxRam, setMaxRam] = React.useState(3072);
   const [numThreads, setNumThreads] = React.useState(2);
@@ -338,6 +338,11 @@ const CreatePlot = () => {
 
   const changePlotSize = event => {
     setPlotSize(event.target.value);
+    for (let pso of plot_size_options) {
+        if (pso.value == event.target.value) {
+            setMaxRam(pso.default_ram);
+        }
+    }
   };
   const changePlotCount = event => {
     setPlotCount(event.target.value);

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ dependencies = [
     "concurrent-log-handler==0.9.17",  # Concurrently log and rotate logs
     "cryptography==3.1.1",  # Python cryptography library for TLS
     "keyring==21.4.0",  # Store keys in MacOS Keychain, Windows Credential Locker
-    "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)
+    "keyrings.cryptfile==1.3.6",  # Secure storage for keys on Linux (Will be replaced)
     "PyYAML==5.3.1",  # Used for config file format
     "sortedcontainers==2.2.2",  # For maintaining sorted mempools
     "websockets==8.1.0",  # For use in wallet RPC and electron UI

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ dependencies = [
     "concurrent-log-handler==0.9.17",  # Concurrently log and rotate logs
     "cryptography==3.1.1",  # Python cryptography library for TLS
     "keyring==21.4.0",  # Store keys in MacOS Keychain, Windows Credential Locker
-    "keyrings.cryptfile==1.3.6",  # Secure storage for keys on Linux (Will be replaced)
+    "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)
     "PyYAML==5.3.1",  # Used for config file format
     "sortedcontainers==2.2.2",  # For maintaining sorted mempools
     "websockets==8.1.0",  # For use in wallet RPC and electron UI

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ dependencies = [
     "chiavdf==0.12.26",  # timelord and vdf verification
     "chiabip158==0.16",  # bip158-style wallet filters
     "chiapos==0.12.31",  # proof of space
-    "clvm==0.5.1",
+    "clvm==0.5.3",
     "clvm_tools==0.1.6",
     "aiohttp==3.6.2",  # HTTP server for full node rpc
     "aiosqlite@git+https://github.com/mariano54/aiosqlite.git@28cb5754deec562ac931da8fca799fb82df97a12#egg=aiosqlite",

--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -262,7 +262,7 @@ def chia_init(root_path: Path):
     MANIFEST: List[str] = [
         "config",
         "db",
-        # "wallet",
+        "wallet",
     ]
 
     for versionnumber in range(chiaMinorReleaseNumber() - 1, 8, -1):

--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -261,8 +261,8 @@ def chia_init(root_path: Path):
     # These are the files that will be migrated
     MANIFEST: List[str] = [
         "config",
-        "db",
-        "wallet",
+        "db/blockchain_v20.db",
+        # "wallet",
     ]
 
     for versionnumber in range(chiaMinorReleaseNumber() - 1, 8, -1):

--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -539,6 +539,8 @@ class AddressManager:
             rand_pos = randrange(len(self.random_pos) - n) + n
             self.swap_random_(n, rand_pos)
             info = self.map_info[self.random_pos[n]]
+            if not info.peer_info.is_valid():
+                continue
             if not info.is_terrible():
                 cur_peer_info = TimestampedPeerInfo(
                     info.peer_info.host,

--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -284,6 +284,8 @@ class AddressManager:
     def mark_good_(self, addr: PeerInfo, test_before_evict: bool, timestamp: int):
         self.last_good = timestamp
         (info, node_id) = self.find_(addr)
+        if not addr.is_valid():
+            return
         if info is None:
             return
         if node_id is None:
@@ -354,6 +356,8 @@ class AddressManager:
             addr.host,
             addr.port,
         )
+        if not peer_info.is_valid():
+            return False
         (info, node_id) = self.find_(peer_info)
         if (
             info is not None

--- a/src/server/address_manager_store.py
+++ b/src/server/address_manager_store.py
@@ -124,10 +124,7 @@ class AddressManagerStore:
         metadata = []
         nodes = []
         new_table_entries = []
-
         metadata.append(("key", str(address_manager.key)))
-        metadata.append(("new_count", str(address_manager.new_count)))
-        metadata.append(("tried_count", str(address_manager.tried_count)))
 
         unique_ids = {}
         count_ids = 0
@@ -138,6 +135,7 @@ class AddressManagerStore:
                 assert count_ids != address_manager.new_count
                 nodes.append((count_ids, info))
                 count_ids += 1
+        metadata.append(("new_count", str(count_ids)))
 
         tried_ids = 0
         for node_id, info in address_manager.map_info.items():
@@ -147,6 +145,7 @@ class AddressManagerStore:
                 nodes.append((count_ids, info))
                 count_ids += 1
                 tried_ids += 1
+        metadata.append(("tried_count", str(tried_ids)))
 
         for bucket in range(NEW_BUCKET_COUNT):
             for i in range(BUCKET_SIZE):

--- a/src/server/address_manager_store.py
+++ b/src/server/address_manager_store.py
@@ -179,7 +179,7 @@ class AddressManagerStore:
             address_manager.map_info[n] = info
             info.random_pos = len(address_manager.random_pos)
             address_manager.random_pos.append(n)
-
+        address_manager.id_count = len(new_table_nodes)
         tried_table_nodes = [
             (node_id, info)
             for node_id, info in nodes
@@ -194,10 +194,12 @@ class AddressManagerStore:
             if address_manager.tried_matrix[tried_bucket][tried_bucket_pos] == -1:
                 info.random_pos = len(address_manager.random_pos)
                 info.is_tried = True
-                address_manager.random_pos.append(node_id)
-                address_manager.map_info[node_id] = info
-                address_manager.map_addr[info.peer_info.host] = node_id
-                address_manager.tried_matrix[tried_bucket][tried_bucket_pos] = node_id
+                id_count = address_manager.id_count
+                address_manager.random_pos.append(id_count)
+                address_manager.map_info[id_count] = info
+                address_manager.map_addr[info.peer_info.host] = id_count
+                address_manager.tried_matrix[tried_bucket][tried_bucket_pos] = id_count
+                address_manager.id_count += 1
             else:
                 lost_count += 1
 

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -207,8 +207,11 @@ class PeerConnections:
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get("http://checkip.amazonaws.com/") as resp:
-                    ip = str(await resp.text())
-                    ip = ip.rstrip()
+                    if resp.status == 200:
+                        ip = str(await resp.text())
+                        ip = ip.rstrip()
+                    else:
+                        ip = None
         except Exception:
             ip = None
         if ip is None:

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -213,7 +213,10 @@ class PeerConnections:
             ip = None
         if ip is None:
             return None
-        return PeerInfo(ip, uint16(port))
+        peer = PeerInfo(ip, uint16(port))
+        if not peer.is_valid():
+            return None
+        return peer
 
     def get_connections(self):
         return self._all_connections

--- a/src/server/connection.py
+++ b/src/server/connection.py
@@ -206,7 +206,7 @@ class PeerConnections:
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get("http://checkip.amazonaws.com/") as resp:
+                async with session.get("https://checkip.amazonaws.com/") as resp:
                     if resp.status == 200:
                         ip = str(await resp.text())
                         ip = ip.rstrip()

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -242,7 +242,9 @@ class FullNodeDiscovery:
                         time.time() - last_timestamp_local_info > 1800
                         or local_peerinfo is None
                     ):
-                        local_peerinfo = await self.global_connections.get_local_peerinfo()
+                        local_peerinfo = (
+                            await self.global_connections.get_local_peerinfo()
+                        )
                         last_timestamp_local_info = uint64(int(time.time()))
                     if local_peerinfo is not None and addr == local_peerinfo:
                         continue

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -108,7 +108,7 @@ class FullNodeDiscovery:
                     await self.address_manager.add_to_new_table(
                         [timestamped_peer_info], peer_info, 0
                     )
-                    await self.address_manager.mark_good(peer_info, True)
+                    # await self.address_manager.mark_good(peer_info, True)
                     if self.relay_queue is not None:
                         self.relay_queue.put_nowait((timestamped_peer_info, 1))
             except Exception as e:
@@ -447,6 +447,9 @@ class FullNodePeers(FullNodeDiscovery):
         while not self.is_closed:
             try:
                 relay_peer, num_peers = await self.relay_queue.get()
+                relay_peer_info = PeerInfo(relay_peer.host, relay_peer.port)
+                if not relay_peer_info.is_valid():
+                    continue
                 # https://en.bitcoin.it/wiki/Satoshi_Client_Node_Discovery#Address_Relay
                 connections = self.global_connections.get_full_node_connections()
                 hashes = []

--- a/src/server/pipeline.py
+++ b/src/server/pipeline.py
@@ -246,7 +246,7 @@ async def perform_handshake(
         async for conn in global_connections.successful_handshake(connection):
             yield conn, global_connections
     except Exception as e:
-        connection.log.warning(f"{e}, handshake not completed. Connection not created.")
+        connection.log.info(f"{e}, handshake not completed. Connection not created.")
         global_connections.failed_handshake(connection, e)
         # Make sure to close the connection even if it's not in global connections
         connection.close()

--- a/src/types/peer_info.py
+++ b/src/types/peer_info.py
@@ -12,6 +12,23 @@ class PeerInfo(Streamable):
     host: str
     port: uint16
 
+    def is_valid(self):
+        ip = None
+        try:
+            ip = ipaddress.IPv6Address(self.host)
+        except ValueError:
+            ip = None
+        if ip is not None:
+            return True
+
+        try:
+            ip = ipaddress.IPv4Address(self.host)
+        except ValueError:
+            ip = None
+        if ip is not None:
+            return True
+        return False
+
     # Functions related to peer bucketing in new/tried tables.
     def get_key(self):
         try:

--- a/src/util/block_tools.py
+++ b/src/util/block_tools.py
@@ -182,10 +182,10 @@ class BlockTools:
                 return AugSchemeMPL.sign(sk_child, bytes(pool_target))
         return None
 
-    def get_farmer_wallet_tool(self):
+    def get_farmer_wallet_tool(self) -> WalletTool:
         return WalletTool(self.farmer_master_sk)
 
-    def get_pool_wallet_tool(self):
+    def get_pool_wallet_tool(self) -> WalletTool:
         return WalletTool(self.pool_master_sk)
 
     def get_consecutive_blocks(

--- a/src/wallet/cc_wallet/cc_wallet.py
+++ b/src/wallet/cc_wallet/cc_wallet.py
@@ -57,16 +57,12 @@ class CCWallet:
         wallet_state_manager: Any,
         wallet: Wallet,
         amount: uint64,
-        name: str = None,
     ):
         self = CCWallet()
         self.base_puzzle_program = None
         self.base_inner_puzzle_hash = None
         self.standard_wallet = wallet
-        if name:
-            self.log = logging.getLogger(name)
-        else:
-            self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger(__name__)
 
         self.wallet_state_manager = wallet_state_manager
 
@@ -143,17 +139,13 @@ class CCWallet:
         wallet_state_manager: Any,
         wallet: Wallet,
         genesis_checker_hex: str,
-        name: str = None,
     ) -> CCWallet:
 
         self = CCWallet()
         self.base_puzzle_program = None
         self.base_inner_puzzle_hash = None
         self.standard_wallet = wallet
-        if name:
-            self.log = logging.getLogger(name)
-        else:
-            self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger(__name__)
 
         self.wallet_state_manager = wallet_state_manager
 
@@ -175,14 +167,10 @@ class CCWallet:
         wallet_state_manager: Any,
         wallet: Wallet,
         wallet_info: WalletInfo,
-        name: str = None,
     ) -> CCWallet:
         self = CCWallet()
 
-        if name:
-            self.log = logging.getLogger(name)
-        else:
-            self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger(__name__)
 
         self.wallet_state_manager = wallet_state_manager
         self.wallet_info = wallet_info

--- a/src/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/src/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -28,8 +28,10 @@ from .load_clvm import load_clvm
 from .p2_conditions import puzzle_for_conditions
 
 
-DEFAULT_HIDDEN_PUZZLE = Program.from_bytes(
-    bytes.fromhex("ff0980")
+DEFAULT_HIDDEN_PUZZLE = Program.from_bytes(bytes.fromhex("ff0980"))
+
+DEFAULT_HIDDEN_PUZZLE_HASH = (
+    DEFAULT_HIDDEN_PUZZLE.get_tree_hash()
 )  # this puzzle `(x)` always fails
 
 MOD = load_clvm("p2_delegated_puzzle_or_hidden_puzzle.clvm")
@@ -38,18 +40,22 @@ SYNTHETIC_MOD = load_clvm("calculate_synthetic_public_key.clvm")
 
 PublicKeyProgram = Union[bytes, Program]
 
+GROUP_ORDER = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
+
 
 def calculate_synthetic_offset(
     public_key: G1Element, hidden_puzzle_hash: bytes32
 ) -> int:
     blob = hashlib.sha256(bytes(public_key) + hidden_puzzle_hash).digest()
-    return int_from_bytes(blob)
+    offset = int_from_bytes(blob)
+    offset %= GROUP_ORDER
+    return offset
 
 
 def calculate_synthetic_public_key(
-    public_key: G1Element, hidden_puzzle: Program
+    public_key: G1Element, hidden_puzzle_hash: bytes32
 ) -> G1Element:
-    r = SYNTHETIC_MOD.run([bytes(public_key), hidden_puzzle.get_tree_hash()])
+    r = SYNTHETIC_MOD.run([bytes(public_key), hidden_puzzle_hash])
     return G1Element.from_bytes(r.as_atom())
 
 
@@ -57,19 +63,31 @@ def puzzle_for_synthetic_public_key(synthetic_public_key: G1Element) -> Program:
     return MOD.curry(bytes(synthetic_public_key))
 
 
-def puzzle_for_public_key_and_hidden_puzzle(
-    public_key: G1Element, hidden_puzzle: Program
+def puzzle_for_public_key_and_hidden_puzzle_hash(
+    public_key: G1Element, hidden_puzzle_hash: bytes32
 ) -> Program:
-    synthetic_public_key = calculate_synthetic_public_key(public_key, hidden_puzzle)
+    synthetic_public_key = calculate_synthetic_public_key(
+        public_key, hidden_puzzle_hash
+    )
 
     return puzzle_for_synthetic_public_key(synthetic_public_key)
 
 
+def puzzle_for_public_key_and_hidden_puzzle(
+    public_key: G1Element, hidden_puzzle: Program
+) -> Program:
+    return puzzle_for_public_key_and_hidden_puzzle_hash(
+        public_key, hidden_puzzle.get_tree_hash()
+    )
+
+
 def puzzle_for_pk(public_key: G1Element) -> Program:
-    return puzzle_for_public_key_and_hidden_puzzle(public_key, DEFAULT_HIDDEN_PUZZLE)
+    return puzzle_for_public_key_and_hidden_puzzle_hash(
+        public_key, DEFAULT_HIDDEN_PUZZLE_HASH
+    )
 
 
-def solution_with_delegated_puzzle(
+def solution_for_delegated_puzzle(
     delegated_puzzle: Program, solution: Program
 ) -> Program:
     return Program.to([[], delegated_puzzle, solution])
@@ -91,4 +109,4 @@ def solution_with_hidden_puzzle(
 
 def solution_for_conditions(conditions: Program) -> Program:
     delegated_puzzle = puzzle_for_conditions(conditions)
-    return solution_with_delegated_puzzle(delegated_puzzle, Program.to(0))
+    return solution_for_delegated_puzzle(delegated_puzzle, Program.to(0))

--- a/src/wallet/rl_wallet/rl_wallet.py
+++ b/src/wallet/rl_wallet/rl_wallet.py
@@ -1,5 +1,3 @@
-import logging
-
 # RLWallet is subclass of Wallet
 from dataclasses import dataclass
 import time
@@ -55,7 +53,6 @@ class RLWallet:
     rl_info: RLInfo
     main_wallet: Wallet
     private_key: PrivateKey
-    log: logging.Logger
 
     @staticmethod
     async def create_rl_admin(

--- a/src/wallet/secret_key_store.py
+++ b/src/wallet/secret_key_store.py
@@ -1,0 +1,19 @@
+from typing import Dict, Optional
+
+from blspy import G1Element, PrivateKey
+
+GROUP_ORDER = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
+
+
+class SecretKeyStore:
+    _pk2sk: Dict[G1Element, PrivateKey]
+
+    def __init__(self):
+        self._pk2sk = {}
+
+    def save_secret_key(self, secret_key: PrivateKey):
+        public_key = secret_key.get_g1()
+        self._pk2sk[bytes(public_key)] = secret_key
+
+    def secret_key_for_public_key(self, public_key: G1Element) -> Optional[PrivateKey]:
+        return self._pk2sk.get(bytes(public_key))

--- a/src/wallet/sign_coin_solutions.py
+++ b/src/wallet/sign_coin_solutions.py
@@ -1,0 +1,40 @@
+from typing import Callable, List, Optional
+from blspy import AugSchemeMPL, PrivateKey
+from src.types.coin_solution import CoinSolution
+from src.types.spend_bundle import SpendBundle
+from src.util.condition_tools import (
+    conditions_dict_for_solution,
+    pkm_pairs_for_conditions_dict,
+)
+
+
+async def sign_coin_solutions(
+    coin_solutions: List[CoinSolution],
+    secret_key_for_public_key_f: Callable[[bytes], Optional[PrivateKey]],
+) -> SpendBundle:
+    signatures = []
+
+    for coin_solution in coin_solutions:
+        # Get AGGSIG conditions
+        err, conditions_dict, cost = conditions_dict_for_solution(
+            coin_solution.solution
+        )
+        if err or conditions_dict is None:
+            error_msg = f"Sign transaction failed, con:{conditions_dict}, error: {err}"
+            raise ValueError(error_msg)
+
+        # Create signature
+        for _, msg in pkm_pairs_for_conditions_dict(
+            conditions_dict, bytes(coin_solution.coin)
+        ):
+            secret_key = secret_key_for_public_key_f(_)
+            if secret_key is None:
+                e_msg = f"no secret key for {_}"
+                raise ValueError(e_msg)
+            assert bytes(secret_key.get_g1()) == bytes(_)
+            signature = AugSchemeMPL.sign(secret_key, msg)
+            signatures.append(signature)
+
+    # Aggregate signatures
+    aggsig = AugSchemeMPL.aggregate(signatures)
+    return SpendBundle(coin_solutions, aggsig)

--- a/tests/full_node/test_address_manager.py
+++ b/tests/full_node/test_address_manager.py
@@ -288,8 +288,8 @@ class TestPeerManager:
         assert len(peers2) == 2
 
         # Test: Ensure GetPeers works with new and tried addresses.
-        await addrman.mark_good(peer1)
-        await addrman.mark_good(peer2)
+        await addrman.mark_good(PeerInfo(peer1.host, peer1.port))
+        await addrman.mark_good(PeerInfo(peer2.host, peer2.port))
         peers3 = await addrman.get_peers()
         assert len(peers3) == 2
 
@@ -302,7 +302,7 @@ class TestPeerManager:
             )
             await addrman.add_to_new_table([peer])
             if i % 8 == 0:
-                await addrman.mark_good(peer)
+                await addrman.mark_good(PeerInfo(peer.host, peer.port))
 
         peers4 = await addrman.get_peers()
         percent = await addrman.size()

--- a/tests/full_node/test_blockchain_transactions.py
+++ b/tests/full_node/test_blockchain_transactions.py
@@ -22,6 +22,9 @@ from src.util.wallet_tools import WalletTool
 
 BURN_PUZZLE_HASH = b"0" * 32
 
+WALLET_A = WalletTool()
+WALLET_A_PUZZLE_HASHES = [WALLET_A.get_new_puzzlehash() for _ in range(5)]
+
 
 @pytest.fixture(scope="module")
 def event_loop():
@@ -45,8 +48,8 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_basic_blockchain_tx(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
@@ -128,8 +131,8 @@ class TestBlockchainTransactions:
     async def test_validate_blockchain_with_double_spend(self, two_nodes):
 
         num_blocks = 5
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
@@ -171,8 +174,8 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_validate_blockchain_duplicate_output(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
@@ -214,8 +217,8 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_validate_blockchain_with_reorg_double_spend(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
@@ -374,11 +377,11 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_validate_blockchain_spend_reorg_coin(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        receiver_1_puzzlehash = wallet_a.get_new_puzzlehash()
-        receiver_2_puzzlehash = wallet_a.get_new_puzzlehash()
-        receiver_3_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
+        receiver_1_puzzlehash = WALLET_A_PUZZLE_HASHES[1]
+        receiver_2_puzzlehash = WALLET_A_PUZZLE_HASHES[2]
+        receiver_3_puzzlehash = WALLET_A_PUZZLE_HASHES[3]
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -492,9 +495,9 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_validate_blockchain_spend_reorg_cb_coin(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        receiver_1_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
+        receiver_1_puzzlehash = WALLET_A_PUZZLE_HASHES[1]
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -564,9 +567,9 @@ class TestBlockchainTransactions:
         self, two_nodes_standard_freeze
     ):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        receiver_1_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
+        receiver_1_puzzlehash = WALLET_A_PUZZLE_HASHES[1]
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -617,9 +620,9 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_validate_blockchain_spend_reorg_since_genesis(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        receiver_1_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
+        receiver_1_puzzlehash = WALLET_A_PUZZLE_HASHES[1]
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -675,8 +678,8 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_assert_my_coin_id(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
@@ -754,8 +757,8 @@ class TestBlockchainTransactions:
     async def test_assert_coin_consumed(self, two_nodes):
 
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
@@ -840,8 +843,8 @@ class TestBlockchainTransactions:
     async def test_assert_block_index_exceeds(self, two_nodes):
 
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
@@ -911,8 +914,8 @@ class TestBlockchainTransactions:
     async def test_assert_block_age_exceeds(self, two_nodes):
 
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
@@ -983,8 +986,8 @@ class TestBlockchainTransactions:
     async def test_assert_time_exceeds(self, two_nodes):
 
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
@@ -1057,8 +1060,8 @@ class TestBlockchainTransactions:
     @pytest.mark.asyncio
     async def test_invalid_filter(self, two_nodes):
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
@@ -1151,8 +1154,8 @@ class TestBlockchainTransactions:
     async def test_assert_fee_condition(self, two_nodes):
 
         num_blocks = 10
-        wallet_a = WalletTool()
-        coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
+        wallet_a = WALLET_A
+        coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
         receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks

--- a/tests/full_node/test_blockchain_transactions.py
+++ b/tests/full_node/test_blockchain_transactions.py
@@ -20,6 +20,8 @@ from src.util.ints import uint64
 from tests.setup_nodes import setup_two_nodes, test_constants, bt
 from src.util.wallet_tools import WalletTool
 
+BURN_PUZZLE_HASH = b"0" * 32
+
 
 @pytest.fixture(scope="module")
 def event_loop():
@@ -45,8 +47,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -129,8 +130,7 @@ class TestBlockchainTransactions:
         num_blocks = 5
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -173,8 +173,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -217,8 +216,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -679,8 +677,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
         blocks = bt.get_consecutive_blocks(
@@ -759,8 +756,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
         blocks = bt.get_consecutive_blocks(
@@ -846,8 +842,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
         blocks = bt.get_consecutive_blocks(
@@ -918,8 +913,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
         blocks = bt.get_consecutive_blocks(
@@ -991,8 +985,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
         blocks = bt.get_consecutive_blocks(
@@ -1066,8 +1059,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(
             test_constants, num_blocks, [], 10, b"", coinbase_puzzlehash
@@ -1161,8 +1153,7 @@ class TestBlockchainTransactions:
         num_blocks = 10
         wallet_a = WalletTool()
         coinbase_puzzlehash = wallet_a.get_new_puzzlehash()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         # Farm blocks
         blocks = bt.get_consecutive_blocks(

--- a/tests/full_node/test_mempool.py
+++ b/tests/full_node/test_mempool.py
@@ -18,9 +18,9 @@ from src.util.condition_tools import (
 from src.util.clvm import int_to_bytes
 from src.util.ints import uint64
 from tests.setup_nodes import setup_two_nodes, test_constants, bt
-from src.util.wallet_tools import WalletTool
 
 BURN_PUZZLE_HASH = b"0" * 32
+BURN_PUZZLE_HASH_2 = b"1" * 32
 
 
 @pytest.fixture(scope="module")
@@ -146,9 +146,8 @@ class TestMempool:
             # Maybe transaction means that it's accepted in mempool
             assert outbound.message.function == "new_transaction"
 
-        other_receiver = WalletTool()
         spend_bundle2 = wallet_a.generate_signed_transaction(
-            1000, other_receiver.get_new_puzzlehash(), block.get_coinbase()
+            1000, BURN_PUZZLE_HASH_2, block.get_coinbase()
         )
         assert spend_bundle2 is not None
         tx2: full_node_protocol.RespondTransaction = (
@@ -817,9 +816,8 @@ class TestMempool:
 
         assert spend_bundle1 is not None
 
-        other_receiver = WalletTool()
         spend_bundle2 = wallet_a.generate_signed_transaction(
-            1000, other_receiver.get_new_puzzlehash(), block.get_coinbase()
+            1000, BURN_PUZZLE_HASH_2, block.get_coinbase()
         )
 
         assert spend_bundle2 is not None

--- a/tests/full_node/test_mempool.py
+++ b/tests/full_node/test_mempool.py
@@ -20,6 +20,8 @@ from src.util.ints import uint64
 from tests.setup_nodes import setup_two_nodes, test_constants, bt
 from src.util.wallet_tools import WalletTool
 
+BURN_PUZZLE_HASH = b"0" * 32
+
 
 @pytest.fixture(scope="module")
 def event_loop():
@@ -44,8 +46,7 @@ class TestMempool:
     async def test_basic_mempool(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -75,8 +76,7 @@ class TestMempool:
     async def test_coinbase_freeze(self, two_nodes_small_freeze):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes_small_freeze
@@ -122,8 +122,7 @@ class TestMempool:
     async def test_double_spend(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -168,8 +167,7 @@ class TestMempool:
     async def test_double_spend_with_higher_fee(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -213,8 +211,7 @@ class TestMempool:
     async def test_invalid_block_index(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -253,8 +250,7 @@ class TestMempool:
     async def test_correct_block_index(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -293,8 +289,7 @@ class TestMempool:
     async def test_invalid_block_age(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -331,8 +326,7 @@ class TestMempool:
     async def test_correct_block_age(self, two_nodes):
         num_blocks = 4
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -371,8 +365,7 @@ class TestMempool:
     async def test_correct_my_id(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -411,8 +404,7 @@ class TestMempool:
     async def test_invalid_my_id(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -453,8 +445,7 @@ class TestMempool:
     async def test_assert_time_exceeds(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -495,8 +486,7 @@ class TestMempool:
     async def test_assert_time_exceeds_both_cases(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -550,8 +540,7 @@ class TestMempool:
     async def test_correct_coin_consumed(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -598,8 +587,7 @@ class TestMempool:
     async def test_invalid_coin_consumed(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -643,8 +631,7 @@ class TestMempool:
     async def test_assert_fee_condition(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -695,8 +682,7 @@ class TestMempool:
     async def test_assert_fee_condition_wrong_fee(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -748,7 +734,7 @@ class TestMempool:
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
         wallet_receiver = bt.get_farmer_wallet_tool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
 
@@ -814,8 +800,7 @@ class TestMempool:
     async def test_double_spend_same_bundle(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -855,8 +840,7 @@ class TestMempool:
     async def test_agg_sig_condition(self, two_nodes):
         num_blocks = 2
         wallet_a = bt.get_pool_wallet_tool()
-        wallet_receiver = WalletTool()
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        receiver_puzzlehash = BURN_PUZZLE_HASH
 
         blocks = bt.get_consecutive_blocks(test_constants, num_blocks, [], 10, b"")
         full_node_1, full_node_2, server_1, server_2 = two_nodes

--- a/tests/test_cost_calculation.py
+++ b/tests/test_cost_calculation.py
@@ -6,7 +6,8 @@ from src.full_node.bundle_tools import best_solution_program
 from src.full_node.cost_calculator import calculate_cost_of_program
 from src.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from tests.setup_nodes import test_constants, bt
-from src.util.wallet_tools import WalletTool
+
+BURN_PUZZLE_HASH = b"0" * 32
 
 
 @pytest.fixture(scope="module")
@@ -19,7 +20,6 @@ class TestCostCalculation:
     @pytest.mark.asyncio
     async def test_basics(self):
         wallet_tool = bt.get_pool_wallet_tool()
-        receiver = WalletTool()
 
         num_blocks = 2
         blocks = bt.get_consecutive_blocks(
@@ -31,7 +31,7 @@ class TestCostCalculation:
 
         spend_bundle = wallet_tool.generate_signed_transaction(
             blocks[1].get_coinbase().amount,
-            receiver.get_new_puzzlehash(),
+            BURN_PUZZLE_HASH,
             blocks[1].get_coinbase(),
         )
         assert spend_bundle is not None

--- a/tests/test_merkle_set.py
+++ b/tests/test_merkle_set.py
@@ -4,7 +4,6 @@ import pytest
 
 from src.util.merkle_set import MerkleSet, confirm_included_already_hashed
 from tests.setup_nodes import test_constants, bt
-from src.util.wallet_tools import WalletTool
 
 
 @pytest.fixture(scope="module")
@@ -16,8 +15,6 @@ def event_loop():
 class TestMerkleSet:
     @pytest.mark.asyncio
     async def test_basics(self):
-        WalletTool()
-
         num_blocks = 10
         blocks = bt.get_consecutive_blocks(
             test_constants,

--- a/tests/wallet/test_taproot.py
+++ b/tests/wallet/test_taproot.py
@@ -1,0 +1,21 @@
+from blspy import G1Element
+
+from src.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
+    DEFAULT_HIDDEN_PUZZLE,
+    calculate_synthetic_offset,
+    calculate_synthetic_public_key,
+)
+
+
+class TestTaproot:
+    def test_1(self):
+        for main_secret_exponent in range(500, 600):
+            hidden_puzzle_hash = DEFAULT_HIDDEN_PUZZLE.get_tree_hash()
+            main_pubkey = G1Element.generator() * main_secret_exponent
+            offset = calculate_synthetic_offset(main_pubkey, hidden_puzzle_hash)
+            offset_pubkey = G1Element.generator() * offset
+            spk1 = main_pubkey + offset_pubkey
+            spk2 = calculate_synthetic_public_key(main_pubkey, hidden_puzzle_hash)
+            assert spk1 == spk2
+
+        return 0


### PR DESCRIPTION
### Changed
- The development tool WalletTool was refactored out.
- Update to clvm 0.5.3.
- As k=30 and k=31 are now ruled out for mainnet, the GUI defaults to a plot size of k=32.

### Fixed
- Over time the new peer gossip protocol could slowly disconnect all peers and take your node offline.
- Sometimes on restart the peer connections database could cause fullnode to crash.

### Added
- Choosing a larger k size in the GUI also increases the default memory buffer.