### PR TITLE
Log better, recalculate tried_count.

### DIFF
--- a/src/server/address_manager.py
+++ b/src/server/address_manager.py
@@ -447,6 +447,9 @@ class AddressManager:
                 cached_tried_matrix_positions = list(self.used_tried_matrix_positions)
             while True:
                 if len(self.used_tried_matrix_positions) < math.sqrt(TRIED_BUCKET_COUNT * BUCKET_SIZE):
+                    if len(self.used_tried_matrix_positions) == 0:
+                        log.error(f"Empty tried table, but tried_count shows {self.tried_count}.")
+                        return None
                     # The table is sparse, randomly pick from positions list.
                     index = randrange(len(cached_tried_matrix_positions))
                     tried_bucket, tried_bucket_pos = cached_tried_matrix_positions[index]
@@ -473,6 +476,9 @@ class AddressManager:
                 cached_new_matrix_positions = list(self.used_new_matrix_positions)
             while True:
                 if len(self.used_new_matrix_positions) < math.sqrt(NEW_BUCKET_COUNT * BUCKET_SIZE):
+                    if len(self.used_new_matrix_positions) == 0:
+                        log.error(f"Empty new table, but new_count shows {self.new_count}.")
+                        return None
                     index = randrange(len(cached_new_matrix_positions))
                     new_bucket, new_bucket_pos = cached_new_matrix_positions[index]
                 else:

--- a/src/server/address_manager_store.py
+++ b/src/server/address_manager_store.py
@@ -160,7 +160,8 @@ class AddressManagerStore:
 
         address_manager.key = int(metadata["key"])
         address_manager.new_count = int(metadata["new_count"])
-        address_manager.tried_count = int(metadata["tried_count"])
+        # address_manager.tried_count = int(metadata["tried_count"])
+        address_manager.tried_count = 0
 
         new_table_nodes = [(node_id, info) for node_id, info in nodes if node_id < address_manager.new_count]
         for n, info in new_table_nodes:
@@ -170,7 +171,7 @@ class AddressManagerStore:
             address_manager.random_pos.append(n)
         address_manager.id_count = len(new_table_nodes)
         tried_table_nodes = [(node_id, info) for node_id, info in nodes if node_id >= address_manager.new_count]
-        lost_count = 0
+        # lost_count = 0
         for node_id, info in tried_table_nodes:
             tried_bucket = info.get_tried_bucket(address_manager.key)
             tried_bucket_pos = info.get_bucket_position(address_manager.key, False, tried_bucket)
@@ -183,10 +184,11 @@ class AddressManagerStore:
                 address_manager.map_addr[info.peer_info.host] = id_count
                 address_manager.tried_matrix[tried_bucket][tried_bucket_pos] = id_count
                 address_manager.id_count += 1
-            else:
-                lost_count += 1
+                address_manager.tried_count += 1
+            # else:
+            #    lost_count += 1
 
-        address_manager.tried_count -= lost_count
+        # address_manager.tried_count -= lost_count
         for node_id, bucket in new_table_entries:
             if node_id >= 0 and node_id < address_manager.new_count:
                 info = address_manager.map_info[node_id]


### PR DESCRIPTION
Add a better log message for the exception:

09:25:25.292 full_node src.full_node.full_node : ERROR    Traceback: Traceback (most recent call last):
  File "src\server\node_discovery.py", line 232, in connectto_peers
  File "src\server\address_manager.py", line 639, in select_peer
  File "src\server\address_manager.py", line 451, in select_peer_
  File "random.py", line 190, in randrange
ValueError: empty range for randrange()

Also calculates tried_count dynamically at deserialisation, as opposed to relying on the number stored in the db.