### PR TITLE
Testnet 4, lower difficulty

### DIFF
--- a/src/consensus/default_constants.py
+++ b/src/consensus/default_constants.py
@@ -10,8 +10,8 @@ testnet_kwargs = {
     "SUB_SLOT_ITERS_STARTING": 2 ** 27,
     # DIFFICULTY_STARTING is the starting difficulty for the first epoch, which is then further
     # multiplied by another factor of DIFFICULTY_CONSTANT_FACTOR, to be used in the VDF iter calculation formula.
-    "DIFFICULTY_CONSTANT_FACTOR": 2 ** 67,
-    "DIFFICULTY_STARTING": 5,
+    "DIFFICULTY_CONSTANT_FACTOR": 2 ** 64,
+    "DIFFICULTY_STARTING": 1,
     "DIFFICULTY_CHANGE_MAX_FACTOR": 3,  # The next difficulty is truncated to range [prev / FACTOR, prev * FACTOR]
     # These 3 constants must be changed at the same time
     "SUB_EPOCH_BLOCKS": 384,  # The number of blocks per sub-epoch, mainnet 384

--- a/src/consensus/default_constants.py
+++ b/src/consensus/default_constants.py
@@ -10,8 +10,8 @@ testnet_kwargs = {
     "SUB_SLOT_ITERS_STARTING": 2 ** 27,
     # DIFFICULTY_STARTING is the starting difficulty for the first epoch, which is then further
     # multiplied by another factor of DIFFICULTY_CONSTANT_FACTOR, to be used in the VDF iter calculation formula.
-    "DIFFICULTY_CONSTANT_FACTOR": 2 ** 64,
-    "DIFFICULTY_STARTING": 1,
+    "DIFFICULTY_CONSTANT_FACTOR": 2 ** 62,
+    "DIFFICULTY_STARTING": 5,
     "DIFFICULTY_CHANGE_MAX_FACTOR": 3,  # The next difficulty is truncated to range [prev / FACTOR, prev * FACTOR]
     # These 3 constants must be changed at the same time
     "SUB_EPOCH_BLOCKS": 384,  # The number of blocks per sub-epoch, mainnet 384

--- a/src/consensus/network_type.py
+++ b/src/consensus/network_type.py
@@ -6,3 +6,4 @@ class NetworkType(IntEnum):
     TESTNET_1 = 1
     TESTNET_2 = 2
     TESTNET_3 = 3
+    TESTNET_4 = 4

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -9,19 +9,12 @@ network_overrides: &network_overrides
   testnet0:
     GENESIS_CHALLENGE: "0000000000000000000000000000000000000000000000000000000000000000"
     NETWORK: 1
-  testnet1:
-    DIFFICULTY_CONSTANT_FACTOR: 33554432
-    DIFFICULTY_STARTING: 16777216
-    GENESIS_CHALLENGE: "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"  # std_hash(b"1")
-    GENESIS_PRE_FARM_POOL_PUZZLE_HASH: "23b039a829f3ed14a260355b9fc55d9ccc4539f05bd4bf529fd2630de1751d52"
-    GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: "23b039a829f3ed14a260355b9fc55d9ccc4539f05bd4bf529fd2630de1751d52"
-    NETWORK: 2
-  testnet2:
-    NETWORK: 3
-    GENESIS_CHALLENGE: "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35" # std_hash(b"2")
+  testnet4:
+    GENESIS_CHALLENGE: "4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a" # std_hash(b"4")
+    NETWORK: 4
 
 
-selected_network: &selected_network "testnet2"
+selected_network: &selected_network "testnet4"
 
 # public ssl ca is included in source code
 # Privet ssl ca is used for trusted connections between machines user owns


### PR DESCRIPTION
* Removes configuration of previous testnet chains, which are no longer compatible
* Adds a testnet4 entry with a new genesis challenge
* Difficulty factor reduced from 2^67 to 2^62.

On rc2 testnet, difficulty 1 = approx 20PB. Here difficulty 1 will be equal to approximately 0.625PB. So difficulty will rise to 40-50 pretty quickly.
* Still waiting on https://github.com/Chia-Network/chia-blockchain/pull/1031 to change the default prefarm puzzle hash