### PR TITLE
New call for logging peer_host

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -195,7 +195,7 @@ class Farmer:
         )
 
     def on_disconnect(self, connection: ws.WSChiaConnection):
-        self.log.info(f"peer disconnected {connection.get_peer_info()}")
+        self.log.info(f"peer disconnected {connection.get_peer_logging()}")
         self.state_changed("close_connection", {})
 
     async def _pool_get_pool_info(self, pool_config: PoolWalletConfig) -> Optional[Dict]:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -313,10 +313,10 @@ class FullNode:
                 fetch_tx: bool = unfinished_block is None or curr_height != target_height
                 curr = await peer.request_block(full_node_protocol.RequestBlock(uint32(curr_height), fetch_tx))
                 if curr is None:
-                    raise ValueError(f"Failed to fetch block {curr_height} from {peer.get_peer_info()}, timed out")
+                    raise ValueError(f"Failed to fetch block {curr_height} from {peer.get_peer_logging()}, timed out")
                 if curr is None or not isinstance(curr, full_node_protocol.RespondBlock):
                     raise ValueError(
-                        f"Failed to fetch block {curr_height} from {peer.get_peer_info()}, wrong type {type(curr)}"
+                        f"Failed to fetch block {curr_height} from {peer.get_peer_logging()}, wrong type {type(curr)}"
                     )
                 responses.append(curr)
                 if self.blockchain.contains_block(curr.block.prev_header_hash) or curr_height == 0:
@@ -542,7 +542,7 @@ class FullNode:
                 await self.send_peak_to_timelords()
 
     def on_disconnect(self, connection: ws.WSChiaConnection):
-        self.log.info(f"peer disconnected {connection.get_peer_info()}")
+        self.log.info(f"peer disconnected {connection.get_peer_logging()}")
         self._state_changed("close_connection")
         self._state_changed("sync_mode")
         if self.sync_store is not None:
@@ -834,7 +834,7 @@ class FullNode:
         for i, block in enumerate(blocks_to_validate):
             if pre_validation_results[i].error is not None:
                 self.log.error(
-                    f"Invalid block from peer: {peer.get_peer_info()} {Err(pre_validation_results[i].error)}"
+                    f"Invalid block from peer: {peer.get_peer_logging()} {Err(pre_validation_results[i].error)}"
                 )
                 return False, advanced_peak, fork_height
 
@@ -847,7 +847,7 @@ class FullNode:
                 advanced_peak = True
             elif result == ReceiveBlockResult.INVALID_BLOCK or result == ReceiveBlockResult.DISCONNECTED_BLOCK:
                 if error is not None:
-                    self.log.error(f"Error: {error}, Invalid block from peer: {peer.get_peer_info()} ")
+                    self.log.error(f"Error: {error}, Invalid block from peer: {peer.get_peer_logging()} ")
                 return False, advanced_peak, fork_height
             block_record = self.blockchain.block_record(block.header_hash)
             if block_record.sub_epoch_summary_included is not None:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -366,7 +366,7 @@ class FullNodeAPI:
         Receive a full block from a peer full node (or ourselves).
         """
 
-        self.log.warning(f"Received unsolicited/late block from peer {peer.get_peer_info()}")
+        self.log.warning(f"Received unsolicited/late block from peer {peer.get_peer_logging()}")
         return None
 
     @api_request

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -74,7 +74,7 @@ class Harvester:
             self.state_changed_callback(change)
 
     def on_disconnect(self, connection: ws.WSChiaConnection):
-        self.log.info(f"peer disconnected {connection.get_peer_info()}")
+        self.log.info(f"peer disconnected {connection.get_peer_logging()}")
         self._state_changed("close_connection")
 
     def get_plots(self) -> Tuple[List[Dict], List[str], List[str]]:

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -256,7 +256,9 @@ class ChiaServer:
             if not self.accept_inbound_connections(connection.connection_type) and not is_in_network(
                 connection.peer_host, self.exempt_peer_networks
             ):
-                self.log.info(f"Not accepting inbound connection: {connection.get_peer_info()}.Inbound limit reached.")
+                self.log.info(
+                    f"Not accepting inbound connection: {connection.get_peer_logging()}.Inbound limit reached."
+                )
                 await connection.close()
                 close_event.set()
             else:
@@ -531,7 +533,7 @@ class ChiaServer:
                             pass
                         except Exception as e:
                             tb = traceback.format_exc()
-                            connection.log.error(f"Exception: {e}, {connection.get_peer_info()}. {tb}")
+                            connection.log.error(f"Exception: {e}, {connection.get_peer_logging()}. {tb}")
                             raise e
                         return None
 
@@ -548,7 +550,7 @@ class ChiaServer:
                     if self.connection_close_task is None:
                         tb = traceback.format_exc()
                         connection.log.error(
-                            f"Exception: {e} {type(e)}, closing connection {connection.get_peer_info()}. {tb}"
+                            f"Exception: {e} {type(e)}, closing connection {connection.get_peer_logging()}. {tb}"
                         )
                     else:
                         connection.log.debug(f"Exception: {e} while closing connection")

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -273,7 +273,7 @@ class WSChiaConnection:
             request_start_t = time.time()
             result = await self.create_request(msg, timeout)
             self.log.debug(
-                f"Time for request {attr_name}: {self.get_peer_info()} = {time.time() - request_start_t}, "
+                f"Time for request {attr_name}: {self.get_peer_logging()} = {time.time() - request_start_t}, "
                 f"None? {result is None}"
             )
             if result is not None:
@@ -468,3 +468,12 @@ class WSChiaConnection:
         connection_host = result[0]
         port = self.peer_server_port if self.peer_server_port is not None else self.peer_port
         return PeerInfo(connection_host, port)
+
+    def get_peer_logging(self) -> PeerInfo:
+        info: Optional[PeerInfo] = self.get_peer_info()
+        if info is None:
+            # in this case, we will use self.peer_host which is friendlier for logging
+            port = self.peer_server_port if self.peer_server_port is not None else self.peer_port
+            return PeerInfo(self.peer_host, port)
+        else:
+            return info

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -375,7 +375,7 @@ class WalletNode:
                         connection.get_peer_info() != full_node_peer
                         and connection.get_peer_info() != full_node_resolved
                     ):
-                        self.log.info(f"Closing unnecessary connection to {connection.get_peer_info()}.")
+                        self.log.info(f"Closing unnecessary connection to {connection.get_peer_logging()}.")
                         asyncio.create_task(connection.close())
                 return True
         return False
@@ -424,7 +424,7 @@ class WalletNode:
                     self.wallet_state_manager.state_changed("sync_changed")
                     await self.wallet_state_manager.new_peak()
                 elif result == ReceiveBlockResult.INVALID_BLOCK:
-                    self.log.info(f"Invalid block from peer: {peer.get_peer_info()} {error}")
+                    self.log.info(f"Invalid block from peer: {peer.get_peer_logging()} {error}")
                     await peer.close()
                     return
                 else:


### PR DESCRIPTION
The implementation of get_peer_info is such that it often returns None. This None return is expected in various parts of the code for maintaining peer lists. However, this isn't very helpful for logging purposes, in which case you get log items like

`INFO peer disconnected None`
`ERROR Exception: Failed to fetch block 673118 from None`

Added new call `get_peer_logging()` that will use the peer_host value (typically an IP address) when the peername cannot be retrieved. Changed various logging code to use this.