### PR TITLE
Use the latest git tag to determine the version

### DIFF
--- a/chia/__init__.py
+++ b/chia/__init__.py
@@ -1,7 +1,8 @@
 from pkg_resources import DistributionNotFound, get_distribution, resource_filename
+import subprocess
 
 try:
-    __version__ = get_distribution("chia-blockchain").version
+    __version__= subprocess.run(["git", "describe", "--tags"], capture_output=True).stdout.decode('UTF-8').replace("\n", "")
 except DistributionNotFound:
     # package is not installed
     __version__ = "unknown"


### PR DESCRIPTION
This will return the correct version when running `chia version`