### PR TITLE
Added get_coin_records_by_parent_id(s)

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -192,6 +192,56 @@ class CoinStore:
             coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
         return list(coins)
 
+    # Checks DB and DiffStores for CoinRecords with parent_id and returns them
+    async def get_coin_records_by_parent_id(
+        self,
+        include_spent_coins: bool,
+        parent_id: bytes32,
+        start_height: uint32 = uint32(0),
+        end_height: uint32 = uint32((2 ** 32) - 1),
+    ) -> List[CoinRecord]:
+
+        coins = set()
+        cursor = await self.coin_record_db.execute(
+            f"SELECT * from coin_record WHERE coin_parent=? AND confirmed_index>=? AND confirmed_index<? "
+            f"{'' if include_spent_coins else 'AND spent=0'}",
+            (parent_id.hex(), start_height, end_height),
+        )
+        rows = await cursor.fetchall()
+
+        await cursor.close()
+        for row in rows:
+            coin = Coin(bytes32(bytes.fromhex(row[6])), bytes32(bytes.fromhex(row[5])), uint64.from_bytes(row[7]))
+            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+        return list(coins)
+
+    async def get_coin_records_by_parent_ids(
+        self,
+        include_spent_coins: bool,
+        parent_ids: List[bytes32],
+        start_height: uint32 = uint32(0),
+        end_height: uint32 = uint32((2 ** 32) - 1),
+    ) -> List[CoinRecord]:
+        if len(parent_ids) == 0:
+            return []
+
+        coins = set()
+        parent_ids_db = tuple([pid.hex() for pid in parent_ids])
+        cursor = await self.coin_record_db.execute(
+            f'SELECT * from coin_record WHERE coin_parent in ({"?," * (len(parent_ids_db) - 1)}?) '
+            f"AND confirmed_index>=? AND confirmed_index<? "
+            f"{'' if include_spent_coins else 'AND spent=0'}",
+            parent_ids_db + (start_height, end_height),
+        )
+
+        rows = await cursor.fetchall()
+
+        await cursor.close()
+        for row in rows:
+            coin = Coin(bytes32(bytes.fromhex(row[6])), bytes32(bytes.fromhex(row[5])), uint64.from_bytes(row[7]))
+            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+        return list(coins)
+
     async def rollback_to_block(self, block_index: int):
         """
         Note that block_index can be negative, in which case everything is rolled back

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -192,29 +192,6 @@ class CoinStore:
             coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
         return list(coins)
 
-    # Checks DB and DiffStores for CoinRecords with parent_id and returns them
-    async def get_coin_records_by_parent_id(
-        self,
-        include_spent_coins: bool,
-        parent_id: bytes32,
-        start_height: uint32 = uint32(0),
-        end_height: uint32 = uint32((2 ** 32) - 1),
-    ) -> List[CoinRecord]:
-
-        coins = set()
-        cursor = await self.coin_record_db.execute(
-            f"SELECT * from coin_record WHERE coin_parent=? AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND spent=0'}",
-            (parent_id.hex(), start_height, end_height),
-        )
-        rows = await cursor.fetchall()
-
-        await cursor.close()
-        for row in rows:
-            coin = Coin(bytes32(bytes.fromhex(row[6])), bytes32(bytes.fromhex(row[5])), uint64.from_bytes(row[7]))
-            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
-        return list(coins)
-
     async def get_coin_records_by_parent_ids(
         self,
         include_spent_coins: bool,

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -43,7 +43,6 @@ class FullNodeRpcApi:
             "/get_coin_records_by_puzzle_hash": self.get_coin_records_by_puzzle_hash,
             "/get_coin_records_by_puzzle_hashes": self.get_coin_records_by_puzzle_hashes,
             "/get_coin_record_by_name": self.get_coin_record_by_name,
-            "/get_coin_records_by_parent_id": self.get_coin_records_by_parent_id,
             "/get_coin_records_by_parent_ids": self.get_coin_records_by_parent_ids,
             "/push_tx": self.push_tx,
             "/get_puzzle_and_solution": self.get_puzzle_and_solution,
@@ -464,25 +463,6 @@ class FullNodeRpcApi:
             raise ValueError(f"Coin record 0x{name.hex()} not found")
 
         return {"coin_record": coin_record}
-
-    async def get_coin_records_by_parent_id(self, request: Dict) -> Optional[Dict]:
-        """
-        Retrieves the coins for a given parent coin ID, by default returns unspent coins.
-        """
-        if "parent_id" not in request:
-            raise ValueError("Parent ID not in request")
-        kwargs: Dict[str, Any] = {"include_spent_coins": False, "parent_id": hexstr_to_bytes(request["parent_id"])}
-        if "start_height" in request:
-            kwargs["start_height"] = uint32(request["start_height"])
-        if "end_height" in request:
-            kwargs["end_height"] = uint32(request["end_height"])
-
-        if "include_spent_coins" in request:
-            kwargs["include_spent_coins"] = request["include_spent_coins"]
-
-        coin_records = await self.service.blockchain.coin_store.get_coin_records_by_parent_id(**kwargs)
-
-        return {"coin_records": coin_records}
 
     async def get_coin_records_by_parent_ids(self, request: Dict) -> Optional[Dict]:
         """

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -117,6 +117,41 @@ class FullNodeRpcClient(RpcClient):
             for coin in (await self.fetch("get_coin_records_by_puzzle_hashes", d))["coin_records"]
         ]
 
