### PR TITLE
make instructions in the issue template be comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,10 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is. (If what you are experiencing is NOT a bug but instead a support issue, please open a Discussion instead!)
+<!-- A clear and concise description of what the bug is. (If what you are experiencing is NOT a bug but instead a support issue, please open a Discussion instead!) -->
 
 **To Reproduce**
+
 Steps to reproduce the behavior:
 
 1. Go to '...'
@@ -19,16 +20,17 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
+**Desktop**
+<!-- Please complete the following information. -->
 
-- OS: [e.g. Linux]
-- OS Version/Flavor: [e.g. CentOS 7.2]
-- CPU: [e.g. Intel Xeon 8175M]
+- OS: <!-- e.g. Linux -->
+- OS Version/Flavor: <!-- e.g. CentOS 7.2 -->
+- CPU: <!-- e.g. Intel Xeon 8175M -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
This avoids the instructions being shown in the final PR submission.  Certainly not a big deal, but I personally prefer to avoid the noise in submissions where the template is not filled out.  For example, this (anonymous) PR I glanced at today.

![image](https://user-images.githubusercontent.com/543719/124833797-b27d5980-df4c-11eb-887f-3af06272a348.png)
