### PR TITLE
Log remote harvesters' plot count.

### DIFF
--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -288,5 +288,5 @@ class FarmerAPI:
                 }
             },
         )
-        self.farmer.log.info(str(request.passed)+ " / "+str(request.total_plots)+" plots from "+str(peer.peer_host)+" "+str(peer.peer_node_id))
+        self.farmer.log.info(f"{request.passed} / {request.total_plots} plots eligible from {peer.peer_host} {peer.peer_node_id} Proofs: {request.proofs} Challenge: {request.challenge_hash} Signage Point: {request.sp_hash}")
 

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -273,7 +273,8 @@ class FarmerAPI:
         await self.farmer.server.send_to_specific([msg], node_id)
 
     @api_request
-    async def farming_info(self, request: farmer_protocol.FarmingInfo):
+    @peer_required
+    async def farming_info(self, request: farmer_protocol.FarmingInfo, peer: ws.WSChiaConnection = None):
         self.farmer.state_changed(
             "new_farming_info",
             {
@@ -287,3 +288,5 @@ class FarmerAPI:
                 }
             },
         )
+        self.farmer.log.info(str(request.passed)+ " / "+str(request.total_plots)+" plots from "+str(peer.peer_host)+" "+str(peer.peer_node_id))
+

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -288,5 +288,6 @@ class FarmerAPI:
                 }
             },
         )
-        self.farmer.log.info(f"{request.passed} / {request.total_plots} plots eligible from {peer.peer_host} {peer.peer_node_id} Proofs: {request.proofs} Challenge: {request.challenge_hash} Signage Point: {request.sp_hash}")
-
+        self.farmer.log.info(f"{request.passed} / {request.total_plots} plots eligible from "
+                             f"{peer.peer_host} {peer.peer_node_id} Proofs: {request.proofs} "
+                             f"Challenge: {request.challenge_hash} Signage Point: {request.sp_hash}")

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -274,7 +274,7 @@ class FarmerAPI:
 
     @api_request
     @peer_required
-    async def farming_info(self, request: farmer_protocol.FarmingInfo, peer: ws.WSChiaConnection = None):
+    async def farming_info(self, request: farmer_protocol.FarmingInfo, peer: ws.WSChiaConnection):
         self.farmer.state_changed(
             "new_farming_info",
             {
@@ -288,6 +288,8 @@ class FarmerAPI:
                 }
             },
         )
-        self.farmer.log.info(f"{request.passed} / {request.total_plots} plots eligible from "
-                             f"{peer.peer_host} {peer.peer_node_id} Proofs: {request.proofs} "
-                             f"Challenge: {request.challenge_hash} Signage Point: {request.sp_hash}")
+        self.farmer.log.info(
+            f"{request.passed} / {request.total_plots} plots eligible from "
+            f"{peer.peer_host} {peer.peer_node_id} Proofs: {request.proofs} "
+            f"Challenge: {request.challenge_hash} Signage Point: {request.sp_hash}"
+        )


### PR DESCRIPTION
Add an INFO-level log line for remote harvester plot counts per received farming_info.
As of right now, there is no way to check this value otherwise, other than the GUI's "Last attempted proof" window.
This is related to [#1718](https://github.com/Chia-Network/chia-blockchain/issues/1718)