### PR TITLE
Create SSL keys/certs with proper permissions, also verify/fix existing installs

### DIFF
--- a/chia/cmds/init.py
+++ b/chia/cmds/init.py
@@ -10,9 +10,14 @@ from chia.util.keychain import supports_keyring_passphrase
     help="Create new SSL certificates based on CA in [directory]",
     type=click.Path(),
 )
+@click.option(
+    "--fix-ssl-permissions",
+    is_flag=True,
+    help="Attempt to fix SSL certificate/key file permissions",
+)
 @click.option("--set-passphrase", "-s", is_flag=True, help="Protect your keyring with a passphrase")
 @click.pass_context
-def init_cmd(ctx: click.Context, create_certs: str, **kwargs):
+def init_cmd(ctx: click.Context, create_certs: str, fix_ssl_permissions: bool, **kwargs):
     """
     Create a new configuration or migrate from previous versions to current
 
@@ -33,7 +38,7 @@ def init_cmd(ctx: click.Context, create_certs: str, **kwargs):
     if set_passphrase:
         initialize_passphrase()
 
-    init(Path(create_certs) if create_certs is not None else None, ctx.obj["root_path"])
+    init(Path(create_certs) if create_certs is not None else None, ctx.obj["root_path"], fix_ssl_permissions)
 
 
 if not supports_keyring_passphrase():

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+import stat
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -13,6 +15,8 @@ from chia.ssl.create_ssl import (
     get_chia_ca_crt_key,
     make_ca_cert,
     write_ssl_cert_and_key,
+    DEFAULT_PERMISSIONS_CERT_FILE,
+    DEFAULT_PERMISSIONS_KEY_FILE,
 )
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import (
@@ -20,6 +24,7 @@ from chia.util.config import (
     initial_config_file,
     load_config,
     save_config,
+    traverse_dict,
     unflatten_properties,
 )
 from chia.util.ints import uint32
@@ -50,6 +55,96 @@ def dict_add_new_default(updated: Dict, default: Dict, do_not_migrate_keys: Dict
             dict_add_new_default(updated[k], default[k], do_not_migrate_keys.get(k, {}))
         elif k not in updated or ignore is True:
             updated[k] = v
+
+
+def verify_file_permissions(path: Path, mask: int) -> Tuple[bool, int]:
+    """
+    Check that the file's permissions are properly restricted, as compared to the
+    permission mask
+    """
+    if not path.exists():
+        raise Exception(f"file {path} does not exist")
+
+    mode = os.stat(path).st_mode & 0o777
+    return (mode & mask == 0, mode)
+
+
+def check_ssl(root_path: Path) -> None:
+    """
+    Sanity checks on the SSL configuration. Checks that file permissions are properly
+    set on the keys and certs, warning and exiting if permissions are incorrect.
+    """
+    config: Dict = load_config(root_path, "config.yaml")
+    cert_config_key_paths = [
+        "chia_ssl_ca:crt",
+        "daemon_ssl:private_crt",
+        "farmer:ssl:private_crt",
+        "farmer:ssl:public_crt",
+        "full_node:ssl:private_crt",
+        "full_node:ssl:public_crt",
+        "harvester:chia_ssl_ca:crt",
+        "harvester:private_ssl_ca:crt",
+        "harvester:ssl:private_crt",
+        "introducer:ssl:public_crt",
+        "private_ssl_ca:crt",
+        "timelord:ssl:private_crt",
+        "timelord:ssl:public_crt",
+        "ui:daemon_ssl:private_crt",
+        "wallet:ssl:private_crt",
+        "wallet:ssl:public_crt",
+    ]
+    key_config_key_paths = [
+        "chia_ssl_ca:key",
+        "daemon_ssl:private_key",
+        "farmer:ssl:private_key",
+        "farmer:ssl:public_key",
+        "full_node:ssl:private_key",
+        "full_node:ssl:public_key",
+        "harvester:chia_ssl_ca:key",
+        "harvester:private_ssl_ca:key",
+        "harvester:ssl:private_key",
+        "introducer:ssl:public_key",
+        "private_ssl_ca:key",
+        "timelord:ssl:private_key",
+        "timelord:ssl:public_key",
+        "ui:daemon_ssl:private_key",
+        "wallet:ssl:private_key",
+        "wallet:ssl:public_key",
+    ]
+
+    # Masks containing permission bits we don't allow
+    cert_perm_mask: int = stat.S_IWGRP | stat.S_IXGRP | stat.S_IWOTH | stat.S_IXOTH  # 0o033
+    key_perm_mask: int = (
+        stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
+    )  # 0o077
+    valid: bool = True
+    warned: bool = False
+
+    for (key_paths, mask, expected_mode) in [
+        (cert_config_key_paths, cert_perm_mask, DEFAULT_PERMISSIONS_CERT_FILE),
+        (key_config_key_paths, key_perm_mask, DEFAULT_PERMISSIONS_KEY_FILE),
+    ]:
+        for key_path in key_paths:
+            try:
+                file = root_path / Path(traverse_dict(config, key_path))
+                # Check that the file permissions are not too permissive
+                (good_perms, mode) = verify_file_permissions(file, mask)
+                if not good_perms:
+                    if not warned:
+                        print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+                        print("@             WARNING: UNPROTECTED SSL FILE!              @")
+                        print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+                        warned = True
+                    print(
+                        f"Permissions 0{oct(mode)[-3:]} for '{file}' are too open. "
+                        f"Expected 0{oct(expected_mode)[-3:]}"
+                    )
+                    valid = False
+            except Exception as e:
+                print(f"Unable to check permissions for {key_path}: {e}")
+    if not valid:
+        print("Please fix your file permissions and try again.")
+        sys.exit(1)
 
 
 def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
@@ -162,9 +257,9 @@ def migrate_from(
     return 1
 
 
-def create_all_ssl(root: Path):
+def create_all_ssl(root_path: Path):
     # remove old key and crt
-    config_dir = root / "config"
+    config_dir = root_path / "config"
     old_key_path = config_dir / "trusted.key"
     old_crt_path = config_dir / "trusted.crt"
     if old_key_path.exists():
@@ -187,7 +282,7 @@ def create_all_ssl(root: Path):
 
     if not private_ca_key_path.exists() or not private_ca_crt_path.exists():
         # Create private CA
-        print(f"Can't find private CA, creating a new one in {root} to generate TLS certificates")
+        print(f"Can't find private CA, creating a new one in {root_path} to generate TLS certificates")
         make_ca_cert(private_ca_crt_path, private_ca_key_path)
         # Create private certs for each node
         ca_key = private_ca_key_path.read_bytes()
@@ -195,7 +290,7 @@ def create_all_ssl(root: Path):
         generate_ssl_for_nodes(ssl_dir, ca_crt, ca_key, True)
     else:
         # This is entered when user copied over private CA
-        print(f"Found private CA in {root}, using it to generate TLS certificates")
+        print(f"Found private CA in {root_path}, using it to generate TLS certificates")
         ca_key = private_ca_key_path.read_bytes()
         ca_crt = private_ca_crt_path.read_bytes()
         generate_ssl_for_nodes(ssl_dir, ca_crt, ca_key, True)
@@ -315,7 +410,7 @@ def chia_full_version_str() -> str:
     return f"{major}.{minor}.{patch}{dev}"
 
 
-def chia_init(root_path: Path, *, should_check_keys: bool = True):
+def chia_init(root_path: Path, *, should_check_keys: bool = True, should_check_ssl: bool = True):
     """
     Standard first run initialization or migration steps. Handles config creation,
     generation of SSL certs, and setting target addresses (via check_keys).
