### PR TITLE
lower weight proof sample size

### DIFF
--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -39,7 +39,7 @@ class WeightProofHandler:
 
     LAMBDA_L = 100
     C = 0.5
-    MAX_SAMPLES = 50
+    MAX_SAMPLES = 20
 
     def __init__(
         self,


### PR DESCRIPTION
lowering the sample size to avoid timeouts,
20 sample response took about 60 sec on a very poor connection. timeout is currently  set on 90 