### PR TITLE
Enable querying AAAA records for DNS Introducer.

### DIFF
--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -208,20 +208,21 @@ class FullNodeDiscovery:
             if self.resolver is None:
                 self.log.warn("Skipping DNS query: asyncresolver not initialized.")
                 return
-            peers: List[TimestampedPeerInfo] = []
-            result = await self.resolver.resolve(qname=dns_address, lifetime=30)
-            for ip in result:
-                peers.append(
-                    TimestampedPeerInfo(
-                        ip.to_text(),
-                        self.default_port,
-                        0,
+            for rdtype in ['A', 'AAAA']:
+                peers: List[TimestampedPeerInfo] = []
+                result = await self.resolver.resolve(qname=dns_address, rdtype=rdtype, lifetime=30)
+                for ip in result:
+                    peers.append(
+                        TimestampedPeerInfo(
+                            ip.to_text(),
+                            self.default_port,
+                            0,
+                        )
                     )
-                )
-            self.log.info(f"Received {len(peers)} peers from DNS seeder.")
-            if len(peers) == 0:
-                return
-            await self._respond_peers_common(full_node_protocol.RespondPeers(peers), None, False)
+                self.log.info(f"Received {len(peers)} peers from DNS seeder, using rdtype = {rdtype}.")
+                if len(peers) == 0:
+                    continue
+                await self._respond_peers_common(full_node_protocol.RespondPeers(peers), None, False)
         except Exception as e:
             self.log.warn(f"querying DNS introducer failed: {e}")
 

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -208,7 +208,7 @@ class FullNodeDiscovery:
             if self.resolver is None:
                 self.log.warn("Skipping DNS query: asyncresolver not initialized.")
                 return
-            for rdtype in ['A', 'AAAA']:
+            for rdtype in ["A", "AAAA"]:
                 peers: List[TimestampedPeerInfo] = []
                 result = await self.resolver.resolve(qname=dns_address, rdtype=rdtype, lifetime=30)
                 for ip in result:

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -220,9 +220,8 @@ class FullNodeDiscovery:
                         )
                     )
                 self.log.info(f"Received {len(peers)} peers from DNS seeder, using rdtype = {rdtype}.")
-                if len(peers) == 0:
-                    continue
-                await self._respond_peers_common(full_node_protocol.RespondPeers(peers), None, False)
+                if len(peers) > 0:
+                    await self._respond_peers_common(full_node_protocol.RespondPeers(peers), None, False)
         except Exception as e:
             self.log.warn(f"querying DNS introducer failed: {e}")
 


### PR DESCRIPTION
Enables querying `AAAA` records for DNS Introducers.

In case the DNS Introducer doesn't support `AAAA` yet, the `A` records will still be received, an exception will be caught for `AAAA`, then the node discovery logic will process the received `A` records:

`full_node chia.full_node.full_node: INFO     Received 32 peers from DNS seeder, using rdtype = A.`
`full_node chia.full_node.full_node: WARNING  querying DNS introducer failed: The DNS response does not contain an answer to the question: dns-introducer.chia.net. IN AAAA`
