### PR TITLE
Simplify get_removals

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -855,9 +855,9 @@ class WalletNode:
     async def get_removals(self, peer: WSChiaConnection, block_i, additions, removals) -> Optional[List[Coin]]:
         assert self.wallet_state_manager is not None
 
-        # Check all additions
+        # Check all additions coins
         REQUEST_TYPES = (
-            WalletType.COLOURED_COIN,  # TODO why ?
+            WalletType.COLOURED_COIN,  # TODO: Why?
             WalletType.DISTRIBUTED_ID,
         )
         puzzle_store = self.wallet_state_manager.puzzle_store

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -855,7 +855,7 @@ class WalletNode:
     async def get_removals(self, peer: WSChiaConnection, block_i, additions, removals) -> Optional[List[Coin]]:
         assert self.wallet_state_manager is not None
 
-        # Check all additions coins
+        # Check all additions (added coins)
         REQUEST_TYPES = (
             WalletType.COLOURED_COIN,  # TODO: Why?
             WalletType.DISTRIBUTED_ID,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -860,10 +860,10 @@ class WalletNode:
             WalletType.COLOURED_COIN,  # TODO: Why?
             WalletType.DISTRIBUTED_ID,
         )
-        puzzle_store = self.wallet_state_manager.puzzle_store
 
         addition_requests = False
         for coin in additions:
+            puzzle_store = self.wallet_state_manager.puzzle_store
             record_info: Optional[DerivationRecord] = await puzzle_store.get_derivation_record_for_puzzle_hash(
                 coin.puzzle_hash.hex()
             )

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -862,7 +862,7 @@ class WalletNode:
         )
         puzzle_store = self.wallet_state_manager.puzzle_store
 
-        def doesnt_have_request_type(coin):
+        async def doesnt_have_request_type(coin):
             record_info: Optional[DerivationRecord] = await puzzle_store.get_derivation_record_for_puzzle_hash(
                 coin.puzzle_hash.hex()
             )

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -861,20 +861,20 @@ class WalletNode:
             WalletType.DISTRIBUTED_ID,
         )
 
-        def dont_request(coin):
+        def no_request(coin):
             record_info: Optional[DerivationRecord] = await puzzle_store.get_derivation_record_for_puzzle_hash(
                 coin.puzzle_hash.hex()
             )
             return (record_info is None) or record_info.wallet_type not in REQUEST_TYPES
 
-        all_dont_request_removal = all(map(dont_request, additions))
-        if all_dont_request_removal and len(removals) == 0:
+        no_requests = all(map(no_request, additions))
+        if no_requests and len(removals) == 0:
             return []
 
+        coin_names = removals if no_requests else None
+        removals_request = wallet_protocol.RequestRemovals(block_i.height, block_i.header_hash, coin_names)
         removals_res: Optional[Union[RespondRemovals, RejectRemovalsRequest]] = await peer.request_removals(
-            wallet_protocol.RequestRemovals(
-                block_i.height, block_i.header_hash, (removals if all_dont_request_removal else None)
-            )
+            removals_request
         )
 
         if isinstance(removals_res, RespondRemovals):

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -874,16 +874,14 @@ class WalletNode:
 
         coin_names = removals if no_addition_requests else None
         request = wallet_protocol.RequestRemovals(block_i.height, block_i.header_hash, coin_names)
-        removals_res_msg: Optional[Union[RespondRemovals, RejectRemovalsRequest]] = await peer.request_removals(request)
+        removals_res: Optional[Union[RespondRemovals, RejectRemovalsRequest]] = await peer.request_removals(request)
 
         # Return list of removed coins. Return None also for RejectRemovalsRequest.
-        if isinstance(removals_res_msg, RespondRemovals):
-            proofs = removals_res_msg.proofs
-            coins = removals_res_msg.coins
+        if isinstance(removals_res, RespondRemovals):
+            coins = removals_res.coins
             removals_root = block_i.foliage_transaction_block.removals_root
-            if self.validate_removals(coins, proofs, removals_root):
-                removed_coins = [coins_l for _, coins_l in coins if coins_l is not None]
-                return removed_coins
+            if self.validate_removals(coins, removals_res.proofs, removals_root):
+                return [coin for _, coin in coins if coin is not None]
 
             await peer.close()
 


### PR DESCRIPTION
Some more logic stratification in a wallet node member function.

PS: I'm not sure but would like to know if it's on purpose that the `puzzle_store` member is set up inside the for-loop. Moving it at least didn't bother the tests, but I leave it unchanged as of here.