### PR TITLE
quick fix to update out-of-date CLI reference to close issue 4397

### DIFF
--- a/chia/cmds/init.py
+++ b/chia/cmds/init.py
@@ -15,7 +15,7 @@ def init_cmd(ctx: click.Context, create_certs: str):
     Create a new configuration or migrate from previous versions to current
 
     \b
-    Follow these steps to create new certifcates for a remote harvester:
+    Follow these steps to create new certificates for a remote harvester:
     - Make a copy of your Farming Machine CA directory: ~/.chia/[version]/config/ssl/ca
     - Shut down all chia daemon processes with `chia stop all -d`
     - Run `chia init -c [directory]` on your remote harvester,

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -21,7 +21,7 @@ def generate_and_print():
     mnemonic = generate_mnemonic()
     print("Generating private key. Mnemonic (24 secret words):")
     print(mnemonic)
-    print('Note that this key has not been added to the keychain. Run chia keys add')
+    print("Note that this key has not been added to the keychain. Run chia keys add")
     return mnemonic
 
 

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -21,7 +21,7 @@ def generate_and_print():
     mnemonic = generate_mnemonic()
     print("Generating private key. Mnemonic (24 secret words):")
     print(mnemonic)
-    print('Note that this key has not been added to the keychain. Run chia keys add "[MNEMONICS]" to add')
+    print('Note that this key has not been added to the keychain. Run chia keys add')
     return mnemonic
 
 

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -21,7 +21,7 @@ def generate_and_print():
     mnemonic = generate_mnemonic()
     print("Generating private key. Mnemonic (24 secret words):")
     print(mnemonic)
-    print('Note that this key has not been added to the keychain. Run chia keys add_seed -m "[MNEMONICS]" to add')
+    print('Note that this key has not been added to the keychain. Run chia keys add "[MNEMONICS]" to add')
     return mnemonic
 
 

--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -125,7 +125,7 @@ def create_cmd(
             self.exclude_final_dir = exclude_final_dir
 
     if size < 32 and not override_k:
-        print("k=32 is the minimun size for farming.")
+        print("k=32 is the minimum size for farming.")
         print("If you are testing and you want to use smaller size please add the --override-k flag.")
         sys.exit(1)
     elif size < 25 and override_k:


### PR DESCRIPTION
Minor quick fix for the out of date CLI help text output to say `chia keys add` instead of `chia keys add_seed -m [mnemonic]'. This closes #4397  

(made an additional typo pass on  the entire cmds/ folder and corrected 3 others, including once that closes #4243 