### PR TITLE
Reduce websocket ping interval and timeout to avoid socket breaking

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -145,8 +145,8 @@ class WebSocketServer:
             self.self_hostname,
             self.daemon_port,
             max_size=50 * 1000 * 1000,
-            ping_interval=500,
-            ping_timeout=300,
+            ping_interval=25,
+            ping_timeout=20,
             ssl=self.ssl_context,
         )
         self.log.info("Waiting Daemon WebSocketServer closure")


### PR DESCRIPTION
Based on my testing, this appears to resolve the main issue raised in #5136 and #2810

The current `ping_interval` is over 8 minutes (500 seconds) which is far too high for many home networks, in particular with some NAT configs. 

The websockets documentation has default values of 20 and 20 for `ping_interval` and `ping_timeout` so these seem fairly sensible. 