### PR TITLE
Ms.double blocks fix 2

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -302,8 +302,10 @@ async def validate_block_body(
                 if curr.transactions_generator is not None:
                     curr_block_generator: Optional[BlockGenerator] = await get_block_generator(curr)
                     assert curr_block_generator is not None
-                    npc_result = get_name_puzzle_conditions(curr_block_generator, constants.MAX_BLOCK_COST_CLVM, False)
-                    removals_in_curr, additions_in_curr = tx_removals_and_additions(npc_result.npc_list)
+                    curr_npc_result = get_name_puzzle_conditions(
+                        curr_block_generator, constants.MAX_BLOCK_COST_CLVM, False
+                    )
+                    removals_in_curr, additions_in_curr = tx_removals_and_additions(curr_npc_result.npc_list)
                 else:
                     removals_in_curr = []
                     additions_in_curr = []

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1064,7 +1064,8 @@ class FullNode:
                 assert new_block.transactions_generator is not None
 
                 self.log.debug(
-                    f"Going recursively into respond block due to wrong info in the cache, {new_block.header_hash}"
+                    f"Wrong info in the cache for bh {new_block.header_hash}, there might be multiple blocks from the "
+                    f"same farmer with the same pospace."
                 )
                 # This recursion ends here, we cannot recurse again because transactions_generator is not None
                 return await self.respond_block(block_response, peer)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1026,7 +1026,12 @@ class FullNode:
             return None
 
         pre_validation_result: Optional[PreValidationResult] = None
-        if block.is_transaction_block() and block.transactions_generator is None:
+        if (
+            block.is_transaction_block()
+            and block.transactions_info is not None
+            and block.transactions_info.generator_root != bytes([0] * 32)
+            and block.transactions_generator is None
+        ):
             # This is the case where we already had the unfinished block, and asked for this block without
             # the transactions (since we already had them). Therefore, here we add the transactions.
             unfinished_rh: bytes32 = block.reward_chain_block.get_unfinished().get_hash()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 ; logging options
 log_cli = 1
-log_level = DEBUG
+log_level = WARNING
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 ; logging options
 log_cli = 1
-log_level = WARNING
+log_level = DEBUG
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s


### PR DESCRIPTION
When a farmer creates two blocks with the same proof of space, this can lead to an issue where we cache the unfinished block for  one version, and then try to validate a finished block with the wrong cached transactions. 

This PR change checks which version we have cached, and then fetches the whole block again if it's different