### PR TITLE
optional no_tx_filter

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -638,7 +638,7 @@ class Blockchain(BlockchainInterface):
         return await self.block_store.get_block_records_in_range(start, stop)
 
     async def get_header_blocks_in_range(
-        self, start: int, stop: int, no_tx_filter: bool = False
+        self, start: int, stop: int, tx_filter: bool = True
     ) -> Dict[bytes32, HeaderBlock]:
         hashes = []
         for height in range(start, stop + 1):
@@ -659,7 +659,7 @@ class Blockchain(BlockchainInterface):
         for block in blocks:
             if self.height_to_hash(block.height) != block.header_hash:
                 raise ValueError(f"Block at {block.header_hash} is no longer in the blockchain (it's in a fork)")
-            if no_tx_filter:
+            if tx_filter is False:
                 header = get_block_header(block, [], [])
             else:
                 tx_additions: List[CoinRecord] = [
@@ -674,9 +674,9 @@ class Blockchain(BlockchainInterface):
         return header_blocks
 
     async def get_header_block_by_height(
-        self, height: int, header_hash: bytes32, no_tx_filter: bool = False
+        self, height: int, header_hash: bytes32, tx_filter: bool = True
     ) -> Optional[HeaderBlock]:
-        header_dict: Dict[bytes32, HeaderBlock] = await self.get_header_blocks_in_range(height, height)
+        header_dict: Dict[bytes32, HeaderBlock] = await self.get_header_blocks_in_range(height, height, tx_filter)
         if len(header_dict) == 0:
             return None
         if header_hash not in header_dict:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -673,7 +673,9 @@ class Blockchain(BlockchainInterface):
 
         return header_blocks
 
-    async def get_header_block_by_height(self, height: int, header_hash: bytes32) -> Optional[HeaderBlock]:
+    async def get_header_block_by_height(
+        self, height: int, header_hash: bytes32, no_tx_filter: bool = False
+    ) -> Optional[HeaderBlock]:
         header_dict: Dict[bytes32, HeaderBlock] = await self.get_header_blocks_in_range(height, height)
         if len(header_dict) == 0:
             return None

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -637,7 +637,9 @@ class Blockchain(BlockchainInterface):
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         return await self.block_store.get_block_records_in_range(start, stop)
 
-    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(
+        self, start: int, stop: int, no_tx_filter: bool = False
+    ) -> Dict[bytes32, HeaderBlock]:
         hashes = []
         for height in range(start, stop + 1):
             if self.contains_height(uint32(height)):

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -637,7 +637,7 @@ class Blockchain(BlockchainInterface):
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         return await self.block_store.get_block_records_in_range(start, stop)
 
-    async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
         hashes = []
         for height in range(start, stop + 1):
             if self.contains_height(uint32(height)):
@@ -657,13 +657,16 @@ class Blockchain(BlockchainInterface):
         for block in blocks:
             if self.height_to_hash(block.height) != block.header_hash:
                 raise ValueError(f"Block at {block.header_hash} is no longer in the blockchain (it's in a fork)")
-            tx_additions: List[CoinRecord] = [
-                c for c in (await self.coin_store.get_coins_added_at_height(block.height)) if not c.coinbase
-            ]
-            removed: List[CoinRecord] = await self.coin_store.get_coins_removed_at_height(block.height)
-            header = get_block_header(
-                block, [record.coin for record in tx_additions], [record.coin.name() for record in removed]
-            )
+            if no_tx_filter:
+                header = get_block_header(block, [], [])
+            else:
+                tx_additions: List[CoinRecord] = [
+                    c for c in (await self.coin_store.get_coins_added_at_height(block.height)) if not c.coinbase
+                ]
+                removed: List[CoinRecord] = await self.coin_store.get_coins_removed_at_height(block.height)
+                header = get_block_header(
+                    block, [record.coin for record in tx_additions], [record.coin.name() for record in removed]
+                )
             header_blocks[header.header_hash] = header
 
         return header_blocks

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -49,7 +49,9 @@ class BlockchainInterface:
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         pass
 
-    async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(
+        self, start: int, stop: int, no_tx_filter: bool = False
+    ) -> Dict[bytes32, HeaderBlock]:
         pass
 
     async def get_header_block_by_height(self, height: int, header_hash: bytes32) -> Optional[HeaderBlock]:

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -50,12 +50,12 @@ class BlockchainInterface:
         pass
 
     async def get_header_blocks_in_range(
-        self, start: int, stop: int, no_tx_filter: bool = False
+        self, start: int, stop: int, tx_filter: bool = True
     ) -> Dict[bytes32, HeaderBlock]:
         pass
 
     async def get_header_block_by_height(
-        self, height: int, header_hash: bytes32, no_tx_filter: bool = False
+        self, height: int, header_hash: bytes32, tx_filter: bool = True
     ) -> Optional[HeaderBlock]:
         pass
 

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -54,7 +54,9 @@ class BlockchainInterface:
     ) -> Dict[bytes32, HeaderBlock]:
         pass
 
