### PR TITLE
ClientSession lifetime simplification

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -260,32 +260,26 @@ class RpcServer:
 
     async def connect_to_daemon(self, self_hostname: str, daemon_port: uint16):
         while True:
-            session = None
             try:
                 if self.shut_down:
                     break
-                session = aiohttp.ClientSession()
-
-                async with session.ws_connect(
-                    f"wss://{self_hostname}:{daemon_port}",
-                    autoclose=True,
-                    autoping=True,
-                    heartbeat=60,
-                    ssl_context=self.ssl_context,
-                    max_msg_size=100 * 1024 * 1024,
-                ) as ws:
-                    self.websocket = ws
-                    await self.connection(ws)
-                self.websocket = None
-                await session.close()
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect(
+                        f"wss://{self_hostname}:{daemon_port}",
+                        autoclose=True,
+                        autoping=True,
+                        heartbeat=60,
+                        ssl_context=self.ssl_context,
+                        max_msg_size=100 * 1024 * 1024,
+                    ) as ws:
+                        self.websocket = ws
+                        await self.connection(ws)
+                    self.websocket = None
             except aiohttp.ClientConnectorError:
                 self.log.warning(f"Cannot connect to daemon at ws://{self_hostname}:{daemon_port}")
             except Exception as e:
                 tb = traceback.format_exc()
                 self.log.warning(f"Exception: {tb} {type(e)}")
-            finally:
-                if session is not None:
-                    await session.close()
             await asyncio.sleep(2)
 
 

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -460,6 +460,9 @@ class FullNodeDiscovery:
 
 
 class FullNodePeers(FullNodeDiscovery):
+    self_advertise_task: Optional[asyncio.Task] = None
+    address_relay_task: Optional[asyncio.Task] = None
+
     def __init__(
         self,
         server,

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -362,54 +362,54 @@ class ChiaServer:
                 )
             except ServerDisconnectedError:
                 self.log.debug(f"Server disconnected error connecting to {url}. Perhaps we are banned by the peer.")
-                await session.close()
                 return False
             except asyncio.TimeoutError:
                 self.log.debug(f"Timeout error connecting to {url}")
-                await session.close()
                 return False
-            if ws is not None:
-                assert ws._response.connection is not None and ws._response.connection.transport is not None
-                transport = ws._response.connection.transport  # type: ignore
-                cert_bytes = transport._ssl_protocol._extra["ssl_object"].getpeercert(True)  # type: ignore
-                der_cert = x509.load_der_x509_certificate(cert_bytes, default_backend())
-                peer_id = bytes32(der_cert.fingerprint(hashes.SHA256()))
-                if peer_id == self.node_id:
-                    raise RuntimeError(f"Trying to connect to a peer ({target_node}) with the same peer_id: {peer_id}")
+            if ws is None:
+                return False
 
-                connection = WSChiaConnection(
-                    self._local_type,
-                    ws,
-                    self._port,
-                    self.log,
-                    True,
-                    False,
-                    target_node.host,
-                    self.incoming_messages,
-                    self.connection_closed,
-                    peer_id,
-                    self._inbound_rate_limit_percent,
-                    self._outbound_rate_limit_percent,
-                    session=session,
-                )
-                handshake = await connection.perform_handshake(
-                    self._network_id,
-                    protocol_version,
-                    self._port,
-                    self._local_type,
-                )
-                assert handshake is True
-                await self.connection_added(connection, on_connect)
-                connection_type_str = ""
-                if connection.connection_type is not None:
-                    connection_type_str = connection.connection_type.name.lower()
-                self.log.info(f"Connected with {connection_type_str} {target_node}")
-                if is_feeler:
-                    asyncio.create_task(connection.close())
-                return True
-            else:
-                await session.close()
-                return False
+            assert ws._response.connection is not None and ws._response.connection.transport is not None
+            transport = ws._response.connection.transport  # type: ignore
+            cert_bytes = transport._ssl_protocol._extra["ssl_object"].getpeercert(True)  # type: ignore
+            der_cert = x509.load_der_x509_certificate(cert_bytes, default_backend())
+            peer_id = bytes32(der_cert.fingerprint(hashes.SHA256()))
+            if peer_id == self.node_id:
+                raise RuntimeError(f"Trying to connect to a peer ({target_node}) with the same peer_id: {peer_id}")
+
+            connection = WSChiaConnection(
+                self._local_type,
+                ws,
+                self._port,
+                self.log,
+                True,
+                False,
+                target_node.host,
+                self.incoming_messages,
+                self.connection_closed,
+                peer_id,
+                self._inbound_rate_limit_percent,
+                self._outbound_rate_limit_percent,
+                session=session,
+            )
+            handshake = await connection.perform_handshake(
+                self._network_id,
+                protocol_version,
+                self._port,
+                self._local_type,
+            )
+            assert handshake is True
+            await self.connection_added(connection, on_connect)
+            # the session has been adopted by the connection, don't close it at
+            # the end of the function
+            session = None
+            connection_type_str = ""
+            if connection.connection_type is not None:
+                connection_type_str = connection.connection_type.name.lower()
+            self.log.info(f"Connected with {connection_type_str} {target_node}")
+            if is_feeler:
+                asyncio.create_task(connection.close())
+            return True
         except client_exceptions.ClientConnectorError as e:
             self.log.info(f"{e}")
         except ProtocolError as e:
@@ -429,9 +429,9 @@ class ChiaServer:
                 await connection.close(self.invalid_protocol_ban_seconds, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
             error_stack = traceback.format_exc()
             self.log.error(f"Exception {e}, exception Stack: {error_stack}")
-
-        if session is not None:
-            await session.close()
+        finally:
+            if session is not None:
+                await session.close()
 
         return False
 


### PR DESCRIPTION
instead of manually closing the client session in all return paths (and missing some), use a context manager to reliably close it when shutting down. This fixes the following error log when closing the full node by pressing Ctrl-C:

```
ERROR    Unclosed client session
```

Since the `async with` blocks affect indentation, please review this with hidden whitespace