### PR TITLE
Simplify logic in difficulty adjustment code

### DIFF
--- a/src/consensus/difficulty_adjustment.py
+++ b/src/consensus/difficulty_adjustment.py
@@ -126,11 +126,11 @@ def _get_second_to_last_transaction_block_in_previous_epoch(
         fetched_index += 1
 
     # Backtrack to find the second to last tx block
-    found_tx_block = 0
+    found_tx_block = 1 if curr_b.is_transaction_block else 0
     while found_tx_block < 2:
+        curr_b = blocks.block_record(curr_b.prev_hash)
         if curr_b.is_transaction_block:
             found_tx_block += 1
-        curr_b = blocks.block_record(curr_b.prev_hash)
 
     return curr_b
 

--- a/src/types/blockchain_format/proof_of_space.py
+++ b/src/types/blockchain_format/proof_of_space.py
@@ -40,10 +40,8 @@ class ProofOfSpace(Streamable):
     ) -> Optional[bytes32]:
         # Exactly one of (pool_public_key, pool_contract_puzzle_hash) must not be None
         if (self.pool_public_key is None) and (self.pool_contract_puzzle_hash is None):
-            log.error("Bad 1")
             return None
         if (self.pool_public_key is not None) and (self.pool_contract_puzzle_hash is not None):
-            log.error("Bad 2")
             return None
         if self.size < constants.MIN_PLOT_SIZE:
             return None
@@ -53,11 +51,9 @@ class ProofOfSpace(Streamable):
         new_challenge: bytes32 = ProofOfSpace.calculate_pos_challenge(plot_id, original_challenge_hash, signage_point)
 
         if new_challenge != self.challenge:
-            log.error("Bad 3")
             return None
 
         if not ProofOfSpace.passes_plot_filter(constants, plot_id, original_challenge_hash, signage_point):
-            log.error("Bad 4")
             return None
 
         return self.get_quality_string(plot_id)


### PR DESCRIPTION
Uses the second to last transaction block, instead of the latest transaction block infused before the signage point of the last block. This is not a hard fork.