### PR TITLE
Formatting of returns in /rpc

### DIFF
--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -39,6 +39,7 @@ class FarmerRpcApi:
                     "wallet_ui",
                 )
             ]
+
         return []
 
     async def get_signage_point(self, request: Dict) -> Dict:
@@ -58,6 +59,7 @@ class FarmerRpcApi:
                         },
                         "proofs": pospaces,
                     }
+
         raise ValueError(f"Signage point {sp_hash.hex()} not found")
 
     async def get_signage_points(self, _: Dict) -> Dict:
@@ -78,6 +80,7 @@ class FarmerRpcApi:
                         "proofs": pospaces,
                     }
                 )
+
         return {"signage_points": result}
 
     async def get_reward_targets(self, request: Dict) -> Dict:

--- a/chia/rpc/farmer_rpc_client.py
+++ b/chia/rpc/farmer_rpc_client.py
@@ -32,6 +32,7 @@ class FarmerRpcClient(RpcClient):
             return_dict["have_pool_sk"] = response["have_pool_sk"]
         if "have_farmer_sk" in response:
             return_dict["have_farmer_sk"] = response["have_farmer_sk"]
+
         return return_dict
 
     async def set_reward_targets(self, farmer_target: Optional[str] = None, pool_target: Optional[str] = None) -> Dict:
@@ -40,4 +41,5 @@ class FarmerRpcClient(RpcClient):
             request["farmer_target"] = farmer_target
         if pool_target is not None:
             request["pool_target"] = pool_target
+
         return await self.fetch("set_reward_targets", request)

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -59,6 +59,7 @@ class FullNodeRpcApi:
                 )
             )
             return payloads
+
         return []
 
     async def get_initial_freeze_period(self, _: Dict):
@@ -87,6 +88,7 @@ class FullNodeRpcApi:
                 },
             }
             return res
+
         peak: Optional[BlockRecord] = self.service.blockchain.get_peak()
 
         if peak is not None and peak.height > 0:
@@ -189,6 +191,7 @@ class FullNodeRpcApi:
             if not exclude_hh:
                 json["header_hash"] = block.header_hash.hex()
             json_blocks.append(json)
+
         return {"blocks": json_blocks}
 
     async def get_block_records(self, request: Dict) -> Optional[Dict]:
@@ -217,6 +220,7 @@ class FullNodeRpcApi:
                 raise ValueError(f"Block {header_hash.hex()} does not exist")
 
             records.append(record)
+
         return {"block_records": records}
 
     async def get_block_record_by_height(self, request: Dict) -> Optional[Dict]:
@@ -236,6 +240,7 @@ class FullNodeRpcApi:
             record = await self.service.blockchain.block_store.get_block_record(header_hash)
         if record is None:
             raise ValueError(f"Block {header_hash} does not exist")
+
         return {"block_record": record}
 
     async def get_block_record(self, request: Dict):
@@ -271,6 +276,7 @@ class FullNodeRpcApi:
                     b"",
                 )
                 response_headers.append(unfinished_header_block)
+
         return {"headers": response_headers}
 
     async def get_network_space(self, request: Dict) -> Optional[Dict]:
@@ -385,6 +391,7 @@ class FullNodeRpcApi:
         if status == MempoolInclusionStatus.FAILED:
             assert error is not None
             raise ValueError(f"Failed to include transaction {spend_name}, error {error.name}")
+
         return {
             "status": status.name,
         }
@@ -414,6 +421,7 @@ class FullNodeRpcApi:
         spends = {}
         for tx_id, item in self.service.mempool_manager.mempool.spends.items():
             spends[tx_id.hex()] = item
+
         return {"mempool_items": spends}
 
     async def get_mempool_item_by_tx_id(self, request: Dict) -> Optional[Dict]:

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -24,6 +24,7 @@ class FullNodeRpcClient(RpcClient):
         response = await self.fetch("get_blockchain_state", {})
         if response["blockchain_state"]["peak"] is not None:
             response["blockchain_state"]["peak"] = BlockRecord.from_json_dict(response["blockchain_state"]["peak"])
+
         return response["blockchain_state"]
 
     async def get_block(self, header_hash) -> Optional[FullBlock]:
@@ -31,6 +32,7 @@ class FullNodeRpcClient(RpcClient):
             response = await self.fetch("get_block", {"header_hash": header_hash.hex()})
         except Exception:
             return None
+
         return FullBlock.from_json_dict(response["block"])
 
     async def get_block_record_by_height(self, height) -> Optional[BlockRecord]:
@@ -38,6 +40,7 @@ class FullNodeRpcClient(RpcClient):
             response = await self.fetch("get_block_record_by_height", {"height": height})
         except Exception:
             return None
