### PR TITLE
get_coins_removed_at_height: special case height 0 to avoid iterating through all unspent coins

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -130,6 +130,9 @@ class CoinStore:
         return coins
 
     async def get_coins_removed_at_height(self, height: uint32) -> List[CoinRecord]:
+        # Special case to avoid querying all unspent coins (spent_index=0)
+        if height == 0:
+            return []
         cursor = await self.coin_record_db.execute("SELECT * from coin_record WHERE spent_index=?", (height,))
         rows = await cursor.fetchall()
         await cursor.close()


### PR DESCRIPTION
The query in CoinStore `get_coins_removed_at_height` has an edge case at height 0 where it returns the entire set of unspent coins: `self.coin_record_db.execute("SELECT * from coin_record WHERE spent_index=?", (height,))`. This can cause significant delays and resource consumption when handling `request_header_blocks` messages. As a simple fix, we can special case height 0 to return an empty array.