### PR TITLE
Random bluebox proofs

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -345,15 +345,18 @@ class BlockStore:
             return None
         return bool(row[0])
 
-    async def get_first_not_compactified(self) -> Optional[int]:
+    async def get_random_not_compactified(self, number: int) -> List[int]:
         # Since orphan blocks do not get compactified, we need to check whether all blocks with a
         # certain height are not compact. And if we do have compact orphan blocks, then all that
         # happens is that the occasional chain block stays uncompact - not ideal, but harmless.
         cursor = await self.db.execute(
-            "SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 ORDER BY height LIMIT 1"
+            f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 ORDER BY RANDOM() LIMIT {number}"
         )
-        row = await cursor.fetchone()
+        rows = await cursor.fetchall()
         await cursor.close()
-        if row is None:
-            return None
-        return int(row[0])
+
+        heights = []
+        for row in rows:
+            heights.append(int(row[0]))
+
+        return heights

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -350,7 +350,8 @@ class BlockStore:
         # certain height are not compact. And if we do have compact orphan blocks, then all that
         # happens is that the occasional chain block stays uncompact - not ideal, but harmless.
         cursor = await self.db.execute(
-            f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 ORDER BY RANDOM() LIMIT {number}"
+            f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 "
+            f"ORDER BY RANDOM() LIMIT {number}"
         )
         rows = await cursor.fetchall()
         await cursor.close()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1922,7 +1922,7 @@ class FullNode:
 
                 self.log.info("Getting random heights for bluebox to compact")
                 heights = await self.block_store.get_random_not_compactified(target_uncompact_proofs)
-                self.log.info('Heights found for bluebox to compact: [%s]' % ', '.join(map(str, heights)))
+                self.log.info("Heights found for bluebox to compact: [%s]" % ", ".join(map(str, heights)))
 
                 batches_finished = 0
                 for h in heights:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1925,7 +1925,6 @@ class FullNode:
                 heights = await self.block_store.get_random_not_compactified(target_uncompact_proofs)
                 self.log.info("Heights found for bluebox to compact: [%s]" % ", ".join(map(str, heights)))
 
-                batches_finished = 0
                 for h in heights:
 
                     headers = await self.blockchain.get_header_blocks_in_range(h, h, tx_filter=False)
@@ -1996,11 +1995,6 @@ class FullNode:
                                     uint8(CompressibleVDFField.CC_IP_VDF),
                                 )
                             )
-
-                    # Small sleep between batches.
-                    batches_finished += 1
-                    if batches_finished % 10 == 0:
-                        await asyncio.sleep(1)
 
                 if len(broadcast_list) > target_uncompact_proofs:
                     broadcast_list = broadcast_list[:target_uncompact_proofs]

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1819,6 +1819,7 @@ class FullNode:
         if not replaced:
             self.log.error(f"Could not replace compact proof: {request.height}")
             return None
+        self.log.info(f"Replaced compact proof at height {request.height}")
         msg = make_msg(
             ProtocolMessageTypes.new_compact_vdf,
             full_node_protocol.NewCompactVDF(request.height, request.header_hash, request.field_vdf, request.vdf_info),

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2006,9 +2006,12 @@ class FullNode:
                 if self.sync_store.get_sync_mode():
                     continue
                 if self.server is not None:
+                    self.log.info(f"Broadcasting {len(broadcast_list)} items to the bluebox")
+                    msgs = []
                     for new_pot in broadcast_list:
                         msg = make_msg(ProtocolMessageTypes.request_compact_proof_of_time, new_pot)
-                        await self.server.send_to_all([msg], NodeType.TIMELORD)
+                        msgs.append(msg)
+                    await self.server.send_to_all(msgs, NodeType.TIMELORD)
                 await asyncio.sleep(uncompact_interval_scan)
         except Exception as e:
             error_stack = traceback.format_exc()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1919,29 +1919,18 @@ class FullNode:
                     await asyncio.sleep(30)
 
                 broadcast_list: List[timelord_protocol.RequestCompactProofOfTime] = []
-                max_height = self.blockchain.get_peak_height()
-                if max_height is None:
-                    await asyncio.sleep(30)
-                    continue
-                assert max_height is not None
-                self.log.info("Getting minimum bluebox work height")
-                min_height = await self.block_store.get_first_not_compactified()
-                if min_height is None or min_height > max(0, max_height - 1000):
-                    min_height = max(0, max_height - 1000)
-                assert min_height is not None
-                max_height = uint32(min(max_height, min_height + 2000))
+
+                self.log.info("Getting random heights for bluebox to compact")
+                heights = await self.block_store.get_random_not_compactified(target_uncompact_proofs)
+                self.log.info('Heights found for bluebox to compact: [%s]' % ', '.join(map(str, heights)))
+
                 batches_finished = 0
-                self.log.info(f"Scanning the blockchain for uncompact blocks. Range: {min_height}..{max_height}")
-                for h in range(min_height, max_height, 100):
-                    # Got 10 times the target header count, sampling the target headers should contain
-                    # enough randomness to split the work between blueboxes.
-                    if len(broadcast_list) > target_uncompact_proofs * 10:
-                        break
-                    stop_height = min(h + 99, max_height)
-                    headers = await self.blockchain.get_header_blocks_in_range(h, stop_height, tx_filter=False)
+                for h in heights:
+
+                    headers = await self.blockchain.get_header_blocks_in_range(h, h, tx_filter=False)
                     records: Dict[bytes32, BlockRecord] = {}
                     if sanitize_weight_proof_only:
-                        records = await self.blockchain.get_block_records_in_range(h, stop_height)
+                        records = await self.blockchain.get_block_records_in_range(h, h)
                     for header in headers.values():
                         expected_header_hash = self.blockchain.height_to_hash(header.height)
                         if header.header_hash != expected_header_hash:
@@ -2012,9 +2001,7 @@ class FullNode:
                     if batches_finished % 10 == 0:
                         await asyncio.sleep(1)
 
-                # sample work randomly from the uncompact blocks we found
                 if len(broadcast_list) > target_uncompact_proofs:
-                    random.shuffle(broadcast_list)
                     broadcast_list = broadcast_list[:target_uncompact_proofs]
                 if self.sync_store.get_sync_mode():
                     continue


### PR DESCRIPTION
Instead of looking at the oldest part of the blockchain and finding uncompacted proofs from (generally) the first 1000 blocks, this gets `target_uncompact_proofs` number of heights for not fully compactified blocks from the DB at random and sends those to the timelord/bluebox. This greatly reduces the likelihood that multiple blueboxes are working on the same proofs at the same time (at least now, when we have tons of uncompact blocks). It also gets rid of the scanning that we used to do to find uncompact blocks which seems to (in my testing) get rid of the full node spikes to 100% while scanning the blockchain.

Running this branch on the same compute power that we had up prior to the branch change resulted in a noticeable increase in compact blocks over time:
<img width="432" alt="Screen Shot 2021-08-30 at 10 36 23 AM" src="https://user-images.githubusercontent.com/1915905/131397956-5423f43a-b812-4341-a323-c25fc1f4bfe8.png">
<img width="432" alt="Screen Shot 2021-08-30 at 10 36 16 AM" src="https://user-images.githubusercontent.com/1915905/131397965-58bcc4ec-f209-48eb-bec0-236e707eec67.png">