@@ -335,6 +430,8 @@ def chia_init(root_path: Path, *, should_check_keys: bool = True):
     if root_path.is_dir() and Path(root_path / "config" / "config.yaml").exists():
         # This is reached if CHIA_ROOT is set, or if user has run chia init twice
         # before a new update.
+        if should_check_ssl:
+            check_ssl(root_path)
         if should_check_keys:
             check_keys(root_path)
         print(f"{root_path} already exists, no migration action taken")
@@ -342,6 +439,8 @@ def chia_init(root_path: Path, *, should_check_keys: bool = True):
 
     create_default_chia_config(root_path)
     create_all_ssl(root_path)
+    if should_check_ssl:
+        check_ssl(root_path)
     if should_check_keys:
         check_keys(root_path)
     print("")

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -25,7 +25,15 @@ from chia.util.config import (
 from chia.util.ints import uint32
 from chia.util.keychain import Keychain
 from chia.util.path import mkdir
-from chia.util.ssl import check_ssl
+from chia.util.ssl import (
+    DEFAULT_PERMISSIONS_CERT_FILE,
+    DEFAULT_PERMISSIONS_KEY_FILE,
+    RESTRICT_MASK_CERT_FILE,
+    RESTRICT_MASK_KEY_FILE,
+    check_and_fix_permissions_for_ssl_file,
+    check_ssl,
+    fix_ssl,
+)
 from chia.wallet.derive_keys import master_sk_to_pool_sk, master_sk_to_wallet_sk
 
 private_node_names = {"full_node", "wallet", "farmer", "harvester", "timelord", "daemon"}
@@ -226,13 +234,19 @@ def generate_ssl_for_nodes(ssl_dir: Path, ca_crt: bytes, ca_key: bytes, private:
 
 
 def copy_cert_files(cert_path: Path, new_path: Path):
-    for ext in "*.crt", "*.key":
-        for old_path_child in cert_path.glob(ext):
-            new_path_child = new_path / old_path_child.name
-            copy_files_rec(old_path_child, new_path_child)
+    # for ext in "*.crt", "*.key":
+    for old_path_child in cert_path.glob("*.crt"):
+        new_path_child = new_path / old_path_child.name
+        copy_files_rec(old_path_child, new_path_child)
+        check_and_fix_permissions_for_ssl_file(new_path_child, RESTRICT_MASK_CERT_FILE, DEFAULT_PERMISSIONS_CERT_FILE)
+
+    for old_path_child in cert_path.glob("*.key"):
+        new_path_child = new_path / old_path_child.name
+        copy_files_rec(old_path_child, new_path_child)
+        check_and_fix_permissions_for_ssl_file(new_path_child, RESTRICT_MASK_KEY_FILE, DEFAULT_PERMISSIONS_KEY_FILE)
 
 
-def init(create_certs: Optional[Path], root_path: Path):
+def init(create_certs: Optional[Path], root_path: Path, fix_ssl_permissions: bool = False):
     if create_certs is not None:
         if root_path.exists():
             if os.path.isdir(create_certs):
@@ -248,13 +262,13 @@ def init(create_certs: Optional[Path], root_path: Path):
         else:
             print(f"** {root_path} does not exist. Executing core init **")
             # sanity check here to prevent infinite recursion
-            if chia_init(root_path) == 0 and root_path.exists():
-                return init(create_certs, root_path)
+            if chia_init(root_path, fix_ssl_permissions=fix_ssl_permissions) == 0 and root_path.exists():
+                return init(create_certs, root_path, fix_ssl_permissions)
 
             print(f"** {root_path} was not created. Exiting **")
             return -1
     else:
-        return chia_init(root_path)
+        return chia_init(root_path, fix_ssl_permissions=fix_ssl_permissions)
 
 
 def chia_version_number() -> Tuple[str, str, str, str]:
@@ -316,7 +330,9 @@ def chia_full_version_str() -> str:
     return f"{major}.{minor}.{patch}{dev}"
 
 
-def chia_init(root_path: Path, *, should_check_keys: bool = True, should_check_ssl: bool = True):
+def chia_init(
+    root_path: Path, *, should_check_keys: bool = True, should_check_ssl: bool = True, fix_ssl_permissions: bool = False
+):
     """
     Standard first run initialization or migration steps. Handles config creation,
     generation of SSL certs, and setting target addresses (via check_keys).
@@ -336,7 +352,9 @@ def chia_init(root_path: Path, *, should_check_keys: bool = True, should_check_s
     if root_path.is_dir() and Path(root_path / "config" / "config.yaml").exists():
         # This is reached if CHIA_ROOT is set, or if user has run chia init twice
         # before a new update.
-        if should_check_ssl:
+        if fix_ssl_permissions:
+            fix_ssl(root_path)
+        elif should_check_ssl:
             check_ssl(root_path)
         if should_check_keys:
             check_keys(root_path)
@@ -345,7 +363,9 @@ def chia_init(root_path: Path, *, should_check_keys: bool = True, should_check_s
 
     create_default_chia_config(root_path)
     create_all_ssl(root_path)
-    if should_check_ssl:
+    if fix_ssl_permissions:
+        fix_ssl(root_path)
+    elif should_check_ssl:
         check_ssl(root_path)
     if should_check_keys:
         check_keys(root_path)

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -234,7 +234,6 @@ def generate_ssl_for_nodes(ssl_dir: Path, ca_crt: bytes, ca_key: bytes, private:
 
 
 def copy_cert_files(cert_path: Path, new_path: Path):
-    # for ext in "*.crt", "*.key":
     for old_path_child in cert_path.glob("*.crt"):
         new_path_child = new_path / old_path_child.name
         copy_files_rec(old_path_child, new_path_child)

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -419,6 +419,10 @@ def chia_init(root_path: Path, *, should_check_keys: bool = True, should_check_s
     protected Keychain. When launching the daemon from the GUI, we want the GUI to
     handle unlocking the keychain.
     """
+    if sys.platform == "win32" or sys.platform == "cygwin":
+        # TODO: ACLs for SSL certs/keys on Windows
+        should_check_ssl = False
+
     if os.environ.get("CHIA_ROOT", None) is not None:
         print(
             f"warning, your CHIA_ROOT is set to {os.environ['CHIA_ROOT']}. "

--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -1,13 +1,11 @@
 import asyncio
 import json
 import ssl
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import websockets
 
-from chia.util.ssl import SSLInvalidPermissions
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.config import load_config
 from chia.util.json_util import dict_to_json_str
@@ -144,9 +142,6 @@ async def connect_to_daemon_and_validate(root_path: Path, quiet: bool = False) -
 
         if "value" in r["data"] and r["data"]["value"] == "pong":
             return connection
-    except SSLInvalidPermissions:
-        print("Failed to create SSL context, exiting...")
-        sys.exit(1)
     except Exception:
         if not quiet:
             print("Daemon not started yet")

--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
 import ssl
+import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import websockets
 
+from chia.util.ssl import SSLInvalidPermissions
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.config import load_config
 from chia.util.json_util import dict_to_json_str
@@ -142,6 +144,9 @@ async def connect_to_daemon_and_validate(root_path: Path, quiet: bool = False) -
 
         if "value" in r["data"] and r["data"]["value"] == "pong":
             return connection
+    except SSLInvalidPermissions:
+        print("Failed to create SSL context, exiting...")
+        sys.exit(1)
     except Exception:
         if not quiet:
             print("Daemon not started yet")

--- a/chia/daemon/keychain_proxy.py
+++ b/chia/daemon/keychain_proxy.py
@@ -1,5 +1,6 @@
 import logging
 import ssl
+import sys
 
 from blspy import AugSchemeMPL, PrivateKey
 from chia.cmds.init_funcs import check_keys
@@ -19,6 +20,7 @@ from chia.util.keychain import (
     mnemonic_to_seed,
     supports_keyring_passphrase,
 )
+from chia.util.ssl import SSLInvalidPermissions
 from chia.util.ws_message import WsRpcMessage
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -345,6 +347,9 @@ async def connect_to_keychain_and_validate(
 
         if "value" in r["data"] and r["data"]["value"] == "pong":
             return connection
+    except SSLInvalidPermissions:
+        print("Failed to create SSL context, exiting...")
+        sys.exit(1)
     except Exception as e:
         print(f"Keychain(daemon) not started yet: {e}")
         return None

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -60,7 +60,7 @@ async def fetch(url: str):
     async with ClientSession() as session:
         try:
             mozilla_root = get_mozilla_ca_crt()
-            ssl_context = ssl_context_for_root(mozilla_root)
+            ssl_context = ssl_context_for_root(mozilla_root, log=log)
             response = await session.get(url, ssl=ssl_context)
             if not response.ok:
                 log.warning("Response not OK.")
@@ -141,12 +141,7 @@ class WebSocketServer:
         self.self_hostname = self.net_config["self_hostname"]
         self.daemon_port = self.net_config["daemon_port"]
         self.websocket_server = None
-        try:
-            self.ssl_context = ssl_context_for_server(ca_crt_path, ca_key_path, crt_path, key_path)
-        except Exception as e:
-            self.log.error(e)
-            print("Failed to create SSL context, exiting...")
-            sys.exit(1)
+        self.ssl_context = ssl_context_for_server(ca_crt_path, ca_key_path, crt_path, key_path, log=self.log)
         self.shut_down = False
         self.keychain_server = KeychainServer()
         self.run_check_keys_on_unlock = run_check_keys_on_unlock

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1137,7 +1137,6 @@ async def async_run_daemon(root_path: Path, wait_for_unlock: bool = False) -> in
     setproctitle("chia_daemon")
     initialize_logging("daemon", config["logging"], root_path)
     lockfile = singleton(daemon_launch_lock_path(root_path))
-
     crt_path = root_path / config["daemon_ssl"]["private_crt"]
     key_path = root_path / config["daemon_ssl"]["private_key"]
     ca_crt_path = root_path / config["private_ssl_ca"]["crt"]

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -141,7 +141,12 @@ class WebSocketServer:
         self.self_hostname = self.net_config["self_hostname"]
         self.daemon_port = self.net_config["daemon_port"]
         self.websocket_server = None
-        self.ssl_context = ssl_context_for_server(ca_crt_path, ca_key_path, crt_path, key_path)
+        try:
+            self.ssl_context = ssl_context_for_server(ca_crt_path, ca_key_path, crt_path, key_path)
+        except Exception as e:
+            self.log.error(e)
+            print("Failed to create SSL context, exiting...")
+            sys.exit(1)
         self.shut_down = False
         self.keychain_server = KeychainServer()
         self.run_check_keys_on_unlock = run_check_keys_on_unlock
@@ -1132,6 +1137,7 @@ async def async_run_daemon(root_path: Path, wait_for_unlock: bool = False) -> in
     setproctitle("chia_daemon")
     initialize_logging("daemon", config["logging"], root_path)
     lockfile = singleton(daemon_launch_lock_path(root_path))
+
     crt_path = root_path / config["daemon_ssl"]["private_crt"]
     key_path = root_path / config["daemon_ssl"]["private_key"]
     ca_crt_path = root_path / config["private_ssl_ca"]["crt"]

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -226,7 +226,7 @@ class Farmer:
         try:
             async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.get(
-                    f"{pool_config.pool_url}/pool_info", ssl=ssl_context_for_root(get_mozilla_ca_crt())
+                    f"{pool_config.pool_url}/pool_info", ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.log)
                 ) as resp:
                     if resp.ok:
                         response: Dict = json.loads(await resp.text())
@@ -266,7 +266,7 @@ class Farmer:
                 async with session.get(
                     f"{pool_config.pool_url}/farmer",
                     params=get_farmer_params,
-                    ssl=ssl_context_for_root(get_mozilla_ca_crt()),
+                    ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.log),
                 ) as resp:
                     if resp.ok:
                         response: Dict = json.loads(await resp.text())
@@ -304,7 +304,7 @@ class Farmer:
                 async with session.post(
                     f"{pool_config.pool_url}/farmer",
                     json=post_farmer_request.to_json_dict(),
-                    ssl=ssl_context_for_root(get_mozilla_ca_crt()),
+                    ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.log),
                 ) as resp:
                     if resp.ok:
                         response: Dict = json.loads(await resp.text())
@@ -342,7 +342,7 @@ class Farmer:
                 async with session.put(
                     f"{pool_config.pool_url}/farmer",
                     json=put_farmer_request.to_json_dict(),
-                    ssl=ssl_context_for_root(get_mozilla_ca_crt()),
+                    ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.log),
                 ) as resp:
                     if resp.ok:
                         response: Dict = json.loads(await resp.text())

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -222,7 +222,7 @@ class FarmerAPI:
                         async with session.post(
                             f"{pool_url}/partial",
                             json=post_partial_request.to_json_dict(),
-                            ssl=ssl_context_for_root(get_mozilla_ca_crt()),
+                            ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.farmer.log),
                         ) as resp:
                             if resp.ok:
                                 pool_response: Dict = json.loads(await resp.text())

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import sys
 import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -37,12 +36,9 @@ class RpcServer:
         self.key_path = root_path / net_config["daemon_ssl"]["private_key"]
         self.ca_cert_path = root_path / net_config["private_ssl_ca"]["crt"]
         self.ca_key_path = root_path / net_config["private_ssl_ca"]["key"]
