### PR TITLE
Show hostname in farm summary for remote harvesters

### DIFF
--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -228,9 +228,9 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
             else:
                 if ip not in harvesters_remote:
                     harvesters_remote[ip] = {}
-                harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
                 if socket.gethostbyaddr(ip):
                     harvesters_hostnames[ip] = socket.gethostbyaddr(ip)[0]
+                harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
 
         def process_harvesters(harvester_peers_in: dict):
             for harvester_peer_id, plots in harvester_peers_in.items():

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -228,8 +228,10 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
             else:
                 if ip not in harvesters_remote:
                     harvesters_remote[ip] = {}
-                    if socket.gethostbyaddr(ip):
+                    try:
                         harvesters_hostnames[ip] = socket.gethostbyaddr(ip)[0]
+                    except Exception:
+                        pass
                 harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
 
         def process_harvesters(harvester_peers_in: dict):

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -245,7 +245,7 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
             process_harvesters(harvesters_local)
         for harvester_ip, harvester_peers in harvesters_remote.items():
-            if harvesters_hostnames[harvester_ip]:
+            if harvester_ip in harvesters_hostnames:
                 print(f"Remote Harvester{'s' if len(harvester_peers) > 1 else ''} for host: {harvesters_hostnames[harvester_ip]} ({harvester_ip})")
             else:
                 print(f"Remote Harvester{'s' if len(harvester_peers) > 1 else ''} for IP: {harvester_ip}")

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -228,8 +228,8 @@ async def summary(rpc_port: int, wallet_rpc_port: int, harvester_rpc_port: int, 
             else:
                 if ip not in harvesters_remote:
                     harvesters_remote[ip] = {}
-                if socket.gethostbyaddr(ip):
-                    harvesters_hostnames[ip] = socket.gethostbyaddr(ip)[0]
+                    if socket.gethostbyaddr(ip):
+                        harvesters_hostnames[ip] = socket.gethostbyaddr(ip)[0]
                 harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
 
         def process_harvesters(harvester_peers_in: dict):


### PR DESCRIPTION
Tested only on Ubuntu 20.04.2 LTS. Imports 'socket' which maybe an issue for some distros. 

I keep track of my remote harvesters by hostname and do not know the IP. This makes it easy.