### PR TITLE
Ms.timelord improvements

### DIFF
--- a/src/consensus/default_constants.py
+++ b/src/consensus/default_constants.py
@@ -53,7 +53,8 @@ testnet_kwargs = {
     # 1 vByte = 108 clvm cost units
     "CLVM_COST_RATIO_CONSTANT": 108,
     # Max block cost in clvm cost units (MAX_BLOCK_COST * CLVM_COST_RATIO_CONSTANT)
-    "MAX_BLOCK_COST_CLVM": 23077872,
+    # Overriding to 40M as specified by arvid
+    "MAX_BLOCK_COST_CLVM": 40000000,
     "WEIGHT_PROOF_THRESHOLD": 2,
     "BLOCKS_CACHE_SIZE": (384 * 2) + (128 * 4),
     "WEIGHT_PROOF_RECENT_BLOCKS": 1000,

--- a/src/consensus/default_constants.py
+++ b/src/consensus/default_constants.py
@@ -53,8 +53,7 @@ testnet_kwargs = {
     # 1 vByte = 108 clvm cost units
     "CLVM_COST_RATIO_CONSTANT": 108,
     # Max block cost in clvm cost units (MAX_BLOCK_COST * CLVM_COST_RATIO_CONSTANT)
-    # Overriding to 40M as specified by arvid
-    "MAX_BLOCK_COST_CLVM": 40000000,
+    "MAX_BLOCK_COST_CLVM": 23077872,
     "WEIGHT_PROOF_THRESHOLD": 2,
     "BLOCKS_CACHE_SIZE": (384 * 2) + (128 * 4),
     "WEIGHT_PROOF_RECENT_BLOCKS": 1000,

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -361,7 +361,9 @@ class FullNode:
             # point being in the past), or we are very far behind. Performs a long sync.
             self._sync_task = asyncio.create_task(self._sync())
 
-    async def send_peak_to_timelords(self, peak_block: Optional[FullBlock] = None):
+    async def send_peak_to_timelords(
+        self, peak_block: Optional[FullBlock] = None, peer: Optional[ws.WSChiaConnection] = None
+    ):
         """
         Sends current peak to timelords
         """
@@ -409,7 +411,10 @@ class FullNode:
             )
 
             msg = make_msg(ProtocolMessageTypes.new_peak_timelord, timelord_new_peak)
-            await self.server.send_to_all([msg], NodeType.TIMELORD)
+            if peer is None:
+                await self.server.send_to_all([msg], NodeType.TIMELORD)
+            else:
+                await peer.new_peak_timelord(timelord_new_peak)
 
     async def synced(self) -> bool:
         curr: Optional[BlockRecord] = self.blockchain.get_peak()
@@ -1134,7 +1139,9 @@ class FullNode:
             await self.server.send_to_all([msg], NodeType.FULL_NODE)
         self._state_changed("unfinished_block")
 
-    async def new_infusion_point_vdf(self, request: timelord_protocol.NewInfusionPointVDF) -> Optional[Message]:
+    async def new_infusion_point_vdf(
+        self, request: timelord_protocol.NewInfusionPointVDF, timelord_peer: Optional[ws.WSChiaConnection] = None
+    ) -> Optional[Message]:
         # Lookup unfinished blocks
         unfinished_block: Optional[UnfinishedBlock] = self.full_node_store.get_unfinished_block(
             request.unfinished_reward_hash
@@ -1228,8 +1235,11 @@ class FullNode:
             return None
         try:
             await self.respond_block(full_node_protocol.RespondBlock(block))
-        except ConsensusError as e:
+        except Exception as e:
             self.log.warning(f"Consensus error validating block: {e}")
+            if timelord_peer is not None:
+                # Only sends to the timelord who sent us this VDF, to reset them to the correct peak
+                await self.send_peak_to_timelords(peer=timelord_peer)
         return None
 
     async def respond_end_of_sub_slot(

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -818,6 +818,7 @@ class FullNode:
 
         added_eos, new_sps, new_ips = self.full_node_store.new_peak(
             record,
+            block,
             sub_slots[0],
             sub_slots[1],
             fork_height != block.height - 1 and block.height != 0,
@@ -1272,7 +1273,8 @@ class FullNode:
             new_infusions = self.full_node_store.new_finished_sub_slot(
                 request.end_of_slot_bundle,
                 self.blockchain,
-                self.blockchain.get_peak(),
+                peak,
+                await self.blockchain.get_full_peak(),
             )
             # It may be an empty list, even if it's not None. Not None means added successfully
             if new_infusions is not None:

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -835,13 +835,16 @@ class FullNodeAPI:
         return None
 
     # TIMELORD PROTOCOL
+    @peer_required
     @api_request
-    async def new_infusion_point_vdf(self, request: timelord_protocol.NewInfusionPointVDF) -> Optional[Message]:
+    async def new_infusion_point_vdf(
+        self, request: timelord_protocol.NewInfusionPointVDF, peer: ws.WSChiaConnection
+    ) -> Optional[Message]:
         if self.full_node.sync_store.get_sync_mode():
             return None
         # Lookup unfinished blocks
         async with self.full_node.timelord_lock:
-            return await self.full_node.new_infusion_point_vdf(request)
+            return await self.full_node.new_infusion_point_vdf(request, peer)
 
     @peer_required
     @api_request

--- a/src/full_node/full_node_api.py
+++ b/src/full_node/full_node_api.py
@@ -884,7 +884,7 @@ class FullNodeAPI:
                 f"{request.end_of_sub_slot_bundle.challenge_chain.challenge_chain_end_of_slot_vdf.challenge}. "
                 f"Re-sending new-peak to timelord"
             )
-            await self.full_node.send_peak_to_timelords()
+            await self.full_node.send_peak_to_timelords(peer=peer)
             return None
         else:
             return msg

--- a/src/full_node/full_node_store.py
+++ b/src/full_node/full_node_store.py
@@ -5,13 +5,17 @@ from typing import Dict, List, Optional, Set, Tuple
 from src.consensus.block_record import BlockRecord
 from src.consensus.blockchain_interface import BlockchainInterface
 from src.consensus.constants import ConsensusConstants
+from src.consensus.difficulty_adjustment import can_finish_sub_and_full_epoch
+from src.consensus.make_sub_epoch_summary import make_sub_epoch_summary, next_sub_epoch_summary
 from src.consensus.multiprocess_validation import PreValidationResult
 from src.full_node.signage_point import SignagePoint
 from src.protocols import timelord_protocol
 from src.types.blockchain_format.classgroup import ClassgroupElement
 from src.types.blockchain_format.sized_bytes import bytes32
+from src.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from src.types.blockchain_format.vdf import VDFInfo
 from src.types.end_of_slot_bundle import EndOfSubSlotBundle
+from src.types.full_block import FullBlock
 from src.types.unfinished_block import UnfinishedBlock
 from src.util.ints import uint8, uint32, uint64, uint128
 
@@ -163,12 +167,14 @@ class FullNodeStore:
         eos: EndOfSubSlotBundle,
         blocks: BlockchainInterface,
         peak: Optional[BlockRecord],
+        peak_full_block: Optional[FullBlock],
     ) -> Optional[List[timelord_protocol.NewInfusionPointVDF]]:
         """
         Returns false if not added. Returns a list if added. The list contains all infusion points that depended
         on this sub slot
         """
         assert len(self.finished_sub_slots) >= 1
+        assert (peak is None) == (peak_full_block is None)
 
         last_slot, _, last_slot_iters = self.finished_sub_slots[-1]
 
@@ -230,6 +236,25 @@ class FullNodeStore:
                     icc_challenge = curr.finished_infused_challenge_slot_hashes[-1]
                     icc_iters = sub_slot_iters
                 assert icc_challenge is not None
+
+            if can_finish_sub_and_full_epoch(
+                self.constants,
+                blocks,
+                peak.height,
+                peak.prev_hash,
+                peak.deficit,
+                peak.sub_epoch_summary_included is not None,
+            ):
+                assert peak_full_block is not None
+                ses: Optional[SubEpochSummary] = next_sub_epoch_summary(
+                    self.constants, blocks, peak.required_iters, peak_full_block, True
+                )
+                if ses is not None:
+                    if eos.challenge_chain.subepoch_summary_hash != ses.get_hash():
+                        return None
+                else:
+                    if eos.challenge_chain.subepoch_summary_hash is not None:
+                        return None
         else:
             # This is on an empty slot
             cc_start_element = ClassgroupElement.get_default_element()
@@ -531,6 +556,7 @@ class FullNodeStore:
     def new_peak(
         self,
         peak: BlockRecord,
+        peak_full_block: FullBlock,
         sp_sub_slot: Optional[EndOfSubSlotBundle],  # None if not overflow, or in first/second slot
         ip_sub_slot: Optional[EndOfSubSlotBundle],  # None if in first slot
         reorg: bool,
@@ -577,7 +603,7 @@ class FullNodeStore:
         new_ips: List[timelord_protocol.NewInfusionPointVDF] = []
 
         for eos in self.future_eos_cache.get(peak.reward_infusion_new_challenge, []):
-            if self.new_finished_sub_slot(eos, blocks, peak) is not None:
+            if self.new_finished_sub_slot(eos, blocks, peak, peak_full_block) is not None:
                 new_eos = eos
                 break
 

--- a/src/full_node/full_node_store.py
+++ b/src/full_node/full_node_store.py
@@ -6,7 +6,7 @@ from src.consensus.block_record import BlockRecord
 from src.consensus.blockchain_interface import BlockchainInterface
 from src.consensus.constants import ConsensusConstants
 from src.consensus.difficulty_adjustment import can_finish_sub_and_full_epoch
-from src.consensus.make_sub_epoch_summary import make_sub_epoch_summary, next_sub_epoch_summary
+from src.consensus.make_sub_epoch_summary import next_sub_epoch_summary
 from src.consensus.multiprocess_validation import PreValidationResult
 from src.full_node.signage_point import SignagePoint
 from src.protocols import timelord_protocol
@@ -244,16 +244,18 @@ class FullNodeStore:
                 peak.prev_hash,
                 peak.deficit,
                 peak.sub_epoch_summary_included is not None,
-            ):
+            )[0]:
                 assert peak_full_block is not None
                 ses: Optional[SubEpochSummary] = next_sub_epoch_summary(
                     self.constants, blocks, peak.required_iters, peak_full_block, True
                 )
                 if ses is not None:
                     if eos.challenge_chain.subepoch_summary_hash != ses.get_hash():
+                        log.warning(f"SES not correct {ses.get_hash(), eos.challenge_chain}")
                         return None
                 else:
                     if eos.challenge_chain.subepoch_summary_hash is not None:
+                        log.warning("SES not correct, should be None")
                         return None
         else:
             # This is on an empty slot

--- a/tests/core/full_node/test_full_node_store.py
+++ b/tests/core/full_node/test_full_node_store.py
@@ -94,16 +94,16 @@ class TestFullNodeStore:
         assert store.get_sub_slot(test_constants.GENESIS_CHALLENGE) is None
         assert store.get_sub_slot(sub_slots[0].challenge_chain.get_hash()) is None
         assert store.get_sub_slot(sub_slots[1].challenge_chain.get_hash()) is None
-        assert store.new_finished_sub_slot(sub_slots[1], {}, None) is None
-        assert store.new_finished_sub_slot(sub_slots[2], {}, None) is None
+        assert store.new_finished_sub_slot(sub_slots[1], {}, None, None) is None
+        assert store.new_finished_sub_slot(sub_slots[2], {}, None, None) is None
 
         # Test adding sub-slots after genesis
-        assert store.new_finished_sub_slot(sub_slots[0], {}, None) is not None
+        assert store.new_finished_sub_slot(sub_slots[0], {}, None, None) is not None
         assert store.get_sub_slot(sub_slots[0].challenge_chain.get_hash())[0] == sub_slots[0]
         assert store.get_sub_slot(sub_slots[1].challenge_chain.get_hash()) is None
-        assert store.new_finished_sub_slot(sub_slots[1], {}, None) is not None
+        assert store.new_finished_sub_slot(sub_slots[1], {}, None, None) is not None
         for i in range(len(sub_slots)):
-            assert store.new_finished_sub_slot(sub_slots[i], {}, None) is not None
+            assert store.new_finished_sub_slot(sub_slots[i], {}, None, None) is not None
             assert store.get_sub_slot(sub_slots[i].challenge_chain.get_hash())[0] == sub_slots[i]
 
         assert store.get_finished_sub_slots(BlockCache({}), None, sub_slots[-1].challenge_chain.get_hash()) == sub_slots
@@ -117,10 +117,11 @@ class TestFullNodeStore:
         # Test adding genesis peak
         await blockchain.receive_block(blocks[0])
         peak = blockchain.get_peak()
+        peak_full_block = blockchain.get_full_peak()
         if peak.overflow:
-            store.new_peak(peak, sub_slots[-2], sub_slots[-1], False, {})
+            store.new_peak(peak, peak_full_block, sub_slots[-2], sub_slots[-1], False, {})
         else:
-            store.new_peak(peak, None, sub_slots[-1], False, {})
+            store.new_peak(peak, peak_full_block, None, sub_slots[-1], False, {})
 
         assert store.get_sub_slot(sub_slots[0].challenge_chain.get_hash()) is None
         assert store.get_sub_slot(sub_slots[1].challenge_chain.get_hash()) is None
@@ -147,7 +148,7 @@ class TestFullNodeStore:
             await blockchain.receive_block(block)
             sb = blockchain.block_record(block.header_hash)
             sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(block.header_hash)
-            res = store.new_peak(sb, sp_sub_slot, ip_sub_slot, False, blockchain)
+            res = store.new_peak(sb, block, sp_sub_slot, ip_sub_slot, False, blockchain)
             assert res[0] is None
 
         # Add reorg blocks
@@ -157,7 +158,7 @@ class TestFullNodeStore:
             if res == ReceiveBlockResult.NEW_PEAK:
                 sb = blockchain.block_record(block.header_hash)
                 sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(block.header_hash)
-                res = store.new_peak(sb, sp_sub_slot, ip_sub_slot, True, blockchain)
+                res = store.new_peak(sb, block, sp_sub_slot, ip_sub_slot, True, blockchain)
                 assert res[0] is None
 
         # Add slots to the end
@@ -165,7 +166,7 @@ class TestFullNodeStore:
             1, block_list_input=blocks_reorg, skip_slots=2, normalized_to_identity=normalized_to_identity
         )
         for slot in blocks_2[-1].finished_sub_slots:
