### PR TITLE
add get_harvesters procedure to farmer rpc

### DIFF
--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -21,6 +21,7 @@ class FarmerRpcApi:
             "/set_payout_instructions": self.set_payout_instructions,
             "/get_plots": self.get_plots,
             "/get_pool_login_link": self.get_pool_login_link,
+            "/get_harvesters": self.get_harvesters,
         }
 
     async def _state_changed(self, change: str, change_data: Dict) -> List[WsRpcMessage]:
@@ -114,6 +115,9 @@ class FarmerRpcApi:
 
     async def get_plots(self, _: Dict):
         return await self.service.get_plots()
+
+    async def get_harvesters(self, _: Dict):
+        return await self.service.get_harvesters()
 
     async def get_pool_login_link(self, request: Dict) -> Dict:
         launcher_id: bytes32 = bytes32(hexstr_to_bytes(request["launcher_id"]))

--- a/chia/rpc/farmer_rpc_client.py
+++ b/chia/rpc/farmer_rpc_client.py
@@ -52,6 +52,9 @@ class FarmerRpcClient(RpcClient):
     async def get_plots(self) -> Dict[str, Any]:
         return await self.fetch("get_plots", {})
 
+    async def get_harvesters(self) -> Dict[str, Any]:
+        return await self.fetch("get_harvesters", {})
+
     async def get_pool_login_link(self, launcher_id: bytes32) -> Optional[str]:
         try:
             return (await self.fetch("get_pool_login_link", {"launcher_id": launcher_id.hex()}))["login_link"]


### PR DESCRIPTION
The farmer rpc endpoint `get_plots` has a lot of utility but the way it serializes is awkward for deserialization in strongly typed languages. Using the harvester Uri as the dictionary key results in json with property names that are invalid when deserialized to an object in languages like C#.

````json
{
  "127.0.0.1:58269": {
    "failed_to_open_filenames": [],
    "no_key_filenames": [],
    "plots": []
  },
  "success": true
}
````

This PR proposes an alternative or complementary procedure `get_harvesters`, which returns a list of harvesters. This also seems to match the pattern of other rpc endpoints that return lists of things.

````json
{
  "harvesters": [
    {
      "connection": {
        "peer_host": "127.0.0.1",
        "peer_port": 63112
      },
      "plots": {
        "failed_to_open_filenames": [],
        "no_key_filenames": [],
        "plots": []
      }
    }
  ],
  "success": true
}
````