### PR TITLE
Ms.offline signing2

### DIFF
--- a/src/rpc/wallet_rpc_api.py
+++ b/src/rpc/wallet_rpc_api.py
@@ -12,6 +12,7 @@ from src.consensus.network_type import NetworkType
 from src.protocols.protocol_message_types import ProtocolMessageTypes
 from src.server.outbound_message import NodeType, make_msg
 from src.simulator.simulator_protocol import FarmNewBlockProtocol
+from src.types.blockchain_format.coin import Coin
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from src.util.byte_types import hexstr_to_bytes
@@ -70,6 +71,7 @@ class WalletRpcApi:
             "/create_backup": self.create_backup,
             "/get_transaction_count": self.get_transaction_count,
             "/get_farmed_amount": self.get_farmed_amount,
+            "/create_signed_transaction": self.create_signed_transaction,
             # Coloured coins and trading
             "/cc_set_name": self.cc_set_name,
             "/cc_get_name": self.cc_get_name,
@@ -728,3 +730,25 @@ class WalletRpcApi:
             "fee_amount": fee_amount,
             "last_height_farmed": last_height_farmed,
         }
+
+    async def create_signed_transaction(self, request):
+        if "amount" not in request:
+            raise ValueError("Specify amount")
+        amount = uint64(request["amount"])
+
+        fee = uint64(0)
+        if "fee" in request:
+            fee = uint64(request["fee"])
+
+        if "puzzle_hash" not in request:
+            raise ValueError("Specify puzzle_hash")
+        puzzle_hash: bytes32 = bytes32(hexstr_to_bytes(request["puzzle_hash"]))
+
+        coins = None
+        if "coins" in request and len(request["coins"]) > 0:
+            coins = set([Coin.from_json_dict(coin_json) for coin_json in request["coins"]])
+
+        signed_tx = await self.service.wallet_state_manager.main_wallet.generate_signed_transaction(
+            amount, puzzle_hash, fee, coins=coins, ignore_max_send_amount=True
+        )
+        return {"signed_tx": signed_tx}

--- a/src/rpc/wallet_rpc_api.py
+++ b/src/rpc/wallet_rpc_api.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
 from blspy import PrivateKey
-from clvm.casts import int_to_bytes
 
 from src.cmds.init_funcs import check_keys
 from src.consensus.block_rewards import calculate_base_farmer_reward
@@ -15,8 +14,6 @@ from src.server.outbound_message import NodeType, make_msg
 from src.simulator.simulator_protocol import FarmNewBlockProtocol
 from src.types.blockchain_format.coin import Coin
 from src.types.blockchain_format.sized_bytes import bytes32
-from src.types.condition_opcodes import ConditionOpcode
-from src.types.condition_var_pair import ConditionVarPair
 from src.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from src.util.byte_types import hexstr_to_bytes
 from src.util.ints import uint32, uint64
@@ -738,7 +735,6 @@ class WalletRpcApi:
         if "additions" not in request or len(request["additions"]) < 1:
             raise ValueError("Specify additions list")
 
-        conditions_dict = {}
         additions: List[Dict] = request["additions"]
         amount_0: uint64 = uint64(additions[0]["amount"])
         assert amount_0 <= self.service.constants.MAX_COIN_AMOUNT
@@ -746,6 +742,7 @@ class WalletRpcApi:
         if len(puzzle_hash_0) != 32:
             raise ValueError(f"Address must be 32 bytes. {puzzle_hash_0}")
 
+        additional_outputs = []
         for addition in additions[1:]:
             receiver_ph = hexstr_to_bytes(addition["puzzle_hash"])
             if len(receiver_ph) != 32:
@@ -753,8 +750,7 @@ class WalletRpcApi:
             amount = uint64(addition["amount"])
             if amount > self.service.constants.MAX_COIN_AMOUNT:
                 raise ValueError(f"Coin amount cannot exceed {self.service.constants.MAX_COIN_AMOUNT}")
