### PR TITLE
Throw errors if any step of macos installer build fails

### DIFF
--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -36,14 +36,25 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 	echo >&2 "npm run build failed!"
 	exit $LAST_EXIT_CODE
 fi
+
 electron-packager . Chia --asar.unpack="**/daemon/**" --platform=darwin \
 --icon=src/assets/img/Chia.icns --overwrite --app-bundle-id=net.chia.blockchain \
 --appVersion=$CHIA_INSTALLER_VERSION
+LAST_EXIT_CODE=$?
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+	echo >&2 "electron-packager failed!"
+	exit $LAST_EXIT_CODE
+fi
 
 electron-osx-sign Chia-darwin-x64/Chia.app --platform=darwin \
 --hardened-runtime=true --provisioning-profile=chiablockchain.provisionprofile \
 --entitlements=entitlements.mac.plist --entitlements-inherit=entitlements.mac.plist \
 --no-gatekeeper-assess
+LAST_EXIT_CODE=$?
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+	echo >&2 "electron-osx-sign failed!"
+	exit $LAST_EXIT_CODE
+fi
 
 mv Chia-darwin-x64 ../build_scripts/dist/
 cd ../build_scripts || exit
@@ -53,6 +64,11 @@ echo "Create $DMG_NAME"
 mkdir final_installer
 electron-installer-dmg dist/Chia-darwin-x64/Chia.app Chia-$CHIA_INSTALLER_VERSION \
 --overwrite --out final_installer
+LAST_EXIT_CODE=$?
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+	echo >&2 "electron-installer-dmg failed!"
+	exit $LAST_EXIT_CODE
+fi
 
 if [ "$NOTARIZE" ]; then
 	echo "Notarize $DMG_NAME on ci"


### PR DESCRIPTION
This is a Sev 1 as we had a Mojave build fail to sign and then fail to notarize. Since the sign failure didn't throw an error, and the most likely reason it failed to sign was connectivity to the timestamp server, we'd have no way of fixing this on release.

With these changes, signature failure would abort the Azure Run and that would allow us to re-run the job. You can't re-run "successful" jobs on Azure.