### PR TITLE
Include all chialisp files in source distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ kwargs = dict(
     },
     package_data={
         "chia": ["pyinstaller.spec"],
-        "chia.wallet.puzzles": ["*.clvm", "*.clvm.hex"],
+        "": ["*.clvm", "*.clvm.hex", "*.clib", "*.clinc", "*.clsp"],
         "chia.util": ["initial-*.yaml", "english.txt"],
         "chia.ssl": ["chia_ca.crt", "chia_ca.key", "dst_root_ca.pem"],
         "mozilla-ca": ["cacert.pem"],


### PR DESCRIPTION
Currently, the only raw chialisp files that are being brought over are files in the chia/wallet/puzzles folder with the file extensions *.clvm and *.clvm.hex.  This is technically fine right now because all of the clvm that the python uses is in the .hex files from that folder which automatically bake in files that are currently being left out (ending with .clib or .clinc).

There's an argument to be made that only the hex files should be packaged, but they do need to start being packaged from places other than the puzzles directory.