### PR TITLE
New puzzle hashes were not being created

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -669,6 +669,8 @@ class WalletNode:
                 self.wallet_state_manager.state_changed("new_block")
             elif result == ReceiveBlockResult.INVALID_BLOCK:
                 raise ValueError("Value error peer sent us invalid block")
+        if advanced_peak:
+            await self.wallet_state_manager.create_more_puzzle_hashes()
         return True, advanced_peak
 
     def validate_additions(

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -606,6 +606,9 @@ class WalletStateManager:
                 await self.coin_added(
                     coin, is_coinbase, is_fee_reward, uint32(wallet_id), wallet_type, height, all_outgoing_tx[wallet_id]
                 )
+            derivation_index = await self.puzzle_store.index_for_puzzle_hash(coin.puzzle_hash)
+            if derivation_index is not None:
+                await self.puzzle_store.set_used_up_to(derivation_index, True)
 
         return trade_adds
 


### PR DESCRIPTION
This PR needs to be merged. Any funds received after the 100th puzzle hash would not be visible by the wallet. The wallet was not updating the puzzle hash db with new ones.

This has been tested with syncing spend bot DB, it worked fine. Without this change, most of the coins were missing when syncing spendbot.