### PR TITLE
RPC updates to support keyring migration and passphrase requirements

### DIFF
--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -7,7 +7,6 @@ from io import TextIOWrapper
 from pathlib import Path
 from typing import Optional, Tuple
 
-MIN_PASSPHRASE_LEN = 8
 # Click drops leading dashes, and converts remaining dashes to underscores. e.g. --set-passphrase -> 'set_passphrase'
 PASSPHRASE_CLI_OPTION_NAMES = ["keys_root_path", "set_passphrase", "passphrase_file", "current_passphrase_file"]
 
@@ -27,14 +26,15 @@ def verify_passphrase_meets_requirements(
     new_passphrase: str, confirmation_passphrase: str
 ) -> Tuple[bool, Optional[str]]:
     match = new_passphrase == confirmation_passphrase
-    meets_len_requirement = len(new_passphrase) >= MIN_PASSPHRASE_LEN
+    min_length = Keychain.minimum_passphrase_length()
+    meets_len_requirement = len(new_passphrase) >= min_length
 
     if match and meets_len_requirement:
         return True, None
     elif not match:
         return False, "Passphrases do not match"
     elif not meets_len_requirement:
-        return False, f"Minimum passphrase length is {MIN_PASSPHRASE_LEN}"
+        return False, f"Minimum passphrase length is {min_length}"
     else:
         raise Exception("Unexpected passphrase verification case")
 
@@ -48,8 +48,9 @@ def tidy_passphrase(passphrase: str) -> str:
 
 
 def prompt_for_new_passphrase() -> str:
-    if MIN_PASSPHRASE_LEN > 0:
-        n = MIN_PASSPHRASE_LEN
+    min_length: int = Keychain.minimum_passphrase_length()
+    if min_length > 0:
+        n = min_length
         print(f"\nPassphrases must be {n} or more characters in length")  # lgtm [py/clear-text-logging-sensitive-data]
     while True:
         passphrase = tidy_passphrase(getpass("New Passphrase: "))

--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -1,7 +1,10 @@
+import click
 import sys
 
+from chia.daemon.client import acquire_connection_to_daemon
 from chia.util.keychain import Keychain, obtain_current_passphrase
 from chia.util.keyring_wrapper import DEFAULT_PASSPHRASE_IF_NO_MASTER_PASSPHRASE
+from chia.util.ws_message import WsRpcMessage
 from getpass import getpass
 from io import TextIOWrapper
 from pathlib import Path
@@ -188,25 +191,45 @@ def using_default_passphrase() -> bool:
 
 
 async def async_update_daemon_passphrase_cache_if_running(root_path: Path) -> None:
-    from chia.daemon.client import connect_to_daemon_and_validate
-
+    """
+    Attempt to connect to the daemon and update the cached passphrase
+    """
     new_passphrase = Keychain.get_cached_master_passphrase()
     assert new_passphrase is not None
 
-    daemon = None
     try:
-        daemon = await connect_to_daemon_and_validate(root_path, quiet=True)
-        if daemon:
-            response = await daemon.unlock_keyring(new_passphrase)
+        async with acquire_connection_to_daemon(root_path, quiet=True) as daemon:
+            if daemon is not None:
+                response = await daemon.unlock_keyring(new_passphrase)
+                if response is None:
+                    raise Exception("daemon didn't respond")
 
-            if not response:
-                raise Exception("daemon didn't respond")
-
-            if response["data"].get("success", False) is False:
-                error = response["data"].get("error", "unknown error")
-                raise Exception(error)
+                success: bool = response.get("data", {}).get("success", False)
+                if success is False:
+                    error = response.get("data", {}).get("error", "unknown error")
+                    raise Exception(error)
     except Exception as e:
         print(f"Failed to notify daemon of updated keyring passphrase: {e}")
 
