### PR TITLE
make the super linter workflow run the same way other workflows do

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -17,11 +17,13 @@ name: GithHub Super Linter
 #############################
 on:
   push:
-    branches-ignore:
-      - 'master'
+    branches:
+      - main
+    tags:
+        - '**'
   pull_request:
-    branches-ignore:
-      - 'master'
+    branches:
+      - '**'
 
 ###############
 # Set the Job #


### PR DESCRIPTION
and not twice on pull requests. This seems to be the CI trigger settings on all other workflows, and they don't run twice on pull requests