-            output = ConditionVarPair(ConditionOpcode.CREATE_COIN, [receiver_ph, int_to_bytes(amount)])
-            conditions_dict[ConditionOpcode.CREATE_COIN].append(output)
+            additional_outputs.append({"puzzlehash": receiver_ph, "amount": amount})
 
         fee = uint64(0)
         if "fee" in request:
@@ -765,6 +761,6 @@ class WalletRpcApi:
             coins = set([Coin.from_json_dict(coin_json) for coin_json in request["coins"]])
 
         signed_tx = await self.service.wallet_state_manager.main_wallet.generate_signed_transaction(
-            amount_0, puzzle_hash_0, fee, coins=coins, ignore_max_send_amount=True
+            amount_0, puzzle_hash_0, fee, coins=coins, ignore_max_send_amount=True, primaries=additional_outputs
         )
         return {"signed_tx": signed_tx}

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -130,14 +130,18 @@ class WalletRpcClient(RpcClient):
     async def get_farmed_amount(self) -> Dict:
         return await self.fetch("get_farmed_amount", {})
 
-    async def create_signed_transaction(self, additions: List[Dict], coins: List[Coin] = None) -> Dict:
+    async def create_signed_transaction(
+        self, additions: List[Dict], coins: List[Coin] = None, fee: uint64 = uint64(0)
+    ) -> Dict:
         # Converts bytes to hex for puzzle hashes
         additions_hex = [{"amount": ad["amount"], "puzzle_hash": ad["puzzle_hash"].hex()} for ad in additions]
         if coins is not None and len(coins) > 0:
-            coins = [c.to_json_dict() for c in coins]
-            return await self.fetch("create_signed_transaction", {"additions": additions_hex, "coins": coins})
+            coins_json = [c.to_json_dict() for c in coins]
+            return await self.fetch(
+                "create_signed_transaction", {"additions": additions_hex, "coins": coins_json, "fee": fee}
+            )
         else:
-            return await self.fetch("create_signed_transaction", {"additions": additions_hex})
+            return await self.fetch("create_signed_transaction", {"additions": additions_hex, "fee": fee})
 
 
 # TODO: add APIs for coloured coins and RL wallet

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -130,17 +130,14 @@ class WalletRpcClient(RpcClient):
     async def get_farmed_amount(self) -> Dict:
         return await self.fetch("get_farmed_amount", {})
 
-    async def create_signed_transaction(self, amount: uint64, puzzle_hash: bytes32, coins: List[Coin]=None) -> Dict:
-
+    async def create_signed_transaction(self, additions: List[Dict], coins: List[Coin] = None) -> Dict:
+        # Converts bytes to hex for puzzle hashes
+        additions_hex = [{"amount": ad["amount"], "puzzle_hash": ad["puzzle_hash"].hex()} for ad in additions]
         if coins is not None and len(coins) > 0:
             coins = [c.to_json_dict() for c in coins]
-            return await self.fetch("create_signed_transaction",
-                                    {"amount": amount, "puzzle_hash": puzzle_hash.hex(), "coins": coins})
+            return await self.fetch("create_signed_transaction", {"additions": additions_hex, "coins": coins})
         else:
-            return await self.fetch("create_signed_transaction",
-                                    {"amount": amount, "puzzle_hash": puzzle_hash.hex()})
-
-
+            return await self.fetch("create_signed_transaction", {"additions": additions_hex})
 
 
 # TODO: add APIs for coloured coins and RL wallet

--- a/src/rpc/wallet_rpc_client.py
+++ b/src/rpc/wallet_rpc_client.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from src.rpc.rpc_client import RpcClient
+from src.types.blockchain_format.coin import Coin
 from src.types.blockchain_format.sized_bytes import bytes32
 from src.util.bech32m import decode_puzzle_hash
 from src.util.ints import uint32, uint64
@@ -128,6 +129,18 @@ class WalletRpcClient(RpcClient):
 
     async def get_farmed_amount(self) -> Dict:
         return await self.fetch("get_farmed_amount", {})
