### PR TITLE
cmds|server|util: Fix, refactor and improve SSL permission checks

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -16,6 +16,7 @@ from chia.cmds.wallet import wallet_cmd
 from chia.cmds.plotnft import plotnft_cmd
 from chia.util.default_root import DEFAULT_KEYS_ROOT_PATH, DEFAULT_ROOT_PATH
 from chia.util.keychain import set_keys_root_path, supports_keyring_passphrase
+from chia.util.ssl import check_ssl
 from typing import Optional
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -71,6 +72,8 @@ def cli(
             cache_passphrase(read_passphrase_from_file(passphrase_file))
         except Exception as e:
             print(f"Failed to read passphrase: {e}")
+
+    check_ssl(Path(root_path))
 
 
 if not supports_keyring_passphrase():

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -31,7 +31,6 @@ from chia.util.ssl import (
     RESTRICT_MASK_CERT_FILE,
     RESTRICT_MASK_KEY_FILE,
     check_and_fix_permissions_for_ssl_file,
-    check_ssl,
     fix_ssl,
 )
 from chia.wallet.derive_keys import master_sk_to_pool_sk, master_sk_to_wallet_sk
@@ -329,9 +328,7 @@ def chia_full_version_str() -> str:
     return f"{major}.{minor}.{patch}{dev}"
 
 
-def chia_init(
-    root_path: Path, *, should_check_keys: bool = True, should_check_ssl: bool = True, fix_ssl_permissions: bool = False
-):
+def chia_init(root_path: Path, *, should_check_keys: bool = True, fix_ssl_permissions: bool = False):
     """
     Standard first run initialization or migration steps. Handles config creation,
     generation of SSL certs, and setting target addresses (via check_keys).
@@ -353,8 +350,6 @@ def chia_init(
         # before a new update.
         if fix_ssl_permissions:
             fix_ssl(root_path)
-        elif should_check_ssl:
-            check_ssl(root_path)
         if should_check_keys:
             check_keys(root_path)
         print(f"{root_path} already exists, no migration action taken")
@@ -364,8 +359,6 @@ def chia_init(
     create_all_ssl(root_path)
     if fix_ssl_permissions:
         fix_ssl(root_path)
-    elif should_check_ssl:
-        check_ssl(root_path)
     if should_check_keys:
         check_keys(root_path)
     print("")

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -39,7 +39,7 @@ def ssl_context_for_server(
     log: Optional[logging.Logger] = None,
 ) -> Optional[ssl.SSLContext]:
     if check_permissions:
-        verify_ssl_certs_and_keys([(ca_cert, ca_key), (private_cert_path, private_key_path)], log)
+        verify_ssl_certs_and_keys([ca_cert, private_cert_path], [ca_key, private_key_path], log)
 
     ssl_context = ssl._create_unverified_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=str(ca_cert))
     ssl_context.check_hostname = False
@@ -52,7 +52,7 @@ def ssl_context_for_root(
     ca_cert_file: str, *, check_permissions: bool = True, log: Optional[logging.Logger] = None
 ) -> Optional[ssl.SSLContext]:
     if check_permissions:
-        verify_ssl_certs_and_keys([(Path(ca_cert_file), None)], log)
+        verify_ssl_certs_and_keys([Path(ca_cert_file)], [], log)
 
     ssl_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=ca_cert_file)
     return ssl_context
@@ -68,7 +68,7 @@ def ssl_context_for_client(
     log: Optional[logging.Logger] = None,
 ) -> Optional[ssl.SSLContext]:
     if check_permissions:
-        verify_ssl_certs_and_keys([(ca_cert, ca_key), (private_cert_path, private_key_path)], log)
+        verify_ssl_certs_and_keys([ca_cert, private_cert_path], [ca_key, private_key_path], log)
 
     ssl_context = ssl._create_unverified_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=str(ca_cert))
     ssl_context.check_hostname = False

--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -58,6 +58,14 @@ KEY_CONFIG_KEY_PATHS = [
 warned_ssl_files: Set[Path] = set()
 
 
+def get_ssl_perm_warning(path: Path, actual_mode: int, expected_mode: int) -> str:
+    return (
+        f"Permissions {octal_mode_string(actual_mode)} for "
+        f"'{path}' are too open. "  # lgtm [py/clear-text-logging-sensitive-data]
+        f"Expected {octal_mode_string(expected_mode)}"
+    )
+
+
 def print_ssl_perm_warning(
     path: Path, actual_mode: int, expected_mode: int, *, show_banner: bool = True, log: Optional[Logger] = None
 ) -> None:
@@ -66,11 +74,7 @@ def print_ssl_perm_warning(
             print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
             print("@             WARNING: UNPROTECTED SSL FILE!              @")
             print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-        msg = (
-            f"Permissions {octal_mode_string(actual_mode)} for "
-            f"'{path}' are too open. "  # lgtm [py/clear-text-logging-sensitive-data]
-            f"Expected {octal_mode_string(expected_mode)}"
-        )
+        msg = get_ssl_perm_warning(path, actual_mode, expected_mode)
         if log is not None:
             log.error(f"{msg}")
         print(f"{msg}")

--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -167,7 +167,7 @@ def check_and_fix_permissions_for_ssl_file(file: Path, mask: int, updated_mode: 
     """Check file permissions and attempt to fix them if found to be too open"""
     if sys.platform == "win32" or sys.platform == "cygwin":
         # TODO: ACLs for SSL certs/keys on Windows
-        return (True, False)
+        return True, False
 
     valid: bool = True
     updated: bool = False
@@ -187,7 +187,7 @@ def check_and_fix_permissions_for_ssl_file(file: Path, mask: int, updated_mode: 
         print(f"Failed to change permissions on {file}: {e}")  # lgtm [py/clear-text-logging-sensitive-data]
         valid = False
 
-    return (valid, updated)
+    return valid, updated
 
 
 def fix_ssl(root_path: Path) -> None:


### PR DESCRIPTION
This PR:

- Fixes an issue which lets the full-node stuck due to failures in multiprocessing validation if the SSL file permissions are not correct (at least on linux). Im not exactly sure yet why this happens but its somehow related to `print` used in there. The "fix" is to just only print the warnings for CLI, see https://github.com/xdustinface/chia-blockchain/commit/f483bb142e1813793aa7d54941e930e3a0c4f140
- Refactors some methods related to SSL permission checks to avoid duplicated code
- It makes sure all SSL files are checked for all CLI commands