### PR TITLE
implements cli options for node count settings

### DIFF
--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -15,7 +15,9 @@ def configure(
     set_log_level: str,
     enable_upnp: str,
     set_outbound_peer_count: str,
-    set_peer_count: str
+    set_peer_count: str,
+    testned: str,
+    main
 ):
     config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     change_made = False
@@ -81,6 +83,29 @@ def configure(
         config["full_node"]["target_peer_count"] = int(set_peer_count)
         print("Target peer count updated")
         change_made = True
+    if testnet is not None:
+        testnet_port = "58444"
+        testnet_introducer = "beta1_introducer.chia.net"
+        testnet = "testnet7"
+        config["full_node"]["port"] = int(testnet_port)
+        config["full_node"]["introducer_peer"]["port"] = int(testnet_port)
+        config["farmer"]["full_node_peer"]["port"] = int(testnet_port)
+        config["timelord"]["full_node_peer"]["port"] = int(testnet_port)
+        config["wallet"]["full_node_peer"]["port"] = int(testnet_port)
+        config["wallet"]["introducer_peer"]["port"] = int(testnet_port)
+        config["introducer"]["port"] = int(testnet_port)
+        config["full_node"]["introducer_peer"]["host"] = testnet_introducer
+        config["selected_network"] = testnet
+        config["harvester"]["selected_network"] = testnet
+        config["pool"]["selected_network"] = testnet
+        config["farmer"]["selected_network"] = testnet
+        config["timelord"]["selected_network"] = testnet
+        config["full_node"]["selected_network"] = testnet
+        config["ui"]["selected_network"] = testnet
+        config["introducer"]["selected_network"] = testnet
+        config["wallet"]["selected_network"] = testnet
+        print("Default full node port, introducer and network setting updated")
+        change_made = True
     if change_made:
         print("Restart any running chia services for changes to take effect")
         save_config(root_path, "config.yaml", config)
@@ -112,11 +137,16 @@ def configure(
     "--set-peer-count", help="Update the target peer count (default 60)", type=str
 )
 @click.pass_context
-def configure_cmd(
-    ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level,
-    enable_upnp, set_outbound_peer_count, set_peer_count
-):
+def configure_cmd(ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level, enable_upnp, target_outbound_peer_count, target_peer_count, testnet):
     configure(
-        ctx.obj["root_path"], set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level,
-        enable_upnp, set_outbound_peer_count, set_peer_count
+        ctx.obj["root_path"],
+        set_farmer_peer,
+        set_node_introducer,
+        set_fullnode_port,
+        set_log_level,
+        enable_upnp,
+        target_outbound_peer_count,
+        target_peer_count,
+        testnet,
+        main
     )

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -16,7 +16,7 @@ def configure(
     enable_upnp: str,
     set_outbound_peer_count: str,
     set_peer_count: str,
-    testnet: str
+    testnet: str,
 ):
     config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     change_made = False

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -14,6 +14,8 @@ def configure(
     set_fullnode_port: str,
     set_log_level: str,
     enable_upnp: str,
+    set_outbound_peer_count: str,
+    set_peer_count: str
 ):
     config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     change_made = False
@@ -71,6 +73,14 @@ def configure(
         else:
             print("uPnP disabled")
         change_made = True
+    if set_outbound_peer_count is not None:
+        config["full_node"]["target_outbound_peer_count"] = int(set_outbound_peer_count)
+        print("Target outbound peer count updated")
+        change_made = True
+    if set_peer_count is not None:
+        config["full_node"]["target_peer_count"] = int(set_peer_count)
+        print("Target peer count updated")
+        change_made = True
     if change_made:
         print("Restart any running chia services for changes to take effect")
         save_config(root_path, "config.yaml", config)
@@ -95,6 +105,18 @@ def configure(
 @click.option(
     "--enable-upnp", "--upnp", "-upnp", help="Enable or disable uPnP", type=click.Choice(["true", "t", "false", "f"])
 )
+@click.option(
+    "--set-outbound-peer-count", help="Update the target outbound peer count (default 10)", type=str
+)
+@click.option(
+    "--set-peer-count", help="Update the target peer count (default 60)", type=str
+)
 @click.pass_context
-def configure_cmd(ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level, enable_upnp):
-    configure(ctx.obj["root_path"], set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level, enable_upnp)
+def configure_cmd(
+    ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level,
+    enable_upnp, set_outbound_peer_count, set_peer_count
+):
+    configure(
+        ctx.obj["root_path"], set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level,
+        enable_upnp, set_outbound_peer_count, set_peer_count
+    )

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -16,8 +16,7 @@ def configure(
     enable_upnp: str,
     set_outbound_peer_count: str,
     set_peer_count: str,
-    testned: str,
-    main
+    testnet: str
 ):
     config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     change_made = False


### PR DESCRIPTION
There has been a fair amount of conversation in the keybase chat about reducing the number of peers as a way to resolve full nodes that are getting slammed and knocked out of sync.  This draft PR attempts to streamline that process by creating command line options for update the `target_peer_count` and `target_outbound_peer_count` settings in `config.yaml`.

Some questions I have for my reviewer(s)!

1. Is this the desired way to change node counts for performance/sync issues?  I see `inbound_rate_limit_percent` as a top-level key in the yaml - would that be a preferable strategy for turning down the inbound traffic to a node?

2. Is there anywhere where I can read about the project's philosophy about which config options get CLI arguments and which ones should be handled via edits to the yaml directly?

Will keep this draft until I add tests.