### PR TITLE
Swap to the chia version of notarize CLI that retries status and has …

### DIFF
--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -15,7 +15,7 @@ echo "Installing npm and electron packagers"
 npm install electron-installer-dmg -g
 npm install electron-packager -g
 npm install electron/electron-osx-sign -g
-npm install notarize-cli -g
+npm install @chia-network/notarize-cli -g
 
 echo "Create dist/"
 sudo rm -rf dist

--- a/build_scripts/build_macos_m1.sh
+++ b/build_scripts/build_macos_m1.sh
@@ -18,7 +18,7 @@ echo "Installing npm and electron packagers"
 npm install electron-installer-dmg -g
 npm install electron-packager -g
 npm install electron/electron-osx-sign -g
-npm install notarize-cli -g
+npm install @chia-network/notarize-cli -g
 
 echo "Create dist/"
 sudo rm -rf dist


### PR DESCRIPTION
…exit codes when it fails

This one might cause a bit of pain for existing PRs if they dont rebase or merge main into their branch, since both notarize-cli can't coexist on the m1 hosts. Can fix any PR failues with a rebase or merge though.