### PR TITLE
Added an RPC for coin records by multiple coin names

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -192,6 +192,33 @@ class CoinStore:
             coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
         return list(coins)
 
+    async def get_coin_records_by_names(
+        self,
+        include_spent_coins: bool,
+        names: List[bytes32],
+        start_height: uint32 = uint32(0),
+        end_height: uint32 = uint32((2 ** 32) - 1),
+    ) -> List[CoinRecord]:
+        if len(names) == 0:
+            return []
+
+        coins = set()
+        names_db = tuple([name.hex() for name in names])
+        cursor = await self.coin_record_db.execute(
+            f'SELECT * from coin_record WHERE coin_name in ({"?," * (len(names_db) - 1)}?) '
+            f"AND confirmed_index>=? AND confirmed_index<? "
+            f"{'' if include_spent_coins else 'AND spent=0'}",
+            names_db + (start_height, end_height),
+        )
+
+        rows = await cursor.fetchall()
+
+        await cursor.close()
+        for row in rows:
+            coin = Coin(bytes32(bytes.fromhex(row[6])), bytes32(bytes.fromhex(row[5])), uint64.from_bytes(row[7]))
+            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+        return list(coins)
+
     async def get_coin_records_by_parent_ids(
         self,
         include_spent_coins: bool,

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -43,6 +43,7 @@ class FullNodeRpcApi:
             "/get_coin_records_by_puzzle_hash": self.get_coin_records_by_puzzle_hash,
             "/get_coin_records_by_puzzle_hashes": self.get_coin_records_by_puzzle_hashes,
             "/get_coin_record_by_name": self.get_coin_record_by_name,
+            "/get_coin_records_by_names": self.get_coin_records_by_names,
             "/get_coin_records_by_parent_ids": self.get_coin_records_by_parent_ids,
             "/push_tx": self.push_tx,
             "/get_puzzle_and_solution": self.get_puzzle_and_solution,
@@ -463,6 +464,28 @@ class FullNodeRpcApi:
             raise ValueError(f"Coin record 0x{name.hex()} not found")
 
         return {"coin_record": coin_record}
+
+    async def get_coin_records_by_names(self, request: Dict) -> Optional[Dict]:
+        """
+        Retrieves the coins for given coin IDs, by default returns unspent coins.
+        """
+        if "names" not in request:
+            raise ValueError("Names not in request")
+        kwargs: Dict[str, Any] = {
+            "include_spent_coins": False,
+            "names": [hexstr_to_bytes(name) for name in request["names"]],
+        }
+        if "start_height" in request:
+            kwargs["start_height"] = uint32(request["start_height"])
+        if "end_height" in request:
+            kwargs["end_height"] = uint32(request["end_height"])
+
+        if "include_spent_coins" in request:
+            kwargs["include_spent_coins"] = request["include_spent_coins"]
+
+        coin_records = await self.service.blockchain.coin_store.get_coin_records_by_names(**kwargs)
+
+        return {"coin_records": coin_records}
 
     async def get_coin_records_by_parent_ids(self, request: Dict) -> Optional[Dict]:
         """

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -82,6 +82,24 @@ class FullNodeRpcClient(RpcClient):
             return None
         return CoinRecord.from_json_dict(response["coin_record"])
 
+    async def get_coin_records_by_names(
+        self,
+        names: List[bytes32],
+        include_spent_coins: bool = True,
+        start_height: Optional[int] = None,
+        end_height: Optional[int] = None,
+    ) -> List:
+        names_hex = [name.hex() for name in names]
+        d = {"names": names_hex, "include_spent_coins": include_spent_coins}
+        if start_height is not None:
+            d["start_height"] = start_height
+        if end_height is not None:
+            d["end_height"] = end_height
+        return [
+            CoinRecord.from_json_dict(coin)
+            for coin in (await self.fetch("get_coin_records_by_names", d))["coin_records"]
+        ]
+
     async def get_coin_records_by_puzzle_hash(
         self,
         puzzle_hash: bytes32,

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -119,6 +119,12 @@ class TestRpc:
             print(coins)
             assert len(coins) == 2
 
+            name = list(blocks[-1].get_included_reward_coins())[0].name()
+            name_2 = list(blocks[-1].get_included_reward_coins())[1].name()
+            coins = await client.get_coin_records_by_names([name, name_2])
+            print(coins)
+            assert len(coins) == 2
+
             additions, removals = await client.get_additions_and_removals(blocks[-1].header_hash)
             assert len(additions) >= 2 and len(removals) == 0
 


### PR DESCRIPTION
This is mostly for consistency with our other methods `get_coin_records_by_puzzle_hashes` and `get_coin_records_by_parent_ids`.