### PR TITLE
Check AttributeError for non-Optional members during node shutdown

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -557,10 +557,17 @@ class FullNode:
         self._shut_down = True
         if self._init_weight_proof is not None:
             self._init_weight_proof.cancel()
-        if self.blockchain is not None:
+        # blockchain is created in _start and in certain cases it may not exist here during _close
+        try:
             self.blockchain.shut_down()
-        if self.mempool_manager is not None:
+        except AttributeError:
+            pass
+        # same for mempool_manager
+        try:
             self.mempool_manager.shut_down()
+        except AttributeError:
+            pass
+
         if self.full_node_peers is not None:
             asyncio.create_task(self.full_node_peers.close())
         if self.uncompact_task is not None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -557,16 +557,13 @@ class FullNode:
         self._shut_down = True
         if self._init_weight_proof is not None:
             self._init_weight_proof.cancel()
+
         # blockchain is created in _start and in certain cases it may not exist here during _close
-        try:
+        if hasattr(self, "blockchain"):
             self.blockchain.shut_down()
-        except AttributeError:
-            pass
         # same for mempool_manager
-        try:
+        if hasattr(self, "mempool_manager"):
             self.mempool_manager.shut_down()
-        except AttributeError:
-            pass
 
         if self.full_node_peers is not None:
             asyncio.create_task(self.full_node_peers.close())


### PR DESCRIPTION
During node shutdown some AttributeErrors could be thrown if the shutdown happens before the node fully started up. Checks against None are not applicable as the attributes in question were not declared Optional and not initialized to None. Added hasattr checks
See #7553 