### PR TITLE
Bug fix for initial Coloured Coin creation

### DIFF
--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -221,7 +221,7 @@ class CCWallet:
         removal_amount = 0
 
         for record in unconfirmed_tx:
-            if record.type is TransactionType.INCOMING_TX:
+            if TransactionType(record.type) is TransactionType.INCOMING_TX:
                 addition_amount += record.amount
             else:
                 removal_amount += record.amount


### PR DESCRIPTION
Fixed an issue on initial creation of a Coloured Coin where code always falls into default else clause due to lack of type conversion