### PR TITLE
Beta 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## Unreleased
+
+### Added
+- The cli now warns if you attempt to create a plot smaller than k=32.
+- `chia configure` now lets you enable or disable uPnP.
+- If a peer gives a bad weight proof it will now be disconnected.
+
+### Changed
+- Harvester now only checks every 2 minutes for new files and otherwise caches the plot listing in memory and logs how long it took to load all plot files at INFO level.
+- Harvester multithreading is now configureable in config.yaml.
+- Bumped Colorlog to 4.7.2, and pyinstaller to 4.2.
+
+### Fixed
+
 ## [1.0beta20] aka Beta 1.20 - 2021-01-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
-## Unreleased
+## [1.0beta21] aka Beta 1.21 - 2021-01-16
 
 ### Added
 - The cli now warns if you attempt to create a plot smaller than k=32.
@@ -16,9 +16,13 @@ for setuptools_scm/PEP 440 reasons.
 ### Changed
 - Harvester now only checks every 2 minutes for new files and otherwise caches the plot listing in memory and logs how long it took to load all plot files at INFO level.
 - Harvester multithreading is now configureable in config.yaml.
+- Websocket heartbeat timeout was increased from 30 seconds to 300 seconds.
 - Bumped Colorlog to 4.7.2, and pyinstaller to 4.2.
 
 ### Fixed
+- Weight proofs were failing to verify contributing to a chain stall. This release gets things moving again but nodes are using too much CPU and can pause/lag at times. This may resolve as people upgrade to Beta 21.
+- A toxic combination of transaction limits set too high and a non performant clvm kept the chain stalled. A faster rust implementation of clvm is already nearing completion.
+- `chia netspace -s` would not correctly look up the start block height by block hash. Additionally netspace now flips to PiB above 1024 TiB. To compare netspace to `chia show` of the GUI use `chia netspace -d 1000` as `chia netspace` defaults to `-d 192` which is one hour.
 
 ## [1.0beta20] aka Beta 1.20 - 2021-01-14
 

--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -22,7 +22,7 @@ sudo rm -rf dist
 mkdir dist
 
 echo "Create executeables with pyinstaller"
-pip install pyinstaller==4.1
+pip install pyinstaller==4.2
 sudo pyinstaller --log-level=INFO daemon.spec
 cp -r dist/daemon ../electron-react
 cd .. || exit

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -21,7 +21,7 @@ python -m venv venv
 python -m pip install --upgrade pip
 pip install wheel pep517
 pip install pywin32
-pip install pyinstaller==4.1
+pip install pyinstaller==4.2
 pip install setuptools_scm
 
 Write-Output "   ---"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,7 +34,7 @@ setuptools_scm>=4.1.2
 
 PyYAML~=5.3.1
 cbor2~=5.2.0
-colorlog~=4.6.2
+colorlog~=4.7.2
 keyring~=21.5.0
 bitstring~=3.1.7
 setproctitle~=1.1.10

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     # asyncio wrapper for sqlite, to store blocks
     "bitstring==3.1.7",  # Binary data management library
     "cbor2==5.2.0",  # Used for network wire format
-    "colorlog==4.6.2",  # Adds color to logs
+    "colorlog==4.7.2",  # Adds color to logs
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
     "cryptography==3.3.1",  # Python cryptography library for TLS
     "keyring==21.5.0",  # Store keys in MacOS Keychain, Windows Credential Locker

--- a/src/cmds/configure.py
+++ b/src/cmds/configure.py
@@ -5,6 +5,7 @@ from src.util.config import (
 from argparse import ArgumentParser
 from typing import Dict
 from src.util.default_root import DEFAULT_ROOT_PATH
+from src.util.config import str2bool
 
 
 def make_parser(parser: ArgumentParser):
@@ -31,6 +32,15 @@ def make_parser(parser: ArgumentParser):
         type=str,
         nargs="?",
         default="",
+    )
+
+    parser.add_argument(
+        "--enable-upnp",
+        "--upnp",
+        help="Enable or disable uPnP. Can be True or False",
+        type=str,
+        nargs="?",
+        default="True",
     )
 
     parser.set_defaults(function=configure)
@@ -87,6 +97,13 @@ def configure(args, parser):
             config["logging"]["log_level"] = args.set_log_level
             print("Logging level updated. Check CHIA_ROOT/log/debug.log")
             change_made = True
