### PR TITLE
Added scientific formatting to address_manager logger output

### DIFF
--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -463,7 +463,7 @@ class AddressManager:
                 info = self.map_info[node_id]
                 if randbits(30) < (chance * info.get_selection_chance() * (1 << 30)):
                     end = time.time()
-                    log.info(f"address_manager.select_peer took {end - start} seconds in tried table.")
+                    log.info(f"address_manager.select_peer took {(end - start):.2e} seconds in tried table.")
                     return info
                 chance *= 1.2
         else:
@@ -486,7 +486,7 @@ class AddressManager:
                 info = self.map_info[node_id]
                 if randbits(30) < chance * info.get_selection_chance() * (1 << 30):
                     end = time.time()
-                    log.info(f"address_manager.select_peer took {end - start} seconds in new table.")
+                    log.info(f"address_manager.select_peer took {(end - start):.2e} seconds in new table.")
                     return info
                 chance *= 1.2
 


### PR DESCRIPTION
Added explicit scientific formatting with a reasonable amount (2) of significant digits to the logger statements in /src/server/address_manager.py.

**Old log statement:**
address_manager.select_peer took 9.226799011230469e-05 seconds ...

**New log statement:**
address_manager.select_peer took 9.27e-05 seconds ...