-        try:
-            self.ssl_context = ssl_context_for_server(self.ca_cert_path, self.ca_key_path, self.crt_path, self.key_path)
-        except Exception as e:
-            self.log.error(e)
-            print("Failed to create SSL context, exiting...")
-            sys.exit(1)
+        self.ssl_context = ssl_context_for_server(
+            self.ca_cert_path, self.ca_key_path, self.crt_path, self.key_path, log=self.log
+        )
 
     async def stop(self):
         self.shut_down = True

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import sys
 import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -36,7 +37,12 @@ class RpcServer:
         self.key_path = root_path / net_config["daemon_ssl"]["private_key"]
         self.ca_cert_path = root_path / net_config["private_ssl_ca"]["crt"]
         self.ca_key_path = root_path / net_config["private_ssl_ca"]["key"]
-        self.ssl_context = ssl_context_for_server(self.ca_cert_path, self.ca_key_path, self.crt_path, self.key_path)
+        try:
+            self.ssl_context = ssl_context_for_server(self.ca_cert_path, self.ca_key_path, self.crt_path, self.key_path)
+        except Exception as e:
+            self.log.error(e)
+            print("Failed to create SSL context, exiting...")
+            sys.exit(1)
 
     async def stop(self):
         self.shut_down = True

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -11,6 +11,9 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.x509.oid import NameOID
 
