### PR TITLE
Peer gossip fixes.

### DIFF
--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -288,9 +288,7 @@ class FullNodeDiscovery:
             connected = [c for c in connected if c is not None]
             if len(connected) >= 3:
                 async with self.address_manager.lock:
-                    self.address_manager.cleanup(
-                        max_timestamp_difference, max_consecutive_failures
-                    )
+                    self.address_manager.cleanup(max_timestamp_difference, max_consecutive_failures)
 
     async def _respond_peers_common(self, request, peer_src, is_full_node):
         # Check if we got the peers from a full node or from the introducer.

--- a/tests/full_node/test_address_manager.py
+++ b/tests/full_node/test_address_manager.py
@@ -566,7 +566,7 @@ class TestPeerManager:
         for target_peer in wanted_peers:
             for current_peer in retrieved_peers:
                 if (
-                    current_peer.peer_info == target_peer.peer_info 
+                    current_peer.peer_info == target_peer.peer_info
                     and current_peer.src == target_peer.src
                     and current_peer.timestamp == target_peer.timestamp
                 ):

--- a/tests/full_node/test_address_manager.py
+++ b/tests/full_node/test_address_manager.py
@@ -550,7 +550,7 @@ class TestPeerManager:
         addrman2 = await address_manager_store.deserialize()
 
         retrieved_peers = []
-        for _ in range(20):
+        for _ in range(50):
             peer = await addrman2.select_peer()
             if peer not in retrieved_peers:
                 retrieved_peers.append(peer)
@@ -565,7 +565,11 @@ class TestPeerManager:
         recovered = 0
         for target_peer in wanted_peers:
             for current_peer in retrieved_peers:
-                if current_peer.peer_info == target_peer.peer_info and current_peer.src == target_peer.src:
+                if (
+                    current_peer.peer_info == target_peer.peer_info 
+                    and current_peer.src == target_peer.src
+                    and current_peer.timestamp == target_peer.timestamp
+                ):
                     recovered += 1
         assert recovered == 3
         await connection.close()


### PR DESCRIPTION
- Saves in peer db the timestamps of the peers as well. 
- Deletes peers with the timestamps older than 14 days ago and with at least 10 consecutive connection failures. This way the new table will be periodically cleaned up of inactive peers, making select_peers() method more likely to find a reachable one.