### PR TITLE
Winner/partial generated plot logging

### DIFF
--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -258,7 +258,7 @@ class HarvesterAPI:
         )
 
         if len(proofs_found_plots) > 0:
-            self.harvester.log.debug(f"✅ Proofs was found by: {proofs_found_plots}")
+            self.harvester.log.debug(f"✅ Proofs were found by: {proofs_found_plots}")
 
     @api_request
     async def request_signatures(self, request: harvester_protocol.RequestSignatures):

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -258,7 +258,7 @@ class HarvesterAPI:
         )
 
         if len(proofs_found_plots) > 0:
-            self.harvester.log.debug(f"✅ Proofs were found by: {proofs_found_plots}")
+            self.harvester.log.info(f"✅ Proofs were found by: {proofs_found_plots}")
 
     @api_request
     async def request_signatures(self, request: harvester_protocol.RequestSignatures):


### PR DESCRIPTION
Add in harvester logs message on proofs like:
```
2021-06-28T15:54:10.550 harvester chia.harvester.harvester: DEBUG    ✅ Proofs were found by: {'plot-k25-2021-06-25-15-37-ec359f6147c72473c756c8b2f766baefaf23393b54a16a97be5e65c14f3ffcd0.plot (non-portable)'}
2021-06-28T15:54:52.618 harvester chia.harvester.harvester: DEBUG    ✅ Proofs were found by: {'plot-k25-2021-06-25-21-08-39c1a3e01df90f53b41fd88309b70ba8fa0ec4302cf82eb8fef5d2a198efafa0.plot (P2: txch1gg8wgwqkgf55nmt03nafzmjnv939tr437358zwpuzhv4f03rygss9yzppn)'}
```

I'm proposing this useful info imo on DEBUG level of logging, but if it can be considered as INFO, can change it.