### PR TITLE
fix windows artifact name

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -128,7 +128,7 @@ jobs:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
         ls ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\
-        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe s3://download-chia-net/builds/.exe
+        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe s3://download-chia-net/builds/
 
     - name: Create Checksums
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Bugfix: Windows artifact was being renamed to ".exe" during s3 upload