### PR TITLE
Ms.mempool cost

### DIFF
--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -236,8 +236,12 @@ class FullNode:
         responses = []
         while curr_sub_height > peak_sub_height - 5:
             curr = await peer.request_sub_block(full_node_protocol.RequestSubBlock(uint32(curr_sub_height), True))
+            if curr is None:
+                raise ValueError(f"Failed to fetch sub block {curr_sub_height} from {peer.get_peer_info()}, timed out")
             if curr is None or not isinstance(curr, full_node_protocol.RespondSubBlock):
-                raise ValueError(f"Failed to fetch sub block {curr_sub_height} from {peer.get_peer_info()}")
+                raise ValueError(
+                    f"Failed to fetch sub block {curr_sub_height} from {peer.get_peer_info()}, wrong type {type(curr)}"
+                )
             responses.append(curr)
             if self.blockchain.contains_sub_block(curr.sub_block.prev_header_hash) or curr_sub_height == 0:
                 found_fork_point = True

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -422,6 +422,7 @@ class FullNode:
     def _close(self):
         self._shut_down = True
         self.blockchain.shut_down()
+        self.mempool_manager.shut_down()
         if self.full_node_peers is not None:
             asyncio.create_task(self.full_node_peers.close())
 

--- a/src/full_node/mempool_manager.py
+++ b/src/full_node/mempool_manager.py
@@ -142,6 +142,10 @@ class MempoolManager:
         npc_list = cached_result.npc_list
         cost = cached_result.cost
 
+        # TODO: remove. This is only temporary until CLVM gets fast
+        if cost > 10000000:
+            return None, MempoolInclusionStatus.FAILED, Err.BLOCK_COST_EXCEEDS_MAX
+
         if cached_result.error is not None:
             return None, MempoolInclusionStatus.FAILED, Err(cached_result.error)
         # build removal list

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -359,7 +359,7 @@ class ChiaServer:
                 except Exception as e:
                     if self.connection_close_task is None:
                         tb = traceback.format_exc()
-                        connection.log.error(f"Exception: {e}, closing connection {connection}. {tb}")
+                        connection.log.error(f"Exception: {e}, closing connection {connection.get_peer_info()}. {tb}")
                     else:
                         connection.log.debug(f"Exception: {e} while closing connection")
                         pass


### PR DESCRIPTION
Large transactions were taking over a minute to validate and blocking the main thread. This will be fixed with rust CLVM, but we still do not want to block at all.

This PR adds:
1. Validation of spend_bundles in a new process
2. A temporary hack which prevents adding large tx to the mempool, until clvm performance is fixed

Note that the large transactions are not added into blocks even prior to this change, because validating them would take too long and stall the network. 