+
+    async def create_signed_transaction(self, amount: uint64, puzzle_hash: bytes32, coins: List[Coin]=None) -> Dict:
+
+        if coins is not None and len(coins) > 0:
+            coins = [c.to_json_dict() for c in coins]
+            return await self.fetch("create_signed_transaction",
+                                    {"amount": amount, "puzzle_hash": puzzle_hash.hex(), "coins": coins})
+        else:
+            return await self.fetch("create_signed_transaction",
+                                    {"amount": amount, "puzzle_hash": puzzle_hash.hex()})
+
+
 
 
 # TODO: add APIs for coloured coins and RL wallet

--- a/src/util/streamable.py
+++ b/src/util/streamable.py
@@ -95,7 +95,7 @@ def recurse_jsonify(d):
             if isinstance(item, Enum):
                 item = item.name
             if isinstance(item, int) and type(item) in big_ints:
-                item = str(item)
+                item = int(item)
             new_list.append(item)
         d = new_list
 
@@ -110,7 +110,7 @@ def recurse_jsonify(d):
             if isinstance(value, Enum):
                 d[key] = value.name
             if isinstance(value, int) and type(value) in big_ints:
-                d[key] = str(value)
+                d[key] = int(value)
     return d
 
 

--- a/src/wallet/puzzles/prefarm/spend_prefarm.py
+++ b/src/wallet/puzzles/prefarm/spend_prefarm.py
@@ -31,10 +31,6 @@ async def main():
         assert pool_amounts == pool_prefarm.amount // 2
         address1 = "xch1rdatypul5c642jkeh4yp933zu3hw8vv8tfup8ta6zfampnyhjnusxdgns6"  # Key 1
         address2 = "xch1duvy5ur5eyj7lp5geetfg84cj2d7xgpxt7pya3lr2y6ke3696w9qvda66e"  # Key 2
-        # address1 = "txch15gx26ndmacfaqlq8m0yajeggzceu7cvmaz4df0hahkukes695rss6lej7h"  # Gene wallet (m/12381/8444/2/42):
-        # address2 = (
-        #     "txch1c2cguswhvmdyz9hr3q6hak2h6p9dw4rz82g4707k2xy2sarv705qcce4pn"  # Mariano address (m/12381/8444/2/0)
-        # )
 
         ph1 = decode_puzzle_hash(address1)
         ph2 = decode_puzzle_hash(address2)

--- a/src/wallet/puzzles/prefarm/spend_prefarm.py
+++ b/src/wallet/puzzles/prefarm/spend_prefarm.py
@@ -29,11 +29,12 @@ async def main():
         print(farmer_prefarm.amount, farmer_amounts)
         assert farmer_amounts == farmer_prefarm.amount // 2
         assert pool_amounts == pool_prefarm.amount // 2
-
-        address1 = "txch15gx26ndmacfaqlq8m0yajeggzceu7cvmaz4df0hahkukes695rss6lej7h"  # Gene wallet (m/12381/8444/2/42):
-        address2 = (
-            "txch1c2cguswhvmdyz9hr3q6hak2h6p9dw4rz82g4707k2xy2sarv705qcce4pn"  # Mariano address (m/12381/8444/2/0)
-        )
+        address1 = "xch1rdatypul5c642jkeh4yp933zu3hw8vv8tfup8ta6zfampnyhjnusxdgns6"  # Key 1
+        address2 = "xch1duvy5ur5eyj7lp5geetfg84cj2d7xgpxt7pya3lr2y6ke3696w9qvda66e"  # Key 2
+        # address1 = "txch15gx26ndmacfaqlq8m0yajeggzceu7cvmaz4df0hahkukes695rss6lej7h"  # Gene wallet (m/12381/8444/2/42):
+        # address2 = (
+        #     "txch1c2cguswhvmdyz9hr3q6hak2h6p9dw4rz82g4707k2xy2sarv705qcce4pn"  # Mariano address (m/12381/8444/2/0)
+        # )
 
         ph1 = decode_puzzle_hash(address1)
         ph2 = decode_puzzle_hash(address2)
@@ -51,8 +52,8 @@ async def main():
         sb_pool = SpendBundle([CoinSolution(pool_prefarm, p_pool_2, p_solution)], G2Element())
 
         print(sb_pool, sb_farmer)
