### PR TITLE
Remove index on coin_record spent column

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -53,8 +53,6 @@ class CoinStore:
 
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent_index on coin_record(spent_index)")
 
-        await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent on coin_record(spent)")
-
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_puzzle_hash on coin_record(puzzle_hash)")
 
         await self.coin_record_db.commit()

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -151,8 +151,8 @@ class CoinStore:
 
         coins = set()
         cursor = await self.coin_record_db.execute(
-            f"SELECT * from coin_record WHERE puzzle_hash=? AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND +spent=0'}",
+            f"SELECT * from coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash=? AND confirmed_index>=? AND confirmed_index<? "
+            f"{'' if include_spent_coins else 'AND spent=0'}",
             (puzzle_hash.hex(), start_height, end_height),
         )
         rows = await cursor.fetchall()
@@ -176,9 +176,9 @@ class CoinStore:
         coins = set()
         puzzle_hashes_db = tuple([ph.hex() for ph in puzzle_hashes])
         cursor = await self.coin_record_db.execute(
-            f'SELECT * from coin_record WHERE puzzle_hash in ({"?," * (len(puzzle_hashes_db) - 1)}?) '
+            f'SELECT * from coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash in ({"?," * (len(puzzle_hashes_db) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND +spent=0'}",
+            f"{'' if include_spent_coins else 'AND spent=0'}",
             puzzle_hashes_db + (start_height, end_height),
         )
 
@@ -203,9 +203,9 @@ class CoinStore:
         coins = set()
         parent_ids_db = tuple([pid.hex() for pid in parent_ids])
         cursor = await self.coin_record_db.execute(
-            f'SELECT * from coin_record WHERE coin_parent in ({"?," * (len(parent_ids_db) - 1)}?) '
+            f'SELECT * from coin_record INDEXED BY coin_puzzle_hash WHERE coin_parent in ({"?," * (len(parent_ids_db) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND +spent=0'}",
+            f"{'' if include_spent_coins else 'AND spent=0'}",
             parent_ids_db + (start_height, end_height),
         )
 

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -152,7 +152,8 @@ class CoinStore:
 
         coins = set()
         cursor = await self.coin_record_db.execute(
-            f"SELECT * from coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash=? AND confirmed_index>=? AND confirmed_index<? "
+            f"SELECT * from coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash=? "
+            f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",
             (puzzle_hash.hex(), start_height, end_height),
         )

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -53,6 +53,8 @@ class CoinStore:
 
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent_index on coin_record(spent_index)")
 
+        await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent on coin_record(spent)")
+        
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_puzzle_hash on coin_record(puzzle_hash)")
 
         await self.coin_record_db.commit()

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -179,7 +179,7 @@ class CoinStore:
         coins = set()
         puzzle_hashes_db = tuple([ph.hex() for ph in puzzle_hashes])
         cursor = await self.coin_record_db.execute(
-            f'SELECT * from coin_record INDEXED BY coin_puzzle_hash '
+            f"SELECT * from coin_record INDEXED BY coin_puzzle_hash "
             f'WHERE puzzle_hash in ({"?," * (len(puzzle_hashes_db) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -178,7 +178,8 @@ class CoinStore:
         coins = set()
         puzzle_hashes_db = tuple([ph.hex() for ph in puzzle_hashes])
         cursor = await self.coin_record_db.execute(
-            f'SELECT * from coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash in ({"?," * (len(puzzle_hashes_db) - 1)}?) '
+            f'SELECT * from coin_record INDEXED BY coin_puzzle_hash '
+            f'WHERE puzzle_hash in ({"?," * (len(puzzle_hashes_db) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",
             puzzle_hashes_db + (start_height, end_height),

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -54,7 +54,6 @@ class CoinStore:
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent_index on coin_record(spent_index)")
 
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent on coin_record(spent)")
-        
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_puzzle_hash on coin_record(puzzle_hash)")
 
         await self.coin_record_db.commit()

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -203,7 +203,7 @@ class CoinStore:
         coins = set()
         parent_ids_db = tuple([pid.hex() for pid in parent_ids])
         cursor = await self.coin_record_db.execute(
-            f'SELECT * from coin_record INDEXED BY coin_puzzle_hash WHERE coin_parent in ({"?," * (len(parent_ids_db) - 1)}?) '
+            f'SELECT * from coin_record WHERE coin_parent in ({"?," * (len(parent_ids_db) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",
             parent_ids_db + (start_height, end_height),

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -54,6 +54,7 @@ class CoinStore:
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent_index on coin_record(spent_index)")
 
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent on coin_record(spent)")
+
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_puzzle_hash on coin_record(puzzle_hash)")
 
         await self.coin_record_db.commit()

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -152,7 +152,7 @@ class CoinStore:
         coins = set()
         cursor = await self.coin_record_db.execute(
             f"SELECT * from coin_record WHERE puzzle_hash=? AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND spent=0'}",
+            f"{'' if include_spent_coins else 'AND +spent=0'}",
             (puzzle_hash.hex(), start_height, end_height),
         )
         rows = await cursor.fetchall()
@@ -178,7 +178,7 @@ class CoinStore:
         cursor = await self.coin_record_db.execute(
             f'SELECT * from coin_record WHERE puzzle_hash in ({"?," * (len(puzzle_hashes_db) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND spent=0'}",
+            f"{'' if include_spent_coins else 'AND +spent=0'}",
             puzzle_hashes_db + (start_height, end_height),
         )
 
@@ -205,7 +205,7 @@ class CoinStore:
         cursor = await self.coin_record_db.execute(
             f'SELECT * from coin_record WHERE coin_parent in ({"?," * (len(parent_ids_db) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND spent=0'}",
+            f"{'' if include_spent_coins else 'AND +spent=0'}",
             parent_ids_db + (start_height, end_height),
         )
 


### PR DESCRIPTION
I have recently looked into the `get_coin_records_by_puzzle_hashes` rpc endpoint (this also applies to the one with only one ph).
It has been reported to be very slow and it also has been to me. 
At least as soon as you start to query for unspent coins only. If you query for all the query runs way faster.
Try yourself with
```sql
SELECT * from coin_record WHERE puzzle_hash = "f2c7f881695d415e03b5905debe37dc64e8e5136e63184085da8aa4d04dec45b"
AND confirmed_index>=0
AND spent=1
```
This query takes about 3 seconds if there is an index on the spent column, but only takes 200ms if you drop that index.
I could not find any query that executes faster with the index than it does without it, please try to find one because I might just have missed something.

This PR just deletes the index creation line so old databases will not be updated.
Currently there are only these 2 queries that use this index and therefore I don't see any reason to keep it.
If keeping the index is required I'd suggest adding `IGNORE INDEX` to the slow queries.
