### PR TITLE
Move chiavdf 0.13.1b2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 dependencies = [
     "aiter==0.13.20191203",  # Used for async generator tools
     "blspy==0.3.0",  # Signature library
-    "chiavdf==0.13.0",  # timelord and vdf verification
+    "chiavdf==0.13.1b1",  # timelord and vdf verification
     "chiabip158==0.17",  # bip158-style wallet filters
     "chiapos==0.12.40",  # proof of space
     "clvm==0.7",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 dependencies = [
     "aiter==0.13.20191203",  # Used for async generator tools
     "blspy==0.3.0",  # Signature library
-    "chiavdf==0.13.1b1",  # timelord and vdf verification
+    "chiavdf==0.13.1b2",  # timelord and vdf verification
     "chiabip158==0.17",  # bip158-style wallet filters
     "chiapos==0.12.40",  # proof of space
     "clvm==0.7",

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -183,6 +183,8 @@ class FullNode:
             return None
         if request.sub_block_height < self.constants.WEIGHT_PROOF_RECENT_BLOCKS:
             self.log.info("not enough blocks for weight proof,request peak sub block")
+            self.sync_store.add_potential_peak(request.header_hash, request.sub_block_height, request.weight)
+            self.sync_store.add_potential_fork_point(request.header_hash, uint32(0))
             return Message(
                 "request_sub_block",
                 full_node_protocol.RequestSubBlock(uint32(request.sub_block_height), True),

--- a/src/timelord/timelord.py
+++ b/src/timelord/timelord.py
@@ -839,8 +839,8 @@ class Timelord:
                     ips = int(iterations_needed / time_taken * 10) / 10
                     log.info(
                         f"Finished PoT chall:{challenge[:10].hex()}.. {iterations_needed}"
-                        f" iters."
-                        f"Estimated IPS: {ips}. Chain: {chain}"
+                        f" iters, "
+                        f"Estimated IPS: {ips}, Chain: {chain}"
                     )
 
                     vdf_info: VDFInfo = VDFInfo(

--- a/tests/consensus/test_weight_proof.py
+++ b/tests/consensus/test_weight_proof.py
@@ -280,7 +280,7 @@ class TestWeightProof:
         blocks = default_1000_blocks
         header_cache, height_to_hash, sub_blocks = await load_blocks_dont_validate(blocks)
         sub_epoch_end, num_of_blocks = get_prev_ses_block(sub_blocks, blocks[-1].header_hash)
-        print("num of blocks to first ses: ", num_of_blocks)
+        # print("num of blocks to first ses: ", num_of_blocks)
 
         curr = sub_epoch_end
         summaries: Dict[uint32, SubEpochSummary] = {}
@@ -303,10 +303,10 @@ class TestWeightProof:
         assert wp is not None
         # todo for each sampled sub epoch, validate number of segments
         valid, fork_point = wpf.validate_weight_proof(wp)
-        print("weight proof size: ", get_size(wp))
-        print("recent size: ", get_size(wp.recent_chain_data))
-        print("sub epochs size: ", get_size(wp.sub_epochs))
-        print("segments size: ", get_size(wp.sub_epoch_segments))
+        # print("weight proof size: ", get_size(wp))
+        # print("recent size: ", get_size(wp.recent_chain_data))
+        # print("sub epochs size: ", get_size(wp.sub_epochs))
+        # print("segments size: ", get_size(wp.sub_epoch_segments))
         assert valid
         assert fork_point == 0
 

--- a/tests/full_node/test_sync_store.py
+++ b/tests/full_node/test_sync_store.py
@@ -29,5 +29,7 @@ class TestStore:
         await db.clear_sync_info()
 
         # add/get potential tip, get potential tips num
-        db.add_potential_peak(blocks[1])
-        assert blocks[1] == db.get_potential_peak(blocks[1].header_hash)
+        db.add_potential_peak(blocks[1].header_hash, blocks[1].sub_block_height, blocks[1].weight)
+        potential_peak = db.get_potential_peak(blocks[1].header_hash)
+        assert blocks[1].sub_block_height == potential_peak[0]
+        assert blocks[1].weight == potential_peak[1]


### PR DESCRIPTION
I have confirmed this fixes the memory leak in node/farmer/harvester so it's better than 0.13.0 which is currently in dev. It's also slightly improved (~20M less total memory) from 0.13.1b1.

However, this still has the 10k ips slower vdf_client in it.

0.13.0b4:
```
20:30:00.524 timelord src.timelord.timelord    : INFO     Finished PoT chall:5a6fcab0934352a645f4.. 2636334 iters.Estimated IPS: 200939.2. Chain: Chain.CHALLENGE_CHAIN
20:30:04.531 timelord src.timelord.timelord    : INFO     Finished PoT chall:5a6fcab0934352a645f4.. 694284 iters.Estimated IPS: 191209.0. Chain: Chain.CHALLENGE_CHAIN
20:30:04.687 timelord src.timelord.timelord    : INFO     Finished PoT chall:46cda9acc18c841d634f.. 694284 iters.Estimated IPS: 188351.2. Chain: Chain.REWARD_CHAIN
20:30:04.724 timelord src.timelord.timelord    : INFO     Finished PoT chall:c8242e66af77cffba842.. 694284 iters.Estimated IPS: 181569.0. Chain: Chain.INFUSED_CHALLENGE_CHAIN
20:30:13.938 timelord src.timelord.timelord    : INFO     Finished PoT chall:1b33773b94c060a98f11.. 1774592 iters.Estimated IPS: 202232.2. Chain: Chain.CHALLENGE_CHAIN
20:30:13.969 timelord src.timelord.timelord    : INFO     Finished PoT chall:7f1bdac64e4d85d0253a.. 1774592 iters.Estimated IPS: 201540.9. Chain: Chain.REWARD_CHAIN
20:30:22.108 timelord src.timelord.timelord    : INFO     Finished PoT chall:7f1bdac64e4d85d0253a.. 3549184 iters.Estimated IPS: 209462.1. Chain: Chain.REWARD_CHAIN
20:30:22.281 timelord src.timelord.timelord    : INFO     Finished PoT chall:1b33773b94c060a98f11.. 3549184 iters.Estimated IPS: 207333.0. Chain: Chain.CHALLENGE_CHAIN
20:30:30.628 timelord src.timelord.timelord    : INFO     Finished PoT chall:7f1bdac64e4d85d0253a.. 5323776 iters.Estimated IPS: 209064.8. Chain: Chain.REWARD_CHAIN
20:30:31.283 timelord src.timelord.timelord    : INFO     Finished PoT chall:1b33773b94c060a98f11.. 5323776 iters.Estimated IPS: 203813.4. Chain: Chain.CHALLENGE_CHAIN
20:30:33.830 timelord src.timelord.timelord    : INFO     Finished PoT chall:7f1bdac64e4d85d0253a.. 5965329 iters.Estimated IPS: 208094.5. Chain: Chain.REWARD_CHAIN
20:30:33.974 timelord src.timelord.timelord    : INFO     Finished PoT chall:1b33773b94c060a98f11.. 5965329 iters.Estimated IPS: 207044.2. Chain: Chain.CHALLENGE_CHAIN
```
![image](https://user-images.githubusercontent.com/30377676/102698980-4298c300-41f6-11eb-8832-3305c9128085.png)
Maxes out around 4GB

Started running 0.13.1b2 around 21:27 UTC and will update the PR with timing results to compare

