### PR TITLE
Improve harvester handling copied files

### DIFF
--- a/src/harvester/harvester_api.py
+++ b/src/harvester/harvester_api.py
@@ -1,11 +1,9 @@
 import asyncio
-import dataclasses
 import time
 from pathlib import Path
 from typing import Callable, List, Tuple
 
 from blspy import AugSchemeMPL, G2Element
-from chiapos import DiskProver
 
 from src.consensus.pot_iterations import (
     calculate_sp_interval_iters,
@@ -94,15 +92,8 @@ class HarvesterAPI:
                 try:
                     quality_strings = plot_info.prover.get_qualities_for_challenge(sp_challenge_hash)
                 except Exception as e:
-                    self.harvester.log.error(f"Error using prover object. Reinitializing prover object. {e}")
-                    try:
-                        self.harvester.provers[filename] = dataclasses.replace(
-                            plot_info, prover=DiskProver(str(filename))
-                        )
-                        quality_strings = plot_info.prover.get_qualities_for_challenge(sp_challenge_hash)
-                    except Exception as e:
-                        self.harvester.log.error(f"Error reinitializing plot {filename}. {e}")
-                        return []
+                    self.harvester.log.error(f"Error using prover object {e}")
+                    return []
 
                 responses: List[Tuple[bytes32, ProofOfSpace]] = []
                 if quality_strings is not None:

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -168,14 +168,18 @@ def load_plots(
                 # Try once every 20 minutes to open the file
                 continue
             if filename in provers:
-                stat_info = filename.stat()
+                try:
+                    stat_info = filename.stat()
+                except Exception as e:
+                    log.error(f"Failed to open file {filename}. {e}")
+                    continue
                 if stat_info.st_mtime == provers[filename].time_modified:
                     total_size += stat_info.st_size
                     new_provers[filename] = provers[filename]
                     continue
             try:
                 prover = DiskProver(str(filename))
-                expected_size = _expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR / 2.0
+                expected_size = _expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR
                 stat_info = filename.stat()
 
                 # TODO: consider checking if the file was just written to (which would mean that the file is still


### PR DESCRIPTION
Don't reinitialize the plot, since this seems to cause crashes. Also, there was a regression from beta26. The minimum file size for a valid plot was ~50GB, instead of the expected 100GB. 