### PR TITLE
Beta 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ for setuptools_scm/PEP 440 reasons.
 ### Changed
 
 - We have moved from using gulrak/filesystem across all platforms to only using it on MacOS. It's required on MacOS as we are still targeting Mojave compatibility. This should resolve Windows path issues.
+- We upgraded to cbor 5.2.0 but expect to deprecate cbor in a future release.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## [1.0beta18] aka Beta 1.18 - 2020-12-03
+
+### Added
+
+- F1 generation in the plotter is now fully parallel for a small speedup.
+- We have bitfield optimized phase 2 of plotting. There is only about a 1% increase in speed from this change but there is a 12% decrease in writes with a penalty of 3% more reads. More details in [PR 120](https://github.com/Chia-Network/chiapos/pull/120). Note that some sorts in phase 2 and phase 3 will now appear "out of order" and that is now expected behavior.
+- Partial support for Python 3.9. That includes new versions of Chia dependencies like chiabip158.
+
+### Changed
+
+- We have moved from using gulrak/filesystem across all platforms to only using it on MacOS. It's required on MacOS as we are still targeting Mojave compatibility. This should resolve Windows path issues.
+
+### Fixed
+
+- A segfault caused by memory leaks in bls-library has been fixed. This should end the random farmer and harvester crashes over time as outlined in [Issue 500](https://github.com/Chia-Network/chia-blockchain/issues/500).
+- Plotting could hang up retrying in an "error 0" state due to a bug in table handling in some edge cases.
+- CPU utilization as reported in the plotter is now accurate for Windows.
+- FreeBSD and OpenBSD should be able to build and install chia-blockchain and its dependencies again.
+- Starting with recent setuptools fixes, we can no longer pass an empty string to the linker on Windows when building binary wheels in the sub repos. Thanks @jaraco for tracking this down.
+
 ## [1.0beta17] aka Beta 1.17 - 2020-10-22
 
 ### Changed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,14 +45,15 @@ steps:
       python -m pip install --upgrade pip
       pip install wheel pep517 setuptools_scm
       node -v
-      pip install -i https://download.chia.net/simple/ miniupnpc==2.1 setproctitle==1.1.10 cbor2==5.1.0
+      pip install -i https://download.chia.net/simple/ miniupnpc==2.1 setproctitle==1.1.10
     displayName: "Install dependencies"
 
   - script: |
       . ./activate
       clang --version
       pip wheel --use-pep517 --only-binary cbor2 --extra-index-url https://download.chia.net/simple/ --wheel-dir=wheels .
-    displayName: "Build wheels"
+      pip install --no-index --find-links=./wheels/ chia-blockchain
+    displayName: "Build and install wheels"
 
   - task: NodeTool@0
     inputs:
@@ -64,13 +65,7 @@ steps:
       cd ./electron-react
       npm install
       npm audit fix
-    displayName: "Build Electron UI"
-
-  #  Using wheels and release style install so no sh install.sh
-  - script: |
-      . ./activate
-      pip install .
-    displayName: "Install wheels"
+    displayName: "Build Electron/React UI"
 
 #  install-timelord.sh in venv
 #  - script: |

--- a/install.sh
+++ b/install.sh
@@ -2,68 +2,64 @@
 set -e
 UBUNTU=false
 if [ "$(uname)" = "Linux" ]; then
-  #LINUX=1
-  if type apt-get; then
-    UBUNTU=true
-  fi
+	#LINUX=1
+	if type apt-get; then
+		UBUNTU=true
+	fi
 fi
 
 UBUNTU_PRE_2004=false
 if $UBUNTU; then
-  LSB_RELEASE=$(lsb_release -rs)
-  UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20.04" | bc)
+	LSB_RELEASE=$(lsb_release -rs)
+	UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20.04" | bc)
 fi
 
 # Manage npm and other install requirements on an OS specific basis
 if [ "$(uname)" = "Linux" ]; then
-  #LINUX=1
-  if [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "1" ]; then
-    # Debian/Ubuntu
-    echo "Installing on Ubuntu/Debian pre 20.04 LTS"
-    sudo apt-get update
-    sudo apt-get install -y  python3.7-venv python3.7-distutils
-  elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ]; then
-    echo "Installing on Ubuntu/Debian 20.04 LTS or newer"
-    sudo apt-get update
-    sudo apt-get install -y  python3.8-venv python3.8-distutils
-  elif type yum && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ]; then
-    # AMZN 2
-    echo "Installing on Amazon Linux 2"
-    sudo yum install -y python3 git
-  elif type yum && [ -f /etc/redhat-release ] || [ -f /etc/centos-release ]; then
-    # CentOS or Redhat
-    echo "Installing on CentOS/Redhat"
-  fi
+	#LINUX=1
+	if [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "1" ]; then
+		# Debian/Ubuntu
+		echo "Installing on Ubuntu/Debian pre 20.04 LTS"
+		sudo apt-get update
+		sudo apt-get install -y python3.7-venv python3.7-distutils
+	elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ]; then
+		echo "Installing on Ubuntu/Debian 20.04 LTS or newer"
+		sudo apt-get update
+		sudo apt-get install -y python3.8-venv python3.8-distutils
+	elif type yum && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ]; then
+		# AMZN 2
+		echo "Installing on Amazon Linux 2"
+		sudo yum install -y python3 git
+	elif type yum && [ -f /etc/redhat-release ] || [ -f /etc/centos-release ]; then
+		# CentOS or Redhat
+		echo "Installing on CentOS/Redhat"
+	fi
 elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
-  echo "Installation currently requires brew on MacOS - https://brew.sh/"
+	echo "Installation currently requires brew on MacOS - https://brew.sh/"
 elif [ "$(uname)" = "OpenBSD" ]; then
