### PR TITLE
Split secret check to signing and aws secrets

### DIFF
--- a/.github/workflows/build-macos-m1-installer.yml
+++ b/.github/workflows/build-macos-m1-installer.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           unset HAS_APPLE_SECRET
           unset HAS_AWS_SECRET
+
           if [ -n "$APPLE_SECRET" ]; then HAS_APPLE_SECRET='true' ; fi
           echo ::set-output name=HAS_APPLE_SECRET::${HAS_APPLE_SECRET}
 

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -65,14 +65,20 @@ jobs:
       id: check_secrets
       shell: bash
       run: |
-        unset HAS_SECRET
-        if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo "::set-output name=HAS_SECRET::${HAS_SECRET}"
+        unset HAS_SIGNING_SECRET
+        unset HAS_AWS_SECRET
+
+        if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
+        echo "::set-output name=HAS_SIGNING_SECRET::${HAS_SIGNING_SECRET}"
+
+        if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
+        echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
       env:
-        SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
+        SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
+        AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
 
     - name: Decode code signing cert into an encrypted file
-      if: steps.check_secrets.outputs.HAS_SECRET
+      if: steps.check_secrets.outputs.HAS_SIGNING_SECRET
       uses: kitek/decode-base64-into-file-action@1.0
       with:
         encoded-value: ${{ secrets.WIN_CODE_SIGN_CERT }}
@@ -93,7 +99,7 @@ jobs:
     - name: Build Windows installer with build_scripts\build_windows.ps1
       env:
         WIN_CODE_SIGN_PASS: ${{ secrets.WIN_CODE_SIGN_PASS }}
-        HAS_SECRET: ${{ steps.check_secrets.outputs.HAS_SECRET }}
+        HAS_SECRET: ${{ steps.check_secrets.outputs.HAS_SIGNING_SECRET }}
       run: |
         $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
         $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
@@ -113,12 +119,12 @@ jobs:
 
 
     - name: Install AWS CLI
-      if: steps.check_secrets.outputs.HAS_SECRET
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
       run: |
           msiexec.exe /i https://awscli.amazonaws.com/AWSCLIV2.msi
 
     - name: Configure AWS Credentials
-      if: steps.check_secrets.outputs.HAS_SECRET
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.INSTALLER_UPLOAD_KEY }}
@@ -126,7 +132,7 @@ jobs:
         aws-region: us-west-2
 
     - name: Upload to s3
-      if: steps.check_secrets.outputs.HAS_SECRET
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
@@ -153,7 +159,7 @@ jobs:
         ls
 
     - name: Upload Release Files
-      if: steps.check_secrets.outputs.HAS_SECRET && startsWith(github.ref, 'refs/tags/')
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET && startsWith(github.ref, 'refs/tags/')
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.INSTALLER_UPLOAD_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.INSTALLER_UPLOAD_SECRET }}


### PR DESCRIPTION
Allows us to still test the AWS actions in the test release project without having code signing cert available