### PR TITLE
Add --debug-show-memo and --challenge-start to chia plots check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ for setuptools_scm/PEP 440 reasons.
 - 'chia wallet show' also shows your wallet's height.
 - Added the ability to specify an address for the pool when making plots (-c flag), as opposed to a public key. The block
 validation was changed to allow blocks like these to be made. This will enable changing pools in the future, by specifying a smart transaction for your pool rewards.
+- Added `chia plots check --debug-show-memo` to display memo in INFO log to allow recreating the same exact plot for debugging purposes. PR @eFishCent
+- Added `chia plots check --challenge-start [start]` that begins at a different `[start]` up to `-n [challenges]`. Useful when you want to do more detailed checks on plots without restarting from lower challenge values you already have done. PR @eFishCent
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ for setuptools_scm/PEP 440 reasons.
 - Added the ability to specify an address for the pool when making plots (-c flag), as opposed to a public key. The block
 validation was changed to allow blocks like these to be made. This will enable changing pools in the future, by specifying a smart transaction for your pool rewards.
 - Added `chia plots check --debug-show-memo` to display memo in INFO log to allow recreating the same exact plot for debugging purposes. PR @eFishCent
-- Added `chia plots check --challenge-start [start]` that begins at a different `[start]` up to `-n [challenges]`. Useful when you want to do more detailed checks on plots without restarting from lower challenge values you already have done. PR @eFishCent
+- Added `chia plots check --challenge-start [start]` that begins at a different `[start]` for `-n [challenges]`. Useful when you want to do more detailed checks on plots without restarting from lower challenge values you already have done. PR @eFishCent
 
 ### Changed
 

--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -36,7 +36,7 @@ def help_message():
     print("  -l: list plots with duplicate IDs")
     print("  Debugging options for chia plots check")
     print("    --debug-show-memo: shows memo to recreate the same exact plot")
-    print("    --challenge-start [start]: begins at a different [start] up to -n [challenges]")
+    print("    --challenge-start [start]: begins at a different [start] for -n [challenges]")
     print("chia plots add -d [directory] (adds a directory of plots)")
     print("chia plots remove -d [directory] (removes a directory of plots from config)")
     print("chia plots show (shows the directory of current plots)")
@@ -145,7 +145,7 @@ def make_parser(parser):
     )
     parser.add_argument(
         "--challenge-start",
-        help="Begins at a different [start] up to -n [challenges]",
+        help="Begins at a different [start] for -n [challenges]",
         type=int,
         default=None,
     )

--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -34,6 +34,9 @@ def help_message():
     print("  -n: number of challenges; 0 = skip opening plot files; can be used with -l")
     print("  -g: checks plots with file or directory name containing [string]")
     print("  -l: list plots with duplicate IDs")
+    print("  Debugging options for chia plots check")
+    print("    --debug-memo: shows memo to recreate the same exact plot")
+    print("    --num-start [start]: begins at a different [start] number up to -n [challenges]")
     print("chia plots add -d [directory] (adds a directory of plots)")
     print("chia plots remove -d [directory] (removes a directory of plots from config)")
     print("chia plots show (shows the directory of current plots)")
@@ -133,6 +136,18 @@ def make_parser(parser):
         help="List plots with duplicate IDs",
         default=False,
         action="store_true",
+    )
+    parser.add_argument(
+        "--debug-memo",
+        help="Shows memo to recreate the same exact plot",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--num-start",
+        help="Begins at a different [start] number up to -n [challenges]",
+        type=int,
+        default=None,
     )
     parser.add_argument(
         "command",

--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -35,8 +35,8 @@ def help_message():
     print("  -g: checks plots with file or directory name containing [string]")
     print("  -l: list plots with duplicate IDs")
     print("  Debugging options for chia plots check")
-    print("    --debug-memo: shows memo to recreate the same exact plot")
-    print("    --num-start [start]: begins at a different [start] number up to -n [challenges]")
+    print("    --debug-show-memo: shows memo to recreate the same exact plot")
+    print("    --challenge-start [start]: begins at a different [start] up to -n [challenges]")
     print("chia plots add -d [directory] (adds a directory of plots)")
     print("chia plots remove -d [directory] (removes a directory of plots from config)")
     print("chia plots show (shows the directory of current plots)")
@@ -138,14 +138,14 @@ def make_parser(parser):
         action="store_true",
     )
     parser.add_argument(
-        "--debug-memo",
+        "--debug-show-memo",
         help="Shows memo to recreate the same exact plot",
         default=False,
         action="store_true",
     )
     parser.add_argument(
-        "--num-start",
-        help="Begins at a different [start] number up to -n [challenges]",
+        "--challenge-start",
+        help="Begins at a different [start] up to -n [challenges]",
         type=int,
         default=None,
     )

