### PR TITLE
GH Action to tag and close stale issues

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: chia-network/stale@v3
+      - uses: chia-network/stale@main
         with:
           operations-per-run: 10000
           ascending: true

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -1,0 +1,26 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 11 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chia-network/stale@v3
+        with:
+          operations-per-run: 10000
+          ascending: true
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          days-before-pr-stale: 60
+          days-before-pr-close: -1
+          exempt-all-pr-milestones: true
+          exempt-all-issue-milestones: true
+          exempt-all-assignees: true
+          stale-issue-label: stale-issue
+          stale-pr-label: stale-pr
+          remove-stale-when-updated: true
+          stale-issue-message: 'This issue has been flagged as stale as there has been no activity on it in 14 days. If this issue is still affecting you and in need of review, please update it to keep it open.'
+          close-issue-message: 'This issue was automatically closed because it has been flagged as stale and subsequently passed 7 days with no further activity.'
+          stale-pr-message: 'This PR has been flagged as stale due to no activity for over 60 days. It will not be automatically closed, but it has been given a stale-pr label and should be manually reviewed.'


### PR DESCRIPTION
This workflow script is designed to do the following every day at 4am PST (11am UTC):

- Flag issues as stale after 14 days of no activity with stale-issue label.
- Flag PRs as stale after 60 days of no activity with stale-pr label.
- Close stale issues after a further 7 days of no activity once flagged.
- Do NOT close stale PRs, only warn with comments when flagged.
- Ignore stale status for any Issues or PRs with either a milestone, or a user assigned to them.
- Remove stable labels if they have been updated during the 7 day period and reset it's status.