### PR TITLE
remove unused MAX_BLOCK_COST constant

### DIFF
--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -43,12 +43,6 @@ class ConsensusConstants:
     MEMPOOL_BLOCK_BUFFER: int
     # Max coin amount uint(1 << 64). This allows coin amounts to fit in 64 bits. This is around 18M chia.
     MAX_COIN_AMOUNT: int
-    # Raw size per block target = 1,000,000 bytes
-    # Rax TX (single in, single out) = 219 bytes (not compressed)
-    # TX = 457 vBytes
-    # floor(1,000,000 / 219) * 457 = 2086662 (size in vBytes)
-    # Max block cost in virtual bytes
-    MAX_BLOCK_COST: int
     # MAX block cost in clvm cost units = MAX_BLOCK_COST * CLVM_COST_RATIO_CONSTANT
     # 1 vByte = 108 clvm cost units
     CLVM_COST_RATIO_CONSTANT: int

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -42,13 +42,6 @@ testnet_kwargs = {
     "MEMPOOL_BLOCK_BUFFER": 10,
     # Max coin amount, fits into 64 bits
     "MAX_COIN_AMOUNT": uint64((1 << 64) - 1),
-    # Targeting twice bitcoin's block size of 1.3MB per block
-    # Raw size per block target = 1,300,000 * 600 / 47 = approx 100 KB
-    # Rax TX (single in, single out) = 219 bytes (not compressed)
-    # TX = 457 vBytes
-    # floor(100 * 1024 / 219) * 457 = 213684 (size in vBytes)
-    # Max block cost in virtual bytes
-    "MAX_BLOCK_COST": 213684,
     # MAX block cost in clvm cost units = MAX_BLOCK_COST * CLVM_COST_RATIO_CONSTANT
     # 1 vByte = 108 clvm cost units
     "CLVM_COST_RATIO_CONSTANT": 108,


### PR DESCRIPTION
leaving MAX_BLOCK_COST_CLVM, which is the one being used. This is in preparation for my upcoming cost patch. This is an independent change.