### PR TITLE
Check for modified files, warn about dev version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,6 @@ fi
 # get submodules
 git submodule update --init mozilla-ca
 
-
 UBUNTU_PRE_2004=false
 if $UBUNTU; then
 	LSB_RELEASE=$(lsb_release -rs)

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ fi
 # get submodules
 git submodule update --init mozilla-ca
 
+
 UBUNTU_PRE_2004=false
 if $UBUNTU; then
 	LSB_RELEASE=$(lsb_release -rs)
@@ -30,6 +31,26 @@ if $UBUNTU; then
 	UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20" | bc)
 	UBUNTU_2100=$(echo "$LSB_RELEASE>=21" | bc)
 fi
+
+check_for_dev() {
+  #Checks to see if there are any modified files and warns the user that their version number will be reported as a dev version.
+  if ! git --git-dir="./.git" diff --quiet
+  then
+      # do stuff...
+      echo "There are modified files. chia version will be reported as a RELEASE.dev version."
+      while true; do
+        read -p "Continue to install dev version (Y/n)? " yn
+          case $yn in
+              [Yy]* ) break;;
+              [Nn]* ) exit;;
+              * ) break;;
+          esac
+      done
+  fi
+
+}
+
+check_for_dev
 
 # Manage npm and other install requirements on an OS specific basis
 if [ "$(uname)" = "Linux" ]; then


### PR DESCRIPTION
If you have any modified tracked files in `chia-blockchain` the version will be reported as a dev version. This is very confusing for most end-users who are trying to upgrade or install a particular version.

This change will warn the user if there are any modified files so they know why they might be getting a dev version reported when they are expecting an actual release version to be reported when they run `chia version`

```
There are modified files. chia version will be reported as a RELEASE.dev version.
Continue to install dev version (Y/n)?
```