### PR TITLE
make return of get_transaction consistent with get_transactions

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -493,8 +493,13 @@ class WalletRpcApi:
         if tr is None:
             raise ValueError(f"Transaction 0x{transaction_id.hex()} not found")
 
+        selected = self.service.config["selected_network"]
+        prefix = self.service.config["network_overrides"]["config"][selected]["address_prefix"]
+        formatted = tr.to_json_dict()
+        formatted["to_address"] = encode_puzzle_hash(tr.to_puzzle_hash, prefix)
+
         return {
-            "transaction": tr,
+            "transaction": formatted,
             "transaction_id": tr.name,
         }
 


### PR DESCRIPTION
Noticed a difference between the `get_transactions` response and the `get_transaction` response - this just adds `to_address` to the return of the `get_transaction` endpoint to be consistent with the `get_transactions` endpoint