### PR TITLE
break problematic dependency

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -11,7 +11,6 @@ from typing import Any, BinaryIO, Dict, List, Tuple, Type, Callable, Optional, I
 
 from blspy import G1Element, G2Element, PrivateKey
 
-from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.hash import std_hash
@@ -39,11 +38,11 @@ size_hints = {
     "ConditionOpcode": 1,
 }
 unhashable_types = [
-    PrivateKey,
-    G1Element,
-    G2Element,
-    Program,
-    SerializedProgram,
+    "PrivateKey",
+    "G1Element",
+    "G2Element",
+    "Program",
+    "SerializedProgram",
 ]
 # JSON does not support big ints, so these types must be serialized differently in JSON
 big_ints = [uint64, int64, uint128, int512]
@@ -77,7 +76,7 @@ def dataclass_from_dict(klass, d):
     elif issubclass(klass, bytes):
         # Type is bytes, data is a hex string
         return klass(hexstr_to_bytes(d))
-    elif klass in unhashable_types:
+    elif klass.__name__ in unhashable_types:
         # Type is unhashable (bls type), so cast from hex string
         return klass.from_bytes(hexstr_to_bytes(d))
     else:
@@ -93,7 +92,7 @@ def recurse_jsonify(d):
     if isinstance(d, list) or isinstance(d, tuple):
         new_list = []
         for item in d:
-            if type(item) in unhashable_types or issubclass(type(item), bytes):
+            if type(item).__name__ in unhashable_types or issubclass(type(item), bytes):
                 item = f"0x{bytes(item).hex()}"
             if isinstance(item, dict):
                 item = recurse_jsonify(item)
@@ -110,7 +109,7 @@ def recurse_jsonify(d):
 
     else:
         for key, value in d.items():
-            if type(value) in unhashable_types or issubclass(type(value), bytes):
+            if type(value).__name__ in unhashable_types or issubclass(type(value), bytes):
                 d[key] = f"0x{bytes(value).hex()}"
             if isinstance(value, dict):
                 d[key] = recurse_jsonify(value)


### PR DESCRIPTION
where the streamable infrastructure depends on Program, G1Element, G2Element and PrivateKey.

Ideally the dependency on the blspy types would also be removed.

I understand that the blspy types are technically not under the control of this repo, and making them support the streamable protocol require some hackery. However, I don't understand why we can't make `Program` and `SerializedProgram` fully implement the streamable protocol, without resorting to having to check the type in the guts of de-serialization. Is there no way for a type to advertise that it has this property that `Program` has?