+    if args.enable_upnp:
+        config["full_node"]["enable_upnp"] = str2bool(args.enable_upnp)
+        if str2bool(args.enable_upnp):
+            print("uPnP enabled.")
+        else:
+            print("uPnP disabled.")
+        change_made = True
     if change_made:
         print("Restart any running chia services for changes to take effect.")
         save_config(args.root_path, "config.yaml", config)

--- a/src/cmds/configure.py
+++ b/src/cmds/configure.py
@@ -40,7 +40,6 @@ def make_parser(parser: ArgumentParser):
         help="Enable or disable uPnP. Can be True or False",
         type=str,
         nargs="?",
-        default="True",
     )
 
     parser.set_defaults(function=configure)
@@ -97,7 +96,7 @@ def configure(args, parser):
             config["logging"]["log_level"] = args.set_log_level
             print("Logging level updated. Check CHIA_ROOT/log/debug.log")
             change_made = True
-    if args.enable_upnp:
+    if args.enable_upnp is not None:
         config["full_node"]["enable_upnp"] = str2bool(args.enable_upnp)
         if str2bool(args.enable_upnp):
             print("uPnP enabled.")

--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -245,6 +245,7 @@ def chia_init(root_path: Path):
         "timelord.full_node_peer.port",
         "full_node.port",
         "harvester.num_threads"
+        "min_mainnet_k_size",
     ]
 
     # These are the files that will be migrated

--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -244,6 +244,7 @@ def chia_init(root_path: Path):
         "farmer.full_node_peer.port",
         "timelord.full_node_peer.port",
         "full_node.port",
+        "harvester.num_threads"
     ]
 
     # These are the files that will be migrated

--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -244,7 +244,7 @@ def chia_init(root_path: Path):
         "farmer.full_node_peer.port",
         "timelord.full_node_peer.port",
         "full_node.port",
-        "harvester.num_threads"
+        "harvester.num_threads",
         "min_mainnet_k_size",
     ]
 

--- a/src/cmds/netspace.py
+++ b/src/cmds/netspace.py
@@ -74,26 +74,26 @@ async def netstorge_async(args, parser):
                 newer_block_header.header_hash, older_block_header.header_hash
             )
             print(
-                f"Older Sub-block Height: {older_block_header.sub_block_height}\n"
-                f"Older Height: {older_block_header.height}\n"
-                f"Header Hash: 0x{older_block_header.header_hash}\n"
-                f"Weight:      {older_block_header.weight}\n"
-                f"Total VDF\n"
-                f" Iterations: {older_block_header.total_iters}\n"
+                "Older Sub Block\n"
+                f"Sub Block Height: {older_block_header.sub_block_height}\n"
+                f"Height:           {older_block_header.height}\n"
+                f"Weight:           {older_block_header.weight}\n"
+                f"VDF Iterations:   {older_block_header.total_iters}\n"
+                f"Header Hash:      0x{older_block_header.header_hash}\n"
             )
             print(
-                f"Newer Sub-block Height: {newer_block_header.sub_block_height}\n"
-                f"Newer Height: {newer_block_header.height}\n"
-                f"Header Hash: 0x{newer_block_header.header_hash}\n"
-                f"Weight:      {newer_block_header.weight}\n"
-                f"Total VDF\n"
-                f" Iterations: {newer_block_header.total_iters}\n"
+                "Newer Sub Block\n"
+                f"Sub Block Height: {newer_block_header.sub_block_height}\n"
+                f"Height:           {newer_block_header.height}\n"
+                f"Weight:           {newer_block_header.weight}\n"
+                f"VDF Iterations:   {newer_block_header.total_iters}\n"
+                f"Header Hash:      0x{newer_block_header.header_hash}\n"
             )
             network_space_terabytes_estimate = network_space_bytes_estimate / 1024 ** 4
             if network_space_terabytes_estimate > 1024:
-                print(f"The network has an estimated {network_space_terabytes_estimate / 1024:.3f}PiB")
+                print(f"The network has an estimated {network_space_terabytes_estimate / 1024:.3f} PiB")
             else:
-                print(f"The network has an estimated {network_space_terabytes_estimate:.3f}TiB")
+                print(f"The network has an estimated {network_space_terabytes_estimate:.3f} TiB")
 
     except Exception as e:
         if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):

