### PR TITLE
match request timeouts

### DIFF
--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -596,7 +596,7 @@ class FullNode:
                 raise ValueError("Not performing sync, already caught up.")
 
             request = full_node_protocol.RequestProofOfWeight(heaviest_peak_height, heaviest_peak_hash)
-            response = await weight_proof_peer.request_proof_of_weight(request, timeout=90)
+            response = await weight_proof_peer.request_proof_of_weight(request, timeout=180)
 
             # Disconnect from this peer, because they have not behaved properly
             if response is None or not isinstance(response, full_node_protocol.RespondProofOfWeight):


### PR DESCRIPTION
not sure this is even necessary but this is the timeout we currently use between node and wallet
 
timing on my machine with 20 samples request time was about 40 sec