### PR TITLE
farmer|cmds: Improve remote harvester info

### DIFF
--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -214,10 +214,13 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
     total_plot_size = 0
     total_plots = 0
     if all_plots is not None:
-        for harvester_ip, harvester_peers in all_plots.items():
-            if harvester_ip == "success":
-                # This key is just "success": True
-                continue
+        harvesters_by_ip: dict = {}
+        for harvester in all_plots["harvesters"]:
+            ip = harvester["connection"]["host"]
+            if ip not in harvesters_by_ip:
+                harvesters_by_ip[ip] = {}
+            harvesters_by_ip[ip][harvester["connection"]["node_id"]] = harvester
+        for harvester_ip, harvester_peers in harvesters_by_ip.items():
             print(f"Harvester{'s' if len(harvester_peers) > 1 else ''} for IP: {harvester_ip}")
             for harvester_peer_id, plots in harvester_peers.items():
                 total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -235,7 +235,7 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
                 PlotStats.total_plots += len(plots["plots"])
                 print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
 
-        if len(harvesters_local):
+        if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
             print_harvesters(harvesters_local)
         for harvester_ip, harvester_peers in harvesters_remote.items():

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -228,7 +228,7 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
                     harvesters_remote[ip] = {}
                 harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
 
-        def print_harvesters(harvester_peers_in: dict):
+        def process_harvesters(harvester_peers_in: dict):
             for harvester_peer_id, plots in harvester_peers_in.items():
                 total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))
                 PlotStats.total_plot_size += total_plot_size_harvester
@@ -237,10 +237,10 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
 
         if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
-            print_harvesters(harvesters_local)
+            process_harvesters(harvesters_local)
         for harvester_ip, harvester_peers in harvesters_remote.items():
             print(f"Remote Harvester{'s' if len(harvester_peers) > 1 else ''} for IP: {harvester_ip}")
-            print_harvesters(harvester_peers)
+            process_harvesters(harvester_peers)
 
         print(f"Plot count for all harvesters: {PlotStats.total_plots}")
 

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -214,15 +214,16 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
     total_plot_size = 0
     total_plots = 0
     if all_plots is not None:
-        for harvester_ip, plots in all_plots.items():
+        for harvester_ip, harvester_peers in all_plots.items():
             if harvester_ip == "success":
                 # This key is just "success": True
                 continue
-            total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))
-            total_plot_size += total_plot_size_harvester
-            total_plots += len(plots["plots"])
-            print(f"Harvester {harvester_ip}:")
-            print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
+            print(f"Harvester{'s' if len(harvester_peers) > 1 else ''} for IP: {harvester_ip}")
+            for harvester_peer_id, plots in harvester_peers.items():
+                total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))
+                total_plot_size += total_plot_size_harvester
+                total_plots += len(plots["plots"])
+                print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
 
         print(f"Plot count for all harvesters: {total_plots}")
 

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -497,8 +497,8 @@ class Farmer:
                 # If the peer cache hasn't been updated for 10x interval, drop it since the harvester doesn't respond
                 if time.time() - last_update > UPDATE_HARVESTER_CACHE_INTERVAL * 10:
                     remove_peers.append(peer_id)
-                for key in remove_peers:
-                    del host_cache[key]
+            for key in remove_peers:
+                del host_cache[key]
             if len(host_cache) == 0:
                 remove_hosts.append(host)
         for key in remove_hosts:

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -536,18 +536,22 @@ class Farmer:
         return host_cache.get(connection.peer_node_id.hex())
 
     async def get_plots(self) -> Dict:
-        rpc_response: Dict = {}
+        harvesters: List = []
         for connection in self.server.get_connections():
             if connection.connection_type != NodeType.HARVESTER:
                 continue
 
             cache_entry = await self.get_cached_plots(connection)
             if cache_entry is not None:
-                if connection.peer_host not in rpc_response:
-                    rpc_response[connection.peer_host] = {}
-                rpc_response[connection.peer_host][connection.peer_node_id.hex()] = cache_entry[0]
+                harvester_object: dict = dict(cache_entry[0])
+                harvester_object["connection"] = {
+                    "node_id": connection.peer_node_id.hex(),
+                    "host": connection.peer_host,
+                    "port": connection.peer_port,
+                }
+                harvesters.append(harvester_object)
 