-    if daemon:
-        await daemon.close()
+
+async def async_update_daemon_migration_completed_if_running() -> None:
+    """
+    Attempt to connect to the daemon to notify that keyring migration has completed.
+    This allows the daemon to refresh its keyring so that it can stop using the
+    legacy keyring.
+    """
+    ctx: click.Context = click.get_current_context()
+    root_path: Path = ctx.obj["root_path"]
+
+    if root_path is None:
+        print("Missing root_path in context. Unable to notify daemon")
+        return None
+
+    async with acquire_connection_to_daemon(root_path, quiet=True) as daemon:
+        if daemon is not None:
+            passphrase: str = Keychain.get_cached_master_passphrase()
+
+            print("Updating daemon... ", end="")
+            response: WsRpcMessage = await daemon.notify_keyring_migration_completed(passphrase)
+            success: bool = response.get("data", {}).get("success", False)
+            print("succeeded" if success is True else "failed")

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -427,6 +427,9 @@ class WebSocketServer:
         if type(new_passphrase) is not str:
             return {"success": False, "error": "missing new_passphrase"}
 
+        if not Keychain.passphrase_meets_requirements(new_passphrase):
+            return {"success": False, "error": "passphrase doesn't satisfy requirements"}
+
         try:
             assert new_passphrase is not None  # mypy, I love you
             Keychain.set_master_passphrase(current_passphrase, new_passphrase, allow_migration=False)

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -382,6 +382,13 @@ class WebSocketServer:
 
     async def migrate_keyring(self, request: Dict[str, Any]) -> Dict[str, Any]:
         if Keychain.needs_migration() is False:
+            # If the keyring has already been migrated, we'll raise an error to the client.
+            # The reason for raising an error is because the migration request has side-
+            # effects beyond copying keys from the legacy keyring to the new keyring. The
+            # request may have set a passphrase and indicated that keys should be cleaned
+            # from the legacy keyring. If we were to return early and indicate success,
+            # the client and user's expectations may not match reality (were my keys
+            # deleted from the legacy keyring? was my passphrase set?).
             return {"success": False, "error": "migration not needed"}
 
         success: bool = False

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -403,8 +403,8 @@ class WebSocketServer:
             success = True
         except Exception as e:
             tb = traceback.format_exc()
-            self.log.error(f"Keyring passphrase validation failed: {e} {tb}")
-            error = f"migration failed: {e}"
+            self.log.error(f"Legacy keyring migration failed: {e} {tb}")
+            error = f"keyring migration failed: {e}"
 
         response: Dict[str, Any] = {"success": success, "error": error}
         return response

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -464,6 +464,15 @@ class Keychain:
         return KeyringWrapper.get_shared_instance().using_legacy_keyring()
 
     @staticmethod
+    def handle_migration_completed():
+        """
+        When migration completes outside of the current process, we rely on a notification to inform
+        the current process that it needs to reset/refresh its keyring. This allows us to stop using
+        the legacy keyring in an already-running daemon if migration is completed using the CLI.
+        """
+        KeyringWrapper.get_shared_instance().refresh_keyrings()
+
+    @staticmethod
     def migrate_legacy_keyring(passphrase: Optional[str] = None, cleanup_legacy_keyring: bool = False) -> None:
         """
         Begins legacy keyring migration in a non-interactive manner

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -21,6 +21,7 @@ DEFAULT_PASSPHRASE_PROMPT = (
 FAILED_ATTEMPT_DELAY = 0.5
 MAX_KEYS = 100
 MAX_RETRIES = 3
+MIN_PASSPHRASE_LEN = 8
 
 
 class KeyringIsLocked(Exception):
@@ -51,8 +52,6 @@ def passphrase_requirements() -> Dict[str, Any]:
     """
     Returns a dictionary specifying current passphrase requirements
     """
-    from chia.cmds.passphrase_funcs import MIN_PASSPHRASE_LEN
-
     if not supports_keyring_passphrase:
         return {}
 

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -1,12 +1,13 @@
 import keyring as keyring_main
 
+from blspy import PrivateKey  # pyright: reportMissingImports=false
 from chia.util.default_root import DEFAULT_KEYS_ROOT_PATH
 from chia.util.file_keyring import FileKeyring
 from chia.util.misc import prompt_yes_no
 from keyrings.cryptfile.cryptfile import CryptFileKeyring  # pyright: reportMissingImports=false
 from pathlib import Path
 from sys import exit, platform
-from typing import Any, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 
 # We want to protect the keyring, even if a user-specified master passphrase isn't provided
@@ -182,7 +183,7 @@ class KeyringWrapper:
                 if not allow_migration:
                     raise KeyringRequiresMigration("keyring requires migration")
 
-                self.migrate_legacy_keyring()
+                self.migrate_legacy_keyring_interactive()
             else:
                 # We're reencrypting the keyring contents using the new passphrase. Ensure that the
                 # payload has been decrypted by calling load_keyring with the current passphrase.
@@ -197,6 +198,19 @@ class KeyringWrapper:
         self.set_master_passphrase(current_passphrase, DEFAULT_PASSPHRASE_IF_NO_MASTER_PASSPHRASE)
 
     # Legacy keyring migration
+
+    class MigrationResults:
+        def __init__(
+            self,
+            original_private_keys: List[Tuple[PrivateKey, bytes]],
+            legacy_keyring: Any,
+            keychain_service: str,
+            keychain_users: List[str],
+        ):
+            self.original_private_keys = original_private_keys
+            self.legacy_keyring = legacy_keyring
+            self.keychain_service = keychain_service
+            self.keychain_users = keychain_users
 
     def confirm_migration(self) -> bool:
         """
