### PR TITLE
Using the top level exceptions from aiohttp

### DIFF
--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -28,7 +28,7 @@ async def get_plots(harvester_rpc_port: int) -> Optional[Dict[str, Any]]:
         )
         plots = await harvester_client.get_plots()
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if harvester is running at {harvester_rpc_port}")
         else:
             print(f"Exception from 'harvester' {e}")
@@ -48,7 +48,7 @@ async def get_blockchain_state(rpc_port: int) -> Optional[Dict[str, Any]]:
         client = await FullNodeRpcClient.create(self_hostname, uint16(rpc_port), DEFAULT_ROOT_PATH, config)
         blockchain_state = await client.get_blockchain_state()
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if full node is running at {rpc_port}")
         else:
             print(f"Exception from 'full node' {e}")
@@ -92,7 +92,7 @@ async def get_average_block_time(rpc_port: int) -> float:
         return (curr.timestamp - past_curr.timestamp) / (curr.height - past_curr.height)
 
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if full node is running at {rpc_port}")
         else:
             print(f"Exception from 'full node' {e}")
@@ -112,7 +112,7 @@ async def get_wallets_stats(wallet_rpc_port: int) -> Optional[Dict[str, Any]]:
         wallet_client = await WalletRpcClient.create(self_hostname, uint16(wallet_rpc_port), DEFAULT_ROOT_PATH, config)
         amounts = await wallet_client.get_farmed_amount()
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if wallet is running at {wallet_rpc_port}")
         else:
             print(f"Exception from 'wallet' {e}")
@@ -133,7 +133,7 @@ async def is_farmer_running(farmer_rpc_port: int) -> bool:
         await farmer_client.get_connections()
         is_running = True
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if farmer is running at {farmer_rpc_port}")
         else:
             print(f"Exception from 'farmer' {e}")
@@ -153,7 +153,7 @@ async def get_challenges(farmer_rpc_port: int) -> Optional[List[Dict[str, Any]]]
         farmer_client = await FarmerRpcClient.create(self_hostname, uint16(farmer_rpc_port), DEFAULT_ROOT_PATH, config)
         signage_points = await farmer_client.get_signage_points()
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if farmer is running at {farmer_rpc_port}")
         else:
             print(f"Exception from 'farmer' {e}")

--- a/chia/cmds/netspace_funcs.py
+++ b/chia/cmds/netspace_funcs.py
@@ -66,7 +66,7 @@ async def netstorge_async(rpc_port: int, delta_block_height: str, start: str) ->
                 print(f"The network has an estimated {network_space_terabytes_estimate:.3f} TiB")
 
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if full node rpc is running at {rpc_port}")
         else:
             print(f"Exception {e}")

--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -261,7 +261,7 @@ async def show_async(
                 print("Block with header hash", block_header_hash_by_height, "not found")
 
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if full node rpc is running at {rpc_port}")
             print("This is normal if full node is still starting up")
         else:

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -225,7 +225,7 @@ async def execute_with_wallet(wallet_rpc_port: int, fingerprint: int, extra_para
     except KeyboardInterrupt:
         pass
     except Exception as e:
-        if isinstance(e, aiohttp.client_exceptions.ClientConnectorError):
+        if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if wallet is running at {wallet_rpc_port}")
         else:
             print(f"Exception from 'wallet' {e}")

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -281,7 +281,7 @@ class RpcServer:
                     await self.connection(ws)
                 self.websocket = None
                 await session.close()
-            except aiohttp.client_exceptions.ClientConnectorError:
+            except aiohttp.ClientConnectorError:
                 self.log.warning(f"Cannot connect to daemon at ws://{self_hostname}:{daemon_port}")
             except Exception as e:
                 tb = traceback.format_exc()


### PR DESCRIPTION
aiohttp's client errors were re-exported to top level modules: https://github.com/aio-libs/aiohttp/blob/master/aiohttp/__init__.py#L8-L14 , so it's more clear and pythonic to just using them in top level aiohttp module, and more friendly for linters.