### PR TITLE
Added an option to sign bytes as well as UTF-8 strings

### DIFF
--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -101,10 +101,18 @@ def generate_and_print_cmd():
     required=True,
 )
 @click.option("--hd_path", "-t", help="Enter the HD path in the form 'm/12381/8444/n/n'", type=str, required=True)
-def sign_cmd(message: str, fingerprint: int, hd_path: str):
+@click.option(
+    "--as-bytes",
+    "-b",
+    help="Sign the message as sequence of bytes rather than UTF-8 string",
+    default=False,
+    show_default=True,
+    is_flag=True,
+)
+def sign_cmd(message: str, fingerprint: int, hd_path: str, as_bytes: bool):
     from .keys_funcs import sign
 
-    sign(message, fingerprint, hd_path)
+    sign(message, fingerprint, hd_path, as_bytes)
 
 
 @keys_cmd.command("verify", short_help="Verify a signature with a pk")

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -105,7 +105,7 @@ def delete(fingerprint: int):
     keychain.delete_key_by_fingerprint(fingerprint)
 
 
-def sign(message: str, fingerprint: int, hd_path: str):
+def sign(message: str, fingerprint: int, hd_path: str, as_bytes: bool):
     k = Keychain()
     private_keys = k.get_all_private_keys()
 
@@ -114,8 +114,9 @@ def sign(message: str, fingerprint: int, hd_path: str):
         if sk.get_g1().get_fingerprint() == fingerprint:
             for c in path:
                 sk = AugSchemeMPL.derive_child_sk(sk, c)
+            data = bytes.fromhex(message) if as_bytes else bytes(message, "utf-8")
             print("Public key:", sk.get_g1())
-            print("Signature:", AugSchemeMPL.sign(sk, bytes(message, "utf-8")))
+            print("Signature:", AugSchemeMPL.sign(sk, data))
             return None
     print(f"Fingerprint {fingerprint} not found in keychain")
 


### PR DESCRIPTION
This is particularly helpful if you're writing Chialisp puzzles that require signatures and you want to test them without necessarily writing a whole python script for signing the relevant data.