### PR TITLE
config branch of submodule mozilla-ca

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "mozilla-ca"]
 	path = mozilla-ca
 	url = https://github.com/Chia-Network/mozilla-ca.git
+	branch = main


### PR DESCRIPTION
Building with jenkins using `Update tracking submodules to tip of branch` option got error
```shell
Cloning into '/var/lib/jenkins/workspace/testnet_pool_server/chia-blockchain/mozilla-ca'...
fatal: Needed a single revision
Unable to find current origin/master revision in submodule path 'mozilla-ca'
Failed to recurse into submodule path 'chia-blockchain'
```

this patch fixes it