### PR TITLE
farmer|protocols: Rename `current_difficulty` for `POST /partial`

### DIFF
--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -233,7 +233,7 @@ class FarmerAPI:
                                         pool_state_dict["next_farmer_update"] = 0
                                         await self.farmer.update_pool_state()
                                 else:
-                                    new_difficulty = pool_response["current_difficulty"]
+                                    new_difficulty = pool_response["new_difficulty"]
                                     pool_state_dict["points_acknowledged_since_start"] += new_difficulty
                                     pool_state_dict["points_acknowledged_24h"].append((time.time(), new_difficulty))
                                     pool_state_dict["current_difficulty"] = new_difficulty

--- a/chia/protocols/pool_protocol.py
+++ b/chia/protocols/pool_protocol.py
@@ -82,7 +82,7 @@ class PostPartialRequest(Streamable):
 @dataclass(frozen=True)
 @streamable
 class PostPartialResponse(Streamable):
-    current_difficulty: uint64
+    new_difficulty: uint64
 
 
 # GET /farmer


### PR DESCRIPTION
This is to match the latest updates to the spec in `pool-reference`