### PR TITLE
plotting|cmds: Fix and improve `chia plots check`

### DIFF
--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -146,11 +146,14 @@ def create_cmd(
 @click.option("-l", "--list_duplicates", help="List plots with duplicate IDs", default=False, is_flag=True)
 @click.option("--debug-show-memo", help="Shows memo to recreate the same exact plot", default=False, is_flag=True)
 @click.option("--challenge-start", help="Begins at a different [start] for -n [challenges]", type=int, default=None)
+@click.option("-s", "--success-rate", help="Require at least [rate] * [challenges] proofs. Default: 0.5 (50%)",
+              type=float, default=0.5)
 @click.pass_context
 def check_cmd(
-    ctx: click.Context, num: int, grep_string: str, list_duplicates: bool, debug_show_memo: bool, challenge_start: int
+    ctx: click.Context, num: int, grep_string: str, list_duplicates: bool, debug_show_memo: bool, challenge_start: int,
+        success_rate: int
 ):
-    check_plots(ctx.obj["root_path"], num, challenge_start, grep_string, list_duplicates, debug_show_memo)
+    check_plots(ctx.obj["root_path"], num, challenge_start, grep_string, list_duplicates, debug_show_memo, success_rate)
 
 
 @plots_cmd.command("add", short_help="Adds a directory of plots")

--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -149,12 +149,14 @@ def create_cmd(
               default=None)
 @click.option("-s", "--success-rate", help="Require at least [rate] * [challenges] proofs. Default: 0.5 (50%)",
               type=float, default=0.5)
+@click.option("-r", "--random", help="Use random challenges", default=False, is_flag=True)
 @click.pass_context
 def check_cmd(
     ctx: click.Context, num: int, grep_string: str, list_duplicates: bool, debug_show_memo: bool, challenge_start: int,
-        success_rate: int
+        success_rate: int, random: bool
 ):
-    check_plots(ctx.obj["root_path"], num, challenge_start, grep_string, list_duplicates, debug_show_memo, success_rate)
+    check_plots(ctx.obj["root_path"], num, challenge_start, grep_string, list_duplicates, debug_show_memo, success_rate,
+                random)
 
 
 @plots_cmd.command("add", short_help="Adds a directory of plots")

--- a/src/cmds/plots.py
+++ b/src/cmds/plots.py
@@ -144,8 +144,9 @@ def create_cmd(
     default=None,
 )
 @click.option("-l", "--list_duplicates", help="List plots with duplicate IDs", default=False, is_flag=True)
-@click.option("--debug-show-memo", help="Shows memo to recreate the same exact plot", default=False, is_flag=True)
-@click.option("--challenge-start", help="Begins at a different [start] for -n [challenges]", type=int, default=None)
+@click.option("-d", "--debug-show-memo", help="Shows memo to recreate the same exact plot", default=False, is_flag=True)
+@click.option("-c", "--challenge-start", help="Begins at a different [start] for -n [challenges]", type=int,
+              default=None)
 @click.option("-s", "--success-rate", help="Require at least [rate] * [challenges] proofs. Default: 0.5 (50%)",
               type=float, default=0.5)
 @click.pass_context

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -1,5 +1,6 @@
 import logging
 from collections import Counter
+from Crypto import Random
 from pathlib import Path
 from typing import Dict, List
 
@@ -22,7 +23,7 @@ max_success_rate = 1.0
 default_success_rate = 0.5
 
 
-def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, debug_show_memo, success_rate):
+def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, debug_show_memo, success_rate, random):
     config = load_config(root_path, "config.yaml")
     if num is not None:
         if num == 0:
@@ -120,7 +121,7 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
         log.info(f"\tLocal sk: {local_sk}")
         plot_proofs = 0
         for i in range(num_start, num_end):
-            challenge = std_hash(i.to_bytes(32, "big"))
+            challenge = std_hash(Random.get_random_bytes(32) if random else i.to_bytes(32, "big"))
             # Some plot errors cause get_qualities_for_challenge to throw a RuntimeError
             try:
                 for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -14,6 +14,8 @@ from src.wallet.derive_keys import master_sk_to_farmer_sk, master_sk_to_local_sk
 
 log = logging.getLogger(__name__)
 
+min_num = 5
+default_num = 30
 
 min_success_rate = 0.0
 max_success_rate = 1.0
@@ -26,13 +28,13 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
         if num == 0:
             log.warning("Not opening plot files")
         else:
-            if num < 5:
+            if num < min_num:
                 log.warning(f"{num} challenges is too low, setting it to the minimum of 5")
-                num = 5
-            if num < 30:
-                log.warning("Use 30 challenges (our default) for balance of speed and accurate results")
+                num = min_num
+            if num < default_num:
+                log.warning(f"Use {default_num} challenges (our default) for balance of speed and accurate results")
     else:
-        num = 30
+        num = default_num
 
     expected_proofs = min(num, int((num * success_rate) + 0.5))
 
@@ -40,7 +42,7 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
         log.error(f"success_rate must be higher than {min_success_rate} and less than {max_success_rate}")
         return
 
-    if success_rate > default_success_rate and num <= 30:
+    if success_rate > default_success_rate and num <= default_num:
         log.error("Higher success_rate requires a higher number of challenges")
         return
 

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -99,9 +99,12 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
     total_size = 0
     bad_plots_list: List[Path] = []
     total_proofs = 0
+    current_plot = 0
     for plot_path, plot_info in provers.items():
+        current_plot += 1
+        progress = min(99, int((float(current_plot) / len(provers)) * 100))
         pr = plot_info.prover
-        log.info(f"Testing plot {plot_path} k={pr.get_size()}")
+        log.info(f"[{progress}%] Testing plot {plot_path} k={pr.get_size()}")
         log.info(f"\tPool public key: {plot_info.pool_public_key}")
 
         # Look up local_sk from plot to save locked memory

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -128,11 +128,11 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
                         else:
                             log.debug(f"error in proving/verifying for plot {plot_path}")
                     except AssertionError as e:
-                        log.error(f"{type(e)}: {e} error in proving/verifying for plot {plot_path}")
-            except BaseException as e:
-                if isinstance(e, KeyboardInterrupt):
-                    log.warning("Interrupted, closing")
-                    return
+                        log.debug(f"{type(e)}: {e} error in proving/verifying for plot {plot_path}")
+            except KeyboardInterrupt:
+                log.warning("Interrupted, closing")
+                return
+            except Exception as e:
                 log.debug(f"{type(e)}: {e} error in getting challenge qualities for plot {plot_path}")
 
         if plot_proofs >= expected_proofs:

--- a/src/plotting/check_plots.py
+++ b/src/plotting/check_plots.py
@@ -126,7 +126,7 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
                         if quality_str == ver_quality_str:
                             plot_proofs += 1
                         else:
-                            log.debug(f"error in proving/verifying for plot {plot_path}")
+                            log.debug(f"challenge: {challenge}, quality does not match for plot {plot_path}")
                     except AssertionError as e:
                         log.debug(f"{type(e)}: {e} error in proving/verifying for plot {plot_path}")
             except KeyboardInterrupt:


### PR DESCRIPTION
Right now it has an issue which leads to false negatives imo. As it 
currently breaks the inner testing loop as soon as one challange did not 
result in valid or even in a proof at all. But to determine if a plot is 
valid i think it should try all provided challenges first and then 
decide if the plot is valid by checking if there were any proofs 
available for the given challenges, no?

So this commit removes `caught_exception` and it's check/break if an 
exception occurs. Instead it just prints the error as debug message and 
it increments `total_proofs` only in case of success.