### PR TITLE
Fix header_hash variable in case begin_transaction() throws

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -256,9 +256,9 @@ class Blockchain(BlockchainInterface):
         # Always add the block to the database
         async with self.block_store.db_wrapper.lock:
             try:
+                header_hash: bytes32 = block.header_hash
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.db_wrapper.begin_transaction()
-                header_hash: bytes32 = block.header_hash
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 fork_height, peak_height, records = await self._reconsider_peak(
                     block_record, genesis, fork_point_with_peak, npc_result

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -127,7 +127,12 @@ class BlockStore:
         return None
 
     def rollback_cache_block(self, header_hash: bytes32):
-        self.block_cache.remove(header_hash)
+        try:
+            self.block_cache.remove(header_hash)
+        except KeyError:
+            # this is best effort. When rolling back, we may not have added the
+            # block to the cache yet
+            pass
 
     async def get_full_block(self, header_hash: bytes32) -> Optional[FullBlock]:
         cached = self.block_cache.get(header_hash)


### PR DESCRIPTION
I got this error, which I expect this patch to fix:

```
15:27:45 full_node_server: ERROR Exception: local variable 'header_hash' referenced before assignment, {'host': '::1', 'port': 21234}. Traceback (most recent call last):
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/consensus/blockchain.py", line 260, in receive_block
    await self.block_store.db_wrapper.begin_transaction()
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/util/db_wrapper.py", line 19, in begin_transaction
    cursor = await self.db.execute("BEGIN TRANSACTION")
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/aiosqlite/core.py", line 184, in execute
    cursor = await self._execute(self._conn.execute, sql, parameters)
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/aiosqlite/core.py", line 129, in _execute
    return await future
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/server/server.py", line 526, in wrapped_coroutine
    result = await coroutine
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/full_node/full_node_api.py", line 106, in new_peak
    return await self.full_node.new_peak(request, peer)
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/full_node/full_node.py", line 373, in new_peak
    if await self.short_sync_backtrack(
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/full_node/full_node.py", line 323, in short_sync_backtrack
    raise e
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/full_node/full_node.py", line 320, in short_sync_backtrack
    await self.respond_block(response, peer)
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/full_node/full_node.py", line 1178, in respond_block
    added, error_code, fork_height = await self.blockchain.receive_block(block, result_to_validate, None)
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/consensus/blockchain.py", line 279, in receive_block
    self.block_store.rollback_cache_block(header_hash)
UnboundLocalError: local variable 'header_hash' referenced before assignment
```