--- a/src/harvester/harvester.py
+++ b/src/harvester/harvester.py
@@ -46,6 +46,7 @@ class Harvester:
         self.farmer_public_keys = []
         self.pool_public_keys = []
         self.match_str = None
+        self.show_memo: bool = False
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=config["num_threads"])
         self.state_changed_callback = None
         self.server = None
@@ -113,6 +114,7 @@ class Harvester:
                     self.farmer_public_keys,
                     self.pool_public_keys,
                     self.match_str,
+                    self.show_memo,
                     self.root_path,
                 )
         if changed:

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -29,12 +29,12 @@ def check_plots(args, root_path):
         num = 30
 
     if args.challenge_start is not None:
-        num_start: int = args.challenge_start
+        num_start = args.challenge_start
         if num_start > num:
             log.warning(f"Start challenge {num_start} > {num} challenges. Setting start challenge = {num}")
             num_start = num
     else:
-        num_start: int = 0
+        num_start = 0
 
     if args.grep_string is not None:
         match_str = args.grep_string

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -27,6 +27,15 @@ def check_plots(args, root_path):
                 log.warning("Use 30 challenges (our default) for balance of speed and accurate results")
     else:
         num = 30
+
+    if args.challenge_start is not None:
+        num_start: int = args.challenge_start
+        if num_start > num:
+            log.warning(f"Start challenge {num_start} > {num} challenges. Setting start challenge = {num}")
+            num_start = num
+    else:
+        num_start: int = 0
+
     if args.grep_string is not None:
         match_str = args.grep_string
     else:
@@ -78,7 +87,7 @@ def check_plots(args, root_path):
         log.info(f"\tLocal sk: {plot_info.local_sk}")
         total_proofs = 0
         try:
-            for i in range(num):
+            for i in range(num_start, num):
                 challenge = std_hash(i.to_bytes(32, "big"))
                 for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):
                     proof = pr.get_full_proof(challenge, index)
@@ -91,12 +100,13 @@ def check_plots(args, root_path):
                 return
             log.error(f"{type(e)}: {e} error in proving/verifying for plot {plot_path}")
         if total_proofs > 0:
-            log.info(f"\tProofs {total_proofs} / {num}, {round(total_proofs/float(num), 4)}")
+            challenges: int = num - num_start
+            log.info(f"\tProofs {total_proofs} / {challenges}, {round(total_proofs/float(challenges), 4)}")
             total_good_plots[pr.get_size()] += 1
             total_size += plot_path.stat().st_size
         else:
             total_bad_plots += 1
-            log.error(f"\tProofs {total_proofs} / {num}, {round(total_proofs/float(num), 4)}")
+            log.error(f"\tProofs {total_proofs} / {challenges}, {round(total_proofs/float(challenges), 4)}")
     log.info("")
     log.info("")
     log.info("Summary")

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -30,11 +30,11 @@ def check_plots(args, root_path):
 
     if args.challenge_start is not None:
         num_start = args.challenge_start
-        if num_start > num:
-            log.warning(f"Start challenge {num_start} > {num} challenges. Setting start challenge = {num}")
-            num_start = num
+        num_end = num_start + num
     else:
         num_start = 0
+        num_end = num
+    challenges = num_end - num_start
 
     if args.grep_string is not None:
         match_str = args.grep_string
@@ -87,7 +87,7 @@ def check_plots(args, root_path):
         log.info(f"\tLocal sk: {plot_info.local_sk}")
         total_proofs = 0
         try:
-            for i in range(num_start, num):
+            for i in range(num_start, num_end):
                 challenge = std_hash(i.to_bytes(32, "big"))
                 for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):
                     proof = pr.get_full_proof(challenge, index)
