### PR TITLE
add missing cost constants for conditions

### DIFF
--- a/chia/consensus/condition_costs.py
+++ b/chia/consensus/condition_costs.py
@@ -6,6 +6,9 @@ class ConditionCost(Enum):
     AGG_SIG = 1200000  # the cost of one G1 subgroup check + aggregated signature validation
     CREATE_COIN = 1800000
     ASSERT_MY_COIN_ID = 0
+    ASSERT_MY_PARENT_ID = 0
+    ASSERT_MY_PUZZLEHASH = 0
+    ASSERT_MY_AMOUNT = 0
     ASSERT_SECONDS_RELATIVE = 0
     ASSERT_SECONDS_ABSOLUTE = 0
     ASSERT_HEIGHT_RELATIVE = 0

--- a/chia/consensus/cost_calculator.py
+++ b/chia/consensus/cost_calculator.py
@@ -42,6 +42,12 @@ def calculate_cost_of_program(program: SerializedProgram, npc_result: NPCResult,
                 total_cost += len(cvp_list) * ConditionCost.ASSERT_HEIGHT_RELATIVE.value
             elif condition is ConditionOpcode.ASSERT_MY_COIN_ID:
                 total_cost += len(cvp_list) * ConditionCost.ASSERT_MY_COIN_ID.value
+            elif condition is ConditionOpcode.ASSERT_MY_PARENT_ID:
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_MY_PARENT_ID.value
+            elif condition is ConditionOpcode.ASSERT_MY_PUZZLEHASH:
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_MY_PUZZLEHASH.value
+            elif condition is ConditionOpcode.ASSERT_MY_AMOUNT:
+                total_cost += len(cvp_list) * ConditionCost.ASSERT_MY_AMOUNT.value
             elif condition is ConditionOpcode.RESERVE_FEE:
                 total_cost += len(cvp_list) * ConditionCost.RESERVE_FEE.value
             elif condition is ConditionOpcode.CREATE_COIN_ANNOUNCEMENT:


### PR DESCRIPTION
Perhaps it's a bit meaningless to have names for all these zeros. I think we should either have these constants, for consistency, or remove all the zero-constants.