### PR TITLE
coordinate blueboxes better

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -345,9 +345,12 @@ class BlockStore:
             return None
         return bool(row[0])
 
-    async def get_first_not_compactified(self, min_height: int) -> Optional[int]:
+    async def get_first_not_compactified(self) -> Optional[int]:
+        # Since orphan blocks do not get compactified, we need to check whether all blocks with a
+        # certain height are not compact. And if we do have compact orphan blocks, then all that
+        # happens is that the occasional chain block stays uncompact - not ideal, but harmless.
         cursor = await self.db.execute(
-            "SELECT MIN(height) from full_blocks WHERE is_fully_compactified=0 AND height>=?", (min_height,)
+            "SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 ORDER BY height LIMIT 1"
         )
         row = await cursor.fetchone()
         await cursor.close()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1924,14 +1924,15 @@ class FullNode:
                 if max_height is None:
                     await asyncio.sleep(30)
                     continue
+                assert max_height is not None
                 self.log.info("Getting minimum bluebox work height")
                 min_height = await self.block_store.get_first_not_compactified()
                 if min_height is None or min_height > max(0, max_height - 1000):
                     min_height = max(0, max_height - 1000)
-                batches_finished = 0
-                self.log.info("Scanning the blockchain for uncompact blocks.")
-                assert max_height is not None
                 assert min_height is not None
+                max_height = uint32(min(max_height, min_height + 2000))
+                batches_finished = 0
+                self.log.info(f"Scanning the blockchain for uncompact blocks. Range: {min_height}..{max_height}")
                 for h in range(min_height, max_height, 100):
                     # Got 10 times the target header count, sampling the target headers should contain
                     # enough randomness to split the work between blueboxes.

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -89,7 +89,7 @@ class Timelord:
         self.total_infused: int = 0
         self.state_changed_callback: Optional[Callable] = None
         self.sanitizer_mode = self.config["sanitizer_mode"]
-        self.pending_bluebox_info: List[timelord_protocol.RequestCompactProofOfTime] = []
+        self.pending_bluebox_info: List[Tuple[float, timelord_protocol.RequestCompactProofOfTime]] = []
         self.last_active_time = time.time()
 
     async def _start(self):
@@ -1005,7 +1005,7 @@ class Timelord:
                         # CC_EOS and ICC_EOS. This guarantees everything is picked uniformly.
                         target_field_vdf = random.randint(1, 4)
                         info = next(
-                            (info for info in self.pending_bluebox_info if info.field_vdf == target_field_vdf),
+                            (info for info in self.pending_bluebox_info if info[1].field_vdf == target_field_vdf),
                             None,
                         )
                         if info is None:
@@ -1016,15 +1016,15 @@ class Timelord:
                             asyncio.create_task(
                                 self._do_process_communication(
                                     Chain.BLUEBOX,
-                                    info.new_proof_of_time.challenge,
+                                    info[1].new_proof_of_time.challenge,
                                     ClassgroupElement.get_default_element(),
                                     ip,
                                     reader,
                                     writer,
-                                    info.new_proof_of_time.number_of_iterations,
-                                    info.header_hash,
-                                    info.height,
-                                    info.field_vdf,
+                                    info[1].new_proof_of_time.number_of_iterations,
+                                    info[1].header_hash,
+                                    info[1].height,
+                                    info[1].field_vdf,
                                 )
                             )
                         )

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Callable, Optional
 
 from chia.protocols import timelord_protocol
@@ -80,5 +81,8 @@ class TimelordAPI:
         async with self.timelord.lock:
             if not self.timelord.sanitizer_mode:
                 return None
-            if vdf_info not in self.timelord.pending_bluebox_info:
-                self.timelord.pending_bluebox_info.append(vdf_info)
+            now = time.time()
+            # work older than 5s can safely be assumed to be from the previous batch, and needs to be cleared
+            while self.timelord.pending_bluebox_info and (now - self.timelord.pending_bluebox_info[0][0] > 5):
+                del self.timelord.pending_bluebox_info[0]
+            self.timelord.pending_bluebox_info.append((now, vdf_info))


### PR DESCRIPTION
This fixes an issue where a lot of bluebox work at the bottom of the chain would be lost by the following mechanism:
* `broadcast_uncompact_blocks` creates a well-randomized list of work (so far so good)
* `request_compact_proof_of_time` enqueues it, removing duplicates (also so far so good)
* but now, since one VDF compaction usually takes over ten minutes on average, while the fullnode adds 100 work items every five minutes (in the recommended configuration), the queue fills up and this undoes all the randomness. Also, if another bluebox compacts a proof that's already in the work queue, the bluebox will still compact it itself because it never removes work.

In one experiment I ran over night (ad-hoc patch: https://pastebin.com/3Dy3yhhE), about 98% of my bluebox's work was in vain due to this. Effectively, this issue reduces bluebox capacity at the bottom of the chain to that of the fastest bluebox down there.

There are various ways to fix this, I went for a minimal one with no protocol changes so that it would be easier to review:
* First of all, flush the work queue whenever new work arrives. There is still a chance of duplicated work, but it's greatly reduced (in another ad-hoc experiment with different measurement code, one overnight run produced no collisions at all).
* Since there is now no more guarantee that work posted to the bluebox will actually be done, orphan blocks need to be handled better so that they don't trip up `broadcast_uncompact_blocks`. Luckily, this in fact simplifies the implementation.

The current effective bluebox capacity is about 30% of what it'd need to be to keep up with the network. Right now I have no idea whether it's two blueboxes stuck down there, or 100, but this PR should unlock those boxes and also give us a better idea of how much capacity is actually at work, and whether it's enough to catch up.