### PR TITLE
Option to revert back to sequential read

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -54,6 +54,7 @@ class Harvester:
         self.state_changed_callback: Optional[Callable] = None
         self.last_load_time: float = 0
         self.plot_load_frequency = config.get("plot_loading_frequency_seconds", 120)
+        self.disable_parallel_read: bool = config.get("disable_parallel_read", False)
 
     async def _start(self):
         self._refresh_lock = asyncio.Lock()

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -54,7 +54,7 @@ class Harvester:
         self.state_changed_callback: Optional[Callable] = None
         self.last_load_time: float = 0
         self.plot_load_frequency = config.get("plot_loading_frequency_seconds", 120)
-        self.disable_parallel_read: bool = config.get("disable_parallel_read", False)
+        self.parallel_read: bool = config.get("parallel_read", True)
 
     async def _start(self):
         self._refresh_lock = asyncio.Lock()

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -124,7 +124,9 @@ class HarvesterAPI:
                             # Found a very good proof of space! will fetch the whole proof from disk,
                             # then send to farmer
                             try:
-                                proof_xs = plot_info.prover.get_full_proof(sp_challenge_hash, index)
+                                proof_xs = plot_info.prover.get_full_proof(
+                                    sp_challenge_hash, index, self.harvester.disable_parallel_read
+                                )
                             except Exception as e:
                                 self.harvester.log.error(f"Exception fetching full proof for {filename}. {e}")
                                 self.harvester.log.error(

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -125,7 +125,7 @@ class HarvesterAPI:
                             # then send to farmer
                             try:
                                 proof_xs = plot_info.prover.get_full_proof(
-                                    sp_challenge_hash, index, self.harvester.disable_parallel_read
+                                    sp_challenge_hash, index, self.harvester.parallel_read
                                 )
                             except Exception as e:
                                 self.harvester.log.error(f"Exception fetching full proof for {filename}. {e}")

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -53,8 +53,12 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
     if num == 0:
         return None
 
+    disable_parallel_read: bool = config["harvester"].get("disable_parallel_read", False)
+
     v = Verifier()
-    log.info("Loading plots in config.yaml using plot_tools loading code\n")
+    log.info(
+        f"Loading plots in config.yaml using plot_tools loading code (parallel read: {not disable_parallel_read})\n"
+    )
     kc: Keychain = Keychain()
     pks = [master_sk_to_farmer_sk(sk).get_g1() for sk, _ in kc.get_all_private_keys()]
     pool_public_keys = [G1Element.from_bytes(bytes.fromhex(pk)) for pk in config["farmer"]["pool_public_keys"]]
@@ -100,7 +104,7 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
                 for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):
                     # Other plot errors cause get_full_proof or validate_proof to throw an AssertionError
                     try:
-                        proof = pr.get_full_proof(challenge, index)
+                        proof = pr.get_full_proof(challenge, index, disable_parallel_read)
                         total_proofs += 1
                         ver_quality_str = v.validate_proof(pr.get_id(), pr.get_size(), challenge, proof)
                         assert quality_str == ver_quality_str

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -53,12 +53,10 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
     if num == 0:
         return None
 
-    disable_parallel_read: bool = config["harvester"].get("disable_parallel_read", False)
+    parallel_read: bool = config["harvester"].get("parallel_read", True)
 
     v = Verifier()
-    log.info(
-        f"Loading plots in config.yaml using plot_tools loading code (parallel read: {not disable_parallel_read})\n"
-    )
+    log.info(f"Loading plots in config.yaml using plot_tools loading code (parallel read: {parallel_read})\n")
     kc: Keychain = Keychain()
     pks = [master_sk_to_farmer_sk(sk).get_g1() for sk, _ in kc.get_all_private_keys()]
     pool_public_keys = [G1Element.from_bytes(bytes.fromhex(pk)) for pk in config["farmer"]["pool_public_keys"]]
@@ -104,7 +102,7 @@ def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, d
                 for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):
                     # Other plot errors cause get_full_proof or validate_proof to throw an AssertionError
                     try:
-                        proof = pr.get_full_proof(challenge, index, disable_parallel_read)
+                        proof = pr.get_full_proof(challenge, index, parallel_read)
                         total_proofs += 1
                         ver_quality_str = v.validate_proof(pr.get_id(), pr.get_size(), challenge, proof)
                         assert quality_str == ver_quality_str

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -130,6 +130,9 @@ harvester:
   num_threads: 30
   plot_loading_frequency_seconds: 120
 
+  # If True use parallel reads in chiapos
+  parallel_read: True
+
   logging: *logging
   network_overrides: *network_overrides
   selected_network: *selected_network

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ dependencies = [
     "blspy==1.0.4",  # Signature library
     "chiavdf==1.0.2",  # timelord and vdf verification
     "chiabip158==1.0",  # bip158-style wallet filters
-    "chiapos==1.0.3",  # proof of space
+    "chiapos==1.0.4",  # proof of space
     "clvm==0.9.7",
     "clvm_rs==0.1.8",
     "clvm_tools==0.4.3",


### PR DESCRIPTION
This allows an option to config.yaml under the harvester that can disable the parallel reads in chiapos (and therefore revert back to the previous sequential reads). The parallel reads in certain situations - primarily macos+exfat - results in very long lookups. This requires the chiapos update in PR https://github.com/Chia-Network/chiapos/pull/296