### PR TITLE
Added missing `get_backup_info` wallet rpc api endpoint

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -78,6 +78,7 @@ class WalletRpcApi:
             "/send_transaction": self.send_transaction,
             "/send_transaction_multi": self.send_transaction_multi,
             "/create_backup": self.create_backup,
+            "/get_backup_info": self.get_backup_info,
             "/get_transaction_count": self.get_transaction_count,
             "/get_farmed_amount": self.get_farmed_amount,
             "/create_signed_transaction": self.create_signed_transaction,


### PR DESCRIPTION
Wallet rpc api `/get_backup_info` is defined but its endpoint is unreachable.