### PR TITLE
Fix type of FileKeyring.keyring_path

### DIFF
--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -123,7 +123,7 @@ class FileKeyring(FileSystemEventHandler):
     The salt is updated each time the master passphrase is changed.
     """
 
-    keyring_path: Optional[Path] = None
+    keyring_path: Path
     keyring_lock_path: Path
     keyring_observer: Observer = None
     load_keyring_lock: threading.RLock  # Guards access to needs_load_keyring


### PR DESCRIPTION
This type is always non-None as it is assigned in __init__ from a call that returns non-None Path