### PR TITLE
Minor bug fix : dnf requires elevated privileges to enable modules.

### DIFF
--- a/install-gui.sh
+++ b/install-gui.sh
@@ -38,7 +38,7 @@ if [ "$(uname)" = "Linux" ]; then
 	elif type yum && [ -f /etc/rocky-release ] || [ -f /etc/fedora-release ]; then
                 # RockyLinux
                 echo "Installing on RockyLinux/Fedora"
-                dnf module enable nodejs:12
+                sudo dnf module enable nodejs:12
                 sudo dnf install -y nodejs
         fi
 


### PR DESCRIPTION
Tested on Fedora 33  and Rocky, dnf requires elevated privileges to enable modules. This would solve the 
"Error: This command has to be run with superuser privileges (under the root user on most systems)." error during the gui install script.