### PR TITLE
Fix install-gui.sh

### DIFF
--- a/install-gui.sh
+++ b/install-gui.sh
@@ -80,9 +80,7 @@ if [ ! "$CI" ]; then
 	fi
 
 	npm install
-	npm audit fix
-	npm run locale:extract
-	npm run locale:compile
+	npm audit fix || true
 	npm run build
 else
 	echo "Skipping node.js in install.sh on MacOS ci"


### PR DESCRIPTION
`npm audit fix` will sometime fail, thus stopping the whole process of installing the GUI and leaving it in a weird state. 
This fix will ignore the return code of `npm audit fix` whether it succeeded or not. 
This PR also removes the `npm run lingui:*` commands which are directly embedded within `npm run build` since the generated locales were removed from the chia-blockchain-gui repository with  Chia-Network/chia-blockchain-gui#168

Related to Chia-Network/chia-blockchain-gui#154