--- a/src/cmds/netspace.py
+++ b/src/cmds/netspace.py
@@ -90,7 +90,10 @@ async def netstorge_async(args, parser):
                 f"Iterations:  {newer_block_header.total_iters}\n"
             )
             network_space_terabytes_estimate = network_space_bytes_estimate / 1024 ** 4
-            print(f"The network has an estimated {network_space_terabytes_estimate:.2f}TiB")
+            if network_space_terabytes_estimate > 1024:
+                print(f"The network has an estimated {network_space_terabytes_estimate / 1024:.3f}PiB")
+            else:
+                print(f"The network has an estimated {network_space_terabytes_estimate:.3f}TiB")
 
     except Exception as e:
         if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):

--- a/src/cmds/netspace.py
+++ b/src/cmds/netspace.py
@@ -4,6 +4,7 @@ import time
 from time import struct_time, localtime
 from src.util.config import load_config
 from src.util.default_root import DEFAULT_ROOT_PATH
+from src.util.byte_types import hexstr_to_bytes
 
 from src.rpc.full_node_rpc_client import FullNodeRpcClient
 
@@ -65,7 +66,13 @@ async def netstorge_async(args, parser):
 
                 newer_block_height = blockchain_state["peak"].sub_block_height
             else:
-                newer_block_height = int(args.start)  # Starting block height in args
+                newer_sub_block = await client.get_sub_block_record(hexstr_to_bytes(args.start))
+                if newer_sub_block is None:
+                    print("Sub block header hash", args.start, "not found.")
+                    return None
+                else:
+                    print("newer_sub_block_height", newer_sub_block.sub_block_height)
+                    newer_block_height = newer_sub_block.sub_block_height
 
             newer_block_header = await client.get_sub_block_record_by_sub_height(newer_block_height)
             older_block_height = max(0, newer_block_height - int(args.delta_block_height))

--- a/src/cmds/netspace.py
+++ b/src/cmds/netspace.py
@@ -79,7 +79,7 @@ async def netstorge_async(args, parser):
                 f"Header Hash: 0x{older_block_header.header_hash}\n"
                 f"Weight:      {older_block_header.weight}\n"
                 f"Total VDF\n"
-                f"Iterations:  {older_block_header.total_iters}\n"
+                f" Iterations: {older_block_header.total_iters}\n"
             )
             print(
                 f"Newer Sub-block Height: {newer_block_header.sub_block_height}\n"
@@ -87,7 +87,7 @@ async def netstorge_async(args, parser):
                 f"Header Hash: 0x{newer_block_header.header_hash}\n"
                 f"Weight:      {newer_block_header.weight}\n"
                 f"Total VDF\n"
-                f"Iterations:  {newer_block_header.total_iters}\n"
+                f" Iterations: {newer_block_header.total_iters}\n"
             )
             network_space_terabytes_estimate = network_space_bytes_estimate / 1024 ** 4
             if network_space_terabytes_estimate > 1024:

--- a/src/cmds/show.py
+++ b/src/cmds/show.py
@@ -165,9 +165,9 @@ async def show_async(args, parser):
             network_space_human_readable = blockchain_state["space"] / 1024 ** 4
             if network_space_human_readable >= 1024:
                 network_space_human_readable = network_space_human_readable / 1024
-                print(f"{network_space_human_readable:.3f}PiB")
+                print(f"{network_space_human_readable:.3f} PiB")
             else:
-                print(f"{network_space_human_readable:.3f}TiB")
+                print(f"{network_space_human_readable:.3f} TiB")
             print(f"Current difficulty: {difficulty}")
             print(f"Current VDF sub_slot_iters: {sub_slot_iters}")
             print("Total iterations since the start of the blockchain:", total_iters)

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -726,8 +726,6 @@ class FullNodeAPI:
                 finished_sub_slots,
             )
             self.log.info("Made the unfinished sub-block")
-            self.log.info(f"Uninifhsed block: {unfinished_block}")
-            self.log.info(f"Unfinished block {bytes(unfinished_block)}")
             if prev_sb is not None:
                 height: uint32 = uint32(prev_sb.sub_block_height + 1)
             else:

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -200,19 +200,25 @@ class FullNodeAPI:
         return Message("respond_proof_of_weight", full_node_protocol.RespondProofOfWeight(wp, request.tip))
 
     @api_request
