### PR TITLE
remove unused get_block_records() function

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -232,26 +232,6 @@ class BlockStore:
             return BlockRecord.from_bytes(row[0])
         return None
 
-    async def get_block_records(
-        self,
-    ) -> Tuple[Dict[bytes32, BlockRecord], Optional[bytes32]]:
-        """
-        Returns a dictionary with all blocks, as well as the header hash of the peak,
-        if present.
-        """
-        cursor = await self.db.execute("SELECT * from block_records")
-        rows = await cursor.fetchall()
-        await cursor.close()
-        ret: Dict[bytes32, BlockRecord] = {}
-        peak: Optional[bytes32] = None
-        for row in rows:
-            header_hash = bytes.fromhex(row[0])
-            ret[header_hash] = BlockRecord.from_bytes(row[3])
-            if row[5]:
-                assert peak is None  # Sanity check, only one peak
-                peak = header_hash
-        return ret, peak
-
     async def get_block_records_in_range(
         self,
         start: int,

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -67,9 +67,6 @@ class TestBlockStore:
             block_record_records = await store.get_block_records_in_range(0, 0xFFFFFFFF)
             assert len(block_record_records) == len(blocks)
 
-            # Peak is correct
-            assert block_record_records[1] == blocks[-1].header_hash
-
         except Exception:
             await connection.close()
             await connection_2.close()

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -65,7 +65,7 @@ class TestBlockStore:
 
             # Get blocks
             block_record_records = await store.get_block_records_in_range(0, 0xFFFFFFFF)
-            assert len(block_record_records[0]) == len(blocks)
+            assert len(block_record_records) == len(blocks)
 
             # Peak is correct
             assert block_record_records[1] == blocks[-1].header_hash

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -64,7 +64,7 @@ class TestBlockStore:
             assert len(await store.get_full_blocks_at([100])) == 0
 
             # Get blocks
-            block_record_records = await store.get_block_records()
+            block_record_records = await store.get_block_records_in_range(0, 0xFFFFFFFF)
             assert len(block_record_records[0]) == len(blocks)
 
             # Peak is correct

--- a/tests/weight_proof/test_weight_proof.py
+++ b/tests/weight_proof/test_weight_proof.py
@@ -505,7 +505,8 @@ class TestWeightProof:
     async def test_weight_proof_from_database(self):
         connection = await aiosqlite.connect("path to db")
         block_store: BlockStore = await BlockStore.create(connection)
-        blocks, peak = await block_store.get_block_records_in_range(0, 0xFFFFFFFF)
+        blocks = await block_store.get_block_records_in_range(0, 0xFFFFFFFF)
+        peak = len(blocks) - 1
         peak_height = blocks[peak].height
         headers = await block_store.get_header_blocks_in_range(0, peak_height)
         sub_height_to_hash = {}

--- a/tests/weight_proof/test_weight_proof.py
+++ b/tests/weight_proof/test_weight_proof.py
@@ -505,7 +505,7 @@ class TestWeightProof:
     async def test_weight_proof_from_database(self):
         connection = await aiosqlite.connect("path to db")
         block_store: BlockStore = await BlockStore.create(connection)
-        blocks, peak = await block_store.get_block_records()
+        blocks, peak = await block_store.get_block_records_in_range(0, 0xFFFFFFFF)
         peak_height = blocks[peak].height
         headers = await block_store.get_header_blocks_in_range(0, peak_height)
         sub_height_to_hash = {}


### PR DESCRIPTION
it's only used by one test. It's also a dangerous function since the whole chain may become very large, and may not fit in memory.