### PR TITLE
remote-daemon-settings

### DIFF
--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -219,6 +219,14 @@ ui:
   ssh_filename: config/ssh_host_key
   logging: *logging
 
+  # this is where the electron UI will find its daemon 
+  # defaults to the one running locally with its private keys
+  daemon_host: *self_hostname
+  daemon_port: 55400
+  daemon_ssl:
+    private_crt: config/ssl/daemon/private_daemon.crt
+    private_key: config/ssl/daemon/private_daemon.key
+
 introducer:
   host: *self_hostname
   port: 8445


### PR DESCRIPTION
This PR adds settings that go along with the `remote-daemon` PR https://github.com/Chia-Network/chia-blockchain-gui/pull/5

_the remote daemon code will work without this change but the two should go together_