@@ -100,7 +100,6 @@ def check_plots(args, root_path):
                 return
             log.error(f"{type(e)}: {e} error in proving/verifying for plot {plot_path}")
         if total_proofs > 0:
-            challenges: int = num - num_start
             log.info(f"\tProofs {total_proofs} / {challenges}, {round(total_proofs/float(challenges), 4)}")
             total_good_plots[pr.get_size()] += 1
             total_size += plot_path.stat().st_size

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -73,9 +73,6 @@ def check_plots(args, root_path):
         log.info(f"\tPool public key: {plot_info.pool_public_key}")
         log.info(f"\tFarmer public key: {plot_info.farmer_public_key}")
         log.info(f"\tLocal sk: {plot_info.local_sk}")
-# Uncomment next two lines if memo is needed for dev debug
-#        plot_memo: bytes32 = stream_plot_info(plot_info.pool_public_key, plot_info.farmer_public_key, plot_info.local_sk)
-#        log.info(f"\tMemo: {plot_memo}")
         total_proofs = 0
         try:
             for i in range(num):

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -73,6 +73,9 @@ def check_plots(args, root_path):
         log.info(f"\tPool public key: {plot_info.pool_public_key}")
         log.info(f"\tFarmer public key: {plot_info.farmer_public_key}")
         log.info(f"\tLocal sk: {plot_info.local_sk}")
+# Uncomment next two lines if memo is needed for dev debug
+#        plot_memo: bytes32 = stream_plot_info(plot_info.pool_public_key, plot_info.farmer_public_key, plot_info.local_sk)
+#        log.info(f"\tMemo: {plot_memo}")
         total_proofs = 0
         try:
             for i in range(num):

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -35,6 +35,8 @@ def check_plots(args, root_path):
         log.warning("Checking for duplicate Plot IDs")
         log.info("Plot filenames expected to end with -[64 char plot ID].plot")
 
+    show_memo: bool = args.debug_show_memo
+
     if args.list_duplicates:
         plot_filenames: Dict[Path, List[Path]] = get_plot_filenames(config["harvester"])
         all_filenames: List[Path] = []
@@ -56,6 +58,7 @@ def check_plots(args, root_path):
         pks,
         pool_public_keys,
         match_str,
+        show_memo,
         root_path,
         open_no_key_filenames=True,
     )

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -143,8 +143,8 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             plot_memo = bytes.fromhex(args.memo)
 
         # Uncomment next two lines if memo is needed for dev debug
-        #        plot_memo_str: str = plot_memo.hex()
-        #        log.info(f"Memo: {plot_memo_str}")
+        plot_memo_str: str = plot_memo.hex()
+        log.info(f"Memo: {plot_memo_str}")
 
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -117,8 +117,8 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             plot_memo = bytes.fromhex(args.memo)
 
         # Uncomment next two lines if memo is needed for dev debug
-        #        plot_memo_str: str = plot_memo.hex()
-        #        log.info(f"Memo: {plot_memo_str}")
+        plot_memo_str: str = plot_memo.hex()
+        log.info(f"Memo: {plot_memo_str}")
 
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -116,9 +116,9 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             log.info(f"Debug memo: {args.memo}")
             plot_memo = bytes.fromhex(args.memo)
 
-# Uncomment next two lines if memo is needed for dev debug
-#        plot_memo_str: str = plot_memo.hex()
-#        log.info(f"Memo: {plot_memo_str}")
+        # Uncomment next two lines if memo is needed for dev debug
+        #        plot_memo_str: str = plot_memo.hex()
+        #        log.info(f"Memo: {plot_memo_str}")
 
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -142,9 +142,9 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             log.info(f"Debug memo: {args.memo}")
             plot_memo = bytes.fromhex(args.memo)
 
-# Uncomment next two lines if memo is needed for dev debug
-#        plot_memo_str: str = plot_memo.hex()
-#        log.info(f"Memo: {plot_memo_str}")
+        # Uncomment next two lines if memo is needed for dev debug
+        #        plot_memo_str: str = plot_memo.hex()
+        #        log.info(f"Memo: {plot_memo_str}")
 
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -116,6 +116,10 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             log.info(f"Debug memo: {args.memo}")
             plot_memo = bytes.fromhex(args.memo)
 
