### PR TITLE
Peer gossip fixes.

### DIFF
--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -3,7 +3,7 @@ import dataclasses
 import time
 
 import src.server.ws_connection as ws
-from typing import AsyncGenerator, List, Optional, Tuple, Callable, Dict, Union
+from typing import AsyncGenerator, List, Optional, Tuple, Callable, Dict
 from chiabip158 import PyBIP158
 from blspy import G2Element, AugSchemeMPL
 
@@ -20,7 +20,6 @@ from src.consensus.sub_block_record import SubBlockRecord
 
 
 from src.protocols import (
-    introducer_protocol,
     farmer_protocol,
     full_node_protocol,
     timelord_protocol,

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -88,8 +88,9 @@ class FullNodeAPI:
             else:
                 is_full_node = True
             await self.full_node.full_node_peers.respond_peers(request, peer.get_peer_info(), is_full_node)
-            if not is_full_node:
-                await peer.close()
+
+        if peer.connection_type is NodeType.INTRODUCER:
+            await peer.close()
         return None
 
     @peer_required

--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -4,7 +4,7 @@ from random import randrange, choice
 
 from src.types.peer_info import PeerInfo, TimestampedPeerInfo
 from src.util.ints import uint16, uint64
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Set
 from asyncio import Lock
 import logging
 import time
@@ -452,8 +452,8 @@ class AddressManager:
                     while self.tried_matrix[tried_bucket][tried_buket_pos] == -1:
                         tried_bucket = (tried_bucket + randbits(LOG_TRIED_BUCKET_COUNT)) % TRIED_BUCKET_COUNT
                         tried_buket_pos = (tried_buket_pos + randbits(LOG_BUCKET_SIZE)) % BUCKET_SIZE
-                    
-                node_id = self.tried_matrix[tried_bucket][tried_buket_pos]
+
+                node_id = self.tried_matrix[tried_bucket][tried_bucket_pos]
                 assert node_id != -1
                 info = self.map_info[node_id]
                 if randbits(30) < (chance * info.get_selection_chance() * (1 << 30)):
@@ -465,7 +465,7 @@ class AddressManager:
             chance = 1.0
             start = time.time()
             if len(self.used_new_matrix_positions) < math.sqrt(NEW_BUCKET_COUNT * BUCKET_SIZE):
-                cached_new_matrix_positions = list(used_new_matrix_positions)
+                cached_new_matrix_positions = list(self.used_new_matrix_positions)
             while True:
                 if len(self.used_new_matrix_positions) < math.sqrt(NEW_BUCKET_COUNT * BUCKET_SIZE):
                     index = randrange(len(cached_new_matrix_positions))

--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -171,6 +171,7 @@ class AddressManager:
     tried_collisions: List[int]
     used_new_matrix_positions: Set[Tuple[int, int]]
     used_tried_matrix_positions: Set[Tuple[int, int]]
+    allow_private_subnets: bool
 
     def __init__(self):
         self.clear()
@@ -190,6 +191,10 @@ class AddressManager:
         self.tried_collisions = []
         self.used_new_matrix_positions = set()
         self.used_tried_matrix_positions = set()
+        self.allow_private_subnets = False
+
+    def make_private_subnets_valid(self):
+        self.allow_private_subnets = True
 
     # Use only this method for modifying new matrix.
     def _set_new_matrix(self, row: int, col: int, value: int):
@@ -293,7 +298,7 @@ class AddressManager:
     def mark_good_(self, addr: PeerInfo, test_before_evict: bool, timestamp: int):
         self.last_good = timestamp
         (info, node_id) = self.find_(addr)
-        if not addr.is_valid():
+        if not addr.is_valid(self.allow_private_subnets):
             return
         if info is None:
             return
@@ -358,7 +363,7 @@ class AddressManager:
             addr.host,
             addr.port,
         )
-        if not peer_info.is_valid():
+        if not peer_info.is_valid(self.allow_private_subnets):
             return False
         (info, node_id) = self.find_(peer_info)
         if info is not None and info.peer_info.host == addr.host and info.peer_info.port == addr.port:
@@ -539,7 +544,7 @@ class AddressManager:
             rand_pos = randrange(len(self.random_pos) - n) + n
             self.swap_random_(n, rand_pos)
             info = self.map_info[self.random_pos[n]]