-    async def respond_proof_of_weight(self, response: full_node_protocol.RespondProofOfWeight) -> Optional[Message]:
+    @peer_required
+    async def respond_proof_of_weight(
+        self,
+        response: full_node_protocol.RespondProofOfWeight,
+        peer: ws.WSChiaConnection,
+    ) -> Optional[Message]:
+        self.full_node.pow_pending.remove(peer.peer_node_id)
         validated, fork_point = self.full_node.weight_proof_handler.validate_weight_proof(response.wp)
-        if validated is True:
-            # get tip params
-            tip_weight = response.wp.recent_chain_data[-1].reward_chain_sub_block.weight
-            tip_height = response.wp.recent_chain_data[-1].reward_chain_sub_block.sub_block_height
-            self.full_node.sync_store.add_potential_peak(response.tip, tip_height, tip_weight)
-            self.full_node.sync_store.add_potential_fork_point(response.tip, fork_point)
-            return Message(
-                "request_sub_block",
-                full_node_protocol.RequestSubBlock(uint32(tip_height), True),
-            )
-        return None
+        if not validated:
+            raise Exception("bad weight proof, disconnecting peer")
+        # get tip params
+        tip_weight = response.wp.recent_chain_data[-1].reward_chain_sub_block.weight
+        tip_height = response.wp.recent_chain_data[-1].reward_chain_sub_block.sub_block_height
+        self.full_node.sync_store.add_potential_peak(response.tip, tip_height, tip_weight)
+        self.full_node.sync_store.add_potential_fork_point(response.tip, fork_point)
+        return Message(
+            "request_sub_block",
+            full_node_protocol.RequestSubBlock(uint32(tip_height), True),
+        )
 
     @api_request
     async def request_sub_block(self, request: full_node_protocol.RequestSubBlock) -> Optional[Message]:

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -552,7 +552,6 @@ class FullNodeAPI:
         by the farmer, and sends the hash of the header data back to the farmer.
         """
         self.log.info(f"Request: {request}")
-        self.log.info(f"Request bytes: {bytes(request)}")
         self.log.info("1")
         async with self.full_node.timelord_lock:
             self.log.info("2")

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -206,7 +206,9 @@ class FullNodeAPI:
         response: full_node_protocol.RespondProofOfWeight,
         peer: ws.WSChiaConnection,
     ) -> Optional[Message]:
-        self.full_node.pow_pending.remove(peer.peer_node_id)
+        if peer.peer_node_id not in self.full_node.pow_pending:
+            self.log.warning("weight proof not in pending request list")
+            return
         validated, fork_point = self.full_node.weight_proof_handler.validate_weight_proof(response.wp)
         if not validated:
             raise Exception("bad weight proof, disconnecting peer")

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -208,7 +208,7 @@ class FullNodeAPI:
     ) -> Optional[Message]:
         if peer.peer_node_id not in self.full_node.pow_pending:
             self.log.warning("weight proof not in pending request list")
-            return
+            return None
         validated, fork_point = self.full_node.weight_proof_handler.validate_weight_proof(response.wp)
         if not validated:
             raise Exception("bad weight proof, disconnecting peer")
@@ -551,10 +551,7 @@ class FullNodeAPI:
         Creates a block body and header, with the proof of space, coinbase, and fee targets provided
         by the farmer, and sends the hash of the header data back to the farmer.
         """
-        self.log.info(f"Request: {request}")
-        self.log.info("1")
         async with self.full_node.timelord_lock:
-            self.log.info("2")
             if request.pool_target is None or request.pool_signature is None:
                 raise ValueError("Adaptable pool protocol not yet available.")
 
@@ -562,7 +559,6 @@ class FullNodeAPI:
                 request.challenge_chain_sp
             )
 
-            self.log.info("3")
             if sp_vdfs is None:
                 self.log.warning(f"Received proof of space for an unknown signage point {request.challenge_chain_sp}")
                 return None
@@ -575,14 +571,12 @@ class FullNodeAPI:
                     )
                     return None
 
-            self.log.info("4")
             if request.signage_point_index == 0:
                 cc_challenge_hash: bytes32 = request.challenge_chain_sp
             else:
                 assert sp_vdfs.cc_vdf is not None
                 cc_challenge_hash = sp_vdfs.cc_vdf.challenge
 
-            self.log.info("5")
             pos_sub_slot: Optional[Tuple[EndOfSubSlotBundle, int, uint128]] = None
             if request.challenge_hash != self.full_node.constants.FIRST_CC_CHALLENGE:
                 # Checks that the proof of space is a response to a recent challenge and valid SP
