### PR TITLE
Add back logging for added coins

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -655,6 +655,7 @@ class WalletStateManager:
         """
         Adding coin to DB
         """
+        self.log.info(f"Adding coin: {coin} at {height}")
         farm_reward = False
         if coinbase or fee_reward:
             farm_reward = True


### PR DESCRIPTION
It was removed in commit ee3dfb9eb19d238aced93daddf1f37502a368f87 for
unknown reason. A few people on keybase have learned to rely on it to
check for new coins being received by their wallet. Arguably not the
best way to do so but seems like a useful log output to have in general.