### PR TITLE
Fix invalid content-type header in pool api requests

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -270,17 +270,12 @@ class Farmer:
         assert owner_sk.get_g1() == pool_config.owner_public_key
         signature: G2Element = AugSchemeMPL.sign(owner_sk, post_farmer_payload.get_hash())
         post_farmer_request = PostFarmerRequest(post_farmer_payload, signature)
-        post_farmer_body = json.dumps(post_farmer_request.to_json_dict())
 
-        headers = {
-            "content-type": "application/json;",
-        }
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(
                     f"{pool_config.pool_url}/farmer",
-                    data=post_farmer_body,
-                    headers=headers,
+                    json=post_farmer_request.to_json_dict(),
                     ssl=ssl_context_for_root(get_mozilla_ca_crt()),
                 ) as resp:
                     if resp.ok:
@@ -313,13 +308,12 @@ class Farmer:
         assert owner_sk.get_g1() == pool_config.owner_public_key
         signature: G2Element = AugSchemeMPL.sign(owner_sk, put_farmer_payload.get_hash())
         put_farmer_request = PutFarmerRequest(put_farmer_payload, signature)
-        put_farmer_body = json.dumps(put_farmer_request.to_json_dict())
 
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.put(
                     f"{pool_config.pool_url}/farmer",
-                    data=put_farmer_body,
+                    json=put_farmer_request.to_json_dict(),
                     ssl=ssl_context_for_root(get_mozilla_ca_crt()),
                 ) as resp:
                     if resp.ok:

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -209,21 +209,17 @@ class FarmerAPI:
                 agg_sig: G2Element = AugSchemeMPL.aggregate([plot_signature, authentication_signature])
 
                 post_partial_request: PostPartialRequest = PostPartialRequest(payload, agg_sig)
-                post_partial_body = json.dumps(post_partial_request.to_json_dict())
                 self.farmer.log.info(
                     f"Submitting partial for {post_partial_request.payload.launcher_id.hex()} to {pool_url}"
                 )
                 pool_state_dict["points_found_since_start"] += pool_state_dict["current_difficulty"]
                 pool_state_dict["points_found_24h"].append((time.time(), pool_state_dict["current_difficulty"]))
-                headers = {
-                    "content-type": "application/json;",
-                }
+
                 try:
                     async with aiohttp.ClientSession() as session:
                         async with session.post(
                             f"{pool_url}/partial",
-                            data=post_partial_body,
-                            headers=headers,
+                            json=post_partial_request.to_json_dict(),
                             ssl=ssl_context_for_root(get_mozilla_ca_crt()),
                         ) as resp:
                             if resp.ok:


### PR DESCRIPTION
Currently the json data for POST and PUT `/farmer` and POST `/partial` requests is manually transformed to json. The `content-type` header is also set manually, but with an invalid value. For single content-type values there is no semicolon allowed at the end.

All this can be avoided by just using the `json` parameter on the aiohttp request, which will automatically add the correct content-type header and transform the value to json.
This PR does exactly that.