### PR TITLE
Make the Pool Contract Address safer 

### DIFF
--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -120,8 +120,8 @@ async def pprint_pool_wallet_state(
     print(f"Owner public key: {pool_wallet_info.current.owner_pubkey}")
 
     print(
-        f"P2 singleton address (pool contract address for plotting): "
-        f"{encode_puzzle_hash(pool_wallet_info.p2_singleton_puzzle_hash, address_prefix)}"
+        f"Pool contract address (used ONLY for plotting - do not send money to this address): "
+        f"{pool_wallet_info.p2_singleton_puzzle_hash.hex()}"
     )
     if pool_wallet_info.target is not None:
         print(f"Target state: {PoolSingletonState(pool_wallet_info.target.state).name}")

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -68,7 +68,14 @@ def create_plots(args, root_path, use_datetime=True, test_private_keys: Optional
             pool_public_key = get_pool_public_key(args.alt_fingerprint)
         else:
             # If the pool contract puzzle hash is set, use that
-            pool_contract_puzzle_hash = decode_puzzle_hash(args.pool_contract_address)
+            try:
+                pool_contract_puzzle_hash = bytes.fromhex(args.pool_contract_address)
+            except ValueError:
+                log.warning(
+                    "Creating plots with pool_contract_address formatted as bech32m is deprecated."
+                    "pool_contract_address should be given as 64 hex digits."
+                )
+                pool_contract_puzzle_hash = decode_puzzle_hash(args.pool_contract_address)
 
     assert (pool_public_key is None) != (pool_contract_puzzle_hash is None)
     num = args.num


### PR DESCRIPTION
The intent is to discourage non-block reward payments to that contract address.

We preserve the ability to use the old format.
