### PR TITLE
Support `-f` and `-p` options for plot creation via daemon API

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -396,6 +396,8 @@ class WebSocketServer:
         b = request["b"]
         u = request["u"]
         r = request["r"]
+        f = request["f"]
+        p = request["p"]
         a = request.get("a")
         e = request["e"]
         x = request["x"]
@@ -414,6 +416,12 @@ class WebSocketServer:
 
         if a is not None:
             command_args.append(f"-a{a}")
+
+        if f is not None:
+            command_args.append(f"-f{f}")
+
+        if p is not None:
+            command_args.append(f"-p{p}")
 
         if e is True:
             command_args.append("-e")

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -913,8 +913,6 @@ class WalletRpcApi:
         wallet_id = uint32(request["wallet_id"])
         wallet: RLWallet = self.service.wallet_state_manager.wallets[wallet_id]
         puzzle_hash = wallet.rl_get_aggregation_puzzlehash(wallet.rl_info.rl_puzzle_hash)
-        request["wallet_id"] = 1
-        request["puzzle_hash"] = puzzle_hash
         async with self.service.wallet_state_manager.lock:
             await wallet.rl_add_funds(request["amount"], puzzle_hash, request["fee"])
         return {"status": "SUCCESS"}


### PR DESCRIPTION
It should be able to post `-f` or `-p` options for `chia plots create` command through daemon API.
I guess why those options are missing is that because creating plots from GUI has not yet supported farmer key nor pool contract address instead of wallet fingerprint.
But pool mining is upcoming and we should prepare to plot via RPC/Websocket.
So adding `-f` and `-p` handling in `daemon` service is required for now.

```python
    def _build_plotting_command_args(self, request: Any, ignoreCount: bool) -> List[str]:
        service_name = request["service"]

        k = request["k"]
        n = 1 if ignoreCount else request["n"]
        t = request["t"]
        t2 = request["t2"]
        d = request["d"]
        b = request["b"]
        u = request["u"]
        r = request["r"]
        f = request["f"] # <-- This should be implemented
        p = request["p"] # <-- This should be implemented
        a = request.get("a")
        e = request["e"]
        x = request["x"]
        override_k = request["overrideK"]

        command_args: List[str] = []
        command_args += service_name.split(" ")
        command_args.append(f"-k{k}")
        command_args.append(f"-n{n}")
        command_args.append(f"-t{t}")
        command_args.append(f"-2{t2}")
        command_args.append(f"-d{d}")
        command_args.append(f"-b{b}")
        command_args.append(f"-u{u}")
        command_args.append(f"-r{r}")

        if a is not None:
            command_args.append(f"-a{a}")

        if f is not None:
            command_args.append(f"-f{f}")

        if p is not None:
            command_args.append(f"-p{p}")

        if e is True:
            command_args.append("-e")

        if x is True:
            command_args.append("-x")

        if override_k is True:
            command_args.append("--override-k")

        self.log.debug(f"command_args are {command_args}")

        return command_args
```
