### PR TITLE
Fix double spend issue in reorgs

### DIFF
--- a/src/consensus/blockchain.py
+++ b/src/consensus/blockchain.py
@@ -214,6 +214,7 @@ class Blockchain:
         error_code = await validate_block_body(
             self.constants,
             self.sub_blocks,
+            self.sub_height_to_hash,
             self.block_store,
             self.coin_store,
             self.get_peak(),
@@ -489,6 +490,7 @@ class Blockchain:
         error_code = await validate_block_body(
             self.constants,
             self.sub_blocks,
+            self.sub_height_to_hash,
             self.block_store,
             self.coin_store,
             self.get_peak(),

--- a/src/rpc/rpc_server.py
+++ b/src/rpc/rpc_server.py
@@ -45,7 +45,6 @@ class RpcServer:
         if self.websocket is None:
             return
         payloads: List[Dict] = await self.rpc_api._state_changed(*args)
-        log.info(f"State changed: {change}")
 
         if change == "add_connection" or change == "close_connection":
             data = await self.get_connections({})

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -67,17 +67,12 @@ class TestCoinStore:
         should_be_included: Set[Coin] = set()
         last_block_height = -1
         for block in blocks:
-            print(f"Block {block.sub_block_height} {block.is_block()}")
             farmer_coin, pool_coin = block.get_future_reward_coins(last_block_height + 1)
             should_be_included.add(farmer_coin)
             should_be_included.add(pool_coin)
             if block.is_block():
                 last_block_height = block.height
                 removals, additions = await block.tx_removals_and_additions()
-
-                print(len(block.get_included_reward_coins()), len(should_be_included_prev))
-                print([c.amount for c in block.get_included_reward_coins()])
-                print([c.amount for c in should_be_included_prev])
 
                 assert block.get_included_reward_coins() == should_be_included_prev
 


### PR DESCRIPTION
Fixes beta19 issue of double spend, which caused a chain split due to the inability to change to another chain with the same transaction spent.

Contains a test case showing the issue. Also, this was tested with one of the stalled blockchains in beta19 and it switched to the new chain successfully.