### PR TITLE
Rust parse serialized

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -6,8 +6,8 @@ from clvm import run_program as default_run_program
 from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
 from clvm.operators import OP_REWRITE, OPERATOR_LOOKUP
-from clvm.serialize import sexp_buffer_from_stream, sexp_from_stream, sexp_to_stream
-from clvm_rs import STRICT_MODE, deserialize_and_run_program
+from clvm.serialize import sexp_from_stream, sexp_to_stream
+from clvm_rs import STRICT_MODE, deserialize_and_run_program, serialized_length
 from clvm_tools.curry import curry, uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -148,8 +148,8 @@ class SerializedProgram:
 
     @classmethod
     def parse(cls, f) -> "SerializedProgram":
-        tmp = sexp_buffer_from_stream(f)
-        return SerializedProgram.from_bytes(tmp)
+        length = serialized_length(f.getvalue()[f.tell() :])
+        return SerializedProgram.from_bytes(f.read(length))
 
     def stream(self, f):
         f.write(self._buf)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ dependencies = [
     "chiabip158==1.0",  # bip158-style wallet filters
     "chiapos==1.0.1",  # proof of space
     "clvm==0.9.6",
-    "clvm_rs==0.1.6",
+    "clvm_rs==0.1.7",
     "clvm_tools==0.4.3",
     "aiohttp==3.7.4",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
This is an attempt at speeding up Streamable deserialization of `SerializedProgram`. We need to half-parse the CLVM buffer to know the size of it.

The main part of this change is here: https://github.com/Chia-Network/clvm_rs/pull/77