### PR TITLE
Catch errors when attempting to verify a VDF proof with a bad form

### DIFF
--- a/src/types/classgroup.py
+++ b/src/types/classgroup.py
@@ -23,11 +23,5 @@ class ClassgroupElement(Streamable):
         return ClassgroupElement.from_bytes(b"\x08")
 
     @staticmethod
-    def get_bad_element(constants: ConsensusConstants):
-        # Used by test_blockchain to check that bad VDF outputs and proofs are
-        # rejected. Use the default element for simplicity.
-        return ClassgroupElement.get_default_element()
-
-    @staticmethod
     def get_size(constants: ConsensusConstants):
         return 100

--- a/src/types/vdf.py
+++ b/src/types/vdf.py
@@ -68,15 +68,14 @@ class VDFProof(Streamable):
             return False
         try:
             disc: int = get_discriminant(info.challenge, constants.DISCRIMINANT_SIZE_BITS)
+            # TODO: parallelize somehow, this might included multiple mini proofs (n weso)
+            return verify_n_wesolowski(
+                str(disc),
+                input_el.data,
+                info.output.data + bytes(self.witness),
+                info.number_of_iterations,
+                constants.DISCRIMINANT_SIZE_BITS,
+                self.witness_type,
+            )
         except Exception:
             return False
-        # TODO: parallelize somehow, this might included multiple mini proofs (n weso)
-        # TODO: check for maximum witness type
-        return verify_n_wesolowski(
-            str(disc),
-            input_el.data,
-            info.output.data + bytes(self.witness),
-            info.number_of_iterations,
-            constants.DISCRIMINANT_SIZE_BITS,
-            self.witness_type,
-        )

--- a/tests/core/consensus/test_blockchain.py
+++ b/tests/core/consensus/test_blockchain.py
@@ -27,6 +27,7 @@ from tests.core.fixtures import default_400_blocks  # noqa: F401
 from tests.core.fixtures import default_10000_blocks  # noqa: F401
 
 log = logging.getLogger(__name__)
+bad_element = ClassgroupElement.from_bytes(b"\x00")
 
 
 @pytest.fixture(scope="session")
@@ -985,7 +986,7 @@ class TestBlockHeaderValidation:
                 block_bad = recursive_replace(
                     blocks[-1],
                     "reward_chain_block.reward_chain_sp_vdf.output",
-                    ClassgroupElement.get_bad_element(test_constants),
+                    bad_element,
                 )
                 assert (await empty_blockchain.receive_block(block_bad))[1] == Err.INVALID_RC_SP_VDF
                 block_bad = recursive_replace(
@@ -1027,7 +1028,7 @@ class TestBlockHeaderValidation:
                 block_bad = recursive_replace(
                     blocks[-1],
                     "reward_chain_block.challenge_chain_sp_vdf.output",
-                    ClassgroupElement.get_bad_element(test_constants),
+                    bad_element,
                 )
                 assert (await empty_blockchain.receive_block(block_bad))[0] == ReceiveBlockResult.INVALID_BLOCK
                 block_bad = recursive_replace(
@@ -1310,7 +1311,7 @@ class TestBlockHeaderValidation:
         block_bad = recursive_replace(
             blocks[-1],
             "reward_chain_block.challenge_chain_ip_vdf.output",
-            ClassgroupElement.get_bad_element(test_constants),
+            bad_element,
         )
         assert (await empty_blockchain.receive_block(block_bad))[1] == Err.INVALID_CC_IP_VDF
         block_bad = recursive_replace(
@@ -1338,7 +1339,7 @@ class TestBlockHeaderValidation:
         block_bad = recursive_replace(
             blocks[-1],
             "reward_chain_block.reward_chain_ip_vdf.output",
-            ClassgroupElement.get_bad_element(test_constants),
+            bad_element,
         )
         assert (await empty_blockchain.receive_block(block_bad))[1] == Err.INVALID_RC_IP_VDF
         block_bad = recursive_replace(
@@ -1369,7 +1370,7 @@ class TestBlockHeaderValidation:
         block_bad = recursive_replace(
             blocks[-1],
             "reward_chain_block.infused_challenge_chain_ip_vdf.output",
-            ClassgroupElement.get_bad_element(test_constants),
+            bad_element,
         )
         assert (await empty_blockchain.receive_block(block_bad))[1] == Err.INVALID_ICC_VDF
         block_bad = recursive_replace(


### PR DESCRIPTION
Remove .get_bad_element() method from ClassgroupElement, do it in
test_blockchain as it's only needed there.