### PR TITLE
Leave programs in SpendBundle serialized

### DIFF
--- a/chia/full_node/generator.py
+++ b/chia/full_node/generator.py
@@ -57,7 +57,7 @@ def create_compressed_generator(
     return BlockGenerator(program, [generator_arg])
 
 
-def setup_generator_args(self: BlockGenerator):
+def setup_generator_args(self: BlockGenerator) -> Tuple[SerializedProgram, Program]:
     args = create_generator_args(self.generator_refs())
     return self.program, args
 

--- a/chia/types/coin_solution.py
+++ b/chia/types/coin_solution.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import List
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, INFINITE_COST
+from chia.types.blockchain_format.program import SerializedProgram, INFINITE_COST
 from chia.util.chain_utils import additions_for_solution
 from chia.util.streamable import Streamable, streamable
 
@@ -17,8 +17,8 @@ class CoinSolution(Streamable):
     """
 
     coin: Coin
-    puzzle_reveal: Program
-    solution: Program
+    puzzle_reveal: SerializedProgram
+    solution: SerializedProgram
 
     def additions(self) -> List[Coin]:
         return additions_for_solution(self.coin.name(), self.puzzle_reveal, self.solution, INFINITE_COST)

--- a/chia/util/chain_utils.py
+++ b/chia/util/chain_utils.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.condition_tools import (
     conditions_dict_for_solution,
@@ -9,7 +9,9 @@ from chia.util.condition_tools import (
 )
 
 
-def additions_for_solution(coin_name: bytes32, puzzle_reveal: Program, solution: Program, max_cost: int) -> List[Coin]:
+def additions_for_solution(
+    coin_name: bytes32, puzzle_reveal: SerializedProgram, solution: SerializedProgram, max_cost: int
+) -> List[Coin]:
     """
     Checks the conditions created by CoinSolution and returns the list of all coins created
     """

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -4,7 +4,7 @@ from blspy import G1Element
 
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
@@ -176,8 +176,8 @@ def puzzle_announcement_names_for_conditions_dict(
 
 
 def conditions_dict_for_solution(
-    puzzle_reveal: Program,
-    solution: Program,
+    puzzle_reveal: SerializedProgram,
+    solution: SerializedProgram,
     max_cost: int,
 ) -> Tuple[Optional[Err], Optional[Dict[ConditionOpcode, List[ConditionWithArgs]]], uint64]:
     error, result, cost = conditions_for_solution(puzzle_reveal, solution, max_cost)
@@ -187,8 +187,8 @@ def conditions_dict_for_solution(
 
 
 def conditions_for_solution(
-    puzzle_reveal: Program,
-    solution: Program,
+    puzzle_reveal: SerializedProgram,
+    solution: SerializedProgram,
     max_cost: int,
 ) -> Tuple[Optional[Err], Optional[List[ConditionWithArgs]], uint64]:
     # get the standard script for a puzzle hash and feed in the solution

--- a/chia/wallet/cc_wallet/cc_utils.py
+++ b/chia/wallet/cc_wallet/cc_utils.py
@@ -224,7 +224,7 @@ def spendable_cc_list_from_coin_solution(coin_solution: CoinSolution, hash_to_pu
     spendable_cc_list = []
 
     coin = coin_solution.coin
-    puzzle = coin_solution.puzzle_reveal
+    puzzle = Program.from_bytes(bytes(coin_solution.puzzle_reveal))
     r = uncurry_cc(puzzle)
     if r:
         mod_hash, genesis_coin_checker, inner_puzzle = r

--- a/chia/wallet/cc_wallet/debug_spend_bundle.py
+++ b/chia/wallet/cc_wallet/debug_spend_bundle.py
@@ -72,7 +72,7 @@ def debug_spend_bundle(spend_bundle: SpendBundle) -> None:
                 pks.append(pk)
                 msgs.append(m)
             print()
-            r = puzzle_reveal.run(solution)
+            r = puzzle_reveal.run_with_cost(INFINITE_COST, solution)
             print(disassemble(r))
             print()
             if conditions and len(conditions) > 0:

--- a/chia/wallet/rl_wallet/rl_wallet.py
+++ b/chia/wallet/rl_wallet/rl_wallet.py
@@ -549,7 +549,7 @@ class RLWallet:
         sigs = []
         for coin_solution in spends:
             pubkey, secretkey = await self.get_keys(coin_solution.coin.puzzle_hash)
-            signature = AugSchemeMPL.sign(secretkey, Program.to(coin_solution.solution).get_tree_hash())
+            signature = AugSchemeMPL.sign(secretkey, coin_solution.solution.get_tree_hash())
             sigs.append(signature)
 
         aggsig = AugSchemeMPL.aggregate(sigs)

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -11,6 +11,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
+from chia.types.coin_solution import CoinSolution
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.db_wrapper import DBWrapper
 from chia.util.hash import std_hash
@@ -361,16 +362,16 @@ class TradeManager:
         if trade_offer is not None:
             offer_spend_bundle: SpendBundle = trade_offer.spend_bundle
 
-        coinsols = []  # [] of CoinSolutions
-        cc_coinsol_outamounts: Dict[bytes32, List[Tuple[Any, int]]] = dict()
+        coinsols: List[CoinSolution] = []  # [] of CoinSolutions
+        cc_coinsol_outamounts: Dict[bytes32, List[Tuple[CoinSolution, int]]] = dict()
         aggsig = offer_spend_bundle.aggregated_signature
         cc_discrepancies: Dict[bytes32, int] = dict()
         chia_discrepancy = None
         wallets: Dict[bytes32, Any] = dict()  # colour to wallet dict
 
         for coinsol in offer_spend_bundle.coin_solutions:
-            puzzle: Program = coinsol.puzzle_reveal
-            solution: Program = coinsol.solution
+            puzzle: Program = Program.from_bytes(bytes(coinsol.puzzle_reveal))
+            solution: Program = Program.from_bytes(bytes(coinsol.solution))
 
             # work out the deficits between coin amount and expected output for each
             r = cc_utils.uncurry_cc(puzzle)
@@ -473,8 +474,8 @@ class TradeManager:
             # Create SpendableCC for each of the coloured coins received
             for cc_coinsol_out in cc_coinsol_outamounts[colour]:
                 cc_coinsol = cc_coinsol_out[0]
-                puzzle = cc_coinsol.puzzle_reveal
-                solution = cc_coinsol.solution
+                puzzle = Program.from_bytes(bytes(cc_coinsol.puzzle_reveal))
+                solution = Program.from_bytes(bytes(cc_coinsol.solution))
 
                 r = uncurry_cc(puzzle)
                 if r:

--- a/chia/wallet/util/trade_utils.py
+++ b/chia/wallet/util/trade_utils.py
@@ -64,8 +64,8 @@ def get_discrepancies_for_spend_bundle(
     try:
         cc_discrepancies: Dict[str, int] = dict()
         for coinsol in trade_offer.coin_solutions:
-            puzzle = coinsol.puzzle_reveal
-            solution = coinsol.solution
+            puzzle: Program = Program.from_bytes(bytes(coinsol.puzzle_reveal))
+            solution: Program = Program.from_bytes(bytes(coinsol.solution))
             # work out the deficits between coin amount and expected output for each
             r = cc_utils.uncurry_cc(puzzle)
             if r:


### PR DESCRIPTION
This is expected to save a lot of work when running, receiving and sending the spend bundle program, since we no longer need to serialize or deserialize it every time.