@@ -244,27 +258,12 @@ class KeyringWrapper:
 
         return prompt_yes_no("Begin keyring migration? (y/n) ")
 
-    def migrate_legacy_keyring(self):
-        """
-        Handle importing keys from the legacy keyring into the new keyring.
-
-        Prior to beginning, we'll ensure that we at least suggest setting a master passphrase
-        and backing up mnemonic seeds. After importing keys from the legacy keyring, we'll
-        perform a before/after comparison of the keyring contents, and on success we'll prompt
-        to cleanup the legacy keyring.
-        """
-
+    def migrate_legacy_keys(self) -> MigrationResults:
         from chia.util.keychain import Keychain, MAX_KEYS
-
-        # Make sure the user is ready to begin migration. We want to ensure that
-        response = self.confirm_migration()
-        if not response:
-            print("Skipping migration. Unable to proceed")
-            exit(0)
 
         print("Migrating contents from legacy keyring")
 
-        keychain = Keychain()
+        keychain: Keychain = Keychain()
         # Obtain contents from the legacy keyring. When using the Keychain interface
         # to read, the legacy keyring will be preferred over the new keyring.
         original_private_keys = keychain.get_all_private_keys()
@@ -287,45 +286,101 @@ class KeyringWrapper:
         for (user, passphrase) in user_passphrase_pairs:
             self.keyring.set_password(service, user, passphrase)
 
+        return KeyringWrapper.MigrationResults(
+            original_private_keys, self.legacy_keyring, service, [user for (user, _) in user_passphrase_pairs]
+        )
+
+    def verify_migration_results(self, migration_results: MigrationResults) -> bool:
+        from chia.util.keychain import Keychain
+
         # Stop using the legacy keyring. This will direct subsequent reads to the new keyring.
-        old_keyring = self.legacy_keyring
         self.legacy_keyring = None
+        success: bool = False
 
         print("Verifying migration results...", end="")
 
         # Compare the original keyring contents with the new
         try:
+            keychain: Keychain = Keychain()
+            original_private_keys = migration_results.original_private_keys
             post_migration_private_keys = keychain.get_all_private_keys()
 
+            # Sort the key collections prior to comparing
+            original_private_keys.sort(key=lambda e: str(e[0]))
+            post_migration_private_keys.sort(key=lambda e: str(e[0]))
+
             if post_migration_private_keys == original_private_keys:
+                success = True
                 print(" Verified")
