### PR TITLE
skip wp validations from trusted peer

### DIFF
--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -144,7 +144,9 @@ class FullNode:
 
     async def initialize_weight_proof(self):
         self.weight_proof_handler = WeightProofHandler(self.constants, self.blockchain)
-        await self.weight_proof_handler.get_proof_of_weight(self.blockchain.get_peak().header_hash)
+        peak = self.blockchain.get_peak()
+        if peak is not None:
+            await self.weight_proof_handler.get_proof_of_weight(self.blockchain.get_peak().header_hash)
 
     def set_server(self, server: ChiaServer):
         self.server = server

--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -467,7 +467,7 @@ class WeightProofHandler:
         return True, self.get_fork_point(summaries)
 
     def get_fork_point_no_validations(self, weight_proof: WeightProof) -> Tuple[bool, uint32]:
-        log.debug(f"get fork point skip validations")
+        log.debug("get fork point skip validations")
         assert self.blockchain is not None
         assert len(weight_proof.sub_epochs) > 0
         if len(weight_proof.sub_epochs) == 0:

--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -300,9 +300,9 @@ class WeightProofHandler:
                 sub_slots_num = 2
                 while sub_slots_num > 0 and curr_sub_rec.height > 0:
                     curr_sub_rec = blocks[curr_sub_rec.prev_hash]
-                if curr_sub_rec.first_in_sub_slot:
-                    assert curr_sub_rec.finished_challenge_slot_hashes is not None
-                    sub_slots_num -= len(curr_sub_rec.finished_challenge_slot_hashes)
+                    if curr_sub_rec.first_in_sub_slot:
+                        assert curr_sub_rec.finished_challenge_slot_hashes is not None
+                        sub_slots_num -= len(curr_sub_rec.finished_challenge_slot_hashes)
             else:
                 while not curr_sub_rec.first_in_sub_slot and curr_sub_rec.height > 0:
                     curr_sub_rec = blocks[curr_sub_rec.prev_hash]
@@ -463,6 +463,18 @@ class WeightProofHandler:
             return False, uint32(0)
         log.info("validate weight proof recent blocks")
         if not _validate_recent_blocks(constants, wp_bytes, summary_bytes):
+            return False, uint32(0)
+        return True, self.get_fork_point(summaries)
+
+    def get_fork_point_no_validations(self, weight_proof: WeightProof) -> Tuple[bool, uint32]:
+        log.debug(f"get fork point skip validations")
+        assert self.blockchain is not None
+        assert len(weight_proof.sub_epochs) > 0
+        if len(weight_proof.sub_epochs) == 0:
+            return False, uint32(0)
+        summaries, sub_epoch_weight_list = _validate_sub_epoch_summaries(self.constants, weight_proof)
+        if summaries is None:
+            log.warning("weight proof failed to validate sub epoch summaries")
             return False, uint32(0)
         return True, self.get_fork_point(summaries)
 

--- a/src/full_node/weight_proof.py
+++ b/src/full_node/weight_proof.py
@@ -299,10 +299,10 @@ class WeightProofHandler:
             if header_block_sub_rec.overflow and header_block_sub_rec.first_in_sub_slot:
                 sub_slots_num = 2
                 while sub_slots_num > 0 and curr_sub_rec.height > 0:
-                    curr_sub_rec = blocks[curr_sub_rec.prev_hash]
                     if curr_sub_rec.first_in_sub_slot:
                         assert curr_sub_rec.finished_challenge_slot_hashes is not None
                         sub_slots_num -= len(curr_sub_rec.finished_challenge_slot_hashes)
+                    curr_sub_rec = blocks[curr_sub_rec.prev_hash]
             else:
                 while not curr_sub_rec.first_in_sub_slot and curr_sub_rec.height > 0:
                     curr_sub_rec = blocks[curr_sub_rec.prev_hash]

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -320,4 +320,4 @@ wallet:
     public_key:  "config/ssl/wallet/public_wallet.key"
 
   trusted_peers:
-    public_crt: "config/ssl/full_node/public_full_node.crt"
+    trusted_node_1: "config/ssl/full_node/public_full_node.crt"

--- a/src/util/initial-config.yaml
+++ b/src/util/initial-config.yaml
@@ -318,3 +318,6 @@ wallet:
     private_key:  "config/ssl/wallet/private_wallet.key"
     public_crt:  "config/ssl/wallet/public_wallet.crt"
     public_key:  "config/ssl/wallet/public_wallet.key"
+
+  trusted_peers:
+    public_crt: "config/ssl/full_node/public_full_node.crt"

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -442,7 +442,7 @@ class WalletNode:
                 weight_proof = weight_proof_response.wp
                 if self.wallet_state_manager is None:
                     return
-                if self.server.is_trusted_peer(peer):
+                if self.server is not None and self.server.is_trusted_peer(peer):
                     valid, fork_point = self.wallet_state_manager.weight_proof_handler.get_fork_point_no_validations(
                         weight_proof
                     )

--- a/src/wallet/wallet_node.py
+++ b/src/wallet/wallet_node.py
@@ -442,16 +442,21 @@ class WalletNode:
                 weight_proof = weight_proof_response.wp
                 if self.wallet_state_manager is None:
                     return
-                valid, fork_point = await self.wallet_state_manager.weight_proof_handler.validate_weight_proof(
-                    weight_proof
-                )
-                if not valid:
-                    self.log.error(
-                        f"invalid weight proof, num of epochs {len(weight_proof.sub_epochs)}"
-                        f" recent blocks num ,{len(weight_proof.recent_chain_data)}"
+                if self.server.is_trusted_peer(peer):
+                    valid, fork_point = self.wallet_state_manager.weight_proof_handler.get_fork_point_no_validations(
+                        weight_proof
                     )
-                    self.log.debug(f"{weight_proof}")
-                    return None
+                else:
+                    valid, fork_point = await self.wallet_state_manager.weight_proof_handler.validate_weight_proof(
+                        weight_proof
+                    )
+                    if not valid:
+                        self.log.error(
+                            f"invalid weight proof, num of epochs {len(weight_proof.sub_epochs)}"
+                            f" recent blocks num ,{len(weight_proof.recent_chain_data)}"
+                        )
+                        self.log.debug(f"{weight_proof}")
+                        return None
                 self.log.info(f"Validated, fork point is {fork_point}")
                 self.wallet_state_manager.sync_store.add_potential_fork_point(
                     header_block.header_hash, uint32(fork_point)


### PR DESCRIPTION
when syncing to a trusted node only validate sub epoch summaries and find fork point.
fix wp mishandled edge case, causes cache miss when creating a challenge segment for overflow challenge block, causes a failure to create proof