### PR TITLE
Ms.full node bug

### DIFF
--- a/src/full_node/full_node.py
+++ b/src/full_node/full_node.py
@@ -410,7 +410,7 @@ class FullNode:
             if peer is None:
                 await self.server.send_to_all([msg], NodeType.TIMELORD)
             else:
-                await peer.new_peak_timelord(timelord_new_peak)
+                await self.server.send_to_specific([msg], peer.peer_node_id)
 
     async def synced(self) -> bool:
         curr: Optional[BlockRecord] = self.blockchain.get_peak()

--- a/src/full_node/full_node_store.py
+++ b/src/full_node/full_node_store.py
@@ -660,9 +660,10 @@ class FullNodeStore:
         found_connecting_challenge = False
         for sub_slot, sps, total_iters in self.finished_sub_slots[1:]:
             assert sub_slot is not None
-            collected_sub_slots.append(sub_slot)
             if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.challenge == challenge_in_chain:
                 found_connecting_challenge = True
+            if found_connecting_challenge:
+                collected_sub_slots.append(sub_slot)
             if found_connecting_challenge and sub_slot.challenge_chain.get_hash() == last_challenge_to_add:
                 found_last_challenge = True
                 break


### PR DESCRIPTION
* The timelord issue was causing the full node to get stuck in a lock for a minute, in the case of a bad block
* The full node store issue was causing the full node to create bad blocks, in the edge case of a slot with very few blocks. This can lead to a network stall

Tested locally on a chain with 2k blocks, no issues