### PR TITLE
farmer|tests: Always bump `last_update` in `update_cached_harvesters`

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -65,9 +65,12 @@ class HarvesterCacheEntry:
         self.data: Optional[dict] = None
         self.last_update: float = 0
 
+    def bump_last_update(self):
+        self.last_update = time.time()
+
     def set_data(self, data):
         self.data = data
-        self.last_update = time.time()
+        self.bump_last_update()
 
     def needs_update(self):
         return time.time() - self.last_update > UPDATE_HARVESTER_CACHE_INTERVAL
@@ -579,6 +582,7 @@ class Farmer:
             cache_entry = await self.get_cached_harvesters(connection)
             if cache_entry.needs_update():
                 self.log.debug(f"update_cached_harvesters update harvester: {connection.peer_node_id}")
+                cache_entry.bump_last_update()
                 response = await connection.request_plots(
                     harvester_protocol.RequestPlots(), timeout=UPDATE_HARVESTER_CACHE_INTERVAL
                 )

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -166,10 +166,15 @@ class TestRpc:
             assert len(res_2["plots"]) == num_plots
 
             # Test farmer get_harvesters
-            await farmer_rpc_api.service.update_cached_harvesters()
-            farmer_res = await client.get_harvesters()
-            assert len(list(farmer_res["harvesters"])) == 1
-            assert len(list(farmer_res["harvesters"][0]["plots"])) == num_plots
+            async def test_get_harvesters():
+                farmer_res = await client.get_harvesters()
+                if len(list(farmer_res["harvesters"])) != 1:
+                    return False
+                if len(list(farmer_res["harvesters"][0]["plots"])) != num_plots:
+                    return False
+                return True
+
+            await time_out_assert(5, test_get_harvesters)
 
             assert len(await client_2.get_plot_directories()) == 1
 


### PR DESCRIPTION
Avoid to fire requests while a request is pending.