### PR TITLE
Improves error handling for unknown protocol types

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -128,9 +128,9 @@ class WSChiaConnection:
                 message_type: ProtocolMessageTypes = ProtocolMessageTypes(inbound_handshake_msg.type)
             except Exception:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
-            else:
-                if message_type != ProtocolMessageTypes.handshake:
-                    raise ProtocolError(Err.INVALID_HANDSHAKE)
+
+            if message_type != ProtocolMessageTypes.handshake:
+                raise ProtocolError(Err.INVALID_HANDSHAKE)
 
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
@@ -152,9 +152,9 @@ class WSChiaConnection:
                 message_type = ProtocolMessageTypes(message.type)
             except Exception:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
-            else:
-                if message_type != ProtocolMessageTypes.handshake:
-                    raise ProtocolError(Err.INVALID_HANDSHAKE)
+
+            if message_type != ProtocolMessageTypes.handshake:
+                raise ProtocolError(Err.INVALID_HANDSHAKE)
 
             inbound_handshake = Handshake.from_bytes(message.data)
             if inbound_handshake.network_id != network_id:

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -122,8 +122,16 @@ class WSChiaConnection:
             if inbound_handshake_msg is None:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
             inbound_handshake = Handshake.from_bytes(inbound_handshake_msg.data)
-            if ProtocolMessageTypes(inbound_handshake_msg.type) != ProtocolMessageTypes.handshake:
+
+            # Handle case of invalid ProtocolMessageType
+            try:
+                message_type: ProtocolMessageTypes = ProtocolMessageTypes(inbound_handshake_msg.type)
+            except Exception:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
+            else:
+                if message_type != ProtocolMessageTypes.handshake:
+                    raise ProtocolError(Err.INVALID_HANDSHAKE)
+
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
 
@@ -138,9 +146,17 @@ class WSChiaConnection:
 
             if message is None:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
-            inbound_handshake = Handshake.from_bytes(message.data)
-            if ProtocolMessageTypes(message.type) != ProtocolMessageTypes.handshake:
+
+            # Handle case of invalid ProtocolMessageType
+            try:
+                message_type = ProtocolMessageTypes(message.type)
+            except Exception:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
+            else:
+                if message_type != ProtocolMessageTypes.handshake:
+                    raise ProtocolError(Err.INVALID_HANDSHAKE)
+
+            inbound_handshake = Handshake.from_bytes(message.data)
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
             outbound_handshake = make_msg(


### PR DESCRIPTION
Small improvement to peer handshake error handling. During peer handshake, if the peer sends a fully invalid protocol type - this error was not being handled in the same way when the peer sent a valid-but-not-handshake type. This makes any non-handshake type throw the same error.
This makes sure the peer is closed and banned in the same way. Previously, an invalid type may get closed but not banned and the logging generated was rather verbose. Related to #7064 