### PR TITLE
Optimize DB access time

### DIFF
--- a/src/server/address_manager_store.py
+++ b/src/server/address_manager_store.py
@@ -93,7 +93,7 @@ class AddressManagerStore:
                 (key, value),
             )
             await cursor.close()
-            await self.db.commit()
+        await self.db.commit()
 
     async def set_nodes(self, node_list):
         for node_id, peer_info in node_list:
@@ -102,7 +102,7 @@ class AddressManagerStore:
                 (node_id, peer_info.to_string()),
             )
             await cursor.close()
-            await self.db.commit()
+        await self.db.commit()
 
     async def set_new_table(self, entries):
         for node_id, bucket in entries:
@@ -111,7 +111,7 @@ class AddressManagerStore:
                 (node_id, bucket),
             )
             await cursor.close()
-            await self.db.commit()
+        await self.db.commit()
 
     async def serialize(self, address_manager: AddressManager):
         metadata = []


### PR DESCRIPTION
Every 15-30 minutes, the peers ips are written to the DB.
This used to take around ~40s on a powerful overclocked machine.
After this change, it takes 0.1-0.2 seconds
Thanks @richardkiss @wjblanke 