### PR TITLE
cryptography 3.4.1 has a toxic interaction with keyrings on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dependencies = [
     "cbor2==5.2.0",  # Used for network wire format
     "colorlog==4.7.2",  # Adds color to logs
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
-#    "cryptography==3.4.1",  # Python cryptography library for TLS - keyring conflict
+    #  "cryptography==3.4.1",  # Python cryptography library for TLS - keyring conflict
     "cryptography==3.3.2",  # Python cryptography library for TLS
     "keyring==21.5.0",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ dependencies = [
     "cbor2==5.2.0",  # Used for network wire format
     "colorlog==4.7.2",  # Adds color to logs
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
-    "cryptography==3.4.1",  # Python cryptography library for TLS
+#    "cryptography==3.4.1",  # Python cryptography library for TLS - keyring conflict
+    "cryptography==3.3.2",  # Python cryptography library for TLS
     "keyring==21.5.0",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)
     "PyYAML==5.3.1",  # Used for config file format


### PR DESCRIPTION
Downgrading to 3.3.2 which has the most recent security fix.