### PR TITLE
exponentially back-off contacting the introducer

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -338,7 +338,7 @@ class ChiaServer:
         session = None
         connection: Optional[WSChiaConnection] = None
         try:
-            timeout = ClientTimeout(total=10)
+            timeout = ClientTimeout(total=30)
             session = ClientSession(timeout=timeout)
 
             try:


### PR DESCRIPTION
(until reaching 5 minute delay).

Tested:

```
$ tail -n 10000 -F ~/.chia/mainnet/log/debug.log | grep " Connecting: wss://introducer.chia.net:8444/"
2021-04-21T09:19:10.652 full_node full_node_server        : DEBUG    Connecting: wss://introducer.chia.net:8444/ws, Peer info: {'host': 'introducer.chia.net', 'port': 8444}
2021-04-21T09:19:25.748 full_node full_node_server        : DEBUG    Connecting: wss://introducer.chia.net:8444/ws, Peer info: {'host': 'introducer.chia.net', 'port': 8444}
2021-04-21T09:19:41.751 full_node full_node_server        : DEBUG    Connecting: wss://introducer.chia.net:8444/ws, Peer info: {'host': 'introducer.chia.net', 'port': 8444}
2021-04-21T09:19:57.743 full_node full_node_server        : DEBUG    Connecting: wss://introducer.chia.net:8444/ws, Peer info: {'host': 'introducer.chia.net', 'port': 8444}
```