### PR TITLE
Rename "not_found_filenames" to "no_key_filenames"

### DIFF
--- a/chia/rpc/harvester_rpc_api.py
+++ b/chia/rpc/harvester_rpc_api.py
@@ -31,7 +31,7 @@ class HarvesterRpcApi:
         return {
             "plots": plots,
             "failed_to_open_filenames": failed_to_open,
-            "not_found_filenames": not_found,
+            "no_key_filenames": not_found,
         }
 
     async def refresh_plots(self, request: Dict) -> Dict:


### PR DESCRIPTION
This changes the name of the field: "not_found_filenames" to "no_key_filenames" to prevent confusion about what the field means.