@@ -594,7 +588,6 @@ class FullNodeAPI:
             else:
                 total_iters_pos_slot = uint128(0)
             assert cc_challenge_hash == request.challenge_hash
-            self.log.info("6")
 
             # Now we know that the proof of space has a signage point either:
             # 1. In the previous sub-slot of the peak (overflow)
@@ -607,17 +600,13 @@ class FullNodeAPI:
             )
             assert quality_string is not None and len(quality_string) == 32
 
-            self.log.info("7")
             # Grab best transactions from Mempool for given tip target
             async with self.full_node.blockchain.lock:
-                self.log.info("8")
                 peak: Optional[SubBlockRecord] = self.full_node.blockchain.get_peak()
                 if peak is None:
                     spend_bundle: Optional[SpendBundle] = None
                 else:
                     spend_bundle = await self.full_node.mempool_manager.create_bundle_from_mempool(peak.header_hash)
-
-            self.log.info("9")
 
             def get_plot_sig(to_sign, _) -> G2Element:
                 if to_sign == request.challenge_chain_sp:
@@ -629,12 +618,10 @@ class FullNodeAPI:
             def get_pool_sig(_1, _2) -> G2Element:
                 return request.pool_signature
 
-            self.log.info("10")
             prev_sb: Optional[SubBlockRecord] = self.full_node.blockchain.get_peak()
 
             # Finds the previous sub block from the signage point, ensuring that the reward chain VDF is correct
             if prev_sb is not None:
-                self.log.info("11")
                 if request.signage_point_index == 0:
                     if pos_sub_slot is None:
                         self.log.warning("Pos sub slot is None")
@@ -644,7 +631,6 @@ class FullNodeAPI:
                     assert sp_vdfs.rc_vdf is not None
                     rc_challenge = sp_vdfs.rc_vdf.challenge
 
-                self.log.info(f"12, {len(self.full_node.full_node_store.finished_sub_slots)}")
                 # Backtrack through empty sub-slots
                 for eos, _, _ in reversed(self.full_node.full_node_store.finished_sub_slots):
                     if eos is not None and eos.reward_chain.get_hash() == rc_challenge:
@@ -652,7 +638,6 @@ class FullNodeAPI:
 
                 found = False
                 attempts = 0
-                self.log.info("13")
                 while prev_sb is not None and attempts < 10:
                     if prev_sb.reward_infusion_new_challenge == rc_challenge:
                         found = True
@@ -670,12 +655,10 @@ class FullNodeAPI:
                     self.log.warning("Did not find a previous block with the correct reward chain hash")
                     return None
 
-            self.log.info("14")
             try:
                 finished_sub_slots: List[EndOfSubSlotBundle] = self.full_node.full_node_store.get_finished_sub_slots(
                     prev_sb, self.full_node.blockchain.sub_blocks, cc_challenge_hash
                 )
