### PR TITLE
Periodocally remove connections that are inactive

### DIFF
--- a/src/full_node/sync_store.py
+++ b/src/full_node/sync_store.py
@@ -11,10 +11,10 @@ log = logging.getLogger(__name__)
 class SyncStore:
     # Whether or not we are syncing
     sync_mode: bool
-    peak_to_peer: Dict[bytes32, List[bytes32]]  # Header hash : peer node id
+    peak_to_peer: Dict[bytes32, Set[bytes32]]  # Header hash : peer node id
     peer_to_peak: Dict[bytes32, Tuple[bytes32, uint32, uint128]]  # peer node id : [header_hash, height, weight]
-    sync_hash_target: Optional[bytes32]  # Peak hash we are syncing towards
-    sync_height_target: Optional[uint32]  # Peak height we are syncing towards
+    sync_target_header_hash: Optional[bytes32]  # Peak hash we are syncing towards
+    sync_target_sub_height: Optional[uint32]  # Peak height we are syncing towards
     peers_changed: asyncio.Event
     batch_syncing: Set[bytes32]  # Set of nodes which we are batch syncing from
 
@@ -23,8 +23,8 @@ class SyncStore:
         self = cls()
 
         self.sync_mode = False
-        self.sync_hash_target = None
-        self.sync_height_target = None
+        self.sync_target_header_hash = None
+        self.sync_target_sub_height = None
         self.peak_fork_point = {}
         self.peak_to_peer = {}
         self.peer_to_peak = {}
@@ -34,14 +34,14 @@ class SyncStore:
         return self
 
     def set_peak_target(self, peak_hash: bytes32, target_sub_height: uint32):
-        self.sync_hash_target = peak_hash
-        self.sync_height_target = target_sub_height
+        self.sync_target_header_hash = peak_hash
+        self.sync_target_sub_height = target_sub_height
 
     def get_sync_target_hash(self) -> Optional[bytes32]:
-        return self.sync_hash_target
+        return self.sync_target_header_hash
 
-    def get_sync_target_height(self) -> Optional[bytes32]:
-        return self.sync_height_target
+    def get_sync_target_sub_height(self) -> Optional[bytes32]:
+        return self.sync_target_sub_height
 
     def set_sync_mode(self, sync_mode: bool):
         self.sync_mode = sync_mode
@@ -49,51 +49,80 @@ class SyncStore:
     def get_sync_mode(self) -> bool:
         return self.sync_mode
 
-    def add_peak_peer(self, peak_hash: bytes32, peer_id: bytes32, weight: uint128, sub_height: uint32):
-        if peak_hash == self.sync_hash_target:
+    def peer_has_sub_block(
+        self, header_hash: bytes32, peer_id: bytes32, weight: uint128, sub_height: uint32, new_peak: bool
+    ):
+        """
+        Adds a record that a certain peer has a sub_block.
+        """
+
+        if header_hash == self.sync_target_header_hash:
             self.peers_changed.set()
-        if peak_hash in self.peak_to_peer:
-            self.peak_to_peer[peak_hash].append(peer_id)
-        else:
-            self.peak_to_peer[peak_hash] = [peer_id]
-        self.set_peer_peak(peer_id, sub_height, weight, peak_hash)
-
-    def set_peer_peak(self, peer_id: bytes32, sub_height: uint32, weight: uint128, peak_hash: bytes32):
-        self.peer_to_peak[peer_id] = (peak_hash, sub_height, weight)
-
-    def get_peak_peers(self, header_hash) -> List[bytes32]:
         if header_hash in self.peak_to_peer:
-            return self.peak_to_peer[header_hash]
+            self.peak_to_peer[header_hash].add(peer_id)
         else:
-            return []
+            self.peak_to_peer[header_hash] = {peer_id}
 
-    def get_peer_peaks(self, current_peers: List[bytes32]) -> Dict[bytes32, Tuple[bytes32, uint32, uint128]]:
+        if new_peak:
+            self.peer_to_peak[peer_id] = (header_hash, sub_height, weight)
+
+    def get_peers_that_have_peak(self, header_hashes: List[bytes32]) -> Set[bytes32]:
+        """
+        Returns: peer ids of peers that have at least one of the header hashes.
+        """
+
+        node_ids: Set[bytes32] = set()
+        for header_hash in header_hashes:
+            if header_hash in self.peak_to_peer:
+                for node_id in self.peak_to_peer[header_hash]:
+                    node_ids.add(node_id)
+        return node_ids
+
+    def get_peak_of_each_peer(self) -> Dict[bytes32, Tuple[bytes32, uint32, uint128]]:
+        """
+        Returns: dictionary of peer id to peak information.
+        """
+
         ret = {}
         for peer_id, v in self.peer_to_peak.items():
             if v[0] not in self.peak_to_peer:
