### PR TITLE
Add full node ports for testnet dns.

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -177,6 +177,12 @@ class FullNode:
     def set_server(self, server: ChiaServer):
         self.server = server
         dns_servers = []
+        try:
+            network_name = self.config["selected_network"]
+            default_port = self.config["network_overrides"]["config"][network_name]["default_full_node_port"]
+        except Exception:
+            self.log.info("Default port field not found in config.")
+            default_port = None
         if "dns_servers" in self.config:
             dns_servers = self.config["dns_servers"]
         elif self.config["port"] == 8444:
@@ -193,6 +199,7 @@ class FullNode:
                 dns_servers,
                 self.config["peer_connect_interval"],
                 self.config["selected_network"],
+                default_port,
                 self.log,
             )
         except Exception as e:

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -195,7 +195,9 @@ class FullNodeDiscovery:
     async def _query_dns(self, dns_address):
         try:
             if self.default_port is None:
-                self.log.error("Network id not supported in NETWORK_ID_DEFAULT_PORTS neither in config. Skipping DNS query.")
+                self.log.error(
+                    "Network id not supported in NETWORK_ID_DEFAULT_PORTS neither in config. Skipping DNS query."
+                )
                 return
             peers: List[TimestampedPeerInfo] = []
             result = await self.resolver.resolve(qname=dns_address, lifetime=30)

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -25,6 +25,11 @@ from chia.util.path import mkdir, path_from_root
 MAX_PEERS_RECEIVED_PER_REQUEST = 1000
 MAX_TOTAL_PEERS_RECEIVED = 3000
 MAX_CONCURRENT_OUTBOUND_CONNECTIONS = 70
+NETWORK_ID_DEFAULT_PORTS = {
+    "mainnet": 8444,
+    "testnet7": 58444,
+    "testnet8": 58445,
+}
 
 
 class FullNodeDiscovery:
@@ -38,6 +43,7 @@ class FullNodeDiscovery:
         dns_servers: List[str],
         peer_connect_interval: int,
         selected_network: str,
+        default_port: Optional[int],
         log,
     ):
         self.server: ChiaServer = server
@@ -73,6 +79,9 @@ class FullNodeDiscovery:
         self.resolver = dns.asyncresolver.Resolver()
         self.pending_outbound_connections: Set[str] = set()
         self.pending_tasks: Set[asyncio.Task] = set()
+        self.default_port: Optional[int] = default_port
+        if default_port is None and selected_network in NETWORK_ID_DEFAULT_PORTS:
+            self.default_port = NETWORK_ID_DEFAULT_PORTS[selected_network]
 
     async def initialize_address_manager(self) -> None:
         mkdir(self.peer_db_path.parent)
@@ -185,13 +194,16 @@ class FullNodeDiscovery:
 
     async def _query_dns(self, dns_address):
         try:
+            if self.default_port is None:
+                self.log.error("Network id not supported in NETWORK_ID_DEFAULT_PORTS neither in config. Skipping DNS query.")
+                return
             peers: List[TimestampedPeerInfo] = []
             result = await self.resolver.resolve(qname=dns_address, lifetime=30)
             for ip in result:
                 peers.append(
                     TimestampedPeerInfo(
                         ip.to_text(),
-                        8444,
+                        self.default_port,
                         0,
                     )
                 )
@@ -478,6 +490,7 @@ class FullNodePeers(FullNodeDiscovery):
         dns_servers,
         peer_connect_interval,
         selected_network,
+        default_port,
         log,
     ):
         super().__init__(
@@ -489,6 +502,7 @@ class FullNodePeers(FullNodeDiscovery):
             dns_servers,
             peer_connect_interval,
             selected_network,
+            default_port,
             log,
         )
         self.relay_queue = asyncio.Queue()
@@ -649,6 +663,7 @@ class WalletPeers(FullNodeDiscovery):
         dns_servers,
         peer_connect_interval,
         selected_network,
+        default_port,
         log,
     ) -> None:
         super().__init__(
@@ -660,6 +675,7 @@ class WalletPeers(FullNodeDiscovery):
             dns_servers,
             peer_connect_interval,
             selected_network,
+            default_port,
             log,
         )
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -72,6 +72,7 @@ network_overrides: &network_overrides
   config:
     mainnet:
       address_prefix: "xch"
+      default_full_node_port: 8444
     testnet0:
       address_prefix: "txch"
     testnet1:
@@ -84,6 +85,7 @@ network_overrides: &network_overrides
       address_prefix: "txch"
     testnet7:
       address_prefix: "txch"
+      default_full_node_port: 58444
 
 selected_network: &selected_network "mainnet"
 ALERTS_URL: https://download.chia.net/notify/mainnet_alert.txt

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -319,6 +319,7 @@ class WalletNode:
             [],
             self.config["peer_connect_interval"],
             self.config["selected_network"],
+            None,
             self.log,
         )
         asyncio.create_task(self.wallet_peers.start())


### PR DESCRIPTION
Use config/hardcoded ports when parsing DNS responses.