### PR TITLE
src|test: Improve time estimate in `cmds.farm_funcs.summary()`

### DIFF
--- a/src/cmds/farm_funcs.py
+++ b/src/cmds/farm_funcs.py
@@ -1,4 +1,3 @@
-import math
 from typing import Any, Dict, List, Optional
 
 import aiohttp
@@ -12,6 +11,7 @@ from src.rpc.wallet_rpc_client import WalletRpcClient
 from src.util.config import load_config
 from src.util.default_root import DEFAULT_ROOT_PATH
 from src.util.ints import uint16
+from src.util.misc import format_minutes
 
 SECONDS_PER_BLOCK = (24 * 3600) / 4608
 
@@ -241,19 +241,9 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
     else:
         print("Estimated network space: Unknown")
 
+    minutes = -1
     if blockchain_state is not None and plots is not None:
-        proportion = total_plot_size / blockchain_state["space"] if blockchain_state["space"] else 0
-        minutes = (await get_average_block_time(rpc_port) / 60) / proportion if proportion else 0
-
-        print("Expected time to win: ", end="")
-        if minutes == 0:
-            print("Unknown")
-        elif minutes > 60 * 24:
-            print(f"{math.floor(minutes/(60*24))} days")
-        elif minutes > 60:
-            print(f"{math.floor(minutes/60)} hours")
-        else:
-            print(f"{math.floor(minutes)} minutes")
-    else:
-        print("Expected time to win: Unknown")
+        proportion = total_plot_size / blockchain_state["space"] if blockchain_state["space"] else -1
+        minutes = int((await get_average_block_time(rpc_port) / 60) / proportion) if proportion else -1
+    print("Expected time to win: " + format_minutes(minutes))
     print("Note: log into your key using 'chia wallet show' to see rewards for each key")

--- a/src/util/misc.py
+++ b/src/util/misc.py
@@ -1,0 +1,44 @@
+def format_minutes(minutes):
+
+    if not isinstance(minutes, int):
+        return "Invalid"
+
+    if minutes == 0:
+        return "Now"
+
+    hour_minutes = 60
+    day_minutes = 24 * hour_minutes
+    week_minutes = 7 * day_minutes
+    months_minutes = 43800
+    year_minutes = 12 * months_minutes
+
+    years = int(minutes / year_minutes)
+    months = int(minutes / months_minutes)
+    weeks = int(minutes / week_minutes)
+    days = int(minutes / day_minutes)
+    hours = int(minutes / hour_minutes)
+
+    def format_unit_string(str_unit, count):
+        return f"{count} {str_unit}{('s' if count > 1 else '')}"
+
+    def format_unit(unit, count, unit_minutes, next_unit, next_unit_minutes):
+        formatted = format_unit_string(unit, count)
+        minutes_left = minutes % unit_minutes
+        if minutes_left >= next_unit_minutes:
+            formatted += " and " + format_unit_string(next_unit, int(minutes_left / next_unit_minutes))
+        return formatted
+
+    if years > 0:
+        return format_unit("year", years, year_minutes, "month", months_minutes)
+    if months > 0:
+        return format_unit("month", months, months_minutes, "week", week_minutes)
+    if weeks > 0:
+        return format_unit("week", weeks, week_minutes, "day", day_minutes)
+    if days > 0:
+        return format_unit("day", days, day_minutes, "hour", hour_minutes)
+    if hours > 0:
+        return format_unit("hour", hours, hour_minutes, "minute", 1)
+    if minutes > 0:
+        return format_unit_string("minute", minutes)
+
+    return "Unknown"

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -1,0 +1,31 @@
+import pytest
+from src.util.misc import format_minutes
+
+
+class TestMisc:
+    @pytest.mark.asyncio
+    async def test_format_minutes(self):
+        assert format_minutes(None) == "Invalid"
+        assert format_minutes(dict()) == "Invalid"
+        assert format_minutes("some minutes") == "Invalid"
+        assert format_minutes(-1) == "Unknown"
+        assert format_minutes(0) == "Now"
+        assert format_minutes(1) == "1 minute"
+        assert format_minutes(59) == "59 minutes"
+        assert format_minutes(60) == "1 hour"
+        assert format_minutes(61) == "1 hour and 1 minute"
+        assert format_minutes(119) == "1 hour and 59 minutes"
+        assert format_minutes(1380) == "23 hours"
+        assert format_minutes(1440) == "1 day"
+        assert format_minutes(2160) == "1 day and 12 hours"
+        assert format_minutes(8640) == "6 days"
+        assert format_minutes(10080) == "1 week"
+        assert format_minutes(20160) == "2 weeks"
+        assert format_minutes(40240) == "3 weeks and 6 days"
+        assert format_minutes(40340) == "4 weeks"
+        assert format_minutes(43800) == "1 month"
+        assert format_minutes(102000) == "2 months and 1 week"
+        assert format_minutes(481800) == "11 months"
+        assert format_minutes(525600) == "1 year"
+        assert format_minutes(1007400) == "1 year and 11 months"
+        assert format_minutes(5256000) == "10 years"


### PR DESCRIPTION
Format the calculated estimated minutes into a string with the format: "`unit` and `sub-unit`"

where `unit` can be the following with always the next smaller unit as `sub-unit`:
- years
- months
- weeks
- days
- hours
- minutes