-                # log.info(f"get_peer_peaks filter {v[0]} not in self.peak_to_peer {self.peak_to_peer}")
                 continue
-            if peer_id in current_peers:
-                ret[peer_id] = v
+            ret[peer_id] = v
         return ret
 
-    def get_heaviest_peak(self, current_peers: List[bytes32]) -> Optional[Tuple[bytes32, uint32, uint128]]:
-        if len(self.get_peer_peaks(current_peers)) == 0:
+    def get_heaviest_peak(self) -> Optional[Tuple[bytes32, uint32, uint128]]:
+        """
+        Returns: the header_hash, sub_height, and weight of the heaviest sub_block that one of our peers has notified
+        us of.
+        """
+
+        if len(self.peer_to_peak) == 0:
             return None
         heaviest_peak_hash: Optional[bytes32] = None
         heaviest_peak_weight: uint128 = uint128(0)
         heaviest_peak_height: Optional[uint32] = None
         for peer_id, (peak_hash, sub_height, weight) in self.peer_to_peak.items():
             if peak_hash not in self.peak_to_peer:
-                # log.info(f"get_heaviest_peak filter {peak_hash} not in self.peak_to_peer {self.peak_to_peer}")
                 continue
-            if peer_id in current_peers:
-                if heaviest_peak_hash is None or weight > heaviest_peak_weight:
-                    heaviest_peak_hash = peak_hash
-                    heaviest_peak_weight = weight
-                    heaviest_peak_height = sub_height
+            if heaviest_peak_hash is None or weight > heaviest_peak_weight:
+                heaviest_peak_hash = peak_hash
+                heaviest_peak_weight = weight
+                heaviest_peak_height = sub_height
         assert heaviest_peak_hash is not None and heaviest_peak_weight is not None and heaviest_peak_height is not None
         return heaviest_peak_hash, heaviest_peak_height, heaviest_peak_weight
 
     async def clear_sync_info(self):
+        """
+        Clears the peak_to_peer info which can get quite large.
+        """
         self.peak_to_peer = {}
+
+    def peer_disconnected(self, node_id: bytes32):
+        if node_id in self.peer_to_peak:
+            del self.peer_to_peak[node_id]
+
+        for peak, peers in self.peak_to_peer.items():
+            if node_id in peers:
+                self.peak_to_peer[peak].remove(node_id)
+            assert node_id not in self.peak_to_peer[peak]
+        self.peers_changed.set()

--- a/src/rpc/full_node_rpc_api.py
+++ b/src/rpc/full_node_rpc_api.py
@@ -75,12 +75,14 @@ class FullNodeRpcApi:
 
         sync_mode: bool = self.service.sync_store.get_sync_mode()
 
-        sync_tip_height = 0
-        sync_tip_sub_height = 0
+        sync_tip_height: Optional[uint32] = uint32(0)
+        sync_tip_sub_height: Optional[uint32] = uint32(0)
         if sync_mode:
-            if self.service.sync_store.sync_height_target is not None:
-                sync_tip_sub_height = self.service.sync_store.sync_height_target
-                sync_tip_height = self.service.sync_store.sync_height_target
+            if self.service.sync_store.get_sync_target_sub_height() is not None:
+                sync_tip_sub_height = self.service.sync_store.get_sync_target_sub_height()
+                sync_tip_height = self.service.sync_store.get_sync_target_sub_height()
+                assert sync_tip_sub_height is not None
+                assert sync_tip_height is not None
             if full_peak is not None:
                 sync_progress_sub_height = full_peak.sub_block_height
                 sync_progress_height = full_peak.height
@@ -93,9 +95,9 @@ class FullNodeRpcApi:
 
         if full_peak is not None and full_peak.height > 1:
             newer_block_hex = full_peak.header_hash.hex()
