### PR TITLE
pass through max cost all the way down to where we execute the CLVM code

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -298,7 +298,7 @@ async def validate_block_body(
                 if curr.transactions_generator is not None:
                     curr_block_generator: Optional[BlockGenerator] = await get_block_generator(curr)
                     assert curr_block_generator is not None
-                    npc_result = get_name_puzzle_conditions(curr_block_generator, False)
+                    npc_result = get_name_puzzle_conditions(curr_block_generator, constants.MAX_BLOCK_COST_CLVM, False)
                     removals_in_curr, additions_in_curr = tx_removals_and_additions(npc_result.npc_list)
                 else:
                     removals_in_curr = []

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -123,7 +123,7 @@ def create_foliage(
         # Calculate the cost of transactions
         if block_generator is not None:
             generator_block_heights_list = block_generator.block_height_list()
-            result: NPCResult = get_name_puzzle_conditions(block_generator, True)
+            result: NPCResult = get_name_puzzle_conditions(block_generator, constants.MAX_BLOCK_COST_CLVM, True)
             cost = calculate_cost_of_program(block_generator.program, result, constants.COST_PER_BYTE)
 
             removal_amount = 0

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -209,7 +209,7 @@ class Blockchain(BlockchainInterface):
                 if block.transactions_generator is not None:
                     block_generator: Optional[BlockGenerator] = await self.get_block_generator(block)
                     assert block_generator is not None
-                    npc_result = get_name_puzzle_conditions(block_generator, False)
+                    npc_result = get_name_puzzle_conditions(block_generator, self.constants.MAX_BLOCK_COST_CLVM, False)
                     removals, additions = block_removals_and_additions(block, npc_result.npc_list)
                 else:
                     removals, additions = [], list(block.get_included_reward_coins())
@@ -367,7 +367,7 @@ class Blockchain(BlockchainInterface):
             if block.transactions_generator is not None:
                 block_generator: Optional[BlockGenerator] = await self.get_block_generator(block)
                 assert block_generator is not None
-                npc_result = get_name_puzzle_conditions(block_generator, False)
+                npc_result = get_name_puzzle_conditions(block_generator, self.constants.MAX_BLOCK_COST_CLVM, False)
                 removals, additions = block_removals_and_additions(block, npc_result.npc_list)
                 return removals, additions
             else:
@@ -507,7 +507,7 @@ class Blockchain(BlockchainInterface):
         if block.transactions_generator is not None:
             block_generator: Optional[BlockGenerator] = await self.get_block_generator(block)
             assert block_generator is not None
-            npc_result = get_name_puzzle_conditions(block_generator, False)
+            npc_result = get_name_puzzle_conditions(block_generator, self.constants.MAX_BLOCK_COST_CLVM, False)
         error_code, cost_result = await validate_block_body(
             self.constants,
             self,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -75,7 +75,7 @@ def batch_pre_validate_blocks(
                     assert prev_generator_bytes is not None
                     block_generator: BlockGenerator = BlockGenerator.from_bytes(prev_generator_bytes)
                     assert block_generator.program == block.transactions_generator
-                    npc_result = get_name_puzzle_conditions(block_generator, True)
+                    npc_result = get_name_puzzle_conditions(block_generator, constants.MAX_BLOCK_COST_CLVM, True)
                     removals, additions = block_removals_and_additions(block, npc_result.npc_list)
 
                 header_block = get_block_header(block, additions, removals)

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1078,7 +1078,9 @@ class FullNodeAPI:
 
         block_generator: Optional[BlockGenerator] = await self.full_node.blockchain.get_block_generator(block)
         assert block_generator is not None
-        error, puzzle, solution = get_puzzle_and_solution_for_coin(block_generator, coin_name)
+        error, puzzle, solution = get_puzzle_and_solution_for_coin(
+            block_generator, coin_name, self.full_node.constants.MAX_BLOCK_COST_CLVM
+        )
 
         if error is not None:
             return reject_msg

--- a/chia/full_node/generator.py
+++ b/chia/full_node/generator.py
@@ -67,15 +67,15 @@ def setup_generator_args(self: BlockGenerator):
     return self.program, args
 
 
-def run_generator(self: BlockGenerator) -> Tuple[int, SerializedProgram]:
+def run_generator(self: BlockGenerator, max_cost: int) -> Tuple[int, SerializedProgram]:
     program, args = setup_generator_args(self)
-    return GENERATOR_MOD.run_safe_with_cost(program, args)
+    return GENERATOR_MOD.run_safe_with_cost(max_cost, program, args)
 
 
-def run_generator_unsafe(self: BlockGenerator) -> Tuple[int, SerializedProgram]:
+def run_generator_unsafe(self: BlockGenerator, max_cost: int) -> Tuple[int, SerializedProgram]:
     """This mode is meant for accepting possibly soft-forked transactions into the mempool"""
     program, args = setup_generator_args(self)
-    return GENERATOR_MOD.run_with_cost(program, args)
+    return GENERATOR_MOD.run_with_cost(max_cost, program, args)
 
 
 def list_to_tree(items):

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -134,13 +134,13 @@ def mempool_assert_my_amount(condition: ConditionWithArgs, unspent: CoinRecord) 
     return None
 
 
-def get_name_puzzle_conditions(generator: BlockGenerator, safe_mode: bool) -> NPCResult:
+def get_name_puzzle_conditions(generator: BlockGenerator, max_cost: int, safe_mode: bool) -> NPCResult:
     try:
         block_program, block_program_args = setup_generator_args(generator)
         if safe_mode:
-            cost, result = GENERATOR_MOD.run_safe_with_cost(block_program, block_program_args)
+            cost, result = GENERATOR_MOD.run_safe_with_cost(max_cost, block_program, block_program_args)
         else:
-            cost, result = GENERATOR_MOD.run_with_cost(block_program, block_program_args)
+            cost, result = GENERATOR_MOD.run_with_cost(max_cost, block_program, block_program_args)
         npc_list: List[NPC] = []
         opcodes: Set[bytes] = set(item.value for item in ConditionOpcode)
 
@@ -172,7 +172,7 @@ def get_name_puzzle_conditions(generator: BlockGenerator, safe_mode: bool) -> NP
         return NPCResult(uint16(Err.GENERATOR_RUNTIME_ERROR.value), [], uint64(0))
 
 
-def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin_name: bytes):
+def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin_name: bytes, max_cost: int):
     try:
         block_program = generator.program
         if not generator.generator_args:
@@ -180,7 +180,9 @@ def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin_name: bytes
         else:
             block_program_args = create_generator_args(generator.generator_refs())
 
-        cost, result = GENERATOR_FOR_SINGLE_COIN_MOD.run_with_cost(block_program, block_program_args, coin_name)
+        cost, result = GENERATOR_FOR_SINGLE_COIN_MOD.run_with_cost(
+            max_cost, block_program, block_program_args, coin_name
+        )
         puzzle = result.first()
         solution = result.rest().first()
         return None, puzzle, solution

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -38,12 +38,10 @@ from chia.util.streamable import recurse_jsonify
 log = logging.getLogger(__name__)
 
 
-def get_npc_multiprocess(
-    spend_bundle_bytes: bytes,
-) -> bytes:
+def get_npc_multiprocess(spend_bundle_bytes: bytes, max_cost: int) -> bytes:
     program = simple_solution_generator(SpendBundle.from_bytes(spend_bundle_bytes))
     # npc contains names of the coins removed, puzzle_hashes and their spend conditions
-    return bytes(get_name_puzzle_conditions(program, True))
+    return bytes(get_name_puzzle_conditions(program, max_cost, True))
 
 
 class MempoolManager:
@@ -199,7 +197,7 @@ class MempoolManager:
         """
         start_time = time.time()
         cached_result_bytes = await asyncio.get_running_loop().run_in_executor(
-            self.pool, get_npc_multiprocess, bytes(new_spend)
+            self.pool, get_npc_multiprocess, bytes(new_spend), self.constants.MAX_BLOCK_COST_CLVM
         )
         end_time = time.time()
         log.info(f"It took {end_time - start_time} to pre validate transaction")

--- a/chia/types/coin_solution.py
+++ b/chia/types/coin_solution.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import List
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.util.chain_utils import additions_for_solution
 from chia.util.streamable import Streamable, streamable
 
@@ -21,4 +21,4 @@ class CoinSolution(Streamable):
     solution: Program
 
     def additions(self) -> List[Coin]:
-        return additions_for_solution(self.coin.name(), self.puzzle_reveal, self.solution)
+        return additions_for_solution(self.coin.name(), self.puzzle_reveal, self.solution, INFINITE_COST)

--- a/chia/util/chain_utils.py
+++ b/chia/util/chain_utils.py
@@ -9,11 +9,11 @@ from chia.util.condition_tools import (
 )
 
 
-def additions_for_solution(coin_name: bytes32, puzzle_reveal: Program, solution: Program) -> List[Coin]:
+def additions_for_solution(coin_name: bytes32, puzzle_reveal: Program, solution: Program, max_cost: int) -> List[Coin]:
     """
     Checks the conditions created by CoinSolution and returns the list of all coins created
     """
-    err, dic, cost = conditions_dict_for_solution(puzzle_reveal, solution)
+    err, dic, cost = conditions_dict_for_solution(puzzle_reveal, solution, max_cost)
     if err or dic is None:
         return []
     return created_outputs_for_conditions_dict(dic, coin_name)

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -169,8 +169,9 @@ def puzzle_announcement_names_for_conditions_dict(
 def conditions_dict_for_solution(
     puzzle_reveal: Program,
     solution: Program,
+    max_cost: int,
 ) -> Tuple[Optional[Err], Optional[Dict[ConditionOpcode, List[ConditionWithArgs]]], uint64]:
-    error, result, cost = conditions_for_solution(puzzle_reveal, solution)
+    error, result, cost = conditions_for_solution(puzzle_reveal, solution, max_cost)
     if error or result is None:
         return error, None, uint64(0)
     return None, conditions_by_opcode(result), cost
@@ -179,10 +180,11 @@ def conditions_dict_for_solution(
 def conditions_for_solution(
     puzzle_reveal: Program,
     solution: Program,
+    max_cost: int,
 ) -> Tuple[Optional[Err], Optional[List[ConditionWithArgs]], uint64]:
     # get the standard script for a puzzle hash and feed in the solution
     try:
-        cost, r = puzzle_reveal.run_with_cost(solution)
+        cost, r = puzzle_reveal.run_with_cost(max_cost, solution)
         error, result = parse_sexp_to_conditions(r)
         return error, result, uint64(cost)
     except Program.EvalError:

--- a/chia/util/generator_tools.py
+++ b/chia/util/generator_tools.py
@@ -88,7 +88,9 @@ def block_removals_and_additions(block: FullBlock, npc_list: List[NPC]) -> Tuple
     return removals, additions
 
 
-def run_and_get_removals_and_additions(block: FullBlock, safe_mode=False) -> Tuple[List[bytes32], List[Coin]]:
+def run_and_get_removals_and_additions(
+    block: FullBlock, max_cost: int, safe_mode=False
+) -> Tuple[List[bytes32], List[Coin]]:
     removals: List[bytes32] = []
     additions: List[Coin] = []
 
@@ -97,7 +99,7 @@ def run_and_get_removals_and_additions(block: FullBlock, safe_mode=False) -> Tup
         return [], []
 
     if block.transactions_generator is not None:
-        npc_result = get_name_puzzle_conditions(BlockGenerator(block.transactions_generator, []), safe_mode)
+        npc_result = get_name_puzzle_conditions(BlockGenerator(block.transactions_generator, []), max_cost, safe_mode)
         # build removals list
         for npc in npc_result.npc_list:
             removals.append(npc.coin_name)

--- a/chia/util/wallet_tools.py
+++ b/chia/util/wallet_tools.py
@@ -174,7 +174,9 @@ class WalletTool:
         for coin_solution in coin_solutions:  # type: ignore # noqa
             secret_key = self.get_private_key_for_puzzle_hash(coin_solution.coin.puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(secret_key, DEFAULT_HIDDEN_PUZZLE_HASH)
-            err, con, cost = conditions_for_solution(coin_solution.puzzle_reveal, coin_solution.solution)
+            err, con, cost = conditions_for_solution(
+                coin_solution.puzzle_reveal, coin_solution.solution, self.constants.MAX_BLOCK_COST_CLVM
+            )
             if not con:
                 raise ValueError(err)
             conditions_dict = conditions_by_opcode(con)

--- a/chia/wallet/cc_wallet/cc_utils.py
+++ b/chia/wallet/cc_wallet/cc_utils.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple
 from blspy import AugSchemeMPL, G2Element
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import CoinSolution, SpendBundle
@@ -120,7 +120,9 @@ def spend_bundle_for_spendable_ccs(
     # figure out what the output amounts are by running the inner puzzles & solutions
     output_amounts = []
     for cc_spend_info, inner_solution in zip(spendable_cc_list, inner_solutions):
-        error, conditions, cost = conditions_dict_for_solution(cc_spend_info.inner_puzzle, inner_solution)
+        error, conditions, cost = conditions_dict_for_solution(
+            cc_spend_info.inner_puzzle, inner_solution, INFINITE_COST
+        )
         total = 0
         if conditions:
             for _ in conditions.get(ConditionOpcode.CREATE_COIN, []):

--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -245,7 +245,9 @@ class CCWallet:
             )
             program: BlockGenerator = simple_solution_generator(tx.spend_bundle)
             # npc contains names of the coins removed, puzzle_hashes and their spend conditions
-            result: NPCResult = get_name_puzzle_conditions(program, True)
+            result: NPCResult = get_name_puzzle_conditions(
+                program, self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM, True
+            )
             cost_result: uint64 = calculate_cost_of_program(
                 program.program, result, self.wallet_state_manager.constants.COST_PER_BYTE
             )
@@ -538,7 +540,9 @@ class CCWallet:
         pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
         synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
         sigs: List[G2Element] = []
-        error, conditions, cost = conditions_dict_for_solution(innerpuz, innersol)
+        error, conditions, cost = conditions_dict_for_solution(
+            innerpuz, innersol, self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM
+        )
         if conditions is not None:
             for _, msg in pkm_pairs_for_conditions_dict(
                 conditions, coin_name, self.wallet_state_manager.constants.AGG_SIG_ME_ADDITIONAL_DATA

--- a/chia/wallet/cc_wallet/debug_spend_bundle.py
+++ b/chia/wallet/cc_wallet/debug_spend_bundle.py
@@ -5,7 +5,7 @@ from clvm import KEYWORD_FROM_ATOM
 from clvm_tools.binutils import disassemble as bu_disassemble
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
@@ -64,7 +64,7 @@ def debug_spend_bundle(spend_bundle: SpendBundle) -> None:
         print(f"  with id {coin_name}")
         print()
         print(f"\nbrun -y main.sym '{bu_disassemble(puzzle_reveal)}' '{bu_disassemble(solution)}'")
-        error, conditions, cost = conditions_dict_for_solution(puzzle_reveal, solution)
+        error, conditions, cost = conditions_dict_for_solution(puzzle_reveal, solution, INFINITE_COST)
         if error:
             print(f"*** error {error}")
         elif conditions is not None:

--- a/chia/wallet/sign_coin_solutions.py
+++ b/chia/wallet/sign_coin_solutions.py
@@ -12,13 +12,16 @@ async def sign_coin_solutions(
     coin_solutions: List[CoinSolution],
     secret_key_for_public_key_f: Callable[[blspy.G1Element], Optional[PrivateKey]],
     additional_data: bytes,
+    max_cost: int,
 ) -> SpendBundle:
     signatures: List[blspy.G2Element] = []
     pk_list: List[blspy.G1Element] = []
     msg_list: List[bytes] = []
     for coin_solution in coin_solutions:
         # Get AGG_SIG conditions
-        err, conditions_dict, cost = conditions_dict_for_solution(coin_solution.puzzle_reveal, coin_solution.solution)
+        err, conditions_dict, cost = conditions_dict_for_solution(
+            coin_solution.puzzle_reveal, coin_solution.solution, max_cost
+        )
         if err or conditions_dict is None:
             error_msg = f"Sign transaction failed, con:{conditions_dict}, error: {err}"
             raise ValueError(error_msg)

--- a/chia/wallet/util/trade_utils.py
+++ b/chia/wallet/util/trade_utils.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional, Tuple
 
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution
@@ -50,7 +50,7 @@ def get_output_discrepancy_for_puzzle_and_solution(coin, puzzle, solution):
 
 
 def get_output_amount_for_puzzle_and_solution(puzzle: Program, solution: Program) -> int:
-    error, conditions, cost = conditions_dict_for_solution(puzzle, solution)
+    error, conditions, cost = conditions_dict_for_solution(puzzle, solution, INFINITE_COST)
     total = 0
     if conditions:
         for _ in conditions.get(ConditionOpcode.CREATE_COIN, []):

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -78,7 +78,9 @@ class Wallet:
             )
             program: BlockGenerator = simple_solution_generator(tx.spend_bundle)
             # npc contains names of the coins removed, puzzle_hashes and their spend conditions
-            result: NPCResult = get_name_puzzle_conditions(program, True)
+            result: NPCResult = get_name_puzzle_conditions(
+                program, self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM, True
+            )
             cost_result: uint64 = calculate_cost_of_program(
                 program.program, result, self.wallet_state_manager.constants.COST_PER_BYTE
             )
@@ -345,6 +347,7 @@ class Wallet:
             coin_solutions,
             self.secret_key_store.secret_key_for_public_key,
             self.wallet_state_manager.constants.AGG_SIG_ME_ADDITIONAL_DATA,
+            self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM,
         )
 
     async def generate_signed_transaction(
@@ -374,6 +377,7 @@ class Wallet:
             transaction,
             self.secret_key_store.secret_key_for_public_key,
             self.wallet_state_manager.constants.AGG_SIG_ME_ADDITIONAL_DATA,
+            self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM,
         )
 
         now = uint64(int(time.time()))
@@ -437,5 +441,6 @@ class Wallet:
             list_of_solutions,
             self.secret_key_store.secret_key_for_public_key,
             self.wallet_state_manager.constants.AGG_SIG_ME_ADDITIONAL_DATA,
+            self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM,
         )
         return spend_bundle

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -326,7 +326,7 @@ class TestBlockchainTransactions:
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
 
         coin_2 = None
-        for coin in run_and_get_removals_and_additions(new_blocks[-1])[1]:
+        for coin in run_and_get_removals_and_additions(new_blocks[-1], test_constants.MAX_BLOCK_COST_CLVM)[1]:
             if coin.puzzle_hash == receiver_1_puzzlehash:
                 coin_2 = coin
                 break
@@ -345,7 +345,7 @@ class TestBlockchainTransactions:
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
 
         coin_3 = None
-        for coin in run_and_get_removals_and_additions(new_blocks[-1])[1]:
+        for coin in run_and_get_removals_and_additions(new_blocks[-1], test_constants.MAX_BLOCK_COST_CLVM)[1]:
             if coin.puzzle_hash == receiver_2_puzzlehash:
                 coin_3 = coin
                 break

--- a/tests/clvm/coin_store.py
+++ b/tests/clvm/coin_store.py
@@ -40,6 +40,7 @@ class CoinStore:
         self,
         spend_bundle: SpendBundle,
         now: CoinTimestamp,
+        max_cost: int,
     ) -> int:
         # this should use blockchain consensus code
 
@@ -49,7 +50,7 @@ class CoinStore:
         conditions_dicts = []
         for coin_solution in spend_bundle.coin_solutions:
             err, conditions_dict, cost = conditions_dict_for_solution(
-                coin_solution.puzzle_reveal, coin_solution.solution
+                coin_solution.puzzle_reveal, coin_solution.solution, max_cost
             )
             if conditions_dict is None:
                 raise BadSpendBundleError(f"clvm validation failure {err}")
@@ -78,8 +79,8 @@ class CoinStore:
 
         return 0
 
-    def update_coin_store_for_spend_bundle(self, spend_bundle: SpendBundle, now: CoinTimestamp):
-        err = self.validate_spend_bundle(spend_bundle, now)
+    def update_coin_store_for_spend_bundle(self, spend_bundle: SpendBundle, now: CoinTimestamp, max_cost: int):
+        err = self.validate_spend_bundle(spend_bundle, now, max_cost)
         if err != 0:
             raise BadSpendBundleError(f"validation failure {err}")
         for spent_coin in spend_bundle.removals():

--- a/tests/clvm/test_chialisp_deserialization.py
+++ b/tests/clvm/test_chialisp_deserialization.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.util.byte_types import hexstr_to_bytes
 from chia.wallet.puzzles.load_clvm import load_clvm
 
@@ -58,7 +58,7 @@ class TestClvmNativeDeserialization(TestCase):
     def test_deserialization_simple_list(self):
         # ("hello" "friend")
         b = hexstr_to_bytes("ff8568656c6c6fff86667269656e6480")
-        cost, output = DESERIALIZE_MOD.run_with_cost([b])
+        cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
         print(cost, output)
         prog = Program.to(output)
         assert prog == Program.from_bytes(b)
@@ -68,7 +68,7 @@ class TestClvmNativeDeserialization(TestCase):
         b = hexstr_to_bytes(
             "ff04ffff0affff0bff0280ffff01ffa02cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b98248080ffff05ffff01ff3380ffff05ff05ffff05ffff01ff6480ffff01ff8080808080ffff01ff8e77726f6e672070617373776f72648080"  # noqa
         )  # noqa
-        cost, output = DESERIALIZE_MOD.run_with_cost([b])
+        cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
         print(cost, output)
         prog = Program.to(output)
         assert prog == Program.from_bytes(b)
@@ -78,7 +78,7 @@ class TestClvmNativeDeserialization(TestCase):
         b = hexstr_to_bytes(
             "ff9c00f316271c7fc3908a8bef464e3945ef7a253609ffffffffffffffffffb00fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa1ff22ea0179500526edb610f148ec0c614155678491902d6000000000000000000180"  # noqa
         )  # noqa
-        cost, output = DESERIALIZE_MOD.run_with_cost([b])
+        cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
         print(cost, output)
         prog = Program.to(output)
         assert prog == Program.from_bytes(b)
@@ -86,28 +86,28 @@ class TestClvmNativeDeserialization(TestCase):
     def test_overflow_atoms(self):
         b = hexstr_to_bytes(serialized_atom_overflow(0xFFFFFFFF))
         try:
-            cost, output = DESERIALIZE_MOD.run_with_cost([b])
+            cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
         except Exception:
             assert True
         else:
             assert False
         b = hexstr_to_bytes(serialized_atom_overflow(0x3FFFFFFFF))
         try:
-            cost, output = DESERIALIZE_MOD.run_with_cost([b])
+            cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
         except Exception:
             assert True
         else:
             assert False
         b = hexstr_to_bytes(serialized_atom_overflow(0xFFFFFFFFFF))
         try:
-            cost, output = DESERIALIZE_MOD.run_with_cost([b])
+            cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
         except Exception:
             assert True
         else:
             assert False
         b = hexstr_to_bytes(serialized_atom_overflow(0x1FFFFFFFFFF))
         try:
-            cost, output = DESERIALIZE_MOD.run_with_cost([b])
+            cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
         except Exception:
             assert True
         else:

--- a/tests/clvm/test_puzzles.py
+++ b/tests/clvm/test_puzzles.py
@@ -18,6 +18,7 @@ from chia.wallet.puzzles import (
     p2_puzzle_hash,
 )
 from tests.util.key_tool import KeyTool
+from chia.util.block_tools import test_constants
 
 from ..core.make_block_generator import int_to_public_key
 from .coin_store import CoinStore, CoinTimestamp
@@ -70,7 +71,7 @@ def do_test_spend(
     coin_solution = CoinSolution(coin, puzzle_reveal, solution)
 
     spend_bundle = SpendBundle([coin_solution], G2Element())
-    coin_db.update_coin_store_for_spend_bundle(spend_bundle, spend_time)
+    coin_db.update_coin_store_for_spend_bundle(spend_bundle, spend_time, test_constants.MAX_BLOCK_COST_CLVM)
 
     # ensure all outputs are there
     for puzzle_hash, amount in payments:

--- a/tests/clvm/test_serialized_program.py
+++ b/tests/clvm/test_serialized_program.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program, SerializedProgram, INFINITE_COST
 from chia.wallet.puzzles.load_clvm import load_clvm
 
 SHA256TREE_MOD = load_clvm("sha256tree_module.clvm")
@@ -16,7 +16,7 @@ class TestSerializedProgram(TestCase):
     def test_program_execution(self):
         p_result = SHA256TREE_MOD.run(SHA256TREE_MOD)
         sp = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
-        cost, sp_result = sp.run_with_cost(sp)
+        cost, sp_result = sp.run_with_cost(INFINITE_COST, sp)
         self.assertEqual(p_result, sp_result)
 
     def test_serialization(self):

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -95,7 +95,7 @@ class TestCoinStore:
             should_be_included.add(farmer_coin)
             should_be_included.add(pool_coin)
             if block.is_transaction_block():
-                removals, additions = run_and_get_removals_and_additions(block)
+                removals, additions = run_and_get_removals_and_additions(block, constants.MAX_BLOCK_COST_CLVM)
 
                 assert block.get_included_reward_coins() == should_be_included_prev
 
@@ -137,7 +137,7 @@ class TestCoinStore:
         # Save/get block
         for block in blocks:
             if block.is_transaction_block():
-                removals, additions = run_and_get_removals_and_additions(block)
+                removals, additions = run_and_get_removals_and_additions(block, constants.MAX_BLOCK_COST_CLVM)
                 await coin_store.new_block(block, additions, removals)
                 coins = block.get_included_reward_coins()
                 records = [await coin_store.get_coin_record(coin.name()) for coin in coins]
@@ -166,7 +166,7 @@ class TestCoinStore:
 
         for block in blocks:
             if block.is_transaction_block():
-                removals, additions = run_and_get_removals_and_additions(block)
+                removals, additions = run_and_get_removals_and_additions(block, constants.MAX_BLOCK_COST_CLVM)
                 await coin_store.new_block(block, additions, removals)
                 coins = block.get_included_reward_coins()
                 records: List[Optional[CoinRecord]] = [await coin_store.get_coin_record(coin.name()) for coin in coins]

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -21,7 +21,7 @@ from tests.connection_utils import connect_and_get_peer
 from tests.core.node_height import node_height_at_least
 from tests.setup_nodes import bt, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 
 BURN_PUZZLE_HASH = b"0" * 32
 BURN_PUZZLE_HASH_2 = b"1" * 32
@@ -985,7 +985,7 @@ class TestMempoolManager:
         assert len(unsigned) == 1
         coin_solution: CoinSolution = unsigned[0]
 
-        err, con, cost = conditions_for_solution(coin_solution.puzzle_reveal, coin_solution.solution)
+        err, con, cost = conditions_for_solution(coin_solution.puzzle_reveal, coin_solution.solution, INFINITE_COST)
         assert con is not None
 
         # TODO(straya): fix this test

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -75,14 +75,15 @@ class TestCostCalculation:
         assert spend_bundle is not None
         program: BlockGenerator = simple_solution_generator(spend_bundle)
 
-        ratio = test_constants.COST_PER_BYTE
-        npc_result: NPCResult = get_name_puzzle_conditions(program, False)
+        npc_result: NPCResult = get_name_puzzle_conditions(program, test_constants.MAX_BLOCK_COST_CLVM, False)
 
-        cost = calculate_cost_of_program(program.program, npc_result, ratio)
+        cost = calculate_cost_of_program(program.program, npc_result, test_constants.COST_PER_BYTE)
 
         assert npc_result.error is None
         coin_name = npc_result.npc_list[0].coin_name
-        error, puzzle, solution = get_puzzle_and_solution_for_coin(program, coin_name)
+        error, puzzle, solution = get_puzzle_and_solution_for_coin(
+            program, coin_name, test_constants.MAX_BLOCK_COST_CLVM
+        )
         assert error is None
 
         # Create condition + agg_sig_condition + length + cpu_cost
@@ -129,13 +130,15 @@ class TestCostCalculation:
             ).as_bin()
         )
         generator = BlockGenerator(program, [])
-        npc_result: NPCResult = get_name_puzzle_conditions(generator, True)
+        npc_result: NPCResult = get_name_puzzle_conditions(generator, test_constants.MAX_BLOCK_COST_CLVM, True)
         assert npc_result.error is not None
-        npc_result: NPCResult = get_name_puzzle_conditions(generator, False)
+        npc_result: NPCResult = get_name_puzzle_conditions(generator, test_constants.MAX_BLOCK_COST_CLVM, False)
         assert npc_result.error is None
 
         coin_name = npc_result.npc_list[0].coin_name
-        error, puzzle, solution = get_puzzle_and_solution_for_coin(generator, coin_name)
+        error, puzzle, solution = get_puzzle_and_solution_for_coin(
+            generator, coin_name, test_constants.MAX_BLOCK_COST_CLVM
+        )
         assert error is None
 
     @pytest.mark.asyncio
@@ -148,9 +151,9 @@ class TestCostCalculation:
         # mode, the unknown operator should be treated as if it returns ().
         program = SerializedProgram.from_bytes(binutils.assemble(f"(i (0xfe (q . 0)) (q . ()) {disassembly})").as_bin())
         generator = BlockGenerator(program, [])
-        npc_result: NPCResult = get_name_puzzle_conditions(generator, True)
+        npc_result: NPCResult = get_name_puzzle_conditions(generator, test_constants.MAX_BLOCK_COST_CLVM, True)
         assert npc_result.error is not None
-        npc_result: NPCResult = get_name_puzzle_conditions(generator, False)
+        npc_result: NPCResult = get_name_puzzle_conditions(generator, test_constants.MAX_BLOCK_COST_CLVM, False)
         assert npc_result.error is None
 
     @pytest.mark.asyncio
@@ -161,14 +164,42 @@ class TestCostCalculation:
 
         start_time = time.time()
         generator = BlockGenerator(program, [])
-        npc_result = get_name_puzzle_conditions(generator, False)
+        npc_result = get_name_puzzle_conditions(generator, test_constants.MAX_BLOCK_COST_CLVM, False)
         end_time = time.time()
         duration = end_time - start_time
         assert npc_result.error is None
         assert len(npc_result.npc_list) == LARGE_BLOCK_COIN_CONSUMED_COUNT
         log.info(f"Time spent: {duration}")
 
-        assert duration < 3
+        assert duration < 1
+
+    @pytest.mark.asyncio
+    async def test_clvm_max_cost(self):
+
+        block = Program.from_bytes(bytes(SMALL_BLOCK_GENERATOR.program))
+        disassembly = binutils.disassemble(block)
+        # this is a valid generator program except the first clvm
+        # if-condition, that depends on executing an unknown operator
+        # ("0xfe"). In strict mode, this should fail, but in non-strict
+        # mode, the unknown operator should be treated as if it returns ().
+        # the CLVM program has a cost of 391969
+        program = SerializedProgram.from_bytes(
+            binutils.assemble(f"(i (softfork (q . 10000000)) (q . ()) {disassembly})").as_bin()
+        )
+
+        # ensure we fail if the program exceeds the cost
+        generator = BlockGenerator(program, [])
+        npc_result: NPCResult = get_name_puzzle_conditions(generator, 10000000, False)
+
+        assert npc_result.error is not None
+        assert npc_result.clvm_cost == 0
+
+        # raise the max cost to make sure this passes
+        # ensure we pass if the program does not exceeds the cost
+        npc_result: NPCResult = get_name_puzzle_conditions(generator, 20000000, False)
+
+        assert npc_result.error is None
+        assert npc_result.clvm_cost > 10000000
 
     @pytest.mark.asyncio
     async def test_standard_tx(self):
@@ -188,7 +219,7 @@ class TestCostCalculation:
         time_start = time.time()
         total_cost = 0
         for i in range(0, 1000):
-            cost, result = puzzle_program.run_with_cost(solution_program)
+            cost, result = puzzle_program.run_with_cost(test_constants.MAX_BLOCK_COST_CLVM, solution_program)
             total_cost += cost
 
         time_end = time.time()

--- a/tests/generator/test_generator_types.py
+++ b/tests/generator/test_generator_types.py
@@ -1,7 +1,7 @@
 from typing import Dict
 from unittest import TestCase
 
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program, SerializedProgram, INFINITE_COST
 from chia.types.generator_types import GeneratorBlockCacheInterface
 from chia.full_node.generator import create_block_generator, create_generator_args, list_to_tree
 from chia.util.ints import uint32
@@ -49,7 +49,7 @@ class TestGeneratorTypes(TestCase):
         # First argument: clvm deserializer
 
         b = bytes.fromhex("ff8568656c6c6fff86667269656e6480")  # ("hello" "friend")
-        cost, output = d.run_with_cost([b])
+        cost, output = d.run_with_cost(INFINITE_COST, [b])
         # print(cost, output)
         out = Program.to(output)
         assert out == Program.from_bytes(b)

--- a/tests/util/benchmark_cost.py
+++ b/tests/util/benchmark_cost.py
@@ -5,7 +5,7 @@ from blspy import AugSchemeMPL, PrivateKey
 from clvm_tools import binutils
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.util.ints import uint32
@@ -40,7 +40,7 @@ def run_and_return_cost_time(chialisp):
     clvm_loop_solution = f"(1000 {chialisp})"
     solution_program = Program.to(binutils.assemble(clvm_loop_solution))
 
-    cost, sexp = loop_program.run_with_cost(solution_program)
+    cost, sexp = loop_program.run_with_cost(solution_program, INFINITE_COST)
 
     end = time.time()
     total_time = end - start
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     puzzle_start = time.time()
     clvm_cost = 0
     for i in range(0, 1000):
-        cost_run, sexp = puzzles[i].run_with_cost(solutions[i])
+        cost_run, sexp = puzzles[i].run_with_cost(solutions[i], INFINITE_COST)
         clvm_cost += cost_run
 
     puzzle_end = time.time()

--- a/tests/util/key_tool.py
+++ b/tests/util/key_tool.py
@@ -6,6 +6,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_solution import CoinSolution
 from chia.util.condition_tools import conditions_by_opcode, conditions_for_solution, pkm_pairs_for_conditions_dict
 from tests.core.make_block_generator import GROUP_ORDER, int_to_public_key
+from chia.util.block_tools import test_constants
 
 
 class KeyTool(dict):
@@ -26,7 +27,9 @@ class KeyTool(dict):
 
     def signature_for_solution(self, coin_solution: CoinSolution, additional_data: bytes) -> AugSchemeMPL:
         signatures = []
-        err, conditions, cost = conditions_for_solution(coin_solution.puzzle_reveal, coin_solution.solution)
+        err, conditions, cost = conditions_for_solution(
+            coin_solution.puzzle_reveal, coin_solution.solution, test_constants.MAX_BLOCK_COST_CLVM
+        )
         assert conditions is not None
         conditions_dict = conditions_by_opcode(conditions)
         for public_key, message_hash in pkm_pairs_for_conditions_dict(

--- a/tests/wallet/test_singleton.py
+++ b/tests/wallet/test_singleton.py
@@ -1,5 +1,5 @@
 from chia.wallet.puzzles.load_clvm import load_clvm
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, INFINITE_COST
 
 DID_CORE_MOD = load_clvm("singleton_top_layer.clvm")
 
@@ -10,7 +10,7 @@ def test_only_odd_coins():
         [did_core_hash, did_core_hash, 1, [0xDEADBEEF, 0xCAFEF00D, 200], 200, [[51, 0xCAFEF00D, 200]]]
     )
     try:
-        result, cost = DID_CORE_MOD.run_with_cost(solution)
+        result, cost = DID_CORE_MOD.run_with_cost(INFINITE_COST, solution)
     except Exception as e:
         assert e.args == ("clvm raise",)
     else:
@@ -19,7 +19,7 @@ def test_only_odd_coins():
         [did_core_hash, did_core_hash, 1, [0xDEADBEEF, 0xCAFEF00D, 210], 205, [[51, 0xCAFEF00D, 205]]]
     )
     try:
-        result, cost = DID_CORE_MOD.run_with_cost(solution)
+        result, cost = DID_CORE_MOD.run_with_cost(INFINITE_COST, solution)
     except Exception:
         assert False
 
@@ -37,7 +37,7 @@ def test_only_one_odd_coin_created():
         ]
     )
     try:
-        result, cost = DID_CORE_MOD.run_with_cost(solution)
+        result, cost = DID_CORE_MOD.run_with_cost(INFINITE_COST, solution)
     except Exception as e:
         assert e.args == ("clvm raise",)
     else:
@@ -53,6 +53,6 @@ def test_only_one_odd_coin_created():
         ]
     )
     try:
-        result, cost = DID_CORE_MOD.run_with_cost(solution)
+        result, cost = DID_CORE_MOD.run_with_cost(INFINITE_COST, solution)
     except Exception:
         assert False


### PR DESCRIPTION
@richardkiss @Yostra I'm especially interested in if all the places where we *don't* enforce an upper limit on CLVM cost are safe.

If we need to enforce cost in those places, a `max_cost` parameter needs to be passed through a lot more paths.