### PR TITLE
use the RotatingFileHandler from the python standard library

### DIFF
--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict
 
 import colorlog
-from concurrent_log_handler import ConcurrentRotatingFileHandler
+from logging.handlers import RotatingFileHandler
 
 from chia.util.path import mkdir, path_from_root
 
@@ -30,7 +30,7 @@ def initialize_logging(service_name: str, logging_config: Dict, root_path: Path)
     else:
         logger = logging.getLogger()
         maxrotation = logging_config.get("log_maxfilesrotation", 7)
-        handler = ConcurrentRotatingFileHandler(log_path, "a", maxBytes=20 * 1024 * 1024, backupCount=maxrotation)
+        handler = RotatingFileHandler(log_path, maxBytes=20 * 1024 * 1024, backupCount=maxrotation)
         handler.setFormatter(
             logging.Formatter(
                 fmt=f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ dependencies = [
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks
     "bitstring==3.1.7",  # Binary data management library
     "colorlog==5.0.1",  # Adds color to logs
-    "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
     "cryptography==3.4.7",  # Python cryptography library for TLS - keyring conflict
     "keyring==23.0.1",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)


### PR DESCRIPTION
it's a lot faster than `ConcurrentRotatingFileHandler`.

The current logging handler uses a lock-file to ensure multiple processes interleave their log lines cleanly. The issues with this are:

1. A lock file is very slow and ends up causing visible delays on the RPi
2. All relevant operating systems already guarantee that writes to files opened in append mode already are atomic. Both POSIX and Windows does this. The need for the lock file is questionable. [[reference](https://stackoverflow.com/questions/1154446/is-file-append-atomic-in-unix)]
3. ~~We only log from the main process anyway, we don't need to play nice with other processes.~~ the full-node, wallet, harvester and farmer all log to the same file, so we *do* rely on multiple processes writing to the same log file. (However, it would be nice to fix this, to let our processes from `ProcessPoolExecutor` also log).

I made a simple test in `full_node.py:

```
        start = time.time()
        for i in range(100000):
            self.log.debug(f"test {i}")
        end = time.time()
        self.log.warning(f"logging took {end -start} seconds")
```

Current timing:

```
2021-05-13T15:12:43.027 full_node chia.full_node.full_node: WARNING  logging took 42.20164489746094 seconds
```

With this patch:

```
2021-05-13T15:10:30.246 full_node chia.full_node.full_node: WARNING  logging took 14.777957677841187 seconds
```

With this, I would hope not not see logging show up in my profiles again. There really is no reason for it to.