### PR TITLE
Wallet

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -202,7 +202,7 @@ class CoinStore:
                 new_record = CoinRecord(
                     coin_record.coin,
                     coin_record.confirmed_block_index,
-                    coin_record.spent_block_index,
+                    uint32(0),
                     False,
                     coin_record.coinbase,
                     coin_record.timestamp,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1171,7 +1171,12 @@ class FullNode:
                 )
                 assert result_to_validate.required_iters == pre_validation_results[0].required_iters
                 added, error_code, fork_height = await self.blockchain.receive_block(block, result_to_validate, None)
-
+                if (
+                    self.full_node_store.previous_generator is not None
+                    and fork_height is not None
+                    and fork_height < self.full_node_store.previous_generator.block_height
+                ):
+                    self.full_node_store.previous_generator = None
             validation_time = time.time() - validation_start
 
             if added == ReceiveBlockResult.ALREADY_HAVE_BLOCK:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -442,16 +442,17 @@ class WalletRpcApi:
         assert self.service.wallet_state_manager is not None
         wallet_id = uint32(int(request["wallet_id"]))
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
-        unspent_records = await self.service.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(wallet_id)
-        balance = await wallet.get_confirmed_balance(unspent_records)
-        pending_balance = await wallet.get_unconfirmed_balance(unspent_records)
-        spendable_balance = await wallet.get_spendable_balance(unspent_records)
-        pending_change = await wallet.get_pending_change_balance()
-        max_send_amount = await wallet.get_max_send_amount(unspent_records)
+        async with self.service.wallet_state_manager.lock:
+            unspent_records = await self.service.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(wallet_id)
+            balance = await wallet.get_confirmed_balance(unspent_records)
+            pending_balance = await wallet.get_unconfirmed_balance(unspent_records)
+            spendable_balance = await wallet.get_spendable_balance(unspent_records)
+            pending_change = await wallet.get_pending_change_balance()
+            max_send_amount = await wallet.get_max_send_amount(unspent_records)
 
