### PR TITLE
Pooling: fix race condition with two plot NFTs at the same time

### DIFF
--- a/chia/wallet/sign_coin_solutions.py
+++ b/chia/wallet/sign_coin_solutions.py
@@ -1,8 +1,8 @@
 import inspect
-from typing import Callable, List, Optional, Union, Coroutine, Any
+from typing import List, Any
 
 import blspy
-from blspy import AugSchemeMPL, PrivateKey
+from blspy import AugSchemeMPL
 
 from chia.types.coin_solution import CoinSolution
 from chia.types.spend_bundle import SpendBundle
@@ -11,9 +11,7 @@ from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_fo
 
 async def sign_coin_solutions(
     coin_solutions: List[CoinSolution],
-    secret_key_for_public_key_f: Callable[
-        [blspy.G1Element], Union[Optional[PrivateKey], Coroutine[Any, Any, blspy.G1Element]]
-    ],
+    secret_key_for_public_key_f: Any,  # Potentially awaitable function from G1Element => Optional[PrivateKey]
     additional_data: bytes,
     max_cost: int,
 ) -> SpendBundle:

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -627,34 +627,20 @@ class TestPoolWalletRpc:
             assert join_pool_tx_2 is not None
 
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
+            status_2: PoolWalletInfo = (await client.pw_status(wallet_id_2))[0]
 
             assert status.current.state == PoolSingletonState.SELF_POOLING.value
-            assert status.current.to_json_dict() == {
-                "owner_pubkey": "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304",
-                "pool_url": None,
-                "relative_lock_height": 0,
-                "state": 1,
-                "target_puzzle_hash": "0x738127e26cb61ffe5530ce0cef02b5eeadb1264aa423e82204a6d6bf9f31c2b7",
-                "version": 1,
-            }
-            assert status.target.to_json_dict() == {
-                "owner_pubkey": "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304",
-                "pool_url": "https://pool.example.com",
-                "relative_lock_height": 10,
-                "state": 3,
-                "target_puzzle_hash": "0x9ba327777484b8300d60427e4f3b776ac81948dfedd069a8d3f55834e101696e",
-                "version": 1,
-            }
+            assert status.target is not None
+            assert status.target.state == PoolSingletonState.FARMING_TO_POOL.value
+            assert status_2.current.state == PoolSingletonState.SELF_POOLING.value
+            assert status_2.target is not None
+            assert status_2.target.state == PoolSingletonState.FARMING_TO_POOL.value
 
             await self.farm_blocks(full_node_api, our_ph, 6)
-
-            status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
-            log.warning(f"New status: {status}")
 
             total_blocks += await self.farm_blocks(full_node_api, our_ph, num_blocks)
 
             async def status_is_farming_to_pool(w_id: int):
-                await self.farm_blocks(full_node_api, our_ph, 1)
                 pw_status: PoolWalletInfo = (await client.pw_status(w_id))[0]
                 return pw_status.current.state == PoolSingletonState.FARMING_TO_POOL.value
 


### PR DESCRIPTION
Issue: when you create two pool wallets at the same time, they will both use the same owner key (using the next wallet_id that is available).

Therefore we cannot rely on the current wallet ID for getting the private key, we must try all potential owner keys, like the farmer already does.

Added a test and confirmed that it fixes the issue. Also, clear target state when clearing unconfirmed transactions, to get out of an invalid state. 