### PR TITLE
Release Candidate 8

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         os: [macOS-latest]
 
     steps:

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.23.0'
+        ref: '0.24.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ for setuptools_scm/PEP 440 reasons.
 
 ### Added
 
+- This is a hard fork/breaking change from RC6/7. TXCH Coins will **not** be moved forward but your plots and keys and parts of your configuration do. When you install this version before 10AM PDST on 3/16/2021 it will load up, start finding peers, and otherwise wait for the flag drop at that time to start farming. This is likely to be the last dress rehearsal for mainnet launch. Our [3/15/2021 blog post](https://www.chia.net/2021/03/15/mainnet-update.html) has more details on the current mainnet launch plan.
 - The GUI now has a tooltip that directs users to the explanation of the plot filter.
 - The GUI now has a tooltip to explain the "Disable bitfield plotting" option. Thanks @shaneo257 for the idea.
 - The GUI now has a tooltip to explain Hierarchical Deterministic keys next to Receive Address on the Wallet page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## 1.0rc8 aka Release Candidate 8 - 2020-03-15
+
+### Added
+
+- The GUI now has a tooltip that directs users to the explanation of the plot filter.
+- The GUI now has a tooltip to explain the "Disable bitfield plotting" option. Thanks @shaneo257 for the idea.
+- The GUI now has a tooltip to explain Hierarchical Deterministic keys next to Receive Address on the Wallet page.
+
+### Changed
+
+- We now use Python 3.9 to build MacOS installers.
+- Harvester now catches another error class and continues to harvest. Thanks to @xorinox for this PR.
+- We now use a smaller weight proof sample size to ease the load on smaller machines when syncing.
+- Starting the GUI from Linux will now also error out if `npm run build` is run outside the venv. Huge thanks to @dkackman for that PR.
+- `chia farm summary` will now display TXCH or XCH as appropriate.
+- We added more time to our API timeouts and improved logging around times outs.
+
+### Fixed
+
+- We no longer use the transaction cache to look up transactions for new transactions as that was causing a wallet sync bug.
+- Sometimes the GUI would not pick up the fingerprint for the plotting key.
+- `chia farm summary` displayed some incorrect amounts.
+- Weight proofs were timing out.
+- Changes to farming rewards target addresses from the GUI were not being saved for restart correctly.
+- Signage points, recent deficit blocks, and slots for overflow challenge blocks had minor issues.
+
+
 ## 1.0rc7 aka Release Candidate 7 - 2020-03-13
 
 ### Changed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ pool:
 strategy:
   matrix:
     Mojave DMG:
-      python.version: "3.8"
+      python.version: "3.9"
 
 variables:
   - group: Apple-Notarize-Variables

--- a/src/cmds/wallet.py
+++ b/src/cmds/wallet.py
@@ -100,6 +100,8 @@ async def get_address(args: dict, wallet_client: WalletRpcClient, fingerprint: i
 
 async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     summaries_response = await wallet_client.get_wallets()
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
 
     print(f"Wallet height: {await wallet_client.get_height_info()}")
     print(f"Balances, fingerprint: {fingerprint}")
@@ -117,19 +119,19 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
             print(f"Wallet ID {wallet_id} type {typ}")
             print(
                 f"   -Confirmed: {balances['confirmed_wallet_balance']} mojo "
-                f"({balances['confirmed_wallet_balance']/units['chia']} TXCH)"
+                f"({balances['confirmed_wallet_balance']/units['chia']} {address_prefix})"
             )
             print(
                 f"   -Unconfirmed: {balances['unconfirmed_wallet_balance']} mojo "
-                f"({balances['unconfirmed_wallet_balance']/units['chia']} TXCH)"
+                f"({balances['unconfirmed_wallet_balance']/units['chia']} {address_prefix})"
             )
             print(
                 f"   -Spendable: {balances['spendable_balance']} mojo "
-                f"({balances['spendable_balance']/units['chia']} TXCH)"
+                f"({balances['spendable_balance']/units['chia']} {address_prefix})"
             )
             print(
                 f"   -Pending change: {balances['pending_change']} mojo "
-                f"({balances['pending_change']/units['chia']} TXCH)"
+                f"({balances['pending_change']/units['chia']} {address_prefix})"
             )
 
 

--- a/src/consensus/default_constants.py
+++ b/src/consensus/default_constants.py
@@ -11,13 +11,13 @@ testnet_kwargs = {
     "SUB_SLOT_ITERS_STARTING": 2 ** 27,
     # DIFFICULTY_STARTING is the starting difficulty for the first epoch, which is then further
     # multiplied by another factor of DIFFICULTY_CONSTANT_FACTOR, to be used in the VDF iter calculation formula.
-    "DIFFICULTY_CONSTANT_FACTOR": 2 ** 62,
+    "DIFFICULTY_CONSTANT_FACTOR": 2 ** 67,
     "DIFFICULTY_STARTING": 5,
     "DIFFICULTY_CHANGE_MAX_FACTOR": 3,  # The next difficulty is truncated to range [prev / FACTOR, prev * FACTOR]
     # These 3 constants must be changed at the same time
     "SUB_EPOCH_BLOCKS": 384,  # The number of blocks per sub-epoch, mainnet 384
-    "EPOCH_BLOCKS": 384 * 4,  # The number of blocks per epoch, mainnet 4608. Must be multiple of SUB_EPOCH_SB
-    "SIGNIFICANT_BITS": 12,  # The number of bits to look at in difficulty and min iters. The rest are zeroed
+    "EPOCH_BLOCKS": 4608,  # The number of blocks per epoch, mainnet 4608. Must be multiple of SUB_EPOCH_SB
+    "SIGNIFICANT_BITS": 8,  # The number of bits to look at in difficulty and min iters. The rest are zeroed
     "DISCRIMINANT_SIZE_BITS": 1024,  # Max is 1024 (based on ClassGroupElement int size)
     "NUMBER_ZERO_BITS_PLOT_FILTER": 9,  # H(plot signature of the challenge) must start with these many zeroes
     "MIN_PLOT_SIZE": 32,  # 32 for mainnet
@@ -59,7 +59,7 @@ testnet_kwargs = {
     "BLOCKS_CACHE_SIZE": 4608 + (128 * 4),
     "WEIGHT_PROOF_RECENT_BLOCKS": 1000,
     "MAX_BLOCK_COUNT_PER_REQUESTS": 32,  # Allow up to 32 blocks per request
-    "INITIAL_FREEZE_PERIOD": 5000,  # Transaction are disabled first 5000 blocks
+    "INITIAL_FREEZE_PERIOD": 42 * 4608,
     "NETWORK_TYPE": 0,
     "MAX_GENERATOR_SIZE": 1000000,
     "MAX_GENERATOR_REF_LIST_SIZE": 10000,  # Number of references allowed in the block generator ref list

--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -435,7 +435,7 @@ class WebSocketServer:
         b = request["b"]
         u = request["u"]
         r = request["r"]
-        a = request["a"]
+        a = request.get("a")
         e = request["e"]
         override_k = request["overrideK"]
 
@@ -458,6 +458,8 @@ class WebSocketServer:
 
         if override_k is True:
             command_args.append("--override-k")
+
+        self.log.debug(f"command_args are {command_args}")
 
         return command_args
 
@@ -501,6 +503,8 @@ class WebSocketServer:
 
             service_name = config["service_name"]
             command_args = config["command_args"]
+            self.log.debug(f"command_args before launch_plotter are {command_args}")
+            self.log.debug(f"self.root_path before launch_plotter is {self.root_path}")
             process, pid_path = launch_plotter(self.root_path, service_name, command_args, id)
 
             current_process = process

--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -555,7 +555,7 @@ class WebSocketServer:
         queue = request.get("queue", "default")
 
         for k in range(count):
-            id = str(uuid.uuid1())
+            id = str(uuid.uuid4())
             config = {
                 "id": id,
                 "size": size,

--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -55,6 +55,9 @@ async def fetch(url: str):
         ssl_context = ssl_context_for_root(mozzila_root)
         response = await session.get(url, ssl=ssl_context)
         await session.close()
+        if not response.ok:
+            log.warning("Response not OK.")
+            return None
         return await response.text()
     except Exception as e:
         await session.close()
@@ -182,7 +185,9 @@ class WebSocketServer:
 
                 selected = self.net_config["selected_network"]
                 alert_url = self.net_config["ALERTS_URL"]
+                log.debug("Fetching alerts")
                 response = await fetch(alert_url)
+                log.debug(f"Fetched alert: {response}")
                 if response is None:
                     continue
 

--- a/src/farmer/farmer.py
+++ b/src/farmer/farmer.py
@@ -160,11 +160,11 @@ class Farmer:
         if farmer_target_encoded is not None:
             self.farmer_target_encoded = farmer_target_encoded
             self.farmer_target = decode_puzzle_hash(farmer_target_encoded)
-            config["farmer"]["farmer_target"] = farmer_target_encoded
+            config["farmer"]["xch_target_address"] = farmer_target_encoded
         if pool_target_encoded is not None:
             self.pool_target_encoded = pool_target_encoded
             self.pool_target = decode_puzzle_hash(pool_target_encoded)
-            config["farmer"]["pool_target"] = pool_target_encoded
+            config["pool"]["xch_target_address"] = pool_target_encoded
         save_config(self._root_path, "config.yaml", config)
 
     async def _periodically_clear_cache_task(self):

--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -549,7 +549,7 @@ def _get_weights_for_sampling(
         # todo check division and type conversions
         weight = q * float(total_weight)
         weight_to_check.append(uint128(weight))
-    return weight_to_check
+    return weight_to_check.sort()
 
 
 def _sample_sub_epoch(
@@ -557,10 +557,19 @@ def _sample_sub_epoch(
     end_of_epoch_weight: uint128,
     weight_to_check: List[uint128],
 ) -> bool:
+    """
+    weight_to_check: List[uint128] is expected to be sorted
+    """
     if weight_to_check is None:
         return True
+    if weight_to_check[-1] < start_of_epoch_weight:
+        return False
+    if weight_to_check[0] > end_of_epoch_weight:
+        return False
     choose = False
     for weight in weight_to_check:
+        if weight > end_of_epoch_weight:
+            return False
         if start_of_epoch_weight < weight < end_of_epoch_weight:
             log.debug(f"start weight: {start_of_epoch_weight}")
             log.debug(f"weight to check {weight}")

--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -39,7 +39,7 @@ class WeightProofHandler:
 
     LAMBDA_L = 100
     C = 0.5
-    MAX_SAMPLES = 50
+    MAX_SAMPLES = 20
 
     def __init__(
         self,

--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -296,8 +296,16 @@ class WeightProofHandler:
                 curr_sub_rec = blocks[curr_sub_rec.prev_hash]
             first_rc_end_of_slot_vdf = self.first_rc_end_of_slot_vdf(header_block, blocks, header_blocks)
         else:
-            while not curr_sub_rec.first_in_sub_slot and curr_sub_rec.height > 0:
-                curr_sub_rec = blocks[curr_sub_rec.prev_hash]
+            if header_block_sub_rec.overflow and header_block_sub_rec.first_in_sub_slot:
+                sub_slots_num = 2
+                while sub_slots_num > 0 and curr_sub_rec.height > 0:
+                    curr_sub_rec = blocks[curr_sub_rec.prev_hash]
+                if curr_sub_rec.first_in_sub_slot:
+                    assert curr_sub_rec.finished_challenge_slot_hashes is not None
+                    sub_slots_num -= len(curr_sub_rec.finished_challenge_slot_hashes)
+            else:
+                while not curr_sub_rec.first_in_sub_slot and curr_sub_rec.height > 0:
+                    curr_sub_rec = blocks[curr_sub_rec.prev_hash]
 
         curr = header_blocks[curr_sub_rec.header_hash]
         sub_slots_data: List[SubSlotData] = []

--- a/src/harvester/harvester_api.py
+++ b/src/harvester/harvester_api.py
@@ -166,18 +166,21 @@ class HarvesterAPI:
         passed = 0
         total = 0
         for try_plot_filename, try_plot_info in self.harvester.provers.items():
-            if try_plot_filename.exists():
-                # Passes the plot filter (does not check sp filter yet though, since we have not reached sp)
-                # This is being executed at the beginning of the slot
-                total += 1
-                if ProofOfSpace.passes_plot_filter(
-                    self.harvester.constants,
-                    try_plot_info.prover.get_id(),
-                    new_challenge.challenge_hash,
-                    new_challenge.sp_hash,
-                ):
-                    passed += 1
-                    awaitables.append(lookup_challenge(try_plot_filename, try_plot_info))
+            try:
+                if try_plot_filename.exists():
+                    # Passes the plot filter (does not check sp filter yet though, since we have not reached sp)
+                    # This is being executed at the beginning of the slot
+                    total += 1
+                    if ProofOfSpace.passes_plot_filter(
+                        self.harvester.constants,
+                        try_plot_info.prover.get_id(),
+                        new_challenge.challenge_hash,
+                        new_challenge.sp_hash,
+                    ):
+                        passed += 1
+                        awaitables.append(lookup_challenge(try_plot_filename, try_plot_info))
+            except Exception as e:
+                self.harvester.log.error(f"Error plot file {try_plot_filename} may no longer exist {e}")
 
         # Concurrently executes all lookups on disk, to take advantage of multiple disk parallelism
         total_proofs_found = 0

--- a/src/rpc/wallet_rpc_api.py
+++ b/src/rpc/wallet_rpc_api.py
@@ -123,7 +123,7 @@ class WalletRpcApi:
 
         fingerprint = request["fingerprint"]
         if self.service.logged_in_fingerprint == fingerprint:
-            return {}
+            return {"fingerprint": fingerprint}
 
         await self._stop_wallet()
         log_in_type = request["type"]
@@ -141,7 +141,7 @@ class WalletRpcApi:
             started = await self.service._start(fingerprint)
 
         if started is True:
-            return {}
+            return {"fingerprint": fingerprint}
         elif testing is True and self.service.backup_initialized is False:
             response = {"success": False, "error": "not_initialized"}
             return response
@@ -228,7 +228,7 @@ class WalletRpcApi:
             started = await self.service._start(fingerprint=fingerprint, backup_file=file_path)
 
         if started is True:
-            return {}
+            return {"fingerprint": fingerprint}
         raise ValueError("Failed to start")
 
     async def delete_key(self, request):

--- a/src/rpc/wallet_rpc_api.py
+++ b/src/rpc/wallet_rpc_api.py
@@ -721,9 +721,10 @@ class WalletRpcApi:
                 pool_reward_amount += record.amount
             if record.type == TransactionType.FEE_REWARD:
                 fee_amount += record.amount - calculate_base_farmer_reward(height)
-                farmer_reward_amount += record.amount - fee_amount
+                farmer_reward_amount += calculate_base_farmer_reward(height)
             amount += record.amount
 
+        assert amount == pool_reward_amount + farmer_reward_amount + fee_amount
         return {
             "farmed_amount": amount,
             "pool_reward_amount": pool_reward_amount,

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -511,7 +511,7 @@ class ChiaServer:
                             connection.log.error(f"Exception: {e}, {connection.get_peer_info()}. {tb}")
                             raise e
 
-                    response: Optional[Message] = await asyncio.wait_for(wrapped_coroutine(), timeout=300)
+                    response: Optional[Message] = await asyncio.wait_for(wrapped_coroutine(), timeout=600)
                     connection.log.debug(
                         f"Time taken to process {message_type} from {connection.peer_node_id} is "
                         f"{time.time() - start_time} seconds"
@@ -523,7 +523,9 @@ class ChiaServer:
                 except Exception as e:
                     if self.connection_close_task is None:
                         tb = traceback.format_exc()
-                        connection.log.error(f"Exception: {e}, closing connection {connection.get_peer_info()}. {tb}")
+                        connection.log.error(
+                            f"Exception: {e} {type(e)}, closing connection {connection.get_peer_info()}. {tb}"
+                        )
                     else:
                         connection.log.debug(f"Exception: {e} while closing connection")
                     # TODO: actually throw one of the errors from errors.py and pass this to close

--- a/src/server/ws_connection.py
+++ b/src/server/ws_connection.py
@@ -203,9 +203,11 @@ class WSChiaConnection:
                     await self._send_message(msg)
         except asyncio.CancelledError:
             pass
+        except ConnectionResetError as e:
+            self.log.warning(f"{e} {self.peer_host}")
         except Exception as e:
             error_stack = traceback.format_exc()
-            self.log.error(f"Exception: {e}")
+            self.log.error(f"Exception: {e} with {self.peer_host}")
             self.log.error(f"Exception Stack: {error_stack}")
 
     async def inbound_handler(self):

--- a/src/types/weight_proof.py
+++ b/src/types/weight_proof.py
@@ -60,7 +60,7 @@ class SubSlotData(Streamable):
         return False
 
     def is_end_of_slot(self):
-        if self.cc_slot_end is not None:
+        if self.cc_slot_end_info is not None:
             return True
         return False
 

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -26,6 +26,13 @@ network_overrides: &network_overrides
       NETWORK_TYPE: 1
       GENESIS_PRE_FARM_POOL_PUZZLE_HASH: "70ac50c1faf71293113e7572e538234065ead0c193241256a620d6f52e06d86a"
       GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: "9e6a07d5cbc019b2fdef559d7c7f8d2a80412546ad6e00c67a19bcdcacd32cab"
+    testnet8:
+      DIFFICULTY_CONSTANT_FACTOR: 36893488147419103232 # 2^65
+      INITIAL_FREEZE_PERIOD: 3000
+      GENESIS_CHALLENGE: null
+      NETWORK_TYPE: 1
+      GENESIS_PRE_FARM_POOL_PUZZLE_HASH: "70ac50c1faf71293113e7572e538234065ead0c193241256a620d6f52e06d86a"
+      GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: "9e6a07d5cbc019b2fdef559d7c7f8d2a80412546ad6e00c67a19bcdcacd32cab"
   config:
     mainnet:
       address_prefix: "xch"
@@ -35,9 +42,11 @@ network_overrides: &network_overrides
       address_prefix: "txch"
     testnet6:
       address_prefix: "txch"
+    testnet8:
+      address_prefix: "txch"
 
-selected_network: &selected_network "testnet6"
-ALERTS_URL: https://download.chia.net/notify/testnet_6_alert.txt
+selected_network: &selected_network "testnet8"
+ALERTS_URL: https://download.chia.net/notify/testnet_8_alert.txt
 CHIA_ALERTS_PUBKEY: 89b7fd87cb56e926ecefb879a29aae308be01f31980569f6a75a69d2a9a69daefd71fb778d865f7c50d6c967e3025937
 
 # public ssl ca is included in source code
@@ -194,9 +203,9 @@ full_node:
   port: 58444
 
   # Run multiple nodes with different databases by changing the database_path
-  database_path: db/blockchain_v30_CHALLENGE.sqlite
+  database_path: db/blockchain_v1_CHALLENGE.sqlite
   peer_db_path: db/peer_table_node.sqlite
-  simulator_database_path: sim_db/simulator_blockchain_v30_CHALLENGE.sqlite
+  simulator_database_path: sim_db/simulator_blockchain_v1_CHALLENGE.sqlite
   simulator_peer_db_path: sim_db/peer_table_node.sqlite
 
   # If True, starts an RPC server at the following port
@@ -238,7 +247,7 @@ full_node:
       host: *self_hostname
       port: 8446
   introducer_peer:
-      host: introducer1.beta.chia.net  # Chia AWS introducer IPv4/IPv6
+      host: introducer.beta.chia.net  # Chia AWS introducer IPv4/IPv6
       port: 58444
   wallet_peer:
     host: *self_hostname
@@ -306,7 +315,7 @@ wallet:
     port: 58444
 
   testing: False
-  database_path: wallet/db/blockchain_wallet_v30_CHALLENGE_KEY.sqlite
+  database_path: wallet/db/blockchain_wallet_v1_CHALLENGE_KEY.sqlite
   wallet_peers_path: wallet/db/wallet_peers.sqlite
 
   logging: *logging
@@ -320,7 +329,7 @@ wallet:
   recent_peer_threshold: 6000
 
   introducer_peer:
-    host: introducer1.beta.chia.net # Chia AWS introducer IPv4/IPv6
+    host: introducer.beta.chia.net # Chia AWS introducer IPv4/IPv6
     port: 58444
 
   ssl:

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -465,7 +465,9 @@ class WalletNode:
                 if self.wallet_state_manager.sync_mode:
                     return
                 weight_request = RequestProofOfWeight(header_block.height, header_block.header_hash)
-                weight_proof_response: RespondProofOfWeight = await peer.request_proof_of_weight(weight_request)
+                weight_proof_response: RespondProofOfWeight = await peer.request_proof_of_weight(
+                    weight_request, timeout=180
+                )
                 if weight_proof_response is None:
                     return
                 weight_proof = weight_proof_response.wp

--- a/src/wallet/wallet_transaction_store.py
+++ b/src/wallet/wallet_transaction_store.py
@@ -381,15 +381,6 @@ class WalletTransactionStore:
         """
         Returns all stored transactions.
         """
-        if wallet_id in self.tx_wallet_cache and type in self.tx_wallet_cache[wallet_id]:
-            wallet_txs = self.tx_wallet_cache[wallet_id][type]
-            txs = []
-            for name in wallet_txs:
-                tx = await self.get_transaction_record(name)
-                assert tx is not None
-                txs.append(tx)
-            return txs
-
         if type is None:
             cursor = await self.db_connection.execute(
                 "SELECT * from transaction_record where wallet_id=?", (wallet_id,)

--- a/tests/blockchain/test_weight_proof.py
+++ b/tests/blockchain/test_weight_proof.py
@@ -193,6 +193,89 @@ class TestWeightProof:
         assert wp is not None
 
     @pytest.mark.asyncio
+    async def test_weight_proof_edge_cases(self, default_400_blocks):
+        blocks: List[FullBlock] = default_400_blocks
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=2
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=1
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1,
+            block_list_input=blocks,
+            seed=b"asdfghjkl",
+            force_overflow=True,
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=2
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1,
+            block_list_input=blocks,
+            seed=b"asdfghjkl",
+            force_overflow=True,
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1,
+            block_list_input=blocks,
+            seed=b"asdfghjkl",
+            force_overflow=True,
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1,
+            block_list_input=blocks,
+            seed=b"asdfghjkl",
+            force_overflow=True,
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1,
+            block_list_input=blocks,
+            seed=b"asdfghjkl",
+            force_overflow=True,
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            10, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=4
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=4
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            10,
+            block_list_input=blocks,
+            seed=b"asdfghjkl",
+            force_overflow=True,
+        )
+
+        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+            300,
+            block_list_input=blocks,
+            seed=b"asdfghjkl",
+            force_overflow=False,
+        )
+
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
+        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
+        assert wp is not None
+        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        valid, fork_point = wpf.validate_weight_proof_single_proc(wp)
+
+        assert valid
+        assert fork_point == 0
+
+    @pytest.mark.asyncio
     async def test_weight_proof1000(self, default_1000_blocks):
         blocks = default_1000_blocks
         header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -15,6 +15,7 @@ from src.rpc.rpc_server import start_rpc_server
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from src.util.block_tools import get_plot_dir
+from src.util.config import load_config
 from src.util.hash import std_hash
 from src.util.ints import uint8, uint16, uint32, uint64
 from src.wallet.derive_keys import master_sk_to_wallet_sk
@@ -202,6 +203,11 @@ class TestRpc:
             assert decode_puzzle_hash(targets_4["farmer_target"]) == new_ph
             assert decode_puzzle_hash(targets_4["pool_target"]) == new_ph_3
             assert not targets_4["have_pool_sk"] and targets_3["have_farmer_sk"]
+
+            root_path = farmer_api.farmer._root_path
+            config = load_config(root_path, "config.yaml")
+            assert config["farmer"]["xch_target_address"] == encode_puzzle_hash(new_ph, "xch")
+            assert config["pool"]["xch_target_address"] == encode_puzzle_hash(new_ph_3, "xch")
 
             new_ph_3_encoded = encode_puzzle_hash(new_ph_3, "xch")
             added_char = new_ph_3_encoded + "a"

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -424,7 +424,7 @@ class TestWalletSimulator:
             ]
         )
 
-        await time_out_assert(25, wallet.get_confirmed_balance, funds)
+        await time_out_assert(90, wallet.get_confirmed_balance, funds)
         max_sent_amount = await wallet.get_max_send_amount()
 
         # 1) Generate transaction that is under the limit


### PR DESCRIPTION
### Added

- This is a hard fork/breaking change from RC6/7. TXCH Coins will **not** be moved forward but your plots and keys and parts of your configuration will. When you install this version before 10AM PDST on 3/16/2021 it will load up, start finding peers, and otherwise wait for the flag drop at that time to start farming. This is likely to be the last dress rehearsal for mainnet launch. Our [3/15/2021 blog post](https://www.chia.net/2021/03/15/mainnet-update.html) has more details on the current mainnet launch plan.
- The GUI now has a tooltip that directs users to the explanation of the plot filter.
- The GUI now has a tooltip to explain the "Disable bitfield plotting" option. Thanks @shaneo257 for the idea.
- The GUI now has a tooltip to explain Hierarchical Deterministic keys next to Receive Address on the Wallet page.

### Changed

- We now use Python 3.9 to build MacOS installers.
- Harvester now catches another error class and continues to harvest. Thanks to @xorinox for this PR.
- We now use a smaller weight proof sample size to ease the load on smaller machines when syncing.
- Starting the GUI from Linux will now also error out if `npm run build` is run outside the venv. Huge thanks to @dkackman for that PR.
- `chia farm summary` will now display TXCH or XCH as appropriate.
- We added more time to our API timeouts and improved logging around times outs.

### Fixed

- We no longer use the transaction cache to look up transactions for new transactions as that was causing a wallet sync bug.
- Sometimes the GUI would not pick up the fingerprint for the plotting key.
- `chia farm summary` displayed some incorrect amounts.
- Weight proofs were timing out.
- Changes to farming rewards target addresses from the GUI were not being saved for restart correctly.
- Signage points, recent deficit blocks, and slots for overflow challenge blocks had minor issues.