### PR TITLE
don't build a dict of the conditions, just to iterate over them

### DIFF
--- a/chia/consensus/cost_calculator.py
+++ b/chia/consensus/cost_calculator.py
@@ -27,7 +27,7 @@ def calculate_cost_of_program(program: SerializedProgram, npc_result: NPCResult,
     # Add cost of conditions
     npc: NPC
     for npc in npc_list:
-        for condition, cvp_list in npc.condition_dict.items():
+        for condition, cvp_list in npc.conditions:
             if condition is ConditionOpcode.AGG_SIG_UNSAFE or condition is ConditionOpcode.AGG_SIG_ME:
                 total_cost += len(cvp_list) * ConditionCost.AGG_SIG.value
             elif condition is ConditionOpcode.CREATE_COIN:


### PR DESCRIPTION
the reason we have the convenience function to turn the list into a dict is for efficient lookups for consuming announcements (I believe). Creating a dict just to iterate it is wasted work, we might as well just iterate it directly.