+            else:
+                print(" Failed")
+                raise Exception("Migrated keys don't match original keys")
+        except Exception as e:
+            print(f"\nMigration failed: {e}")
+            print("Leaving legacy keyring intact")
+            self.legacy_keyring = migration_results.legacy_keyring  # Restore the legacy keyring
+
+        return success
+
+    def confirm_legacy_keyring_cleanup(self, migration_results) -> bool:
+        """
+        Ask the user whether we should remove keys from the legacy keyring.
+        """
+        return prompt_yes_no(
+            f"Remove keys from old keyring ({str(migration_results.legacy_keyring.file_path)})? (y/n) "
+        )
+
+    def cleanup_legacy_keyring(self, migration_results: MigrationResults):
+        """
+        Remove keys from the legacy keyring. We can't just delete the file because other
+        python processes might use the same keyring file.
+        """
+        for user in migration_results.keychain_users:
+            migration_results.legacy_keyring.delete_password(migration_results.keychain_service, user)
+
+        # TODO: CryptFileKeyring doesn't cleanup section headers
+        # [chia_2Duser_2Dchia_2D1_2E8] is left behind
+
+    def migrate_legacy_keyring(self, cleanup_legacy_keyring: bool = False):
+        results = self.migrate_legacy_keys()
+        success = self.verify_migration_results(results)
+
+        if success and cleanup_legacy_keyring:
+            self.cleanup_legacy_keyring(results)
+
+    def migrate_legacy_keyring_interactive(self):
+        """
+        Handle importing keys from the legacy keyring into the new keyring.
+
+        Prior to beginning, we'll ensure that we at least suggest setting a master passphrase
+        and backing up mnemonic seeds. After importing keys from the legacy keyring, we'll
+        perform a before/after comparison of the keyring contents, and on success we'll prompt
+        to cleanup the legacy keyring.
+        """
+
+        # Make sure the user is ready to begin migration.
+        response = self.confirm_migration()
+        if not response:
+            print("Skipping migration. Unable to proceed")
+            exit(0)
+
+        try:
+            results = self.migrate_legacy_keys()
+            success = self.verify_migration_results(results)
+
+            if success:
+                print(f"Keyring migration completed successfully ({str(self.keyring.keyring_path)})\n")
         except Exception as e:
             print(f"\nMigration failed: {e}")
             print("Leaving legacy keyring intact")
             exit(1)
 
-        print(f"Keyring migration completed successfully ({str(self.keyring.keyring_path)})\n")
-
         # Ask if we should clean up the legacy keyring
-        self.confirm_legacy_keyring_cleanup(old_keyring, service, [user for (user, _) in user_passphrase_pairs])
-
-    def confirm_legacy_keyring_cleanup(self, legacy_keyring, service, users):
-        """
-        Ask the user whether we should remove keys from the legacy keyring. We can't just
-        delete the file because other python processes might use the same keyring file.
-        """
-
-        response = prompt_yes_no(f"Remove keys from old keyring ({str(legacy_keyring.file_path)})? (y/n) ")
-
-        if response:
-            for user in users:
-                legacy_keyring.delete_password(service, user)
+        if self.confirm_legacy_keyring_cleanup(results):
+            self.cleanup_legacy_keyring(results)
             print("Removed keys from old keyring")
         else:
             print("Keys in old keyring left intact")
-
-        # TODO: CryptFileKeyring doesn't cleanup section headers
-        # [chia_2Duser_2Dchia_2D1_2E8] is left behind
 
     # Keyring interface
 
@@ -340,13 +395,13 @@ class KeyringWrapper:
     def set_passphrase(self, service: str, user: str, passphrase: str):
         # On the first write while using the legacy keyring, we'll start migration
         if self.using_legacy_keyring() and self.has_cached_master_passphrase():
-            self.migrate_legacy_keyring()
+            self.migrate_legacy_keyring_interactive()
 
         self.get_keyring().set_password(service, user, passphrase)
 
     def delete_passphrase(self, service: str, user: str):
         # On the first write while using the legacy keyring, we'll start migration
         if self.using_legacy_keyring() and self.has_cached_master_passphrase():
-            self.migrate_legacy_keyring()
+            self.migrate_legacy_keyring_interactive()
 
         self.get_keyring().delete_password(service, user)

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -314,11 +314,12 @@ class KeyringWrapper:
                 print(" Verified")
             else:
                 print(" Failed")
-                raise Exception("Migrated keys don't match original keys")
+                raise ValueError("Migrated keys don't match original keys")
         except Exception as e:
             print(f"\nMigration failed: {e}")
             print("Leaving legacy keyring intact")
             self.legacy_keyring = migration_results.legacy_keyring  # Restore the legacy keyring
+            raise e
 
         return success
 


### PR DESCRIPTION
NOTE: New keyring + passphrase support is still disabled

RPC support has been added to allow the GUI to migrate keys to the new keyring. The new RPC message is `migrate_keyring` and can take an optional passphrase, as well as a flag that indicates whether the old keyring should have its keys scrubbed (post-migration).

The existing keyring migration CLI flow has been refactored to support both interactive and non-interactive modes (CLI and RPC (GUI) respectively)

Passphrase requirements are now formalized and bundled into a passphrase_requirements dictionary that is provided to the GUI, as well as used internally by the CLI.