### PR TITLE
only use the last line of chia version output in installhelper.py

### DIFF
--- a/installhelper.py
+++ b/installhelper.py
@@ -53,7 +53,7 @@ def update_version():
     version: str = "0.0"
     output = subprocess.run(["chia", "version"], capture_output=True)
     if output.returncode == 0:
-        version = str(output.stdout.strip(), "utf-8")
+        version = str(output.stdout.strip(), "utf-8").splitlines()[-1]
 
     data["version"] = make_semver(version)
 


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/issues/8234

The warning that is being output by `chia version` is causing confusion
when trying to parse the version.  This change ignores the warning by
only trying to parse the last line of the output as the version.  Other
changes should be considered such as not outputting the warning for
small commands like `--help` and `version`.

```
$ chia version
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@             WARNING: UNPROTECTED SSL FILE!              @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0664 for '/home/altendky/repos/chia-blockchain/mozilla-ca/cacert.pem' are too open. Expected 0644
One or more SSL files were found with permission issues.
Run `chia init --fix-ssl-permissions` to fix issues.
1.2.5.dev0
```