### PR TITLE
fix type error

### DIFF
--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -169,7 +169,7 @@ def check_cmd(
 def add_cmd(ctx: click.Context, final_dir: str):
     from chia.plotting.plot_tools import add_plot_directory
 
-    add_plot_directory(Path(final_dir), ctx.obj["root_path"])
+    add_plot_directory(final_dir, ctx.obj["root_path"])
     print(f'Added plot directory "{final_dir}".')
 
 
@@ -186,7 +186,7 @@ def add_cmd(ctx: click.Context, final_dir: str):
 def remove_cmd(ctx: click.Context, final_dir: str):
     from chia.plotting.plot_tools import remove_plot_directory
 
-    remove_plot_directory(Path(final_dir), ctx.obj["root_path"])
+    remove_plot_directory(final_dir, ctx.obj["root_path"])
     print(f'Removed plot directory "{final_dir}".')
 
 


### PR DESCRIPTION
This two functions https://github.com/Chia-Network/chia-blockchain/blob/main/chia/plotting/plot_tools.py#L109 https://github.com/Chia-Network/chia-blockchain/blob/main/chia/plotting/plot_tools.py#L122 accept str as their first param and cast it to Path. So we should not cast it before calling these functions.

The current codes works well is because `pathlib.Path` accept itselfs and do nothing.