### PR TITLE
Fix repeated connections.

### DIFF
--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -225,6 +225,7 @@ class FullNodeDiscovery:
         dns_server_index: int = 0
         local_peerinfo: Optional[PeerInfo] = await self.server.get_peer_info()
         last_timestamp_local_info: uint64 = uint64(int(time.time()))
+        last_collision_timestamp = 0
         if self.initial_wait > 0:
             await asyncio.sleep(self.initial_wait)
 
@@ -321,10 +322,11 @@ class FullNodeDiscovery:
                         retry_introducers = True
                         break
                     info: Optional[ExtendedPeerInfo] = await self.address_manager.select_tried_collision()
-                    if info is None:
+                    if info is None or time.time() - last_collision_timestamp <= 60:
                         info = await self.address_manager.select_peer(is_feeler)
                     else:
                         has_collision = True
+                        last_collision_timestamp = int(time.time())
                     if info is None:
                         if not is_feeler:
                             retry_introducers = True


### PR DESCRIPTION
A collision can take 1 minute to get resolved. In this time, connect_to_peers loop will constantly pick it, and initiate connections to it. This patch forces we pick at most one collision per minute, the remaining time it'll select a random peer from the tables as expected.