### PR TITLE
Build RPM in Chia Centos7 base image instead of VM

### DIFF
--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - test-docker-rpm-build
     tags:
         - '**'
   pull_request:
@@ -100,7 +99,7 @@ jobs:
           aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/*.rpm s3://download-chia-net/builds/
 
     - name: Create Checksums
-      #if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
@@ -109,12 +108,12 @@ jobs:
          ls $GITHUB_WORKSPACE/build_scripts/final_installer/
 
     - name: Install py3createtorrent
-      #if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
         pip3 install py3createtorrent
 
     - name: Create .rpm torrent
-      #if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       run: |
           py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.torrent --webseed https://download-chia-net.s3.us-west-2.amazonaws.com/install/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm
           ls

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -96,17 +96,17 @@ jobs:
       env:
           CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-          ls ${{ github.workspace }}/build_scripts/final_installer/
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/*.rpm s3://download-chia-net/builds/
+          ls $GITHUB_WORKSPACE/build_scripts/final_installer/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/*.rpm s3://download-chia-net/builds/
 
     - name: Create Checksums
       #if: startsWith(github.ref, 'refs/tags/')
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-         ls ${{ github.workspace }}/build_scripts/final_installer/
-         sha256sum ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm > ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.sha256
-         ls ${{ github.workspace }}/build_scripts/final_installer/
+         ls $GITHUB_WORKSPACE/build_scripts/final_installer/
+         sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.sha256
+         ls $GITHUB_WORKSPACE/build_scripts/final_installer/
 
     - name: Install py3createtorrent
       #if: startsWith(github.ref, 'refs/tags/')
@@ -116,15 +116,15 @@ jobs:
     - name: Create .rpm torrent
       #if: startsWith(github.ref, 'refs/tags/')
       run: |
-          py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm -o ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.torrent --webseed https://download-chia-net.s3.us-west-2.amazonaws.com/install/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm
+          py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.torrent --webseed https://download-chia-net.s3.us-west-2.amazonaws.com/install/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm
           ls
 
     - name: Upload Release Files
       if: steps.check_secrets.outputs.HAS_SECRET && startsWith(github.ref, 'refs/tags/')
       run: |
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm s3://download-chia-net/install/
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.sha256 s3://download-chia-net/install/
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.torrent s3://download-chia-net/torrents/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm s3://download-chia-net/install/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.sha256 s3://download-chia-net/install/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.torrent s3://download-chia-net/torrents/
 
     - name: Get tag name
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - test-docker-rpm-build
     tags:
         - '**'
   pull_request:
@@ -14,14 +15,15 @@ on:
 jobs:
   build:
     name: Linux .rpm installer on Python 3.9
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    container:
+      image: chianetwork/centos7-builder:latest
     timeout-minutes: 40
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
         python-version: [3.9]
-        os: [centos]
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -66,11 +68,6 @@ jobs:
       run: |
         sh install.sh
 
-    - name: Setup Node 12.x
-      uses: actions/setup-node@v2.3.0
-      with:
-        node-version: '12.x'
-
     - name: Build .rpm package
       run: |
         . ./activate
@@ -103,7 +100,7 @@ jobs:
           aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/*.rpm s3://download-chia-net/builds/
 
     - name: Create Checksums
-      if: startsWith(github.ref, 'refs/tags/')
+      #if: startsWith(github.ref, 'refs/tags/')
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
@@ -112,12 +109,12 @@ jobs:
          ls ${{ github.workspace }}/build_scripts/final_installer/
 
     - name: Install py3createtorrent
-      if: startsWith(github.ref, 'refs/tags/')
+      #if: startsWith(github.ref, 'refs/tags/')
       run: |
         pip3 install py3createtorrent
 
     - name: Create .rpm torrent
-      if: startsWith(github.ref, 'refs/tags/')
+      #if: startsWith(github.ref, 'refs/tags/')
       run: |
           py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm -o ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm.torrent --webseed https://download-chia-net.s3.us-west-2.amazonaws.com/install/chia-blockchain-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}-1.x86_64.rpm
           ls


### PR DESCRIPTION
Tested resulting rpms again on fedora and centos7 and they work as expected.

Base docker images are all in this repo - this image is configured the same as the VM was [here](https://github.com/Chia-Network/build-images/blob/main/centos7/Dockerfile)