### PR TITLE
add ids to the return response of start_plotting

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -538,8 +538,10 @@ class WebSocketServer:
             }
             return response
 
+        ids : List[str] = [] 
         for k in range(count):
             id = str(uuid.uuid4())
+            ids.append(id)
             config = {
                 "id": id,
                 "size": size,
@@ -572,6 +574,7 @@ class WebSocketServer:
 
         response = {
             "success": True,
+            "ids": ids,
             "service_name": service_name,
         }
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -538,7 +538,7 @@ class WebSocketServer:
             }
             return response
 
-        ids : List[str] = [] 
+        ids : List[str] = []
         for k in range(count):
             id = str(uuid.uuid4())
             ids.append(id)

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -538,7 +538,7 @@ class WebSocketServer:
             }
             return response
 
-        ids : List[str] = []
+        ids: List[str] = []
         for k in range(count):
             id = str(uuid.uuid4())
             ids.append(id)

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -562,7 +562,7 @@ class WebSocketServer:
             # notify GUI about new plot queue item
             self.state_changed(service_plotter, self.prepare_plot_state_message(PlotEvent.STATE_CHANGED, id))
 
-            # only first item can start when user selected serial plotting
+            # only the first item can start when user selected serial plotting
             can_start_serial_plotting = k == 0 and self._is_serial_plotting_running(queue) is False
 
             if parallel is True or can_start_serial_plotting:


### PR DESCRIPTION
This is a simple addition to collect the id's of plots as they are queued and return them with the response. Makes it a titch easier on the caller to manage the work.