### PR TITLE
plotting|tests: Fix two `PlotsRefreshParameter` instantiations

### DIFF
--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -29,7 +29,7 @@ def plot_refresh_callback(refresh_result: PlotRefreshResult):
 
 def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, debug_show_memo):
     config = load_config(root_path, "config.yaml")
-    plot_refresh_parameter: PlotsRefreshParameter = PlotsRefreshParameter(100, 100, 1)
+    plot_refresh_parameter: PlotsRefreshParameter = PlotsRefreshParameter(batch_sleep_milliseconds=0)
     plot_manager: PlotManager = PlotManager(
         root_path,
         match_str=grep_string,

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -248,7 +248,7 @@ class BlockTools:
             sys.exit(1)
 
         refresh_done = False
-        refresh_parameter: PlotsRefreshParameter = PlotsRefreshParameter(120, 2, 10)
+        refresh_parameter: PlotsRefreshParameter = PlotsRefreshParameter(batch_size=2)
 
         def test_callback(update_result: PlotRefreshResult):
             if update_result.remaining_files == 0:


### PR DESCRIPTION
See commit messages. This was not adressed in #8279.