### PR TITLE
Fetch file stat() before opening it in DiskProver

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -293,7 +293,7 @@ class PlotManager:
                 log.debug(f"process_file {str(file_path)}")
 
                 expected_size = _expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR
-                
+
                 # TODO: consider checking if the file was just written to (which would mean that the file is still
                 # being copied). A segfault might happen in this edge case.
 

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -287,13 +287,13 @@ class PlotManager:
                         return None
                     result.processed_files += 1
 
+                stat_info = file_path.stat()
                 prover = DiskProver(str(file_path))
 
                 log.debug(f"process_file {str(file_path)}")
 
                 expected_size = _expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR
-                stat_info = file_path.stat()
-
+                
                 # TODO: consider checking if the file was just written to (which would mean that the file is still
                 # being copied). A segfault might happen in this edge case.
 


### PR DESCRIPTION
I don't know what is causing it, but with my plots mounted on a NAS over SMB I sometimes get a strange condition where file_path.stat() returns incorrect values (it gives the current system time for the st_mtime and st_ctime).

I can easily recreate this outside of Chia with a python script that opens an old file on the NAS in 'r' mode. After immediately closing the file which it doesn't write to (not even opened with 'w', '+', etc, ) an immediate call to stat() gives the current system time rather then the true modified time. Waiting a second or so and then calling stat() gives the correct value.

I don't know if this is an issue with my NAS, SMB, or what but in any case this causes issues for Chia when detecting new plots. The DiskProver opens the file for reading, which causes the immediately subsequent call to .stat() to get the wrong value for st_mtime when adding the file to self.plots[], when the file is scanned again and the correct time is found the code on about L275 `if stat_info.st_mtime == self.plots[file_path].time_modified:` fails to match, ultimately a warning in the logs appears about a duplicate plot existing but the warning is strange as it will say that the duplicate is in the same directory as the original and neither one actually gets added to the scanned plots.

I can fix this by adding the samba directive `,actimeo=0` in my mount, but this causes the NAS to run a little slow.

I can also fix this just by moving the line calling .stat() to above the DiskProver so that it always gets the correct value. Since the DiskProver does not actually change anything in the file I don't see any negative effect of this and it might help someone else.