### PR TITLE
Path saving functions type mismatch

### DIFF
--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -169,7 +169,7 @@ def check_cmd(
 def add_cmd(ctx: click.Context, final_dir: str):
     from chia.plotting.plot_tools import add_plot_directory
 
-    add_plot_directory(Path(final_dir), ctx.obj["root_path"])
+    _config = add_plot_directory(final_dir, ctx.obj["root_path"])
     print(f'Added plot directory "{final_dir}".')
 
 
@@ -186,7 +186,7 @@ def add_cmd(ctx: click.Context, final_dir: str):
 def remove_cmd(ctx: click.Context, final_dir: str):
     from chia.plotting.plot_tools import remove_plot_directory
 
-    remove_plot_directory(Path(final_dir), ctx.obj["root_path"])
+    remove_plot_directory(final_dir, ctx.obj["root_path"])
     print(f'Removed plot directory "{final_dir}".')
 
 

--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -169,7 +169,7 @@ def check_cmd(
 def add_cmd(ctx: click.Context, final_dir: str):
     from chia.plotting.plot_tools import add_plot_directory
 
-    _config = add_plot_directory(final_dir, ctx.obj["root_path"])
+    add_plot_directory(final_dir, ctx.obj["root_path"])  # Unused config return value
     print(f'Added plot directory "{final_dir}".')
 
 

--- a/chia/plotting/plot_tools.py
+++ b/chia/plotting/plot_tools.py
@@ -110,7 +110,9 @@ def add_plot_directory(str_path: str, root_path: Path) -> Dict:
     config = load_config(root_path, "config.yaml")
     if str(Path(str_path).resolve()) not in config["harvester"]["plot_directories"]:
         config["harvester"]["plot_directories"].append(str(Path(str_path).resolve()))
+
     save_config(root_path, "config.yaml", config)
+
     return config
 
 
@@ -122,6 +124,7 @@ def get_plot_directories(root_path: Path) -> List[str]:
 def remove_plot_directory(str_path: str, root_path: Path) -> None:
     config = load_config(root_path, "config.yaml")
     str_paths: List[str] = config["harvester"]["plot_directories"]
+
     # If path str matches exactly, remove
     if str_path in str_paths:
         str_paths.remove(str_path)
@@ -132,6 +135,7 @@ def remove_plot_directory(str_path: str, root_path: Path) -> None:
         new_paths.remove(Path(str_path).resolve())
 
     config["harvester"]["plot_directories"] = [str(np) for np in new_paths]
+
     save_config(root_path, "config.yaml", config)
 
 


### PR DESCRIPTION
Lint hints at a type mismatch (string vs. path) of some plotting tool functions.

Came across it when pushing https://github.com/Chia-Network/chia-blockchain/pull/5158.

----
Related observation: The corresponding functions in harvesters are set up as async and typed with `-> bool` but I think they can only return `True` and so there's some suspicious (i.e. redundant) if-clauses in `HarvesterRpcApi`. Although it's all bit confusion since member functions of various modules are called the same.