### PR TITLE
Fixed an issue where queued plotter task cannot be cannceled because of missing plotter uuid.

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -600,8 +600,9 @@ class WebSocketServer:
             if process is not None and state == PlotState.RUNNING:
                 run_next = True
                 config["state"] = PlotState.REMOVING
-                self.state_changed(service_plotter,
-                                   self.prepare_plot_state_message(PlotEvent.STATE_CHANGED, plotter_uuid))
+                self.state_changed(
+                    service_plotter, self.prepare_plot_state_message(PlotEvent.STATE_CHANGED, plotter_uuid)
+                )
                 await kill_process(process, self.root_path, service_plotter, plotter_uuid)
 
             config["state"] = PlotState.FINISHED

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -600,7 +600,8 @@ class WebSocketServer:
             if process is not None and state == PlotState.RUNNING:
                 run_next = True
                 config["state"] = PlotState.REMOVING
-                self.state_changed(service_plotter, self.prepare_plot_state_message(PlotEvent.STATE_CHANGED, plotter_uuid))
+                self.state_changed(service_plotter,
+                                   self.prepare_plot_state_message(PlotEvent.STATE_CHANGED, plotter_uuid))
                 await kill_process(process, self.root_path, service_plotter, plotter_uuid)
 
             config["state"] = PlotState.FINISHED


### PR DESCRIPTION
This PR includes 2 modifications:
- Renamed `id` to `plotter_uuid` in `start_plotting` method in `daemon/service.ts`
- Added `plotter_uuids: List[str]` to `start_plotting` response dict.

### Renamed `id` to `plotter_uuid` in `start_plotting` method in `daemon/service.ts`
The term `plot id` is confusing developers, as there are several kind of ids called `plot id`.
The `id` used in `chia/daemon/server.py` shown below is only used for plotter 'log' file name, or for canceling plotter tasks managed only in daemon process and nothing to do with a plot key.

So I propose this PR to make it clear that id used here is `plotter_uuid` and not a `plot id` associated with any kind of chia keys.

```python
    async def start_plotting(self, request: Dict[str, Any]):
        service_name = request["service"]

        # ...

        for k in range(count):
            plotter_uuid = str(uuid.uuid4()) # <- Updated from `id = str(uuid.uuid4())`
            # ...
            config = {
                "id": plotter_uuid, # <- Updated from `id`
                # ...
            }

            self.plots_queue.append(config)

```

### Added `plotter_uuids: List[str]` to `start_plotting` response dict.

There is a problem regarding to canceling queued plotter task.
It cannot be canceled via `stop_plotting` request to daemon as users have no way to find those canceling task's uuid before sending the cancel requests because `start_plotting` request does not return `plotter_uuid` of the tasks.
Uuid of queued plot task is kept in daemon instance, and finally come out in a plot log file name when those tasks get out of a queue and start running.

Users can only find uuids via plotter log file name as below, but if plot task is still in a queue, they have no way to know task's  uuid.
`$CHIA_HOME/plotter/plotter_log_{plotter_uuid}.txt`

Those who want to cancel running plotter task may have hard time finding target task's uuid, because they must look in recent plotter log files to know which plotter task is which.

So, When requesting daemon to start plotting via `start_plotting` request, daemon must respond with `plotter_uuids`, in order to cancel plotting tasks later.