### PR TITLE
Add an explicit error message

### DIFF
--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -73,6 +73,8 @@ def bytes_from_mnemonic(mnemonic_str: str) -> bytes:
     bit_array = BitArray()
     for i in range(0, len(mnemonic)):
         word = mnemonic[i]
+        if word not in word_list:
+            raise ValueError(f"'{word}' is not in the mnemonic dictionary; may be misspelled")
         value = word_list[word]
         bit_array.append(BitArray(uint=value, length=11))
 

--- a/tests/core/util/test_keychain.py
+++ b/tests/core/util/test_keychain.py
@@ -23,9 +23,10 @@ class TesKeychain(unittest.TestCase):
         mnemonic_2 = generate_mnemonic()
 
         # misspelled words in the mnemonic
-        bad_mnemonic = mnemonic.split(" ");
-        bad_mnemonic[6] = "ZZZZZZ";
-        self.assertRaisesRegex(ValueError, "'ZZZZZZ' is not in the mnemonic dictionary; may be misspelled", bytes_from_mnemonic, " ".join(bad_mnemonic))
+        bad_mnemonic = mnemonic.split(" ")
+        bad_mnemonic[6] = "ZZZZZZ"
+        self.assertRaisesRegex(ValueError, "'ZZZZZZ' is not in the mnemonic dictionary; may be misspelled",
+                               bytes_from_mnemonic, " ".join(bad_mnemonic))
 
         kc.add_private_key(mnemonic, "")
         assert kc._get_free_private_key_index() == 1

--- a/tests/core/util/test_keychain.py
+++ b/tests/core/util/test_keychain.py
@@ -25,8 +25,12 @@ class TesKeychain(unittest.TestCase):
         # misspelled words in the mnemonic
         bad_mnemonic = mnemonic.split(" ")
         bad_mnemonic[6] = "ZZZZZZ"
-        self.assertRaisesRegex(ValueError, "'ZZZZZZ' is not in the mnemonic dictionary; may be misspelled",
-                               bytes_from_mnemonic, " ".join(bad_mnemonic))
+        self.assertRaisesRegex(
+            ValueError,
+            "'ZZZZZZ' is not in the mnemonic dictionary; may be misspelled",
+            bytes_from_mnemonic,
+            " ".join(bad_mnemonic),
+        )
 
         kc.add_private_key(mnemonic, "")
         assert kc._get_free_private_key_index() == 1

--- a/tests/core/util/test_keychain.py
+++ b/tests/core/util/test_keychain.py
@@ -22,6 +22,11 @@ class TesKeychain(unittest.TestCase):
         assert bytes_to_mnemonic(entropy) == mnemonic
         mnemonic_2 = generate_mnemonic()
 
+        # misspelled words in the mnemonic
+        bad_mnemonic = mnemonic.split(" ");
+        bad_mnemonic[6] = "ZZZZZZ";
+        self.assertRaisesRegex(ValueError, "'ZZZZZZ' is not in the mnemonic dictionary; may be misspelled", bytes_from_mnemonic, " ".join(bad_mnemonic))
+
         kc.add_private_key(mnemonic, "")
         assert kc._get_free_private_key_index() == 1
         assert len(kc.get_all_private_keys()) == 1


### PR DESCRIPTION
Add an explicit error message when mnemonic words are not in the dictionary; should help users self-service issues like #3425 faster.