### PR TITLE
Update harvester_api.py

### DIFF
--- a/src/harvester/harvester_api.py
+++ b/src/harvester/harvester_api.py
@@ -166,18 +166,21 @@ class HarvesterAPI:
         passed = 0
         total = 0
         for try_plot_filename, try_plot_info in self.harvester.provers.items():
-            if try_plot_filename.exists():
-                # Passes the plot filter (does not check sp filter yet though, since we have not reached sp)
-                # This is being executed at the beginning of the slot
-                total += 1
-                if ProofOfSpace.passes_plot_filter(
-                    self.harvester.constants,
-                    try_plot_info.prover.get_id(),
-                    new_challenge.challenge_hash,
-                    new_challenge.sp_hash,
-                ):
-                    passed += 1
-                    awaitables.append(lookup_challenge(try_plot_filename, try_plot_info))
+            try:
+                if try_plot_filename.exists():
+                    # Passes the plot filter (does not check sp filter yet though, since we have not reached sp)
+                    # This is being executed at the beginning of the slot
+                    total += 1
+                    if ProofOfSpace.passes_plot_filter(
+                        self.harvester.constants,
+                        try_plot_info.prover.get_id(),
+                        new_challenge.challenge_hash,
+                        new_challenge.sp_hash,
+                    ):
+                        passed += 1
+                        awaitables.append(lookup_challenge(try_plot_filename, try_plot_info))
+            except Exception as e:
+                self.harvester.log.error(f"Error plot file {try_plot_filename} may no longer exist {e}")
 
         # Concurrently executes all lookups on disk, to take advantage of multiple disk parallelism
         total_proofs_found = 0


### PR DESCRIPTION
An exception while calling try_plot_filename.exists()   can cause the harvester to restart the initial load, which can lead to endless loop of initial loading.