### PR TITLE
Update cryptography to 3.4.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     "bitstring==3.1.7",  # Binary data management library
     "colorlog==4.8.0",  # Adds color to logs
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
-    "cryptography==3.4.6",  # Python cryptography library for TLS - keyring conflict
+    "cryptography==3.4.7",  # Python cryptography library for TLS - keyring conflict
     "keyring==23.0",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)
     #  "keyrings.cryptfile==1.3.8",  # Secure storage for keys on Linux (Will be replaced)


### PR DESCRIPTION
Updated Windows, macOS, and ``manylinux`` wheels to be compiled with OpenSSL 1.1.1k due to a security issue in OpenSSL...