### PR TITLE
Added support for Raspberry Pi 4 64Bit

### DIFF
--- a/install-gui.sh
+++ b/install-gui.sh
@@ -29,8 +29,8 @@ if [ "$(uname)" = "Linux" ]; then
 		OSNAME="$(uname -n)"
 		
 		# Check if we are running a Raspberry PI 4
-		if [ OSARCH == "aarch64" ] \
-		&& [ OSNAME == "raspberrypi" ]; then
+		if [ $OSARCH == "aarch64" ] \
+		&& [ $OSNAME == "raspberrypi" ]; then
 			# Check if NodeJS & NPM is installed
 			type npm >/dev/null 2>&1 || {
 					echo >&2 "Please install NODEJS&NPM manually then"

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -24,7 +24,21 @@ if [ "$(uname)" = "Linux" ]; then
 	if type apt-get; then
 		# Debian/Ubuntu
 		UBUNTU=true
-		sudo apt-get install -y npm nodejs libxss1
+		
+		OSARCH="$(uname -m)"
+		OSNAME="$(uname -n)"
+		
+		# Check if we are running a Raspberry PI 4
+		if [ OSARCH == "aarch64" ] \
+		&& [ OSNAME == "raspberrypi" ]; then
+			# Check if NodeJS & NPM is installed
+			type npm >/dev/null 2>&1 || {
+					echo >&2 "Please install NODEJS&NPM manually then"
+					read -rsp $'Press enter to continue...\n'
+			}
+		else
+			sudo apt-get install -y npm nodejs libxss1
+		fi
 	elif type yum &&  [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f /etc/rocky-release ] && [ ! -f /etc/fedora-release ]; then
 		# AMZN 2
 		echo "Installing on Amazon Linux 2."


### PR DESCRIPTION
Due to lack of NPM in APT on a Raspberry Pi 4 Debian 64bit installation user needs to install NodeJS and NPM manually.