### PR TITLE
Fix macOS installation failed due to missing cargo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,12 @@ if [ "$(uname)" = "Linux" ]; then
 		# CentOS or Redhat or Fedora
 		echo "Installing on CentOS/Redhat/Fedora"
 	fi
-elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
-	echo "Installation currently requires brew on MacOS - https://brew.sh/"
+elif [ "$(uname)" = "Darwin" ]; then
+	if type brew >/dev/null 2>&1; then
+		type cargo >/dev/null 2>&1 || brew install rust
+	else
+		echo "Installation currently requires brew on MacOS - https://brew.sh/"
+	fi
 elif [ "$(uname)" = "OpenBSD" ]; then
 	export MAKE=${MAKE:-gmake}
 	export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}


### PR DESCRIPTION
close #3783

This change fixed the macOS installation failure case due to cargo/rust not being installed before calling pip.

```bash
$ sh ./install.sh
...
Collecting clvm-rs==0.1.7
  Downloading clvm_rs-0.1.7.tar.gz (470 kB)
     |████████████████████████████████| 470 kB 384 kB/s
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: /Users/weyl/dev/blockchain/chia-blockchain/venv/bin/python /Users/weyl/dev/blockchain/chia-blockchain/venv/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /var/folders/12/t63fx99x3ggd3yvgsp1wfk580000gn/T/tmp40_f6o_c
         cwd: /private/var/folders/12/t63fx99x3ggd3yvgsp1wfk580000gn/T/pip-install-t_n_puqa/clvm-rs_85c6b04db01d4c1c85f25345059de533
    Complete output (6 lines):

    Cargo, the Rust package manager, is not installed or is not on PATH.
    This package requires Rust and Cargo to compile extensions. Install it through
    the system's package manager or via https://rustup.rs/

    Checking for Rust toolchain....
    ----------------------------------------


```