-        unconfirmed_removals: Dict[bytes32, Coin] = await wallet.wallet_state_manager.unconfirmed_removals_for_wallet(
-            wallet_id
-        )
+            unconfirmed_removals: Dict[bytes32, Coin] = await wallet.wallet_state_manager.unconfirmed_removals_for_wallet(
+                wallet_id
+            )
 
         wallet_balance = {
             "wallet_id": wallet_id,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -450,9 +450,9 @@ class WalletRpcApi:
             pending_change = await wallet.get_pending_change_balance()
             max_send_amount = await wallet.get_max_send_amount(unspent_records)
 
-            unconfirmed_removals: Dict[bytes32, Coin] = await wallet.wallet_state_manager.unconfirmed_removals_for_wallet(
-                wallet_id
-            )
+            unconfirmed_removals: Dict[
+                bytes32, Coin
+            ] = await wallet.wallet_state_manager.unconfirmed_removals_for_wallet(wallet_id)
 
         wallet_balance = {
             "wallet_id": wallet_id,

--- a/chia/wallet/rl_wallet/rl_wallet.py
+++ b/chia/wallet/rl_wallet/rl_wallet.py
@@ -469,7 +469,7 @@ class RLWallet:
         rl_parent_id = self.rl_coin_record.coin.parent_coin_info
         if rl_parent_id == self.rl_info.rl_origin_id:
             return self.rl_info.rl_origin
-        rl_parent = await self.wallet_state_manager.coin_store.get_coin_record_by_coin_id(rl_parent_id)
+        rl_parent = await self.wallet_state_manager.coin_store.get_coin_record(rl_parent_id)
         if rl_parent is None:
             return None
 

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -189,7 +189,7 @@ class TradeManager:
         result = {}
         removals = bundle.removals()
         for coin in removals:
-            coin_record = await self.wallet_state_manager.coin_store.get_coin_record_by_coin_id(coin.name())
+            coin_record = await self.wallet_state_manager.coin_store.get_coin_record(coin.name())
             if coin_record is None:
                 continue
             result[coin_record.name()] = coin_record

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -24,6 +24,7 @@ from chia.util.streamable import recurse_jsonify
 from chia.wallet.block_record import HeaderBlockRecord
 from chia.wallet.wallet_block_store import WalletBlockStore
 from chia.wallet.wallet_coin_store import WalletCoinStore
+from chia.wallet.wallet_transaction_store import WalletTransactionStore
 
 log = logging.getLogger(__name__)
 
@@ -58,6 +59,7 @@ class WalletBlockchain(BlockchainInterface):
     __sub_epoch_summaries: Dict[uint32, SubEpochSummary] = {}
     # Unspent Store
     coin_store: WalletCoinStore
+    tx_store: WalletTransactionStore
     # Store
     block_store: WalletBlockStore
     # Used to verify blocks in parallel
@@ -77,6 +79,8 @@ class WalletBlockchain(BlockchainInterface):
     @staticmethod
     async def create(
         block_store: WalletBlockStore,
+        coin_store: WalletCoinStore,
+        tx_store: WalletTransactionStore,
         consensus_constants: ConsensusConstants,
         coins_of_interest_received: Callable,  # f(removals: List[Coin], additions: List[Coin], height: uint32)
         reorg_rollback: Callable,
@@ -88,7 +92,9 @@ class WalletBlockchain(BlockchainInterface):
         in the consensus constants config.
         """
         self = WalletBlockchain()
-        self.lock = asyncio.Lock()  # External lock handled by full node
+        self.lock = asyncio.Lock()
+        self.coin_store = coin_store
+        self.tx_store = tx_store
         cpu_count = multiprocessing.cpu_count()
         if cpu_count > 61:
             cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
@@ -228,7 +234,10 @@ class WalletBlockchain(BlockchainInterface):
                     await self.block_store.db_wrapper.commit_transaction()
                 except BaseException as e:
                     self.log.error(f"Error during db transaction: {e}")
-                    await self.block_store.db_wrapper.rollback_transaction()
+                    if self.block_store.db_wrapper.db._connection is not None:
+                        await self.block_store.db_wrapper.rollback_transaction()
+                        await self.coin_store.rebuild_wallet_cache()
+                        await self.tx_store.rebuild_tx_cache()
                     raise
             if fork_height is not None:
                 self.log.info(f"💰 Updated wallet peak to height {block_record.height}, weight {block_record.weight}, ")
@@ -271,7 +280,8 @@ class WalletBlockchain(BlockchainInterface):
 
             # Rollback to fork
             self.log.debug(f"fork_h: {fork_h}, SB: {block_record.height}, peak: {peak.height}")
-            await self.reorg_rollback(fork_h)
+            if block_record.prev_hash != peak.header_hash:
+                await self.reorg_rollback(fork_h)
 
             # Rollback sub_epoch_summaries
             heights_to_delete = []

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Dict, List, Optional, Set
 
 import aiosqlite

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -18,8 +18,10 @@ class WalletCoinStore:
     """
 
     db_connection: aiosqlite.Connection
+    # coin_record_cache keeps ALL coin records in memory. [record_name: record]
     coin_record_cache: Dict[bytes32, WalletCoinRecord]
-    coin_wallet_record_cache: Dict[int, Dict[bytes32, WalletCoinRecord]]
+    # unspent_coin_wallet_cache keeps ALL unspent coin records for wallet in memory [wallet_id: [record_name: record]]
+    unspent_coin_wallet_cache: Dict[int, Dict[bytes32, WalletCoinRecord]]
     wallet_cache_lock: asyncio.Lock
     db_wrapper: DBWrapper
 
@@ -62,13 +64,10 @@ class WalletCoinStore:
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
 
         await self.db_connection.commit()
-        self.coin_record_cache = dict()
-        self.coin_wallet_record_cache = {}
-        all_coins = await self.get_all_coins()
-        for coin_record in all_coins:
-            self.coin_record_cache[coin_record.coin.name()] = coin_record
-
+        self.coin_record_cache = {}
+        self.unspent_coin_wallet_cache = {}
         self.wallet_cache_lock = asyncio.Lock()
+        await self.rebuild_wallet_cache()
         return self
 
     async def _clear_database(self):
@@ -76,44 +75,53 @@ class WalletCoinStore:
         await cursor.close()
         await self.db_connection.commit()
 
+    async def rebuild_wallet_cache(self):
+        # First update all coins that were reorged, then re-add coin_records
+        async with self.wallet_cache_lock:
+            all_coins = await self.get_all_coins()
+            self.unspent_coin_wallet_cache = {}
+            self.coin_record_cache = {}
+            for coin_record in all_coins:
+                name = coin_record.name()
+                self.coin_record_cache[name] = coin_record
+                if coin_record.spent is False:
+                    if coin_record.wallet_id not in self.unspent_coin_wallet_cache:
+                        self.unspent_coin_wallet_cache[coin_record.wallet_id] = {}
+                    self.unspent_coin_wallet_cache[coin_record.wallet_id][name] = coin_record
+
     # Store CoinRecord in DB and ram cache
     async def add_coin_record(self, record: WalletCoinRecord) -> None:
         # update wallet cache
+        async with self.wallet_cache_lock:
+            name = record.name()
+            self.coin_record_cache[name] = record
+            if record.wallet_id in self.unspent_coin_wallet_cache:
+                if record.spent and name in self.unspent_coin_wallet_cache[record.wallet_id]:
+                    self.unspent_coin_wallet_cache[record.wallet_id].pop(name)
+                if not record.spent:
+                    self.unspent_coin_wallet_cache[record.wallet_id][name] = record
 
-        await self.wallet_cache_lock.acquire()
-        try:
-            if record.wallet_id in self.coin_wallet_record_cache:
-                cache_dict = self.coin_wallet_record_cache[record.wallet_id]
-                if record.coin.name() in cache_dict and record.spent:
-                    cache_dict.pop(record.coin.name())
-                else:
-                    cache_dict[record.coin.name()] = record
-
-            cursor = await self.db_connection.execute(
-                "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    record.coin.name().hex(),
-                    record.confirmed_block_height,
-                    record.spent_block_height,
-                    int(record.spent),
-                    int(record.coinbase),
-                    str(record.coin.puzzle_hash.hex()),
-                    str(record.coin.parent_coin_info.hex()),
-                    bytes(record.coin.amount),
-                    record.wallet_type,
-                    record.wallet_id,
-                ),
-            )
-            await cursor.close()
-            self.coin_record_cache[record.coin.name()] = record
-        finally:
-            self.wallet_cache_lock.release()
+        cursor = await self.db_connection.execute(
+            "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                name.hex(),
+                record.confirmed_block_height,
+                record.spent_block_height,
+                int(record.spent),
+                int(record.coinbase),
+                str(record.coin.puzzle_hash.hex()),
+                str(record.coin.parent_coin_info.hex()),
+                bytes(record.coin.amount),
+                record.wallet_type,
+                record.wallet_id,
+            ),
+        )
+        await cursor.close()
 
     # Update coin_record to be spent in DB
-    async def set_spent(self, coin_name: bytes32, height: uint32):
+    async def set_spent(self, coin_name: bytes32, height: uint32) -> WalletCoinRecord:
         current: Optional[WalletCoinRecord] = await self.get_coin_record(coin_name)
-        if current is None:
-            return None
+        assert current is not None
 
         spent: WalletCoinRecord = WalletCoinRecord(
             current.coin,
@@ -126,6 +134,7 @@ class WalletCoinStore:
         )
 
         await self.add_coin_record(spent)
+        return spent
 
     def coin_record_from_row(self, row: sqlite3.Row) -> WalletCoinRecord:
         coin = Coin(bytes32(bytes.fromhex(row[6])), bytes32(bytes.fromhex(row[5])), uint64.from_bytes(row[7]))
@@ -181,8 +190,8 @@ class WalletCoinStore:
     async def get_unspent_coins_for_wallet(self, wallet_id: int) -> Set[WalletCoinRecord]:
         """ Returns set of CoinRecords that have not been spent yet for a wallet. """
         async with self.wallet_cache_lock:
-            if wallet_id in self.coin_wallet_record_cache:
-                wallet_coins: Dict[bytes32, WalletCoinRecord] = self.coin_wallet_record_cache[wallet_id]
+            if wallet_id in self.unspent_coin_wallet_cache:
+                wallet_coins: Dict[bytes32, WalletCoinRecord] = self.unspent_coin_wallet_cache[wallet_id]
                 return set(wallet_coins.values())
 
             coin_set = set()
@@ -199,7 +208,7 @@ class WalletCoinStore:
                 coin_set.add(coin_record)
                 cache_dict[coin_record.name()] = coin_record
 
-            self.coin_wallet_record_cache[wallet_id] = cache_dict
+            self.unspent_coin_wallet_cache[wallet_id] = cache_dict
             return coin_set
 
     async def get_all_coins(self) -> Set[WalletCoinRecord]:
@@ -219,43 +228,40 @@ class WalletCoinStore:
 
         return [self.coin_record_from_row(row) for row in rows]
 
-    async def get_coin_record_by_coin_id(self, coin_id: bytes32) -> Optional[WalletCoinRecord]:
-        """Returns a coin records with the given name, if it exists"""
-        # TODO: This is a duplicate of get_coin_record()
-        return await self.get_coin_record(coin_id)
-
     async def rollback_to_block(self, height: int):
         """
         Rolls back the blockchain to block_index. All blocks confirmed after this point
         are removed from the LCA. All coins confirmed after this point are removed.
         All coins spent after this point are set to unspent. Can be -1 (rollback all)
         """
-        # Update memory cache
-
-        delete_queue: List[WalletCoinRecord] = []
-        for coin_name, coin_record in self.coin_record_cache.items():
-            if coin_record.spent_block_height > height:
-                new_record = WalletCoinRecord(
-                    coin_record.coin,
-                    coin_record.confirmed_block_height,
-                    coin_record.spent_block_height,
-                    False,
-                    coin_record.coinbase,
-                    coin_record.wallet_type,
-                    coin_record.wallet_id,
-                )
-                self.coin_record_cache[coin_record.coin.name()] = new_record
-            if coin_record.confirmed_block_height > height:
-                delete_queue.append(coin_record)
-
-        for coin_record in delete_queue:
-            self.coin_record_cache.pop(coin_record.coin.name())
-            if coin_record.wallet_id in self.coin_wallet_record_cache:
-                coin_cache = self.coin_wallet_record_cache[coin_record.wallet_id]
-                if coin_record.coin.name() in coin_cache:
-                    coin_cache.pop(coin_record.coin.name())
-
         # Delete from storage
+        async with self.wallet_cache_lock:
+            delete_queue: List[WalletCoinRecord] = []
+            for coin_name, coin_record in self.coin_record_cache.items():
+                if coin_record.spent_block_height > height:
+                    new_record = WalletCoinRecord(
+                        coin_record.coin,
+                        coin_record.confirmed_block_height,
+                        uint32(0),
+                        False,
+                        coin_record.coinbase,
+                        coin_record.wallet_type,
+                        coin_record.wallet_id,
+                    )
+                    self.coin_record_cache[coin_record.coin.name()] = new_record
+                    if coin_record.wallet_id in self.unspent_coin_wallet_cache:
+                        coin_cache = self.unspent_coin_wallet_cache[coin_record.wallet_id]
+                        coin_cache[coin_record.coin.name()] = new_record
+                if coin_record.confirmed_block_height > height:
+                    delete_queue.append(coin_record)
+
+            for coin_record in delete_queue:
+                self.coin_record_cache.pop(coin_record.coin.name())
+                if coin_record.wallet_id in self.unspent_coin_wallet_cache:
+                    coin_cache = self.unspent_coin_wallet_cache[coin_record.wallet_id]
+                    if coin_record.coin.name() in coin_cache:
+                        coin_cache.pop(coin_record.coin.name())
+
         c1 = await self.db_connection.execute("DELETE FROM coin_record WHERE confirmed_height>?", (height,))
         await c1.close()
         c2 = await self.db_connection.execute(

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -121,6 +121,7 @@ class WalletCoinStore:
     async def set_spent(self, coin_name: bytes32, height: uint32) -> WalletCoinRecord:
         current: Optional[WalletCoinRecord] = await self.get_coin_record(coin_name)
         assert current is not None
+        assert current.spent is False
 
         spent: WalletCoinRecord = WalletCoinRecord(
             current.coin,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -504,7 +504,7 @@ class WalletNode:
                 break
             asyncio.create_task(self.check_new_peak())
             await self.sync_event.wait()
-            self.last_new_peak_messages = LRUCache(10)
+            self.last_new_peak_messages = LRUCache(5)
             self.sync_event.clear()
 
             if self._shut_down is True:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -37,6 +37,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.errors import Err, ValidationError
 from chia.util.ints import uint32, uint128
 from chia.util.keychain import Keychain
+from chia.util.lru_cache import LRUCache
 from chia.util.merkle_set import MerkleSet, confirm_included_already_hashed, confirm_not_included_already_hashed
 from chia.util.path import mkdir, path_from_root
 from chia.wallet.block_record import HeaderBlockRecord
@@ -109,6 +110,7 @@ class WalletNode:
         self.logged_in_fingerprint: Optional[int] = None
         self.peer_task = None
         self.logged_in = False
+        self.last_new_peak_messages = LRUCache(5)
 
     def get_key_for_fingerprint(self, fingerprint: Optional[int]):
         private_keys = self.keychain.get_all_private_keys()
@@ -442,6 +444,7 @@ class WalletNode:
                 # Request weight proof
                 # Sync if PoW validates
                 if self.wallet_state_manager.sync_mode:
+                    self.last_new_peak_messages.put(peer, peak)
                     return None
                 weight_request = RequestProofOfWeight(header_block.height, header_block.header_hash)
                 weight_proof_response: RespondProofOfWeight = await peer.request_proof_of_weight(
@@ -501,6 +504,7 @@ class WalletNode:
                 break
             asyncio.create_task(self.check_new_peak())
             await self.sync_event.wait()
+            self.last_new_peak_messages = LRUCache(10)
             self.sync_event.clear()
 
             if self._shut_down is True:
@@ -515,6 +519,8 @@ class WalletNode:
             finally:
                 if self.wallet_state_manager is not None:
                     self.wallet_state_manager.set_sync_mode(False)
+                for peer, peak in self.last_new_peak_messages.cache.items():
+                    asyncio.create_task(self.new_peak_wallet(peak, peer))
             self.log.info("Loop end in sync job")
 
     async def _sync(self) -> None:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -639,7 +639,7 @@ class WalletStateManager:
             if coin.name() in trade_removals:
                 trade_coin_removed.append(coin)
             if record is None:
-                self.log.warning(f"Record for removed coin {coin.name()} is None")
+                self.log.info(f"Record for removed coin {coin.name()} is None. (ephemeral)")
                 continue
             await self.coin_store.set_spent(coin.name(), height)
             for unconfirmed_record in all_unconfirmed:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -483,13 +483,14 @@ class WalletStateManager:
         """
         Returns the confirmed balance, including coinbase rewards that are not spendable.
         """
-        if unspent_coin_records is None:
-            unspent_coin_records = await self.coin_store.get_unspent_coins_for_wallet(wallet_id)
-        amount: uint128 = uint128(0)
-        for record in unspent_coin_records:
-            amount = uint128(amount + record.coin.amount)
-        self.log.info(f"Confirmed balance amount is {amount}")
-        return uint128(amount)
+        async with self.lock:
+            if unspent_coin_records is None:
+                unspent_coin_records = await self.coin_store.get_unspent_coins_for_wallet(wallet_id)
+            amount: uint128 = uint128(0)
+            for record in unspent_coin_records:
+                amount = uint128(amount + record.coin.amount)
+            self.log.info(f"Confirmed balance amount is {amount}")
+            return uint128(amount)
 
     async def get_unconfirmed_balance(
         self, wallet_id, unspent_coin_records: Optional[Set[WalletCoinRecord]] = None

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -483,14 +483,16 @@ class WalletStateManager:
         """
         Returns the confirmed balance, including coinbase rewards that are not spendable.
         """
-        async with self.lock:
-            if unspent_coin_records is None:
-                unspent_coin_records = await self.coin_store.get_unspent_coins_for_wallet(wallet_id)
-            amount: uint128 = uint128(0)
-            for record in unspent_coin_records:
-                amount = uint128(amount + record.coin.amount)
-            self.log.info(f"Confirmed balance amount is {amount}")
-            return uint128(amount)
+        # lock only if unspent_coin_records is None
+        if unspent_coin_records is None:
+            async with self.lock:
+                if unspent_coin_records is None:
+                    unspent_coin_records = await self.coin_store.get_unspent_coins_for_wallet(wallet_id)
+        amount: uint128 = uint128(0)
+        for record in unspent_coin_records:
+            amount = uint128(amount + record.coin.amount)
+        self.log.info(f"Confirmed balance amount is {amount}")
+        return uint128(amount)
 
     async def get_unconfirmed_balance(
         self, wallet_id, unspent_coin_records: Optional[Set[WalletCoinRecord]] = None

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import aiosqlite
 
@@ -19,17 +19,14 @@ class WalletTransactionStore:
 
     db_connection: aiosqlite.Connection
     db_wrapper: DBWrapper
-    cache_size: uint32
     tx_record_cache: Dict[bytes32, TransactionRecord]
-    tx_wallet_cache: Dict[int, Dict[Any, Set[bytes32]]]
     tx_submitted: Dict[bytes32, Tuple[int, int]]  # tx_id: [time submitted: count]
     unconfirmed_for_wallet: Dict[int, Dict[bytes32, TransactionRecord]]
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper, cache_size: uint32 = uint32(600000)):
+    async def create(cls, db_wrapper: DBWrapper):
         self = cls()
 
-        self.cache_size = cache_size
         self.db_wrapper = db_wrapper
         self.db_connection = self.db_wrapper.db
 
@@ -79,15 +76,24 @@ class WalletTransactionStore:
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on transaction_record(wallet_id)")
 
         await self.db_connection.commit()
-        self.tx_record_cache = dict()
-        self.tx_wallet_cache = dict()
-        self.tx_submitted = dict()
-        self.unconfirmed_for_wallet = dict()
+        self.tx_record_cache = {}
+        self.tx_submitted = {}
+        self.unconfirmed_for_wallet = {}
+        await self.rebuild_tx_cache()
         return self
 
-    async def _init_cache(self):
+    async def rebuild_tx_cache(self):
         # init cache here
-        pass
+        all_records = await self.get_all_transactions()
+        self.tx_record_cache = {}
+        self.unconfirmed_for_wallet = {}
+
+        for record in all_records:
+            self.tx_record_cache[record.name] = record
+            if record.wallet_id not in self.unconfirmed_for_wallet:
+                self.unconfirmed_for_wallet[record.name] = {}
+            if not record.confirmed:
+                self.unconfirmed_for_wallet[record.name] = record
 
     async def _clear_database(self):
         cursor = await self.db_connection.execute("DELETE FROM transaction_record")
@@ -98,6 +104,15 @@ class WalletTransactionStore:
         """
         Store TransactionRecord in DB and Cache.
         """
+        self.tx_record_cache[record.name] = record
+        if record.wallet_id not in self.unconfirmed_for_wallet:
+            self.unconfirmed_for_wallet[record.wallet_id] = {}
+        unconfirmed_dict = self.unconfirmed_for_wallet[record.wallet_id]
+        if record.confirmed and record.name in unconfirmed_dict:
+            unconfirmed_dict.pop(record.name)
+        if not record.confirmed:
+            unconfirmed_dict[record.name] = record
+
         if not in_transaction:
             await self.db_wrapper.lock.acquire()
         try:
@@ -119,33 +134,15 @@ class WalletTransactionStore:
                 ),
             )
             await cursor.close()
-        finally:
             if not in_transaction:
                 await self.db_connection.commit()
+        except BaseException:
+            if not in_transaction:
+                await self.rebuild_tx_cache()
+            raise
+        finally:
+            if not in_transaction:
                 self.db_wrapper.lock.release()
-        self.tx_record_cache[record.name] = record
-
-        if record.wallet_id in self.unconfirmed_for_wallet:
-            unconfirmed: Dict[bytes32, TransactionRecord] = self.unconfirmed_for_wallet[record.wallet_id]
-            if record.name in unconfirmed:
-                if record.confirmed:
-                    unconfirmed.pop(record.name)
-                else:
-                    unconfirmed[record.name] = record
-            else:
-                if not record.confirmed:
-                    unconfirmed[record.name] = record
-
-        if record.wallet_id in self.tx_wallet_cache:
-            if None in self.tx_wallet_cache[record.wallet_id]:
-                self.tx_wallet_cache[record.wallet_id][None].add(record.name)
-            if record.type in self.tx_wallet_cache[record.wallet_id]:
-                self.tx_wallet_cache[record.wallet_id][record.type].add(record.name)
-
-        if len(self.tx_record_cache) > self.cache_size:
-            while len(self.tx_record_cache) > self.cache_size:
-                first_in = list(self.tx_record_cache.keys())[0]
-                self.tx_record_cache.pop(first_in)
 
     async def set_confirmed(self, tx_id: bytes32, height: uint32):
         """
@@ -225,30 +222,26 @@ class WalletTransactionStore:
         await self.add_transaction_record(tx, False)
         return True
 
-    async def tx_reorged(self, tx_id: bytes32):
+    async def tx_reorged(self, record: TransactionRecord):
         """
         Updates transaction sent count to 0 and resets confirmation data
         """
-
-        current: Optional[TransactionRecord] = await self.get_transaction_record(tx_id)
-        if current is None:
-            return None
         tx: TransactionRecord = TransactionRecord(
             confirmed_at_height=uint32(0),
-            created_at_time=current.created_at_time,
-            to_puzzle_hash=current.to_puzzle_hash,
-            amount=current.amount,
-            fee_amount=current.fee_amount,
+            created_at_time=record.created_at_time,
+            to_puzzle_hash=record.to_puzzle_hash,
+            amount=record.amount,
+            fee_amount=record.fee_amount,
             confirmed=False,
             sent=uint32(0),
-            spend_bundle=current.spend_bundle,
-            additions=current.additions,
-            removals=current.removals,
-            wallet_id=current.wallet_id,
+            spend_bundle=record.spend_bundle,
+            additions=record.additions,
+            removals=record.removals,
+            wallet_id=record.wallet_id,
             sent_to=[],
             trade_id=None,
-            type=current.type,
-            name=current.name,
+            type=record.type,
+            name=record.name,
         )
         await self.add_transaction_record(tx, True)
 
@@ -393,7 +386,7 @@ class WalletTransactionStore:
         await cursor.close()
         return count
 
-    async def get_all_transactions(self, wallet_id: int, type: int = None) -> List[TransactionRecord]:
+    async def get_all_transactions_for_wallet(self, wallet_id: int, type: int = None) -> List[TransactionRecord]:
         """
         Returns all stored transactions.
         """
@@ -419,9 +412,20 @@ class WalletTransactionStore:
             records.append(record)
             cache_set.add(record.name)
 
-        if wallet_id not in self.tx_wallet_cache:
-            self.tx_wallet_cache[wallet_id] = {}
-        self.tx_wallet_cache[wallet_id][type] = cache_set
+        return records
+
+    async def get_all_transactions(self) -> List[TransactionRecord]:
+        """
+        Returns all stored transactions.
+        """
+        cursor = await self.db_connection.execute("SELECT * from transaction_record")
+        rows = await cursor.fetchall()
+        await cursor.close()
+        records = []
+
+        for row in rows:
+            record = TransactionRecord.from_bytes(row[0])
+            records.append(record)
 
         return records
 
@@ -443,7 +447,12 @@ class WalletTransactionStore:
 
     async def rollback_to_block(self, height: int):
         # Delete from storage
-        self.tx_wallet_cache = {}
-        self.unconfirmed_for_wallet = {}
+        to_delete = []
+        for tx in self.tx_record_cache.values():
+            if tx.confirmed_at_height > height:
+                to_delete.append(tx)
+        for tx in to_delete:
+            self.tx_record_cache.pop(tx.name)
+
         c1 = await self.db_connection.execute("DELETE FROM transaction_record WHERE confirmed_at_height>?", (height,))
         await c1.close()

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -331,24 +331,8 @@ class WalletTransactionStore:
         """
         if wallet_id in self.unconfirmed_for_wallet:
             return list(self.unconfirmed_for_wallet[wallet_id].values())
-        cursor = await self.db_connection.execute(
-            "SELECT * from transaction_record WHERE confirmed=? and wallet_id=?",
-            (
-                0,
-                wallet_id,
-            ),
-        )
-        rows = await cursor.fetchall()
-        await cursor.close()
-        records = []
-        dict = {}
-        for row in rows:
-            record = TransactionRecord.from_bytes(row[0])
-            records.append(record)
-            dict[record.name] = record
-
-        self.unconfirmed_for_wallet[wallet_id] = dict
-        return records
+        else:
+            return []
 
     async def get_transactions_between(self, wallet_id: int, start, end) -> List[TransactionRecord]:
         """Return a list of transaction between start and end index. List is in reverse chronological order.

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -365,6 +365,7 @@ class TestFullNodeBlockCompression:
         all_blocks: List[FullBlock] = await full_node_1.get_all_full_blocks()
         assert height == len(all_blocks) - 1
 
+        assert full_node_1.full_node.full_node_store.previous_generator is not None
         if test_reorgs:
             reog_blocks = bt.get_consecutive_blocks(14)
             for r in range(0, len(reog_blocks), 3):
@@ -386,6 +387,11 @@ class TestFullNodeBlockCompression:
                         assert results is not None
                         for result in results:
                             assert result.error is None
+
+            # Test revert previous_generator
+            for block in reog_blocks:
+                await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            assert full_node_1.full_node.full_node_store.previous_generator is None
 
     @pytest.mark.asyncio
     async def test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain):

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -1,8 +1,6 @@
 import asyncio
-
 import pytest
 import time
-
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.protocols.full_node_protocol import RespondBlock
 from chia.server.server import ChiaServer
@@ -11,6 +9,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.transaction_record import TransactionRecord
+from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_state_manager import WalletStateManager
 from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert, time_out_assert_not_none
@@ -539,3 +538,70 @@ class TestWalletSimulator:
         outstanding_coinbase_rewards = 2000000000000
         await time_out_assert(5, wallet.get_confirmed_balance, funds + outstanding_coinbase_rewards)
         await time_out_assert(5, wallet.get_confirmed_balance, funds + outstanding_coinbase_rewards)
+
+    @pytest.mark.asyncio
+    async def test_wallet_tx_reorg(self, two_wallet_nodes):
+        num_blocks = 5
+        full_nodes, wallets = two_wallet_nodes
+        full_node_api = full_nodes[0]
+        fn_server = full_node_api.full_node.server
+        wallet_node, server_2 = wallets[0]
+        wallet_node: WalletNode = wallet_node
+        wallet_node_2, server_3 = wallets[1]
+        wallet = wallet_node.wallet_state_manager.main_wallet
+        wallet_2 = wallet_node_2.wallet_state_manager.main_wallet
+
+        ph = await wallet.get_new_puzzlehash()
+        ph2 = await wallet_2.get_new_puzzlehash()
+
+        await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
+        await server_3.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
+        for i in range(0, num_blocks):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+        funds = sum(
+            [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
+        )
+        tx = await wallet.generate_signed_transaction(1000, ph2)
+        await wallet.push_transaction(tx)
+        await full_node_api.full_node.respond_transaction(tx.spend_bundle, tx.name)
+        await time_out_assert(5, wallet.get_confirmed_balance, funds)
+        for i in range(0, 2):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
+        await time_out_assert(5, wallet_2.get_confirmed_balance, 1000)
+
+        await time_out_assert(5, wallet_node.wallet_state_manager.blockchain.get_peak_height, 7)
+
+        await full_node_api.reorg_from_index_to_new_index(ReorgProtocol(uint32(3), uint32(num_blocks + 6), 32 * b"0"))
+
+        funds = sum(
+            [
+                calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i))
+                for i in range(1, num_blocks - 2)
+            ]
+        )
+        await time_out_assert(7, full_node_api.full_node.blockchain.get_peak_height, 10)
+        await time_out_assert(7, wallet_node.wallet_state_manager.blockchain.get_peak_height, 10)
+
+        for i in range(0, num_blocks):
+            await asyncio.sleep(1)
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
+
+        await time_out_assert(15, wallet.get_confirmed_balance, funds - 1000)
+        unconfirmed = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(int(wallet.id()))
+        assert len(unconfirmed) == 0
+        tx_record = await wallet_node.wallet_state_manager.tx_store.get_transaction_record(tx.name)
+        removed = tx_record.removals[0]
+        added = tx_record.additions[0]
+        added_1 = tx_record.additions[1]
+        wallet_coin_record_rem = await wallet_node.wallet_state_manager.coin_store.get_coin_record(removed.name())
+        assert wallet_coin_record_rem.spent
+
+        coin_record_full_node = await full_node_api.full_node.coin_store.get_coin_record(removed.name())
+        assert coin_record_full_node.spent
+        add_1_coin_record_full_node = await full_node_api.full_node.coin_store.get_coin_record(added.name())
+        assert add_1_coin_record_full_node is not None
+        assert add_1_coin_record_full_node.confirmed_block_index > 0
+        add_2_coin_record_full_node = await full_node_api.full_node.coin_store.get_coin_record(added_1.name())
+        assert add_2_coin_record_full_node is not None
+        assert add_2_coin_record_full_node.confirmed_block_index > 0


### PR DESCRIPTION
- Keeps all coin records and unspent_for_wallet records in memory. Operations that modify db, modify the cache as well. In case of failure to write into db, cache gets fully rebuilt. 
- Same ^ for TXs. Keeps all tx records and unconfirmed_per_wallet records in memory...
- Keeps last few new peak messages while wallet is syncing and reapplies them after sync is done. 
- Fixes TX reorgs. 
- Full node & wallet were not reseting spent height back to 0 in case of rollback.
- Wallet to call rollback only when new peak.prev_hash is different from current_peak.header_hash
- Use get_block_record_from_db, block_recrod cache is limited in size. 
-  TX block used for generator ref can be reorged, handle that case. 
