### PR TITLE
Ms.wallet fix

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -34,6 +34,7 @@ from chia.types.blockchain_format.coin import Coin, hash_coin_list
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_solution import CoinSolution
 from chia.types.header_block import HeaderBlock
+from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.errors import Err, ValidationError
@@ -312,7 +313,8 @@ class WalletNode:
             )
             already_sent = set()
             for peer, status, _ in record.sent_to:
-                already_sent.add(hexstr_to_bytes(peer))
+                if status == MempoolInclusionStatus.SUCCESS.value:
+                    already_sent.add(hexstr_to_bytes(peer))
             messages.append((msg, already_sent))
 
         return messages

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -292,7 +292,7 @@ class TestFullNodeBlockCompression:
 
         # Creates a cc wallet
         cc_wallet: CCWallet = await CCWallet.create_new_cc(wallet_node_1.wallet_state_manager, wallet, uint64(100))
-        tx_queue: List[TransactionRecord] = await wallet_node_1.wallet_state_manager.get_send_queue()
+        tx_queue: List[TransactionRecord] = await wallet_node_1.wallet_state_manager.tx_store.get_not_sent()
         tr = tx_queue[0]
         await time_out_assert(
             10,

--- a/tests/wallet/cc_wallet/test_cc_wallet.py
+++ b/tests/wallet/cc_wallet/test_cc_wallet.py
@@ -73,7 +73,7 @@ class TestCCWallet:
         await time_out_assert(15, wallet.get_confirmed_balance, funds)
 
         cc_wallet: CCWallet = await CCWallet.create_new_cc(wallet_node.wallet_state_manager, wallet, uint64(100))
-        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.get_send_queue()
+        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.tx_store.get_not_sent()
         tx_record = tx_queue[0]
         await time_out_assert(
             15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()
@@ -113,7 +113,7 @@ class TestCCWallet:
         await time_out_assert(15, wallet.get_confirmed_balance, funds)
 
         cc_wallet: CCWallet = await CCWallet.create_new_cc(wallet_node.wallet_state_manager, wallet, uint64(100))
-        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.get_send_queue()
+        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.tx_store.get_not_sent()
         tx_record = tx_queue[0]
         await time_out_assert(
             15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()
@@ -283,7 +283,7 @@ class TestCCWallet:
         await time_out_assert(15, wallet.get_confirmed_balance, funds)
 
         cc_wallet: CCWallet = await CCWallet.create_new_cc(wallet_node.wallet_state_manager, wallet, uint64(100))
-        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.get_send_queue()
+        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.tx_store.get_not_sent()
         tx_record = tx_queue[0]
         await time_out_assert(
             15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()
@@ -363,7 +363,7 @@ class TestCCWallet:
         await time_out_assert(15, wallet_0.get_confirmed_balance, funds)
 
         cc_wallet_0: CCWallet = await CCWallet.create_new_cc(wallet_node_0.wallet_state_manager, wallet_0, uint64(100))
-        tx_queue: List[TransactionRecord] = await wallet_node_0.wallet_state_manager.get_send_queue()
+        tx_queue: List[TransactionRecord] = await wallet_node_0.wallet_state_manager.tx_store.get_not_sent()
         tx_record = tx_queue[0]
         await time_out_assert(
             15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()
@@ -461,7 +461,7 @@ class TestCCWallet:
         await time_out_assert(15, wallet.get_confirmed_balance, funds)
 
         cc_wallet: CCWallet = await CCWallet.create_new_cc(wallet_node.wallet_state_manager, wallet, uint64(100000))
-        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.get_send_queue()
+        tx_queue: List[TransactionRecord] = await wallet_node.wallet_state_manager.tx_store.get_not_sent()
         tx_record = tx_queue[0]
         await time_out_assert(
             15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()


### PR DESCRIPTION
Resend transaction if it did not succeed on the first try. Sometimes we get MEMPOOL_NOT_INITIALIZED, or other failures, so this should help prevent stuck pending transactions. 