### PR TITLE
implements cli options for node count settings

### DIFF
--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -139,7 +139,17 @@ def configure(
     "--set-peer-count", help="Update the target peer count (default 60)", type=str
 )
 @click.pass_context
-def configure_cmd(ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level, enable_upnp, set_outbound_peer_count, set_peer_count, testnet):
+def configure_cmd(
+    ctx,
+    set_farmer_peer,
+    set_node_introducer,
+    set_fullnode_port,
+    set_log_level,
+    enable_upnp,
+    set_outbound_peer_count,
+    set_peer_count,
+    testnet
+):
     configure(
         ctx.obj["root_path"],
         set_farmer_peer,

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -45,9 +45,7 @@ def configure(
                 config["full_node"]["farmer_peer"]["port"] = int(port)
                 config["harvester"]["farmer_peer"]["host"] = host
                 config["harvester"]["farmer_peer"]["port"] = int(port)
-                print(
-                    "Farmer peer updated, make sure your harvester has the proper cert installed"
-                )
+                print("Farmer peer updated, make sure your harvester has the proper cert installed")
                 change_made = True
         except ValueError:
             print("Farmer address must be in format [IP:Port]")
@@ -120,12 +118,8 @@ def configure(
     help="configures for connection to testnet",
     type=click.Choice(["true", "t", "false", "f"]),
 )
-@click.option(
-    "--set-node-introducer", help="Set the introducer for node - IP:Port", type=str
-)
-@click.option(
-    "--set-farmer-peer", help="Set the farmer peer for harvester - IP:Port", type=str
-)
+@click.option("--set-node-introducer", help="Set the introducer for node - IP:Port", type=str)
+@click.option("--set-farmer-peer", help="Set the farmer peer for harvester - IP:Port", type=str)
 @click.option(
     "--set-fullnode-port",
     help="Set the port to use for the fullnode, useful for testing",
@@ -150,9 +144,7 @@ def configure(
     help="Update the target outbound peer count (default 10)",
     type=str,
 )
-@click.option(
-    "--set-peer-count", help="Update the target peer count (default 60)", type=str
-)
+@click.option("--set-peer-count", help="Update the target peer count (default 60)", type=str)
 @click.pass_context
 def configure_cmd(
     ctx,

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -141,10 +141,10 @@ def configure(
 )
 @click.option(
     "--set_outbound-peer-count",
-    help="Update the target outbound peer count (default 10)",
+    help="Update the target outbound peer count (default 8)",
     type=str,
 )
-@click.option("--set-peer-count", help="Update the target peer count (default 60)", type=str)
+@click.option("--set-peer-count", help="Update the target peer count (default 80)", type=str)
 @click.pass_context
 def configure_cmd(
     ctx,

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -45,7 +45,9 @@ def configure(
                 config["full_node"]["farmer_peer"]["port"] = int(port)
                 config["harvester"]["farmer_peer"]["host"] = host
                 config["harvester"]["farmer_peer"]["port"] = int(port)
-                print("Farmer peer updated, make sure your harvester has the proper cert installed")
+                print(
+                    "Farmer peer updated, make sure your harvester has the proper cert installed"
+                )
                 change_made = True
         except ValueError:
             print("Farmer address must be in format [IP:Port]")
@@ -113,10 +115,17 @@ def configure(
 
 @click.command("configure", short_help="Modify configuration")
 @click.option(
-    "--testnet", "-t", help="configures for connection to testnet", type=click.Choice(["true", "t", "false", "f"])
+    "--testnet",
+    "-t",
+    help="configures for connection to testnet",
+    type=click.Choice(["true", "t", "false", "f"]),
 )
-@click.option("--set-node-introducer", help="Set the introducer for node - IP:Port", type=str)
-@click.option("--set-farmer-peer", help="Set the farmer peer for harvester - IP:Port", type=str)
+@click.option(
+    "--set-node-introducer", help="Set the introducer for node - IP:Port", type=str
+)
+@click.option(
+    "--set-farmer-peer", help="Set the farmer peer for harvester - IP:Port", type=str
+)
 @click.option(
     "--set-fullnode-port",
     help="Set the port to use for the fullnode, useful for testing",
@@ -130,10 +139,16 @@ def configure(
     type=click.Choice(["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]),
 )
 @click.option(
-    "--enable-upnp", "--upnp", "-upnp", help="Enable or disable uPnP", type=click.Choice(["true", "t", "false", "f"])
+    "--enable-upnp",
+    "--upnp",
+    "-upnp",
+    help="Enable or disable uPnP",
+    type=click.Choice(["true", "t", "false", "f"]),
 )
 @click.option(
-    "--set_outbound-peer-count", help="Update the target outbound peer count (default 10)", type=str
+    "--set_outbound-peer-count",
+    help="Update the target outbound peer count (default 10)",
+    type=str,
 )
 @click.option(
     "--set-peer-count", help="Update the target peer count (default 60)", type=str
@@ -148,7 +163,7 @@ def configure_cmd(
     enable_upnp,
     set_outbound_peer_count,
     set_peer_count,
-    testnet
+    testnet,
 ):
     configure(
         ctx.obj["root_path"],

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -14,6 +14,8 @@ def configure(
     set_fullnode_port: str,
     set_log_level: str,
     enable_upnp: str,
+    set_outbound_peer_count: str,
+    set_peer_count: str,
     testnet: str,
 ):
     config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml")
@@ -72,6 +74,14 @@ def configure(
         else:
             print("uPnP disabled")
         change_made = True
+    if set_outbound_peer_count is not None:
+        config["full_node"]["target_outbound_peer_count"] = int(set_outbound_peer_count)
+        print("Target outbound peer count updated")
+        change_made = True
+    if set_peer_count is not None:
+        config["full_node"]["target_peer_count"] = int(set_peer_count)
+        print("Target peer count updated")
+        change_made = True
     if testnet is not None:
         testnet_port = "58444"
         testnet_introducer = "beta1_introducer.chia.net"
@@ -122,8 +132,14 @@ def configure(
 @click.option(
     "--enable-upnp", "--upnp", "-upnp", help="Enable or disable uPnP", type=click.Choice(["true", "t", "false", "f"])
 )
+@click.option(
+    "--set_outbound-peer-count", help="Update the target outbound peer count (default 10)", type=str
+)
+@click.option(
+    "--set-peer-count", help="Update the target peer count (default 60)", type=str
+)
 @click.pass_context
-def configure_cmd(ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level, enable_upnp, testnet):
+def configure_cmd(ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, set_log_level, enable_upnp, set_outbound_peer_count, set_peer_count, testnet):
     configure(
         ctx.obj["root_path"],
         set_farmer_peer,
@@ -131,5 +147,7 @@ def configure_cmd(ctx, set_farmer_peer, set_node_introducer, set_fullnode_port, 
         set_fullnode_port,
         set_log_level,
         enable_upnp,
+        set_outbound_peer_count,
+        set_peer_count,
         testnet,
     )


### PR DESCRIPTION
There has been a fair amount of conversation in the keybase chat about reducing the number of peers as a way to resolve full nodes that are getting slammed and knocked out of sync.  This draft PR attempts to streamline that process by creating command line options for update the `target_peer_count` and `target_outbound_peer_count` settings in `config.yaml`.

Some questions I have for my reviewer(s)!

1. Is this the desired way to change node counts for performance/sync issues?  I see `inbound_rate_limit_percent` as a top-level key in the yaml - would that be a preferable strategy for turning down the inbound traffic to a node?

2. Is there anywhere where I can read about the project's philosophy about which config options get CLI arguments and which ones should be handled via edits to the yaml directly?

Will keep this draft until I add tests.