### PR TITLE
limit use of additions() call

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -41,8 +41,8 @@ class Mempool:
         """
         Removes an item from the mempool.
         """
-        removals: List[Coin] = item.spend_bundle.removals()
-        additions: List[Coin] = item.spend_bundle.additions()
+        removals: List[Coin] = item.removals
+        additions: List[Coin] = item.additions
         for rem in removals:
             del self.removals[rem.name()]
         for add in additions:
@@ -58,8 +58,6 @@ class Mempool:
     def add_to_pool(
         self,
         item: MempoolItem,
-        additions: List[Coin],
-        removals_dic: Dict[bytes32, Coin],
     ):
         """
         Adds an item to the mempool by kicking out transactions (if it doesn't fit), in order of increasing fee per cost
@@ -79,10 +77,10 @@ class Mempool:
 
         self.sorted_spends[item.fee_per_cost][item.name] = item
 
-        for add in additions:
+        for add in item.additions:
             self.additions[add.name()] = item
-        for key in removals_dic.keys():
-            self.removals[key] = item
+        for coin in item.removals:
+            self.removals[coin.name()] = item
         self.total_mempool_cost += item.cost
 
     def at_full_capacity(self, cost: int) -> bool:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -119,7 +119,6 @@ class MempoolManager:
                 f"full: {cost_sum / self.constants.MAX_BLOCK_COST_CLVM}"
             )
             agg = SpendBundle.aggregate(spend_bundles)
-            assert set(agg.additions()) == set(additions)
             assert set(agg.removals()) == set(removals)
             return agg, additions, removals
         else:
@@ -436,7 +435,7 @@ class MempoolManager:
                 self.mempool.remove_from_pool(mempool_item)
 
         new_item = MempoolItem(new_spend, uint64(fees), npc_result, cost, spend_name, additions, removals, program)
-        self.mempool.add_to_pool(new_item, additions, removal_coin_dict)
+        self.mempool.add_to_pool(new_item)
         log.info(
             f"add_spendbundle took {time.time() - start_time} seconds, cost {cost} "
             f"({round(100.0 * cost/self.constants.MAX_BLOCK_COST_CLVM, 3)}%)"


### PR DESCRIPTION
calling SpendBundle.additions() or CoinSpend.additions() runs the CLVM program and parses the conditions outputs. It can be expensive and should not be done willy nilly