-                self.log.info(f"15, {len(finished_sub_slots)}")
                 if (
                     len(finished_sub_slots) > 0
                     and pos_sub_slot is not None
@@ -686,7 +669,6 @@ class FullNodeAPI:
             except ValueError as e:
                 self.log.warning(f"Value Error: {e}")
                 return None
-            self.log.info(f"16")
             if prev_sb is None:
                 pool_target = PoolTarget(
                     self.full_node.constants.GENESIS_PRE_FARM_POOL_PUZZLE_HASH,
@@ -695,13 +677,10 @@ class FullNodeAPI:
             else:
                 pool_target = request.pool_target
 
-            self.log.info(f"17")
             if peak is None or peak.sub_block_height <= self.full_node.constants.MAX_SUB_SLOT_SUB_BLOCKS:
-                self.log.info(f"18")
                 difficulty = self.full_node.constants.DIFFICULTY_STARTING
                 sub_slot_iters = self.full_node.constants.SUB_SLOT_ITERS_STARTING
             else:
-                self.log.info(f"19")
                 difficulty = uint64(peak.weight - self.full_node.blockchain.sub_blocks[peak.prev_hash].weight)
                 sub_slot_iters = peak.sub_slot_iters
                 for sub_slot in finished_sub_slots:
@@ -710,7 +689,6 @@ class FullNodeAPI:
                     if sub_slot.challenge_chain.new_sub_slot_iters is not None:
                         sub_slot_iters = sub_slot.challenge_chain.new_sub_slot_iters
 
-            self.log.info(f"20")
             required_iters: uint64 = calculate_iterations_quality(
                 quality_string,
                 request.proof_of_space.size,
@@ -718,7 +696,6 @@ class FullNodeAPI:
                 request.challenge_chain_sp,
             )
             sp_iters: uint64 = calculate_sp_iters(self.full_node.constants, sub_slot_iters, request.signage_point_index)
-            self.log.info(f"21")
             ip_iters: uint64 = calculate_ip_iters(
                 self.full_node.constants,
                 sub_slot_iters,
@@ -726,7 +703,7 @@ class FullNodeAPI:
                 required_iters,
             )
 
-            self.log.info(f"22")
+            self.log.info("Starting to make the unfinished sub-block")
             unfinished_block: UnfinishedBlock = create_unfinished_block(
                 self.full_node.constants,
                 total_iters_pos_slot,
@@ -748,23 +725,21 @@ class FullNodeAPI:
                 self.full_node.blockchain.sub_blocks,
                 finished_sub_slots,
             )
-            self.log.info(f"23")
+            self.log.info("Made the unfinished sub-block")
             self.log.info(f"Uninifhsed block: {unfinished_block}")
-            self.log.info(f"Uninifhsed block bytes: {bytes(unfinished_block)}")
+            self.log.info(f"Unfinished block {bytes(unfinished_block)}")
             if prev_sb is not None:
                 height: uint32 = uint32(prev_sb.sub_block_height + 1)
             else:
                 height = uint32(0)
             self.full_node.full_node_store.add_candidate_block(quality_string, height, unfinished_block)
 
-            self.log.info(f"24")
             foliage_sb_data_hash = unfinished_block.foliage_sub_block.foliage_sub_block_data.get_hash()
             if unfinished_block.is_block():
                 foliage_block_hash = unfinished_block.foliage_sub_block.foliage_block_hash
             else:
                 foliage_block_hash = bytes([0] * 32)
 
-            self.log.info(f"25")
             message = farmer_protocol.RequestSignedValues(
                 quality_string,
                 foliage_sb_data_hash,

--- a/src/full_node/mempool_manager.py
+++ b/src/full_node/mempool_manager.py
@@ -68,7 +68,7 @@ class MempoolManager:
             for item in dic.values():
                 # TODO: reenable big blocks
                 # if item.cost + cost_sum <= self.constants.MAX_BLOCK_COST_CLVM:
-                if item.cost + cost_sum <= 100000:
+                if item.cost + cost_sum <= 10000000:
                     spend_bundles.append(item.spend_bundle)
                     cost_sum += item.cost
                 else:

--- a/src/full_node/mempool_manager.py
+++ b/src/full_node/mempool_manager.py
@@ -66,7 +66,9 @@ class MempoolManager:
         spend_bundles: List[SpendBundle] = []
         for dic in self.mempool.sorted_spends.values():
             for item in dic.values():
-                if item.cost + cost_sum <= self.constants.MAX_BLOCK_COST_CLVM:
+                # TODO: reenable big blocks
+                # if item.cost + cost_sum <= self.constants.MAX_BLOCK_COST_CLVM:
+                if item.cost + cost_sum <= 100000:
                     spend_bundles.append(item.spend_bundle)
                     cost_sum += item.cost
                 else:

--- a/src/harvester/harvester.py
+++ b/src/harvester/harvester.py
@@ -53,6 +53,7 @@ class Harvester:
         self.cached_challenges = []
         self.log = log
         self.state_changed_callback: Optional[Callable] = None
+        self.last_load_time: float = 0
 
     async def _start(self):
         self._refresh_lock = asyncio.Lock()
@@ -102,8 +103,8 @@ class Harvester:
     async def refresh_plots(self):
         locked: bool = self._refresh_lock.locked()
         changed: bool = False
-        async with self._refresh_lock:
-            if not locked:
+        if not locked:
+            async with self._refresh_lock:
                 # Avoid double refreshing of plots
                 (changed, self.provers, self.failed_to_open_filenames, self.no_key_filenames,) = load_plots(
                     self.provers,

--- a/src/harvester/harvester.py
+++ b/src/harvester/harvester.py
@@ -34,7 +34,7 @@ class Harvester:
     constants: ConsensusConstants
     _refresh_lock: asyncio.Lock
 
-    def __init__(self, root_path: Path, constants: ConsensusConstants):
+    def __init__(self, root_path: Path, config: Dict, constants: ConsensusConstants):
         self.root_path = root_path
 
         # From filename to prover
@@ -46,7 +46,7 @@ class Harvester:
         self.farmer_public_keys = []
         self.pool_public_keys = []
         self.match_str = None
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=config["num_threads"])
         self.state_changed_callback = None
         self.server = None
         self.constants = constants

--- a/src/harvester/harvester_api.py
+++ b/src/harvester/harvester_api.py
@@ -97,8 +97,7 @@ class HarvesterAPI:
                         )
                         quality_strings = plot_info.prover.get_qualities_for_challenge(sp_challenge_hash)
                     except Exception as e:
-                        self.harvester.log.error(f"Error reinitializing. Will not try to farm plot. {e}")
-                        self.harvester.provers.pop(filename, None)
+                        self.harvester.log.error(f"Error reinitializing plot {filename}. {e}")
                         return []
 
                 responses: List[Tuple[bytes32, ProofOfSpace]] = []

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -51,6 +51,7 @@ def get_pool_public_key(alt_fingerprint: Optional[int] = None) -> G1Element:
 
 def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional[List] = None):
     config_filename = config_path_for_filename(root_path, "config.yaml")
+    config = load_config(root_path, config_filename)
 
     if args.tmp2_dir is None:
         args.tmp2_dir = args.tmp_dir
@@ -70,6 +71,11 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
         num = args.num
     else:
         num = 1
+
+    if args.size < config["min_mainnet_k_size"]:
+        log.warn(
+            f"CREATING PLOTS WITH SIZE k={args.size}, which is less than the minimum required for mainnet"
+        )
     log.info(
         f"Creating {num} plots of size {args.size}, pool public key:  "
         f"{bytes(pool_public_key).hex()} farmer public key: {bytes(farmer_public_key).hex()}"
@@ -88,7 +94,6 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
     mkdir(args.final_dir)
 
     finished_filenames = []
-    config = load_config(root_path, config_filename)
     plot_filenames = get_plot_filenames(config["harvester"])
     for i in range(num):
         # Generate a random master secret key

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -73,9 +73,7 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
         num = 1
 
     if args.size < config["min_mainnet_k_size"]:
-        log.warn(
-            f"CREATING PLOTS WITH SIZE k={args.size}, which is less than the minimum required for mainnet"
-        )
+        log.warn(f"CREATING PLOTS WITH SIZE k={args.size}, which is less than the minimum required for mainnet")
     log.info(
         f"Creating {num} plots of size {args.size}, pool public key:  "
         f"{bytes(pool_public_key).hex()} farmer public key: {bytes(farmer_public_key).hex()}"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -116,6 +116,7 @@ def load_plots(
     root_path: Path,
     open_no_key_filenames=False,
 ) -> Tuple[bool, Dict[Path, PlotInfo], Dict[Path, int], Set[Path]]:
+    start_time = time.time()
     config_file = load_config(root_path, "config.yaml", "harvester")
     changed = False
     no_key_filenames: Set[Path] = set()
@@ -186,5 +187,8 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
-    log.info(f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB")
+    log.info(
+        f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"
+        f" {time.time()-start_time} seconds"
+    )
     return changed, new_provers, failed_to_open_filenames, no_key_filenames

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -236,7 +236,7 @@ class ChiaServer:
             self.log.info(f"Connecting: {url}, Peer info: {target_node}")
             try:
                 ws = await session.ws_connect(
-                    url, autoclose=False, autoping=True, heartbeat=30, ssl=ssl_context, max_msg_size=50 * 1024 * 1024
+                    url, autoclose=False, autoping=True, heartbeat=300, ssl=ssl_context, max_msg_size=50 * 1024 * 1024
                 )
             except asyncio.TimeoutError:
                 self.log.info(f"Timeout error connecting to {url}")

--- a/src/server/start_harvester.py
+++ b/src/server/start_harvester.py
@@ -27,7 +27,7 @@ def service_kwargs_for_harvester(
 ) -> Dict:
     connect_peers = [PeerInfo(config["farmer_peer"]["host"], config["farmer_peer"]["port"])]
 
-    harvester = Harvester(root_path, consensus_constants)
+    harvester = Harvester(root_path, config, consensus_constants)
     peer_api = HarvesterAPI(harvester)
 
     kwargs = dict(

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -1,4 +1,6 @@
 network_id: testnet  # testnet/mainnet
+min_mainnet_k_size: 32
+
 # Send a ping to all peers after ping_interval seconds
 ping_interval: 120
 self_hostname: &self_hostname "localhost"

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -23,6 +23,7 @@ harvester:
   # If True, starts an RPC server at the following port
   start_rpc_server: True
   rpc_port: 8560
+  num_threads: 30
 
   logging: *logging
 

--- a/src/wallet/wallet_blockchain.py
+++ b/src/wallet/wallet_blockchain.py
@@ -227,7 +227,9 @@ class WalletBlockchain:
 
         fork_height: Optional[uint32] = await self._reconsider_peak(sub_block, genesis)
         if fork_height is not None:
-            self.log.info(f"💰💰💰 Updated peak to sub height {sub_block.sub_block_height}, weight {sub_block.weight}, ")
+            self.log.info(
+                f"💰💰💰 Updated wallet peak to sub height {sub_block.sub_block_height}, weight {sub_block.weight}, "
+            )
             return ReceiveBlockResult.NEW_PEAK, None, fork_height
         else:
             return ReceiveBlockResult.ADDED_AS_ORPHAN, None, None

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -560,7 +560,6 @@ class WalletNode:
             ) = await self.wallet_state_manager.blockchain.receive_block(header_block_record)
             if result == ReceiveBlockResult.NEW_PEAK:
                 self.wallet_state_manager.state_changed("new_block")
-                self.log.info("New Peak")
             elif result == ReceiveBlockResult.INVALID_BLOCK:
                 raise ValueError("Value error peer sent us invalid block")
 

--- a/tests/core/consensus/test_weight_proof.py
+++ b/tests/core/consensus/test_weight_proof.py
@@ -22,7 +22,6 @@ from src.consensus.pot_iterations import calculate_iterations_quality, calculate
 from src.consensus.sub_block_record import SubBlockRecord
 from src.full_node.weight_proof import (  # type: ignore
     WeightProofHandler,
-    _get_last_ses_block_idx,
     _map_summaries,
     BlockCache,
 )
@@ -142,19 +141,6 @@ async def _test_map_summaries(blocks, header_cache, height_to_hash, sub_blocks, 
 
 
 class TestWeightProof:
-    @pytest.mark.asyncio
-    async def test_get_last_ses_block_idx(self, default_1000_blocks):
-        blocks = default_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        sub_epoch_end, _ = get_prev_ses_block(sub_blocks, blocks[-1].prev_header_hash)
-        recent_blocks: List[ProofBlockHeader] = []
-        for block in header_cache.values():
-            recent_blocks.append(ProofBlockHeader(block.finished_sub_slots, block.reward_chain_sub_block))
-        block = _get_last_ses_block_idx(test_constants, recent_blocks)
-        assert block is not None
-        assert block.reward_chain_sub_block.sub_block_height == sub_epoch_end.sub_block_height
-        assert sub_blocks[height_to_hash[block.reward_chain_sub_block.sub_block_height]].sub_epoch_summary_included
-
     @pytest.mark.asyncio
     async def test_weight_proof_map_summaries_1(self, default_400_blocks):
         header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(default_400_blocks)


### PR DESCRIPTION
### Added
- The cli now warns if you attempt to create a plot smaller than k=32.
- `chia configure` now lets you enable or disable uPnP.
- If a peer gives a bad weight proof it will now be disconnected.

### Changed
- Harvester now only checks every 2 minutes for new files and otherwise caches the plot listing in memory and logs how long it took to load all plot files at INFO level.
- Harvester multithreading is now configureable in config.yaml.
- Websocket heartbeat timeout was increased from 30 seconds to 300 seconds.
- Bumped Colorlog to 4.7.2, and pyinstaller to 4.2.

### Fixed
- Weight proofs were failing to verify contributing to a chain stall. This release gets things moving again but nodes are using too much CPU and can pause/lag at times. This may resolve as people upgrade to Beta 21.
- A toxic combination of transaction limits set too high and a non performant clvm kept the chain stalled. A faster rust implementation of clvm is already nearing completion.
- `chia netspace -s` would not correctly look up the start block height by block hash. Additionally netspace now flips to PiB above 1024 TiB. To compare netspace to `chia show` of the GUI use `chia netspace -d 1000` as `chia netspace` defaults to `-d 192` which is one hour.