### PR TITLE
Add Python 3.9 to Ubuntu install

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -1,11 +1,11 @@
-name: Build MacOS installer on Catalina and Python 3.8
+name: MacOS installer on Catalina and Python 3.8
 
 
 on: [push, pull_request]
 
 jobs:
   build:
-    name: Build MacOS installer on Python 3.8
+    name: MacOS installer on Catalina and Python 3.8
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/build-test-macos.yml
+++ b/.github/workflows/build-test-macos.yml
@@ -1,11 +1,10 @@
-name: Build MacOS and test on 3.8 and 3.9
-
+name: Build and test MacOS
 
 on: [push, pull_request]
 
 jobs:
   build:
-    name: Build and test MacOS-latest on Python 3.8, 3.9
+    name: Build and test MacOS
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1,18 +1,18 @@
-name: Build and test Ubuntu on Python 3.7, 3.8
+name: Build and test Ubuntu on Python 3.7, 3.8, 3.9
 
 
 on: [push, pull_request]
 
 jobs:
   build:
-    name: Ubuntu-latest on Python 3.7, 3.8
+    name: Ubuntu-latest on Python 3.7, 3.8, 3.9
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1,4 +1,4 @@
-name: Build and test Ubuntu on Python 3.7, 3.8, 3.9
+name: Build and test Ubuntu
 
 
 on: [push, pull_request]

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -61,6 +61,8 @@ jobs:
 
     - name: Install ubuntu dependencies
       run: |
+        sudo apt-get install software-properties-common
+        sudo add-apt-repository ppa:deadsnakes/ppa
         sudo apt-get update
         sudo apt-get install python${{ matrix.python-version }}-venv python${{ matrix.python-version }}-distutils git -y
 

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Ubuntu-latest on Python 3.7, 3.8, 3.9
+    name: Build and test Ubuntu
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,10 +1,10 @@
-name: Windows Installer
+name: Windows Installer on Windows 10 and Python 3.7
 
 on: [push, pull_request]
 
 jobs:
   build:
-    name: Windows Installer on 3.7
+    name: Windows Installer on Windows 10 and Python 3.7
     runs-on: [windows-latest]
     timeout-minutes: 90
 

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,10 +1,10 @@
-name: Build Windows
+name: Windows Installer
 
 on: [push, pull_request]
 
 jobs:
   build:
-    name: Windows installer on 3.7
+    name: Windows Installer on 3.7
     runs-on: [windows-latest]
     timeout-minutes: 90
 

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -1,4 +1,4 @@
-name: Lint and upload source distribution to PyPI
+name: Lint and upload source distribution
 
 on: [push, pull_request]
 


### PR DESCRIPTION
This builds and test Python 3.7, 3.8, and 3.9 on Ubuntu-latest. There are still issues with install.sh and Python 3.9 in the wild, but adding ppa:deadsnakes/ppa solves them on ci.