### PR TITLE
optimize CoinRecord DB access

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -129,8 +129,8 @@ class SpendSim:
             uint64(calculate_base_farmer_reward(next_block_height) + fees),
             self.defaults.GENESIS_CHALLENGE,
         )
-        await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(pool_coin, True)], False)
-        await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(farmer_coin, True)], False)
+        await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(pool_coin, True)])
+        await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(farmer_coin, True)])
 
         # Coin store gets updated
         generator_bundle: Optional[SpendBundle] = None
@@ -148,9 +148,10 @@ class SpendSim:
                     return_removals = removals
 
                 for addition in additions:
-                    await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(addition)], False)
-                for removal in removals:
-                    await self.mempool_manager.coin_store._set_spent(removal.name(), uint32(self.block_height + 1))
+                    await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(addition)])
+                await self.mempool_manager.coin_store._set_spent(
+                    [r.name() for r in removals], uint32(self.block_height + 1)
+                )
 
         # SimBlockRecord is created
         generator: Optional[BlockGenerator] = await self.generate_transaction_generator(generator_bundle)

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -129,8 +129,8 @@ class SpendSim:
             uint64(calculate_base_farmer_reward(next_block_height) + fees),
             self.defaults.GENESIS_CHALLENGE,
         )
-        await self.mempool_manager.coin_store._add_coin_record(self.new_coin_record(pool_coin, True), False)
-        await self.mempool_manager.coin_store._add_coin_record(self.new_coin_record(farmer_coin, True), False)
+        await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(pool_coin, True)], False)
+        await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(farmer_coin, True)], False)
 
         # Coin store gets updated
         generator_bundle: Optional[SpendBundle] = None
@@ -148,7 +148,7 @@ class SpendSim:
                     return_removals = removals
 
                 for addition in additions:
-                    await self.mempool_manager.coin_store._add_coin_record(self.new_coin_record(addition), False)
+                    await self.mempool_manager.coin_store._add_coin_records([self.new_coin_record(addition)], False)
                 for removal in removals:
                     await self.mempool_manager.coin_store._set_spent(removal.name(), uint32(self.block_height + 1))
 

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -9,6 +9,10 @@ from chia.types.full_block import FullBlock
 from chia.util.db_wrapper import DBWrapper
 from chia.util.ints import uint32, uint64
 from chia.util.lru_cache import LRUCache
+from time import time
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class CoinStore:
@@ -69,6 +73,7 @@ class CoinStore:
             return None
         assert block.foliage_transaction_block is not None
 
+        start = time()
         to_add: List[CoinRecord] = []
 
         for coin in tx_additions:
@@ -101,6 +106,7 @@ class CoinStore:
 
         await self._add_coin_records(to_add)
         await self._set_spent(tx_removals, block.height)
+        log.info(f"new_block() took {time() - start:0.6}s additions: {len(tx_additions)} removals: {len(tx_removals)}")
 
     # Checks DB and DiffStores for CoinRecord with coin_name and returns it
     async def get_coin_record(self, coin_name: bytes32) -> Optional[CoinRecord]:

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -167,10 +167,7 @@ class TestCoinStore:
                     coins = block.get_included_reward_coins()
                     records = [await coin_store.get_coin_record(coin.name()) for coin in coins]
 
-                    for record in records:
-                        await coin_store._set_spent(record.coin.name(), block.height)
-                        with pytest.raises(AssertionError):
-                            await coin_store._set_spent(record.coin.name(), block.height)
+                    await coin_store._set_spent([r.coin.name() for r in records], block.height)
 
                     records = [await coin_store.get_coin_record(coin.name()) for coin in coins]
                     for record in records:
@@ -201,8 +198,7 @@ class TestCoinStore:
                         await coin_store.get_coin_record(coin.name()) for coin in coins
                     ]
 
-                    for record in records:
-                        await coin_store._set_spent(record.coin.name(), block.height)
+                    await coin_store._set_spent([r.coin.name() for r in records], block.height)
 
                     records: List[Optional[CoinRecord]] = [
                         await coin_store.get_coin_record(coin.name()) for coin in coins


### PR DESCRIPTION
This PR has 3 distinct patches:

1. instead of looking up coin records one at a time, from the database. Look them all up in a single SQL query
2. instead of inserting new coins one at a time, insert them all in a single SQL command
3. When marking coins as spent, instead of looking them up, modifying them and writing them back (one at a time), issue a single SQL command to set the `spent_index` and `spent=1` on the records.

Of these, (3) probably has the most significant performance impact, since it entirely avoids a redundant read from the DB of the coins we're about to mark as spent. It's quite possible we won't need the CoinRecord cache anymore with these changes, but I would want to have better measurements before making such change.

I would expect (1) and (2) primarily saves time on reduced overhead in python and aiosqlite. But (2) can probably also take better advantage of a future relaxation on the sync setting in the DB.

I was hoping to be able to collect better data on this change, but since the current callback mechanism in aiosqlite only calls us *once* when the query is issued, we can't (easily) time them.