-        # res = await client.push_tx(sb_farmer)
-        res = await client.push_tx(sb_pool)
+        res = await client.push_tx(sb_farmer)
+        # res = await client.push_tx(sb_pool)
 
         print(res)
         up = await client.get_coin_records_by_puzzle_hash(farmer_prefarm.puzzle_hash, True)

--- a/src/wallet/wallet_state_manager.py
+++ b/src/wallet/wallet_state_manager.py
@@ -144,7 +144,6 @@ class WalletStateManager:
         assert main_wallet_info is not None
 
         self.private_key = private_key
-        self.log.warning(f"Main wallet info: {main_wallet_info}, bytes: {bytes(main_wallet_info)}")
         self.main_wallet = await Wallet.create(self, main_wallet_info)
 
         self.wallets = {main_wallet_info.id: self.main_wallet}

--- a/src/wallet/wallet_state_manager.py
+++ b/src/wallet/wallet_state_manager.py
@@ -144,7 +144,7 @@ class WalletStateManager:
         assert main_wallet_info is not None
 
         self.private_key = private_key
-
+        self.log.warning(f"Main wallet info: {main_wallet_info}, bytes: {bytes(main_wallet_info)}")
         self.main_wallet = await Wallet.create(self, main_wallet_info)
 
         self.wallets = {main_wallet_info.id: self.main_wallet}

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -5,14 +5,18 @@ from pathlib import Path
 import pytest
 
 from src.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
+from src.rpc.full_node_rpc_api import FullNodeRpcApi
+from src.rpc.full_node_rpc_client import FullNodeRpcClient
 from src.rpc.rpc_server import start_rpc_server
 from src.rpc.wallet_rpc_api import WalletRpcApi
 from src.rpc.wallet_rpc_client import WalletRpcClient
 from src.simulator.simulator_protocol import FarmNewBlockProtocol
+from src.types.blockchain_format.coin import Coin
 from src.types.peer_info import PeerInfo
+from src.types.spend_bundle import SpendBundle
 from src.util.bech32m import encode_puzzle_hash
 from src.util.ints import uint16, uint32
-from tests.setup_nodes import bt, setup_simulators_and_wallets
+from tests.setup_nodes import bt, setup_simulators_and_wallets, self_hostname
 from tests.time_out_assert import time_out_assert
 
 log = logging.getLogger(__name__)
@@ -27,6 +31,7 @@ class TestWalletRpc:
     @pytest.mark.asyncio
     async def test_wallet_make_transaction(self, two_wallet_nodes):
         test_rpc_port = uint16(21529)
+        test_rpc_port_node = uint16(21530)
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -62,6 +67,18 @@ class TestWalletRpc:
         def stop_node_cb():
             pass
 
+        full_node_rpc_api = FullNodeRpcApi(full_node_api.full_node)
+
+        rpc_cleanup_node = await start_rpc_server(
+            full_node_rpc_api,
+            hostname,
+            daemon_port,
+            test_rpc_port_node,
+            stop_node_cb,
+            bt.root_path,
+            config,
+            connect_to_daemon=False,
+        )
         rpc_cleanup = await start_rpc_server(
             wallet_rpc_api,
             hostname,
@@ -76,7 +93,8 @@ class TestWalletRpc:
         await time_out_assert(5, wallet.get_confirmed_balance, initial_funds)
         await time_out_assert(5, wallet.get_unconfirmed_balance, initial_funds)
 
-        client = await WalletRpcClient.create("localhost", test_rpc_port, bt.root_path, config)
+        client = await WalletRpcClient.create(self_hostname, test_rpc_port, bt.root_path, config)
+        client_node = await FullNodeRpcClient.create(self_hostname, test_rpc_port_node, bt.root_path, config)
         try:
             addr = encode_puzzle_hash(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), "xch")
             tx_amount = 15600000