+DEFAULT_PERMISSIONS_CERT_FILE = 0o644
+DEFAULT_PERMISSIONS_KEY_FILE = 0o600
+
 
 def get_chia_ca_crt_key() -> Tuple[Any, Any]:
     crt = pkg_resources.resource_string(__name__, "chia_ca.crt")
@@ -26,7 +29,10 @@ def get_mozilla_ca_crt() -> str:
 def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, key_data: bytes):
     flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
 
-    for path, data, mode in [(cert_path, cert_data, 0o644), (key_path, key_data, 0o600)]:
+    for path, data, mode in [
+        (cert_path, cert_data, DEFAULT_PERMISSIONS_CERT_FILE),
+        (key_path, key_data, DEFAULT_PERMISSIONS_KEY_FILE),
+    ]:
         with open(os.open(str(path), flags, mode), "wb") as f:
             f.write(data)
 

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -33,6 +33,9 @@ def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, ke
         (cert_path, cert_data, DEFAULT_PERMISSIONS_CERT_FILE),
         (key_path, key_data, DEFAULT_PERMISSIONS_KEY_FILE),
     ]:
+        if path.exists():
+            path.unlink()
+
         with open(os.open(str(path), flags, mode), "wb") as f:
             f.write(data)
 

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -1,6 +1,7 @@
 import datetime
+import os
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any, List, Tuple
 
 import pkg_resources
 from cryptography import x509
@@ -20,6 +21,21 @@ def get_chia_ca_crt_key() -> Tuple[Any, Any]:
 def get_mozilla_ca_crt() -> str:
     mozilla_path = Path(__file__).parent.parent.parent.absolute() / "mozilla-ca/cacert.pem"
     return str(mozilla_path)
+
+
+def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, key_data: bytes):
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+
+    for path, data, mode in [(cert_path, cert_data, 0o644), (key_path, key_data, 0o600)]:
+        with open(os.open(str(path), flags, mode), "wb") as f:
+            f.write(data)
+
+
+def ensure_ssl_dirs(dirs: List[Path]):
+    """Create SSL dirs with a default 755 mode if necessary"""
+    for dir in dirs:
+        if not dir.exists():
+            dir.mkdir(mode=0o755)
 
 
 def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_out: Path):
@@ -58,8 +74,7 @@ def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_ou
         encryption_algorithm=serialization.NoEncryption(),
     )
 
-    cert_out.write_bytes(cert_pem)
-    key_out.write_bytes(key_pem)
+    write_ssl_cert_and_key(cert_out, cert_pem, key_out, key_pem)
 
 
 def make_ca_cert(cert_path: Path, key_path: Path):
@@ -83,19 +98,14 @@ def make_ca_cert(cert_path: Path, key_path: Path):
         .sign(root_key, hashes.SHA256(), default_backend())
     )
 
-    cert_path.write_bytes(
-        root_cert.public_bytes(
-            encoding=serialization.Encoding.PEM,
-        )
+    cert_pem = root_cert.public_bytes(encoding=serialization.Encoding.PEM)
+    key_pem = root_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
     )
 
-    key_path.write_bytes(
-        root_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.TraditionalOpenSSL,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-    )
+    write_ssl_cert_and_key(cert_path, cert_pem, key_path, key_pem)
 
 
 def main():

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -35,7 +35,7 @@ def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, ke
             path.unlink()
 
         with open(os.open(str(path), flags, mode), "wb") as f:
-            f.write(data)
+            f.write(data)  # lgtm [py/clear-text-storage-sensitive-data]
 
 
 def ensure_ssl_dirs(dirs: List[Path]):

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -4,15 +4,13 @@ from pathlib import Path
 from typing import Any, List, Tuple
 
 import pkg_resources
+from chia.util.ssl import DEFAULT_PERMISSIONS_CERT_FILE, DEFAULT_PERMISSIONS_KEY_FILE
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.x509.oid import NameOID
-
-DEFAULT_PERMISSIONS_CERT_FILE = 0o644
-DEFAULT_PERMISSIONS_KEY_FILE = 0o600
 
 
 def get_chia_ca_crt_key() -> Tuple[Any, Any]:

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -124,3 +124,29 @@ def str2bool(v: Union[str, bool]) -> bool:
         return False
     else:
         raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
