### PR TITLE
pre-commit: Update some hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.0.1
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.2
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: check-ast
     -   id: debug-statements
 -   repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 21.8b0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
For the record: flake8 (3.7.9) was reporting a false negative: 

```
chia/util/keyring_wrapper.py:266:38: F821 undefined name 'MigrationResults'
```