@@ -101,7 +119,7 @@ class TestWalletRpc:
 
             for i in range(0, 5):
                 await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.5)
 
             async def eventual_balance():
                 return (await client.get_wallet_balance("1"))["confirmed_wallet_balance"]
@@ -109,73 +127,125 @@ class TestWalletRpc:
             await time_out_assert(5, eventual_balance, initial_funds_eventually - tx_amount)
 
             # Tests offline signing
-            ph_1 = await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash()
-            ph_2 = await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash()
-            tx_res = await client.create_signed_transaction([{"amount": 888000, "puzzle_hash": ph_1}])
-            print(tx_res)
+            ph_3 = await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash()
+            ph_4 = await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash()
+            ph_5 = await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash()
+
+            # Test basic transaction to one output
+            signed_tx_amount = 888000
+            tx_res = await client.create_signed_transaction([{"amount": signed_tx_amount, "puzzle_hash": ph_3}])
 
             assert tx_res["success"]
-            assert tx_res["fee_amount"] == 0
-            assert tx_res["amount"] == 888000
+            assert tx_res["signed_tx"]["fee_amount"] == 0
+            assert tx_res["signed_tx"]["amount"] == signed_tx_amount
             assert len(tx_res["signed_tx"]["additions"]) == 2  # The output and the change
-            assert any([addition.amount == 888000 for addition in tx_res["signed_tx"]["additions"]])
+            assert any([addition["amount"] == signed_tx_amount for addition in tx_res["signed_tx"]["additions"]])
 