-        return rpc_response
+        return {"harvesters": harvesters}
 
     async def _periodically_update_pool_state_task(self):
         time_slept: uint64 = uint64(0)

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -19,7 +19,7 @@ class FarmerRpcApi:
             "/set_reward_targets": self.set_reward_targets,
             "/get_pool_state": self.get_pool_state,
             "/set_payout_instructions": self.set_payout_instructions,
-            "/get_plots": self.get_plots,
+            "/get_harvesters": self.get_harvesters,
             "/get_pool_login_link": self.get_pool_login_link,
         }
 
@@ -112,8 +112,8 @@ class FarmerRpcApi:
         await self.service.set_payout_instructions(launcher_id, request["payout_instructions"])
         return {}
 
-    async def get_plots(self, _: Dict):
-        return await self.service.get_plots()
+    async def get_harvesters(self, _: Dict):
+        return await self.service.get_harvesters()
 
     async def get_pool_login_link(self, request: Dict) -> Dict:
         launcher_id: bytes32 = bytes32(hexstr_to_bytes(request["launcher_id"]))

--- a/chia/rpc/farmer_rpc_client.py
+++ b/chia/rpc/farmer_rpc_client.py
@@ -49,8 +49,8 @@ class FarmerRpcClient(RpcClient):
         request = {"launcher_id": launcher_id.hex(), "payout_instructions": payout_instructions}
         return await self.fetch("set_payout_instructions", request)
 
-    async def get_plots(self) -> Dict[str, Any]:
-        return await self.fetch("get_plots", {})
+    async def get_harvesters(self) -> Dict[str, Any]:
+        return await self.fetch("get_harvesters", {})
 
     async def get_pool_login_link(self, launcher_id: bytes32) -> Optional[str]:
         try:

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -165,9 +165,9 @@ class TestRpc:
             res_2 = await client_2.get_plots()
             assert len(res_2["plots"]) == num_plots
 
-            # Test farmer get_plots
-            await farmer_rpc_api.service.update_cached_plots()
-            farmer_res = await client.get_plots()
+            # Test farmer get_harvesters
+            await farmer_rpc_api.service.update_cached_harvesters()
+            farmer_res = await client.get_harvesters()
             assert len(list(farmer_res["harvesters"])) == 1
             assert len(list(farmer_res["harvesters"][0]["plots"])) == num_plots
 

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -166,8 +166,9 @@ class TestRpc:
             assert len(res_2["plots"]) == num_plots
 
             # Test farmer get_plots
+            await farmer_rpc_api.service.update_cached_plots()
             farmer_res = await client.get_plots()
-            assert len(list(farmer_res.values())[0]["plots"]) == num_plots
+            assert len(list(dict(list(farmer_res.values())[0]).values())[0]["plots"]) == num_plots
 
             assert len(await client_2.get_plot_directories()) == 1
 

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -168,7 +168,8 @@ class TestRpc:
             # Test farmer get_plots
             await farmer_rpc_api.service.update_cached_plots()
             farmer_res = await client.get_plots()
-            assert len(list(dict(list(farmer_res.values())[0]).values())[0]["plots"]) == num_plots
+            assert len(list(farmer_res["harvesters"])) == 1
+            assert len(list(farmer_res["harvesters"][0]["plots"])) == num_plots
 
             assert len(await client_2.get_plot_directories()) == 1
 


### PR DESCRIPTION
b5ea430 Changes the output of `chia farm summary` to be like

```
Local Harvester
    10 plots of size ...
Remote Harvesters for IP: 1.1.1.1
    10 plots of size ...
    5 plots of size ...
Remote Harvester for IP: 2.2.2.2
    11 plots of size ...
```

instead of 

```
Harvester 1.1.1.1:<incoming_port_1_0>: 
    10 plots of size xxx
Harvester 1.1.1.1:<incoming_port_1_1>: 
    5 plots of size xxx
Harvester 2.2.2.2:<incoming_port_2>: 
    11 plots of size xxx
```

which imo makes more sense because the incoming port isn't really interesting unless i miss something. Additionally we could maybe add a small version like the first x chars of the `peer_node_id` or so to distinguish between multiple harvesters from the same IP or add a mapping to the config where the user can give them names.

5d0ca29 Implements caching for the harvester responses because i noticed weird behavior of some harvester missing from time to time because they fail to respond or run into the 5s request timeout which lead to harvesters disappear/appear over time when running for example `watch chia farm summary`.