### PR TITLE
Revert "sets up wallet before running farm summary (#3235)"

### DIFF
--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -47,23 +47,11 @@ def farm_cmd() -> None:
     default=None,
     show_default=True,
 )
-@click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def summary_cmd(
-    rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, farmer_rpc_port: int, fingerprint: int
-) -> None:
+def summary_cmd(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, farmer_rpc_port: int) -> None:
     from .farm_funcs import summary
     import asyncio
 
-    from .wallet_funcs import execute_with_wallet
-
-    asyncio.run(
-        execute_with_wallet(
-            wallet_rpc_port,
-            fingerprint,
-            {},
-            lambda *ignored: summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port),
-        )
-    )
+    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port))
 
 
 @farm_cmd.command("challenges", short_help="Show the latest challenges")

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -194,7 +194,6 @@ class WalletNode:
         self.sync_task = asyncio.create_task(self.sync_job())
         self.logged_in_fingerprint = fingerprint
         self.logged_in = True
-        asyncio.create_task(self.wallet_peers.start())
         return True
 
     def _close(self):
@@ -315,6 +314,7 @@ class WalletNode:
             self.config["peer_connect_interval"],
             self.log,
         )
+        asyncio.create_task(self.wallet_peers.start())
 
     async def on_connect(self, peer: WSChiaConnection):
         if self.wallet_state_manager is None or self.backup_initialized is False:


### PR DESCRIPTION
This reverts commit 880df53f72b352ee523147d77b24a5de182887dc. This was causing an issue in the wallet RPC tests in CI.