### PR TITLE
cli: Use correct type annotations

### DIFF
--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -29,6 +29,17 @@ def farm_cmd() -> None:
     show_default=True,
 )
 @click.option(
+    "-hp",
+    "--harvester-rpc-port",
+    help=(
+        "Set the port where the Harvester is hosting the RPC interface"
+        "See the rpc_port under harvester in config.yaml"
+    ),
+    type=int,
+    default=None,
+    show_default=True,
+)
+@click.option(
     "-fp",
     "--farmer-rpc-port",
     help=(
@@ -38,11 +49,13 @@ def farm_cmd() -> None:
     default=None,
     show_default=True,
 )
-def summary_cmd(rpc_port: int, wallet_rpc_port: Optional[int], farmer_rpc_port: Optional[int]) -> None:
+def summary_cmd(
+    rpc_port: int, wallet_rpc_port: Optional[int], harvester_rpc_port: Optional[int], farmer_rpc_port: Optional[int]
+) -> None:
     from .farm_funcs import summary
     import asyncio
 
-    asyncio.run(summary(rpc_port, wallet_rpc_port, farmer_rpc_port))
+    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port))
 
 
 @farm_cmd.command("challenges", short_help="Show the latest challenges")

--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -50,7 +50,10 @@ def farm_cmd() -> None:
     show_default=True,
 )
 def summary_cmd(
-    rpc_port: int, wallet_rpc_port: Optional[int], harvester_rpc_port: Optional[int], farmer_rpc_port: Optional[int]
+    rpc_port: Optional[int],
+    wallet_rpc_port: Optional[int],
+    harvester_rpc_port: Optional[int],
+    farmer_rpc_port: Optional[int],
 ) -> None:
     from .farm_funcs import summary
     import asyncio

--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 
@@ -27,17 +29,6 @@ def farm_cmd() -> None:
     show_default=True,
 )
 @click.option(
-    "-hp",
-    "--harvester-rpc-port",
-    help=(
-        "Set the port where the Harvester is hosting the RPC interface"
-        "See the rpc_port under harvester in config.yaml"
-    ),
-    type=int,
-    default=None,
-    show_default=True,
-)
-@click.option(
     "-fp",
     "--farmer-rpc-port",
     help=(
@@ -47,11 +38,11 @@ def farm_cmd() -> None:
     default=None,
     show_default=True,
 )
-def summary_cmd(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, farmer_rpc_port: int) -> None:
+def summary_cmd(rpc_port: int, wallet_rpc_port: Optional[int], farmer_rpc_port: Optional[int]) -> None:
     from .farm_funcs import summary
     import asyncio
 
-    asyncio.run(summary(rpc_port, wallet_rpc_port, harvester_rpc_port, farmer_rpc_port))
+    asyncio.run(summary(rpc_port, wallet_rpc_port, farmer_rpc_port))
 
 
 @farm_cmd.command("challenges", short_help="Show the latest challenges")
@@ -71,7 +62,7 @@ def summary_cmd(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, fa
     default=20,
     show_default=True,
 )
-def challenges_cmd(farmer_rpc_port: int, limit: int) -> None:
+def challenges_cmd(farmer_rpc_port: Optional[int], limit: int) -> None:
     from .farm_funcs import challenges
     import asyncio
 

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -17,7 +17,7 @@ from chia.util.network import is_localhost
 SECONDS_PER_BLOCK = (24 * 3600) / 4608
 
 
-async def get_harvesters(farmer_rpc_port: int) -> Optional[Dict[str, Any]]:
+async def get_harvesters(farmer_rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
         self_hostname = config["self_hostname"]
@@ -36,7 +36,7 @@ async def get_harvesters(farmer_rpc_port: int) -> Optional[Dict[str, Any]]:
     return plots
 
 
-async def get_blockchain_state(rpc_port: int) -> Optional[Dict[str, Any]]:
+async def get_blockchain_state(rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
     blockchain_state = None
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
@@ -56,7 +56,7 @@ async def get_blockchain_state(rpc_port: int) -> Optional[Dict[str, Any]]:
     return blockchain_state
 
 
-async def get_average_block_time(rpc_port: int) -> float:
+async def get_average_block_time(rpc_port: Optional[int]) -> float:
     try:
         blocks_to_compare = 500
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
@@ -100,7 +100,7 @@ async def get_average_block_time(rpc_port: int) -> float:
     return SECONDS_PER_BLOCK
 
 
-async def get_wallets_stats(wallet_rpc_port: int) -> Optional[Dict[str, Any]]:
+async def get_wallets_stats(wallet_rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
     amounts = None
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
@@ -119,7 +119,7 @@ async def get_wallets_stats(wallet_rpc_port: int) -> Optional[Dict[str, Any]]:
     return amounts
 
 
-async def is_farmer_running(farmer_rpc_port: int) -> bool:
+async def is_farmer_running(farmer_rpc_port: Optional[int]) -> bool:
     is_running = False
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
@@ -140,7 +140,7 @@ async def is_farmer_running(farmer_rpc_port: int) -> bool:
     return is_running
 
 
-async def get_challenges(farmer_rpc_port: int) -> Optional[List[Dict[str, Any]]]:
+async def get_challenges(farmer_rpc_port: Optional[int]) -> Optional[List[Dict[str, Any]]]:
     signage_points = None
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
@@ -160,7 +160,7 @@ async def get_challenges(farmer_rpc_port: int) -> Optional[List[Dict[str, Any]]]
     return signage_points
 
 
-async def challenges(farmer_rpc_port: int, limit: int) -> None:
+async def challenges(farmer_rpc_port: Optional[int], limit: int) -> None:
     signage_points = await get_challenges(farmer_rpc_port)
     if signage_points is None:
         return None
@@ -178,7 +178,7 @@ async def challenges(farmer_rpc_port: int, limit: int) -> None:
         )
 
 
-async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, farmer_rpc_port: int) -> None:
+async def summary(rpc_port: int, wallet_rpc_port: Optional[int], farmer_rpc_port: Optional[int]) -> None:
     all_harvesters = await get_harvesters(farmer_rpc_port)
     blockchain_state = await get_blockchain_state(rpc_port)
     farmer_running = await is_farmer_running(farmer_rpc_port)

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -178,7 +178,9 @@ async def challenges(farmer_rpc_port: Optional[int], limit: int) -> None:
         )
 
 
-async def summary(rpc_port: int, wallet_rpc_port: Optional[int], farmer_rpc_port: Optional[int]) -> None:
+async def summary(
+    rpc_port: int, wallet_rpc_port: Optional[int], harvester_rpc_port: Optional[int], farmer_rpc_port: Optional[int]
+) -> None:
     all_harvesters = await get_harvesters(farmer_rpc_port)
     blockchain_state = await get_blockchain_state(rpc_port)
     farmer_running = await is_farmer_running(farmer_rpc_port)

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -179,7 +179,10 @@ async def challenges(farmer_rpc_port: Optional[int], limit: int) -> None:
 
 
 async def summary(
-    rpc_port: int, wallet_rpc_port: Optional[int], harvester_rpc_port: Optional[int], farmer_rpc_port: Optional[int]
+    rpc_port: Optional[int],
+    wallet_rpc_port: Optional[int],
+    harvester_rpc_port: Optional[int],
+    farmer_rpc_port: Optional[int],
 ) -> None:
     all_harvesters = await get_harvesters(farmer_rpc_port)
     blockchain_state = await get_blockchain_state(rpc_port)

--- a/chia/cmds/netspace.py
+++ b/chia/cmds/netspace.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 
@@ -32,7 +34,7 @@ import click
     type=str,
     default="",
 )