-    async def get_header_block_by_height(self, height: int, header_hash: bytes32) -> Optional[HeaderBlock]:
+    async def get_header_block_by_height(
+        self, height: int, header_hash: bytes32, no_tx_filter: bool = False
+    ) -> Optional[HeaderBlock]:
         pass
 
     async def get_block_records_at(self, heights: List[uint32]) -> List[BlockRecord]:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1664,7 +1664,7 @@ class FullNode:
         if not vdf_proof.is_valid(self.constants, ClassgroupElement.get_default_element(), vdf_info):
             self.log.error(f"Received compact vdf proof is not valid: {vdf_proof}.")
             return False
-        header_block = await self.blockchain.get_header_block_by_height(height, header_hash)
+        header_block = await self.blockchain.get_header_block_by_height(height, header_hash, True)
         if header_block is None:
             self.log.error(f"Can't find block for given compact vdf. Height: {height} Header hash: {header_hash}")
             return False
@@ -1737,7 +1737,7 @@ class FullNode:
         is_fully_compactified = await self.block_store.is_fully_compactified(request.header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             return False
-        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash)
+        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, True)
         if header_block is None:
             return None
         field_vdf = CompressibleVDFField(int(request.field_vdf))
@@ -1750,7 +1750,7 @@ class FullNode:
                 await self.respond_compact_vdf(response, peer)
 
     async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: ws.WSChiaConnection):
-        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash)
+        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, True)
         if header_block is None:
             return None
         vdf_proof: Optional[VDFProof] = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1845,7 +1845,7 @@ class FullNode:
                         break
                     stop_height = min(h + 99, max_height)
                     assert min_height is not None
-                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height, True)
+                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height, tx_filter=True)
                     records: Dict[bytes32, BlockRecord] = {}
                     if sanitize_weight_proof_only:
                         records = await self.blockchain.get_block_records_in_range(min_height, stop_height)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1664,7 +1664,7 @@ class FullNode:
         if not vdf_proof.is_valid(self.constants, ClassgroupElement.get_default_element(), vdf_info):
             self.log.error(f"Received compact vdf proof is not valid: {vdf_proof}.")
             return False
-        header_block = await self.blockchain.get_header_block_by_height(height, header_hash, False)
+        header_block = await self.blockchain.get_header_block_by_height(height, header_hash, tx_filter=False)
         if header_block is None:
             self.log.error(f"Can't find block for given compact vdf. Height: {height} Header hash: {header_hash}")
             return False
@@ -1737,7 +1737,9 @@ class FullNode:
         is_fully_compactified = await self.block_store.is_fully_compactified(request.header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             return False
-        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, False)
+        header_block = await self.blockchain.get_header_block_by_height(
+            request.height, request.header_hash, tx_filter=False
+        )
         if header_block is None:
             return None
         field_vdf = CompressibleVDFField(int(request.field_vdf))
@@ -1750,7 +1752,9 @@ class FullNode:
                 await self.respond_compact_vdf(response, peer)
 
     async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: ws.WSChiaConnection):
-        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, False)
+        header_block = await self.blockchain.get_header_block_by_height(
+            request.height, request.header_hash, tx_filter=False
+        )
         if header_block is None:
             return None
         vdf_proof: Optional[VDFProof] = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1664,7 +1664,7 @@ class FullNode:
         if not vdf_proof.is_valid(self.constants, ClassgroupElement.get_default_element(), vdf_info):
             self.log.error(f"Received compact vdf proof is not valid: {vdf_proof}.")
             return False
-        header_block = await self.blockchain.get_header_block_by_height(height, header_hash, True)
+        header_block = await self.blockchain.get_header_block_by_height(height, header_hash, False)
         if header_block is None:
             self.log.error(f"Can't find block for given compact vdf. Height: {height} Header hash: {header_hash}")
             return False
@@ -1737,7 +1737,7 @@ class FullNode:
         is_fully_compactified = await self.block_store.is_fully_compactified(request.header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             return False
-        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, True)
+        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, False)
         if header_block is None:
             return None
         field_vdf = CompressibleVDFField(int(request.field_vdf))
@@ -1750,7 +1750,7 @@ class FullNode:
                 await self.respond_compact_vdf(response, peer)
 
     async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: ws.WSChiaConnection):
