### PR TITLE
Translate hostname on every reconnection attempt

### DIFF
--- a/chia/server/reconnect_task.py
+++ b/chia/server/reconnect_task.py
@@ -18,6 +18,7 @@ def start_reconnect_task(server: ChiaServer, peer_info_arg: PeerInfo, log, auth:
                 if connection.get_peer_info() == peer_info or connection.get_peer_info() == peer_info_arg:
                     peer_retry = False
             if peer_retry:
+                peer_info = PeerInfo(socket.gethostbyname(peer_info_arg.host), peer_info_arg.port)
                 log.info(f"Reconnecting to peer {peer_info}")
                 try:
                     await server.start_client(peer_info, None, auth=auth)


### PR DESCRIPTION
When a farmer is behind a dyndns domain, remote harvesters will not try to re-translate the hostname and attempt reconnecting only to the out-of-date IP. The same happens for other entities (node, wallet, etc.), I assume.
This forces a retranslation of hostname on every reconnect attempt. This fixed the issue for remote harvesting in a test on my setup.
This fixes issue [#2147](https://github.com/Chia-Network/chia-blockchain/issues/2147)