### PR TITLE
call core init if needed when `-c` is specified

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -243,8 +243,12 @@ def init(create_certs: Optional[Path], root_path: Path):
             else:
                 print(f"** Directory {create_certs} does not exist **")
         else:
-            print(f"** {root_path} does not exist **")
-            print("** Please run `chia init` to migrate or create new config files **")
+            print(f"** {root_path} does not exist. Executing core init **")
+            chia_init(root_path)
+            if root_path.exists():
+                init(create_certs, root_path)
+            else:
+                print(f"** {root_path} was not created. Exiting **")
     else:
         return chia_init(root_path)
 

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -244,11 +244,12 @@ def init(create_certs: Optional[Path], root_path: Path):
                 print(f"** Directory {create_certs} does not exist **")
         else:
             print(f"** {root_path} does not exist. Executing core init **")
-            chia_init(root_path)
-            if root_path.exists():
-                init(create_certs, root_path)
-            else:
-                print(f"** {root_path} was not created. Exiting **")
+            # sanity check here to prevent infinite recursion
+            if chia_init(root_path) == 0 and root_path.exists():
+                return init(create_certs, root_path)
+
+            print(f"** {root_path} was not created. Exiting **")
+            return -1
     else:
         return chia_init(root_path)
 


### PR DESCRIPTION
Currently, when using another machine's cert on a new setup, the user has to:

````bash
chia init
chia init -c path_to_certs
````

`init -c` is kind enough to tell the user they need to `init` if it hasn't been already. Just go ahead and call the core `init` allowing the user to use a single command to init a new setup.

````bash
chia init -c path_to_certs
````
