### PR TITLE
add --paginate/--no-paginate to chia wallet get_transactions

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -65,6 +65,17 @@ def get_transactions_cmd(
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transactions
 
+    import sys
+    import click.utils
+
+    # The pacification avoids output like below when piping through `head -n 1`
+    # which will close stdout.
+    #
+    # Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
+    # BrokenPipeError: [Errno 32] Broken pipe
+    sys.stdout = click.utils.PacifyFlushWrapper(sys.stdout)
+    sys.stderr = click.utils.PacifyFlushWrapper(sys.stderr)
+
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, get_transactions))
 
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -53,7 +53,14 @@ def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: in
     default=None,
     help="Prompt for each page of data.  Defaults to true for interactive consoles, otherwise false.",
 )
-def get_transactions_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, offset: int, verbose: bool, paginate: Optional[bool]) -> None:
+def get_transactions_cmd(
+    wallet_rpc_port: Optional[int],
+    fingerprint: int,
+    id: int,
+    offset: int,
+    verbose: bool,
+    paginate: Optional[bool],
+) -> None:
     extra_params = {"id": id, "verbose": verbose, "offset": offset, "paginate": paginate}
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transactions

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -48,8 +48,13 @@ def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: in
     required=True,
 )
 @click.option("--verbose", "-v", count=True, type=int)
-def get_transactions_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, offset: int, verbose: bool) -> None:
-    extra_params = {"id": id, "verbose": verbose, "offset": offset}
+@click.option(
+    "--paginate/--no-paginate",
+    default=None,
+    help="Prompt for each page of data.  Defaults to true for interactive consoles, otherwise false.",
+)
+def get_transactions_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, offset: int, verbose: bool, paginate: Optional[bool]) -> None:
+    extra_params = {"id": id, "verbose": verbose, "offset": offset, "paginate": paginate}
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transactions
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional
 
 import click
@@ -65,18 +66,15 @@ def get_transactions_cmd(
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transactions
 
-    import sys
-    import click.utils
+    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, get_transactions))
 
-    # The pacification avoids output like below when piping through `head -n 1`
+    # The flush/close avoids output like below when piping through `head -n 1`
     # which will close stdout.
     #
     # Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
     # BrokenPipeError: [Errno 32] Broken pipe
-    sys.stdout = click.utils.PacifyFlushWrapper(sys.stdout)
-    sys.stderr = click.utils.PacifyFlushWrapper(sys.stderr)
-
-    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, get_transactions))
+    sys.stdout.flush()
+    sys.stdout.close()
 
 
 @wallet_cmd.command("send", short_help="Send chia to another wallet")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -44,6 +44,9 @@ async def get_transaction(args: dict, wallet_client: WalletRpcClient, fingerprin
 
 async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["id"]
+    paginate = args["paginate"]
+    if paginate is None:
+        paginate = sys.stdout.isatty()
     txs: List[TransactionRecord] = await wallet_client.get_transactions(wallet_id)
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
     name = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
@@ -51,7 +54,7 @@ async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerpri
         print("There are no transactions to this address")
 
     offset = args["offset"]
-    num_per_screen = 5
+    num_per_screen = 5 if paginate else len(txs)
     for i in range(offset, len(txs), num_per_screen):
         for j in range(0, num_per_screen):
             if i + j >= len(txs):


### PR DESCRIPTION
The default remains to paginate if sys.stdout.isatty(), otherwise it defaults to not paginating.  This addresses cases such as piping and output redirection to a file where the command previously just hung while waiting for the user to press c for the next page.