### PR TITLE
don't save unknown conditions

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -284,9 +284,9 @@ def parse_condition(cond: SExp, safe_mode: bool) -> Tuple[int, Optional[Conditio
         cost, args = parse_condition_args(cond.rest(), opcode, safe_mode)
         cvl = ConditionWithArgs(opcode, args) if args is not None else None
     elif not safe_mode:
-        opcode = ConditionOpcode.UNKNOWN
-        cvl = ConditionWithArgs(opcode, cond.rest().as_atom_list())
-        cost = 0
+        # we don't need to save unknown conditions. We can't do anything with them anyway
+        # safe_mode just tells us whether we can tolerate them or not
+        return 0, None
     else:
         raise ValidationError(Err.INVALID_CONDITION)
     return cost, cvl

--- a/chia/types/condition_opcodes.py
+++ b/chia/types/condition_opcodes.py
@@ -4,9 +4,6 @@ from typing import Any
 
 # See chia/wallet/puzzles/condition_codes.clvm
 class ConditionOpcode(bytes, enum.Enum):
-    # UNKNOWN is ascii "0"
-    UNKNOWN = bytes([48])
-
     # AGG_SIG is ascii "1"
 
     # the conditions below require bls12-381 signatures

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -27,12 +27,7 @@ def parse_sexp_to_condition(
     if len(as_atoms) < 1:
         return Err.INVALID_CONDITION, None
     opcode = as_atoms[0]
-    try:
-        opcode = ConditionOpcode(opcode)
-    except ValueError:
-        # TODO: this remapping is bad, and should probably not happen
-        # it's simple enough to just store the opcode as a byte
-        opcode = ConditionOpcode.UNKNOWN
+    opcode = ConditionOpcode(opcode)
     return None, ConditionWithArgs(opcode, as_atoms[1:])
 
 

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -26,7 +26,7 @@ from chia.util.ints import uint64
 from chia.util.hash import std_hash
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.api_decorators import api_request, peer_required, bytes_required
-from chia.full_node.mempool_check_conditions import parse_condition_args
+from chia.full_node.mempool_check_conditions import parse_condition_args, parse_condition
 
 from tests.connection_utils import connect_and_get_peer
 from tests.core.node_height import node_height_at_least
@@ -1932,6 +1932,22 @@ class TestConditionParser:
 
             with pytest.raises(ValidationError):
                 cost, args = parse_condition_args(SExp.to([]), opcode, False)
+
+    def test_parse_condition(self):
+
+        for opcode in [129, 0, 1, 1000, 74]:
+            with pytest.raises(ValidationError):
+                cost, args = parse_condition(SExp.to([int_to_bytes(opcode), b"test"]), safe_mode=True)
+
+            with pytest.raises(ValidationError):
+                cost, args = parse_condition(SExp.to([int_to_bytes(opcode), b"foo", b"bar"]), safe_mode=True)
+
+            with pytest.raises(ValidationError):
+                cost, args = parse_condition(SExp.to([int_to_bytes(opcode)]), safe_mode=True)
+
+            assert (0, None) == parse_condition(SExp.to([int_to_bytes(opcode), b"test"]), safe_mode=False)
+            assert (0, None) == parse_condition(SExp.to([int_to_bytes(opcode), b"foo", b"bar"]), safe_mode=False)
+            assert (0, None) == parse_condition(SExp.to([int_to_bytes(opcode)]), safe_mode=False)
 
 
 # the following tests generate generator programs and run them through get_name_puzzle_conditions()

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -1548,20 +1548,6 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
         assert err == Err.ASSERT_MY_AMOUNT_FAILED
 
-    @pytest.mark.asyncio
-    async def test_unknown_condition(self, two_nodes):
-
-        full_node_1, full_node_2, server_1, server_2 = two_nodes
-        cvp = ConditionWithArgs(ConditionOpcode.UNKNOWN, [])
-        dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
-
-        sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
-
-        assert sb1 is None
-        assert status == MempoolInclusionStatus.FAILED
-        assert err == Err.INVALID_CONDITION
-
 
 class TestConditionParser:
     @pytest.mark.parametrize("safe_mode", [True, False])


### PR DESCRIPTION
This makes the conditions parser either ignore or fail when it encounters unknown conditions. It also removes the `UNKNOWN` enum value from `ConditionOpcodes`, which means the high-level test had to be removed because there's no way to specify a valid `ConditionOpcode` that's invalid now. The low level tests that specify integers are still working.

This is not urgent, and perhaps should not land for monday's release.