### PR TITLE
deduplicate conditions when parsing the output from a generator program

### DIFF
--- a/chia/types/condition_with_args.py
+++ b/chia/types/condition_with_args.py
@@ -5,7 +5,7 @@ from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.streamable import Streamable, streamable
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 @streamable
 class ConditionWithArgs(Streamable):
     """
@@ -15,3 +15,11 @@ class ConditionWithArgs(Streamable):
 
     opcode: ConditionOpcode
     vars: List[bytes]
+
+    def __hash__(self):
+        return hash((self.opcode.value, tuple(self.vars)))
+
+    def __eq__(self, rhs):
+        if not isinstance(rhs, ConditionWithArgs):
+            return False
+        return self.opcode == rhs.opcode and self.vars == rhs.vars

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -26,7 +26,7 @@ from chia.util.ints import uint64
 from chia.util.hash import std_hash
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.api_decorators import api_request, peer_required, bytes_required
-from chia.full_node.mempool_check_conditions import parse_condition_args
+from chia.full_node.mempool_check_conditions import parse_condition_args, get_name_puzzle_conditions
 
 from tests.connection_utils import connect_and_get_peer
 from tests.core.node_height import node_height_at_least
@@ -34,6 +34,11 @@ from tests.setup_nodes import bt, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.consensus.condition_costs import ConditionCost
+from chia.types.blockchain_format.program import SerializedProgram
+from clvm_tools import binutils
+from chia.types.generator_types import BlockGenerator
+from tests.block_tools import test_constants
+from chia.consensus.cost_calculator import NPCResult
 
 BURN_PUZZLE_HASH = b"0" * 32
 BURN_PUZZLE_HASH_2 = b"1" * 32
@@ -158,6 +163,50 @@ class TestMempoolManager:
             spend_bundle,
             spend_bundle.name(),
         )
+
+    @pytest.mark.asyncio
+    async def test_coin_announcement_duplicate_consumed(self, two_nodes):
+        def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
+            announce = Announcement(coin_2.name(), b"test")
+            cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
+            dic = {cvp.opcode: [cvp] * 100}
+
+            cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
+            dic2 = {cvp.opcode: [cvp2]}
+            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
+            return bundle
+
+        full_node_1, full_node_2, server_1, server_2 = two_nodes
+        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
+
+        assert mempool_bundle is bundle
+        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_coin_duplicate_announcement_consumed(self, two_nodes):
+        def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
+            announce = Announcement(coin_2.name(), b"test")
+            cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
+            dic = {cvp.opcode: [cvp]}
+
+            cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
+            dic2 = {cvp.opcode: [cvp2] * 100}
+            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
+            return bundle
+
+        full_node_1, full_node_2, server_1, server_2 = two_nodes
+        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
+
+        assert mempool_bundle is bundle
+        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is None
 
     @pytest.mark.asyncio
     async def test_double_spend(self, two_nodes):
@@ -1823,3 +1872,168 @@ class TestConditionParser:
 
             with pytest.raises(ValidationError):
                 cost, args = parse_condition_args(SExp.to([]), opcode)
+
+
+# the following tests generate generator programs and run them through get_name_puzzle_conditions()
+
+
+def generator_condition_tester(conditions: str) -> NPCResult:
+    program = SerializedProgram.from_bytes(
+        binutils.assemble(
+            f"(q ((0x0101010101010101010101010101010101010101010101010101010101010101 (q {conditions}) 123 (() (q . ())))))"  # noqa
+        ).as_bin()
+    )
+    generator = BlockGenerator(program, [])
+    npc_result: NPCResult = get_name_puzzle_conditions(
+        generator, test_constants.MAX_BLOCK_COST_CLVM, cost_per_byte=test_constants.COST_PER_BYTE, safe_mode=True
+    )
+    return npc_result
+
+
+class TestGeneratorConditions:
+    def test_duplicate_height_time_conditions(self):
+        # ASSERT_SECONDS_RELATIVE
+        # ASSERT_SECONDS_ABSOLUTE
+        # ASSERT_HEIGHT_RELATIVE
+        # ASSERT_HEIGHT_ABSOLUTE
+        for cond in [80, 81, 82, 83]:
+            # even though the generator outputs 50 conditions, we only need to return one copy
+            npc_result = generator_condition_tester(f"({cond} 100) " * 50)
+            assert npc_result.error is None
+            assert len(npc_result.npc_list) == 1
+            opcode = ConditionOpcode(bytes([cond]))
+            assert npc_result.npc_list[0].conditions == [
+                (
+                    opcode,
+                    [ConditionWithArgs(opcode, [bytes([100])])],
+                )
+            ]
+
+    def test_duplicate_announcement(self):
+        # CREATE_COIN_ANNOUNCEMENT
+        # CREATE_PUZZLE_ANNOUNCEMENT
+        for cond in [60, 62]:
+            message = "a" * 1024
+            # even though the generator outputs 50 conditions, we only need to return one copy
+            npc_result = generator_condition_tester(f'({cond} "{message}") ' * 50)
+            assert npc_result.error is None
+            assert len(npc_result.npc_list) == 1
+            opcode = ConditionOpcode(bytes([cond]))
+            assert npc_result.npc_list[0].conditions == [
+                (
+                    opcode,
+                    [ConditionWithArgs(opcode, [message.encode("ascii")])],
+                )
+            ]
+
+    def test_duplicate_consume(self):
+
+        # ASSERT_COIN_ANNOUNCEMENT
+        # ASSERT_PUZZLE_ANNOUNCEMENT
+        # ASSERT_MY_COIN_ID
+        # ASSERT_MY_PARENT_ID
+        # ASSERT_MY_PUZZLEHASH
+        for cond in [61, 63, 70, 71, 72]:
+            # even though the generator outputs 50 conditions, we only need to return one copy
+            npc_result = generator_condition_tester(f'({cond} "abababababababababababababababab") ' * 50)
+            assert npc_result.error is None
+            assert len(npc_result.npc_list) == 1
+            opcode = ConditionOpcode(bytes([cond]))
+            assert npc_result.npc_list[0].conditions == [
+                (
+                    opcode,
+                    [ConditionWithArgs(opcode, [b"abababababababababababababababab"])],
+                )
+            ]
+
+    def test_duplicate_amounts(self):
+        # RESERVE_FEE
+        # ASSERT_MY_AMOUNT
+        for cond in [73, 52]:
+            # even though the generator outputs 50 conditions, we only need to return one copy
+            npc_result = generator_condition_tester(f"({cond} 100) " * 50)
+            assert npc_result.error is None
+            assert len(npc_result.npc_list) == 1
+            opcode = ConditionOpcode(bytes([cond]))
+            assert npc_result.npc_list[0].conditions == [
+                (
+                    opcode,
+                    [ConditionWithArgs(opcode, [bytes([100])])],
+                )
+            ]
+
+    def test_duplicate_create_coin(self):
+        # CREATE_COIN
+        # creating multiple coins with the same properties (same parent, same
+        # target puzzle hash and same amount) is not allowed. That's a consensus
+        # failure.
+        puzzle_hash = "abababababababababababababababab"
+        npc_result = generator_condition_tester(f'(51 "{puzzle_hash}" 10) ' * 2)
+        assert npc_result.error == Err.DUPLICATE_OUTPUT.value
+        assert len(npc_result.npc_list) == 0
+
+    def test_create_coin_different_parent(self):
+
+        # if the coins we create have different parents, they are never
+        # considered duplicate, even when they have the same puzzle hash and
+        # amount
+        puzzle_hash = "abababababababababababababababab"
+        program = SerializedProgram.from_bytes(
+            binutils.assemble(
+                f'(q ((0x0101010101010101010101010101010101010101010101010101010101010101 (q (51 "{puzzle_hash}" 10)) 123 (() (q . ())))(0x0101010101010101010101010101010101010101010101010101010101010102 (q (51 "{puzzle_hash}" 10)) 123 (() (q . ()))) ))'  # noqa
+            ).as_bin()
+        )
+        generator = BlockGenerator(program, [])
+        npc_result: NPCResult = get_name_puzzle_conditions(
+            generator, test_constants.MAX_BLOCK_COST_CLVM, cost_per_byte=test_constants.COST_PER_BYTE, safe_mode=True
+        )
+        assert npc_result.error is None
+        assert len(npc_result.npc_list) == 2
+        opcode = ConditionOpcode.CREATE_COIN
+        assert npc_result.npc_list[0].conditions == [
+            (
+                opcode.value,
+                [ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([10])])],
+            )
+        ]
+        assert npc_result.npc_list[1].conditions == [
+            (
+                opcode.value,
+                [ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([10])])],
+            )
+        ]
+
+    def test_create_coin_different_puzzhash(self):
+        # CREATE_COIN
+        # coins with diffeerent puzzle hashes are not considered duplicate
+        puzzle_hash_1 = "abababababababababababababababab"
+        puzzle_hash_2 = "cbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcb"
+        npc_result = generator_condition_tester(f'(51 "{puzzle_hash_1}" 5) (51 "{puzzle_hash_2}" 5)')
+        assert npc_result.error is None
+        assert len(npc_result.npc_list) == 1
+        opcode = ConditionOpcode.CREATE_COIN.value
+        assert (
+            ConditionWithArgs(opcode, [puzzle_hash_1.encode("ascii"), bytes([5])])
+            in npc_result.npc_list[0].conditions[0][1]
+        )
+        assert (
+            ConditionWithArgs(opcode, [puzzle_hash_2.encode("ascii"), bytes([5])])
+            in npc_result.npc_list[0].conditions[0][1]
+        )
+
+    def test_create_coin_different_amounts(self):
+        # CREATE_COIN
+        # coins with diffeerent amounts are not considered duplicate
+        puzzle_hash = "abababababababababababababababab"
+        npc_result = generator_condition_tester(f'(51 "{puzzle_hash}" 5) (51 "{puzzle_hash}" 4)')
+        assert npc_result.error is None
+        assert len(npc_result.npc_list) == 1
+        opcode = ConditionOpcode.CREATE_COIN.value
+        assert (
+            ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([5])])
+            in npc_result.npc_list[0].conditions[0][1]
+        )
+        assert (
+            ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([4])])
+            in npc_result.npc_list[0].conditions[0][1]
+        )


### PR DESCRIPTION
This patch makes the assumption that multiple identical conditions can be collapsed into just one copy, except for `CREATE_COIN`, where duplicates are a consensus violation.

This aims to, potentially, reduce the amount of data returned from the process executing the generator program and the main process, that validates the conditions. It also catches duplicate output errors earlier.