### PR TITLE
fix typo in p2_delegated_puzzle_or_hidden_puzzle.clvm.MANUALLY_COMPILED

### DIFF
--- a/src/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.clvm.MANUALLY_COMPILED
+++ b/src/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.clvm.MANUALLY_COMPILED
@@ -93,7 +93,7 @@
 
 ; the hex file disassembles to:
 ;
-; (a (q #a (i 11 (q a (i (= 5 (point_add 11 (pubkey_for_exp (sha256 11 (a 6 (c 2 (c 23 0))))))) (q a 23 47) (q 8)) 1) (q 4 (c 4 (c 5 (c (a 6 (c 2 (c 23 0))) 0))) (a 23 47))) 1) (c (q 50 a (i (l 5) (q 11 (q . 2) (a 6 (c 2 (c 9 0))) (a 6 (c 2 (c 13 0)))) (q 11 (q . 1) 5)) 1) 1))
+; (a (q 2 (i 11 (q 2 (i (= 5 (point_add 11 (pubkey_for_exp (sha256 11 (a 6 (c 2 (c 23 ()))))))) (q 2 23 47) (q 8)) 1) (q 4 (c 4 (c 5 (c (a 6 (c 2 (c 23 ()))) ()))) (a 23 47))) 1) (c (q 50 2 (i (l 5) (q 11 (q . 2) (a 6 (c 2 (c 9 ()))) (a 6 (c 2 (c 13 ())))) (q 11 (q . 1) 5)) 1) 1))
 ;
 ; This file may *not* yet compile to that. The output has been hand-tweaked to include some extra optimiziations.
 ; Eventually, the compiler should produce the output above.


### PR DESCRIPTION
The comment says "the hex file disassembles to:", followed by something that it *does not* disassemble to.

The main issue is a spurious "#". the `a` -> `2` are just different representations of the same thing. However, the `0` -> `()` seems like a pessimization. i.e. encoding zero as `0` should be more compact than `()`. However, this patch contains the *actual* output from `opd`, so I would expect those zeros *are* encoded as `()`. Maybe it should be encoded as 0, but it doesn't appear to be the case now.