### PR TITLE
Remove the useless loop iterator variable for did_wallet

### DIFF
--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -680,7 +680,7 @@ class DIDWallet:
         private = master_sk_to_wallet_sk(self.wallet_state_manager.private_key, index)
         message = bytes(puzhash)
         sigs = [AugSchemeMPL.sign(private, message)]
-        for c in spend_bundle.coin_solutions:
+        for _ in spend_bundle.coin_solutions:
             sigs.append(AugSchemeMPL.sign(private, message))
         aggsig = AugSchemeMPL.aggregate(sigs)
         # assert AugSchemeMPL.verify(pubkey, message, aggsig)


### PR DESCRIPTION
This patch removes the useless loop iterator variable in the `did_wallet.py` file.