### PR TITLE
plotting|util: Adjust plot refresh parameter

### DIFF
--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -17,8 +17,8 @@ log = logging.getLogger(__name__)
 class PlotsRefreshParameter:
     interval_seconds: int = 120
     retry_invalid_seconds: int = 1200
-    batch_size: int = 30
-    batch_sleep_milliseconds: int = 10
+    batch_size: int = 300
+    batch_sleep_milliseconds: int = 1
 
 
 @dataclass

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -128,8 +128,8 @@ harvester:
   plots_refresh_parameter:
     interval_seconds: 120 # The interval in seconds to refresh the plot file manager
     retry_invalid_seconds: 1200 # How long to wait before re-trying plots which failed to load
-    batch_size: 30 # How many plot files the harvester processes before it waits batch_sleep_milliseconds
-    batch_sleep_milliseconds: 10 # Milliseconds the harvester sleeps between batch processing
+    batch_size: 300 # How many plot files the harvester processes before it waits batch_sleep_milliseconds
+    batch_sleep_milliseconds: 1 # Milliseconds the harvester sleeps between batch processing
 
 
   # If True use parallel reads in chiapos


### PR DESCRIPTION
Seems like i was a bit too conservative with the initial batch size of 30 and the 10ms sleep. This change leads to faster loading times while still being responsive enough to process signage points (at least on my system it processes a batch of 300 plots in around 3s). This should probably be done adaptive rather based on the local batch processing time but at the end with #8009 applied it doesn't matter that much i guess.  