### PR TITLE
fix get_block_records_in_range

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -611,7 +611,10 @@ class Blockchain(BlockchainInterface):
         self.clean_block_record(peak.height - self.constants.BLOCKS_CACHE_SIZE)
 
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
-        return await self.block_store.get_block_records_in_range(start, stop)
+        hashes = []
+        for height in range(start, stop + 1):
+            hashes.append(self.height_to_hash(height))
+        return await self.block_store.get_block_records_by_hash(hashes)
 
     async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
         hashes = []

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -613,7 +613,7 @@ class Blockchain(BlockchainInterface):
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         hashes = []
         for height in range(start, stop + 1):
-            hashes.append(self.height_to_hash(height))
+            hashes.append(self.height_to_hash(uint32(height)))
         return await self.block_store.get_block_records_by_hash(hashes)
 
     async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -611,8 +611,12 @@ class FullNode:
             if self.blockchain.get_peak() is not None and heaviest_peak_weight <= self.blockchain.get_peak().weight:
                 raise ValueError("Not performing sync, already caught up.")
 
+            wp_timeout = 180
+            if "weight_proof_timeout" in self.config:
+                wp_timeout = self.config["weight_proof_timeout"]
+            self.log.debug(f"weight proof timeout is {wp_timeout} sec")
             request = full_node_protocol.RequestProofOfWeight(heaviest_peak_height, heaviest_peak_hash)
-            response = await weight_proof_peer.request_proof_of_weight(request, timeout=180)
+            response = await weight_proof_peer.request_proof_of_weight(request, timeout=wp_timeout)
 
             # Disconnect from this peer, because they have not behaved properly
             if response is None or not isinstance(response, full_node_protocol.RespondProofOfWeight):

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -258,6 +258,8 @@ full_node:
   # Setting this flag as True, blueboxes will sanitize only data needed in weight proof calculation, as opposed to whole blocks.
   # Default is set to False, as the network needs only one or two blueboxes like this.
   sanitize_weight_proof_only: False
+  # timeout for weight proof request
+  weight_proof_timeout: 180
 
   farmer_peer:
       host: *self_hostname


### PR DESCRIPTION
make get_block_records_in_range to fetch by header_hash and not height
wp timeout config cherry picked from 1.0.x