-            store.new_finished_sub_slot(slot, blockchain, blockchain.get_peak())
+            store.new_finished_sub_slot(slot, blockchain, blockchain.get_peak(), await blockchain.get_full_peak())
 
         assert store.get_sub_slot(sub_slots[3].challenge_chain.get_hash()) is None
         assert store.get_sub_slot(sub_slots[4].challenge_chain.get_hash()) is None
@@ -195,7 +196,7 @@ class TestFullNodeStore:
                 sb = blockchain.block_record(blocks[-1].header_hash)
                 sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(blocks[-1].header_hash)
 
-                res = store.new_peak(sb, sp_sub_slot, ip_sub_slot, True, blockchain)
+                res = store.new_peak(sb, blocks[-1], sp_sub_slot, ip_sub_slot, True, blockchain)
                 assert res[0] is None
                 if sb.overflow and sp_sub_slot is not None:
                     assert sp_sub_slot != ip_sub_slot
@@ -211,7 +212,7 @@ class TestFullNodeStore:
             1, block_list_input=blocks, skip_slots=3, normalized_to_identity=normalized_to_identity
         )
         for slot in blocks_2[-1].finished_sub_slots[:-1]:
-            store.new_finished_sub_slot(slot, blockchain, blockchain.get_peak())
+            store.new_finished_sub_slot(slot, blockchain, blockchain.get_peak(), await blockchain.get_full_peak())
         finished_sub_slots = blocks_2[-1].finished_sub_slots
         assert len(store.finished_sub_slots) == 4
 