+    async def get_coin_records_by_parent_id(
+        self,
+        parent_id: bytes32,
+        include_spent_coins: bool = True,
+        start_height: Optional[int] = None,
+        end_height: Optional[int] = None,
+    ) -> List:
+        d = {"parent_id": parent_id.hex(), "include_spent_coins": include_spent_coins}
+        if start_height is not None:
+            d["start_height"] = start_height
+        if end_height is not None:
+            d["end_height"] = end_height
+        return [
+            CoinRecord.from_json_dict(coin)
+            for coin in (await self.fetch("get_coin_records_by_parent_id", d))["coin_records"]
+        ]
+
+    async def get_coin_records_by_parent_ids(
+        self,
+        parent_ids: List[bytes32],
+        include_spent_coins: bool = True,
+        start_height: Optional[int] = None,
+        end_height: Optional[int] = None,
+    ) -> List:
+        parent_ids_hex = [pid.hex() for pid in parent_ids]
+        d = {"parent_ids": parent_ids_hex, "include_spent_coins": include_spent_coins}
+        if start_height is not None:
+            d["start_height"] = start_height
+        if end_height is not None:
+            d["end_height"] = end_height
+        return [
+            CoinRecord.from_json_dict(coin)
+            for coin in (await self.fetch("get_coin_records_by_parent_ids", d))["coin_records"]
+        ]
+
     async def get_additions_and_removals(self, header_hash: bytes32) -> Tuple[List[CoinRecord], List[CoinRecord]]:
         try:
             response = await self.fetch("get_additions_and_removals", {"header_hash": header_hash.hex()})

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -117,23 +117,6 @@ class FullNodeRpcClient(RpcClient):
             for coin in (await self.fetch("get_coin_records_by_puzzle_hashes", d))["coin_records"]
         ]
 
-    async def get_coin_records_by_parent_id(
-        self,
-        parent_id: bytes32,
-        include_spent_coins: bool = True,
-        start_height: Optional[int] = None,
-        end_height: Optional[int] = None,
-    ) -> List:
-        d = {"parent_id": parent_id.hex(), "include_spent_coins": include_spent_coins}
-        if start_height is not None:
-            d["start_height"] = start_height
-        if end_height is not None:
-            d["end_height"] = end_height
-        return [
-            CoinRecord.from_json_dict(coin)
-            for coin in (await self.fetch("get_coin_records_by_parent_id", d))["coin_records"]
-        ]
-
     async def get_coin_records_by_parent_ids(
         self,
         parent_ids: List[bytes32],

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -113,6 +113,15 @@ class TestRpc:
             print(coins)
             assert len(coins) >= 1
 
+            pid = list(blocks[-1].get_included_reward_coins())[0].parent_coin_info
+            pid_2 = list(blocks[-1].get_included_reward_coins())[1].parent_coin_info
+            coins = await client.get_coin_records_by_parent_id(pid)
+            print(coins)
+            assert len(coins) == 1
+            coins = await client.get_coin_records_by_parent_ids([pid, pid_2])
+            print(coins)
+            assert len(coins) == 2
+
             additions, removals = await client.get_additions_and_removals(blocks[-1].header_hash)
             assert len(additions) >= 2 and len(removals) == 0
 

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -115,9 +115,6 @@ class TestRpc:
 
             pid = list(blocks[-1].get_included_reward_coins())[0].parent_coin_info
             pid_2 = list(blocks[-1].get_included_reward_coins())[1].parent_coin_info
-            coins = await client.get_coin_records_by_parent_id(pid)
-            print(coins)
-            assert len(coins) == 1
             coins = await client.get_coin_records_by_parent_ids([pid, pid_2])
             print(coins)
             assert len(coins) == 2


### PR DESCRIPTION
This RPC is useful when trying to walk down the history of a coin's spends.  Right now there's no way to go directly from parent to children.