### PR TITLE
farmer: Reload keys when config changes, so we can detect new plot NFTs

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -510,6 +510,8 @@ class Farmer:
             # Every time the config file changes, read it to check the pool state
             stat_info = config_path.stat()
             if stat_info.st_mtime > self.last_config_access_time:
+                # If we detect the config file changed, refresh private keys first just in case
+                self.all_root_sks: List[PrivateKey] = [sk for sk, _ in self.keychain.get_all_private_keys()]
                 self.last_config_access_time = stat_info.st_mtime
                 await self.update_pool_state()
                 time_slept = uint64(0)


### PR DESCRIPTION
This means we can create a new key, sync up, and create a plotNFT, without having to restart the farmer