### PR TITLE
Decrease the cache size, which requires a linear search for each block

### DIFF
--- a/src/full_node/coin_store.py
+++ b/src/full_node/coin_store.py
@@ -20,7 +20,7 @@ class CoinStore:
     cache_size: uint32
 
     @classmethod
-    async def create(cls, connection: aiosqlite.Connection, cache_size: uint32 = uint32(600000)):
+    async def create(cls, connection: aiosqlite.Connection, cache_size: uint32 = uint32(60000)):
         self = cls()
 
         self.cache_size = cache_size


### PR DESCRIPTION
I was seeing some very bad performance numbers on a long blockchain (> 100000 blocks). This should keep it fairly small, although it might hurt performance for transactions spending old coins.

The root of the issue is we are doing a linear search in the coin store whenever doing a "rollback", which happens every block.