### PR TITLE
Update all platforms to miniupnpc 2.2.2 and Windows to Python 3.9

### DIFF
--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -59,7 +59,7 @@ jobs:
             echo "Emulating install.sh" && \
             pip install --upgrade pip && \
             pip install wheel && \
-            pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.1 && \
+            pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2 && \
             pip install . --extra-index-url https://pypi.chia.net/simple/ && \
             ldd --version && \
             cd build_scripts && \

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -57,9 +57,9 @@ jobs:
 
 #  We can't upgrade to Python 3.8 until we have a miniupnpc binary
     - uses: actions/setup-python@v2
-      name: Install Python 3.7
+      name: Install Python 3.9
       with:
-        python-version: "3.7"
+        python-version: "3.9"
 
     - name: Test for secrets access
       id: check_secrets

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,4 +1,4 @@
-name: Windows Installer on Windows 10 and Python 3.7
+name: Windows Installer on Windows 10 and Python 3.9
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Windows Installer on Windows 10 and Python 3.7
+    name: Windows Installer on Windows 10 and Python 3.9
     runs-on: [windows-latest]
     timeout-minutes: 40
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ steps:
       python -m pip install --upgrade pip
       pip install wheel pep517 setuptools_scm
       node -v
-      pip install -i https://pypi.chia.net/simple/ miniupnpc==2.1
+      pip install -i https://pypi.chia.net/simple/ miniupnpc==2.2.2
     displayName: "Install dependencies"
 
   - script: |

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -10,8 +10,9 @@ git status
 Write-Output "   ---"
 Write-Output "curl miniupnpc"
 Write-Output "   ---"
-Invoke-WebRequest -Uri "https://pypi.chia.net/simple/miniupnpc/miniupnpc-2.1-cp37-cp37m-win_amd64.whl" -OutFile "miniupnpc-2.1-cp37-cp37m-win_amd64.whl"
-Write-Output "Using win_amd64 python 3.7 wheel from https://github.com/miniupnp/miniupnp/pull/475 (2.2.0-RC1)"
+Invoke-WebRequest -Uri "https://pypi.chia.net/simple/miniupnpc/miniupnpc-2.2.2-cp39-cp39-win_amd64.whl" -OutFile "miniupnpc-2.2.2-cp39-cp39-win_amd64.whl"
+Write-Output "Using win_amd64 python 3.9 wheel from https://github.com/miniupnp/miniupnp/pull/475 (2.2.0-RC1)"
+Write-Output "Actual build from https://github.com/miniupnp/miniupnp/commit/7783ac1545f70e3341da5866069bde88244dd848"
 If ($LastExitCode -gt 0){
     Throw "Failed to download miniupnpc!"
 }
@@ -22,7 +23,7 @@ else
 }
 
 Write-Output "   ---"
-Write-Output "Create venv - python3.7 or 3.8 is required in PATH"
+Write-Output "Create venv - python3.9 is required in PATH"
 Write-Output "   ---"
 python -m venv venv
 . .\venv\Scripts\Activate.ps1

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,7 @@ python -m pip install --upgrade pip
 python -m pip install wheel
 #if [ "$INSTALL_PYTHON_VERSION" = "3.8" ]; then
 # This remains in case there is a diversion of binary wheels
-python -m pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.1
+python -m pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2
 python -m pip install -e . --extra-index-url https://pypi.chia.net/simple/
 
 echo ""

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 upnp_dependencies = [
-    "miniupnpc==2.1",  # Allows users to open ports on their router
+    "miniupnpc==2.2.2",  # Allows users to open ports on their router
 ]
 
 dev_dependencies = [


### PR DESCRIPTION
Now that miniupnpc is building Windows Python 3.9 wheels (https://ci.appveyor.com/project/miniupnp/miniupnp/builds/39279415/job/eecqje66ec053m6e/artifacts) we can update Windows to 3.9 and move everything else to 2.2.2. We're using this commit for all platforms - https://github.com/miniupnp/miniupnp/commit/7783ac1545f70e3341da5866069bde88244dd848

For everything but windows and M1 this was built using the github-builds branch of the Chia Network fork of miniupnp. Windows was downloaded from Appveyor and the M1 was hand built on an M1. All were uploaded to Keybase/Chia Pypi