### PR TITLE
Locale extraction and compiling is now part of run build

### DIFF
--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -31,8 +31,6 @@ cd chia-blockchain-gui || exit
 echo "npm build"
 npm install
 npm audit fix
-npm run locale:extract
-npm run locale:compile
 npm run build
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -83,8 +83,6 @@ npm install --save-dev electron-winstaller
 npm install -g electron-packager
 npm install
 npm audit fix
-npm run locale:extract
-npm run locale:compile
 
 git status
 

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -81,8 +81,6 @@ if [ ! "$CI" ]; then
 
 	npm install
 	npm audit fix || true
-	npm run locale:extract
-	npm run locale:compile
 	npm run build
 else
 	echo "Skipping node.js in install.sh on MacOS ci"


### PR DESCRIPTION
Now that craco runs the local extraction etc - pull it out of installer builds and install-gui.sh for being repetitive.