### PR TITLE
Add missing linux specfile change. Error on pyinstaller failure (#1668)

### DIFF
--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -39,19 +39,28 @@ jobs:
       run: |
         podman run --rm=true \
           -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-          quay.io/pypa/manylinux2014_aarch64 \
+          docker.io/library/ubuntu:18.04 \
           bash -exc '\
             echo $PATH && \
-            yum install -y epel-release && \
-            curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \
-            yum clean all && yum makecache fast && \
-            yum install -y nodejs fakeroot dpkg && \
+            apt update && \
+            apt upgrade -y && \
+            apt -y install software-properties-common build-essential \
+            curl git dialog apt-utils zlib1g-dev && \
+            add-apt-repository ppa:deadsnakes/ppa -y && \
+            curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+            apt -y install nodejs fakeroot \
+            python3.8 python3.8-venv libpython3.8-dev python3.8-distutils && \
             rm -rf venv && \
-            export PATH=/opt/python/cp38-cp38/bin/:$PATH && \
-            /opt/python/cp38-cp38/bin/python -m venv venv && \
-            if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi && \
-            . ./activate && \
-            sh install.sh && \
+            python3 --version && \
+            python3.8 -m venv venv && \
+            source venv/bin/activate && \
+            echo "Should be Python 3.8.x" && \
+            python --version && \
+            echo "Emulating install.sh" && \
+            pip install --upgrade pip && \
+            pip install wheel && \
+            pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.1 && \
+            pip install . --extra-index-url https://pypi.chia.net/simple/ && \
             ldd --version && \
             cd build_scripts && \
             sh build_linux.sh arm64 \

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -35,7 +35,14 @@ mkdir dist
 
 echo "Create executables with pyinstaller"
 pip install pyinstaller==4.2
-pyinstaller --log-level=INFO daemon.spec
+SPEC_FILE=$(python -c 'import src; print(src.PYINSTALLER_SPEC_PATH)')
+pyinstaller --log-level=INFO "$SPEC_FILE"
+LAST_EXIT_CODE=$?
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+	echo >&2 "pyinstaller failed!"
+	exit $LAST_EXIT_CODE
+fi
+
 cp -r dist/daemon ../chia-blockchain-gui
 cd .. || exit
 cd chia-blockchain-gui || exit

--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -25,6 +25,11 @@ echo "Create executables with pyinstaller"
 pip install pyinstaller==4.2
 SPEC_FILE=$(python -c 'import src; print(src.PYINSTALLER_SPEC_PATH)')
 pyinstaller --log-level=INFO "$SPEC_FILE"
+LAST_EXIT_CODE=$?
+if [ "$LAST_EXIT_CODE" -ne 0 ]; then
+	echo >&2 "pyinstaller failed!"
+	exit $LAST_EXIT_CODE
+fi
 cp -r dist/daemon ../chia-blockchain-gui
 cd .. || exit
 cd chia-blockchain-gui || exit


### PR DESCRIPTION
* Add missing linux specfile change. Error on pyinstaller failure

* Build ARM64 in Ubuntu 18.04 LTS

* It's apt upgrade...

* drop sudo

* install add-apt-repository

* missing -y

* Need python3.8-venv python3.8-distutils too

* python3.8 was not happy

* apt install even... Need curl

* git and others are missing

* need sudo to support sh install.sh

* debug venv

* Emulate install.sh instead

* still needs git...

* Need build essentials for pyinstaller

* pyinstaller needs zlib1g-dev

* need libpython3.8-dev

* don't use -e with pip install