+def traverse_dict(d: Dict, key_path: str) -> Any:
+    """
+    Traverse nested dictionaries to find the element pointed-to by key_path.
+    Key path components are separated by a ':' e.g.
+      "root:child:a"
+    """
+    if type(d) is not dict:
+        raise Exception(f"unable to traverse into non-dict value with key path: {key_path}")
+
+    # Extract one path component at a time
+    components = key_path.split(":", maxsplit=1)
+    if components is None or len(components) == 0:
+        raise Exception(f"invalid config key path: {key_path}")
+
+    key = components[0]
+    remaining_key_path = components[1] if len(components) > 1 else None
+
+    val: Any = d.get(key, None)
+    if val is not None:
+        if remaining_key_path is not None:
+            return traverse_dict(val, remaining_key_path)
+        return val
+    else:
+        raise Exception(f"value not found for key: {key}")

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -133,12 +133,12 @@ def traverse_dict(d: Dict, key_path: str) -> Any:
       "root:child:a"
     """
     if type(d) is not dict:
-        raise Exception(f"unable to traverse into non-dict value with key path: {key_path}")
+        raise TypeError(f"unable to traverse into non-dict value with key path: {key_path}")
 
     # Extract one path component at a time
     components = key_path.split(":", maxsplit=1)
     if components is None or len(components) == 0:
-        raise Exception(f"invalid config key path: {key_path}")
+        raise KeyError(f"invalid config key path: {key_path}")
 
     key = components[0]
     remaining_key_path = components[1] if len(components) > 1 else None
@@ -149,4 +149,4 @@ def traverse_dict(d: Dict, key_path: str) -> Any:
             return traverse_dict(val, remaining_key_path)
         return val
     else:
-        raise Exception(f"value not found for key: {key}")
+        raise KeyError(f"value not found for key: {key}")

--- a/chia/util/permissions.py
+++ b/chia/util/permissions.py
@@ -16,4 +16,5 @@ def verify_file_permissions(path: Path, mask: int) -> Tuple[bool, int]:
 
 
 def octal_mode_string(mode: int) -> str:
+    """Yields a permission mode string: e.g. 0644"""
     return f"0{oct(mode)[-3:]}"

--- a/chia/util/permissions.py
+++ b/chia/util/permissions.py
@@ -1,0 +1,19 @@
+import os
+from pathlib import Path
+from typing import Tuple
+
+
+def verify_file_permissions(path: Path, mask: int) -> Tuple[bool, int]:
+    """
+    Check that the file's permissions are properly restricted, as compared to the
+    permission mask
+    """
+    if not path.exists():
+        raise Exception(f"file {path} does not exist")
+
+    mode = os.stat(path).st_mode & 0o777
+    return (mode & mask == 0, mode)
+
+
+def octal_mode_string(mode: int) -> str:
+    return f"0{oct(mode)[-3:]}"

--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -16,6 +16,7 @@ RESTRICT_MASK_KEY_FILE: int = (
 
 
 class SSLInvalidPermissions(Exception):
+    """Exception which encapsulates info regarding SSL file permission errors"""
     def __init__(self, files: List[Tuple[Path, int]]):
         msg = "One or more file permissions are too open:\n"
         for (file, mode) in files:
@@ -41,6 +42,7 @@ def print_ssl_perm_warning(path: Path, actual_mode: int, expected_mode: int, sho
 def verify_ssl_certs_and_keys(
     cert_and_key_paths: List[Tuple[Optional[Path], Optional[Path]]]
 ) -> List[Tuple[Path, int]]:
+    """Check that file permissions are properly set for the provided SSL cert and key files"""
     if sys.platform == "win32" or sys.platform == "cygwin":
         # TODO: ACLs for SSL certs/keys on Windows
         return []
@@ -138,6 +140,7 @@ def check_ssl(root_path: Path) -> None:
             except Exception as e:
                 print(f"Unable to check permissions for {key_path}: {e}")
 
+    # Check the Mozilla Root CAs as well
     mozilla_root_ca = get_mozilla_ca_crt()
     (good_perms, mode) = verify_file_permissions(Path(mozilla_root_ca), RESTRICT_MASK_CERT_FILE)
     if not good_perms:

--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -77,6 +77,10 @@ def check_ssl(root_path: Path) -> None:
     """
     from chia.ssl.create_ssl import get_mozilla_ca_crt
 