+# Uncomment next two lines if memo is needed for dev debug
+#        plot_memo_str: str = plot_memo.hex()
+#        log.info(f"Memo: {plot_memo_str}")
+
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 
         if use_datetime:

--- a/src/plotting/create_plots.py
+++ b/src/plotting/create_plots.py
@@ -142,6 +142,10 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             log.info(f"Debug memo: {args.memo}")
             plot_memo = bytes.fromhex(args.memo)
 
+# Uncomment next two lines if memo is needed for dev debug
+#        plot_memo_str: str = plot_memo.hex()
+#        log.info(f"Memo: {plot_memo_str}")
+
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 
         if use_datetime:

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -202,11 +202,10 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
-# Uncomment next three lines if memo is needed for dev debug
-#            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
-#            plot_memo_str: str = plot_memo.hex()
-#            log.info(f"Memo: {plot_memo_str}")
-
+    # Uncomment next three lines if memo is needed for dev debug
+    #            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
+    #            plot_memo_str: str = plot_memo.hex()
+    #            log.info(f"Memo: {plot_memo_str}")
 
     log.info(
         f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -12,11 +12,7 @@ from src.types.blockchain_format.proof_of_space import ProofOfSpace
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.config import load_config, save_config
 from src.wallet.derive_keys import master_sk_to_local_sk
-<<<<<<< HEAD
 from src.types.blockchain_format.sized_bytes import bytes32
-=======
-from src.types.sized_bytes import bytes32
->>>>>>> 367008599da67c80e5550bff644c0635841f87d2
 
 
 log = logging.getLogger(__name__)
@@ -145,6 +141,7 @@ def load_plots(
     farmer_public_keys: Optional[List[G1Element]],
     pool_public_keys: Optional[List[G1Element]],
     match_str: Optional[str],
+    show_memo: bool,
     root_path: Path,
     open_no_key_filenames=False,
 ) -> Tuple[bool, Dict[Path, PlotInfo], Dict[Path, int], Set[Path]]:
@@ -250,10 +247,13 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
-            # Uncomment next three lines if memo is needed for dev debug
-            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
-            plot_memo_str: str = plot_memo.hex()
-            log.info(f"Memo: {plot_memo_str}")
+            if show_memo:
+                if pool_contract_puzzle_hash is None:
+                    plot_memo: bytes32 = stream_plot_info_pk(pool_public_key, farmer_public_key, local_master_sk)
+                else:
+                    plot_memo: bytes32 = stream_plot_info_ph(pool_contract_puzzle_hash, farmer_public_key, local_master_sk)
+                plot_memo_str: str = plot_memo.hex()
+                log.info(f"Memo: {plot_memo_str}")
 
     log.info(
         f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -12,7 +12,6 @@ from src.types.blockchain_format.proof_of_space import ProofOfSpace
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.config import load_config, save_config
 from src.wallet.derive_keys import master_sk_to_local_sk
-from src.types.blockchain_format.sized_bytes import bytes32
 
 
 log = logging.getLogger(__name__)
@@ -248,10 +247,11 @@ def load_plots(
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
             if show_memo:
+                plot_memo: bytes32
                 if pool_contract_puzzle_hash is None:
-                    plot_memo: bytes32 = stream_plot_info_pk(pool_public_key, farmer_public_key, local_master_sk)
+                    plot_memo = stream_plot_info_pk(pool_public_key, farmer_public_key, local_master_sk)
                 else:
-                    plot_memo: bytes32 = stream_plot_info_ph(pool_contract_puzzle_hash, farmer_public_key, local_master_sk)
+                    plot_memo = stream_plot_info_ph(pool_contract_puzzle_hash, farmer_public_key, local_master_sk)
                 plot_memo_str: str = plot_memo.hex()
                 log.info(f"Memo: {plot_memo_str}")
 

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -11,6 +11,7 @@ from src.consensus.pos_quality import _expected_plot_size, UI_ACTUAL_SPACE_CONST
 from src.types.proof_of_space import ProofOfSpace
 from src.util.config import load_config, save_config
 from src.wallet.derive_keys import master_sk_to_local_sk
+from src.types.sized_bytes import bytes32
 
 
 log = logging.getLogger(__name__)
@@ -202,10 +203,10 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
-    # Uncomment next three lines if memo is needed for dev debug
-    #            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
-    #            plot_memo_str: str = plot_memo.hex()
-    #            log.info(f"Memo: {plot_memo_str}")
+            # Uncomment next three lines if memo is needed for dev debug
+            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
+            plot_memo_str: str = plot_memo.hex()
+            log.info(f"Memo: {plot_memo_str}")
 
     log.info(
         f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -202,6 +202,12 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
+# Uncomment next three lines if memo is needed for dev debug
+#            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
+#            plot_memo_str: str = plot_memo.hex()
+#            log.info(f"Memo: {plot_memo_str}")
+
+
     log.info(
         f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"
         f" {time.time()-start_time} seconds"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -245,11 +245,10 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
-# Uncomment next three lines if memo is needed for dev debug
-#            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
-#            plot_memo_str: str = plot_memo.hex()
-#            log.info(f"Memo: {plot_memo_str}")
-
+    # Uncomment next three lines if memo is needed for dev debug
+    #            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
+    #            plot_memo_str: str = plot_memo.hex()
+    #            log.info(f"Memo: {plot_memo_str}")
 
     log.info(
         f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -12,6 +12,7 @@ from src.types.blockchain_format.proof_of_space import ProofOfSpace
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.config import load_config, save_config
 from src.wallet.derive_keys import master_sk_to_local_sk
+from src.types.sized_bytes import bytes32
 
 
 log = logging.getLogger(__name__)
@@ -245,10 +246,10 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
-    # Uncomment next three lines if memo is needed for dev debug
-    #            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
-    #            plot_memo_str: str = plot_memo.hex()
-    #            log.info(f"Memo: {plot_memo_str}")
+            # Uncomment next three lines if memo is needed for dev debug
+            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
+            plot_memo_str: str = plot_memo.hex()
+            log.info(f"Memo: {plot_memo_str}")
 
     log.info(
         f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -245,6 +245,12 @@ def load_plots(
                 continue
             log.info(f"Found plot {filename} of size {new_provers[filename].prover.get_size()}")
 
+# Uncomment next three lines if memo is needed for dev debug
+#            plot_memo: bytes32 = stream_plot_info(pool_public_key, farmer_public_key, local_master_sk)
+#            plot_memo_str: str = plot_memo.hex()
+#            log.info(f"Memo: {plot_memo_str}")
+
+
     log.info(
         f"Loaded a total of {len(new_provers)} plots of size {total_size / (1024 ** 4)} TiB, in"
         f" {time.time()-start_time} seconds"

--- a/src/plotting/plot_tools.py
+++ b/src/plotting/plot_tools.py
@@ -12,7 +12,7 @@ from src.types.blockchain_format.proof_of_space import ProofOfSpace
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.config import load_config, save_config
 from src.wallet.derive_keys import master_sk_to_local_sk
-from src.types.sized_bytes import bytes32
+from src.types.blockchain_format.sized_bytes import bytes32
 
 
 log = logging.getLogger(__name__)

--- a/src/util/block_tools.py
+++ b/src/util/block_tools.py
@@ -140,7 +140,7 @@ class BlockTools:
         if len(self.pool_pubkeys) == 0 or len(farmer_pubkeys) == 0:
             raise RuntimeError("Keys not generated. Run `chia generate keys`")
 
-        _, loaded_plots, _, _ = load_plots({}, {}, farmer_pubkeys, self.pool_pubkeys, None, root_path)
+        _, loaded_plots, _, _ = load_plots({}, {}, farmer_pubkeys, self.pool_pubkeys, None, False, root_path)
         self.plots: Dict[Path, PlotInfo] = loaded_plots
         self._config = load_config(self.root_path, "config.yaml")
         self._config["logging"]["log_stdout"] = True


### PR DESCRIPTION
- Added `chia plots check --debug-show-memo` to display memo in INFO log to allow recreating the same exact plot for debugging purposes.
- Added `chia plots check --challenge-start [start]` that begins at a different `[start]` for `-n [challenges]`. Useful when you want to do more detailed checks on plots without restarting from lower challenge values you already have done.