### PR TITLE
chia plots create -x Skips adding [final dir] to harvester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ for setuptools_scm/PEP 440 reasons.
 ## [1.0beta22] aka Beta 1.22 - 2021-01-??
 
 ### Added
-- `chia plot create -x` skips adding [final dir] to harvester for farming
+- `chia plots create -x` skips adding [final dir] to harvester for farming
 
 ### Fixed
 - Removed loading plot file names when starting `chia plots create`; decreases plotter time when there are a lot of plots on the machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## [1.0beta22] aka Beta 1.22 - 2021-01-??
+
+### Added
+- `chia plot create -x` skips adding [final dir] to harvester for farming
+
+### Fixed
+- Removed loading plot file names when starting `chia plots create`; decreases plotter time when there are a lot of plots on the machine
+
 ## [1.0beta21] aka Beta 1.21 - 2021-01-16
 
 ### Added

--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -27,6 +27,7 @@ def help_message():
         + " -t [tmp dir] -2 [tmp dir 2] -d [final dir] (creates plots)"
     )
     print("-e disables bitfield plotting")
+    print("-x skips adding [final dir] to harvester for farming")
     print("-i [plotid] -m [memo] are available for debugging")
     print("chia plots check -n [num checks] -g [string] (checks plots)")
     print("  Default: check all plots in every directory")
@@ -104,6 +105,13 @@ def make_parser(parser):
         "-e",
         "--nobitfield",
         help="Disable bitfield",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude_final_dir",
+        help="Skips adding [final dir] to harvester for farming",
         default=False,
         action="store_true",
     )

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -121,9 +121,17 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             filename = f"plot-k{args.size}-{plot_id}.plot"
         full_path: Path = args.final_dir / filename
 
-        if str(args.final_dir.resolve()) not in config["harvester"]["plot_directories"]:
-            # Adds the directory to the plot directories if it is not present
-            config = add_plot_directory(str(args.final_dir.resolve()), root_path)
+        resolved_final_dir: str = str(Path(args.final_dir).resolve())
+        plot_directories_list: str = config["harvester"]["plot_directories"]
+
+        if args.exclude_final_dir:
+            log.info(f"Not adding directory {resolved_final_dir} to harvester for farming")
+            if resolved_final_dir in plot_directories_list:
+                log.warn(f"Directory {resolved_final_dir} already exists for harvester, you will need to remove it manually")
+        else:
+            if resolved_final_dir not in plot_directories_list:
+                # Adds the directory to the plot directories if it is not present
+                config = add_plot_directory(resolved_final_dir, root_path)
 
         if not full_path.exists():
             log.info(f"Starting plot {i + 1}/{num}")

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -11,7 +11,6 @@ from src.util.keychain import Keychain
 from src.util.config import config_path_for_filename, load_config
 from src.util.path import mkdir
 from src.plotting.plot_tools import (
-    get_plot_filenames,
     stream_plot_info,
     add_plot_directory,
 )
@@ -92,7 +91,6 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
     mkdir(args.final_dir)
 
     finished_filenames = []
-    plot_filenames = get_plot_filenames(config["harvester"])
     for i in range(num):
         # Generate a random master secret key
         if test_private_keys is not None:
@@ -123,10 +121,9 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             filename = f"plot-k{args.size}-{plot_id}.plot"
         full_path: Path = args.final_dir / filename
 
-        if args.final_dir.resolve() not in plot_filenames:
-            if str(args.final_dir.resolve()) not in config["harvester"]["plot_directories"]:
-                # Adds the directory to the plot directories if it is not present
-                config = add_plot_directory(str(args.final_dir.resolve()), root_path)
+        if str(args.final_dir.resolve()) not in config["harvester"]["plot_directories"]:
+            # Adds the directory to the plot directories if it is not present
+            config = add_plot_directory(str(args.final_dir.resolve()), root_path)
 
         if not full_path.exists():
             log.info(f"Starting plot {i + 1}/{num}")

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -127,7 +127,7 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
         if args.exclude_final_dir:
             log.info(f"Not adding directory {resolved_final_dir} to harvester for farming")
             if resolved_final_dir in plot_directories_list:
-                log.warn(f"Directory {resolved_final_dir} already exists for harvester, you will need to remove it manually")
+                log.warn(f"Directory {resolved_final_dir} already exists for harvester, please remove it manually")
         else:
             if resolved_final_dir not in plot_directories_list:
                 # Adds the directory to the plot directories if it is not present

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -125,12 +125,13 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
         plot_directories_list: str = config["harvester"]["plot_directories"]
 
         if args.exclude_final_dir:
-            log.info(f"Not adding directory {resolved_final_dir} to harvester for farming")
+            log.info(f"NOT adding directory {resolved_final_dir} to harvester for farming")
             if resolved_final_dir in plot_directories_list:
                 log.warn(f"Directory {resolved_final_dir} already exists for harvester, please remove it manually")
         else:
             if resolved_final_dir not in plot_directories_list:
                 # Adds the directory to the plot directories if it is not present
+                log.info(f"Adding directory {resolved_final_dir} to harvester for farming")
                 config = add_plot_directory(resolved_final_dir, root_path)
 
         if not full_path.exists():

--- a/src/util/block_tools.py
+++ b/src/util/block_tools.py
@@ -161,6 +161,7 @@ class BlockTools:
         args.stripe_size = 2000
         args.num_threads = 0
         args.nobitfield = False
+        args.exclude_final_dir = False
         test_private_keys = [AugSchemeMPL.key_gen(std_hash(i.to_bytes(2, "big"))) for i in range(args.num)]
         try:
             # No datetime in the filename, to get deterministic filenames and not re-plot


### PR DESCRIPTION
Added -x argument to `chia plots create`
-x flag skips adding [final dir] to harvester for farming
Removed loading plot file names when starting `chia plots create`; decreases time to start plotting for whales