+    if sys.platform == "win32" or sys.platform == "cygwin":
+        # TODO: ACLs for SSL certs/keys on Windows
+        return []
+
     config: Dict = load_config(root_path, "config.yaml")
     cert_config_key_paths = [
         "chia_ssl_ca:crt",

--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -181,7 +181,7 @@ def check_and_fix_permissions_for_ssl_file(file: Path, mask: int, updated_mode: 
         print(f"Failed to change permissions on {file}: {e}")
         valid = False
 
-    return [valid, updated]
+    return (valid, updated)
 
 
 def fix_ssl(root_path: Path) -> None:

--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -1,3 +1,4 @@
+import os
 import stat
 import sys
 from chia.util.config import load_config, traverse_dict
@@ -14,9 +15,47 @@ RESTRICT_MASK_KEY_FILE: int = (
     stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
 )  # 0o077
 
+CERT_CONFIG_KEY_PATHS = [
+    "chia_ssl_ca:crt",
+    "daemon_ssl:private_crt",
+    "farmer:ssl:private_crt",
+    "farmer:ssl:public_crt",
+    "full_node:ssl:private_crt",
+    "full_node:ssl:public_crt",
+    "harvester:chia_ssl_ca:crt",
+    "harvester:private_ssl_ca:crt",
+    "harvester:ssl:private_crt",
+    "introducer:ssl:public_crt",
+    "private_ssl_ca:crt",
+    "timelord:ssl:private_crt",
+    "timelord:ssl:public_crt",
+    "ui:daemon_ssl:private_crt",
+    "wallet:ssl:private_crt",
+    "wallet:ssl:public_crt",
+]
+KEY_CONFIG_KEY_PATHS = [
+    "chia_ssl_ca:key",
+    "daemon_ssl:private_key",
+    "farmer:ssl:private_key",
+    "farmer:ssl:public_key",
+    "full_node:ssl:private_key",
+    "full_node:ssl:public_key",
+    "harvester:chia_ssl_ca:key",
+    "harvester:private_ssl_ca:key",
+    "harvester:ssl:private_key",
+    "introducer:ssl:public_key",
+    "private_ssl_ca:key",
+    "timelord:ssl:private_key",
+    "timelord:ssl:public_key",
+    "ui:daemon_ssl:private_key",
+    "wallet:ssl:private_key",
+    "wallet:ssl:public_key",
+]
+
 
 class SSLInvalidPermissions(Exception):
     """Exception which encapsulates info regarding SSL file permission errors"""
+
     def __init__(self, files: List[Tuple[Path, int]]):
         msg = "One or more file permissions are too open:\n"
         for (file, mode) in files:
@@ -28,7 +67,7 @@ class SSLInvalidPermissions(Exception):
     pass
 
 
-def print_ssl_perm_warning(path: Path, actual_mode: int, expected_mode: int, show_banner: bool = True):
+def print_ssl_perm_warning(path: Path, actual_mode: int, expected_mode: int, show_banner: bool = True) -> None:
     if show_banner:
         print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
         print("@             WARNING: UNPROTECTED SSL FILE!              @")
@@ -84,70 +123,106 @@ def check_ssl(root_path: Path) -> None:
         return []
 
     config: Dict = load_config(root_path, "config.yaml")
-    cert_config_key_paths = [
-        "chia_ssl_ca:crt",
-        "daemon_ssl:private_crt",
-        "farmer:ssl:private_crt",
-        "farmer:ssl:public_crt",
-        "full_node:ssl:private_crt",
-        "full_node:ssl:public_crt",
-        "harvester:chia_ssl_ca:crt",
-        "harvester:private_ssl_ca:crt",
-        "harvester:ssl:private_crt",
-        "introducer:ssl:public_crt",
-        "private_ssl_ca:crt",
-        "timelord:ssl:private_crt",
-        "timelord:ssl:public_crt",
-        "ui:daemon_ssl:private_crt",
-        "wallet:ssl:private_crt",
-        "wallet:ssl:public_crt",
-    ]
-    key_config_key_paths = [
-        "chia_ssl_ca:key",
-        "daemon_ssl:private_key",
-        "farmer:ssl:private_key",
-        "farmer:ssl:public_key",
-        "full_node:ssl:private_key",
-        "full_node:ssl:public_key",
-        "harvester:chia_ssl_ca:key",
-        "harvester:private_ssl_ca:key",
-        "harvester:ssl:private_key",
-        "introducer:ssl:public_key",
-        "private_ssl_ca:key",
-        "timelord:ssl:private_key",
-        "timelord:ssl:public_key",
-        "ui:daemon_ssl:private_key",
-        "wallet:ssl:private_key",
-        "wallet:ssl:public_key",
-    ]
-
+    files_to_check: List[Tuple[Path, int, int]] = []
     valid: bool = True
     banner_shown: bool = False
 
+    # Lookup config values and append to a list of files whose permissions we need to check
     for (key_paths, mask, expected_mode) in [
-        (cert_config_key_paths, RESTRICT_MASK_CERT_FILE, DEFAULT_PERMISSIONS_CERT_FILE),
-        (key_config_key_paths, RESTRICT_MASK_KEY_FILE, DEFAULT_PERMISSIONS_KEY_FILE),
+        (CERT_CONFIG_KEY_PATHS, RESTRICT_MASK_CERT_FILE, DEFAULT_PERMISSIONS_CERT_FILE),
+        (KEY_CONFIG_KEY_PATHS, RESTRICT_MASK_KEY_FILE, DEFAULT_PERMISSIONS_KEY_FILE),
     ]:
         for key_path in key_paths:
             try:
                 file = root_path / Path(traverse_dict(config, key_path))
-                # Check that the file permissions are not too permissive
-                (good_perms, mode) = verify_file_permissions(file, mask)
-                if not good_perms:
-                    print_ssl_perm_warning(file, mode, expected_mode, show_banner=not banner_shown)
-                    banner_shown = True
-                    valid = False
+                files_to_check.append((file, mask, expected_mode))
             except Exception as e:
-                print(f"Unable to check permissions for {key_path}: {e}")
+                print(f"Failed to lookup config value for {key_path}: {e}")
 
     # Check the Mozilla Root CAs as well
     mozilla_root_ca = get_mozilla_ca_crt()
-    (good_perms, mode) = verify_file_permissions(Path(mozilla_root_ca), RESTRICT_MASK_CERT_FILE)
-    if not good_perms:
-        print_ssl_perm_warning(file, mode, expected_mode, show_banner=not banner_shown)
-        banner_shown = True
-        valid = False
+    files_to_check.append((Path(mozilla_root_ca), RESTRICT_MASK_CERT_FILE, DEFAULT_PERMISSIONS_CERT_FILE))
+
+    for (file, mask, expected_mode) in files_to_check:
+        try:
+            # Check that the file permissions are not too permissive
+            (good_perms, mode) = verify_file_permissions(file, mask)
+            if not good_perms:
+                print_ssl_perm_warning(file, mode, expected_mode, show_banner=not banner_shown)
+                banner_shown = True
+                valid = False
+        except Exception as e:
+            print(f"Unable to check permissions for {key_path}: {e}")
 
     if not valid:
-        print("Please fix your file permissions and try again.")
+        print("One or more SSL files were found with permission issues.")
+        print("Use `chia init --fix-ssl-permissions` and try again.")
         sys.exit(1)
+
+
+def check_and_fix_permissions_for_ssl_file(file: Path, mask: int, updated_mode: int) -> Tuple[bool, bool]:
+    """Check file permissions and attempt to fix them if found to be too open"""
+    if sys.platform == "win32" or sys.platform == "cygwin":
+        # TODO: ACLs for SSL certs/keys on Windows
+        return True
+
+    valid: bool = True
+    updated: bool = False
+
+    # Check that the file permissions are not too permissive
+    try:
+        (good_perms, mode) = verify_file_permissions(file, mask)
+        if not good_perms:
+            valid = False
+            print(f"Attempting to set permissions {octal_mode_string(mode)} on {file}")
+            os.chmod(str(file), updated_mode)
+            updated = True
+    except Exception as e:
+        print(f"Failed to change permissions on {file}: {e}")
+        valid = False
+
+    return [valid, updated]
+
+
+def fix_ssl(root_path: Path) -> None:
+    """Attempts to fix SSL cert/key file permissions that are too open"""
+    from chia.ssl.create_ssl import get_mozilla_ca_crt
+
+    if sys.platform == "win32" or sys.platform == "cygwin":
+        # TODO: ACLs for SSL certs/keys on Windows
+        return None
+
+    config: Dict = load_config(root_path, "config.yaml")
+    files_to_fix: List[Tuple[Path, int, int]] = []
+    updated: bool = False
+    encountered_error: bool = False
+
+    for (key_paths, mask, updated_mode) in [
+        (CERT_CONFIG_KEY_PATHS, RESTRICT_MASK_CERT_FILE, DEFAULT_PERMISSIONS_CERT_FILE),
+        (KEY_CONFIG_KEY_PATHS, RESTRICT_MASK_KEY_FILE, DEFAULT_PERMISSIONS_KEY_FILE),
+    ]:
+        for key_path in key_paths:
+            try:
+                file = root_path / Path(traverse_dict(config, key_path))
+                files_to_fix.append((file, mask, updated_mode))
+            except Exception as e:
+                print(f"Failed to lookup config value for {key_path}: {e}")
+
+    # Check the Mozilla Root CAs as well
+    mozilla_root_ca = get_mozilla_ca_crt()
+    files_to_fix.append((Path(mozilla_root_ca), RESTRICT_MASK_CERT_FILE, DEFAULT_PERMISSIONS_CERT_FILE))
+
+    for (file, mask, updated_mode) in files_to_fix:
+        # Check that permissions are correct, and if not, attempt to fix
+        (valid, fixed) = check_and_fix_permissions_for_ssl_file(file, mask, updated_mode)
+        if fixed:
+            updated = True
+        if not valid and not fixed:
+            encountered_error = True
+
+    if encountered_error:
+        print("One or more errors were encountered while updating SSL file permissions...")
+    elif updated:
+        print("Finished updating SSL file permissions")
+    else:
+        print("SSL file permissions are correct")

--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -1,0 +1,146 @@
+import stat
+import sys
+from chia.util.config import load_config, traverse_dict
+from chia.util.permissions import octal_mode_string, verify_file_permissions
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+DEFAULT_PERMISSIONS_CERT_FILE: int = 0o644
+DEFAULT_PERMISSIONS_KEY_FILE: int = 0o600
+
+# Masks containing permission bits we don't allow
+RESTRICT_MASK_CERT_FILE: int = stat.S_IWGRP | stat.S_IXGRP | stat.S_IWOTH | stat.S_IXOTH  # 0o033
+RESTRICT_MASK_KEY_FILE: int = (
+    stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
+)  # 0o077
+
+
+class SSLInvalidPermissions(Exception):
+    def __init__(self, files: List[Tuple[Path, int]]):
+        msg = "One or more file permissions are too open:\n"
+        for (file, mode) in files:
+            msg += f"\t{file} (permissions = {octal_mode_string(mode)})\n"
+        msg += f"Expected permissions are {octal_mode_string(DEFAULT_PERMISSIONS_CERT_FILE)} "
+        msg += f"for crt files and {octal_mode_string(DEFAULT_PERMISSIONS_KEY_FILE)} for key files"
+        super().__init__(msg)
+
+    pass
+
+
+def print_ssl_perm_warning(path: Path, actual_mode: int, expected_mode: int, show_banner: bool = True):
+    if show_banner:
+        print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+        print("@             WARNING: UNPROTECTED SSL FILE!              @")
+        print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
+    print(
+        f"Permissions {octal_mode_string(actual_mode)} for '{path}' are too open. "
+        f"Expected {octal_mode_string(expected_mode)}"
+    )
+
+
+def verify_ssl_certs_and_keys(
+    cert_and_key_paths: List[Tuple[Optional[Path], Optional[Path]]]
+) -> List[Tuple[Path, int]]:
+    if sys.platform == "win32" or sys.platform == "cygwin":
+        # TODO: ACLs for SSL certs/keys on Windows
+        return []
+
+    invalid_files_and_modes: List[Tuple[Path, int]] = []
+    banner_shown: bool = False
+
+    for (cert_path, key_path) in cert_and_key_paths:
+        if cert_path is not None:
+            cert_perms_valid, cert_actual_mode = verify_file_permissions(cert_path, RESTRICT_MASK_CERT_FILE)
+            if not cert_perms_valid:
+                print_ssl_perm_warning(
+                    cert_path, cert_actual_mode, DEFAULT_PERMISSIONS_CERT_FILE, show_banner=not banner_shown
+                )
+                banner_shown = True
+                invalid_files_and_modes.append((cert_path, cert_actual_mode))
+
+        if key_path is not None:
+            key_perms_valid, key_actual_mode = verify_file_permissions(key_path, RESTRICT_MASK_KEY_FILE)
+            if not key_perms_valid:
+                print_ssl_perm_warning(
+                    key_path, key_actual_mode, DEFAULT_PERMISSIONS_KEY_FILE, show_banner=not banner_shown
+                )
+                banner_shown = True
+                invalid_files_and_modes.append((key_path, key_actual_mode))
+
+    return invalid_files_and_modes
+
+
+def check_ssl(root_path: Path) -> None:
+    """
+    Sanity checks on the SSL configuration. Checks that file permissions are properly
+    set on the keys and certs, warning and exiting if permissions are incorrect.
+    """
+    from chia.ssl.create_ssl import get_mozilla_ca_crt
+
+    config: Dict = load_config(root_path, "config.yaml")
+    cert_config_key_paths = [
+        "chia_ssl_ca:crt",
+        "daemon_ssl:private_crt",
+        "farmer:ssl:private_crt",
+        "farmer:ssl:public_crt",
+        "full_node:ssl:private_crt",
+        "full_node:ssl:public_crt",
+        "harvester:chia_ssl_ca:crt",
+        "harvester:private_ssl_ca:crt",
+        "harvester:ssl:private_crt",
+        "introducer:ssl:public_crt",
+        "private_ssl_ca:crt",
+        "timelord:ssl:private_crt",
+        "timelord:ssl:public_crt",
+        "ui:daemon_ssl:private_crt",
+        "wallet:ssl:private_crt",
+        "wallet:ssl:public_crt",
+    ]
+    key_config_key_paths = [
+        "chia_ssl_ca:key",
+        "daemon_ssl:private_key",
+        "farmer:ssl:private_key",
+        "farmer:ssl:public_key",
+        "full_node:ssl:private_key",
+        "full_node:ssl:public_key",
+        "harvester:chia_ssl_ca:key",
+        "harvester:private_ssl_ca:key",
+        "harvester:ssl:private_key",
+        "introducer:ssl:public_key",
+        "private_ssl_ca:key",
+        "timelord:ssl:private_key",
+        "timelord:ssl:public_key",
+        "ui:daemon_ssl:private_key",
+        "wallet:ssl:private_key",
+        "wallet:ssl:public_key",
+    ]
+
+    valid: bool = True
+    banner_shown: bool = False
+
+    for (key_paths, mask, expected_mode) in [
+        (cert_config_key_paths, RESTRICT_MASK_CERT_FILE, DEFAULT_PERMISSIONS_CERT_FILE),
+        (key_config_key_paths, RESTRICT_MASK_KEY_FILE, DEFAULT_PERMISSIONS_KEY_FILE),
+    ]:
+        for key_path in key_paths:
+            try:
+                file = root_path / Path(traverse_dict(config, key_path))
+                # Check that the file permissions are not too permissive
+                (good_perms, mode) = verify_file_permissions(file, mask)
+                if not good_perms:
+                    print_ssl_perm_warning(file, mode, expected_mode, show_banner=not banner_shown)
+                    banner_shown = True
+                    valid = False
+            except Exception as e:
+                print(f"Unable to check permissions for {key_path}: {e}")
+
+    mozilla_root_ca = get_mozilla_ca_crt()
+    (good_perms, mode) = verify_file_permissions(Path(mozilla_root_ca), RESTRICT_MASK_CERT_FILE)
+    if not good_perms:
+        print_ssl_perm_warning(file, mode, expected_mode, show_banner=not banner_shown)
+        banner_shown = True
+        valid = False
+
+    if not valid:
+        print("Please fix your file permissions and try again.")
+        sys.exit(1)

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -96,7 +96,7 @@ class TestSSL:
             priv_key,
         )
         ssl_context = ssl_context_for_client(
-            farmer_server.ca_private_crt_path, farmer_server.ca_private_crt_path, priv_crt, priv_key
+            farmer_server.ca_private_crt_path, farmer_server.ca_private_key_path, priv_crt, priv_key
         )
         connected = await establish_connection(farmer_server, 12312, ssl_context)
         assert connected is True
@@ -108,12 +108,12 @@ class TestSSL:
             farmer_server.chia_ca_crt_path.read_bytes(), farmer_server.chia_ca_key_path.read_bytes(), pub_crt, pub_key
         )
         ssl_context = ssl_context_for_client(
-            farmer_server.chia_ca_crt_path, farmer_server.chia_ca_crt_path, pub_crt, pub_key
+            farmer_server.chia_ca_crt_path, farmer_server.chia_ca_key_path, pub_crt, pub_key
         )
         connected = await establish_connection(farmer_server, 12312, ssl_context)
         assert connected is False
         ssl_context = ssl_context_for_client(
-            farmer_server.ca_private_crt_path, farmer_server.ca_private_crt_path, pub_crt, pub_key
+            farmer_server.ca_private_crt_path, farmer_server.ca_private_key_path, pub_crt, pub_key
         )
         connected = await establish_connection(farmer_server, 12312, ssl_context)
         assert connected is False
