### PR TITLE
fix err type in wallet_blockchain.py

### DIFF
--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -206,7 +206,7 @@ class WalletBlockchain(BlockchainInterface):
             required_iters, val_error = validate_unfinished_header_block(
                 self.constants, self, unfinished_header_block, False, difficulty, sub_slot_iters, False, True
             )
-            error = ValidationError(Err(val_error)) if val_error is not None else None
+            error = val_error if val_error is not None else None
         else:
             assert pre_validation_result is not None
             required_iters = pre_validation_result.required_iters


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/issues/7516
"2021-07-14T23:22:52.616 wallet chia.wallet.wallet_node : ERROR Error while trying to fetch from peer:ValidationError(<Err.INVALID_PLOT_SIGNATURE: 28>) is not a valid Err Traceback (most recent call last):"


