### PR TITLE
Add pending coin removal count as well

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -449,6 +449,10 @@ class WalletRpcApi:
         pending_change = await wallet.get_pending_change_balance()
         max_send_amount = await wallet.get_max_send_amount(unspent_records)
 
+        unconfirmed_removals: Dict[bytes32, Coin] = await wallet.wallet_state_manager.unconfirmed_removals_for_wallet(
+            wallet_id
+        )
+
         wallet_balance = {
             "wallet_id": wallet_id,
             "confirmed_wallet_balance": balance,
@@ -457,6 +461,7 @@ class WalletRpcApi:
             "pending_change": pending_change,
             "max_send_amount": max_send_amount,
             "unspent_coin_count": len(unspent_records),
+            "pending_coin_removal_count": len(unconfirmed_removals),
         }
 
         return {"wallet_balance": wallet_balance}


### PR DESCRIPTION
Initially, I assumed `unspent_records` was going to already have the pending removals removed, but it does not, so I need the pending removal count as well, and then I can do additional math downstream to get the particular numbers I need