### PR TITLE
Add max files in rotation

### DIFF
--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -29,7 +29,8 @@ def initialize_logging(service_name: str, logging_config: Dict, root_path: Path)
         logger.addHandler(handler)
     else:
         logger = logging.getLogger()
-        handler = ConcurrentRotatingFileHandler(log_path, "a", maxBytes=20 * 1024 * 1024, backupCount=logging_config.get("log_maxfilesrotation", 7))
+        maxrotation = logging_config.get("log_maxfilesrotation", 7)
+        handler = ConcurrentRotatingFileHandler(log_path, "a", maxBytes=20 * 1024 * 1024, backupCount=maxrotation)
         handler.setFormatter(
             logging.Formatter(
                 fmt=f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",

--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -29,7 +29,7 @@ def initialize_logging(service_name: str, logging_config: Dict, root_path: Path)
         logger.addHandler(handler)
     else:
         logger = logging.getLogger()
-        handler = ConcurrentRotatingFileHandler(log_path, "a", maxBytes=20 * 1024 * 1024, backupCount=7)
+        handler = ConcurrentRotatingFileHandler(log_path, "a", maxBytes=20 * 1024 * 1024, backupCount=logging_config.get("log_maxfilesrotation", 7))
         handler.setFormatter(
             logging.Formatter(
                 fmt=f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -99,6 +99,7 @@ logging: &logging
   log_stdout: False  # If True, outputs to stdout instead of a file
   log_filename: "log/debug.log"
   log_level: "WARNING"  # Can be CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
+  log_maxfilesrotation: 7 #  Max files in rotation. Default value 7 if the key is not set
 
 harvester:
   # The harvester server (if run) will run on this port


### PR DESCRIPTION
To increase the number of files for the log. If you have more that 120 connection like me, in the log there is only a few hours. If you want you can add a parameter to configuration for ad more file for rotation.