@@ -134,7 +134,7 @@ class TestSSL:
             pub_key,
         )
         ssl_context = ssl_context_for_client(
-            full_node_server.chia_ca_crt_path, full_node_server.chia_ca_crt_path, pub_crt, pub_key
+            full_node_server.chia_ca_crt_path, full_node_server.chia_ca_key_path, pub_crt, pub_key
         )
         connected = await establish_connection(full_node_server, 12312, ssl_context)
         assert connected is True
@@ -151,7 +151,7 @@ class TestSSL:
             wallet_server.chia_ca_crt_path.read_bytes(), wallet_server.chia_ca_key_path.read_bytes(), pub_crt, pub_key
         )
         ssl_context = ssl_context_for_client(
-            wallet_server.chia_ca_crt_path, wallet_server.chia_ca_crt_path, pub_crt, pub_key
+            wallet_server.chia_ca_crt_path, wallet_server.chia_ca_key_path, pub_crt, pub_key
         )
         connected = await establish_connection(wallet_server, 12312, ssl_context)
         assert connected is False
@@ -166,7 +166,7 @@ class TestSSL:
             priv_key,
         )
         ssl_context = ssl_context_for_client(
-            wallet_server.ca_private_crt_path, wallet_server.ca_private_crt_path, priv_crt, priv_key
+            wallet_server.ca_private_crt_path, wallet_server.ca_private_key_path, priv_crt, priv_key
         )
         connected = await establish_connection(wallet_server, 12312, ssl_context)
         assert connected is False
