### PR TITLE
Don't use a global

### DIFF
--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -15,7 +15,7 @@ except ImportError:
 from chia.rpc.rpc_server import start_rpc_server
 from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer
-from chia.server.upnp import upnp
+from chia.server.upnp import UPnP
 from chia.types.peer_info import PeerInfo
 from chia.util.chia_logging import initialize_logging
 from chia.util.config import load_config, load_config_cli
@@ -108,6 +108,7 @@ class Service:
         self._on_connect_callback = on_connect_callback
         self._advertised_port = advertised_port
         self._reconnect_tasks: List[asyncio.Task] = []
+        self.upnp: Optional[UPnP] = None
 
     async def start(self, **kwargs) -> None:
         # we include `kwargs` as a hack for the wallet, which for some
@@ -127,7 +128,8 @@ class Service:
         await self._node._start(**kwargs)
 
         for port in self._upnp_ports:
-            upnp.remap(port)
+            self.upnp = UPnP()
+            self.upnp.remap(port)
 
         await self._server.start_server(self._on_connect_callback)
 
@@ -190,7 +192,8 @@ class Service:
                 self._rpc_close_task = asyncio.create_task(close_rpc_server())
 
             for port in self._upnp_ports:
-                upnp.release(port)
+                if self.upnp is not None:
+                    self.upnp.release(port)
 
     async def wait_closed(self) -> None:
         await self._is_stopping.wait()

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -128,7 +128,9 @@ class Service:
         await self._node._start(**kwargs)
 
         for port in self._upnp_ports:
-            self.upnp = UPnP()
+            if self.upnp is None:
+                self.upnp = UPnP()
+
             self.upnp.remap(port)
 
         await self._server.start_server(self._on_connect_callback)

--- a/chia/server/upnp.py
+++ b/chia/server/upnp.py
@@ -60,6 +60,3 @@ class UPnP:
 
     def __del__(self):
         self.shutdown()
-
-
-upnp: UPnP = UPnP()


### PR DESCRIPTION
This fixes chia wallet show, which was hanging (even without servers running). Upnp was getting activated just by importing the file, due to the global.

Is there a reason for the global?