### PR TITLE
fix duplicate-output test to not also do a double-spend

### DIFF
--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -161,16 +161,15 @@ class TestBlockchainTransactions:
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
 
-        spend_bundle = wallet_a.generate_signed_transaction(1000, receiver_puzzlehash, spend_coin)
-        spend_bundle_double = wallet_a.generate_signed_transaction(1000, receiver_puzzlehash, spend_coin)
-
-        block_spendbundle = SpendBundle.aggregate([spend_bundle, spend_bundle_double])
+        spend_bundle = wallet_a.generate_signed_transaction(
+            1000, receiver_puzzlehash, spend_coin, additional_outputs=[(receiver_puzzlehash, 1000)]
+        )
 
         new_blocks = bt.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             farmer_reward_puzzle_hash=coinbase_puzzlehash,
-            transaction_data=block_spendbundle,
+            transaction_data=spend_bundle,
             guarantee_transaction_block=True,
         )
 


### PR DESCRIPTION
the test that's supposed to exercise a duplicate output, is *also* performing a double-spend. This fixes the test to *only* produce duplicate output, using the same coin.