### PR TITLE
Clarify units of amount and fees in wallet help dialog

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -66,7 +66,13 @@ def get_transactions_cmd(wallet_rpc_port: int, fingerprint: int, id: int, offset
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-a", "--amount", help="How much chia to send, in XCH", type=str, required=True)
 @click.option(
-    "-m", "--fee", help="Set the fees for the transaction, in XCH", type=str, default="0", show_default=True, required=True
+    "-m",
+    "--fee",
+    help="Set the fees for the transaction, in XCH",
+    type=str,
+    default="0",
+    show_default=True,
+    required=True,
 )
 @click.option("-t", "--address", help="Address to send the XCH", type=str, required=True)
 def send_cmd(wallet_rpc_port: int, fingerprint: int, id: int, amount: str, fee: str, address: str) -> None:

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -64,11 +64,11 @@ def get_transactions_cmd(wallet_rpc_port: int, fingerprint: int, id: int, offset
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
-@click.option("-a", "--amount", help="How much chia to send, in TXCH/XCH", type=str, required=True)
+@click.option("-a", "--amount", help="How much chia to send, in XCH", type=str, required=True)
 @click.option(
-    "-m", "--fee", help="Set the fees for the transaction", type=str, default="0", show_default=True, required=True
+    "-m", "--fee", help="Set the fees for the transaction, in XCH", type=str, default="0", show_default=True, required=True
 )
-@click.option("-t", "--address", help="Address to send the TXCH/XCH", type=str, required=True)
+@click.option("-t", "--address", help="Address to send the XCH", type=str, required=True)
 def send_cmd(wallet_rpc_port: int, fingerprint: int, id: int, amount: str, fee: str, address: str) -> None:
     extra_params = {"id": id, "amount": amount, "fee": fee, "address": address}
     import asyncio


### PR DESCRIPTION
1. nit: clarify that fees are also in XHC
2. Is there a reason to still be showing TXCH in newer version?