### PR TITLE
Sanitize WP only.

### DIFF
--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -1677,7 +1677,8 @@ class FullNode:
                                 )
                         # Running in 'sanitize_weight_proof_only' ignores CC_SP_VDF and CC_IP_VDF
                         # unless this is a challenge block.
-                        if sanitize_weight_proof_only and not record.is_challenge_block(self.constants):
+                        if sanitize_weight_proof_only:
+                            if not record.is_challenge_block(self.constants):
                             # Calculates 'new_min_height' as described below.
                             if (
                                 prev_broadcast_list_len == 0

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -1679,15 +1679,15 @@ class FullNode:
                         # unless this is a challenge block.
                         if sanitize_weight_proof_only:
                             if not record.is_challenge_block(self.constants):
-                            # Calculates 'new_min_height' as described below.
-                            if (
-                                prev_broadcast_list_len == 0
-                                and len(broadcast_list) > 0
-                                and h <= max(0, max_height - 1000)
-                            ):
-                                new_min_height = header.height
-                            # Skip calculations for CC_SP_VDF and CC_IP_VDF.
-                            continue
+                                # Calculates 'new_min_height' as described below.
+                                if (
+                                    prev_broadcast_list_len == 0
+                                    and len(broadcast_list) > 0
+                                    and h <= max(0, max_height - 1000)
+                                ):
+                                    new_min_height = header.height
+                                # Skip calculations for CC_SP_VDF and CC_IP_VDF.
+                                continue
                         if header.challenge_chain_sp_proof is not None and (
                             header.challenge_chain_sp_proof.witness_type > 0
                             or not header.challenge_chain_sp_proof.normalized_to_identity

--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -131,12 +131,15 @@ class FullNode:
             full_peak = await self.blockchain.get_full_peak()
             await self.peak_post_processing(full_peak, peak, max(peak.height - 1, 0), None)
         if self.config["send_uncompact_interval"] != 0:
+            sanitize_weight_proof_only = False
+            if "sanitize_weight_proof_only" in self.config:
+                sanitize_weight_proof_only = self.config["sanitize_weight_proof_only"]
             assert self.config["target_uncompact_proofs"] != 0
             self.uncompact_task = asyncio.create_task(
                 self.broadcast_uncompact_blocks(
                     self.config["send_uncompact_interval"],
                     self.config["target_uncompact_proofs"],
-                    self.config["sanitize_weight_proof_only"],
+                    sanitize_weight_proof_only,
                 )
             )
         self.initialized = True

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -220,6 +220,9 @@ full_node:
   send_uncompact_interval: 0
   # At every 'send_uncompact_interval' seconds, send blueboxes 'target_uncompact_proofs' proofs to be normalized.
   target_uncompact_proofs: 100
+  # Setting this flag as True, blueboxes will sanitize only data needed in weight proof calculation, as opposed to whole blocks.
+  # Default is set to False, as the network needs only one or two blueboxes like this.
+  sanitize_weight_proof_only: False
 
   farmer_peer:
       host: *self_hostname

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -76,6 +76,7 @@ async def setup_full_node(
     config["send_uncompact_interval"] = send_uncompact_interval
     config["target_uncompact_proofs"] = 30
     config["peer_connect_interval"] = 50
+    config["sanitize_weight_proof_only"] = True
     if introducer_port is not None:
         config["introducer_peer"]["host"] = self_hostname
         config["introducer_peer"]["port"] = introducer_port

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -66,7 +66,8 @@ async def setup_full_node(
     local_bt,
     introducer_port=None,
     simulator=False,
-    send_uncompact_interval=30,
+    send_uncompact_interval=0,
+    sanitize_weight_proof_only=False,
 ):
     db_path = local_bt.root_path / f"{db_name}"
     if db_path.exists():
@@ -76,7 +77,7 @@ async def setup_full_node(
     config["send_uncompact_interval"] = send_uncompact_interval
     config["target_uncompact_proofs"] = 30
     config["peer_connect_interval"] = 50
-    config["sanitize_weight_proof_only"] = True
+    config["sanitize_weight_proof_only"] = sanitize_weight_proof_only
     if introducer_port is not None:
         config["introducer_peer"]["host"] = self_hostname
         config["introducer_peer"]["port"] = introducer_port
@@ -441,8 +442,8 @@ async def setup_full_system(consensus_constants: ConsensusConstants, b_tools=Non
         setup_farmer(21235, consensus_constants, b_tools, uint16(21237)),
         setup_vdf_clients(8000),
         setup_timelord(21236, 21237, False, consensus_constants, b_tools),
-        setup_full_node(consensus_constants, "blockchain_test.db", 21237, b_tools, 21233, False, 10),
-        setup_full_node(consensus_constants, "blockchain_test_2.db", 21238, b_tools_1, 21233, False, 10),
+        setup_full_node(consensus_constants, "blockchain_test.db", 21237, b_tools, 21233, False, 10, True),
+        setup_full_node(consensus_constants, "blockchain_test_2.db", 21238, b_tools_1, 21233, False, 10, True),
         setup_vdf_client(7999),
         setup_timelord(21239, 21238, True, consensus_constants, b_tools_1),
     ]


### PR DESCRIPTION
Add an option for blueboxes to pick only CC_SP and CC_IP needed for weight proof calculation, as opposed to sanitising all of them. Running only a few in all network should make sure weight proof has all its data blueboxed.
