### PR TITLE
Added new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Reuqest
+name: Request
 about: Create a request for an enhancement or feature
 title: "[REQ]"
 labels: enhancement
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of your suggested enhancement, as well as some basic rationale to allow us to balance the effort/reward for the work, if possible.
 
 **Images**
-If applicable (but not required), add diagrams or wirefames to help explain your request if it is GUI related.
+If applicable (but not required), add diagrams or wireframes to help explain your request if it is GUI related.
 
 **Additional notes**
 Add any other closing comments here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Reuqest
+about: Create a request for an enhancement or feature
+title: "[REQ]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the request**
+A clear and concise description of your suggested enhancement, as well as some basic rationale to allow us to balance the effort/reward for the work, if possible.
+
+**Images**
+If applicable (but not required), add diagrams or wirefames to help explain your request if it is GUI related.
+
+**Additional notes**
+Add any other closing comments here.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Describe the issue**
-PLEASE NOTE!: The issue tracker is NOT a place to seek general support. You are better served starting a conversation in the Discussions area at https://github.com/Chia-Network/chia-blockchain/discussions or in the Keybase.io #support channel. If you create a support request here, it may or may not recieve a response before being closed, and we cannot guarantee a timeply response, or one at all. In the event that your issue is deemed to be the result of a bug, we will endeavor to review and update it accordingly as such instead of closing it.
+PLEASE NOTE!: The issue tracker is NOT a place to seek general support. You are better served starting a conversation in the Discussions area at https://github.com/Chia-Network/chia-blockchain/discussions or in the Keybase.io #support channel. If you create a support request here, it may or may not receive a response before being closed, and we cannot guarantee a timely response, or one at all. In the event that your issue is deemed to be the result of a bug, we will endeavor to review and update it accordingly as such instead of closing it.
 
 **To Reproduce**
 Steps that led up to your issue.

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,23 @@
+---
+name: Support
+about: Create a support-related issue.
+title: "[help]"
+labels: Support
+assignees: ''
+
+---
+
+**Describe the issue**
+PLEASE NOTE!: The issue tracker is NOT a place to seek general support. You are better served starting a conversation in the Discussions area at https://github.com/Chia-Network/chia-blockchain/discussions or in the Keybase.io #support channel. If you create a support request here, it may or may not recieve a response before being closed, and we cannot guarantee a timeply response, or one at all. In the event that your issue is deemed to be the result of a bug, we will endeavor to review and update it accordingly as such instead of closing it.
+
+**To Reproduce**
+Steps that led up to your issue.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen before you encountered your issue.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Based on my conversation with @hoffmang9, this PR adds two new issue templates for Requests and Support to help clarify the issue creation process and reduce the number of erroneous Bug tags on new issues by submitters who reflexively click through the flow quickly. 