-        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, True)
+        header_block = await self.blockchain.get_header_block_by_height(request.height, request.header_hash, False)
         if header_block is None:
             return None
         vdf_proof: Optional[VDFProof] = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1841,7 +1841,7 @@ class FullNode:
                         break
                     stop_height = min(h + 99, max_height)
                     assert min_height is not None
-                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height)
+                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height, True)
                     records: Dict[bytes32, BlockRecord] = {}
                     if sanitize_weight_proof_only:
                         records = await self.blockchain.get_block_records_in_range(min_height, stop_height)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1845,7 +1845,7 @@ class FullNode:
                         break
                     stop_height = min(h + 99, max_height)
                     assert min_height is not None
-                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height, tx_filter=True)
+                    headers = await self.blockchain.get_header_blocks_in_range(min_height, stop_height, tx_filter=False)
                     records: Dict[bytes32, BlockRecord] = {}
                     if sanitize_weight_proof_only:
                         records = await self.blockchain.get_block_records_in_range(min_height, stop_height)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -177,7 +177,7 @@ class WeightProofHandler:
                 min_height = ses_height - 1
                 break
         log.debug(f"start {min_height} end {tip_height}")
-        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height)
+        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height, True)
         blocks = await self.blockchain.get_block_records_in_range(min_height, tip_height)
         ses_count = 0
         curr_height = tip_height
@@ -275,7 +275,7 @@ class WeightProofHandler:
             start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS
         )
         header_blocks = await self.blockchain.get_header_blocks_in_range(
-            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS
+            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS, True
         )
         curr: Optional[HeaderBlock] = header_blocks[se_start.header_hash]
         height = se_start.height

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -177,7 +177,7 @@ class WeightProofHandler:
                 min_height = ses_height - 1
                 break
         log.debug(f"start {min_height} end {tip_height}")
-        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height, True)
+        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height, False)
         blocks = await self.blockchain.get_block_records_in_range(min_height, tip_height)
         ses_count = 0
         curr_height = tip_height
@@ -275,7 +275,7 @@ class WeightProofHandler:
             start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS
         )
         header_blocks = await self.blockchain.get_header_blocks_in_range(
-            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS, True
+            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS, False
         )
         curr: Optional[HeaderBlock] = header_blocks[se_start.header_hash]
         height = se_start.height

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -177,7 +177,7 @@ class WeightProofHandler:
                 min_height = ses_height - 1
                 break
         log.debug(f"start {min_height} end {tip_height}")
-        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height, False)
+        headers = await self.blockchain.get_header_blocks_in_range(min_height, tip_height, tx_filter=False)
         blocks = await self.blockchain.get_block_records_in_range(min_height, tip_height)
         ses_count = 0
         curr_height = tip_height
@@ -275,7 +275,7 @@ class WeightProofHandler:
             start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS
         )
         header_blocks = await self.blockchain.get_header_blocks_in_range(
-            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS, False
+            start_height, ses_block.height + self.constants.MAX_SUB_SLOT_BLOCKS, tx_filter=False
         )
         curr: Optional[HeaderBlock] = header_blocks[se_start.header_hash]
         height = se_start.height

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -75,7 +75,7 @@ class BlockCache(BlockchainInterface):
         self._block_records[block.header_hash] = block
 
     async def get_header_blocks_in_range(
-        self, start: int, stop: int, no_tx_filter: bool = False
+        self, start: int, stop: int, tx_filter: bool = True
     ) -> Dict[bytes32, HeaderBlock]:
         return self._headers
 

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -74,7 +74,9 @@ class BlockCache(BlockchainInterface):
     def add_block_record(self, block: BlockRecord):
         self._block_records[block.header_hash] = block
 
