### PR TITLE
Ms.optimize rpi

### DIFF
--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -319,7 +319,7 @@ class FullNode:
             if request.height < curr_peak_height + self.config["sync_sub_blocks_behind_threshold"]:
                 # This case of being behind but not by so much
                 self.log.debug("Doing batch sync")
-                if await self.short_sync_batch(peer, uint32(max(curr_peak_height - 20, 0)), request.height):
+                if await self.short_sync_batch(peer, uint32(max(curr_peak_height - 6, 0)), request.height):
                     return
 
             # This is the either the case where we were not able to sync successfully (for example, due to the fork

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -929,7 +929,7 @@ class FullNode:
         block = respond_unfinished_sub_block.unfinished_sub_block
 
         if block.prev_header_hash != self.constants.GENESIS_CHALLENGE and not self.blockchain.contains_sub_block(
-                block.prev_header_hash
+            block.prev_header_hash
         ):
             # No need to request the parent, since the peer will send it to us anyway, via NewPeak
             self.log.debug("Received a disconnected unfinished block")

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -317,7 +317,6 @@ class FullNode:
                         )
         else:
             if request.height <= curr_peak_height + self.config["short_sync_sub_blocks_behind_threshold"]:
-                self.log.debug("Doing backtrack sync")
                 # This is the normal case of receiving the next sub-block
                 if await self.short_sync_backtrack(
                     peer, curr_peak_height, request.height, request.unfinished_reward_block_hash
@@ -333,7 +332,6 @@ class FullNode:
 
             if request.height < curr_peak_height + self.config["sync_sub_blocks_behind_threshold"]:
                 # This case of being behind but not by so much
-                self.log.debug("Doing batch sync")
                 if await self.short_sync_batch(peer, uint32(max(curr_peak_height - 6, 0)), request.height):
                     return
 

--- a/src/full_node/full_node_store.py
+++ b/src/full_node/full_node_store.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Set
 
 from src.consensus.blockchain_interface import BlockchainInterface
 from src.consensus.constants import ConsensusConstants
@@ -47,6 +47,9 @@ class FullNodeStore:
     # Infusion point VDFs which depend on infusions that we don't have
     future_ip_cache: Dict[bytes32, List[timelord_protocol.NewInfusionPointVDF]]
 
+    # Partial hashes of unfinished blocks we are requesting
+    requesting_unfinished_blocks: Set[bytes32] = set()
+
     def __init__(self):
         self.candidate_blocks = {}
         self.seen_unfinished_blocks = set()
@@ -55,6 +58,7 @@ class FullNodeStore:
         self.future_eos_cache = {}
         self.future_sp_cache = {}
         self.future_ip_cache = {}
+        self.requesting_unfinished_blocks = set()
 
     @classmethod
     async def create(cls, constants: ConsensusConstants):

--- a/src/full_node/sync_store.py
+++ b/src/full_node/sync_store.py
@@ -17,6 +17,7 @@ class SyncStore:
     sync_target_height: Optional[uint32]  # Peak height we are syncing towards
     peers_changed: asyncio.Event
     batch_syncing: Set[bytes32]  # Set of nodes which we are batch syncing from
+    backtrack_syncing: Dict[bytes32, int]  # Set of nodes which we are backtrack syncing from, and how many threads
 
     @classmethod
     async def create(cls):
@@ -31,6 +32,7 @@ class SyncStore:
         self.peers_changed = asyncio.Event()
 
         self.batch_syncing = set()
+        self.backtrack_syncing = {}
         return self
 
     def set_peak_target(self, peak_hash: bytes32, target_height: uint32):

--- a/src/server/start_wallet.py
+++ b/src/server/start_wallet.py
@@ -81,7 +81,7 @@ def main():
     else:
         constants = DEFAULT_CONSTANTS
         genesis_challenge = bytes32(bytes.fromhex(config["network_genesis_challenges"][config["selected_network"]]))
-        constants.replace(GENESIS_CHALLENGE=genesis_challenge)
+        constants = constants.replace(GENESIS_CHALLENGE=genesis_challenge)
     keychain = Keychain(testing=False)
     kwargs = service_kwargs_for_wallet(DEFAULT_ROOT_PATH, config, constants, keychain)
     return run_service(**kwargs)

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -180,7 +180,7 @@ full_node:
   sync_sub_blocks_behind_threshold: 300
 
   # If node is more than these blocks behind, will do a short batch-sync, if it's less, will do a backtrack sync
-  short_sync_sub_blocks_behind_threshold: 10
+  short_sync_sub_blocks_behind_threshold: 20
 
   # How often to initiate outbound connections to other full nodes.
   peer_connect_interval: 30

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -415,7 +415,6 @@ class WalletNode:
                 while (
                     not self.wallet_state_manager.blockchain.contains_sub_block(top.prev_header_hash) and top.height > 0
                 ):
-                    self.log.info(f"FETCHING {top.height - 1}")
                     request_prev = wallet_protocol.RequestSubBlockHeader(top.height - 1)
                     response_prev: Optional[RespondSubBlockHeader] = await peer.request_sub_block_header(request_prev)
                     if response_prev is None:
@@ -445,7 +444,7 @@ class WalletNode:
                         f"invalid weight proof, num of epochs {len(weight_proof.sub_epochs)}"
                         f" recent blocks num ,{len(weight_proof.recent_chain_data)}"
                     )
-                    # self.log.error(f"{weight_proof}")
+                    self.log.debug(f"{weight_proof}")
                     return None
                 self.log.info(f"Validated, fork point is {fork_point}")
                 self.wallet_state_manager.sync_store.add_potential_fork_point(


### PR DESCRIPTION
RPI has been really struggling to keep up with the fast blocks.This makes it a little better:

1. Only request unfinished blocks from one peer (for 5 seconds, then can make other requests). This prevents re downloading and parsing the whole block multiple times. 
2. Don't batch sync to the same peer at the same time. Before we were doing one request every time we got a new peak, and that slowed it down
3. Avoid recomputing some hashes, although not sure if this has an effect
4. Many backtrack syncs can happen simultaneously. But if backtrack syncing, do not batch sync
5. Increase limit of backtrack sync from 20 to 10. So even if we are 20 blocks behind, we do backtrack sync which is faster/more efficient.