+
         return BlockRecord.from_json_dict(response["block_record"])
 
     async def get_block_record(self, header_hash) -> Optional[BlockRecord]:
@@ -47,6 +50,7 @@ class FullNodeRpcClient(RpcClient):
                 return None
         except Exception:
             return None
+
         return BlockRecord.from_json_dict(response["block_record"])
 
     async def get_unfinished_block_headers(self) -> List[UnfinishedHeaderBlock]:
@@ -70,6 +74,7 @@ class FullNodeRpcClient(RpcClient):
             )
         except Exception:
             return None
+
         return network_space_bytes_estimate["space"]
 
     async def get_coin_records_by_puzzle_hash(
@@ -84,9 +89,10 @@ class FullNodeRpcClient(RpcClient):
             d["start_height"] = start_height
         if end_height is not None:
             d["end_height"] = end_height
+
         return [
             CoinRecord.from_json_dict(coin)
-            for coin in ((await self.fetch("get_coin_records_by_puzzle_hash", d))["coin_records"])
+            for coin in (await self.fetch("get_coin_records_by_puzzle_hash", d))["coin_records"]
         ]
 
     async def get_coin_records_by_puzzle_hashes(
@@ -102,9 +108,10 @@ class FullNodeRpcClient(RpcClient):
             d["start_height"] = start_height
         if end_height is not None:
             d["end_height"] = end_height
+
         return [
             CoinRecord.from_json_dict(coin)
-            for coin in ((await self.fetch("get_coin_records_by_puzzle_hashes", d))["coin_records"])
+            for coin in (await self.fetch("get_coin_records_by_puzzle_hashes", d))["coin_records"]
         ]
 
     async def get_additions_and_removals(self, header_hash: bytes32) -> Tuple[List[CoinRecord], List[CoinRecord]]:
@@ -112,12 +119,10 @@ class FullNodeRpcClient(RpcClient):
             response = await self.fetch("get_additions_and_removals", {"header_hash": header_hash.hex()})
         except Exception:
             return [], []
-        removals = []
-        additions = []
-        for coin_record in response["removals"]:
-            removals.append(CoinRecord.from_json_dict(coin_record))
-        for coin_record in response["additions"]:
-            additions.append(CoinRecord.from_json_dict(coin_record))
+
+        removals = [CoinRecord.from_json_dict(coin_record) for coin_record in response["removals"]]
+        additions = [CoinRecord.from_json_dict(coin_record) for coin_record in response["additions"]]
+
         return additions, removals
 
     async def get_block_records(self, start: int, end: int) -> List:
@@ -127,7 +132,9 @@ class FullNodeRpcClient(RpcClient):
                 return []
         except Exception:
             return []
+
         # TODO: return block records
+        # ??
         return response["block_records"]
 
     async def push_tx(self, spend_bundle: SpendBundle):
@@ -142,6 +149,7 @@ class FullNodeRpcClient(RpcClient):
         converted: Dict[bytes32, Dict] = {}
         for tx_id_hex, item in response["mempool_items"].items():
             converted[bytes32(hexstr_to_bytes(tx_id_hex))] = item
+
         return converted
 
     async def get_mempool_item_by_tx_id(self, tx_id: bytes32) -> Optional[Dict]:

--- a/chia/rpc/harvester_rpc_api.py
+++ b/chia/rpc/harvester_rpc_api.py
@@ -24,6 +24,7 @@ class HarvesterRpcApi:
             data = await self.get_plots({})
             payload = create_payload_dict("get_plots", data, self.service_name, "wallet_ui")
             return [payload]
+
         return []
 
     async def get_plots(self, request: Dict) -> Dict:
@@ -40,15 +41,19 @@ class HarvesterRpcApi:
 
     async def delete_plot(self, request: Dict) -> Dict:
         filename = request["filename"]
-        if self.service.delete_plot(filename):
-            return {}
-        raise ValueError(f"Not able to delete file {filename}")
+        if not self.service.delete_plot(filename):
+            raise ValueError(f"Not able to delete file {filename}")
+            return None
+
+        return {}
 
     async def add_plot_directory(self, request: Dict) -> Dict:
         directory_name = request["dirname"]
-        if await self.service.add_plot_directory(directory_name):
-            return {}
-        raise ValueError(f"Did not add plot directory {directory_name}")
+        if not await self.service.add_plot_directory(directory_name):
+            raise ValueError(f"Did not add plot directory {directory_name}")
+            return None
+
+        return {}
 
     async def get_plot_directories(self, request: Dict) -> Dict:
         plot_dirs = await self.service.get_plot_directories()
@@ -56,6 +61,8 @@ class HarvesterRpcApi:
 
     async def remove_plot_directory(self, request: Dict) -> Dict:
         directory_name = request["dirname"]
-        if await self.service.remove_plot_directory(directory_name):
-            return {}
-        raise ValueError(f"Did not remove plot directory {directory_name}")
+        if not await self.service.remove_plot_directory(directory_name):
+            raise ValueError(f"Did not remove plot directory {directory_name}")
+            return None
+
+        return {}

--- a/chia/rpc/harvester_rpc_api.py
+++ b/chia/rpc/harvester_rpc_api.py
@@ -43,7 +43,6 @@ class HarvesterRpcApi:
         filename = request["filename"]
         if not self.service.delete_plot(filename):
             raise ValueError(f"Not able to delete file {filename}")
-            return None
 
         return {}
 
@@ -51,7 +50,6 @@ class HarvesterRpcApi:
         directory_name = request["dirname"]
         if not await self.service.add_plot_directory(directory_name):
             raise ValueError(f"Did not add plot directory {directory_name}")
-            return None
 
         return {}
 
@@ -63,6 +61,5 @@ class HarvesterRpcApi:
         directory_name = request["dirname"]
         if not await self.service.remove_plot_directory(directory_name):
             raise ValueError(f"Did not remove plot directory {directory_name}")
-            return None
 
         return {}

--- a/chia/rpc/rpc_client.py
+++ b/chia/rpc/rpc_client.py
@@ -43,12 +43,14 @@ class RpcClient:
             res_json = await response.json()
             if not res_json["success"]:
                 raise ValueError(res_json)
+
             return res_json
 
     async def get_connections(self) -> List[Dict]:
         response = await self.fetch("get_connections", {})
         for connection in response["connections"]:
             connection["node_id"] = hexstr_to_bytes(connection["node_id"])
+
         return response["connections"]
 
     async def open_connection(self, host: str, port: int) -> Dict:

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -100,6 +100,7 @@ class RpcServer:
     async def get_connections(self, request: Dict) -> Dict:
         if self.rpc_api.service.server is None:
             raise ValueError("Global connections is not set")
+
         if self.rpc_api.service.server._local_type is NodeType.FULL_NODE:
             # TODO add peaks for peers
             connections = self.rpc_api.service.server.get_connections()
@@ -169,9 +170,11 @@ class RpcServer:
         node_id = hexstr_to_bytes(request["node_id"])
         if self.rpc_api.service.server is None:
             raise aiohttp.web.HTTPInternalServerError()
+
         connections_to_close = [c for c in self.rpc_api.service.server.get_connections() if c.peer_node_id == node_id]
         if len(connections_to_close) == 0:
             raise ValueError(f"Connection with node_id {node_id.hex()} does not exist")
+
         for connection in connections_to_close:
             await connection.close()
 
@@ -210,7 +213,6 @@ class RpcServer:
             return await f(data)
 
         raise ValueError(f"unknown_command {command}")
-        return None
 
     async def safe_handle(self, websocket, payload):
         message = None

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -802,7 +802,7 @@ class WalletRpcApi:
         async with self.service.wallet_state_manager.lock:
             coins = await wallet.select_coins(1)
 
-        # ??? success==True either way here?
+        # ?? success==True either way here?
         res = {"success": True, "wallet_id": wallet_id, "my_did": my_did}
         if coins not in [None, set()]:
             coin = coins.pop()

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -184,7 +184,8 @@ class WalletRpcApi:
 
             return response
 
-        return {"success": False, "error": "Unknown Error"} # ??? to the response values have blanks?
+        return {"success": False, "error": "Unknown Error"}
+        # ??? to the response values have blanks?
 
     async def get_public_keys(self, request: Dict):
         fingerprints = [sk.get_g1().get_fingerprint() for (sk, seed) in self.service.keychain.get_all_private_keys()]
@@ -251,7 +252,6 @@ class WalletRpcApi:
             return {"fingerprint": fingerprint}
 
         raise ValueError("Failed to start")
-        return None
 
     async def delete_key(self, request):
         await self._stop_wallet()
@@ -668,7 +668,6 @@ class WalletRpcApi:
             return {}
 
         raise ValueError(error)
-        return None
 
     async def get_discrepancies_for_offer(self, request):
         assert self.service.wallet_state_manager is not None
@@ -685,7 +684,6 @@ class WalletRpcApi:
             return {"discrepancies": discrepancies}
 
         raise ValueError(error)
-        return None
 
     async def respond_to_offer(self, request):
         assert self.service.wallet_state_manager is not None
@@ -804,7 +802,7 @@ class WalletRpcApi:
         async with self.service.wallet_state_manager.lock:
             coins = await wallet.select_coins(1)
 
-        ## ??? success==True either way here?
+        # ??? success==True either way here?
         res = {"success": True, "wallet_id": wallet_id, "my_did": my_did}
         if coins not in [None, set()]:
             coin = coins.pop()
@@ -904,7 +902,8 @@ class WalletRpcApi:
 
     async def did_create_backup_file(self, request):
         try:
-            wallet_id = int(request["wallet_id"]) # ??? can be move out? seperate exception handling?
+            wallet_id = int(request["wallet_id"])
+            # ??? can be move out? seperate exception handling?
             did_wallet: DIDWallet = self.service.wallet_state_manager.wallets[wallet_id]
             did_wallet.create_backup(request["filename"])
             return {"wallet_id": wallet_id, "success": True}

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -141,7 +141,8 @@ class WalletRpcClient(RpcClient):
         if coins is not None and len(coins) > 0:
             coins_json = [c.to_json_dict() for c in coins]
             return await self.fetch(
-                "create_signed_transaction", {"additions": additions_hex, "coins": coins_json, "fee": fee} ### ??? does the order of this dict matter here in any way
+                "create_signed_transaction", {"additions": additions_hex, "coins": coins_json, "fee": fee}
+                ## ??? does the order of this dict matter here in any way
             )
         else:
             return await self.fetch("create_signed_transaction", {"additions": additions_hex, "fee": fee})

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -138,11 +138,11 @@ class WalletRpcClient(RpcClient):
     ) -> Dict:
         # Converts bytes to hex for puzzle hashes
         additions_hex = [{"amount": ad["amount"], "puzzle_hash": ad["puzzle_hash"].hex()} for ad in additions]
+        # ?? does the order of this dict matter here in any way
         if coins is not None and len(coins) > 0:
             coins_json = [c.to_json_dict() for c in coins]
             return await self.fetch(
                 "create_signed_transaction", {"additions": additions_hex, "coins": coins_json, "fee": fee}
-                # ??? does the order of this dict matter here in any way
             )
         else:
             return await self.fetch("create_signed_transaction", {"additions": additions_hex, "fee": fee})

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -142,7 +142,7 @@ class WalletRpcClient(RpcClient):
             coins_json = [c.to_json_dict() for c in coins]
             return await self.fetch(
                 "create_signed_transaction", {"additions": additions_hex, "coins": coins_json, "fee": fee}
-                ## ??? does the order of this dict matter here in any way
+                # ??? does the order of this dict matter here in any way
             )
         else:
             return await self.fetch("create_signed_transaction", {"additions": additions_hex, "fee": fee})

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -112,6 +112,7 @@ class WalletRpcClient(RpcClient):
             modified_tx["to_puzzle_hash"] = decode_puzzle_hash(modified_tx["to_address"]).hex()
             del modified_tx["to_address"]
             reverted_tx.append(TransactionRecord.from_json_dict(modified_tx))
+
         return reverted_tx
 
     async def get_next_address(self, wallet_id: str, new_address: bool) -> str:
@@ -120,7 +121,6 @@ class WalletRpcClient(RpcClient):
     async def send_transaction(
         self, wallet_id: str, amount: uint64, address: str, fee: uint64 = uint64(0)
     ) -> TransactionRecord:
-
         res = await self.fetch(
             "send_transaction",
             {"wallet_id": wallet_id, "amount": amount, "address": address, "fee": fee},
@@ -141,7 +141,7 @@ class WalletRpcClient(RpcClient):
         if coins is not None and len(coins) > 0:
             coins_json = [c.to_json_dict() for c in coins]
             return await self.fetch(
-                "create_signed_transaction", {"additions": additions_hex, "coins": coins_json, "fee": fee}
+                "create_signed_transaction", {"additions": additions_hex, "coins": coins_json, "fee": fee} ### ??? does the order of this dict matter here in any way
             )
         else:
             return await self.fetch("create_signed_transaction", {"additions": additions_hex, "fee": fee})


### PR DESCRIPTION
This is mostly just some formatting in `chia/rpc/` to make the return style more consistent.
* When a function has return statements at all, e.g. in if-clauses, but it ends in not returning, I add an explicit `return None`
* I add a newline before a return if the function body below had another indent.
* Also adding a newline after return and exceptions
* There's some basic refactorings when code is duplicated. 

With the exceptions, I actively didn't change the function behaviours, although sometimes it maybe could.
Finally there's few questions I marked in the comments (for the moment) - I'll annotate my thinking in the diff.
