### PR TITLE
Make syncing message in CLI more intuitive like the GUI

### DIFF
--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -50,18 +50,13 @@ async def show_async(
             total_iters = peak.total_iters if peak is not None else 0
             num_blocks: int = 10
 
-            if sync_mode:
-                sync_max_block = blockchain_state["sync"]["sync_tip_height"]
-                sync_current_block = blockchain_state["sync"]["sync_progress_height"]
-                print(
-                    "Current Blockchain Status: Full Node syncing to block",
-                    sync_max_block,
-                    "\nCurrently synced to block:",
-                    sync_current_block,
-                )
             if synced:
                 print("Current Blockchain Status: Full Node Synced")
                 print("\nPeak: Hash:", peak.header_hash if peak is not None else "")
+            elif peak is not None and sync_mode:
+                sync_max_block = blockchain_state["sync"]["sync_tip_height"]
+                sync_current_block = blockchain_state["sync"]["sync_progress_height"]
+                print(f"Current Blockchain Status: Syncing {sync_current_block}/{sync_max_block}. Peak height: {peak.height}")
             elif peak is not None:
                 print(f"Current Blockchain Status: Not Synced. Peak height: {peak.height}")
             else:

--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -56,7 +56,8 @@ async def show_async(
             elif peak is not None and sync_mode:
                 sync_max_block = blockchain_state["sync"]["sync_tip_height"]
                 sync_current_block = blockchain_state["sync"]["sync_progress_height"]
-                print(f"Current Blockchain Status: Syncing {sync_current_block}/{sync_max_block}. Peak height: {peak.height}")
+                print(f"Current Blockchain Status: Syncing {sync_current_block}/{sync_max_block}.")
+                print("Peak: Hash:", peak.header_hash if peak is not None else "")
             elif peak is not None:
                 print(f"Current Blockchain Status: Not Synced. Peak height: {peak.height}")
             else:


### PR DESCRIPTION
The current CLI command for `chia show -s -c` has a duplicated line for "Current Blockchain Status". 
This is not really intuitive to tell if the node is actually syncing from the misleading second line, especially when coming from the GUI.

Current command output (snippet):
```
Current Blockchain Status: Full Node syncing to block 47449 
Currently synced to block: 15360
Current Blockchain Status: Not Synced. Peak height: 15360
      Time: Sat Jun 05 2021 00:12:34 UTC                  Height:      15360
```

New command output with PR (snippet):
```
Current Blockchain Status: Syncing 15360/47449. Peak height: 15360
      Time: Sat Jun 05 2021 00:12:34 UTC                  Height:      15360
```