### PR TITLE
Factors out loading one plot, and no longer uses shared mutable state…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ In the event an emergency fix is required for the release version of Chia, membe
 1. All changes go into the main branch.
 2. Main is stable at all times, all tests pass.
 3. Features (with tests) are developed and fully tested on feature branches, and reviewed before landing in main.
-4. Chia Network's nodes on the public testnet are running latest version x.y.z
+4. Chia Network's nodes on the public testnet are running latest version x.y.z.
 5. The `main` branch will have a long running `beta testnet` to allow previewing of changes.
 6. Pull Request events may require a `beta testnet` review environment, at the moment this is at the discretion of the reviewer.
 7. Hotfixes land in the release branch they fix, and all later versions. (this will be achieved by regularly merging from 1.0.x -> main).

--- a/chia/plotting/plot_tools.py
+++ b/chia/plotting/plot_tools.py
@@ -183,7 +183,7 @@ def load_one_plot(
         no_key: bool = False  # This gets set when when we don't have the pool or farmer keys on this machine
         prover: DiskProver = DiskProver(str(filename))
 
-        expected_size: int = _expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR
+        expected_size: int = int(_expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR)
         stat_info = filename.stat()
 
         # TODO: consider checking if the file was just written to (which would mean that the file is still being copied)

--- a/chia/plotting/plot_tools.py
+++ b/chia/plotting/plot_tools.py
@@ -282,12 +282,14 @@ def load_plots(
     if match_str is not None:
         log.info(f'Only loading plots that contain "{match_str}" in the file or directory name')
 
+    failed_to_open_filenames_copy = failed_to_open_filenames.copy()
+
     with ThreadPoolExecutor() as executor:
         future_to_filename: Dict[Future, Path] = {
             executor.submit(
                 load_one_plot,
                 filename,
-                failed_to_open_filenames,
+                failed_to_open_filenames_copy,
                 provers,
                 match_str,
                 show_memo,


### PR DESCRIPTION
… between all the threads.

This fixes some flaky tests (harvester and farmer rpc duplicate plots check).

This is passing except for ARM64 which is broken on all branches