### PR TITLE
Implemented unregister_service command for daemon

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -706,17 +706,11 @@ class WebSocketServer:
         self.log.info(f"Unregister service {request}")
         service = request["service"]
 
-        connection_removed = False
+        num_connections = len(self.connections.get(service, []))
         if service in self.connections:
-            after_removal = []
-            for connection in self.connections[service]:
-                if connection == websocket:
-                    connection_removed = True
-                    continue
-                else:
-                    after_removal.append(connection)
-            self.connections[service] = after_removal
+            self.connections[service] = list(filter(lambda conn: conn != websocket, self.connections[service]))
 
+        connection_removed = num_connections > len(self.connections.get(service, []))
         if connection_removed:
             self.log.info(f"unregistered service {service}")
 


### PR DESCRIPTION
Hi
I'm a developer implementing chia agent which talks to chia daemon/rpc services via websocket.

As my implementation goes deeper, I found there should be a feature which removes registered service without closing entire websocket connection.

Currently, if one want to stop subscribing messages broadcasted from a registered service, it needs to close entire websocket connection even if it still want to listen to other registered message channels.

That's why I propose this PR.
Thanks.