### PR TITLE
1.1.x release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
-## Unreleased
+## 1.1.0 Chia Blockchain 2021-04-21
 
 ### Added
 
-### Fixed
+- This fork release includes full transaction support for the Chia Blockchain. Transactions are still disabled until 5/3/2021 at 10:00AM PDT. It is hard understate how much work and clean up went into this release.
+- This is the 1.0 release of Chialisp. Much has been massaged and finalized. We will be putting a focus on updating and expanding the documentation on [chialisp.com](https://chialisp.com) shortly.
+- Farmers now compress blocks using code snippets from previous blocks. This saves storage space and allows larger smart coins to have a library of sorts on chain.
+- You can now ask for an offset wallet receive address in the cli. Thanks @jespino.
+- When adding plots we attempt to detect a duplicate and not load it.
 
 ### Changed
 
+- We have changed how transactions will unlock from a blockheight to a timestamp. As noted above that timestamp is 5/3/2021 at 10AM PDT.
+- We have temporarily disabled the "Delete Plots" button in the Windows GUI as we are still working on debugging upstream issues that are causing it.
+- There are various optimizations in node and wallet to increase sync speed and lower work to stay in sync. We expect to add additional significant performance improvements in the next release also.
+- Transactions now add the agg_sig_me of the genesis block for chain compatibility reasons.
+- Wallet is far less chatty to unload the classic introducers. DNS introducers will be coming shortly to replace the classic introducers that are still deployed.
+- Netspace is now calculated across the previous 4068 blocks (generally the past 24 hours) in the GUI and cli.
+
+### Fixed
+
 - Performance of streamable has been increased, which should help the full node use less CPU - especially when syncing.
+- Timelords are now successfully infusing almost 100% of blocks.
+- Harvester should be a bit more tolerant of some bad plots.
 
 ## 1.0.5 Chia Blockchain 2021-04-14
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -112,7 +112,7 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
         if typ != "STANDARD_WALLET":
             print(f"Wallet ID {wallet_id} type {typ} {summary['name']}")
             print(f"   -Confirmed: " f"{balances['confirmed_wallet_balance']/units['colouredcoin']}")
-            print(f"   -Unconfirmed: {balances['unconfirmed_wallet_balance']/units['colouredcoin']}")
+            print(f"   -Confirmed - Pending Outgoing: {balances['unconfirmed_wallet_balance']/units['colouredcoin']}")
             print(f"   -Spendable: {balances['spendable_balance']/units['colouredcoin']}")
             print(f"   -Pending change: {balances['pending_change']/units['colouredcoin']}")
         else:

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from dataclasses import replace
 from typing import Callable, Dict, List, Optional, Tuple
@@ -30,6 +31,8 @@ from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.merkle_set import MerkleSet
 from chia.util.prev_transaction_block import get_prev_transaction_block
 from chia.util.recursive_replace import recursive_replace
+
+log = logging.getLogger(__name__)
 
 
 def create_foliage(

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -201,8 +201,10 @@ class Blockchain(BlockchainInterface):
                         block_generator: Optional[BlockGenerator] = await self.get_block_generator(block)
                     except ValueError:
                         return ReceiveBlockResult.INVALID_BLOCK, Err.GENERATOR_REF_HAS_NO_GENERATOR, None
-                    assert block_generator is not None
-                    npc_result = get_name_puzzle_conditions(block_generator, self.constants.MAX_BLOCK_COST_CLVM, False)
+                    assert block_generator is not None and block.transactions_info is not None
+                    npc_result = get_name_puzzle_conditions(
+                        block_generator, min(self.constants.MAX_BLOCK_COST_CLVM, block.transactions_info.cost), False
+                    )
                     removals, additions = block_removals_and_additions(block, npc_result.npc_list)
                 else:
                     removals, additions = [], list(block.get_included_reward_coins())

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -79,9 +79,6 @@ class CoinStore:
             )
             await self._add_coin_record(record)
 
-        for coin_name in removals:
-            await self._set_spent(coin_name, block.height)
-
         included_reward_coins = block.get_included_reward_coins()
         if block.height == 0:
             assert len(included_reward_coins) == 0
@@ -98,6 +95,9 @@ class CoinStore:
                 block.foliage_transaction_block.timestamp,
             )
             await self._add_coin_record(reward_coin_r)
+
+        for coin_name in removals:
+            await self._set_spent(coin_name, block.height)
 
     # Checks DB and DiffStores for CoinRecord with coin_name and returns it
     async def get_coin_record(self, coin_name: bytes32) -> Optional[CoinRecord]:
