### PR TITLE
Add chia plots create  -a [alt fingerprint]

### DIFF
--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -21,9 +21,10 @@ def help_message():
     print(f"command can be any of {command_list}")
     print("")
     print(
-        "chia plots create -k [size] -n [number of plots] -b [memory buffer size MiB] "
-        + "-r [number of threads] -u [number of buckets] -s [stripe size]"
-        + " -f [farmer pk] -p [pool pk] -t [tmp dir] -2 [tmp dir 2] -d [final dir]  (creates plots)"
+        "chia plots create -k [size] -n [number of plots] -b [memory buffer size MiB]"
+        + " -r [number of threads] -u [number of buckets] -s [stripe size]"
+        + " -a [fingerprint] -f [farmer public key] -p [pool public key]"
+        + " -t [tmp dir] -2 [tmp dir 2] -d [final dir] (creates plots)"
     )
     print("-i [plotid] [-m memo] are available for debugging")
     print("chia plots check -n [num checks] -g [string] (checks plots)")
@@ -50,6 +51,13 @@ def make_parser(parser):
     )
     parser.add_argument("-s", "--stripe_size", help="Stripe size", type=int, default=0)
     parser.add_argument(
+        "-a",
+        "--alt_fingerprint",
+        type=int,
+        default=None,
+        help="Enter the alternative fingerprint of the key you want to use",
+    )
+    parser.add_argument(
         "-f",
         "--farmer_public_key",
         help="Hex farmer public key",
@@ -57,14 +65,14 @@ def make_parser(parser):
         default=None,
     )
     parser.add_argument(
+        "-p", "--pool_public_key", help="Hex public key of pool", type=str, default=None
+    )
+    parser.add_argument(
         "-g",
         "--grep_string",
         help="Shows only plots that contain the string in the filename or directory name",
         type=str,
         default=None,
-    )
-    parser.add_argument(
-        "-p", "--pool_public_key", help="Hex public key of pool", type=str, default=None
     )
     parser.add_argument(
         "-t",

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from secrets import token_bytes
-from typing import Optional, List
+from typing import Optional, List, Tuple
 import logging
 from blspy import AugSchemeMPL, G1Element, PrivateKey
 from chiapos import DiskPlotter
@@ -25,7 +25,8 @@ from src.wallet.derive_keys import (
 log = logging.getLogger(__name__)
 
 
-def get_farmer_public_key(alt_fingerprint=None) -> G1Element:
+def get_farmer_public_key(alt_fingerprint: Optional[int] = None) -> G1Element:
+    sk_ent: Optional[Tuple[PrivateKey, bytes]]
     keychain: Keychain = Keychain()
     if alt_fingerprint is not None:
         sk_ent = keychain.get_private_key_by_fingerprint(alt_fingerprint)
@@ -38,7 +39,8 @@ def get_farmer_public_key(alt_fingerprint=None) -> G1Element:
     return master_sk_to_farmer_sk(sk_ent[0]).get_g1()
 
 
-def get_pool_public_key(alt_fingerprint=None) -> G1Element:
+def get_pool_public_key(alt_fingerprint: Optional[int] = None) -> G1Element:
+    sk_ent: Optional[Tuple[PrivateKey, bytes]]
     keychain: Keychain = Keychain()
     if alt_fingerprint is not None:
         sk_ent = keychain.get_private_key_by_fingerprint(alt_fingerprint)

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -59,22 +59,17 @@ def create_plots(
     if args.tmp2_dir is None:
         args.tmp2_dir = args.tmp_dir
 
-    if args.alt_fingerprint is not None:
-        alt_fingerprint = args.alt_fingerprint
-    else:
-        alt_fingerprint = None
-
     farmer_public_key: G1Element
     if args.farmer_public_key is not None:
         farmer_public_key = G1Element.from_bytes(bytes.fromhex(args.farmer_public_key))
     else:
-        farmer_public_key = get_farmer_public_key(alt_fingerprint)
+        farmer_public_key = get_farmer_public_key(args.alt_fingerprint)
 
     pool_public_key: G1Element
     if args.pool_public_key is not None:
         pool_public_key = bytes.fromhex(args.pool_public_key)
     else:
-        pool_public_key = get_pool_public_key(alt_fingerprint)
+        pool_public_key = get_pool_public_key(args.alt_fingerprint)
     if args.num is not None:
         num = args.num
     else:

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -25,22 +25,28 @@ from src.wallet.derive_keys import (
 log = logging.getLogger(__name__)
 
 
-def get_default_farmer_public_key() -> G1Element:
+def get_farmer_public_key(alt_fingerprint=None) -> G1Element:
     keychain: Keychain = Keychain()
-    sk_ent = keychain.get_first_private_key()
+    if alt_fingerprint is not None:
+        sk_ent = keychain.get_private_key_by_fingerprint(alt_fingerprint)
+    else:
+        sk_ent = keychain.get_first_private_key()
     if sk_ent is None:
         raise RuntimeError(
-            "No keys, please run 'chia keys generate' or provide a public key with -f"
+            "No keys, please run 'chia keys add', 'chia keys generate' or provide a public key with -f"
         )
     return master_sk_to_farmer_sk(sk_ent[0]).get_g1()
 
 
-def get_default_pool_public_key() -> G1Element:
+def get_pool_public_key(alt_fingerprint=None) -> G1Element:
     keychain: Keychain = Keychain()
-    sk_ent = keychain.get_first_private_key()
+    if alt_fingerprint is not None:
+        sk_ent = keychain.get_private_key_by_fingerprint(alt_fingerprint)
+    else:
+        sk_ent = keychain.get_first_private_key()
     if sk_ent is None:
         raise RuntimeError(
-            "No keys, please run 'chia keys generate' or provide a public key with -f"
+            "No keys, please run 'chia keys add', 'chia keys generate' or provide a public key with -p"
         )
     return master_sk_to_pool_sk(sk_ent[0]).get_g1()
 
@@ -53,17 +59,22 @@ def create_plots(
     if args.tmp2_dir is None:
         args.tmp2_dir = args.tmp_dir
 
+    if args.alt_fingerprint is not None:
+        alt_fingerprint = args.alt_fingerprint
+    else:
+        alt_fingerprint = None
+
     farmer_public_key: G1Element
     if args.farmer_public_key is not None:
         farmer_public_key = G1Element.from_bytes(bytes.fromhex(args.farmer_public_key))
     else:
-        farmer_public_key = get_default_farmer_public_key()
+        farmer_public_key = get_farmer_public_key(alt_fingerprint)
 
     pool_public_key: G1Element
     if args.pool_public_key is not None:
         pool_public_key = bytes.fromhex(args.pool_public_key)
     else:
-        pool_public_key = get_default_pool_public_key()
+        pool_public_key = get_pool_public_key(alt_fingerprint)
     if args.num is not None:
         num = args.num
     else:

--- a/src/util/keychain.py
+++ b/src/util/keychain.py
@@ -216,8 +216,7 @@ class Keychain:
         return None
 
     def get_private_key_by_fingerprint(
-        self, fingerprint: int,
-        passphrases: List[str] = [""]
+        self, fingerprint: int, passphrases: List[str] = [""]
     ) -> Optional[Tuple[PrivateKey, bytes]]:
         """
         Return first private key which have the given public key fingerprint.

--- a/src/util/keychain.py
+++ b/src/util/keychain.py
@@ -215,6 +215,28 @@ class Keychain:
             pkent = self._get_pk_and_entropy(self._get_private_key_user(index))
         return None
 
+    def get_private_key_by_fingerprint(
+        self, fingerprint: int,
+        passphrases: List[str] = [""]
+    ) -> Optional[Tuple[PrivateKey, bytes]]:
+        """
+        Return first private key which have the given public key fingerprint.
+        """
+        index = 0
+        pkent = self._get_pk_and_entropy(self._get_private_key_user(index))
+        while index <= MAX_KEYS:
+            if pkent is not None:
+                pk, ent = pkent
+                for pp in passphrases:
+                    mnemonic = bytes_to_mnemonic(ent)
+                    seed = mnemonic_to_seed(mnemonic, pp)
+                    key = AugSchemeMPL.key_gen(seed)
+                    if pk.get_fingerprint() == fingerprint:
+                        return (key, ent)
+            index += 1
+            pkent = self._get_pk_and_entropy(self._get_private_key_user(index))
+        return None
+
     def get_all_private_keys(
         self, passphrases: List[str] = [""]
     ) -> List[Tuple[PrivateKey, bytes]]:


### PR DESCRIPTION
Allows user to create plots using different keys in their keychain by specifying an alternative fingerprint. Default behavior without the -a flag is to load keys for the first fingerprint in the keychain. -f and -p flag behavior is preserved and will override keys loaded by -a.