### PR TITLE
Display successful points in `chia plotnft show`

### DIFF
--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -142,6 +142,11 @@ async def pprint_pool_wallet_state(
         if pool_wallet_info.launcher_id in pool_state_dict:
             print(f"Current difficulty: {pool_state_dict[pool_wallet_info.launcher_id]['current_difficulty']}")
             print(f"Points balance: {pool_state_dict[pool_wallet_info.launcher_id]['current_points']}")
+            num_points_found_24h = len(pool_state_dict[pool_wallet_info.launcher_id]["points_found_24h"])
+            if num_points_found_24h > 0:
+                num_points_ack_24h = len(pool_state_dict[pool_wallet_info.launcher_id]["points_acknowledged_24h"])
+                success_pct = num_points_ack_24h / num_points_found_24h
+                print(f"Percent Successful Points (24h): {success_pct:.2%}")
         print(f"Relative lock height: {pool_wallet_info.current.relative_lock_height} blocks")
         payout_instructions: str = pool_state_dict[pool_wallet_info.launcher_id]["pool_config"]["payout_instructions"]
         try:


### PR DESCRIPTION
The GUI has a useful "Percent Successful Points" display and it just gets this
from `get_pool_state`

Since `chia plotnft show` is already calling this API and getting this
data, I've updated the output to show it