@@ -186,7 +186,7 @@ class TestSSL:
             pub_key,
         )
         ssl_context = ssl_context_for_client(
-            harvester_server.chia_ca_crt_path, harvester_server.chia_ca_crt_path, pub_crt, pub_key
+            harvester_server.chia_ca_crt_path, harvester_server.chia_ca_key_path, pub_crt, pub_key
         )
         connected = await establish_connection(harvester_server, 12312, ssl_context)
         assert connected is False
@@ -201,7 +201,7 @@ class TestSSL:
             priv_key,
         )
         ssl_context = ssl_context_for_client(
-            harvester_server.ca_private_crt_path, harvester_server.ca_private_crt_path, priv_crt, priv_key
+            harvester_server.ca_private_crt_path, harvester_server.ca_private_key_path, priv_crt, priv_key
         )
         connected = await establish_connection(harvester_server, 12312, ssl_context)
         assert connected is False
@@ -220,7 +220,7 @@ class TestSSL:
             pub_key,
         )
         ssl_context = ssl_context_for_client(
-            introducer_server.chia_ca_crt_path, introducer_server.chia_ca_crt_path, pub_crt, pub_key
+            introducer_server.chia_ca_crt_path, introducer_server.chia_ca_key_path, pub_crt, pub_key
         )
         connected = await establish_connection(introducer_server, 12312, ssl_context)
         assert connected is True
@@ -239,7 +239,7 @@ class TestSSL:
             pub_key,
         )
         ssl_context = ssl_context_for_client(
-            timelord_server.chia_ca_crt_path, timelord_server.chia_ca_crt_path, pub_crt, pub_key
+            timelord_server.chia_ca_crt_path, timelord_server.chia_ca_key_path, pub_crt, pub_key
         )
         connected = await establish_connection(timelord_server, 12312, ssl_context)
         assert connected is False
@@ -254,7 +254,7 @@ class TestSSL:
             priv_key,
         )
         ssl_context = ssl_context_for_client(
-            timelord_server.ca_private_crt_path, timelord_server.ca_private_crt_path, priv_crt, priv_key
+            timelord_server.ca_private_crt_path, timelord_server.ca_private_key_path, priv_crt, priv_key
         )
         connected = await establish_connection(timelord_server, 12312, ssl_context)
         assert connected is False


### PR DESCRIPTION
NOTE: This set of changes does not affect Windows.

When creating SSL certificate and private key files, ensure that files are written with the proper file permissions. For certificates, we'll write files using -rw-r--r-- (0644), and key files will use -rw------- (0600). Cert/key files imported using `chia init -c [ca_dir]` will similarly have their permissions set.

When launching the daemon, or running `chia init`, the cert/key file locations will be extracted from the config and have their file permissions checked. If the permissions are found to be too permissive, a message will be printed to the console (and the log if available). When constructing an SSL context, the cert and key file permissions will be checked and logged as appropriate.

Added `chia init --fix-ssl-permissions` to attempt to set cert/key file permissions correctly.

Tracked in Trello as:
https://trello.com/c/k4jQR9w9/920-node-private-key-file-permissions