### PR TITLE
Multiple grep strings for 'chia plots check'

### DIFF
--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -140,7 +140,8 @@ def create_cmd(
 @click.option(
     "-g",
     "--grep_string",
-    help="Check only plots that contain any of the specified strings in their file or directory name. Specify multiple match strings by using double-quotes \"\" with TEXT separated by a single space.",
+    help='Check only plots that contain any of the specified strings in their file or directory name. Specify'
+            'multiple match strings by using double-quotes "" with TEXT separated by a single space.',
     type=str,
     default=None,
 )

--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -140,7 +140,7 @@ def create_cmd(
 @click.option(
     "-g",
     "--grep_string",
-    help="Shows only plots that contain the string in the filename or directory name",
+    help="Check only plots that contain any of the specified strings in their file or directory name. Specify multiple match strings by using double-quotes \"\" with TEXT separated by a single space.",
     type=str,
     default=None,
 )

--- a/chia/plotting/plot_tools.py
+++ b/chia/plotting/plot_tools.py
@@ -164,7 +164,8 @@ def load_plots(
         if len(match_strings) == 1:
             log.info(f'Only loading plots that contain "{match_str}" in the file or directory name')
         else:
-            log.info(f'Only loading plots that contain any of the {len(match_strings)} strings provided in their file or directory names')
+            log.info(f'Only loading plots that contain any of the {len(match_strings)} strings provided in their'
+                    'file or directory names')
 
     def process_file(filename: Path) -> Tuple[int, Dict]:
         new_provers: Dict[Path, PlotInfo] = {}


### PR DESCRIPTION
Support for multiple grep/match strings to the plots check -g/--grep-string optarg. Strings to match are separated by a space, like:

`chia plots check -g "bc4a6372a8ae3ffeb3a6088de8d8cfe9f60919c91e8afa79542cc3c5079c623b 4f98eb950a6a24ecff77cefc77ffbdb00a23d7fa21e6635eaa1146ecb3c4bd1d 2021-05-21-"
`
The particular use case is speeding up the plots check when matching multiple plots. Shell 'for' loops iterating a list of individual grep strings and executing "chia plots check -g <string>" is of course much slower than building it in. This provides a much cleaner and faster interface to this case.