### PR TITLE
Update get_address wallet cli function to pass new_address=True

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -94,7 +94,7 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
 
 async def get_address(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["id"]
-    res = await wallet_client.get_next_address(wallet_id, False)
+    res = await wallet_client.get_next_address(wallet_id, True)
     print(res)
 
 


### PR DESCRIPTION
`chia wallet get_address` was previously passing a value of `new_address=False` to the RPC endpoint, which resulted in the same address being returned from the CLI every time the command was called. This PR simply changes the param to `True` which forces generation of a new address every time you run the command.

Fixes #4135 and #4869. 