### PR TITLE
fix uri from master to main branch

### DIFF
--- a/electron-react/src/components/locale/LocaleToggle.tsx
+++ b/electron-react/src/components/locale/LocaleToggle.tsx
@@ -60,7 +60,7 @@ export default function LocaleToggle() {
         ))}
         <MenuItem
           component="a"
-          href="https://github.com/Chia-Network/chia-blockchain/tree/master/electron-react/src/locales/README.md"
+          href="https://github.com/Chia-Network/chia-blockchain/tree/main/electron-react/src/locales/README.md"
           target="_blank"
           onClick={() => handleClose()}
         >


### PR DESCRIPTION
The **Help to Translate** menu item points to the `master` branch. This switches it to `main`