### PR TITLE
Cleanup sqlite pragmas

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -28,8 +28,6 @@ class BlockStore:
         # All full blocks which have been added to the blockchain. Header_hash -> block
         self.db_wrapper = db_wrapper
         self.db = db_wrapper.db
-        await self.db.execute("pragma journal_mode=wal")
-        await self.db.execute("pragma synchronous=2")
         await self.db.execute(
             "CREATE TABLE IF NOT EXISTS full_blocks(header_hash text PRIMARY KEY, height bigint,"
             "  is_block tinyint, is_fully_compactified tinyint, block blob)"

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -29,8 +29,8 @@ class CoinStore:
         self.cache_size = cache_size
         self.db_wrapper = db_wrapper
         self.coin_record_db = db_wrapper.db
-        await self.coin_record_db.execute("pragma journal_mode=wal")
-        await self.coin_record_db.execute("pragma synchronous=2")
+        # the coin_name is unique in this table because the CoinStore always
+        # only represent a single peak
         await self.coin_record_db.execute(
             (
                 "CREATE TABLE IF NOT EXISTS coin_record("

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -122,6 +122,8 @@ class FullNode:
         self.new_peak_sem = asyncio.Semaphore(8)
         # create the store (db) and full node instance
         self.connection = await aiosqlite.connect(self.db_path)
+        await self.connection.execute("pragma journal_mode=wal")
+        await self.connection.execute("pragma synchronous=FULL")
         if self.config.get("log_sqlite_cmds", False):
             sql_log_path = path_from_root(self.root_path, "log/sql.log")
             self.log.info(f"logging SQL commands to {sql_log_path}")

--- a/chia/server/address_manager_store.py
+++ b/chia/server/address_manager_store.py
@@ -38,8 +38,6 @@ class AddressManagerStore:
         self = cls()
         self.db = connection
         await self.db.commit()
-        await self.db.execute("pragma journal_mode=wal")
-        await self.db.execute("pragma synchronous=2")
         await self.db.execute("CREATE TABLE IF NOT EXISTS peer_metadata(key text,value text)")
         await self.db.commit()
 

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -92,6 +92,8 @@ class FullNodeDiscovery:
     async def initialize_address_manager(self) -> None:
         mkdir(self.peer_db_path.parent)
         self.connection = await aiosqlite.connect(self.peer_db_path)
+        await self.connection.execute("pragma journal_mode=wal")
+        await self.connection.execute("pragma synchronous=FULL")
         self.address_manager_store = await AddressManagerStore.create(self.connection)
         if not await self.address_manager_store.is_empty():
             self.address_manager = await self.address_manager_store.deserialize()

--- a/chia/wallet/key_val_store.py
+++ b/chia/wallet/key_val_store.py
@@ -20,9 +20,6 @@ class KeyValStore:
         self = cls()
         self.db_wrapper = db_wrapper
         self.db_connection = db_wrapper.db
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
-
         await self.db_connection.execute(
             ("CREATE TABLE IF NOT EXISTS key_val_store(" " key text PRIMARY KEY," " value text)")
         )

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -27,9 +27,6 @@ class TradeStore:
         self.cache_size = cache_size
         self.db_wrapper = db_wrapper
         self.db_connection = db_wrapper.db
-
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
         await self.db_connection.execute(
             (
                 "CREATE TABLE IF NOT EXISTS trade_records("

--- a/chia/wallet/wallet_block_store.py
+++ b/chia/wallet/wallet_block_store.py
@@ -36,9 +36,6 @@ class WalletBlockStore:
 
         self.db_wrapper = db_wrapper
         self.db = db_wrapper.db
-        await self.db.execute("pragma journal_mode=wal")
-        await self.db.execute("pragma synchronous=2")
-
         await self.db.execute(
             "CREATE TABLE IF NOT EXISTS header_blocks(header_hash text PRIMARY KEY, height int,"
             " timestamp int, block blob)"

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -29,9 +29,6 @@ class WalletCoinStore:
 
         self.db_connection = wrapper.db
         self.db_wrapper = wrapper
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
-
         await self.db_connection.execute(
             (
                 "CREATE TABLE IF NOT EXISTS coin_record("

--- a/chia/wallet/wallet_interested_store.py
+++ b/chia/wallet/wallet_interested_store.py
@@ -21,7 +21,7 @@ class WalletInterestedStore:
         self.db_connection = wrapper.db
         self.db_wrapper = wrapper
         await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
+        await self.db_connection.execute("pragma synchronous=FULL")
 
         await self.db_connection.execute("CREATE TABLE IF NOT EXISTS interested_coins(coin_name text PRIMARY KEY)")
 

--- a/chia/wallet/wallet_pool_store.py
+++ b/chia/wallet/wallet_pool_store.py
@@ -22,7 +22,7 @@ class WalletPoolStore:
         self.db_connection = wrapper.db
         self.db_wrapper = wrapper
         await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
+        await self.db_connection.execute("pragma synchronous=FULL")
 
         await self.db_connection.execute(
             "CREATE TABLE IF NOT EXISTS pool_state_transitions(transition_index integer, wallet_id integer, "

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -35,8 +35,6 @@ class WalletPuzzleStore:
 
         self.db_wrapper = db_wrapper
         self.db_connection = self.db_wrapper.db
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
         await self.db_connection.execute(
             (
                 "CREATE TABLE IF NOT EXISTS derivation_paths("

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -137,6 +137,9 @@ class WalletStateManager:
         self.lock = asyncio.Lock()
         self.log.debug(f"Starting in db path: {db_path}")
         self.db_connection = await aiosqlite.connect(db_path)
+        await self.db_connection.execute("pragma journal_mode=wal")
+        await self.db_connection.execute("pragma synchronous=FULL")
+
         self.db_wrapper = DBWrapper(self.db_connection)
         self.coin_store = await WalletCoinStore.create(self.db_wrapper)
         self.tx_store = await WalletTransactionStore.create(self.db_wrapper)

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -29,9 +29,6 @@ class WalletTransactionStore:
 
         self.db_wrapper = db_wrapper
         self.db_connection = self.db_wrapper.db
-
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
         await self.db_connection.execute(
             (
                 "CREATE TABLE IF NOT EXISTS transaction_record("

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -23,8 +23,6 @@ class WalletUserStore:
 
         self.db_wrapper = db_wrapper
         self.db_connection = db_wrapper.db
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=2")
         await self.db_connection.execute(
             (
                 "CREATE TABLE IF NOT EXISTS users_wallets("


### PR DESCRIPTION
* execute the sqlite pragmas only once, at the level where the database is opened
* change pragma synchronous command from `2` to `FULL` to make it clearer what it means. See the sqlite documentation [here](https://sqlite.org/pragma.html#pragma_synchronous).