### PR TITLE
Fix DB invalid format for additional_coin_spends

### DIFF
--- a/chia/wallet/wallet_block_store.py
+++ b/chia/wallet/wallet_block_store.py
@@ -126,7 +126,8 @@ class WalletBlockStore:
         if len(additional_coin_spends) > 0:
             blob: bytes = bytes(AdditionalCoinSpends(additional_coin_spends))
             cursor_3 = await self.db.execute(
-                "INSERT OR REPLACE INTO additional_coin_spends VALUES(?, ?)", (header_block_record.header_hash, blob)
+                "INSERT OR REPLACE INTO additional_coin_spends VALUES(?, ?)",
+                (header_block_record.header_hash.hex(), blob),
             )
             await cursor_3.close()
 


### PR DESCRIPTION
We were inserting bytes into the DB instead of hex. This was causing issues only when adding more than 1 block at a time (in reorgs), but not when adding one at time.

If you used plotNFTs and experienced a double spend issue (or stuck plot NFT /can't change pools), please update and delete wallet DB.