### PR TITLE
More friendly error reporting for peername errors

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -278,6 +278,11 @@ class ChiaServer:
                 error_stack = traceback.format_exc()
                 self.log.error(f"Exception {e}, exception Stack: {error_stack}")
                 close_event.set()
+        except ValueError as e:
+            if connection is not None:
+                await connection.close(self.invalid_protocol_ban_seconds, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
+            self.log.warning(f"{e} - closing connection")
+            close_event.set()
         except Exception as e:
             if connection is not None:
                 await connection.close(ws_close_code=WSCloseCode.PROTOCOL_ERROR, error=Err.UNKNOWN)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -56,7 +56,7 @@ class WSChiaConnection:
 
         peername = self.ws._writer.transport.get_extra_info("peername")
         if peername is None:
-            raise ValueError(f"Was not able to get peername from {self.ws_witer} at {self.peer_host}")
+            raise ValueError(f"Was not able to get peername from {self.peer_host}")
 
         connection_port = peername[1]
         self.peer_port = connection_port


### PR DESCRIPTION
When unable to get the peername during construction of WSChiaConnection, some frightening exception information was logged.
Improved the error handling in this one specific case to be less alarming and fixed what was almost certainly a typo
See #3861