-            if not info.peer_info.is_valid():
+            if not info.peer_info.is_valid(self.allow_private_subnets):
                 continue
             if not info.is_terrible():
                 cur_peer_info = TimestampedPeerInfo(

--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -410,6 +410,7 @@ class AddressManager:
                 node_id = self.tried_matrix[tried_bucket][tried_buket_pos]
                 info = self.map_info[node_id]
                 if randbits(30) < (chance * info.get_selection_chance() * (1 << 30)):
+                    log.info(f"address_manager.select_peer took {end - start} seconds in tried table.")
                     return info
                 chance *= 1.2
         else:
@@ -425,9 +426,9 @@ class AddressManager:
                 info = self.map_info[node_id]
                 if randbits(30) < chance * info.get_selection_chance() * (1 << 30):
                     end = time.time()
-                    log.info(f"address_manager.select_peer took {end - start} seconds.")
+                    log.info(f"address_manager.select_peer took {end - start} seconds in new table.")
                     return info
-                chance *= 1.4
+                chance *= 1.2
 
     def resolve_tried_collisions_(self):
         for node_id in self.tried_collisions[:]:

--- a/src/server/address_manager_store.py
+++ b/src/server/address_manager_store.py
@@ -196,4 +196,5 @@ class AddressManagerStore:
         for node_id, info in list(address_manager.map_info.items()):
             if not info.is_tried and info.ref_count == 0:
                 address_manager.delete_new_entry_(node_id)
+        address_manager.load_used_table_positions()
         return address_manager

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -200,8 +200,7 @@ class FullNodeDiscovery:
                     max_tries = 25
                 while not got_peer and not self.is_closed:
                     sleep_interval = 1 + len(groups) * 0.5
-                                    sleep_interval = min(sleep_interval, self.peer_connect_interval)
-
+                    sleep_interval = min(sleep_interval, self.peer_connect_interval)
                     await asyncio.sleep(sleep_interval)
                     tries += 1
                     if tries > max_tries:

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -57,7 +57,7 @@ class FullNodeDiscovery:
         self.log = log
         self.relay_queue = None
         self.address_manager = None
-        self.connection_time_pretest = {}
+        self.connection_time_pretest: Dict = {}
 
     async def initialize_address_manager(self):
         mkdir(self.peer_db_path.parent)

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -240,7 +240,7 @@ class FullNodeDiscovery:
                         addr = None
                         continue
                     # only consider very recently tried nodes after 30 failed attempts
-                    if now - info.last_try < 3600 and tries < 30:
+                    if now - info.last_try < 600 and tries < 30:
                         continue
                     if time.time() - last_timestamp_local_info > 1800 or local_peerinfo is None:
                         local_peerinfo = await self.server.get_peer_info()

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -103,7 +103,7 @@ class FullNodeDiscovery:
                 self.relay_queue.put_nowait((timestamped_peer_info, 1))
 
     # Updates timestamps each time we receive a message for outbound connections.
-    async def update_peer_timestamp_on_message(self, peer: WSChiaConnection):
+    async def update_peer_timestamp_on_message(self, peer: ws.WSChiaConnection):
         if (
             peer.is_outbound
             and peer.peer_server_port is not None

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -152,7 +152,7 @@ class FullNodeDiscovery:
                 size = await self.address_manager.size()
                 if size == 0 or empty_tables:
                     await self._introducer_client()
-                    await asyncio.sleep(min(30, self.peer_connect_interval))
+                    await asyncio.sleep(min(5, self.peer_connect_interval))
                     empty_tables = False
                     continue
 
@@ -199,7 +199,9 @@ class FullNodeDiscovery:
                 elif len(groups) <= 5:
                     max_tries = 25
                 while not got_peer and not self.is_closed:
-                    sleep_interval = min(15, self.peer_connect_interval)
+                    sleep_interval = 1 + len(groups) * 0.5
+                                    sleep_interval = min(sleep_interval, self.peer_connect_interval)
+
                     await asyncio.sleep(sleep_interval)
                     tries += 1
                     if tries > max_tries:

--- a/src/server/node_discovery.py
+++ b/src/server/node_discovery.py
@@ -101,6 +101,15 @@ class FullNodeDiscovery:
             await self.address_manager.add_to_new_table([timestamped_peer_info], peer.get_peer_info(), 0)
             if self.relay_queue is not None:
                 self.relay_queue.put_nowait((timestamped_peer_info, 1))
+        if (
+            peer.is_outbound
+            and peer.peer_server_port is not None
+            and peer.connection_type is NodeType.FULL_NODE
+            and self.server._local_type is NodeType.FULL_NODE
+            and self.address_manager is not None
+        ):
+            msg = Message("request_peers", full_node_protocol.RequestPeers())
+            await peer.send_message(msg)
 
     # Updates timestamps each time we receive a message for outbound connections.
     async def update_peer_timestamp_on_message(self, peer: ws.WSChiaConnection):

--- a/src/types/peer_info.py
+++ b/src/types/peer_info.py
@@ -12,7 +12,7 @@ class PeerInfo(Streamable):
     host: str
     port: uint16
 
-    def is_valid(self, allow_private_subnets: bool = False):
+    def is_valid(self, allow_private_subnets=False):
         ip = None
         try:
             ip = ipaddress.IPv6Address(self.host)

--- a/src/types/peer_info.py
+++ b/src/types/peer_info.py
@@ -13,6 +13,9 @@ class PeerInfo(Streamable):
     port: uint16
 
     def is_valid(self):
+        if host == "127.0.0.1" or host == "localhost":
+            return True
+
         ip = None
         try:
             ip = ipaddress.IPv6Address(self.host)

--- a/src/types/peer_info.py
+++ b/src/types/peer_info.py
@@ -19,6 +19,8 @@ class PeerInfo(Streamable):
         except ValueError:
             ip = None
         if ip is not None:
+            if ip.is_private:
+                return False
             return True
 
         try:
@@ -26,6 +28,8 @@ class PeerInfo(Streamable):
         except ValueError:
             ip = None
         if ip is not None:
+            if ip.is_private:
+                return False
             return True
         return False
 

--- a/src/types/peer_info.py
+++ b/src/types/peer_info.py
@@ -12,17 +12,14 @@ class PeerInfo(Streamable):
     host: str
     port: uint16
 
-    def is_valid(self):
-        if self.host == "127.0.0.1" or self.host == "localhost":
-            return True
-
+    def is_valid(self, allow_private_subnets: bool = False):
         ip = None
         try:
             ip = ipaddress.IPv6Address(self.host)
         except ValueError:
             ip = None
         if ip is not None:
-            if ip.is_private:
+            if ip.is_private and not allow_private_subnets:
                 return False
             return True
 
@@ -31,7 +28,7 @@ class PeerInfo(Streamable):
         except ValueError:
             ip = None
         if ip is not None:
-            if ip.is_private:
+            if ip.is_private and not allow_private_subnets:
                 return False
             return True
         return False

--- a/src/types/peer_info.py
+++ b/src/types/peer_info.py
@@ -13,7 +13,7 @@ class PeerInfo(Streamable):
     port: uint16
 
     def is_valid(self):
-        if host == "127.0.0.1" or host == "localhost":
+        if self.host == "127.0.0.1" or self.host == "localhost":
             return True
 
         ip = None

--- a/tests/core/full_node/test_address_manager.py
+++ b/tests/core/full_node/test_address_manager.py
@@ -20,6 +20,7 @@ class AddressManagerTest(AddressManager):
         super().__init__()
         if make_deterministic:
             self.make_deterministic()
+        self.make_private_subnets_valid()
 
     def make_deterministic(self):
         # Fix seed.

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -152,7 +152,7 @@ class TestFullNodeProtocol:
     @pytest.mark.asyncio
     async def test_request_peers(self, two_empty_nodes):
         full_node_1, full_node_2, server_1, server_2 = two_empty_nodes
-        full_node_2.full_node_peers.address_manager.make_private_subnets_valid()
+        full_node_2.full_node.full_node_peers.address_manager.make_private_subnets_valid()
         await server_2.start_client(PeerInfo("127.0.0.1", uint16(server_1._port)))
 
         async def have_msgs():

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -152,7 +152,7 @@ class TestFullNodeProtocol:
     @pytest.mark.asyncio
     async def test_request_peers(self, two_empty_nodes):
         full_node_1, full_node_2, server_1, server_2 = two_empty_nodes
-
+        full_node_2.full_node_peers.address_manager.make_private_subnets_valid()
         await server_2.start_client(PeerInfo("127.0.0.1", uint16(server_1._port)))
 
         async def have_msgs():


### PR DESCRIPTION
- Update timestamps of outbound peers every time we receive a message.
- Don't count failure attempts for self connections and duplicate connections.
- Speed up peer table lookup for sparse tables and decrease sleep time for finding outbound connections.
- Re enable peer cleanup (https://github.com/Chia-Network/chia-blockchain/pull/593)
- Request peers after initiating an outbound connection.
- Don't store or gossip private IPs subnets.