@@ -331,7 +332,7 @@ class TestFullNodeStore:
 
         blocks_3 = bt.get_consecutive_blocks(1, skip_slots=2, normalized_to_identity=normalized_to_identity)
         for slot in blocks_3[-1].finished_sub_slots:
-            store.new_finished_sub_slot(slot, {}, None)
+            store.new_finished_sub_slot(slot, {}, None, None)
         assert len(store.finished_sub_slots) == 3
         finished_sub_slots = blocks_3[-1].finished_sub_slots
 
@@ -364,7 +365,7 @@ class TestFullNodeStore:
         )
         await blockchain.receive_block(blocks_4[-1])
         sb = blockchain.block_record(blocks_4[-1].header_hash)
-        store.new_peak(sb, None, None, False, blockchain)
+        store.new_peak(sb, blocks_4[-1], None, None, False, blockchain)
         for i in range(
             sb.signage_point_index + test_constants.NUM_SP_INTERVALS_EXTRA,
             test_constants.NUM_SPS_SUB_SLOT,
@@ -399,18 +400,20 @@ class TestFullNodeStore:
                 break
         assert len(blocks) >= 2
         dependant_sub_slots = blocks[-1].finished_sub_slots
+        peak_full_block = None
         for block in blocks[:-2]:
             sb = blockchain.block_record(block.header_hash)
             sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(block.header_hash)
             peak = sb
-            res = store.new_peak(sb, sp_sub_slot, ip_sub_slot, False, blockchain)
+            peak_full_block = peak_full_block
+            res = store.new_peak(sb, block, sp_sub_slot, ip_sub_slot, False, blockchain)
             assert res[0] is None
 
-        assert store.new_finished_sub_slot(dependant_sub_slots[0], blockchain, peak) is None
+        assert store.new_finished_sub_slot(dependant_sub_slots[0], blockchain, peak, peak_full_block) is None
         block = blocks[-2]
         sb = blockchain.block_record(block.header_hash)
         sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(block.header_hash)
-        res = store.new_peak(sb, sp_sub_slot, ip_sub_slot, False, blockchain)
+        res = store.new_peak(sb, block, sp_sub_slot, ip_sub_slot, False, blockchain)
         assert res[0] == dependant_sub_slots[0]
         assert res[1] == res[2] == []
 
@@ -423,7 +426,7 @@ class TestFullNodeStore:
             sb = blockchain.block_record(block.header_hash)
 
             sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(block.header_hash)
-            res = store.new_peak(sb, sp_sub_slot, ip_sub_slot, False, blockchain)
+            res = store.new_peak(sb, block, sp_sub_slot, ip_sub_slot, False, blockchain)
             assert res[0] is None
 
         case_0, case_1 = False, False
@@ -444,7 +447,7 @@ class TestFullNodeStore:
             await blockchain.receive_block(prev_block)
             sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(prev_block.header_hash)
             sb = blockchain.block_record(prev_block.header_hash)
-            res = store.new_peak(sb, sp_sub_slot, ip_sub_slot, False, blockchain)
+            res = store.new_peak(sb, prev_block, sp_sub_slot, ip_sub_slot, False, blockchain)
             if len(block.finished_sub_slots) == 0:
                 case_0 = True
                 assert res[2] == [new_ip]
@@ -453,7 +456,7 @@ class TestFullNodeStore:
                 assert res[2] == []
                 found_ips = []
                 for ss in block.finished_sub_slots:
-                    found_ips += store.new_finished_sub_slot(ss, blockchain, sb)
+                    found_ips += store.new_finished_sub_slot(ss, blockchain, sb, prev_block)
                 assert found_ips == [new_ip]
 
         # If flaky, increase the number of blocks created

--- a/tests/core/full_node/test_full_node_store.py
+++ b/tests/core/full_node/test_full_node_store.py
@@ -400,7 +400,8 @@ class TestFullNodeStore:
                 break
         assert len(blocks) >= 2
         dependant_sub_slots = blocks[-1].finished_sub_slots
-        peak_full_block = None
+        peak = blockchain.get_peak()
+        peak_full_block = await blockchain.get_full_peak()
         for block in blocks[:-2]:
             sb = blockchain.block_record(block.header_hash)
             sp_sub_slot, ip_sub_slot = await blockchain.get_sp_and_ip_sub_slots(block.header_hash)


### PR DESCRIPTION
This does two things:
1. Validate the sub-epoch summary included in end of sub slots, to prevent adding bad sub slots
2. If a bad block is created and infused into the timelord, the full node resets the timelord to the previous peak

Either of these changes would have allowed timelords to recover from yesterday's issue.The root cause is still not found though, working on that. 