-def netspace_cmd(rpc_port: int, delta_block_height: str, start: str) -> None:
+def netspace_cmd(rpc_port: Optional[int], delta_block_height: str, start: str) -> None:
     """
     Calculates the estimated space on the network given two block header hashes.
     """

--- a/chia/cmds/netspace_funcs.py
+++ b/chia/cmds/netspace_funcs.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import aiohttp
 
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
@@ -8,7 +10,7 @@ from chia.util.ints import uint16
 from chia.util.misc import format_bytes
 
 
-async def netstorge_async(rpc_port: int, delta_block_height: str, start: str) -> None:
+async def netstorge_async(rpc_port: Optional[int], delta_block_height: str, start: str) -> None:
     """
     Calculates the estimated space on the network given two block header hashes.
     """

--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 
@@ -16,7 +18,7 @@ def plotnft_cmd() -> None:
 )
 @click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=False)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def show_cmd(wallet_rpc_port: int, fingerprint: int, id: int) -> None:
+def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet
     from .plotnft_funcs import show
@@ -47,7 +49,7 @@ def get_login_link_cmd(launcher_id: str) -> None:
     type=int,
     default=None,
 )
-def create_cmd(wallet_rpc_port: int, fingerprint: int, pool_url: str, state: str, yes: bool) -> None:
+def create_cmd(wallet_rpc_port: Optional[int], fingerprint: int, pool_url: str, state: str, yes: bool) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet
     from .plotnft_funcs import create
@@ -75,7 +77,7 @@ def create_cmd(wallet_rpc_port: int, fingerprint: int, pool_url: str, state: str
     type=int,
     default=None,
 )
-def join_cmd(wallet_rpc_port: int, fingerprint: int, id: int, pool_url: str, yes: bool) -> None:
+def join_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, pool_url: str, yes: bool) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet
     from .plotnft_funcs import join_pool
@@ -95,7 +97,7 @@ def join_cmd(wallet_rpc_port: int, fingerprint: int, id: int, pool_url: str, yes
     type=int,
     default=None,
 )
-def self_pool_cmd(wallet_rpc_port: int, fingerprint: int, id: int, yes: bool) -> None:
+def self_pool_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, yes: bool) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet
     from .plotnft_funcs import self_pool
@@ -114,7 +116,7 @@ def self_pool_cmd(wallet_rpc_port: int, fingerprint: int, id: int, yes: bool) ->
     type=int,
     default=None,
 )
