### PR TITLE
Last commit for 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## 1.0.4 Chia Blockchain 2021-04-12
+
+### Added
+
+- Starting approximately April 21, 2021, the GUI will notify you that this version will stop working at block height 193,536 and will persistently warn you from that block on that you can not use this version (or any earlier version) to farm. This is to support the upgrade to the transaction fork.
+- We now have translations for Brazilian Portuguese, Australian English, and Pirate. Thanks to @fsavaget, @darkflare, @maahhh, @harold_257, @kontin, and @Gulli. Yarr - don't be losing your 24 word treasure map...
+
+### Changed
+
+- The plotter in bitfield mode is much improved in plotting speed (~15% faster than in 1.0.3), now requires 28% less temporary space (238.3 GiB/256 GB), and now uses its maximum memory in phase 1 and only needs 3389MiB for optimal sorting of a k32. Total writes should also be down by about 20%. On almost all machines we expect bitfield to be as fast or faster. For CPUs that predate the [Nahalem architecture](https://en.wikipedia.org/wiki/Nehalem_(microarchitecture)), bitfield plotting will not work and you will need to use no bitfield. Those CPUs were generally designed before 2010.
+- The `src` directory in chia-blockchian has been changed to `chia` to avoid namespace collisions.
+- GUI install builds have been simplified to rely on one `.spec` file in `chia/`
+- The weight proof timeout can now be configured in config.yaml.
+- Peer discovery is now retried more often after you receive initial peers.
+
+### Fixed
+
+- We have made significant improvements and bug fixes to stop blockchain and wallet database corruption issues.
+- We now pass the environment into the Daemon and this should solve some Windows and MacOS startup bugs.
+- The ARM64 .deb installer will now work well on Raspberry Pi OS 64 bit and Ubuntu 18.04 LTS or newer.
+- We have made improvements in weight proof generation and saving.
+- Wallet start up would have a race condition that output a harmless error on startup.
+- Thanks for a typo fix from @alfonsoperez.
+
+
 ## 1.0.3 Chia Blockchain 2021-03-30
 
 ### Added

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -28,7 +28,6 @@ echo "Installing npm and electron packagers"
 npm install electron-packager -g
 npm install electron-installer-debian -g
 npm install electron-installer-redhat -g
-npm install imagemin-gifsicle
 
 echo "Create dist/"
 rm -rf dist
@@ -53,6 +52,7 @@ echo "\nPLATFORM is $PLATFORM\n"
 if [ $PLATFORM = "arm64" ]; then
   echo "Installing dh-autoreconf to work around gifsicle issue.\n"
   apt-get install -y dh-autoreconf
+  npm install imagemin-gifsicle
 fi
 
 echo "npm build"

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -33,6 +33,13 @@ echo "Create dist/"
 rm -rf dist
 mkdir dist
 
+# See https://github.com/imagemin/gifsicle-bin/issues/113
+echo "\nPLATFORM is $PLATFORM\n"
+if [ $PLATFORM="aarch64" ]; then
+  echo "\nInstalling dh-autoreconf to work around gifsicle issue.\n"
+  apt-get install dh-autoreconf
+fi
+
 echo "Create executables with pyinstaller"
 pip install pyinstaller==4.2
 SPEC_FILE=$(python -c 'import chia; print(chia.PYINSTALLER_SPEC_PATH)')

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -35,9 +35,9 @@ mkdir dist
 
 # See https://github.com/imagemin/gifsicle-bin/issues/113
 echo "\nPLATFORM is $PLATFORM\n"
-if [ $PLATFORM="aarch64" ]; then
-  echo "\nInstalling dh-autoreconf to work around gifsicle issue.\n"
-  apt-get install dh-autoreconf
+if [ $PLATFORM = "arm64" ]; then
+  echo "Installing dh-autoreconf to work around gifsicle issue.\n"
+  apt-get install -y dh-autoreconf
 fi
 
 echo "Create executables with pyinstaller"

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -48,11 +48,14 @@ cd .. || exit
 cd chia-blockchain-gui || exit
 
 # See https://github.com/imagemin/gifsicle-bin/issues/113
-echo "\nPLATFORM is $PLATFORM\n"
-if [ $PLATFORM = "arm64" ]; then
-  echo "Installing dh-autoreconf to work around gifsicle issue.\n"
+echo ""
+echo "PLATFORM is $PLATFORM"
+echo ""
+if [ "$PLATFORM" = "arm64" ]; then
+  echo "Installing dh-autoreconf to work around gifsicle issue."
   apt-get install -y dh-autoreconf
   npm install imagemin-gifsicle
+  npm install imagemin-mozjpeg
 fi
 
 echo "npm build"

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -53,11 +53,14 @@ echo "PLATFORM is $PLATFORM"
 echo ""
 if [ "$PLATFORM" = "arm64" ]; then
   echo "Installing dh-autoreconf to work around gifsicle issue."
-  apt-get install -y dh-autoreconf
-  npm install imagemin-gifsicle
+  apt-get install -y dh-autoreconf cmake autoconf automake libtool nasm pkg-config
+  echo "npm install imagemin-mozjpeg"
   npm install imagemin-mozjpeg
+  echo "npm install imagemin-gifsicle"
+  npm install imagemin-gifsicle
 fi
 
+echo ""
 echo "npm build"
 npm install
 npm audit fix

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -59,6 +59,7 @@ if [ "$PLATFORM" = "arm64" ]; then
   npm install imagemin-mozjpeg
   echo "npm install imagemin-gifsicle"
   npm install imagemin-gifsicle
+  npm rebuild
 fi
 
 echo ""

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -28,17 +28,11 @@ echo "Installing npm and electron packagers"
 npm install electron-packager -g
 npm install electron-installer-debian -g
 npm install electron-installer-redhat -g
+npm install imagemin-gifsicle
 
 echo "Create dist/"
 rm -rf dist
 mkdir dist
-
-# See https://github.com/imagemin/gifsicle-bin/issues/113
-echo "\nPLATFORM is $PLATFORM\n"
-if [ $PLATFORM = "arm64" ]; then
-  echo "Installing dh-autoreconf to work around gifsicle issue.\n"
-  apt-get install -y dh-autoreconf
-fi
 
 echo "Create executables with pyinstaller"
 pip install pyinstaller==4.2
@@ -53,6 +47,13 @@ fi
 cp -r dist/daemon ../chia-blockchain-gui
 cd .. || exit
 cd chia-blockchain-gui || exit
+
+# See https://github.com/imagemin/gifsicle-bin/issues/113
+echo "\nPLATFORM is $PLATFORM\n"
+if [ $PLATFORM = "arm64" ]; then
+  echo "Installing dh-autoreconf to work around gifsicle issue.\n"
+  apt-get install -y dh-autoreconf
+fi
 
 echo "npm build"
 npm install

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -53,8 +53,9 @@ echo "PLATFORM is $PLATFORM"
 echo ""
 if [ "$PLATFORM" = "arm64" ]; then
   echo "Installing dh-autoreconf to work around gifsicle issue."
-  apt-get install -y dh-autoreconf cmake autoconf automake libtool nasm pkg-config libpng-dev
+  apt-get install -y dh-autoreconf cmake autoconf automake libtool nasm pkg-config libpng-dev optipng
   echo "npm install imagemin-mozjpeg"
+  export CPPFLAGS="-DPNG_ARM_NEON_OPT=0"
   npm install imagemin-mozjpeg
   echo "npm install imagemin-gifsicle"
   npm install imagemin-gifsicle

--- a/build_scripts/build_linux.sh
+++ b/build_scripts/build_linux.sh
@@ -53,7 +53,7 @@ echo "PLATFORM is $PLATFORM"
 echo ""
 if [ "$PLATFORM" = "arm64" ]; then
   echo "Installing dh-autoreconf to work around gifsicle issue."
-  apt-get install -y dh-autoreconf cmake autoconf automake libtool nasm pkg-config
+  apt-get install -y dh-autoreconf cmake autoconf automake libtool nasm pkg-config libpng-dev
   echo "npm install imagemin-mozjpeg"
   npm install imagemin-mozjpeg
   echo "npm install imagemin-gifsicle"


### PR DESCRIPTION
## 1.0.4 Chia Blockchain 2021-04-12

### Added

- Starting approximately April 21, 2021, the GUI will notify you that this version will stop working at block height 193,536 and will persistently warn you from that block on that you can not use this version (or any earlier version) to farm. This is to support the upgrade to the transaction fork.
- We now have translations for Brazilian Portuguese, Australian English, and Pirate. Thanks to @fsavaget, @darkflare, @maahhh, @harold_257, @kontin, and @Gulli. Yarr - don't be losing your 24 word treasure map...

### Changed

- The plotter in bitfield mode is much improved in plotting speed (~15% faster than in 1.0.3), now requires 28% less temporary space (238.3 GiB/256 GB), and now uses its maximum memory in phase 1 and only needs 3389MiB for optimal sorting of a k32. Total writes should also be down by about 20%. On almost all machines we expect bitfield to be as fast or faster. For CPUs that predate the [Nahalem architecture](https://en.wikipedia.org/wiki/Nehalem_(microarchitecture)), bitfield plotting will not work and you will need to use no bitfield. Those CPUs were generally designed before 2010.
- The `src` directory in chia-blockchian has been changed to `chia` to avoid namespace collisions.
- GUI install builds have been simplified to rely on one `.spec` file in `chia/`
- The weight proof timeout can now be configured in config.yaml.
- Peer discovery is now retried more often after you receive initial peers.

### Fixed

- We have made significant improvements and bug fixes to stop blockchain and wallet database corruption issues.
- We now pass the environment into the Daemon and this should solve some Windows and MacOS startup bugs.
- The ARM64 .deb installer will now work well on Raspberry Pi OS 64 bit and Ubuntu 18.04 LTS or newer.
- We have made improvements in weight proof generation and saving.
- Wallet start up would have a race condition that output a harmless error on startup.
- Thanks for a typo fix from @alfonsoperez.