@@ -215,7 +215,7 @@ class CoinStore:
     async def _set_spent(self, coin_name: bytes32, index: uint32):
         current: Optional[CoinRecord] = await self.get_coin_record(coin_name)
         if current is None:
-            return
+            raise ValueError(f"Cannot spend a coin that does not exist in db: {coin_name}")
         spent: CoinRecord = CoinRecord(
             current.coin,
             current.confirmed_block_index,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1501,7 +1501,7 @@ class FullNode:
         if self.mempool_manager.seen(spend_name):
             return MempoolInclusionStatus.FAILED, Err.ALREADY_INCLUDING_TRANSACTION
         self.mempool_manager.add_and_maybe_pop_seen(spend_name)
-        self.log.debug(f"Processing transaction: {spend_name}")
+        self.log.debug(f"Processingetransaction: {spend_name}")
         # Ignore if syncing
         if self.sync_store.get_sync_mode():
             status = MempoolInclusionStatus.FAILED

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -71,38 +71,36 @@ def mempool_assert_relative_block_height_exceeds(
     return None
 
 
-def mempool_assert_absolute_time_exceeds(
-    condition: ConditionWithArgs, timestamp: Optional[uint64] = None
-) -> Optional[Err]:
+def mempool_assert_absolute_time_exceeds(condition: ConditionWithArgs, timestamp: uint64) -> Optional[Err]:
     """
-    Check if the current time in millis exceeds the time specified by condition
+    Check if the current time in seconds exceeds the time specified by condition
     """
     try:
-        expected_mili_time = int_from_bytes(condition.vars[0])
+        expected_seconds = int_from_bytes(condition.vars[0])
     except ValueError:
         return Err.INVALID_CONDITION
 
     if timestamp is None:
-        timestamp = uint64(int(time.time() * 1000))
-    if timestamp < expected_mili_time:
+        timestamp = uint64(int(time.time()))
+    if timestamp < expected_seconds:
         return Err.ASSERT_SECONDS_ABSOLUTE_FAILED
     return None
 
 
 def mempool_assert_relative_time_exceeds(
-    condition: ConditionWithArgs, unspent: CoinRecord, timestamp: Optional[uint64] = None
+    condition: ConditionWithArgs, unspent: CoinRecord, timestamp: uint64
 ) -> Optional[Err]:
     """
-    Check if the current time in millis exceeds the time specified by condition
+    Check if the current time in seconds exceeds the time specified by condition
     """
     try:
-        expected_mili_time = int_from_bytes(condition.vars[0])
+        expected_seconds = int_from_bytes(condition.vars[0])
     except ValueError:
         return Err.INVALID_CONDITION
 
     if timestamp is None:
-        timestamp = uint64(int(time.time() * 1000))
-    if timestamp < expected_mili_time + unspent.timestamp:
+        timestamp = uint64(int(time.time()))
+    if timestamp < expected_seconds + unspent.timestamp:
         return Err.ASSERT_SECONDS_RELATIVE_FAILED
     return None
 
@@ -196,7 +194,7 @@ def mempool_check_conditions_dict(
     puzzle_announcement_names: Set[bytes32],
     conditions_dict: Dict[ConditionOpcode, List[ConditionWithArgs]],
     prev_transaction_block_height: uint32,
-    timestamp: Optional[uint64] = None,
+    timestamp: uint64,
 ) -> Optional[Err]:
     """
     Check all conditions against current state.

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -189,6 +189,14 @@ class FullNodeDiscovery:
                     except asyncio.CancelledError:
                         return
                     await self._introducer_client()
+                    # there's some delay between receiving the peers from the
+                    # introducer until they get incorporated to prevent this
+                    # loop for running one more time. Add this delay to ensure
+                    # that once we get peers, we stop contacting the introducer.
+                    try:
+                        await asyncio.sleep(5)
+                    except asyncio.CancelledError:
+                        return
                     empty_tables = False
                     # keep doubling the introducer delay until we reach 5
                     # minutes

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -338,7 +338,7 @@ class ChiaServer:
         session = None
         connection: Optional[WSChiaConnection] = None
         try:
-            timeout = ClientTimeout(total=10)
+            timeout = ClientTimeout(total=30)
             session = ClientSession(timeout=timeout)
 
             try:

--- a/chia/types/coin_record.py
+++ b/chia/types/coin_record.py
@@ -19,7 +19,7 @@ class CoinRecord(Streamable):
     spent_block_index: uint32
     spent: bool
     coinbase: bool
-    timestamp: uint64
+    timestamp: uint64  # Timestamp of the block at height confirmed_block_index
 
     @property
     def name(self) -> bytes32:

--- a/chia/util/default_root.py
+++ b/chia/util/default_root.py
@@ -1,4 +1,4 @@
 import os
 from pathlib import Path
 
-DEFAULT_ROOT_PATH = Path(os.path.expanduser(os.getenv("CHIA_ROOT", "~/.chia/testnet5"))).resolve()
+DEFAULT_ROOT_PATH = Path(os.path.expanduser(os.getenv("CHIA_ROOT", "~/.chia/mainnet"))).resolve()

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -146,6 +146,7 @@ class Err(Enum):
     INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT = 119
     FUTURE_GENERATOR_REFS = 120  # All refs must be to blocks in the past
     GENERATOR_REF_HAS_NO_GENERATOR = 121
+    DOUBLE_SPEND_IN_FORK = 122
 
 
 class ValidationError(Exception):

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -281,7 +281,7 @@ full_node:
       host: *self_hostname
       port: 8446
   introducer_peer:
-      host: beta1_introducer.chia.net  # Chia AWS introducer IPv4/IPv6
+      host: introducer.chia.net  # Chia AWS introducer IPv4/IPv6
       port: 8444
   wallet_peer:
     host: *self_hostname
@@ -363,7 +363,7 @@ wallet:
   recent_peer_threshold: 6000
 
   introducer_peer:
-    host: beta1_introducer.chia.net # Chia AWS introducer IPv4/IPv6
+    host: introducer.chia.net # Chia AWS introducer IPv4/IPv6
     port: 8444
 
   ssl:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -145,7 +145,7 @@ farmer:
   # The farmer will attempt to connect to this full node and harvester
   full_node_peer:
     host: *self_hostname
-    port: 58444
+    port: 8444
   harvester_peer:
     host: *self_hostname
     port: 8448
@@ -194,7 +194,7 @@ timelord:
       - 150000
   full_node_peer:
       host: *self_hostname
-      port: 58444
+      port: 8444
   # Maximum number of seconds allowed for a client to reconnect to the server.
   max_connection_time: 60
   # The ip and port where the TCP clients will connect.
@@ -229,7 +229,7 @@ timelord:
 
 full_node:
   # The full node server (if run) will run on this port
-  port: 58444
+  port: 8444
 
   # Run multiple nodes with different databases by changing the database_path
   database_path: db/blockchain_v1_CHALLENGE.sqlite
@@ -282,7 +282,7 @@ full_node:
       port: 8446
   introducer_peer:
       host: beta1_introducer.chia.net  # Chia AWS introducer IPv4/IPv6
-      port: 58444
+      port: 8444
   wallet_peer:
     host: *self_hostname
     port: 8449
@@ -346,7 +346,7 @@ wallet:
 
   full_node_peer:
     host: *self_hostname
-    port: 58444
+    port: 8444
 
   testing: False
   database_path: wallet/db/blockchain_wallet_v1_CHALLENGE_KEY.sqlite
@@ -364,7 +364,7 @@ wallet:
 
   introducer_peer:
     host: beta1_introducer.chia.net # Chia AWS introducer IPv4/IPv6
-    port: 58444
+    port: 8444
 
   ssl:
     private_crt:  "config/ssl/wallet/private_wallet.crt"

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -74,7 +74,7 @@ network_overrides: &network_overrides
     testnet5:
       address_prefix: "txch"
 
-selected_network: &selected_network "testnet5"
+selected_network: &selected_network "mainnet"
 ALERTS_URL: https://download.chia.net/notify/mainnet_alert.txt
 CHIA_ALERTS_PUBKEY: 89b7fd87cb56e926ecefb879a29aae308be01f31980569f6a75a69d2a9a69daefd71fb778d865f7c50d6c967e3025937
 

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -319,6 +319,12 @@ class Wallet:
         spends: List[CoinSolution] = []
         output_created = False
 
+        # Check for duplicates
+        if primaries is not None:
+            all_primaries_list = [(p["puzzlehash"], p["amount"]) for p in primaries] + [(newpuzzlehash, amount)]
+            if len(set(all_primaries_list)) != len(all_primaries_list):
+                raise ValueError("Cannot create two identical coins")
+
         for coin in coins:
             self.log.info(f"coin from coins {coin}")
             puzzle: Program = await self.puzzle_for_puzzle_hash(coin.puzzle_hash)

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -669,6 +669,8 @@ class WalletNode:
                 self.wallet_state_manager.state_changed("new_block")
             elif result == ReceiveBlockResult.INVALID_BLOCK:
                 raise ValueError("Value error peer sent us invalid block")
+        if advanced_peak:
+            await self.wallet_state_manager.create_more_puzzle_hashes()
         return True, advanced_peak
 
     def validate_additions(

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -609,6 +609,9 @@ class WalletStateManager:
                 await self.coin_added(
                     coin, is_coinbase, is_fee_reward, uint32(wallet_id), wallet_type, height, all_outgoing_tx[wallet_id]
                 )
+            derivation_index = await self.puzzle_store.index_for_puzzle_hash(coin.puzzle_hash)
+            if derivation_index is not None:
+                await self.puzzle_store.set_used_up_to(derivation_index, True)
 
         return trade_adds
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -72,6 +72,8 @@ class WalletStateManager:
     # Makes sure only one asyncio thread is changing the blockchain state at one time
     lock: asyncio.Lock
 
+    tx_lock: asyncio.Lock
+
     log: logging.Logger
 
     # TODO Don't allow user to send tx until wallet is synced
@@ -119,6 +121,7 @@ class WalletStateManager:
         else:
             self.log = logging.getLogger(__name__)
         self.lock = asyncio.Lock()
+        self.tx_lock = asyncio.Lock()
 
         self.log.debug(f"Starting in db path: {db_path}")
         self.db_connection = await aiosqlite.connect(db_path)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -5,21 +5,25 @@ import multiprocessing
 import time
 from dataclasses import replace
 from secrets import token_bytes
-from typing import Optional
 
 import pytest
 from blspy import AugSchemeMPL, G2Element
+from clvm.casts import int_to_bytes
 
+from chia.consensus.block_rewards import calculate_base_farmer_reward
 from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.coinbase import create_farmer_coin
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.bundle_tools import detect_potential_template_generator
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.foliage import TransactionsInfo, FoliageTransactionBlock
+from chia.types.blockchain_format.foliage import TransactionsInfo
 from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import InfusedChallengeChainSubSlot
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
+from chia.types.condition_opcodes import ConditionOpcode
+from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
@@ -28,6 +32,7 @@ from chia.util.block_tools import BlockTools, get_vdf_info_and_proof
 from chia.util.errors import Err
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint64, uint32
+from chia.util.merkle_set import MerkleSet
 from chia.util.recursive_replace import recursive_replace
 from chia.util.wallet_tools import WalletTool
 from tests.core.fixtures import default_400_blocks  # noqa: F401; noqa: F401
@@ -1543,6 +1548,54 @@ class TestBlockHeaderValidation:
             assert (await empty_blockchain.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
 
 
+class TestPreValidation:
+    @pytest.mark.asyncio
+    async def test_pre_validation_fails_bad_blocks(self, empty_blockchain):
+        blocks = bt.get_consecutive_blocks(2)
+        assert (await empty_blockchain.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        block_bad = recursive_replace(
+            blocks[-1], "reward_chain_block.total_iters", blocks[-1].reward_chain_block.total_iters + 1
+        )
+        res = await empty_blockchain.pre_validate_blocks_multiprocessing([blocks[0], block_bad], {})
+        assert res[0].error is None
+        assert res[1].error is not None
+
+    @pytest.mark.asyncio
+    async def test_pre_validation(self, empty_blockchain, default_1000_blocks):
+        blocks = default_1000_blocks[:100]
+        start = time.time()
+        n_at_a_time = min(multiprocessing.cpu_count(), 32)
+        times_pv = []
+        times_rb = []
+        for i in range(0, len(blocks), n_at_a_time):
+            end_i = min(i + n_at_a_time, len(blocks))
+            blocks_to_validate = blocks[i:end_i]
+            start_pv = time.time()
+            res = await empty_blockchain.pre_validate_blocks_multiprocessing(blocks_to_validate, {})
+            end_pv = time.time()
+            times_pv.append(end_pv - start_pv)
+            assert res is not None
+            for n in range(end_i - i):
+                assert res[n] is not None
+                assert res[n].error is None
+                block = blocks_to_validate[n]
+                start_rb = time.time()
+                result, err, _ = await empty_blockchain.receive_block(block, res[n])
+                end_rb = time.time()
+                times_rb.append(end_rb - start_rb)
+                assert err is None
+                assert result == ReceiveBlockResult.NEW_PEAK
+                log.info(
+                    f"Added block {block.height} total iters {block.total_iters} "
+                    f"new slot? {len(block.finished_sub_slots)}, time {end_rb - start_rb}"
+                )
+        end = time.time()
+        log.info(f"Total time: {end - start} seconds")
+        log.info(f"Average pv: {sum(times_pv)/(len(blocks)/n_at_a_time)}")
+        log.info(f"Average rb: {sum(times_rb)/(len(blocks))}")
+
+
 class TestBodyValidation:
     @pytest.mark.asyncio
     async def test_not_tx_block_but_has_data(self, empty_blockchain):
@@ -1866,6 +1919,481 @@ class TestBodyValidation:
             assert err == Err.GENERATOR_REF_HAS_NO_GENERATOR or err == Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
             assert (await b.pre_validate_blocks_multiprocessing([block_2], {})) is None
 
+    @pytest.mark.asyncio
+    async def test_cost_exceeds_max(self, empty_blockchain):
+        # 7
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        condition_dict = {ConditionOpcode.CREATE_COIN: []}
+        for i in range(7000):
+            output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt.pool_ph, int_to_bytes(i)])
+            condition_dict[ConditionOpcode.CREATE_COIN].append(output)
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0], condition_dic=condition_dict
+        )
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        assert (await b.receive_block(blocks[-1]))[1] == Err.BLOCK_COST_EXCEEDS_MAX
+
+    @pytest.mark.asyncio
+    async def test_clvm_must_not_fail(self, empty_blockchain):
+        # 8
+        pass
+
+    @pytest.mark.asyncio
+    async def test_invalid_cost_in_block(self, empty_blockchain):
+        # 9
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        block: FullBlock = blocks[-1]
+
+        # zero
+        block_2: FullBlock = recursive_replace(block, "transactions_info.cost", uint64(0))
+        block_2 = recursive_replace(
+            block_2, "foliage_transaction_block.transactions_info_hash", block_2.transactions_info.get_hash()
+        )
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+
+        err = (await b.receive_block(block_2))[1]
+        assert err == Err.INVALID_BLOCK_COST
+
+        # too low
+        block_2: FullBlock = recursive_replace(block, "transactions_info.cost", uint64(1))
+        block_2 = recursive_replace(
+            block_2, "foliage_transaction_block.transactions_info_hash", block_2.transactions_info.get_hash()
+        )
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+        err = (await b.receive_block(block_2))[1]
+        assert err == Err.GENERATOR_RUNTIME_ERROR
+
+        # too high
+        block_2: FullBlock = recursive_replace(block, "transactions_info.cost", uint64(1000000))
+        block_2 = recursive_replace(
+            block_2, "foliage_transaction_block.transactions_info_hash", block_2.transactions_info.get_hash()
+        )
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+
+        err = (await b.receive_block(block_2))[1]
+        assert err == Err.INVALID_BLOCK_COST
+
+        err = (await b.receive_block(block))[1]
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_max_coin_amount(self):
+        # 10
+        # TODO: fix, this is not reaching validation. Because we can't create a block with such amounts due to uint64
+        # limit in Coin
+
+        new_test_constants = test_constants.replace(
+            **{"GENESIS_PRE_FARM_POOL_PUZZLE_HASH": bt.pool_ph, "GENESIS_PRE_FARM_FARMER_PUZZLE_HASH": bt.pool_ph}
+        )
+        b, connection, db_path = await create_blockchain(new_test_constants)
+        bt_2 = BlockTools(new_test_constants)
+        bt_2.constants = bt_2.constants.replace(
+            **{"GENESIS_PRE_FARM_POOL_PUZZLE_HASH": bt.pool_ph, "GENESIS_PRE_FARM_FARMER_PUZZLE_HASH": bt.pool_ph}
+        )
+        blocks = bt_2.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt_2.get_pool_wallet_tool()
+
+        condition_dict = {ConditionOpcode.CREATE_COIN: []}
+        output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt_2.pool_ph, int_to_bytes(2 ** 64)])
+        condition_dict[ConditionOpcode.CREATE_COIN].append(output)
+
+        tx: SpendBundle = wt.generate_signed_transaction_multiple_coins(
+            10,
+            wt.get_new_puzzlehash(),
+            list(blocks[1].get_included_reward_coins()),
+            condition_dic=condition_dict,
+        )
+        try:
+            blocks = bt_2.get_consecutive_blocks(
+                1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+            )
+            assert False
+        except Exception as e:
+            pass
+        await connection.close()
+        b.shut_down()
+        db_path.unlink()
+
+    @pytest.mark.asyncio
+    async def test_invalid_merkle_roots(self, empty_blockchain):
+        # 11
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        block: FullBlock = blocks[-1]
+
+        merkle_set = MerkleSet()
+        # additions
+        block_2 = recursive_replace(block, "foliage_transaction_block.additions_root", merkle_set.get_root())
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+
+        err = (await b.receive_block(block_2))[1]
+        assert err == Err.BAD_ADDITION_ROOT
+
+        # removals
+        merkle_set.add_already_hashed(std_hash(b"1"))
+        block_2 = recursive_replace(block, "foliage_transaction_block.removals_root", merkle_set.get_root())
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+
+        err = (await b.receive_block(block_2))[1]
+        assert err == Err.BAD_REMOVAL_ROOT
+
+    @pytest.mark.asyncio
+    async def test_invalid_filter(self, empty_blockchain):
+        # 12
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        block: FullBlock = blocks[-1]
+        block_2 = recursive_replace(block, "foliage_transaction_block.filter_hash", std_hash(b"3"))
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+
+        err = (await b.receive_block(block_2))[1]
+        assert err == Err.INVALID_TRANSACTIONS_FILTER_HASH
+
+    @pytest.mark.asyncio
+    async def test_duplicate_outputs(self, empty_blockchain):
+        # 13
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        condition_dict = {ConditionOpcode.CREATE_COIN: []}
+        for i in range(2):
+            output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt.pool_ph, int_to_bytes(1)])
+            condition_dict[ConditionOpcode.CREATE_COIN].append(output)
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0], condition_dic=condition_dict
+        )
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        assert (await b.receive_block(blocks[-1]))[1] == Err.DUPLICATE_OUTPUT
+
+    @pytest.mark.asyncio
+    async def test_duplicate_removals(self, empty_blockchain):
+        # 14
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+        tx_2: SpendBundle = wt.generate_signed_transaction(
+            11, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+        agg = SpendBundle.aggregate([tx, tx_2])
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=agg
+        )
+        assert (await b.receive_block(blocks[-1]))[1] == Err.DOUBLE_SPEND
+
+    @pytest.mark.asyncio
+    async def test_double_spent_in_coin_store(self, empty_blockchain):
+        # 15
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        tx_2: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-2].get_included_reward_coins())[0]
+        )
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx_2
+        )
+
+        assert (await b.receive_block(blocks[-1]))[1] == Err.DOUBLE_SPEND
+
+    @pytest.mark.asyncio
+    async def test_double_spent_in_reorg(self, empty_blockchain):
+        # 15
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        new_coin: Coin = tx.additions()[0]
+        tx_2: SpendBundle = wt.generate_signed_transaction(10, wt.get_new_puzzlehash(), new_coin)
+        # This is fine because coin exists
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx_2
+        )
+        assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+        blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, guarantee_transaction_block=True)
+        for block in blocks[-5:]:
+            assert (await b.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
+
+        blocks_reorg = bt.get_consecutive_blocks(2, block_list_input=blocks[:-7], guarantee_transaction_block=True)
+        assert (await b.receive_block(blocks_reorg[-2]))[0] == ReceiveBlockResult.ADDED_AS_ORPHAN
+        assert (await b.receive_block(blocks_reorg[-1]))[0] == ReceiveBlockResult.ADDED_AS_ORPHAN
+
+        # Coin does not exist in reorg
+        blocks_reorg = bt.get_consecutive_blocks(
+            1, block_list_input=blocks_reorg, guarantee_transaction_block=True, transaction_data=tx_2
+        )
+
+        assert (await b.receive_block(blocks_reorg[-1]))[1] == Err.UNKNOWN_UNSPENT
+
+        # Finally add the block to the fork (spending both in same bundle, this is ephemeral)
+        agg = SpendBundle.aggregate([tx, tx_2])
+        blocks_reorg = bt.get_consecutive_blocks(
+            1, block_list_input=blocks_reorg[:-1], guarantee_transaction_block=True, transaction_data=agg
+        )
+        assert (await b.receive_block(blocks_reorg[-1]))[1] is None
+
+        blocks_reorg = bt.get_consecutive_blocks(
+            1, block_list_input=blocks_reorg, guarantee_transaction_block=True, transaction_data=tx_2
+        )
+        assert (await b.receive_block(blocks_reorg[-1]))[1] == Err.DOUBLE_SPEND_IN_FORK
+
+        rewards_ph = wt.get_new_puzzlehash()
+        blocks_reorg = bt.get_consecutive_blocks(
+            10,
+            block_list_input=blocks_reorg[:-1],
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=rewards_ph,
+        )
+        for block in blocks_reorg[-10:]:
+            r, e, _ = await b.receive_block(block)
+            assert e is None
+
+        # ephemeral coin is spent
+        first_coin = await b.coin_store.get_coin_record(new_coin.name())
+        assert first_coin is not None and first_coin.spent
+        second_coin = await b.coin_store.get_coin_record(tx_2.additions()[0].name())
+        assert second_coin is not None and not second_coin.spent
+
+        farmer_coin = create_farmer_coin(
+            blocks_reorg[-1].height,
+            rewards_ph,
+            calculate_base_farmer_reward(blocks_reorg[-1].height),
+            bt.constants.GENESIS_CHALLENGE,
+        )
+        tx_3: SpendBundle = wt.generate_signed_transaction(10, wt.get_new_puzzlehash(), farmer_coin)
+
+        blocks_reorg = bt.get_consecutive_blocks(
+            1, block_list_input=blocks_reorg, guarantee_transaction_block=True, transaction_data=tx_3
+        )
+        assert (await b.receive_block(blocks_reorg[-1]))[1] is None
+
+        farmer_coin = await b.coin_store.get_coin_record(farmer_coin.name())
+        assert first_coin is not None and farmer_coin.spent
+
+    @pytest.mark.asyncio
+    async def test_minting_coin(self, empty_blockchain):
+        # 16 TODO
+        # 17 is tested in mempool tests
+        pass
+
+    @pytest.mark.asyncio
+    async def test_max_coin_amount_fee(self):
+        # 18 TODO: we can't create a block with such amounts due to uint64
+        pass
+
+    @pytest.mark.asyncio
+    async def test_invalid_fees_in_block(self, empty_blockchain):
+        # 19
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+            pool_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+        )
+
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        block: FullBlock = blocks[-1]
+
+        # wrong feees
+        block_2: FullBlock = recursive_replace(block, "transactions_info.fees", uint64(1239))
+        block_2 = recursive_replace(
+            block_2, "foliage_transaction_block.transactions_info_hash", block_2.transactions_info.get_hash()
+        )
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+
+        err = (await b.receive_block(block_2))[1]
+        assert err == Err.INVALID_BLOCK_FEE_AMOUNT
+
 
 class TestReorgs:
     @pytest.mark.asyncio
@@ -2026,51 +2554,3 @@ class TestReorgs:
         for block in blocks_fork:
             result, error_code, _ = await b.receive_block(block)
             assert error_code is None
-
-
-class TestPreValidation:
-    @pytest.mark.asyncio
-    async def test_pre_validation_fails_bad_blocks(self, empty_blockchain):
-        blocks = bt.get_consecutive_blocks(2)
-        assert (await empty_blockchain.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
-
-        block_bad = recursive_replace(
-            blocks[-1], "reward_chain_block.total_iters", blocks[-1].reward_chain_block.total_iters + 1
-        )
-        res = await empty_blockchain.pre_validate_blocks_multiprocessing([blocks[0], block_bad], {})
-        assert res[0].error is None
-        assert res[1].error is not None
-
-    @pytest.mark.asyncio
-    async def test_pre_validation(self, empty_blockchain, default_1000_blocks):
-        blocks = default_1000_blocks[:100]
-        start = time.time()
-        n_at_a_time = min(multiprocessing.cpu_count(), 32)
-        times_pv = []
-        times_rb = []
-        for i in range(0, len(blocks), n_at_a_time):
-            end_i = min(i + n_at_a_time, len(blocks))
-            blocks_to_validate = blocks[i:end_i]
-            start_pv = time.time()
-            res = await empty_blockchain.pre_validate_blocks_multiprocessing(blocks_to_validate, {})
-            end_pv = time.time()
-            times_pv.append(end_pv - start_pv)
-            assert res is not None
-            for n in range(end_i - i):
-                assert res[n] is not None
-                assert res[n].error is None
-                block = blocks_to_validate[n]
-                start_rb = time.time()
-                result, err, _ = await empty_blockchain.receive_block(block, res[n])
-                end_rb = time.time()
-                times_rb.append(end_rb - start_rb)
-                assert err is None
-                assert result == ReceiveBlockResult.NEW_PEAK
-                log.info(
-                    f"Added block {block.height} total iters {block.total_iters} "
-                    f"new slot? {len(block.finished_sub_slots)}, time {end_rb - start_rb}"
-                )
-        end = time.time()
-        log.info(f"Total time: {end - start} seconds")
-        log.info(f"Average pv: {sum(times_pv)/(len(blocks)/n_at_a_time)}")
-        log.info(f"Average rb: {sum(times_rb)/(len(blocks))}")

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -7,6 +7,7 @@ import pytest
 
 from chia.full_node.mempool import Mempool
 from chia.protocols import full_node_protocol
+from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.coin_solution import CoinSolution
@@ -458,7 +459,7 @@ class TestMempoolManager:
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
-        time_now = uint64(int(time() * 1000))
+        time_now = uint64(int(time()))
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [time_now.to_bytes(8, "big")])
         dic = {cvp.opcode: [cvp]}
@@ -474,7 +475,7 @@ class TestMempoolManager:
         assert sb1 is spend_bundle1
 
     @pytest.mark.asyncio
-    async def test_assert_time_exceeds_both_cases(self, two_nodes):
+    async def test_assert_time_relative_exceeds(self, two_nodes):
         reward_ph = WALLET_A.get_new_puzzlehash()
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
@@ -493,20 +494,22 @@ class TestMempoolManager:
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
-        time_now = uint64(int(time() * 1000))
-        time_now_plus_3 = time_now + 3000
+        time_relative = uint64(3)
 
-        cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [time_now_plus_3.to_bytes(8, "big")])
+        cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [time_relative.to_bytes(8, "big")])
         dic = {cvp.opcode: [cvp]}
 
         spend_bundle1 = generate_test_spend_bundle(list(blocks[-1].get_included_reward_coins())[0], dic)
-
         assert spend_bundle1 is not None
+
         tx1: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle1)
         await full_node_1.respond_transaction(tx1, peer)
 
-        # Sleep so that 3 sec passes
-        await asyncio.sleep(3)
+        sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
+        assert sb1 is None
+
+        for i in range(0, 4):
+            await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
         tx2: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle1)
         await full_node_1.respond_transaction(tx2, peer)

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -118,8 +118,7 @@ class TestWalletRpc:
             assert (await client.get_wallet_balance("1"))["confirmed_wallet_balance"] == initial_funds
 
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
-                await asyncio.sleep(0.5)
+                await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
 
             async def eventual_balance():
                 return (await client.get_wallet_balance("1"))["confirmed_wallet_balance"]


### PR DESCRIPTION
## 1.1.0 Chia Blockchain 2021-04-21

### Added

- This fork release includes full transaction support for the Chia Blockchain. Transactions are still disabled until 5/3/2021 at 10:00AM PDT. It is hard understate how much work and clean up went into this release.
- This is the 1.0 release of Chialisp. Much has been massaged and finalized. We will be putting a focus on updating and expanding the documentation on [chialisp.com](https://chialisp.com) shortly.
- Farmers now compress blocks using code snippets from previous blocks. This saves storage space and allows larger smart coins to have a library of sorts on chain.
- You can now ask for an offset wallet receive address in the cli. Thanks @jespino.
- When adding plots we attempt to detect a duplicate and not load it.

### Changed

- We have changed how transactions will unlock from a blockheight to a timestamp. As noted above that timestamp is 5/3/2021 at 10AM PDT.
- We have temporarily disabled the "Delete Plots" button in the Windows GUI as we are still working on debugging upstream issues that are causing it.
- There are various optimizations in node and wallet to increase sync speed and lower work to stay in sync. We expect to add additional significant performance improvements in the next release also.
- Transactions now add the agg_sig_me of the genesis block for chain compatibility reasons.
- Wallet is far less chatty to unload the classic introducers. DNS introducers will be coming shortly to replace the classic introducers that are still deployed.
- Netspace is now calculated across the previous 4068 blocks (generally the past 24 hours) in the GUI and cli.

### Fixed

- Performance of streamable has been increased, which should help the full node use less CPU - especially when syncing.
- Timelords are now successfully infusing almost 100% of blocks.
- Harvester should be a bit more tolerant of some bad plots.