### PR TITLE
optional tx filter when fetching headers

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -637,7 +637,7 @@ class Blockchain(BlockchainInterface):
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         return await self.block_store.get_block_records_in_range(start, stop)
 
-    async def get_header_blocks_in_range(self, start: int, stop: int,no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
         hashes = []
         for height in range(start, stop + 1):
             if self.contains_height(uint32(height)):
@@ -670,7 +670,6 @@ class Blockchain(BlockchainInterface):
             header_blocks[header.header_hash] = header
 
         return header_blocks
-
 
     async def get_header_block_by_height(self, height: int, header_hash: bytes32) -> Optional[HeaderBlock]:
         header_dict: Dict[bytes32, HeaderBlock] = await self.get_header_blocks_in_range(height, height)

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -49,7 +49,7 @@ class BlockchainInterface:
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         pass
 
-    async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(self, start: int, stop: int,no_tx_filter:bool=False) -> Dict[bytes32, HeaderBlock]:
         pass
 
     async def get_header_block_by_height(self, height: int, header_hash: bytes32) -> Optional[HeaderBlock]:

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -49,7 +49,9 @@ class BlockchainInterface:
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         pass
 
-    async def get_header_blocks_in_range(self, start: int, stop: int,no_tx_filter:bool=False) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(
+        self, start: int, stop: int, no_tx_filter: bool = False
+    ) -> Dict[bytes32, HeaderBlock]:
         pass
 
     async def get_header_block_by_height(self, height: int, header_hash: bytes32) -> Optional[HeaderBlock]:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1841,7 +1841,7 @@ class FullNode:
                         break
                     stop_height = min(h + 99, max_height)
                     assert min_height is not None
-                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height,True)
+                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height, True)
                     records: Dict[bytes32, BlockRecord] = {}
                     if sanitize_weight_proof_only:
                         records = await self.blockchain.get_block_records_in_range(min_height, stop_height)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1841,7 +1841,7 @@ class FullNode:
                         break
                     stop_height = min(h + 99, max_height)
                     assert min_height is not None
-                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height)
+                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height,True)
                     records: Dict[bytes32, BlockRecord] = {}
                     if sanitize_weight_proof_only:
                         records = await self.blockchain.get_block_records_in_range(min_height, stop_height)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -177,7 +177,7 @@ class WeightProofHandler:
                 min_height = ses_height - 1
                 break
         log.debug(f"start {min_height} end {tip_height}")
-        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height)
+        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height, True)
         blocks = await self.blockchain.get_block_records_in_range(min_height, tip_height)
         ses_count = 0
         curr_height = tip_height
@@ -275,7 +275,7 @@ class WeightProofHandler:
             start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS
         )
         header_blocks = await self.blockchain.get_header_blocks_in_range(
-            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS
+            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS, True
         )
         curr: Optional[HeaderBlock] = header_blocks[se_start.header_hash]
         height = se_start.height

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -74,7 +74,7 @@ class BlockCache(BlockchainInterface):
     def add_block_record(self, block: BlockRecord):
         self._block_records[block.header_hash] = block
 
-    async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
         return self._headers
 
     async def persist_sub_epoch_challenge_segments(

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -421,7 +421,7 @@ class WalletBlockchain(BlockchainInterface):
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         return await self.block_store.get_block_records_in_range(start, stop)
 
-    async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
         return await self.block_store.get_header_blocks_in_range(start, stop)
 
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:


### PR DESCRIPTION
Getting the tx filter when calling get_header_blocks_in_range is not always necessary
getting the tx filter requires a call to get_coins_added_at_height and a call to get_coins_removed_at_height for each block in the range.

adding this optional will reduce load when creating weight proofs and broadcasting uncompact blocks 