-            hash = self.service.blockchain.sub_height_to_hash(uint32(max(1, full_peak.sub_block_height - 1000)))
-            assert hash is not None
-            older_block_hex = hash.hex()
+            header_hash = self.service.blockchain.sub_height_to_hash(uint32(max(1, full_peak.sub_block_height - 1000)))
+            assert header_hash is not None
+            older_block_hex = header_hash.hex()
             space = await self.get_network_space(
                 {"newer_block_header_hash": newer_block_hex, "older_block_header_hash": older_block_hex}
             )

--- a/tests/core/full_node/test_sync_store.py
+++ b/tests/core/full_node/test_sync_store.py
@@ -1,8 +1,8 @@
 import asyncio
-import sqlite3
 
 import pytest
 from src.full_node.sync_store import SyncStore
+from src.util.hash import std_hash
 
 
 @pytest.fixture(scope="module")
@@ -14,14 +14,54 @@ def event_loop():
 class TestStore:
     @pytest.mark.asyncio
     async def test_basic_store(self):
-        assert sqlite3.threadsafety == 1
-        db = await SyncStore.create()
+        store = await SyncStore.create()
         await SyncStore.create()
 
         # Save/get sync
         for sync_mode in (False, True):
-            db.set_sync_mode(sync_mode)
-            assert sync_mode == db.get_sync_mode()
+            store.set_sync_mode(sync_mode)
+            assert sync_mode == store.get_sync_mode()
 
         # clear sync info
-        await db.clear_sync_info()
+        await store.clear_sync_info()
+
+        store.set_peak_target(std_hash(b"1"), 100)
+        assert store.get_sync_target_hash() == std_hash(b"1")
+        assert store.get_sync_target_sub_height() == 100
+
+        peer_ids = [std_hash(bytes([a])) for a in range(3)]
+
+        assert store.get_peers_that_have_peak([]) == set()
+        assert store.get_peers_that_have_peak([std_hash(b"block1")]) == set()
+
+        assert store.get_heaviest_peak() is None
+        assert len(store.get_peak_of_each_peer()) == 0
+        store.peer_has_sub_block(std_hash(b"block10"), peer_ids[0], 500, 10, True)
+        store.peer_has_sub_block(std_hash(b"block1"), peer_ids[0], 300, 1, False)
+        store.peer_has_sub_block(std_hash(b"block1"), peer_ids[1], 300, 1, True)
+        store.peer_has_sub_block(std_hash(b"block10"), peer_ids[2], 500, 10, False)
+        store.peer_has_sub_block(std_hash(b"block1"), peer_ids[2], 300, 1, False)
+
+        assert store.get_heaviest_peak()[0] == std_hash(b"block10")
+        assert store.get_heaviest_peak()[1] == 10
+        assert store.get_heaviest_peak()[2] == 500
+
+        assert len(store.get_peak_of_each_peer()) == 2
+        store.peer_has_sub_block(std_hash(b"block1"), peer_ids[2], 500, 1, True)
+        assert len(store.get_peak_of_each_peer()) == 3
+        assert store.get_peak_of_each_peer()[peer_ids[0]][2] == 500
+        assert store.get_peak_of_each_peer()[peer_ids[1]][2] == 300
+        assert store.get_peak_of_each_peer()[peer_ids[2]][2] == 500
+
+        assert store.get_peers_that_have_peak([std_hash(b"block1")]) == set(peer_ids)
+        assert store.get_peers_that_have_peak([std_hash(b"block10")]) == {peer_ids[0], peer_ids[2]}
+
+        store.peer_disconnected(peer_ids[0])
+        assert store.get_heaviest_peak()[2] == 500
+        assert len(store.get_peak_of_each_peer()) == 2
+        assert store.get_peers_that_have_peak([std_hash(b"block10")]) == {peer_ids[2]}
+        store.peer_disconnected(peer_ids[2])
+        assert store.get_heaviest_peak()[2] == 300
+        store.peer_has_sub_block(std_hash(b"block30"), peer_ids[0], 700, 30, True)
+        assert store.get_peak_of_each_peer()[peer_ids[0]][2] == 700
+        assert store.get_heaviest_peak()[2] == 700


### PR DESCRIPTION
After 1 hour of inactivity, connection is closed. Also refactors the sync store to be more clear, simpler, and consistent with the current active connections.