### PR TITLE
Clean up some lingering sub block language

### DIFF
--- a/src/consensus/block_body_validation.py
+++ b/src/consensus/block_body_validation.py
@@ -231,16 +231,16 @@ async def validate_block_body(
 
     # 15. Check if removals exist and were not previously spent. (unspent_db + diff_store + this_block)
     if peak is None or height == 0:
-        fork_sub_h: int = -1
+        fork_h: int = -1
     elif fork_point_with_peak is not None:
-        fork_sub_h = fork_point_with_peak
+        fork_h = fork_point_with_peak
     else:
-        fork_sub_h = find_fork_point_in_chain(blocks, peak, blocks.block_record(block.prev_header_hash))
+        fork_h = find_fork_point_in_chain(blocks, peak, blocks.block_record(block.prev_header_hash))
 
-    if fork_sub_h == -1:
+    if fork_h == -1:
         coin_store_reorg_height = -1
     else:
-        last_sb_in_common = await blocks.get_block_record_from_db(blocks.height_to_hash(uint32(fork_sub_h)))
+        last_sb_in_common = await blocks.get_block_record_from_db(blocks.height_to_hash(uint32(fork_h)))
         assert last_sb_in_common is not None
         coin_store_reorg_height = last_sb_in_common.height
 
@@ -253,7 +253,7 @@ async def validate_block_body(
         curr: Optional[FullBlock] = await block_store.get_full_block(block.prev_header_hash)
         assert curr is not None
 
-        while curr.height > fork_sub_h:
+        while curr.height > fork_h:
             removals_in_curr, additions_in_curr = curr.tx_removals_and_additions()
             for c_name in removals_in_curr:
                 removals_since_fork.add(c_name)

--- a/src/consensus/blockchain.py
+++ b/src/consensus/blockchain.py
@@ -572,8 +572,9 @@ class Blockchain(BlockchainInterface):
 
     def clean_block_records(self):
         """
-        Cleans the cache so that we only maintain relevant blocks. This removes block records that have sub
-        height < peak - BLOCKS_CACHE_SIZE. These blocks are necessary for calculating future difficulty adjustments.
+        Cleans the cache so that we only maintain relevant blocks. This removes
+        block records that have height < peak - BLOCKS_CACHE_SIZE.
+        These blocks are necessary for calculating future difficulty adjustments.
         """
 
         if len(self.__block_records) < self.constants.BLOCKS_CACHE_SIZE:

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -404,7 +404,7 @@ class FullNodeAPI:
                 num_non_empty_sub_slots_seen = 0
                 for _ in range(30):
                     if num_non_empty_sub_slots_seen >= 3:
-                        self.log.debug("Diverged from peer. Don't have the same sub-blocks")
+                        self.log.debug("Diverged from peer. Don't have the same blocks")
                         return None
                     # If this is an end of sub slot, and we don't have the prev, request the prev instead
                     # We want to catch up to the latest slot so we can receive signage points

--- a/src/wallet/wallet_blockchain.py
+++ b/src/wallet/wallet_blockchain.py
@@ -245,7 +245,7 @@ class WalletBlockchain(BlockchainInterface):
 
         fork_height: Optional[uint32] = await self._reconsider_peak(block_record, genesis, fork_point_with_peak)
         if fork_height is not None:
-            self.log.info(f"💰 Updated wallet peak to sub height {block_record.height}, weight {block_record.weight}, ")
+            self.log.info(f"💰 Updated wallet peak to height {block_record.height}, weight {block_record.weight}, ")
             return ReceiveBlockResult.NEW_PEAK, None, fork_height
         else:
             return ReceiveBlockResult.ADDED_AS_ORPHAN, None, None
@@ -437,8 +437,9 @@ class WalletBlockchain(BlockchainInterface):
 
     def clean_block_records(self):
         """
-        Cleans the cache so that we only maintain relevant blocks. This removes block records that have sub
-        height < peak - BLOCKS_CACHE_SIZE. These blocks are necessary for calculating future difficulty adjustments.
+        Cleans the cache so that we only maintain relevant blocks.
+        This removes block records that have height < peak - BLOCKS_CACHE_SIZE.
+        These blocks are necessary for calculating future difficulty adjustments.
         """
 
         if len(self.__block_records) < self.constants.BLOCKS_CACHE_SIZE:

--- a/src/wallet/wallet_state_manager.py
+++ b/src/wallet/wallet_state_manager.py
@@ -488,8 +488,8 @@ class WalletStateManager:
         farmer_rewards = set()
 
         prev = await self.blockchain.get_block_record_from_db(block.prev_hash)
-        # [sub 1] [sub 2] [block 3] [sub 4] [sub 5] [block6]
-        # [block 6] will contain rewards for [sub 1] [sub 2] [block 3]
+        # [block 1] [block 2] [tx block 3] [block 4] [block 5] [tx block 6]
+        # [tx block 6] will contain rewards for [block 1] [block 2] [tx block 3]
         while prev is not None:
             # step 1 find previous block
             if prev.is_transaction_block:


### PR DESCRIPTION
I found and removed all the remaining references to sub block save maybe 1.

`src/util/block_tools.py:                        full_block, block_record = get_full_block_and_sub_record`

I think that's referring to a sub block but since it could be the sub slot I didn't want to presume @mariano54 