### PR TITLE
fix mypy warning

### DIFF
--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -33,6 +33,8 @@ NETWORK_ID_DEFAULT_PORTS = {
 
 
 class FullNodeDiscovery:
+    resolver: Optional[dns.asyncresolver.Resolver]
+
     def __init__(
         self,
         server: ChiaServer,


### PR DESCRIPTION
This fixes a `mypy` error for me:

```
chia/server/node_discovery.py:82: error: Incompatible types in assignment (expression has type "None", variable has type "Resolver")
Found 1 error in 1 file (checked 370 source files)
```