### PR TITLE
Disable sqlite sync

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -123,7 +123,7 @@ class FullNode:
         # create the store (db) and full node instance
         self.connection = await aiosqlite.connect(self.db_path)
         await self.connection.execute("pragma journal_mode=wal")
-        await self.connection.execute("pragma synchronous=FULL")
+        await self.connection.execute("pragma synchronous=NORMAL")
         if self.config.get("log_sqlite_cmds", False):
             sql_log_path = path_from_root(self.root_path, "log/sql.log")
             self.log.info(f"logging SQL commands to {sql_log_path}")

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -93,7 +93,7 @@ class FullNodeDiscovery:
         mkdir(self.peer_db_path.parent)
         self.connection = await aiosqlite.connect(self.peer_db_path)
         await self.connection.execute("pragma journal_mode=wal")
-        await self.connection.execute("pragma synchronous=FULL")
+        await self.connection.execute("pragma synchronous=NORMAL")
         self.address_manager_store = await AddressManagerStore.create(self.connection)
         if not await self.address_manager_store.is_empty():
             self.address_manager = await self.address_manager_store.deserialize()

--- a/chia/wallet/wallet_interested_store.py
+++ b/chia/wallet/wallet_interested_store.py
@@ -21,7 +21,7 @@ class WalletInterestedStore:
         self.db_connection = wrapper.db
         self.db_wrapper = wrapper
         await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=FULL")
+        await self.db_connection.execute("pragma synchronous=NORMAL")
 
         await self.db_connection.execute("CREATE TABLE IF NOT EXISTS interested_coins(coin_name text PRIMARY KEY)")
 

--- a/chia/wallet/wallet_interested_store.py
+++ b/chia/wallet/wallet_interested_store.py
@@ -20,8 +20,6 @@ class WalletInterestedStore:
 
         self.db_connection = wrapper.db
         self.db_wrapper = wrapper
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=NORMAL")
 
         await self.db_connection.execute("CREATE TABLE IF NOT EXISTS interested_coins(coin_name text PRIMARY KEY)")
 

--- a/chia/wallet/wallet_pool_store.py
+++ b/chia/wallet/wallet_pool_store.py
@@ -21,8 +21,6 @@ class WalletPoolStore:
 
         self.db_connection = wrapper.db
         self.db_wrapper = wrapper
-        await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=NORMAL")
 
         await self.db_connection.execute(
             "CREATE TABLE IF NOT EXISTS pool_state_transitions(transition_index integer, wallet_id integer, "

--- a/chia/wallet/wallet_pool_store.py
+++ b/chia/wallet/wallet_pool_store.py
@@ -22,7 +22,7 @@ class WalletPoolStore:
         self.db_connection = wrapper.db
         self.db_wrapper = wrapper
         await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=FULL")
+        await self.db_connection.execute("pragma synchronous=NORMAL")
 
         await self.db_connection.execute(
             "CREATE TABLE IF NOT EXISTS pool_state_transitions(transition_index integer, wallet_id integer, "

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -138,7 +138,7 @@ class WalletStateManager:
         self.log.debug(f"Starting in db path: {db_path}")
         self.db_connection = await aiosqlite.connect(db_path)
         await self.db_connection.execute("pragma journal_mode=wal")
-        await self.db_connection.execute("pragma synchronous=FULL")
+        await self.db_connection.execute("pragma synchronous=NORMAL")
 
         self.db_wrapper = DBWrapper(self.db_connection)
         self.coin_store = await WalletCoinStore.create(self.db_wrapper)


### PR DESCRIPTION
This patch changes our sqlite configuration from `synchronous=FULL` to `synchronous=OFF`.

The main motivation is to lower the disk pressure caused by the chia full node. It's especially high against the `blockchain_v1_mainnet.sqlite`.

I measured the disk I/O patterns with `strace` before and after this patch. Before this patch, there's a fair number of calls to `fdatasync()` that are not made with this patch.

Most `fdatasync()` calls are made against the sqlite journal file `.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal`. These appear to be small and relatively cheap. For example:

```
3091379 13:35:52.405825 (+     0.000046) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:36:06.327662 (+     0.000050) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:36:11.398634 (+     0.000053) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:36:15.267889 (+     0.000057) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:36:19.747974 (+     0.000062) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:36:25.379157 (+     0.000059) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:36:30.503639 (+     0.000052) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:36:35.358668 (+     0.000045) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:37:00.844666 (+     0.000063) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
3091379 13:37:06.631114 (+     0.000040) fdatasync(9</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite-wal>) = 0
```

They're in the range of 40-60 microseconds each. However, the `fdatasync()` calls against the main database file are more expensive:

```
3091379 13:25:35.130433 (+     0.000057) fdatasync(8</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite> <unfinished ...>
3091379 13:25:38.694665 (+     2.714334) <... fdatasync resumed>) = 0
3091379 13:27:32.631285 (+     0.000058) fdatasync(8</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite> <unfinished ...>
3091379 13:27:38.776850 (+     3.670194) <... fdatasync resumed>) = 0
3091379 13:31:04.991207 (+     0.000060) fdatasync(8</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite> <unfinished ...>
3091379 13:31:15.948983 (+     1.107865) <... fdatasync resumed>) = 0
3091379 13:31:55.060278 (+     0.000063) fdatasync(8</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite> <unfinished ...>
3091379 13:32:04.415366 (+     0.483797) <... fdatasync resumed>) = 0
3091379 13:34:14.762268 (+     0.000057) fdatasync(8</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite> <unfinished ...>
3091379 13:34:22.728568 (+     2.013777) <... fdatasync resumed>) = 0
3091379 13:35:42.918906 (+     0.000071) fdatasync(8</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite> <unfinished ...>
3091379 13:35:49.870846 (+     1.966265) <... fdatasync resumed>) = 0
3091379 13:37:46.414737 (+     0.000065) fdatasync(8</home/arvid/.chia/mainnet/db/blockchain_v1_mainnet.sqlite> <unfinished ...>
3091379 13:37:49.470174 (+     0.020280) <... fdatasync resumed>) = 0
```

All of these calls take such a long time that they are almost always interrupted by the kernel, and later resumed. Also note that these take in the order of *seconds* to complete.

With this patch, all `fdatasync()` calls go away.

Why is it safe to relax the disk I/O like this?

Fundamentally, in case of catastrophic failure (of the hardware, power or kernel), our database can always be rebuilt by syncing from the network.