-            # address = await client.get_next_address("1", True)
-            # assert len(address) > 10
-            #
-            # transactions = await client.get_transactions("1")
-            # assert len(transactions) > 1
-            #
-            # pks = await client.get_public_keys()
-            # assert len(pks) == 1
-            #
-            # assert (await client.get_height_info()) > 0
-            #
-            # sk_dict = await client.get_private_key(pks[0])
-            # assert sk_dict["fingerprint"] == pks[0]
-            # assert sk_dict["sk"] is not None
-            # assert sk_dict["pk"] is not None
-            # assert sk_dict["seed"] is not None
-            #
-            # mnemonic = await client.generate_mnemonic()
-            # assert len(mnemonic) == 24
-            #
-            # await client.add_key(mnemonic)
-            #
-            # pks = await client.get_public_keys()
-            # assert len(pks) == 2
-            #
-            # await client.log_in_and_skip(pks[1])
-            # sk_dict = await client.get_private_key(pks[1])
-            # assert sk_dict["fingerprint"] == pks[1]
-            #
-            # await client.delete_key(pks[0])
-            # await client.log_in_and_skip(pks[1])
-            # assert len(await client.get_public_keys()) == 1
-            #
-            # assert not (await client.get_sync_status())
-            #
-            # wallets = await client.get_wallets()
-            # assert len(wallets) == 1
-            # balance = await client.get_wallet_balance(wallets[0]["id"])
-            # assert balance["unconfirmed_wallet_balance"] == 0
-            #
-            # test_wallet_backup_path = Path("test_wallet_backup_file")
-            # await client.create_backup(test_wallet_backup_path)
-            # assert test_wallet_backup_path.exists()
-            # test_wallet_backup_path.unlink()
-            #
-            # try:
-            #     await client.send_transaction(wallets[0]["id"], 100, addr)
-            #     raise Exception("Should not create tx if no balance")
-            # except ValueError:
-            #     pass
-            #
-            # await client.delete_all_keys()
-            #
-            # assert len(await client.get_public_keys()) == 0
+            push_res = await client_node.push_tx(SpendBundle.from_json_dict(tx_res["signed_tx"]["spend_bundle"]))
+            assert push_res["success"]
+            assert (await client.get_wallet_balance("1"))[
+                "confirmed_wallet_balance"
+            ] == initial_funds_eventually - tx_amount
+
+            for i in range(0, 5):
+                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await asyncio.sleep(0.5)
+
+            await time_out_assert(5, eventual_balance, initial_funds_eventually - tx_amount - signed_tx_amount)
+
+            # Test transaction to two outputs, from a specified coin, with a fee
+            coin_to_spend = None
+            for addition in tx_res["signed_tx"]["additions"]:
+                if addition["amount"] != signed_tx_amount:
+                    coin_to_spend = Coin.from_json_dict(addition)
+            assert coin_to_spend is not None
+
+            tx_res = await client.create_signed_transaction(
+                [{"amount": 444, "puzzle_hash": ph_4}, {"amount": 999, "puzzle_hash": ph_5}],
+                coins=[coin_to_spend],
+                fee=100,
+            )
+            assert tx_res["success"]
+            assert tx_res["signed_tx"]["fee_amount"] == 100
+            assert tx_res["signed_tx"]["amount"] == 444 + 999
+            assert len(tx_res["signed_tx"]["additions"]) == 3  # The outputs and the change
+            assert any([addition["amount"] == 444 for addition in tx_res["signed_tx"]["additions"]])
+            assert any([addition["amount"] == 999 for addition in tx_res["signed_tx"]["additions"]])
+            assert (
+                sum([rem["amount"] for rem in tx_res["signed_tx"]["removals"]])
+                - sum([ad["amount"] for ad in tx_res["signed_tx"]["additions"]])
+                == 100
+            )
+
+            push_res = await client_node.push_tx(SpendBundle.from_json_dict(tx_res["signed_tx"]["spend_bundle"]))
+            assert push_res["success"]
+            for i in range(0, 5):
+                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await asyncio.sleep(0.5)
+
+            await time_out_assert(
+                5, eventual_balance, initial_funds_eventually - tx_amount - signed_tx_amount - 444 - 999 - 100
+            )
+
+            address = await client.get_next_address("1", True)
+            assert len(address) > 10
+
+            transactions = await client.get_transactions("1")
+            assert len(transactions) > 1
+
+            pks = await client.get_public_keys()
+            assert len(pks) == 1
+
+            assert (await client.get_height_info()) > 0
+
+            sk_dict = await client.get_private_key(pks[0])
+            assert sk_dict["fingerprint"] == pks[0]
+            assert sk_dict["sk"] is not None
+            assert sk_dict["pk"] is not None
+            assert sk_dict["seed"] is not None
+
+            mnemonic = await client.generate_mnemonic()
+            assert len(mnemonic) == 24
+
+            await client.add_key(mnemonic)
+
+            pks = await client.get_public_keys()
+            assert len(pks) == 2
+
+            await client.log_in_and_skip(pks[1])
+            sk_dict = await client.get_private_key(pks[1])
+            assert sk_dict["fingerprint"] == pks[1]
+
+            await client.delete_key(pks[0])
+            await client.log_in_and_skip(pks[1])
+            assert len(await client.get_public_keys()) == 1
+
+            assert not (await client.get_sync_status())
+
+            wallets = await client.get_wallets()
+            assert len(wallets) == 1
+            balance = await client.get_wallet_balance(wallets[0]["id"])
+            assert balance["unconfirmed_wallet_balance"] == 0
+
+            test_wallet_backup_path = Path("test_wallet_backup_file")
+            await client.create_backup(test_wallet_backup_path)
+            assert test_wallet_backup_path.exists()
+            test_wallet_backup_path.unlink()
+
+            try:
+                await client.send_transaction(wallets[0]["id"], 100, addr)
+                raise Exception("Should not create tx if no balance")
+            except ValueError:
+                pass
+
+            await client.delete_all_keys()
+
+            assert len(await client.get_public_keys()) == 0
         finally:
             # Checks that the RPC manages to stop the node
             client.close()
+            client_node.close()
             await client.await_closed()
+            await client_node.await_closed()
             await rpc_cleanup()
+            await rpc_cleanup_node()


### PR DESCRIPTION
Adds a new rpc to the wallet: `create_signed_transaction`. This allows making a transaction, where you can specify the optional `coins` field, to spend specific coins. You can also specify multiple outputs for the transaction with `additions`, as well as the fee.

This also has a fix to JSON in rpcs, where integers are now returned as integers and not strings. @freddiecoleman , @seeden , this might affect RPC responses.