### PR TITLE
Timlord updates state immediately, prevents race condition

### DIFF
--- a/src/consensus/difficulty_adjustment.py
+++ b/src/consensus/difficulty_adjustment.py
@@ -298,7 +298,7 @@ def _get_next_difficulty(
     """
     next_height: uint32 = uint32(height + 1)
 
-    if next_height < constants.EPOCH_BLOCKS:
+    if next_height < (constants.EPOCH_BLOCKS - 3 * constants.MAX_SUB_SLOT_BLOCKS):
         # We are in the first epoch
         return uint64(constants.DIFFICULTY_STARTING)
 

--- a/src/timelord/timelord.py
+++ b/src/timelord/timelord.py
@@ -706,6 +706,8 @@ class Timelord:
             self.overflow_blocks = []
             self.new_subslot_end = eos_bundle
 
+            await self._handle_subslot_end()
+
     async def _handle_failures(self):
         while len(self.vdf_failures) > 0:
             log.error(f"Vdf clients failed {self.vdf_failures_count} times.")


### PR DESCRIPTION
- The first issue is what we saw in the first epoch in testnet6. The full node was hardcoding the default difficulty if block height is < EPOCH_BLOCKS. However there were many overlapping blocks, so none of the blocks reached the height, and therefore the timelord infused the wrong difficulty.
- The second fix is fixing a race condition in the timelord, where it took time to update the state, so it ignored the new_peak_timelord form the full_node, which should have reset the timelord to a good state.

This should be tested for a few hours on the fastest timelord in testnet6.