### PR TITLE
make the mempool cost calculation use serialized programs

### DIFF
--- a/src/full_node/mempool_check_conditions.py
+++ b/src/full_node/mempool_check_conditions.py
@@ -135,7 +135,7 @@ def get_name_puzzle_conditions(block_program: SerializedProgram, safe_mode: bool
 
 def get_puzzle_and_solution_for_coin(block_program: SerializedProgram, coin_name: bytes):
     try:
-        cost, result = GENERATOR_FOR_SINGLE_COIN_MOD.run_with_cost([block_program, coin_name])
+        cost, result = GENERATOR_FOR_SINGLE_COIN_MOD.run_with_cost(block_program, coin_name)
         puzzle = result.first()
         solution = result.rest().first()
         return None, puzzle, solution

--- a/src/wallet/puzzles/generator_loader.py
+++ b/src/wallet/puzzles/generator_loader.py
@@ -1,4 +1,4 @@
-from src.wallet.puzzles.load_clvm import load_clvm, load_serialized_clvm
+from src.wallet.puzzles.load_clvm import load_serialized_clvm
 
 GENERATOR_MOD = load_serialized_clvm("generator.clvm", package_or_requirement=__name__)
-GENERATOR_FOR_SINGLE_COIN_MOD = load_clvm("generator_for_single_coin.clvm", package_or_requirement=__name__)
+GENERATOR_FOR_SINGLE_COIN_MOD = load_serialized_clvm("generator_for_single_coin.clvm", package_or_requirement=__name__)

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -55,8 +55,10 @@ class TestCostCalculation:
         clvm_cost = result.cost
 
         error, npc_list, cost = get_name_puzzle_conditions(program, False)
+        assert error is None
         coin_name = npc_list[0].coin_name
         error, puzzle, solution = get_puzzle_and_solution_for_coin(program, coin_name)
+        assert error is None
 
         # Create condition + agg_sig_condition + length + cpu_cost
         assert clvm_cost == 200 * ratio + 20 * ratio + len(bytes(program)) * ratio + cost


### PR DESCRIPTION
(and arguments) correctly. Add asserts to test that otherwise would fail