### PR TITLE
Partial reversion of CoinSpend rename for API compatibility

### DIFF
--- a/.github/workflows/build-test-macos-core-types.yml
+++ b/.github/workflows/build-test-macos-core-types.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Test core-types code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/types/test_coin.py tests/core/types/test_proof_of_space.py -s -v --durations 0 
+        ./venv/bin/py.test tests/core/types/test_coin.py tests/core/types/test_proof_of_space.py tests/core/types/test_spend_bundle.py -s -v --durations 0
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-ubuntu-core-types.yml
+++ b/.github/workflows/build-test-ubuntu-core-types.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Test core-types code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/types/test_coin.py tests/core/types/test_proof_of_space.py -s -v --durations 0 
+        ./venv/bin/py.test tests/core/types/test_coin.py tests/core/types/test_proof_of_space.py tests/core/types/test_spend_bundle.py -s -v --durations 0
 
 
 #

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -490,10 +490,6 @@ class FullNodeRpcApi:
         if "spend_bundle" not in request:
             raise ValueError("Spend bundle not in request")
 
-        # This is for backwards compatibility since CoinSolution has been renamed to CoinSpend
-        if "coin_solutions" in request["spend_bundle"]:
-            request["spend_bundle"]["coin_spends"] = request["spend_bundle"].pop("coin_solutions")
-
         spend_bundle = SpendBundle.from_json_dict(request["spend_bundle"])
         spend_name = spend_bundle.name()
 

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -21,8 +21,12 @@ class SpendBundle(Streamable):
     between transactions are more flexible than in bitcoin).
     """
 
-    coin_spends: List[CoinSpend]
+    coin_solutions: List[CoinSpend]
     aggregated_signature: G2Element
+
+    @property
+    def coin_spends(self):
+        return self.coin_solutions
 
     @classmethod
     def aggregate(cls, spend_bundles) -> "SpendBundle":

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -1,3 +1,6 @@
+import dataclasses
+import warnings
+
 from dataclasses import dataclass
 from typing import List
 
@@ -5,7 +8,7 @@ from blspy import AugSchemeMPL, G2Element
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.streamable import Streamable, streamable
+from chia.util.streamable import Streamable, dataclass_from_dict, recurse_jsonify, streamable
 from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
 from .coin_spend import CoinSpend
@@ -21,12 +24,12 @@ class SpendBundle(Streamable):
     between transactions are more flexible than in bitcoin).
     """
 
-    coin_solutions: List[CoinSpend]
+    coin_spends: List[CoinSpend]
     aggregated_signature: G2Element
 
     @property
-    def coin_spends(self):
-        return self.coin_solutions
+    def coin_solutions(self):
+        return self.coin_spends
 
     @classmethod
     def aggregate(cls, spend_bundles) -> "SpendBundle":
@@ -72,3 +75,34 @@ class SpendBundle(Streamable):
             result.append(add)
 
         return result
+
+    # Note that `coin_spends` used to have the bad name `coin_solutions`.
+    # Some API still expects this name. For now, we accept both names.
+    #
+    # TODO: continue this deprecation. Eventually, all code below here should be removed.
+    #  1. set `exclude_modern_keys` to `False` (and manually set to `True` where necessary)
+    #  2. set `include_legacy_keys` to `False` (and manually set to `False` where necessary)
+    #  3. remove all references to `include_legacy_keys=True`
+    #  4. remove all code below this point
+
+    @classmethod
+    def from_json_dict(cls, json_dict):
+        if "coin_solutions" in json_dict:
+            if "coin_spends" not in json_dict:
+                json_dict = dict(
+                    aggregated_signature=json_dict["aggregated_signature"], coin_spends=json_dict["coin_solutions"]
+                )
+                warnings.warn("`coin_solutions` is now `coin_spends` in `SpendBundle.from_json_dict`")
+            else:
+                raise ValueError("JSON contains both `coin_solutions` and `coin_spends`, just use `coin_spends`")
+        return dataclass_from_dict(cls, json_dict)
+
+    def to_json_dict(self, include_legacy_keys: bool = True, exclude_modern_keys: bool = True):
+        if include_legacy_keys is False and exclude_modern_keys is True:
+            raise ValueError("`coin_spends` not included in legacy or modern outputs")
+        d = dataclasses.asdict(self)
+        if include_legacy_keys:
+            d["coin_solutions"] = d["coin_spends"]
+        if exclude_modern_keys:
+            del d["coin_spends"]
+        return recurse_jsonify(d)

