### PR TITLE
config branch of submodule mozilla-ca. based on 7020 from opct

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "mozilla-ca"]
 	path = mozilla-ca
 	url = https://github.com/Chia-Network/mozilla-ca.git
+        branch = main


### PR DESCRIPTION
From opct

Building with jenkins using Update tracking submodules to tip of branch option got error

Cloning into '/var/lib/jenkins/workspace/testnet_pool_server/chia-blockchain/mozilla-ca'...
fatal: Needed a single revision
Unable to find current origin/master revision in submodule path 'mozilla-ca'
Failed to recurse into submodule path 'chia-blockchain'

this patch fixes it