### PR TITLE
Ms.spikes4 (Fix duplicate signage points)

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -174,7 +174,7 @@ class Farmer:
                 now = time.time()
                 removed_keys: List[bytes32] = []
                 for key, add_time in self.cache_add_time.items():
-                    if now - float(add_time) > self.constants.SUB_SLOT_TIME_TARGET * 2:
+                    if now - float(add_time) > self.constants.SUB_SLOT_TIME_TARGET * 3:
                         self.sps.pop(key, None)
                         self.proofs_of_space.pop(key, None)
                         self.quality_str_to_identifiers.pop(key, None)

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -249,6 +249,10 @@ class FarmerAPI:
         await self.farmer.server.send_to_all([msg], NodeType.HARVESTER)
         if new_signage_point.challenge_chain_sp not in self.farmer.sps:
             self.farmer.sps[new_signage_point.challenge_chain_sp] = []
+        if new_signage_point in self.farmer.sps[new_signage_point.challenge_chain_sp]:
+            self.farmer.log.debug(f"Duplicate signage point {new_signage_point.signage_point_index}")
+            return
+
         self.farmer.sps[new_signage_point.challenge_chain_sp].append(new_signage_point)
         self.farmer.cache_add_time[new_signage_point.challenge_chain_sp] = uint64(int(time.time()))
         self.farmer.state_changed("new_signage_point", {"sp_hash": new_signage_point.challenge_chain_sp})

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -950,12 +950,17 @@ class FullNode:
         if not self.sync_store.get_sync_mode():
             self.blockchain.clean_block_records()
 
+        fork_block: Optional[BlockRecord] = None
+        if fork_height != block.height - 1 and block.height != 0:
+            # This is a reorg
+            fork_block = self.blockchain.height_to_hash(fork_height)
+
         added_eos, new_sps, new_ips = self.full_node_store.new_peak(
             record,
             block,
             sub_slots[0],
             sub_slots[1],
-            fork_height != block.height - 1 and block.height != 0,
+            fork_block,
             self.blockchain,
         )
         if sub_slots[1] is None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -953,7 +953,7 @@ class FullNode:
         fork_block: Optional[BlockRecord] = None
         if fork_height != block.height - 1 and block.height != 0:
             # This is a reorg
