### PR TITLE
proof of concept: faster large syncing using parallel fetching of multiple blocks

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -768,11 +768,9 @@ class FullNode:
                     continue
                 elif isinstance(response, RespondBlocks):
                     while start_height - batch_size in queued_blocks:
-                        self.log.info(
-                            f"batch {start_height} waiting for {start_height - batch_size} - sleeping..."
-                        )
+                        self.log.info(f"batch {start_height} waiting for {start_height - batch_size} - sleeping...")
                         await asyncio.sleep(multi_request_sleep_time)
-                    # TODO: advanced_peak across parallel calls...                    
+                    # TODO: advanced_peak across parallel calls...
                     success, advanced_peak, _ = await self.receive_block_batch(
                         response.blocks, peer, None if advanced_peak else uint32(fork_point_height), summaries
                     )
@@ -806,15 +804,13 @@ class FullNode:
                 self.sync_store.peers_changed.clear()
 
             if batch_added is False:
-                self.log.info(
-                    f"Failed to fetch blocks {start_height} to {end_height} from peers: {peers_with_peak}"
-                )
+                self.log.info(f"Failed to fetch blocks {start_height} to {end_height} from peers: {peers_with_peak}")
                 failed_to_fetch_blocks = True
                 return
             else:
                 self.log.info(
-                    f"Added blocks {start_height} to {end_height}. "+
-                    f"queued_blocks={len(queued_blocks)} peers={len(peers_with_peak)}"
+                    f"Added blocks {start_height} to {end_height}. "
+                    + f"queued_blocks={len(queued_blocks)} peers={len(peers_with_peak)}"
                 )
                 self.blockchain.clean_block_record(
                     min(
@@ -828,9 +824,7 @@ class FullNode:
         for start_height in range(fork_point_height, target_peak_sb_height, batch_size):
             while len(queued_blocks) > max_queue_size:
                 if failed_to_fetch_blocks:
-                    self.log.info(
-                        f"Failed to fetch blocks, stranding queue={len(queued_blocks)} - terminating..."
-                    )
+                    self.log.info(f"Failed to fetch blocks, stranding queue={len(queued_blocks)} - terminating...")
                     break
                 self.log.info(
                     f"batch launcher height {start_height}: queue full with {max_queue_size} entries - sleeping..."

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -742,7 +742,7 @@ class FullNode:
                             fork_point_height = our_peak_height
                         break
 
-        queued_blocks = {}
+        queued_blocks: Dict[int, bool] = {}
         multi_request_sleep_time = 2
         failed_to_fetch_blocks = False
 
@@ -768,8 +768,11 @@ class FullNode:
                     continue
                 elif isinstance(response, RespondBlocks):
                     while start_height - batch_size in queued_blocks:
-                        self.log.info(f"batch {start_height} waiting for {start_height - batch_size} - sleeping...")
+                        self.log.info(
+                            f"batch {start_height} waiting for {start_height - batch_size} - sleeping..."
+                        )
                         await asyncio.sleep(multi_request_sleep_time)
+                    # TODO: advanced_peak across parallel calls...                    
                     success, advanced_peak, _ = await self.receive_block_batch(
                         response.blocks, peer, None if advanced_peak else uint32(fork_point_height), summaries
                     )
@@ -803,13 +806,16 @@ class FullNode:
                 self.sync_store.peers_changed.clear()
 
             if batch_added is False:
-                self.log.info(f"Failed to fetch blocks {start_height} to {end_height} "+
-                              f"from peers: {peers_with_peak}")
+                self.log.info(
+                    f"Failed to fetch blocks {start_height} to {end_height} from peers: {peers_with_peak}"
+                )
                 failed_to_fetch_blocks = True
                 return
             else:
-                self.log.info(f"Added blocks {start_height} to {end_height}. "+
-                              f"queued_blocks={len(queued_blocks)} peers={len(peers_with_peak)}")
+                self.log.info(
+                    f"Added blocks {start_height} to {end_height}. "+
+                    f"queued_blocks={len(queued_blocks)} peers={len(peers_with_peak)}"
+                )
                 self.blockchain.clean_block_record(
                     min(
                         end_height - self.constants.BLOCKS_CACHE_SIZE,
@@ -822,9 +828,13 @@ class FullNode:
         for start_height in range(fork_point_height, target_peak_sb_height, batch_size):
             while len(queued_blocks) > max_queue_size:
                 if failed_to_fetch_blocks:
-                    self.log.info(f"Failed to fetch blocks, stranding queue={len(queued_blocks)} - terminating...")
+                    self.log.info(
+                        f"Failed to fetch blocks, stranding queue={len(queued_blocks)} - terminating..."
+                    )
                     break
-                self.log.info(f"batch launcher height {start_height}: queue full with {max_queue_size} entries - sleeping...")
+                self.log.info(
+                    f"batch launcher height {start_height}: queue full with {max_queue_size} entries - sleeping..."
+                )
                 await asyncio.sleep(multi_request_sleep_time)
             queued_blocks[start_height] = True
             asyncio.create_task(request_range(start_height))

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -745,8 +745,9 @@ class FullNode:
         queued_blocks = {}
         multi_request_sleep_time = 2
         failed_to_fetch_blocks = False
+
         async def request_range(start_height):
-            nonlocal queued_blocks, multi_request_sleep_time
+            nonlocal queued_blocks, multi_request_sleep_time, failed_to_fetch_blocks
             nonlocal peer_ids, peers_with_peak, advanced_peak, batch_size, target_peak_sb_height
             end_height = min(target_peak_sb_height, start_height + batch_size)
             request = RequestBlocks(uint32(start_height), uint32(end_height), True)
@@ -802,11 +803,13 @@ class FullNode:
                 self.sync_store.peers_changed.clear()
 
             if batch_added is False:
-                self.log.info(f"Failed to fetch blocks {start_height} to {end_height} from peers: {peers_with_peak}")
+                self.log.info(f"Failed to fetch blocks {start_height} to {end_height} "+
+                              f"from peers: {peers_with_peak}")
                 failed_to_fetch_blocks = True
                 return
             else:
-                self.log.info(f"Added blocks {start_height} to {end_height}. queued_blocks={len(queued_blocks)} peers={len(peers_with_peak)}")
+                self.log.info(f"Added blocks {start_height} to {end_height}. "+
+                              f"queued_blocks={len(queued_blocks)} peers={len(peers_with_peak)}")
                 self.blockchain.clean_block_record(
                     min(
                         end_height - self.constants.BLOCKS_CACHE_SIZE,


### PR DESCRIPTION
note: nowhere near ready for merge (see below)

This proof of concept PR attempts to parallelize fetching ranges of blocks (in addition to the existing parallelization of each range across peers). This POC achieves ~50% speedup (in my environment, default settings that I pulled out of thin air, etc), which seems worth sharing but IMHO not enough to publish. IMHO the next step is to (for fullnodes with lots of peers...) partition the peers list across the list of future blocks and blockN gets peers-set P and blockN+1 gets peers-set P+1, etc. But maybe y'all have better ideas?

Please be gentle: I'm a novice at python asyncio. :-) If you like this direction but hate my code, no worries.

Lightly tested: on my Ubuntu 20.04 node, this passes tests/core/full_node/full_sync/test_full_sync.py and also seems to work when I run it against mainnet. If you like this direction, of course I'll get more serious.
