### PR TITLE
Release Candidate 7

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -104,10 +104,6 @@ jobs:
       run: |
         . ./activate
         cd ./chia-blockchain-gui
-        npm install
-        npm audit fix
-        npm run locale:extract
-        npm run locale:compile
         git status
         cd ../build_scripts
         sh build_macos.sh

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ chia-blockchain.tar.gz.tar.gz
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
+#*.spec
 build_scripts/*.dmg
 build_scripts/build
 

--- a/BUILD_TIMELORD.md
+++ b/BUILD_TIMELORD.md
@@ -1,9 +1,10 @@
 # Building timelords
 
 The Linux and MacOS chiavdf binary wheels currently exclude an executable
-required to run a Timelord. If you want to run a Timelord on Linux or MacOS,
-you must install the wheel from source (which may require some additional
-development packages) while in the virtual environment.
+required to run a [Timelord](https://github.com/Chia-Network/chia-blockchain/wiki/Timelords).
+If you want to run a Timelord on Linux or MacOS, you must install the wheel
+from source (which may require some additional development packages) while in
+the virtual environment.
 
 ```bash
 . ./activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
-## 1.0rc7 aka Release Candidate 7 - 2020-03-12
+## 1.0rc7 aka Release Candidate 7 - 2020-03-13
 
 ### Changed
 
@@ -16,8 +16,13 @@ for setuptools_scm/PEP 440 reasons.
 
 ### Fixed
 
+- Setting difficulty way too low on the testnet_6 launch revealed a Timelord edge case. The full node was hardcoding the default difficulty if block height is < EPOCH_BLOCKS. However there were many overlapping blocks, so none of the blocks reached the height, and therefore the timelord infused the wrong difficulty.
+- Fixed a race condition in the Timelord, where it took time to update the state, so it ignored the new_peak_timelord form the full_node, which should have reset the timelord to a good state.
+- Wallet notoriously showed "not synced" when it was in sync.
 - Installers were not correctly placing root TLS certificates into the bundle.
 - Weight proofs had a logic typo.
+- There was a typo in `chia netspace`. Thanks @altendky.
+- There was a typo in `chia plots`. Thanks @adamfiddler.
 
 ## 1.0rc6 aka Release Candidate 6 - 2020-03-11
 
@@ -78,7 +83,7 @@ for setuptools_scm/PEP 440 reasons.
 - The RC5 release is a new breaking change/hard fork blockchain. Plots and keys from previous chains will work fine on RC5 but balances of TXCH will not come forward.
 - We now support a "green flag" chain launch process. A new version of the software will poll download.chia.net/notify/ for a signed json file that will be the genesis block of the chain for that version. This will allow unattended start at mainnet.
 - Bluebox Timelords are back. These are Timelords most anyone can run. They search through the historical chain and find large proofs of times and compact them down to their smallest representation. This significantly speeds up syncing for newly started nodes. Currently this is only supported on Linux and MacOS x86_64 but we will expand that. Any desktop or server of any age will be fast enough to be a useful Bluebox Timelord.
-- Thanks to @jespino there is now `chia farm show`. You can now get almost exactly the same farming information on the CLI as the GUI.
+- Thanks to @jespino there is now `chia farm summary`. You can now get almost exactly the same farming information on the CLI as the GUI.
 - We have added Romanian to the GUI translations. Thank you to @bicilis on [Crowdin](https://crowdin.com/project/chia-blockchain). We also added a couple of additional target languages. Klingon anyone?
 - `chia wallet` now takes get_address to get a new wallet receive address from the CLI.
 - `chia plots check` will list out all the failed plot filenames at the end of the report. Thanks for the PR go to @eFishCent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
-## Unreleased 1.0rc6 aka Release Candidate 6 - 2020-03-11
+## 1.0rc7 aka Release Candidate 7 - 2020-03-12
+
+### Changed
+
+- Our green flag test blockchain launch worked but it uncovered a flaw in our installer versions. This release is a bug fix release to address that flaw. You should read the RC6 changes below if this is your first time installing since RC5.
+- `chia netspace` now defaults to 1000 blocks to mirror the GUI.
+- The installer build process was spruced up some.
+
+### Fixed
+
+- Installers were not correctly placing root TLS certificates into the bundle.
+- Weight proofs had a logic typo.
+
+## 1.0rc6 aka Release Candidate 6 - 2020-03-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ for setuptools_scm/PEP 440 reasons.
 - There was a typo in `chia netspace`. Thanks @altendky.
 - There was a typo in `chia plots`. Thanks @adamfiddler.
 
+### Known Issues
+
+- Some users can't plot in the GUI in MacOS Big Sur - especially on M1. See issue [1189](https://github.com/Chia-Network/chia-blockchain/issues/1189)
+
 ## 1.0rc6 aka Release Candidate 6 - 2020-03-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ for setuptools_scm/PEP 440 reasons.
 ### Changed
 
 - Our green flag test blockchain launch worked but it uncovered a flaw in our installer versions. This release is a bug fix release to address that flaw. You should read the RC6 changes below if this is your first time installing since RC5.
+- Thanks to @dkackman for implementing an early exit of the GUI if you run `npm run build` without being in the `venv`.
 - `chia netspace` now defaults to 1000 blocks to mirror the GUI.
 - The installer build process was spruced up some.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 | Current Release/main | Development Branch/dev |
 |         :---:          |          :---:         |
-| ![Build Ubuntu on 3.7 and 3.8](https://github.com/Chia-Network/chia-blockchain/workflows/Build%20Ubuntu%20on%20Python%203.7%20and%203.8/badge.svg) ![Build MacOS](https://github.com/Chia-Network/chia-blockchain/workflows/Build%20MacOS/badge.svg) ![Build Windows](https://github.com/Chia-Network/chia-blockchain/workflows/Build%20Windows/badge.svg)  |  ![Build Ubuntu on 3.7 and 3.8](https://github.com/Chia-Network/chia-blockchain/workflows/Build%20Ubuntu%20on%20Python%203.7%20and%203.8/badge.svg?branch=dev) ![Build MacOS](https://github.com/Chia-Network/chia-blockchain/workflows/Build%20MacOS/badge.svg?branch=dev) ![Build Windows](https://github.com/Chia-Network/chia-blockchain/workflows/Build%20Windows/badge.svg?branch=dev) |
+| [![Ubuntu Core Tests](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-ubuntu-core.yml/badge.svg)](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-ubuntu-core.yml) [![MacOS Core Tests](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-macos-core.yml/badge.svg)](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-macos-core.yml) [![Windows Installer on Windows 10 and Python 3.7](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-windows-installer.yml/badge.svg)](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-windows-installer.yml)  |  [![Ubuntu Core Tests](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-ubuntu-core.yml/badge.svg?branch=dev)](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-ubuntu-core.yml) [![MacOS Core Tests](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-macos-core.yml/badge.svg?branch=dev)](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-test-macos-core.yml) [![Windows Installer on Windows 10 and Python 3.7](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-windows-installer.yml/badge.svg?branch=dev)](https://github.com/Chia-Network/chia-blockchain/actions/workflows/build-windows-installer.yml) |
 
 ![GitHub contributors](https://img.shields.io/github/contributors/Chia-Network/chia-blockchain?logo=GitHub)
 
@@ -22,9 +22,9 @@ TCP port 8444 access to your peer.
 These methods tend to be router make/model specific.
 
 Most should only install harvesters, farmers, plotter, full nodes, and wallets.
-Building timelords and VDFs is for sophisticated users in most environments.
+Building Timelords and VDFs is for sophisticated users in most environments.
 Chia Network and additional volunteers are running sufficient Timelords
-for testnet consensus.
+for consensus.
 
 ## Installing
 Install instructions are available in the

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,16 +58,6 @@ steps:
       versionSpec: '12.x'
     displayName: "Setup Node 12.x"
 
-  - script: |
-      . ./activate
-      git submodule update --init --recursive
-      cd ./chia-blockchain-gui
-      npm install
-      npm audit fix
-      npm run locale:extract
-      npm run locale:compile
-    displayName: "Build Electron/React UI"
-
   - bash: |
       . ./activate
       APPLE_NOTARIZE_USERNAME="$(APPLE_NOTARIZE_USERNAME)"
@@ -75,6 +65,7 @@ steps:
       APPLE_NOTARIZE_PASSWORD="$(APPLE_NOTARIZE_PASSWORD)"
       export APPLE_NOTARIZE_PASSWORD
       if [ "$(APPLE_NOTARIZE_PASSWORD)" ]; then NOTARIZE="true"; export NOTARIZE; fi
+      git submodule update --init --recursive
       cd build_scripts || exit
       sh build_macos.sh
     displayName: "Build DMG with build_scripts/build_macos.sh"

--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -30,6 +30,7 @@ cd chia-blockchain-gui || exit
 
 echo "npm build"
 npm install
+npm audit fix
 npm run locale:extract
 npm run locale:compile
 npm run build

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -82,6 +82,7 @@ Write-Output "   ---"
 npm install --save-dev electron-winstaller
 npm install -g electron-packager
 npm install
+npm audit fix
 npm run locale:extract
 npm run locale:compile
 

--- a/build_scripts/daemon.spec
+++ b/build_scripts/daemon.spec
@@ -25,17 +25,18 @@ root = build.parent
 version_data = copy_metadata(get_distribution("chia-blockchain"))[0]
 
 SUBCOMMANDS = [
+    "configure",
+    "farm",
     "init",
-    "plots",
     "keys",
+    "netspace",
+    "plots",
+    "run_daemon",
     "show",
     "start",
     "stop",
     "version",
-    "netspace",
-    "run_daemon",
     "wallet",
-    "configure",
 ]
 block_cipher = None
 subcommand_modules = [f"{root}/src.cmds.%s" % _ for _ in SUBCOMMANDS]
@@ -60,7 +61,7 @@ subcommand_modules.extend(entry_points)
 
 
 daemon = Analysis([f"{root}/src/daemon/server.py"],
-             pathex=[f"{root}/venv/lib/python3.7/site-packages/aiter/", f"{root}"],
+             pathex=[f"{root}/venv/lib/python3.8/site-packages/aiter/", f"{root}"],
              binaries = [],
              datas=[version_data, (f"../src/util/initial-config.yaml", f"./src/util/"), ] +
              hex_puzzles,
@@ -74,7 +75,7 @@ daemon = Analysis([f"{root}/src/daemon/server.py"],
              noarchive=False)
 
 full_node = Analysis([f"{root}/src/server/start_full_node.py"],
-             pathex=[f"{root}/venv/lib/python3.7/site-packages/aiter/", f"{root}"],
+             pathex=[f"{root}/venv/lib/python3.8/site-packages/aiter/", f"{root}"],
              binaries = [],
              datas=[version_data],
              hiddenimports=subcommand_modules,
@@ -87,7 +88,7 @@ full_node = Analysis([f"{root}/src/server/start_full_node.py"],
              noarchive=False)
 
 wallet = Analysis([f"{root}/src/server/start_wallet.py"],
-             pathex=[f"{root}/venv/lib/python3.7/site-packages/aiter/", f"{root}"],
+             pathex=[f"{root}/venv/lib/python3.8/site-packages/aiter/", f"{root}"],
              binaries = [],
              datas=[(f"../mozilla-ca/cacert.pem", f"./mozilla-ca/"), (f"../src/ssl/dst_root_ca.pem", f"./src/ssl/"), (f"../src/ssl/chia_ca.key", f"./src/ssl/"), (f"../src/ssl/chia_ca.crt", f"./src/ssl/"), (f"../src/util/english.txt", f"./src/util/"), version_data ] + hex_puzzles,
              hiddenimports=subcommand_modules,
@@ -100,7 +101,7 @@ wallet = Analysis([f"{root}/src/server/start_wallet.py"],
              noarchive=False)
 
 chia = Analysis([f"{root}/src/cmds/chia.py"],
-             pathex=[f"{root}/venv/lib/python3.7/site-packages/aiter/", f"{root}"],
+             pathex=[f"{root}/venv/lib/python3.8/site-packages/aiter/", f"{root}"],
              binaries = [],
              datas=[version_data],
              hiddenimports=subcommand_modules,
@@ -113,7 +114,7 @@ chia = Analysis([f"{root}/src/cmds/chia.py"],
              noarchive=False)
 
 farmer = Analysis([f"{root}/src/server/start_farmer.py"],
-             pathex=[f"{root}/venv/lib/python3.7/site-packages/aiter/", f"{root}"],
+             pathex=[f"{root}/venv/lib/python3.8/site-packages/aiter/", f"{root}"],
              binaries = [],
              datas=[version_data],
              hiddenimports=subcommand_modules,
@@ -126,7 +127,7 @@ farmer = Analysis([f"{root}/src/server/start_farmer.py"],
              noarchive=False)
 
 harvester = Analysis([f"{root}/src/server/start_harvester.py"],
-             pathex=[f"{root}/venv/lib/python3.7/site-packages/aiter/", f"{root}"],
+             pathex=[f"{root}/venv/lib/python3.8/site-packages/aiter/", f"{root}"],
              binaries = [],
              datas=[version_data],
              hiddenimports=subcommand_modules,

--- a/build_scripts/daemon_windows.spec
+++ b/build_scripts/daemon_windows.spec
@@ -22,17 +22,18 @@ keyring_datas = copy_metadata('keyring')[0]
 version_data = copy_metadata(get_distribution("chia-blockchain"))[0]
 
 SUBCOMMANDS = [
+    "configure",
+    "farm",
     "init",
     "keys",
+    "netspace",
     "plots",
+    "run_daemon",
     "show",
     "start",
     "stop",
     "version",
-    "netspace",
-    "run_daemon",
     "wallet",
-    "configure",
 ]
 block_cipher = None
 subcommand_modules = [f"../src.cmds.%s" % _ for _ in SUBCOMMANDS]

--- a/src/cmds/init.py
+++ b/src/cmds/init.py
@@ -379,7 +379,8 @@ def chia_init(root_path: Path):
 
     # Starting with RC2 is the first version that used the bech32m addresses
     # range current version and 0=version 1
-    for version_number in range(chia_minor_release_number() - 1, 2, -1):
+    # for version_number in range(chia_minor_release_number() - 1, 2, -1):
+    for version_number in range(5, 2, -1):
         old_path = Path(os.path.expanduser("~/.chia/1.0rc%s" % version_number))
         print(f"Checking {old_path}")
         # This is reached if the user has updated the application, and therefore a new configuration

--- a/src/cmds/netspace.py
+++ b/src/cmds/netspace.py
@@ -95,12 +95,12 @@ async def netstorge_async(rpc_port: int, delta_block_height: str, start: str) ->
     "--delta-block-height",
     help=(
         "Compare a block X blocks older to estimate total network space. "
-        "Defaults to 192 blocks (~1 hour) and Peak block as the starting block. "
+        "Defaults to 1000 blocks (~5.2 hours) and Peak block as the starting block. "
         "Use --start BLOCK_HEIGHT to specify starting block. "
-        "Use 1000 blocks to replicate the GUI estimate."
+        "Use 192 blocks to estimate over the last hour."
     ),
     type=str,
-    default="192",
+    default="1000",
 )
 @click.option(
     "-s",

--- a/src/cmds/netspace.py
+++ b/src/cmds/netspace.py
@@ -12,7 +12,7 @@ from src.util.ints import uint16
 
 async def netstorge_async(rpc_port: int, delta_block_height: str, start: str) -> None:
     """
-    Calculates the estimated space on the network given two block header hases
+    Calculates the estimated space on the network given two block header hashes.
     """
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
@@ -111,6 +111,6 @@ async def netstorge_async(rpc_port: int, delta_block_height: str, start: str) ->
 )
 def netspace_cmd(rpc_port: int, delta_block_height: str, start: str) -> None:
     """
-    Calculates the estimated space on the network given two block header hases.
+    Calculates the estimated space on the network given two block header hashes.
     """
     asyncio.run(netstorge_async(rpc_port, delta_block_height, start))

--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -128,7 +128,7 @@ def create_cmd(
         print("If you are testing and you want to use smaller size please add the --override-k flag.")
         sys.exit(1)
     elif size < 25 and override_k:
-        print("Error: The minimun k size allowed from the cli is k=25.")
+        print("Error: The minimum k size allowed from the cli is k=25.")
         sys.exit(1)
 
     create_plots(Params(), ctx.obj["root_path"])

--- a/src/consensus/difficulty_adjustment.py
+++ b/src/consensus/difficulty_adjustment.py
@@ -298,7 +298,7 @@ def _get_next_difficulty(
     """
     next_height: uint32 = uint32(height + 1)
 
-    if next_height < constants.EPOCH_BLOCKS:
+    if next_height < (constants.EPOCH_BLOCKS - 3 * constants.MAX_SUB_SLOT_BLOCKS):
         # We are in the first epoch
         return uint64(constants.DIFFICULTY_STARTING)
 

--- a/src/consensus/pot_iterations.py
+++ b/src/consensus/pot_iterations.py
@@ -1,7 +1,7 @@
+from src.consensus.constants import ConsensusConstants
+from src.consensus.pos_quality import _expected_plot_size
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.hash import std_hash
-from src.consensus.pos_quality import _expected_plot_size
-from src.consensus.constants import ConsensusConstants
 from src.util.ints import uint8, uint64, uint128
 
 

--- a/src/farmer/farmer.py
+++ b/src/farmer/farmer.py
@@ -6,10 +6,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from blspy import G1Element
 
-from src.consensus.coinbase import create_puzzlehash_for_pk
-from src.util.config import load_config, save_config
-
 import src.server.ws_connection as ws  # lgtm [py/import-and-import-from]
+from src.consensus.coinbase import create_puzzlehash_for_pk
 from src.consensus.constants import ConsensusConstants
 from src.protocols import farmer_protocol, harvester_protocol
 from src.protocols.protocol_message_types import ProtocolMessageTypes
@@ -18,7 +16,8 @@ from src.server.ws_connection import WSChiaConnection
 from src.types.blockchain_format.proof_of_space import ProofOfSpace
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.bech32m import decode_puzzle_hash
-from src.util.ints import uint64, uint32
+from src.util.config import load_config, save_config
+from src.util.ints import uint32, uint64
 from src.util.keychain import Keychain
 from src.wallet.derive_keys import master_sk_to_farmer_sk, master_sk_to_pool_sk, master_sk_to_wallet_sk
 

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -33,20 +33,19 @@ from src.server.node_discovery import FullNodePeers
 from src.server.outbound_message import Message, NodeType, make_msg
 from src.server.server import ChiaServer
 from src.types.blockchain_format.classgroup import ClassgroupElement
-from src.types.end_of_slot_bundle import EndOfSubSlotBundle
 from src.types.blockchain_format.pool_target import PoolTarget
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from src.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof
+from src.types.end_of_slot_bundle import EndOfSubSlotBundle
 from src.types.full_block import FullBlock
 from src.types.header_block import HeaderBlock
 from src.types.mempool_inclusion_status import MempoolInclusionStatus
 from src.types.spend_bundle import SpendBundle
 from src.types.unfinished_block import UnfinishedBlock
 from src.util.errors import ConsensusError, Err
-from src.util.ints import uint8, uint32, uint64, uint128
 from src.util.genesis_wait import wait_for_genesis_challenge
-
+from src.util.ints import uint8, uint32, uint64, uint128
 from src.util.path import mkdir, path_from_root
 
 

--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -859,7 +859,7 @@ def _validate_segment(
             if not _validate_challenge_block_vdfs(constants, idx, segment.sub_slots, curr_ssi):
                 log.error(f"failed to validate challenge slot {idx} vdfs")
                 return False, uint64(0), uint64(0), uint64(0)
-        if sampled and after_challenge:
+        elif sampled and after_challenge:
             if not _validate_sub_slot_data(constants, idx, segment.sub_slots, curr_ssi):
                 log.error(f"failed to validate sub slot data {idx} vdfs")
                 return False, uint64(0), uint64(0), uint64(0)

--- a/src/protocols/shared_protocol.py
+++ b/src/protocols/shared_protocol.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import Tuple, List
-
 from enum import IntEnum
+from typing import List, Tuple
+
 from src.util.ints import uint8, uint16
 from src.util.streamable import Streamable, streamable
 

--- a/src/server/rate_limits.py
+++ b/src/server/rate_limits.py
@@ -1,11 +1,10 @@
 import dataclasses
 import logging
 import time
+from collections import Counter
 from typing import Optional
 
 from src.protocols.protocol_message_types import ProtocolMessageTypes
-from collections import Counter
-
 from src.server.outbound_message import Message
 
 log = logging.getLogger(__name__)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from secrets import token_bytes
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
-from aiohttp import ClientSession, ClientTimeout, WSCloseCode, client_exceptions, web, ServerDisconnectedError
+from aiohttp import ClientSession, ClientTimeout, ServerDisconnectedError, WSCloseCode, client_exceptions, web
 from aiohttp.web_app import Application
 from aiohttp.web_runner import TCPSite
 from cryptography import x509
@@ -25,7 +25,6 @@ from src.types.blockchain_format.sized_bytes import bytes32
 from src.types.peer_info import PeerInfo
 from src.util.errors import Err, ProtocolError
 from src.util.ints import uint16
-
 from src.util.network import is_localhost
 
 
@@ -527,7 +526,6 @@ class ChiaServer:
                         connection.log.error(f"Exception: {e}, closing connection {connection.get_peer_info()}. {tb}")
                     else:
                         connection.log.debug(f"Exception: {e} while closing connection")
-                        pass
                     # TODO: actually throw one of the errors from errors.py and pass this to close
                     await connection.close(self.api_exception_ban_seconds, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
                 finally:

--- a/src/server/start_service.py
+++ b/src/server/start_service.py
@@ -5,7 +5,7 @@ import signal
 from sys import platform
 from typing import Any, Callable, List, Optional, Tuple
 
-from src.server.ssl_context import private_ssl_ca_paths, chia_ssl_ca_paths
+from src.server.ssl_context import chia_ssl_ca_paths, private_ssl_ca_paths
 
 try:
     import uvloop

--- a/src/server/ws_connection.py
+++ b/src/server/ws_connection.py
@@ -8,7 +8,7 @@ from aiohttp import WSCloseCode, WSMessage, WSMsgType
 
 from src.cmds.init import chia_full_version_str
 from src.protocols.protocol_message_types import ProtocolMessageTypes
-from src.protocols.shared_protocol import Handshake, Capability
+from src.protocols.shared_protocol import Capability, Handshake
 from src.server.outbound_message import Message, NodeType, make_msg
 from src.server.rate_limits import RateLimiter
 from src.types.blockchain_format.sized_bytes import bytes32

--- a/src/ssl/create_ssl.py
+++ b/src/ssl/create_ssl.py
@@ -1,4 +1,5 @@
 import datetime
+import pathlib
 from pathlib import Path
 from typing import Any, Tuple
 
@@ -18,8 +19,8 @@ def get_chia_ca_crt_key() -> Tuple[Any, Any]:
 
 
 def get_mozzila_ca_crt() -> str:
-    crt = pkg_resources.resource_filename("mozilla-ca", "cacert.pem")
-    return crt
+    mozilla_path = pathlib.Path(__file__).parent.parent.parent.absolute() / "mozilla-ca/cacert.pem"
+    return str(mozilla_path)
 
 
 def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_out: Path):

--- a/src/ssl/create_ssl.py
+++ b/src/ssl/create_ssl.py
@@ -1,5 +1,4 @@
 import datetime
-import pathlib
 from pathlib import Path
 from typing import Any, Tuple
 
@@ -19,7 +18,7 @@ def get_chia_ca_crt_key() -> Tuple[Any, Any]:
 
 
 def get_mozzila_ca_crt() -> str:
-    mozilla_path = pathlib.Path(__file__).parent.parent.parent.absolute() / "mozilla-ca/cacert.pem"
+    mozilla_path = Path(__file__).parent.parent.parent.absolute() / "mozilla-ca/cacert.pem"
     return str(mozilla_path)
 
 

--- a/src/timelord/timelord.py
+++ b/src/timelord/timelord.py
@@ -706,6 +706,8 @@ class Timelord:
             self.overflow_blocks = []
             self.new_subslot_end = eos_bundle
 
+            await self._handle_subslot_end()
+
     async def _handle_failures(self):
         while len(self.vdf_failures) > 0:
             log.error(f"Vdf clients failed {self.vdf_failures_count} times.")

--- a/src/timelord/timelord.py
+++ b/src/timelord/timelord.py
@@ -27,10 +27,10 @@ from src.types.blockchain_format.slots import (
     RewardChainSubSlot,
     SubSlotProofs,
 )
-from src.util.genesis_wait import wait_for_genesis_challenge
 from src.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from src.types.blockchain_format.vdf import VDFInfo, VDFProof
 from src.types.end_of_slot_bundle import EndOfSubSlotBundle
+from src.util.genesis_wait import wait_for_genesis_challenge
 from src.util.ints import uint8, uint32, uint64
 
 log = logging.getLogger(__name__)

--- a/src/wallet/puzzles/lowlevel_generator.py
+++ b/src/wallet/puzzles/lowlevel_generator.py
@@ -1,6 +1,7 @@
-from src.wallet.chialisp import eval, sexp, args, make_if, quote, make_list, rest, cons, sha256tree
-from src.types.blockchain_format.program import SerializedProgram, Program
 from clvm_tools import binutils
+
+from src.types.blockchain_format.program import Program, SerializedProgram
+from src.wallet.chialisp import args, cons, eval, make_if, make_list, quote, rest, sexp, sha256tree
 
 
 def get_generator():

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -414,6 +414,7 @@ class WalletNode:
                     if not self.wallet_state_manager.sync_mode:
                         self.wallet_state_manager.blockchain.clean_block_records()
                     self.wallet_state_manager.state_changed("new_block")
+                    self.wallet_state_manager.state_changed("sync_changed")
                 elif result == ReceiveBlockResult.INVALID_BLOCK:
                     self.log.info(f"Invalid block from peer: {peer.get_peer_info()} {error}")
                     await peer.close()

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -35,7 +35,7 @@ from src.types.blockchain_format.sized_bytes import bytes32
 from src.types.header_block import HeaderBlock
 from src.types.peer_info import PeerInfo
 from src.util.byte_types import hexstr_to_bytes
-from src.util.errors import ValidationError, Err
+from src.util.errors import Err, ValidationError
 from src.util.genesis_wait import wait_for_genesis_challenge
 from src.util.ints import uint32, uint128
 from src.util.keychain import Keychain

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -14,23 +14,22 @@ from src.consensus.pot_iterations import is_overflow_block
 from src.types.blockchain_format.classgroup import ClassgroupElement
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.types.blockchain_format.slots import InfusedChallengeChainSubSlot
+from src.types.blockchain_format.vdf import VDFInfo, VDFProof
 from src.types.end_of_slot_bundle import EndOfSubSlotBundle
 from src.types.full_block import FullBlock
 from src.types.unfinished_block import UnfinishedBlock
-from src.types.blockchain_format.vdf import VDFInfo, VDFProof
-from src.util.block_tools import get_vdf_info_and_proof, BlockTools
+from src.util.block_tools import BlockTools, get_vdf_info_and_proof
 from src.util.errors import Err
 from src.util.hash import std_hash
 from src.util.ints import uint8, uint64
 from src.util.recursive_replace import recursive_replace
-from tests.core.fixtures import empty_blockchain, create_blockchain  # noqa: F401
-from tests.core.fixtures import default_1000_blocks  # noqa: F401
 from src.util.wallet_tools import WalletTool
-from tests.core.fixtures import default_400_blocks  # noqa: F401
+from tests.core.fixtures import default_400_blocks  # noqa: F401; noqa: F401
 from tests.core.fixtures import default_1000_blocks  # noqa: F401
 from tests.core.fixtures import default_10000_blocks  # noqa: F401
 from tests.core.fixtures import default_10000_blocks_compact  # noqa: F401
 from tests.core.fixtures import empty_blockchain  # noqa: F401
+from tests.core.fixtures import create_blockchain
 from tests.setup_nodes import bt, test_constants
 
 log = logging.getLogger(__name__)

--- a/tests/clvm/test_chialisp_deserialization.py
+++ b/tests/clvm/test_chialisp_deserialization.py
@@ -1,9 +1,8 @@
 from unittest import TestCase
 
-from src.wallet.puzzles.load_clvm import load_clvm
-from src.util.byte_types import hexstr_to_bytes
 from src.types.blockchain_format.program import Program
-
+from src.util.byte_types import hexstr_to_bytes
+from src.wallet.puzzles.load_clvm import load_clvm
 
 DESERIALIZE_MOD = load_clvm("chialisp_deserialisation.clvm", package_or_requirement="src.wallet.puzzles")
 

--- a/tests/core/daemon/test_daemon_alerts.py
+++ b/tests/core/daemon/test_daemon_alerts.py
@@ -10,10 +10,10 @@ from src.util.hash import std_hash
 from src.util.ints import uint16
 from src.util.validate_alert import create_alert_file, create_not_ready_alert_file
 from tests.core.full_node.test_full_sync import node_height_at_least
-from tests.setup_nodes import setup_daemon, self_hostname, setup_full_system
+from tests.setup_nodes import self_hostname, setup_daemon, setup_full_system
 from tests.simulation.test_simulation import test_constants_modified
-from tests.util.alert_server import AlertServer
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
+from tests.util.alert_server import AlertServer
 
 no_genesis = dataclasses.replace(test_constants_modified, GENESIS_CHALLENGE=None)
 b_tools = BlockTools(constants=no_genesis)

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -1,14 +1,13 @@
 import pickle
 from os import path
+from pathlib import Path
+from typing import List
 
 import aiosqlite
 import pytest
-from typing import List
-from pathlib import Path
-
-from src.consensus.constants import ConsensusConstants
 
 from src.consensus.blockchain import Blockchain
+from src.consensus.constants import ConsensusConstants
 from src.full_node.block_store import BlockStore
 from src.full_node.coin_store import CoinStore
 from src.types.full_block import FullBlock

--- a/tests/core/full_node/test_full_node_store.py
+++ b/tests/core/full_node/test_full_node_store.py
@@ -18,7 +18,7 @@ from src.util.block_cache import BlockCache
 from src.util.block_tools import get_signage_point
 from src.util.hash import std_hash
 from src.util.ints import uint8, uint32, uint64, uint128
-from tests.core.fixtures import empty_blockchain, default_1000_blocks  # noqa: F401
+from tests.core.fixtures import default_1000_blocks, empty_blockchain  # noqa: F401
 from tests.setup_nodes import bt, test_constants
 
 log = logging.getLogger(__name__)

--- a/tests/core/server/test_rate_limits.py
+++ b/tests/core/server/test_rate_limits.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from src.protocols.protocol_message_types import ProtocolMessageTypes

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -16,7 +16,7 @@ from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from src.util.block_tools import get_plot_dir
 from src.util.hash import std_hash
-from src.util.ints import uint8, uint16, uint64, uint32
+from src.util.ints import uint8, uint16, uint32, uint64
 from src.wallet.derive_keys import master_sk_to_wallet_sk
 from tests.setup_nodes import bt, self_hostname, setup_farmer_harvester, test_constants
 from tests.time_out_assert import time_out_assert


### PR DESCRIPTION
### Changed

- Our green flag test blockchain launch worked but it uncovered a flaw in our installer versions. This release is a bug fix release to address that flaw. You should read the RC6 changes below if this is your first time installing since RC5.
- `chia netspace` now defaults to 1000 blocks to mirror the GUI.
- The installer build process was spruced up some.

### Fixed

- Setting difficulty way too low on the testnet_6 launch revealed a Timelord edge case. The full node was hardcoding the default difficulty if block height is < EPOCH_BLOCKS. However there were many overlapping blocks, so none of the blocks reached the height, and therefore the timelord infused the wrong difficulty.
- Fixed a race condition in the Timelord, where it took time to update the state, so it ignored the new_peak_timelord form the full_node, which should have reset the timelord to a good state.
- Wallet notoriously showed "not synced" when it was in sync.
- Installers were not correctly placing root TLS certificates into the bundle.
- Weight proofs had a logic typo.
- There was a typo in `chia netspace`. Thanks @altendky.
- There was a typo in `chia plots`. Thanks @adamfiddler.

### Known Issues

- Some users can't plot in the GUI in MacOS Big Sur - especially on M1. See issue [1189](https://github.com/Chia-Network/chia-blockchain/issues/1189)