### PR TITLE
Clean up the GHA mac build to just build and upload to GHA

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -35,6 +35,9 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
+    - name: Cleanup any leftovers that exist from previous runs
+      run: bash build_scripts/clean-runner.sh || true
+
     - name: Setup Python environment
       uses: actions/setup-python@v2
       with:
@@ -108,60 +111,8 @@ jobs:
         cd ../build_scripts
         sh build_macos.sh
 
-    - name: Create installer version number
-      id: version_number
-      run: |
-        . ./activate
-        echo "::set-output name=CHIA_INSTALLER_VERSION::$(chia version)"
-
     - name: Upload MacOS artifacts
       uses: actions/upload-artifact@v2
       with:
         name: Chia-Installer-on-MacOS-10.15-dmg
         path: ${{ github.workspace }}/build_scripts/final_installer/
-
-    - name: Install AWS CLI
-      run: |
-        curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-        sudo installer -pkg AWSCLIV2.pkg -target /
-
-    - name: Configure AWS Credentials
-      if: steps.check_secrets.outputs.HAS_SECRET
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.INSTALLER_UPLOAD_KEY }}
-        aws-secret-access-key: ${{ secrets.INSTALLER_UPLOAD_SECRET }}
-        aws-region: us-west-2
-
-    - name: Rename Artifact
-      run: |
-        ls
-        mv ${{ github.workspace }}/build_scripts/final_installer/Chia-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg  ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg
-
-    - name: Create Checksums
-      run: |
-        ls
-        shasum -a 256 ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg > ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg.sha256
-
-    - name: Upload to s3
-      if: steps.check_secrets.outputs.HAS_SECRET
-      run: |
-        aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg s3://download-chia-net/builds/
-
-    - name: Install py3createtorrent
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        pip3 install py3createtorrent
-
-#    - name: Create torrent
-#      if: startsWith(github.ref, 'refs/tags/')
-#      run: |
-#        py3createtorrent -t torrent.chia.net ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg.torrent
-
-#Temporarily disable release uploads
-#    - name: Upload Release Files
-#      if: startsWith(github.ref, 'refs/tags/')
-#      run: |
-#          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg s3://download-chia-net/install/
-#          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg.sha256 s3://download-chia-net/install/
-#          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/Chia-Catalina-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.dmg.torrent s3://download-chia-net/install/


### PR DESCRIPTION
This is just for easy dev access - it doesn't upload to S3 or the release - the azure DMG is uploaded to s3, release, torrents, etc