### PR TITLE
only copy cert files for init -c

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -223,7 +223,7 @@ def generate_ssl_for_nodes(ssl_dir: Path, ca_crt: bytes, ca_key: bytes, private:
 
 
 def copy_cert_files(cert_path: Path, new_path: Path):
-    for ext in ('*.crt', '*.key'):
+    for ext in ("*.crt', '*.key"):
         for old_path_child in cert_path.glob(ext):
             new_path_child = new_path / old_path_child.name
             copy_files_rec(old_path_child, new_path_child)

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -223,7 +223,7 @@ def generate_ssl_for_nodes(ssl_dir: Path, ca_crt: bytes, ca_key: bytes, private:
 
 
 def copy_cert_files(cert_path: Path, new_path: Path):
-    for ext in ("*.crt', '*.key"):
+    for ext in "*.crt", "*.key":
         for old_path_child in cert_path.glob(ext):
             new_path_child = new_path / old_path_child.name
             copy_files_rec(old_path_child, new_path_child)

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -222,6 +222,13 @@ def generate_ssl_for_nodes(ssl_dir: Path, ca_crt: bytes, ca_key: bytes, private:
         generate_ca_signed_cert(ca_crt, ca_key, crt_path, key_path)
 
 
+def copy_cert_files(cert_path: Path, new_path: Path):
+    for ext in ('*.crt', '*.key'):
+        for old_path_child in cert_path.glob(ext):
+            new_path_child = new_path / old_path_child.name
+            copy_files_rec(old_path_child, new_path_child)
+
+
 def init(create_certs: Optional[Path], root_path: Path):
     if create_certs is not None:
         if root_path.exists():
@@ -231,7 +238,7 @@ def init(create_certs: Optional[Path], root_path: Path):
                     print(f"Deleting your OLD CA in {ca_dir}")
                     shutil.rmtree(ca_dir)
                 print(f"Copying your CA from {create_certs} to {ca_dir}")
-                copy_files_rec(create_certs, ca_dir)
+                copy_cert_files(create_certs, ca_dir)
                 create_all_ssl(root_path)
             else:
                 print(f"** Directory {create_certs} does not exist **")


### PR DESCRIPTION
Currently when you `chia init -c <folder>` the code will copy _all_ files in `<folder>` into the config tree. It's a natural step, when copying the certs from one machine to another, to drop them in an existing network share that might contain a bunch of plots or other large files. 

This change only copies files with `crt` or `key` extension.