### PR TITLE
Fix another issue with green flag

### DIFF
--- a/src/daemon/server.py
+++ b/src/daemon/server.py
@@ -49,20 +49,18 @@ service_plotter = "chia plots create"
 
 
 async def fetch(url: str):
-    session = ClientSession()
-    try:
-        mozzila_root = get_mozzila_ca_crt()
-        ssl_context = ssl_context_for_root(mozzila_root)
-        response = await session.get(url, ssl=ssl_context)
-        await session.close()
-        if not response.ok:
-            log.warning("Response not OK.")
+    async with ClientSession() as session:
+        try:
+            mozzila_root = get_mozzila_ca_crt()
+            ssl_context = ssl_context_for_root(mozzila_root)
+            response = await session.get(url, ssl=ssl_context)
+            if not response.ok:
+                log.warning("Response not OK.")
+                return None
+            return await response.text()
+        except Exception as e:
+            log.error(f"Exception while fetching {url}, exception: {e}")
             return None
-        return await response.text()
-    except Exception as e:
-        await session.close()
-        log.error(f"Exception while fetching {url}, exception: {e}")
-        return None
 
 
 class PlotState(str, Enum):


### PR DESCRIPTION
This fixes the issue with linux machines not getting the green flag sometimes. On certain runs, it would fetch the json once. On other runs, it would never succeed in fetching the json.

I managed to consistently replicate the green flag issue on linux. I do not think the issue was related to sub-modules, because I experienced it on two linux machines. We were using a deprecated Api (ClientSession in synchronous mode). This change uses it in asynchronous mode. 

This has been tested on both linux machines and works perfectly. Also tested on mac. TODO: test on windows

