### PR TITLE
update cost and max cost according to new plan

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -196,7 +196,7 @@ async def validate_block_body(
             if cached_cost_result is not None:
                 result: Optional[CostResult] = cached_cost_result
             else:
-                result = calculate_cost_of_program(block.transactions_generator, constants.CLVM_COST_RATIO_CONSTANT)
+                result = calculate_cost_of_program(block.transactions_generator, constants.COST_PER_BYTE)
             # The call to calculate cost runs the generator program
             if result is None:
                 return Err.INVALID_COST_RESULT, None

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -127,7 +127,7 @@ def create_foliage(
 
         # Calculate the cost of transactions
         if solution_program is not None:
-            result: CostResult = calculate_cost_of_program(solution_program, constants.CLVM_COST_RATIO_CONSTANT)
+            result: CostResult = calculate_cost_of_program(solution_program, constants.COST_PER_BYTE)
             cost = result.cost
             removal_amount = 0
             addition_amount = 0

--- a/chia/consensus/condition_costs.py
+++ b/chia/consensus/condition_costs.py
@@ -3,8 +3,8 @@ from enum import Enum
 
 class ConditionCost(Enum):
     # Condition Costs
-    AGG_SIG = 92  # 1 ms BLS verify = 10,000 clvm cost / 108 cost multiplier
-    CREATE_COIN = 200
+    AGG_SIG = 1200000  # the cost of one G1 subgroup check + aggregated signature validation
+    CREATE_COIN = 1800000
     ASSERT_MY_COIN_ID = 0
     ASSERT_SECONDS_NOW_EXCEEDS = 0
     ASSERT_SECONDS_AGE_EXCEEDS = 0

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -43,10 +43,10 @@ class ConsensusConstants:
     MEMPOOL_BLOCK_BUFFER: int
     # Max coin amount uint(1 << 64). This allows coin amounts to fit in 64 bits. This is around 18M chia.
     MAX_COIN_AMOUNT: int
-    # 1 vByte = 108 clvm cost units
-    CLVM_COST_RATIO_CONSTANT: int
     # Max block cost in clvm cost units
     MAX_BLOCK_COST_CLVM: int
+    # Cost per byte of generator program
+    COST_PER_BYTE: int
 
     WEIGHT_PROOF_THRESHOLD: uint8
     WEIGHT_PROOF_RECENT_BLOCKS: uint32

--- a/chia/consensus/cost_calculator.py
+++ b/chia/consensus/cost_calculator.py
@@ -18,52 +18,47 @@ class CostResult(Streamable):
     cost: uint64
 
 
-def calculate_cost_of_program(
-    program: SerializedProgram, clvm_cost_ratio_constant: int, strict_mode: bool = False
-) -> CostResult:
+def calculate_cost_of_program(program: SerializedProgram, cost_per_byte: int, strict_mode: bool = False) -> CostResult:
     """
     This function calculates the total cost of either a block or a spendbundle
     """
-    total_clvm_cost = 0
+    total_cost = 0
     error, npc_list, cost = get_name_puzzle_conditions(program, strict_mode)
     if error or cost is None or npc_list is None:
         raise Exception("get_name_puzzle_conditions raised error:" + str(error))
-    total_clvm_cost += cost
+    total_cost += cost
 
     # Add cost of conditions
     npc: NPC
-    total_vbyte_cost = 0
     for npc in npc_list:
         for condition, cvp_list in npc.condition_dict.items():
             if condition is ConditionOpcode.AGG_SIG or condition is ConditionOpcode.AGG_SIG_ME:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.AGG_SIG.value
+                total_cost += len(cvp_list) * ConditionCost.AGG_SIG.value
             elif condition is ConditionOpcode.CREATE_COIN:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.CREATE_COIN.value
+                total_cost += len(cvp_list) * ConditionCost.CREATE_COIN.value
             elif condition is ConditionOpcode.ASSERT_SECONDS_NOW_EXCEEDS:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.ASSERT_SECONDS_NOW_EXCEEDS.value
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_SECONDS_NOW_EXCEEDS.value
             elif condition is ConditionOpcode.ASSERT_HEIGHT_AGE_EXCEEDS:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.ASSERT_HEIGHT_AGE_EXCEEDS.value
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_HEIGHT_AGE_EXCEEDS.value
             elif condition is ConditionOpcode.ASSERT_HEIGHT_NOW_EXCEEDS:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.ASSERT_HEIGHT_NOW_EXCEEDS.value
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_HEIGHT_NOW_EXCEEDS.value
             elif condition is ConditionOpcode.ASSERT_MY_COIN_ID:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.ASSERT_MY_COIN_ID.value
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_MY_COIN_ID.value
             elif condition is ConditionOpcode.RESERVE_FEE:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.RESERVE_FEE.value
+                total_cost += len(cvp_list) * ConditionCost.RESERVE_FEE.value
             elif condition is ConditionOpcode.CREATE_COIN_ANNOUNCEMENT:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.CREATE_COIN_ANNOUNCEMENT.value
+                total_cost += len(cvp_list) * ConditionCost.CREATE_COIN_ANNOUNCEMENT.value
             elif condition is ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.ASSERT_COIN_ANNOUNCEMENT.value
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_COIN_ANNOUNCEMENT.value
             elif condition is ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.CREATE_PUZZLE_ANNOUNCEMENT.value
+                total_cost += len(cvp_list) * ConditionCost.CREATE_PUZZLE_ANNOUNCEMENT.value
             elif condition is ConditionOpcode.ASSERT_PUZZLE_ANNOUNCEMENT:
-                total_vbyte_cost += len(cvp_list) * ConditionCost.ASSERT_PUZZLE_ANNOUNCEMENT.value
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_PUZZLE_ANNOUNCEMENT.value
             else:
                 # We ignore unknown conditions in order to allow for future soft forks
                 pass
 
     # Add raw size of the program
-    total_vbyte_cost += len(bytes(program))
+    total_cost += len(bytes(program)) * cost_per_byte
 
-    total_clvm_cost += total_vbyte_cost * clvm_cost_ratio_constant
-
-    return CostResult(None, npc_list, uint64(total_clvm_cost))
+    return CostResult(None, npc_list, uint64(total_cost))

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -42,10 +42,10 @@ testnet_kwargs = {
     "MEMPOOL_BLOCK_BUFFER": 150,
     # Max coin amount, fits into 64 bits
     "MAX_COIN_AMOUNT": uint64((1 << 64) - 1),
-    # 1 vByte = 108 clvm cost units
-    "CLVM_COST_RATIO_CONSTANT": 108,
     # Max block cost in clvm cost units
-    "MAX_BLOCK_COST_CLVM": 40000000,  # Based on arvid analysis
+    "MAX_BLOCK_COST_CLVM": 11000000000,
+    # The cost per byte of generator program
+    "COST_PER_BYTE": 12000,
     "WEIGHT_PROOF_THRESHOLD": 2,
     "BLOCKS_CACHE_SIZE": 4608 + (128 * 4),
     "WEIGHT_PROOF_RECENT_BLOCKS": 1000,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -72,7 +72,7 @@ def batch_pre_validate_blocks(
             else:
                 if not error and generator is not None and validate_transactions:
                     cost_result = calculate_cost_of_program(
-                        SerializedProgram.from_bytes(generator), constants.CLVM_COST_RATIO_CONSTANT
+                        SerializedProgram.from_bytes(generator), constants.COST_PER_BYTE
                     )
             results.append(PreValidationResult(error_int, required_iters, cost_result))
         except Exception:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -46,7 +46,7 @@ def validate_transaction_multiprocess(
     # Calculate the cost and fees
     program = best_solution_program(SpendBundle.from_bytes(spend_bundle_bytes))
     # npc contains names of the coins removed, puzzle_hashes and their spend conditions
-    return bytes(calculate_cost_of_program(program, constants.CLVM_COST_RATIO_CONSTANT, True))
+    return bytes(calculate_cost_of_program(program, constants.COST_PER_BYTE, True))
 
 
 class MempoolManager:

--- a/chia/util/block_tools.py
+++ b/chia/util/block_tools.py
@@ -87,8 +87,8 @@ test_constants = DEFAULT_CONSTANTS.replace(
         "MAX_FUTURE_TIME": 3600
         * 24
         * 10,  # Allows creating blockchains with timestamps up to 10 days in the future, for testing
+        "COST_PER_BYTE": 1337,
         "MEMPOOL_BLOCK_BUFFER": 6,
-        "CLVM_COST_RATIO_CONSTANT": 108,
         "INITIAL_FREEZE_PERIOD": 0,
         "NETWORK_TYPE": 1,
     }

--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -244,7 +244,7 @@ class CCWallet:
             program = best_solution_program(tx.spend_bundle)
             # npc contains names of the coins removed, puzzle_hashes and their spend conditions
             cost_result: CostResult = calculate_cost_of_program(
-                program, self.wallet_state_manager.constants.CLVM_COST_RATIO_CONSTANT, True
+                program, self.wallet_state_manager.constants.COST_PER_BYTE, True
             )
             self.cost_of_single_tx = cost_result.cost
             self.log.info(f"Cost of a single tx for standard wallet: {self.cost_of_single_tx}")

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -77,7 +77,7 @@ class Wallet:
             program = best_solution_program(tx.spend_bundle)
             # npc contains names of the coins removed, puzzle_hashes and their spend conditions
             cost_result: CostResult = calculate_cost_of_program(
-                program, self.wallet_state_manager.constants.CLVM_COST_RATIO_CONSTANT, True
+                program, self.wallet_state_manager.constants.COST_PER_BYTE, True
             )
             self.cost_of_single_tx = cost_result.cost
             self.log.info(f"Cost of a single tx for standard wallet: {self.cost_of_single_tx}")

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ dependencies = [
     "chiavdf==1.0.1",  # timelord and vdf verification
     "chiabip158==1.0",  # bip158-style wallet filters
     "chiapos==1.0.1",  # proof of space
-    "clvm==0.9.5",
-    "clvm_rs==0.1.5",
+    "clvm==0.9.6",
+    "clvm_rs==0.1.6",
     "clvm_tools==0.4.3",
     "aiohttp==3.7.4",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ dev_dependencies = [
     "flake8",
     "mypy",
     "black",
-    "aiotthp_cors",  # For blackd
+    "aiohttp_cors",  # For blackd
     "ipython",  # For asyncio debugging
 ]
 

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -6,6 +6,7 @@ import time
 import pytest
 from clvm_tools import binutils
 
+from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.cost_calculator import CostResult, calculate_cost_of_program
 from chia.full_node.bundle_tools import best_solution_program
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, get_puzzle_and_solution_for_coin
@@ -73,9 +74,7 @@ class TestCostCalculation:
         assert spend_bundle is not None
         program = best_solution_program(spend_bundle)
 
-        ratio = test_constants.CLVM_COST_RATIO_CONSTANT
-
-        result: CostResult = calculate_cost_of_program(program, ratio)
+        result: CostResult = calculate_cost_of_program(program, test_constants.COST_PER_BYTE)
         clvm_cost = result.cost
 
         error, npc_list, cost = get_name_puzzle_conditions(program, False)
@@ -85,7 +84,13 @@ class TestCostCalculation:
         assert error is None
 
         # Create condition + agg_sig_condition + length + cpu_cost
-        assert clvm_cost == 200 * ratio + 92 * ratio + len(bytes(program)) * ratio + cost
+        assert (
+            clvm_cost
+            == ConditionCost.CREATE_COIN.value
+            + ConditionCost.AGG_SIG.value
+            + len(bytes(program)) * test_constants.COST_PER_BYTE
+            + cost
+        )
 
     @pytest.mark.asyncio
     async def test_strict_mode(self):


### PR DESCRIPTION
of even split between (1) generator program size (2) generator program CPU and
memory costs (3) CREATE_COIN conditions for and archetype block with 1000
vanilla transactions, 2 inputs and 2 outputs each.

update costs of conditions to use the same unit (as CLVM). Remove CLVM_COST_RATIO_CONSTANT

Add COST_PER_BYTE constant, defining the cost for each byte of generator program.