-def inspect(wallet_rpc_port: int, fingerprint: int, id: int) -> None:
+def inspect(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet
     from .plotnft_funcs import inspect_cmd
@@ -133,7 +135,7 @@ def inspect(wallet_rpc_port: int, fingerprint: int, id: int) -> None:
     type=int,
     default=None,
 )
-def claim(wallet_rpc_port: int, fingerprint: int, id: int) -> None:
+def claim(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet
     from .plotnft_funcs import claim_cmd

--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -1,10 +1,10 @@
-from typing import Any
+from typing import Any, Optional
 
 import click
 
 
 async def show_async(
-    rpc_port: int,
+    rpc_port: Optional[int],
     state: bool,
     show_connections: bool,
     exit_node: bool,
@@ -296,8 +296,8 @@ async def show_async(
 )
 @click.option("-b", "--block-by-header-hash", help="Look up a block by block header hash", type=str, default="")
 def show_cmd(
-    rpc_port: int,
-    wallet_rpc_port: int,
+    rpc_port: Optional[int],
+    wallet_rpc_port: Optional[int],
     state: bool,
     connections: bool,
     exit_node: bool,

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import click
 
 
@@ -18,7 +20,7 @@ def wallet_cmd() -> None:
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-tx", "--tx_id", help="transaction id to search for", type=str, required=True)
 @click.option("--verbose", "-v", count=True, type=int)
-def get_transaction_cmd(wallet_rpc_port: int, fingerprint: int, id: int, tx_id: str, verbose: int) -> None:
+def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, tx_id: str, verbose: int) -> None:
     extra_params = {"id": id, "tx_id": tx_id, "verbose": verbose}
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transaction
@@ -46,7 +48,7 @@ def get_transaction_cmd(wallet_rpc_port: int, fingerprint: int, id: int, tx_id: 
     required=True,
 )
 @click.option("--verbose", "-v", count=True, type=int)
-def get_transactions_cmd(wallet_rpc_port: int, fingerprint: int, id: int, offset: int, verbose: bool) -> None:
+def get_transactions_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, offset: int, verbose: bool) -> None:
     extra_params = {"id": id, "verbose": verbose, "offset": offset}
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transactions
@@ -79,7 +81,7 @@ def get_transactions_cmd(wallet_rpc_port: int, fingerprint: int, id: int, offset
     "-o", "--override", help="Submits transaction without checking for unusual values", is_flag=True, default=False
 )
 def send_cmd(
-    wallet_rpc_port: int, fingerprint: int, id: int, amount: str, fee: str, address: str, override: bool
+    wallet_rpc_port: Optional[int], fingerprint: int, id: int, amount: str, fee: str, address: str, override: bool
 ) -> None:
     extra_params = {"id": id, "amount": amount, "fee": fee, "address": address, "override": override}
     import asyncio
@@ -97,11 +99,11 @@ def send_cmd(
     default=None,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def show_cmd(wallet_rpc_port: int, fingerprint: int) -> None:
+def show_cmd(wallet_rpc_port: Optional[int], farmer_rpc_port: int, fingerprint: int) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet, print_balances
 
-    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, {}, print_balances))
+    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, {"farmer_rpc_port": farmer_rpc_port}, print_balances))
 
 
 @wallet_cmd.command("get_address", short_help="Get a wallet receive address")
@@ -114,7 +116,7 @@ def show_cmd(wallet_rpc_port: int, fingerprint: int) -> None:
 )
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def get_address_cmd(wallet_rpc_port: int, id, fingerprint: int) -> None:
+def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int) -> None:
     extra_params = {"id": id}
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_address
@@ -134,7 +136,7 @@ def get_address_cmd(wallet_rpc_port: int, id, fingerprint: int) -> None:
 )
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def delete_unconfirmed_transactions_cmd(wallet_rpc_port: int, id, fingerprint: int) -> None:
+def delete_unconfirmed_transactions_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int) -> None:
     extra_params = {"id": id}
     import asyncio
     from .wallet_funcs import execute_with_wallet, delete_unconfirmed_transactions

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -99,11 +99,11 @@ def send_cmd(
     default=None,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def show_cmd(wallet_rpc_port: Optional[int], farmer_rpc_port: int, fingerprint: int) -> None:
+def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet, print_balances
 
-    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, {"farmer_rpc_port": farmer_rpc_port}, print_balances))
+    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, {}, print_balances))
 
 
 @wallet_cmd.command("get_address", short_help="Get a wallet receive address")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -3,7 +3,7 @@ import sys
 import time
 from datetime import datetime
 from decimal import Decimal
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Dict
 
 import aiohttp
 
@@ -223,7 +223,9 @@ async def get_wallet(wallet_client: WalletRpcClient, fingerprint: int = None) ->
     return wallet_client, fingerprint
 
 
-async def execute_with_wallet(wallet_rpc_port: int, fingerprint: int, extra_params: dict, function: Callable) -> None:
+async def execute_with_wallet(
+    wallet_rpc_port: Optional[int], fingerprint: int, extra_params: Dict, function: Callable
+) -> None:
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
         self_hostname = config["self_hostname"]


### PR DESCRIPTION
These ports are Optionals but they were incorrectly types as `int`.
Also removes unused argument `harvester_rpc_port`, since we connect to farmer now