### PR TITLE
init.py should not migrate old ports at 8444

### DIFF
--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -240,6 +240,9 @@ def chia_init(root_path: Path):
         "full_node.database_path",
         "wallet.database_path",
         "full_node.simulator_database_path",
+        "farmer.full_node_peer.port",
+        "timelord.full_node_peer.port",
+        "full_node.port",
     ]
 
     # These are the files that will be migrated


### PR DESCRIPTION
`chia init` will now properly migrate from beta 18 to beta 19 and move over to port 58444