### PR TITLE
plotting|harvester|tests: Improve batch processing

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -15,6 +15,7 @@ from chia.plotting.util import (
     remove_plot,
     PlotsRefreshParameter,
     PlotRefreshResult,
+    PlotRefreshEvents,
 )
 from chia.util.streamable import dataclass_from_dict
 
@@ -76,9 +77,9 @@ class Harvester:
         if self.state_changed_callback is not None:
             self.state_changed_callback(change)
 
-    def _plot_refresh_callback(self, update_result: PlotRefreshResult):
+    def _plot_refresh_callback(self, event: PlotRefreshEvents, update_result: PlotRefreshResult):
         self.log.info(
-            f"refresh_batch: loaded {update_result.loaded}, "
+            f"refresh_batch: event {event.name}, loaded {update_result.loaded}, "
             f"removed {update_result.removed}, processed {update_result.processed}, "
             f"remaining {update_result.remaining}, "
             f"duration: {update_result.duration:.2f} seconds"

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -11,6 +11,7 @@ from chia.plotting.manager import PlotManager
 from chia.plotting.util import (
     PlotRefreshResult,
     PlotsRefreshParameter,
+    PlotRefreshEvents,
     get_plot_filenames,
     find_duplicate_plot_IDs,
     parse_plot_info,
@@ -23,8 +24,8 @@ from chia.wallet.derive_keys import master_sk_to_farmer_sk, master_sk_to_local_s
 log = logging.getLogger(__name__)
 
 
-def plot_refresh_callback(refresh_result: PlotRefreshResult):
-    log.info(f"loaded {refresh_result.loaded} plots, {refresh_result.remaining} remaining")
+def plot_refresh_callback(event: PlotRefreshEvents, refresh_result: PlotRefreshResult):
+    log.info(f"event: {event.name}, loaded {refresh_result.loaded} plots, {refresh_result.remaining} remaining")
 
 
 def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, debug_show_memo):

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -4,7 +4,7 @@ import threading
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Iterator
 from concurrent.futures.thread import ThreadPoolExecutor
 
 from blspy import G1Element
@@ -15,6 +15,7 @@ from chia.plotting.util import (
     PlotInfo,
     PlotRefreshResult,
     PlotsRefreshParameter,
+    PlotRefreshEvents,
     get_plot_filenames,
     parse_plot_info,
     stream_plot_info_pk,
@@ -223,19 +224,39 @@ class PlotManager:
                 plot_paths += paths
 
             total_result: PlotRefreshResult = PlotRefreshResult()
-            while self.needs_refresh() and self._refreshing_enabled:
-                batch_result: PlotRefreshResult = self.refresh_batch(plot_paths, plot_directories)
+            total_size = len(plot_paths)
+
+            self._refresh_callback(PlotRefreshEvents.started, PlotRefreshResult(remaining=total_size))
+
+            def batches() -> Iterator[Tuple[int, List[Path]]]:
+                if total_size > 0:
+                    for batch_start in range(0, total_size, self.refresh_parameter.batch_size):
+                        batch_end = min(batch_start + self.refresh_parameter.batch_size, total_size)
+                        yield total_size - batch_end, plot_paths[batch_start:batch_end]
+                else:
+                    yield 0, []
+
+            for remaining, batch in batches():
+                if not self._refreshing_enabled:
+                    self.log.debug("refresh_plots: Aborted")
+                    break
+                batch_result: PlotRefreshResult = self.refresh_batch(batch, plot_directories)
+                # Set the remaining files since `refresh_batch()` doesn't know them but we want to report it
+                batch_result.remaining = remaining
                 total_result.loaded += batch_result.loaded
                 total_result.removed += batch_result.removed
                 total_result.processed += batch_result.processed
-                total_result.remaining = batch_result.remaining
                 total_result.duration += batch_result.duration
-                self._refresh_callback(batch_result)
-                if batch_result.remaining == 0:
+
+                self._refresh_callback(PlotRefreshEvents.batch_processed, batch_result)
+                if remaining == 0:
                     break
                 batch_sleep = self.refresh_parameter.batch_sleep_milliseconds
                 self.log.debug(f"refresh_plots: Sleep {batch_sleep} milliseconds")
                 time.sleep(float(batch_sleep) / 1000.0)
+
+            if self._refreshing_enabled:
+                self._refresh_callback(PlotRefreshEvents.done, total_result)
 
             # Cleanup unused cache
             available_ids = set([plot_info.prover.get_id() for plot_info in self.plots.values()])
@@ -256,7 +277,7 @@ class PlotManager:
 
     def refresh_batch(self, plot_paths: List[Path], plot_directories: Set[Path]) -> PlotRefreshResult:
         start_time: float = time.time()
-        result: PlotRefreshResult = PlotRefreshResult()
+        result: PlotRefreshResult = PlotRefreshResult(processed=len(plot_paths))
         counter_lock = threading.Lock()
 
         log.debug(f"refresh_batch: {len(plot_paths)} files in directories {plot_directories}")
@@ -292,12 +313,6 @@ class PlotManager:
                     log.debug(f"Skip duplicated plot {str(file_path)}")
                     return None
             try:
-                with counter_lock:
-                    if result.processed >= self.refresh_parameter.batch_size:
-                        result.remaining += 1
-                        return None
-                    result.processed += 1
-
                 prover = DiskProver(str(file_path))
 
                 log.debug(f"process_file {str(file_path)}")
@@ -408,8 +423,11 @@ class PlotManager:
                 filenames_to_remove: List[str] = []
                 for plot_filename, paths_entry in self.plot_filename_paths.items():
                     loaded_path, duplicated_paths = paths_entry
-                    if plot_removed(Path(loaded_path) / Path(plot_filename)):
+                    loaded_plot = Path(loaded_path) / Path(plot_filename)
+                    if plot_removed(loaded_plot):
                         filenames_to_remove.append(plot_filename)
+                        if loaded_plot in self.plots:
+                            del self.plots[loaded_plot]
                         result.removed += 1
                         # No need to check the duplicates here since we drop the whole entry
                         continue
@@ -429,7 +447,7 @@ class PlotManager:
             for new_plot in executor.map(process_file, plot_paths):
                 if new_plot is not None:
                     plots_refreshed[Path(new_plot.prover.get_filename())] = new_plot
-            self.plots = plots_refreshed
+            self.plots.update(plots_refreshed)
 
         result.duration = time.time() - start_time
 

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -1,6 +1,7 @@
 import logging
 
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -29,6 +30,27 @@ class PlotInfo:
     plot_public_key: G1Element
     file_size: int
     time_modified: float
+
+
+class PlotRefreshEvents(Enum):
+    """
+    This are the events the `PlotManager` will trigger with the callback during a full refresh cycle:
+
+      - started: This event indicates the start of a refresh cycle and contains the total number of files to
+                 process in `PlotRefreshResult.remaining`.
+
+      - batch_processed: This event gets triggered if one batch has been processed. The values of
+                         `PlotRefreshResult.{loaded|removed|processed}` are the results of this specific batch.
+
+      - done: This event gets triggered after all batches has been processed. The values of
+              `PlotRefreshResult.{loaded|removed|processed}` are the totals of all batches.
+
+      Note: The values of `PlotRefreshResult.{remaining|duration}` have the same meaning for all events.
+    """
+
+    started = 0
+    batch_processed = 1
+    done = 2
 
 
 @dataclass


### PR DESCRIPTION
Let it only process `batch_size` files per `refresh_batch` call instead of all files.