### PR TITLE
Shorter _action_messages call

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -239,18 +239,17 @@ class WalletNode:
             return []
 
         actions: List[WalletAction] = await self.wallet_state_manager.action_store.get_all_pending_actions()
-        puzzle_actions = filter(lambda action: action.name == "request_puzzle_solution", actions)
+        solution_actions = filter(lambda a: a.name == "request_puzzle_solution", actions)
 
         def make_msg_from_action(action) -> Message:
             data = json.loads(action.data)
             action_data = data["data"]["action_data"]
             coin_name = bytes32(hexstr_to_bytes(action_data["coin_name"]))
             height = uint32(action_data["height"])
-            return make_msg(
-                ProtocolMessageTypes.request_puzzle_solution, wallet_protocol.RequestPuzzleSolution(coin_name, height),
-            )
+            msg_data = wallet_protocol.RequestPuzzleSolution(coin_name, height)
+            return make_msg(ProtocolMessageTypes.request_puzzle_solution, msg_data)
 
-        return map(make_msg_from_action, puzzle_actions)
+        return map(make_msg_from_action, solution_actions)
 
     async def _resend_queue(self):
         if (

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -5,7 +5,7 @@ import socket
 import time
 import traceback
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set, Tuple, Union, Any
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from blspy import PrivateKey
 
@@ -234,9 +234,9 @@ class WalletNode:
             return None
         asyncio.create_task(self._resend_queue())
 
-    async def _action_messages(self):
+    async def _action_messages(self) -> Iterable[Message]:
         if self.wallet_state_manager is None or self.backup_initialized is False:
-            return []
+            return ()
 
         def make_msg_from_action(action) -> Message:
             data = json.loads(action.data)

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1140,17 +1140,17 @@ class WalletStateManager:
     async def puzzle_solution_received(self, response: RespondPuzzleSolution):
         unwrapped: PuzzleSolutionResponse = response.response
         actions: List[WalletAction] = await self.action_store.get_all_pending_actions()
-        for action in actions:
-            if action.name == "request_puzzle_solution":
-                data = json.loads(action.data)
-                action_data = data["data"]["action_data"]
-                stored_coin_name = bytes32(hexstr_to_bytes(action_data["coin_name"]))
-                height = uint32(action_data["height"])
-                if stored_coin_name == unwrapped.coin_name and height == unwrapped.height:
-                    if action.done:
-                        return None
-                    wallet = self.wallets[uint32(action.wallet_id)]
-                    callback_str = action.wallet_callback
-                    if callback_str is not None:
-                        callback = getattr(wallet, callback_str)
-                        await callback(unwrapped, action.id)
+        solution_actions = filter(lambda a: a.name == "request_puzzle_solution", actions)
+        for action in solution_actions:
+            data = json.loads(action.data)
+            action_data = data["data"]["action_data"]
+            stored_coin_name = bytes32(hexstr_to_bytes(action_data["coin_name"]))
+            height = uint32(action_data["height"])
+            if stored_coin_name == unwrapped.coin_name and height == unwrapped.height:
+                if action.done:
+                    return None
+                wallet = self.wallets[uint32(action.wallet_id)]
+                callback_str = action.wallet_callback
+                if callback_str is not None:
+                    callback = getattr(wallet, callback_str)
+                    await callback(unwrapped, action.id)

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1141,9 +1141,9 @@ class WalletStateManager:
         unwrapped: PuzzleSolutionResponse = response.response
         actions: List[WalletAction] = await self.action_store.get_all_pending_actions()
         for action in actions:
-            data = json.loads(action.data)
-            action_data = data["data"]["action_data"]
             if action.name == "request_puzzle_solution":
+                data = json.loads(action.data)
+                action_data = data["data"]["action_data"]
                 stored_coin_name = bytes32(hexstr_to_bytes(action_data["coin_name"]))
                 height = uint32(action_data["height"])
                 if stored_coin_name == unwrapped.coin_name and height == unwrapped.height:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1120,22 +1120,21 @@ class WalletStateManager:
         await self.action_store.action_done(action_id)
 
     async def generator_received(self, height: uint32, header_hash: uint32, program: Program):
-
         actions: List[WalletAction] = await self.action_store.get_all_pending_actions()
-        for action in actions:
+        generator_actions = filter(lambda a: a.name == "request_generator", actions)
+        for action in generator_actions:
             data = json.loads(action.data)
             action_data = data["data"]["action_data"]
-            if action.name == "request_generator":
-                stored_header_hash = bytes32(hexstr_to_bytes(action_data["header_hash"]))
-                stored_height = uint32(action_data["height"])
-                if stored_header_hash == header_hash and stored_height == height:
-                    if action.done:
-                        return None
-                    wallet = self.wallets[uint32(action.wallet_id)]
-                    callback_str = action.wallet_callback
-                    if callback_str is not None:
-                        callback = getattr(wallet, callback_str)
-                        await callback(height, header_hash, program, action.id)
+            stored_header_hash = bytes32(hexstr_to_bytes(action_data["header_hash"]))
+            stored_height = uint32(action_data["height"])
+            if stored_header_hash == header_hash and stored_height == height:
+                if action.done:
+                    return None
+                wallet = self.wallets[uint32(action.wallet_id)]
+                callback_str = action.wallet_callback
+                if callback_str is not None:
+                    callback = getattr(wallet, callback_str)
+                    await callback(height, header_hash, program, action.id)
 
     async def puzzle_solution_received(self, response: RespondPuzzleSolution):
         unwrapped: PuzzleSolutionResponse = response.response


### PR DESCRIPTION
It appears there's some unnecessary calls being made to json load, so I filter the actions upfront. 
I also omit a cast `list(map(..))` that's functionally unnecessary for how the function output is further consumed in the code.