-  export MAKE=${MAKE:-gmake}
-  export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}
+	export MAKE=${MAKE:-gmake}
+	export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}
 elif [ "$(uname)" = "FreeBSD" ]; then
-  export MAKE=${MAKE:-gmake}
-  export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}
+	export MAKE=${MAKE:-gmake}
+	export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}
 fi
 
 find_python() {
-    set +e
-    unset BEST_VERSION
-    for V in 37 3.7 38 3.8 3
-    do
-        if which python$V > /dev/null
-        then
-            if [ x"$BEST_VERSION" = x ]
-            then
-                BEST_VERSION=$V
-            fi
-        fi
-    done
-    echo $BEST_VERSION
-    set -e
+	set +e
+	unset BEST_VERSION
+	for V in 37 3.7 38 3.8 3; do
+		if which python$V >/dev/null; then
+			if [ x"$BEST_VERSION" = x ]; then
+				BEST_VERSION=$V
+			fi
+		fi
+	done
+	echo $BEST_VERSION
+	set -e
 }
 
-if [ x"$INSTALL_PYTHON_VERSION" = x ]
-then
-  INSTALL_PYTHON_VERSION=$(find_python)
+if [ x"$INSTALL_PYTHON_VERSION" = x ]; then
+	INSTALL_PYTHON_VERSION=$(find_python)
 fi
 
 # this fancy syntax sets INSTALL_PYTHON_PATH to "python3.7" unless INSTALL_PYTHON_VERSION is defined
@@ -74,7 +70,7 @@ INSTALL_PYTHON_PATH=python${INSTALL_PYTHON_VERSION:-3.7}
 echo "Python version is $INSTALL_PYTHON_VERSION"
 $INSTALL_PYTHON_PATH -m venv venv
 if [ ! -f "activate" ]; then
-    ln -s venv/bin/activate .
+	ln -s venv/bin/activate .
 fi
 
 # shellcheck disable=SC1091
@@ -84,8 +80,8 @@ pip install --upgrade pip
 pip install wheel
 #if [ "$INSTALL_PYTHON_VERSION" = "3.8" ]; then
 # This remains in case there is a diversion of binary wheels
-pip install --extra-index-url https://download.chia.net/simple/ miniupnpc==2.1 setproctitle==1.1.10 cbor2==5.1.2
-pip install -e .
+pip install --extra-index-url https://download.chia.net/simple/ miniupnpc==2.1 setproctitle==1.1.10
+pip install -e . --extra-index-url https://download.chia.net/simple/
 
 echo ""
 echo "Chia blockchain install.sh complete."

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ dependencies = [
     "aiosqlite@git+https://github.com/mariano54/aiosqlite.git@28cb5754deec562ac931da8fca799fb82df97a12#egg=aiosqlite",
     # asyncio wrapper for sqlite, to store blocks
     "bitstring==3.1.7",  # Binary data management library
-    "cbor2==5.1.2",  # Used for network wire format
+    "cbor2==5.2.0",  # Used for network wire format
     "colorlog==4.4.0",  # Adds color to logs
     "concurrent-log-handler==0.9.17",  # Concurrently log and rotate logs
     "cryptography==3.1.1",  # Python cryptography library for TLS

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 
 dependencies = [
     "aiter==0.13.20191203",  # Used for async generator tools
-    "blspy==0.2.4",  # Signature library
+    "blspy==0.2.9",  # Signature library
     "chiavdf==0.12.26",  # timelord and vdf verification
-    "chiabip158==0.16",  # bip158-style wallet filters
-    "chiapos==0.12.33",  # proof of space
+    "chiabip158==0.17",  # bip158-style wallet filters
+    "chiapos==0.12.37",  # proof of space
     "clvm==0.5.3",
     "clvm_tools==0.1.6",
     "aiohttp==3.6.3",  # HTTP server for full node rpc

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ dependencies = [
     "blspy==0.2.9",  # Signature library
     "chiavdf==0.12.26",  # timelord and vdf verification
     "chiabip158==0.17",  # bip158-style wallet filters
-    "chiapos==0.12.37",  # proof of space
+    "chiapos==0.12.38",  # proof of space
     "clvm==0.5.3",
     "clvm_tools==0.1.6",
     "aiohttp==3.6.3",  # HTTP server for full node rpc


### PR DESCRIPTION
## [1.0beta18] aka Beta 1.18 - 2020-12-03

### Added

- F1 generation in the plotter is now fully parallel for a small speedup.
- We have bitfield optimized phase 2 of plotting. There is only about a 1% increase in speed from this change but there is a 12% decrease in writes with a penalty of 3% more reads. More details in [PR 120](https://github.com/Chia-Network/chiapos/pull/120). Note that some sorts in phase 2 and phase 3 will now appear "out of order" and that is now expected behavior.
- Partial support for Python 3.9. That includes new versions of Chia dependencies like chiabip158.

### Changed

- We have moved from using gulrak/filesystem across all platforms to only using it on MacOS. It's required on MacOS as we are still targeting Mojave compatibility. This should resolve Windows path issues.
- We upgraded to cbor 5.2.0 but expect to deprecate cbor in a future release.

### Fixed

- A segfault caused by memory leaks in bls-library has been fixed. This should end the random farmer and harvester crashes over time as outlined in [Issue 500](https://github.com/Chia-Network/chia-blockchain/issues/500).
- Plotting could hang up retrying in an "error 0" state due to a bug in table handling in some edge cases.
- CPU utilization as reported in the plotter is now accurate for Windows.
- FreeBSD and OpenBSD should be able to build and install chia-blockchain and its dependencies again.
- Starting with recent setuptools fixes, we can no longer pass an empty string to the linker on Windows when building binary wheels in the sub repos. Thanks @jaraco for tracking this down.