### PR TITLE
Changed 'not checking subdirectory' message from info to debug.

### DIFF
--- a/chia/plotting/plot_tools.py
+++ b/chia/plotting/plot_tools.py
@@ -46,7 +46,7 @@ def _get_filenames(directory: Path) -> List[Path]:
                 if child.suffix == ".plot" and not child.name.startswith("._"):
                     all_files.append(child)
             else:
-                log.info(f"Not checking subdirectory {child}, subdirectories not added by default")
+                log.debug(f"Not checking subdirectory {child}, subdirectories not added by default")
     except Exception as e:
         log.warning(f"Error reading directory {directory} {e}")
     return all_files


### PR DESCRIPTION
I think this message should be in debug not info, available if needed but not shown constantly.

Not checking subdirectory messages make up around 70% of log entries on windows harvesters.

Example:

Searching directories [...]
Not checking subdirectory C:\FARM1\1\$RECYCLE.BIN, subdirectories not added by default
Not checking subdirectory C:\FARM1\1\System Volume Information, subdirectories not added by default
...
Loaded a total of n plots...
