### PR TITLE
brake if end of ses list

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -635,8 +635,10 @@ class FullNode:
 
             # dont sync to wp if local peak is heavier,
             # dont ban peer, we asked for this peak
-            if response.wp.recent_chain_data[-1].reward_chain_block.weight <= self.blockchain.get_peak().weight:
-                raise RuntimeError(f"current peak is heavier than Weight proof peek: {weight_proof_peer.peer_host}")
+            current_peak = self.blockchain.get_peak()
+            if current_peak is not None:
+                if response.wp.recent_chain_data[-1].reward_chain_block.weight <= current_peak.weight:
+                    raise RuntimeError(f"current peak is heavier than Weight proof peek: {weight_proof_peer.peer_host}")
 
             try:
                 validated, fork_point, summaries = await self.weight_proof_handler.validate_weight_proof(response.wp)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -632,6 +632,9 @@ class FullNode:
             if response.wp.recent_chain_data[-1].reward_chain_block.weight != heaviest_peak_weight:
                 await weight_proof_peer.close(600)
                 raise RuntimeError(f"Weight proof had the wrong weight: {weight_proof_peer.peer_host}")
+
+            # dont sync to wp if local peak is heavier,
+            # dont ban peer, we asked for this peak
             if response.wp.recent_chain_data[-1].reward_chain_block.weight <= self.blockchain.get_peak().weight:
                 raise RuntimeError(f"current peak is heavier than Weight proof peek: {weight_proof_peer.peer_host}")
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -632,6 +632,8 @@ class FullNode:
             if response.wp.recent_chain_data[-1].reward_chain_block.weight != heaviest_peak_weight:
                 await weight_proof_peer.close(600)
                 raise RuntimeError(f"Weight proof had the wrong weight: {weight_proof_peer.peer_host}")
+            if response.wp.recent_chain_data[-1].reward_chain_block.weight <= self.blockchain.get_peak().weight:
+                raise RuntimeError(f"current peak is heavier than Weight proof peek: {weight_proof_peer.peer_host}")
 
             try:
                 validated, fork_point, summaries = await self.weight_proof_handler.validate_weight_proof(response.wp)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -616,8 +616,11 @@ class WeightProofHandler:
         fork_point_index = 0
         ses_heights = self.blockchain.get_ses_heights()
         for idx, summary_height in enumerate(ses_heights):
-            log.debug(f"check summary {idx} height {summary_height}")
+            log.info(f"check summary {idx} height {summary_height}")
             local_ses = self.blockchain.get_ses(summary_height)
+            if idx == len(received_summaries) - 1:
+                # break if end of wp summaries
+                break
             if local_ses is None or local_ses.get_hash() != received_summaries[idx].get_hash():
                 break
             fork_point_index = idx

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -616,7 +616,7 @@ class WeightProofHandler:
         fork_point_index = 0
         ses_heights = self.blockchain.get_ses_heights()
         for idx, summary_height in enumerate(ses_heights):
-            log.info(f"check summary {idx} height {summary_height}")
+            log.debug(f"check summary {idx} height {summary_height}")
             local_ses = self.blockchain.get_ses(summary_height)
             if idx == len(received_summaries) - 1:
                 # break if end of wp summaries

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -619,7 +619,7 @@ class WeightProofHandler:
             log.debug(f"check summary {idx} height {summary_height}")
             local_ses = self.blockchain.get_ses(summary_height)
             if idx == len(received_summaries) - 1:
-                # break if end of wp summaries
+                # end of wp summaries, local chain is longer or equal to wp chain
                 break
             if local_ses is None or local_ses.get_hash() != received_summaries[idx].get_hash():
                 break


### PR DESCRIPTION
throw and keep in sync if weight proof peak is not heavier then current peak we know
this can happen if we batch sync while request is pending 