-            fork_block = self.blockchain.height_to_hash(fork_height)
+            fork_block = self.blockchain.block_record(self.blockchain.height_to_hash(fork_height))
 
         added_eos, new_sps, new_ips = self.full_node_store.new_peak(
             record,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -873,7 +873,8 @@ class FullNode:
         self.log.info(
             f"⏲️  Finished signage point {request.index_from_challenge}/"
             f"{self.constants.NUM_SPS_SUB_SLOT}: "
-            f"{request.challenge_chain_vdf.output.get_hash()} "
+            f"CC: {request.challenge_chain_vdf.output.get_hash()} "
+            f"RC: {request.reward_chain_vdf.output.get_hash()} "
         )
         self.signage_point_times[request.index_from_challenge] = time.time()
         sub_slot_tuple = self.full_node_store.get_sub_slot(request.challenge_chain_vdf.challenge)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1600,7 +1600,7 @@ class FullNode:
                         await self.server.send_to_all_except([msg], NodeType.FULL_NODE, peer.peer_node_id)
                 else:
                     self.mempool_manager.remove_seen(spend_name)
-                    self.log.warning(
+                    self.log.info(
                         f"Wasn't able to add transaction with id {spend_name}, " f"status {status} error: {error}"
                     )
         return status, error

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1181,7 +1181,6 @@ class FullNode:
                 # Only propagate blocks which extend the blockchain (becomes one of the heads)
                 new_peak: Optional[BlockRecord] = self.blockchain.get_peak()
                 assert new_peak is not None and fork_height is not None
-                self.log.debug(f"Validation time for peak: {validation_time}")
 
                 await self.peak_post_processing(block, new_peak, fork_height, peer)
 
@@ -1192,6 +1191,20 @@ class FullNode:
             else:
                 # Should never reach here, all the cases are covered
                 raise RuntimeError(f"Invalid result from receive_block {added}")
+        percent_full_str = (
+            (
+                ", percent full: "
+                + str(round(100.0 * float(block.transactions_info.cost) / self.constants.MAX_BLOCK_COST_CLVM, 3))
+                + "%"
+            )
+            if block.transactions_info is not None
+            else ""
+        )
+        self.log.info(
+            f"Block validation time: {validation_time}, "
+            f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
+            f"{percent_full_str}"
+        )
 
         # This code path is reached if added == ADDED_AS_ORPHAN or NEW_TIP
         peak = self.blockchain.get_peak()
@@ -1272,6 +1285,7 @@ class FullNode:
 
         async with self.blockchain.lock:
             # TODO: pre-validate VDFs outside of lock
+            validation_start = time.time()
             validate_result = await self.blockchain.validate_unfinished_block(block)
             if validate_result.error is not None:
                 if validate_result.error == Err.COIN_AMOUNT_NEGATIVE.value:
@@ -1279,6 +1293,7 @@ class FullNode:
                     self.log.info(f"Consensus error {validate_result.error}, not disconnecting")
                     return
                 raise ConsensusError(Err(validate_result.error))
+            validation_time = time.time() - validation_start
 
         assert validate_result.required_iters is not None
 
@@ -1302,14 +1317,28 @@ class FullNode:
         self.full_node_store.add_unfinished_block(height, block, validate_result)
         if farmed_block is True:
             self.log.info(
-                f"🍀 ️Farmed unfinished_block {block_hash}, SP: {block.reward_chain_block.signage_point_index}"
+                f"🍀 ️Farmed unfinished_block {block_hash}, SP: {block.reward_chain_block.signage_point_index}, "
+                f"validation time: {validation_time}, "
+                f"cost: {block.transactions_info.cost if block.transactions_info else 'None'}"
             )
         else:
+            percent_full_str = (
+                (
+                    ", percent full: "
+                    + str(round(100.0 * float(block.transactions_info.cost) / self.constants.MAX_BLOCK_COST_CLVM, 3))
+                    + "%"
+                )
+                if block.transactions_info is not None
+                else ""
+            )
             self.log.info(
                 f"Added unfinished_block {block_hash}, not farmed by us,"
-                f" SP: {block.reward_chain_block.signage_point_index} time: "
-                f"{time.time() - self.signage_point_times[block.reward_chain_block.signage_point_index]}"
-                f"Pool pk {encode_puzzle_hash(block.foliage.foliage_block_data.pool_target.puzzle_hash, 'xch')}"
+                f" SP: {block.reward_chain_block.signage_point_index} farmer response time: "
+                f"{time.time() - self.signage_point_times[block.reward_chain_block.signage_point_index]}, "
+                f"Pool pk {encode_puzzle_hash(block.foliage.foliage_block_data.pool_target.puzzle_hash, 'xch')}, "
+                f"validation time: {validation_time}, "
+                f"cost: {block.transactions_info.cost if block.transactions_info else 'None'}"
+                f"{percent_full_str}"
             )
 
         sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
@@ -1600,7 +1629,7 @@ class FullNode:
                         await self.server.send_to_all_except([msg], NodeType.FULL_NODE, peer.peer_node_id)
                 else:
                     self.mempool_manager.remove_seen(spend_name)
-                    self.log.info(
+                    self.log.debug(
                         f"Wasn't able to add transaction with id {spend_name}, " f"status {status} error: {error}"
                     )
         return status, error

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -678,11 +678,10 @@ class FullNodeStore:
                     for i, sp in enumerate(sps):
                         if (total_iters + i * interval_iters) < fork_block.total_iters:
                             # Sps before the fork point as still valid
-                            # log.warning(f"Not Reverting sp: {i}")
                             replaced_sps.append(sp)
                         else:
                             if sp is not None:
-                                log.warning(
+                                log.debug(
                                     f"Reverting {i} {(total_iters + i * interval_iters)} {fork_block.total_iters}"
                                 )
                             # Sps after the fork point should be removed

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -436,7 +436,10 @@ class MempoolManager:
 
         new_item = MempoolItem(new_spend, uint64(fees), npc_result, cost, spend_name, additions, removals, program)
         self.mempool.add_to_pool(new_item, additions, removal_coin_dict)
-        log.info(f"add_spendbundle took {time.time() - start_time} seconds")
+        log.info(
+            f"add_spendbundle took {time.time() - start_time} seconds, cost {cost} "
+            f"({round(100.0 * cost/self.constants.MAX_BLOCK_COST_CLVM, 3)}%)"
+        )
         return uint64(cost), MempoolInclusionStatus.SUCCESS, None
 
     async def check_removals(self, removals: Dict[bytes32, CoinRecord]) -> Tuple[Optional[Err], List[Coin]]:
@@ -529,7 +532,7 @@ class MempoolManager:
             )
             if status == MempoolInclusionStatus.SUCCESS:
                 txs_added.append((item.spend_bundle, item.npc_result, item.spend_bundle_name))
-        log.debug(
+        log.info(
             f"Size of mempool: {len(self.mempool.spends)} spends, cost: {self.mempool.total_mempool_cost} "
             f"minimum fee to get in: {self.mempool.get_min_fee_rate(100000)}"
         )

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -489,7 +489,7 @@ class ChiaServer:
                 try:
                     if self.received_message_callback is not None:
                         await self.received_message_callback(connection)
-                    connection.log.info(
+                    connection.log.debug(
                         f"<- {ProtocolMessageTypes(full_message.type).name} from peer "
                         f"{connection.peer_node_id} {connection.peer_host}"
                     )

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -319,7 +319,7 @@ class WSChiaConnection:
         if message.id in self.request_results:
             result = self.request_results[message.id]
             assert result is not None
-            self.log.info(f"<- {ProtocolMessageTypes(result.type).name} from: {self.peer_host}:{self.peer_port}")
+            self.log.debug(f"<- {ProtocolMessageTypes(result.type).name} from: {self.peer_host}:{self.peer_port}")
             self.request_results.pop(result.id)
 
         return result
@@ -366,7 +366,7 @@ class WSChiaConnection:
                 )
 
         await self.ws.send_bytes(encoded)
-        self.log.info(f"-> {ProtocolMessageTypes(message.type).name} to peer {self.peer_host} {self.peer_node_id}")
+        self.log.debug(f"-> {ProtocolMessageTypes(message.type).name} to peer {self.peer_host} {self.peer_node_id}")
         self.bytes_written += size
 
     async def _read_one_message(self) -> Optional[Message]:

--- a/tests/core/full_node/test_full_node_store.py
+++ b/tests/core/full_node/test_full_node_store.py
@@ -2,12 +2,13 @@
 import asyncio
 import logging
 from secrets import token_bytes
-from typing import List
+from typing import List, Optional
 
 import pytest
 from pytest import raises
 
 from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.full_node_store import FullNodeStore
@@ -575,6 +576,110 @@ class TestFullNodeStore:
 
         # If flaky, increase the number of blocks created
         assert case_0 and case_1
+
+        # Try to get two blocks in the same slot, such that we have
+        # SP, B2 SP .... SP B1
+        #     i2 .........  i1
+        # Then do a reorg up to B2, removing all signage points after B2, but not before
+        for block in blocks:
+            await blockchain.receive_block(block)
+
+        while True:
+            blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1)
+            assert (await blockchain.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+            peak = blockchain.get_peak()
+            sub_slots = await blockchain.get_sp_and_ip_sub_slots(peak.header_hash)
+            store.new_peak(peak, blocks[-1], sub_slots[0], sub_slots[1], None, blockchain)
+
+            blocks = bt.get_consecutive_blocks(2, block_list_input=blocks, guarantee_transaction_block=True)
+
+            i3 = blocks[-3].reward_chain_block.signage_point_index
+            i2 = blocks[-2].reward_chain_block.signage_point_index
+            i1 = blocks[-1].reward_chain_block.signage_point_index
+            log.warning(f"{(len(blocks[-2].finished_sub_slots), len(blocks[-1].finished_sub_slots),i2, i1)}")
+            if (
+                len(blocks[-2].finished_sub_slots) == len(blocks[-1].finished_sub_slots) == 0
+                and not is_overflow_block(test_constants, signage_point_index=i2)
+                and not is_overflow_block(test_constants, signage_point_index=i1)
+                and i2 > i3 + 4
+                and i1 > (i2 + 3)
+            ):
+                log.warning("Made it!!")
+                # We hit all the conditions that we want
+                all_sps: List[Optional[SignagePoint]] = [None] * test_constants.NUM_SPS_SUB_SLOT
+                for i in range(i2 - 1, i2):
+                    finished_sub_slots = []
+                    sp = get_signage_point(
+                        test_constants,
+                        blockchain,
+                        peak,
+                        uint128(peak.ip_sub_slot_total_iters(bt.constants)),
+                        uint8(i),
+                        finished_sub_slots,
+                        peak.sub_slot_iters,
+                    )
+                    all_sps[i] = sp
+                    assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
+
+                assert (await blockchain.receive_block(blocks[-2]))[0] == ReceiveBlockResult.NEW_PEAK
+                peak = blockchain.get_peak()
+                sub_slots = await blockchain.get_sp_and_ip_sub_slots(peak.header_hash)
+                store.new_peak(peak, blocks[-2], sub_slots[0], sub_slots[1], None, blockchain)
+
+                for i in range(i2, test_constants.NUM_SPS_SUB_SLOT):
+                    if is_overflow_block(test_constants, uint8(i)):
+                        blocks_alt = bt.get_consecutive_blocks(1, block_list_input=blocks[:-1], skip_slots=1)
+                        finished_sub_slots = blocks_alt[-1].finished_sub_slots
+                    else:
+                        finished_sub_slots = []
+                    sp = get_signage_point(
+                        test_constants,
+                        blockchain,
+                        peak,
+                        uint128(peak.ip_sub_slot_total_iters(bt.constants)),
+                        uint8(i),
+                        finished_sub_slots,
+                        peak.sub_slot_iters,
+                    )
+                    all_sps[i] = sp
+                    assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
+
+                def assert_sp_none(sp_index: int, is_none: bool):
+                    sp_to_check: Optional[SignagePoint] = all_sps[i2]
+                    assert sp_to_check is not None
+                    assert sp_to_check.cc_vdf is not None
+                    fetched = store.get_signage_point(sp_to_check.cc_vdf.output.get_hash())
+                    assert (fetched is None) == is_none
+
+                assert_sp_none(i2, False)
+                assert_sp_none(i2 + 1, False)
+                assert_sp_none(i1, False)
+                assert_sp_none(i1 + 1, False)
+                assert_sp_none(i1 + 4, False)
+
+                assert (await blockchain.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+                peak = blockchain.get_peak()
+                sub_slots = await blockchain.get_sp_and_ip_sub_slots(peak.header_hash)
+
+                # Do a reorg, which should remove everything after i2
+                store.new_peak(
+                    peak,
+                    blocks[-1],
+                    sub_slots[0],
+                    sub_slots[1],
+                    (await blockchain.get_block_records_at([blocks[-2].height]))[0],
+                    blockchain,
+                )
+
+                assert_sp_none(i2, False)
+                assert_sp_none(i2 + 1, False)
+                assert_sp_none(i1, False)
+                assert_sp_none(i1 + 1, True)
+                assert_sp_none(i1 + 4, True)
+                break
+            else:
+                for block in blocks[-2:]:
+                    assert (await blockchain.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
 
     @pytest.mark.asyncio
     async def test_basic_store_compact_blockchain(self, empty_blockchain):

--- a/tests/core/full_node/test_full_node_store.py
+++ b/tests/core/full_node/test_full_node_store.py
@@ -206,7 +206,7 @@ class TestFullNodeStore:
 
             if res == ReceiveBlockResult.NEW_PEAK:
                 if fork_height is not None and fork_height != block.height - 1:
-                    fork_block = blockchain.height_to_hash(fork_height)
+                    fork_block = blockchain.block_record(blockchain.height_to_hash(fork_height))
                 else:
                     fork_block = None
                 sb = blockchain.block_record(block.header_hash)
@@ -258,7 +258,7 @@ class TestFullNodeStore:
             res, _, fork_height = await blockchain.receive_block(blocks[-1])
             if res == ReceiveBlockResult.NEW_PEAK:
                 if fork_height is not None and fork_height != blocks[-1].height - 1:
-                    fork_block = blockchain.height_to_hash(fork_height)
+                    fork_block = blockchain.block_record(blockchain.height_to_hash(fork_height))
                 else:
                     fork_block = None
 


### PR DESCRIPTION
* Farmer no longer farms the same signage point twice.
* Increased farmer signage point cache to 3 slots.
* Accept signage points which are newer, at the same index.
* Correctly removes all signage points after the peak.
* In the case of a reorg, does not reapply every single signage point in the slot, only those after the fork block. This fixes chiadog issues with "out of order" signage points.
* Various logs were changing from WARNING to INFO and from INFO to DEBUG.