### PR TITLE
Fix broken UPnP in upnp.py

### DIFF
--- a/chia/server/upnp.py
+++ b/chia/server/upnp.py
@@ -29,7 +29,10 @@ class UPnP:
                     if msg[0] == "remap":
                         port = msg[1]
                         log.info(f"Attempting to enable UPnP (open up port {port})")
-                        self.upnp.deleteportmapping(port, "TCP")
+                        try: 
+                            self.upnp.deleteportmapping(port, "TCP")
+                        except Exception as e:
+                            log.info("Removal of previous portmapping failed. This does not indicate an error: {e}")
                         self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "chia", "")
                         log.info(
                             f"Port {port} opened with UPnP. lanaddr {self.upnp.lanaddr} "

--- a/chia/server/upnp.py
+++ b/chia/server/upnp.py
@@ -29,7 +29,7 @@ class UPnP:
                     if msg[0] == "remap":
                         port = msg[1]
                         log.info(f"Attempting to enable UPnP (open up port {port})")
-                        try: 
+                        try:
                             self.upnp.deleteportmapping(port, "TCP")
                         except Exception as e:
                             log.info(f"Removal of previous portmapping failed. This does not indicate an error: {e}")

--- a/chia/server/upnp.py
+++ b/chia/server/upnp.py
@@ -32,7 +32,7 @@ class UPnP:
                         try: 
                             self.upnp.deleteportmapping(port, "TCP")
                         except Exception as e:
-                            log.info("Removal of previous portmapping failed. This does not indicate an error: {e}")
+                            log.info(f"Removal of previous portmapping failed. This does not indicate an error: {e}")
                         self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "chia", "")
                         log.info(
                             f"Port {port} opened with UPnP. lanaddr {self.upnp.lanaddr} "


### PR DESCRIPTION
Contributed by phoyd: 39ef696 introduced deleteportmapping to cleanup previous mappings. deleteportmapping might throw an error from a upnp server reply when the port mapping to delete does not exist (see rfc6970, section-5.8 NoSuchEntryInArray). This prevents the subsequent addportmapping() and hence opening upnp does not work anymore (For example, issue #6250)