### PR TITLE
Case insensitive payout_instructions comparison

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -432,7 +432,7 @@ class Farmer:
                         # Update the payout instructions on the pool if required
                         if (
                             farmer_info is not None
-                            and pool_config.payout_instructions != farmer_info.payout_instructions
+                            and pool_config.payout_instructions.lower() != farmer_info.payout_instructions.lower()
                         ):
                             owner_sk = await find_owner_sk(self.all_root_sks, pool_config.owner_public_key)
                             put_farmer_response_dict = await self._pool_put_farmer(


### PR DESCRIPTION
This handles the case of pools storing the payout instructions in a different format (e.g. just bytes of the puzzle hash) and returning those with in upper/lower case instead of the exact input.