### PR TITLE
Fixed type annotation

### DIFF
--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -143,7 +143,7 @@ class FullNodeRpcClient(RpcClient):
     async def push_tx(self, spend_bundle: SpendBundle):
         return await self.fetch("push_tx", {"spend_bundle": spend_bundle.to_json_dict()})
 
-    async def get_puzzle_and_solution(self, coin_id: bytes32, height: uint32) -> Optional[CoinRecord]:
+    async def get_puzzle_and_solution(self, coin_id: bytes32, height: uint32) -> Optional[CoinSpend]:
         try:
             response = await self.fetch("get_puzzle_and_solution", {"coin_id": coin_id.hex(), "height": height})
             return CoinSpend.from_json_dict(response["coin_solution"])


### PR DESCRIPTION
It is unfortunate to revert f4a685 by https://github.com/Chia-Network/chia-blockchain/commit/e14159b21750cba0e24e4f260053cbee7cdee533

The previous commit f4a685 was correct before https://github.com/Chia-Network/chia-blockchain/pull/6841 has merged.
The name of type was changed by the #6841 .
So it was a bad luck. Just a timing issue.