-    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(
+        self, start: int, stop: int, no_tx_filter: bool = False
+    ) -> Dict[bytes32, HeaderBlock]:
         return self._headers
 
     async def persist_sub_epoch_challenge_segments(

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -74,7 +74,7 @@ class BlockCache(BlockchainInterface):
     def add_block_record(self, block: BlockRecord):
         self._block_records[block.header_hash] = block
 
-    async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
         return self._headers
 
     async def persist_sub_epoch_challenge_segments(

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -421,7 +421,7 @@ class WalletBlockchain(BlockchainInterface):
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         return await self.block_store.get_block_records_in_range(start, stop)
 
-    async def get_header_blocks_in_range(self, start: int, stop: int) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
         return await self.block_store.get_header_blocks_in_range(start, stop)
 
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -421,7 +421,9 @@ class WalletBlockchain(BlockchainInterface):
     async def get_block_records_in_range(self, start: int, stop: int) -> Dict[bytes32, BlockRecord]:
         return await self.block_store.get_block_records_in_range(start, stop)
 
-    async def get_header_blocks_in_range(self, start: int, stop: int, no_tx_filter=False) -> Dict[bytes32, HeaderBlock]:
+    async def get_header_blocks_in_range(
+        self, start: int, stop: int, no_tx_filter: bool = False
+    ) -> Dict[bytes32, HeaderBlock]:
         return await self.block_store.get_header_blocks_in_range(start, stop)
 
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -422,7 +422,7 @@ class WalletBlockchain(BlockchainInterface):
         return await self.block_store.get_block_records_in_range(start, stop)
 
     async def get_header_blocks_in_range(
-        self, start: int, stop: int, no_tx_filter: bool = False
+        self, start: int, stop: int, tx_filter: bool = True
     ) -> Dict[bytes32, HeaderBlock]:
         return await self.block_store.get_header_blocks_in_range(start, stop)
 

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import multiprocessing
 import time
-from _datetime import datetime
 from dataclasses import replace
 from secrets import token_bytes
 
@@ -2557,7 +2556,6 @@ class TestReorgs:
             result, error_code, _ = await b.receive_block(block)
             assert error_code is None
 
-
     @pytest.mark.asyncio
     async def test_get_header_blocks_in_range_tx_filter(self, empty_blockchain):
         b = empty_blockchain
@@ -2583,9 +2581,11 @@ class TestReorgs:
         err = (await b.receive_block(blocks[-1]))[1]
         assert not err
 
-        blocks_with_filter = await b.get_header_blocks_in_range(0,10,tx_filter=True)
-        blocks_without_filter = await b.get_header_blocks_in_range(0,10,tx_filter=False)
+        blocks_with_filter = await b.get_header_blocks_in_range(0, 10, tx_filter=True)
+        blocks_without_filter = await b.get_header_blocks_in_range(0, 10, tx_filter=False)
         header_hash = blocks[-1].header_hash
-        assert blocks_with_filter[header_hash].transactions_filter != blocks_without_filter[header_hash].transactions_filter
+        assert (
+            blocks_with_filter[header_hash].transactions_filter
+            != blocks_without_filter[header_hash].transactions_filter
+        )
         assert blocks_with_filter[header_hash].header_hash == blocks_without_filter[header_hash].header_hash
-

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import multiprocessing
 import time
+from _datetime import datetime
 from dataclasses import replace
 from secrets import token_bytes
 
@@ -2555,3 +2556,36 @@ class TestReorgs:
         for block in blocks_fork:
             result, error_code, _ = await b.receive_block(block)
             assert error_code is None
+
+
+    @pytest.mark.asyncio
+    async def test_get_header_blocks_in_range_tx_filter(self, empty_blockchain):
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(
+            3,
+            guarantee_transaction_block=True,
+            pool_reward_puzzle_hash=bt.pool_ph,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+        )
+        assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        wt: WalletTool = bt.get_pool_wallet_tool()
+        tx: SpendBundle = wt.generate_signed_transaction(
+            10, wt.get_new_puzzlehash(), list(blocks[2].get_included_reward_coins())[0]
+        )
+        blocks = bt.get_consecutive_blocks(
+            1,
+            block_list_input=blocks,
+            guarantee_transaction_block=True,
+            transaction_data=tx,
+        )
+        err = (await b.receive_block(blocks[-1]))[1]
+        assert not err
+
+        blocks_with_filter = await b.get_header_blocks_in_range(0,10,tx_filter=True)
+        blocks_without_filter = await b.get_header_blocks_in_range(0,10,tx_filter=False)
+        header_hash = blocks[-1].header_hash
+        assert blocks_with_filter[header_hash].transactions_filter != blocks_without_filter[header_hash].transactions_filter
+        assert blocks_with_filter[header_hash].header_hash == blocks_without_filter[header_hash].header_hash
+


### PR DESCRIPTION
Getting the tx filter when calling get_header_blocks_in_range is not always necessary
getting the tx filter requires a call to get_coins_added_at_height and a call to get_coins_removed_at_height for each block in the range.

Avoiding the transaction filter creation when creating weight proofs and handling of compact blocks will reduce load 


these are logs for creating a proof from mainnet db main
12:00:20 chia.full_node.weight_proof: INFO sub_epochs: 685 time to create proof 50.316962242126465

skipping the tx filter
11:58:19 chia.full_node.weight_proof: INFO sub_epochs: 685 time to create proof 3.3708062171936035
