### PR TITLE
Verify RPC in full node

### DIFF
--- a/src/rpc/full_node_rpc_api.py
+++ b/src/rpc/full_node_rpc_api.py
@@ -32,7 +32,7 @@ class FullNodeRpcApi:
             "/get_additions_and_removals": self.get_additions_and_removals,
             "/get_blocks": self.get_blocks,
             "/get_initial_freeze_period": self.get_initial_freeze_period,
-            "/verify": self.verify
+            "/verify": self.verify,
         }
 
     async def _state_changed(self, change: str) -> List[Dict]:

--- a/src/rpc/full_node_rpc_client.py
+++ b/src/rpc/full_node_rpc_client.py
@@ -97,3 +97,12 @@ class FullNodeRpcClient(RpcClient):
             return []
         # TODO: return block records
         return response["block_records"]
+
+    async def verify(self, message: str, public_key: bytes32, signature: bytes32) -> Optional[bool]:
+        try:
+            response = await self.fetch(
+                "verify", {"message": message, "public_key": public_key, "signature": signature}
+            )
+        except Exception:
+            return False
+        return response["valid"]

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -111,6 +111,15 @@ class TestRpc:
 
             await client.close_connection(connections[0]["node_id"])
             await time_out_assert(10, num_connections, 0)
+
+            pk = "820e3f84e1368deab22350e6f500bc50726cb9b7c1c3be215996c77be029843b790381f9b0925a68cd23dbaebd8eadb3"
+            signature = (
+                "ab91e486c838186cc0f096239a04efdb8cbbf9853920fb4f3254591c7c957598e58aab5e0ac04a76f63d0007ebcbcc730"
+                "c6bb0251d972423f532e4cacca79f19081fd818d28dcf6d1ef122cfa4c8644e35e3ebf94aae89d73eafe5ecc350cc73"
+            )
+
+            assert (await client.verify("hello", pk, signature)) is True
+            assert (await client.verify("goodbye", pk, signature)) is False
         finally:
             # Checks that the RPC manages to stop the node
             client.close()


### PR DESCRIPTION
**Why?**

* To make it simple to verify pool owners.
* By adding it as a RPC other people can benefit from the feature as well.

This will make it possible to do things like this where the pool owner is able to set it up themselves.

![pool-tags](https://user-images.githubusercontent.com/4749434/107858780-d4efc880-6e2d-11eb-806f-8747db61640a.png)

**Manual tests**

Valid

```bash
(venv) ubuntu@ip-172-26-6-102:~/.chia/beta-1.0b28.dev6/config/ssl/full_node$ curl -k --key private_full_node.key --cert private_full_node.crt -X POST  -d '{ "message": 
"hello", "public_key": "820e3f84e1368deab22350e6f500bc50726cb9b7c1c3be215996c77be029843b790381f9b0925a68cd23dbaebd8eadb3", "signature": "ab91e486c838186cc0f096239a04efd
b8cbbf9853920fb4f3254591c7c957598e58aab5e0ac04a76f63d0007ebcbcc730c6bb0251d972423f532e4cacca79f19081fd818d28dcf6d1ef122cfa4c8644e35e3ebf94aae89d73eafe5ecc350cc73"  }' h
ttps://localhost:8555/verify | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   378  100    32  100   346   1391  15043 --:--:-- --:--:-- --:--:-- 16434
{
  "success": true,
  "valid": true
}
```

Invalid

```bash
(venv) ubuntu@ip-172-26-6-102:~/.chia/beta-1.0b28.dev6/config/ssl/full_node$ curl -k --key private_full_node.key --cert private_full_node.crt -X POST  -d '{ "message": 
"goodbye", "public_key": "820e3f84e1368deab22350e6f500bc50726cb9b7c1c3be215996c77be029843b790381f9b0925a68cd23dbaebd8eadb3", "signature": "ab91e486c838186cc0f096239a04e
fdb8cbbf9853920fb4f3254591c7c957598e58aab5e0ac04a76f63d0007ebcbcc730c6bb0251d972423f532e4cacca79f19081fd818d28dcf6d1ef122cfa4c8644e35e3ebf94aae89d73eafe5ecc350cc73"  }'
 https://localhost:8555/verify | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   381  100    33  100   348   1434  15130 --:--:-- --:--:-- --:--:-- 16565
{
  "success": true,
  "valid": false
}
```
