### PR TITLE
Smoother netspace

### DIFF
--- a/chia/cmds/netspace.py
+++ b/chia/cmds/netspace.py
@@ -18,12 +18,12 @@ import click
     "--delta-block-height",
     help=(
         "Compare a block X blocks older to estimate total network space. "
-        "Defaults to 1000 blocks (~5.2 hours) and Peak block as the starting block. "
+        "Defaults to 4608 blocks (~1 day) and Peak block as the starting block. "
         "Use --start BLOCK_HEIGHT to specify starting block. "
         "Use 192 blocks to estimate over the last hour."
     ),
     type=str,
-    default="1000",
+    default="4608",
 )
 @click.option(
     "-s",

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -113,7 +113,8 @@ class FullNodeRpcApi:
 
         if peak is not None and peak.height > 1:
             newer_block_hex = peak.header_hash.hex()
-            header_hash = self.service.blockchain.height_to_hash(uint32(max(1, peak.height - 1000)))
+            # Average over the last day
+            header_hash = self.service.blockchain.height_to_hash(uint32(max(1, peak.height - 4608)))
             assert header_hash is not None
             older_block_hex = header_hash.hex()
             space = await self.get_network_space(


### PR DESCRIPTION
Changes from last 1000 blocks to last 4608 blocks. 
This reduces our visibility into short term space movements, but those are most likely just random anyway