### PR TITLE
Shell script fix (nodejs/npm on ubuntu).

### DIFF
--- a/install-gui.sh
+++ b/install-gui.sh
@@ -17,7 +17,7 @@ if [ "$(uname)" = "Linux" ]; then
 	if type apt-get; then
 		# Debian/Ubuntu
 		UBUNTU=true
-		sudo apt-get install -y npm nodejs libxss1
+		sudo apt-get install -y nodejs libxss1
 	elif type yum && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ]; then
 		# AMZN 2
 		echo "Installing on Amazon Linux 2"


### PR DESCRIPTION
Current script throws me out of installation process with error:
```(venv) moshensky@ssd:/var/www/chia-blockchain$ sh install-gui.sh 
apt-get is /usr/bin/apt-get
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package npm
```

My environment: Ubuntu 20.04
We shouldn't install `npm` as package, it comes with `nodejs` package (accroding to https://www.npmjs.com/get-npm)
```npm is distributed with Node.js- which means that when you download Node.js, you automatically get npm installed on your computer.```