--- a/tests/core/types/test_spend_bundle.py
+++ b/tests/core/types/test_spend_bundle.py
@@ -1,0 +1,76 @@
+import json
+import unittest
+
+from blspy import G2Element
+
+from chia.types.spend_bundle import SpendBundle
+
+
+BLANK_SPEND_BUNDLE = SpendBundle(coin_spends=[], aggregated_signature=G2Element())
+NULL_SIGNATURE = "0xc" + "0" * 191
+
+
+class TestStructStream(unittest.TestCase):
+    def test_from_json_legacy(self):
+        JSON = (
+            """
+        {
+          "coin_solutions": [],
+          "aggregated_signature": "%s"
+        }
+        """
+            % NULL_SIGNATURE
+        )
+        spend_bundle = SpendBundle.from_json_dict(json.loads(JSON))
+        json_1 = json.loads(JSON)
+        json_2 = spend_bundle.to_json_dict(include_legacy_keys=True, exclude_modern_keys=True)
+        assert json_1 == json_2
+
+    def test_from_json_new(self):
+        JSON = (
+            """
+        {
+          "coin_spends": [],
+          "aggregated_signature": "%s"
+        }
+        """
+            % NULL_SIGNATURE
+        )
+        spend_bundle = SpendBundle.from_json_dict(json.loads(JSON))
+        json_1 = json.loads(JSON)
+        json_2 = spend_bundle.to_json_dict(include_legacy_keys=False, exclude_modern_keys=False)
+        assert json_1 == json_2
+
+    def test_round_trip(self):
+        spend_bundle = BLANK_SPEND_BUNDLE
+        round_trip(spend_bundle, include_legacy_keys=True, exclude_modern_keys=True)
+        round_trip(spend_bundle, include_legacy_keys=True, exclude_modern_keys=False)
+        round_trip(spend_bundle, include_legacy_keys=False, exclude_modern_keys=False)
+
+    def test_dont_use_both_legacy_and_modern(self):
+        json_1 = BLANK_SPEND_BUNDLE.to_json_dict(include_legacy_keys=True, exclude_modern_keys=False)
+        with self.assertRaises(ValueError):
+            SpendBundle.from_json_dict(json_1)
+
+
+def round_trip(spend_bundle: SpendBundle, **kwargs):
+    json_dict = spend_bundle.to_json_dict(**kwargs)
+
+    if kwargs.get("include_legacy_keys", True):
+        assert "coin_solutions" in json_dict
+    else:
+        assert "coin_solutions" not in json_dict
+
+    if kwargs.get("exclude_modern_keys", True):
+        assert "coin_spends" not in json_dict
+    else:
+        assert "coin_spends" in json_dict
+
+    if "coin_spends" in json_dict and "coin_solutions" in json_dict:
+        del json_dict["coin_solutions"]
+
+    sb = SpendBundle.from_json_dict(json_dict)
+    json_dict_2 = sb.to_json_dict()
+    sb = SpendBundle.from_json_dict(json_dict_2)
+    json_dict_3 = sb.to_json_dict()
+    assert json_dict_2 == json_dict_3


### PR DESCRIPTION
This change should allow us to use the name coin_spend everywhere in our code, but does not change it in the API requests, both outgoing and incoming.  We can then at a later date decide when to cut over completely to the coin_spend name.