### PR TITLE
Fix shown permissions on --fix-ssl-permissions

### DIFF
--- a/chia/util/ssl.py
+++ b/chia/util/ssl.py
@@ -161,7 +161,7 @@ def check_and_fix_permissions_for_ssl_file(file: Path, mask: int, updated_mode: 
         if not good_perms:
             valid = False
             print(
-                f"Attempting to set permissions {octal_mode_string(mode)} on "
+                f"Attempting to set permissions {octal_mode_string(updated_mode)} on "
                 f"{file}"  # lgtm [py/clear-text-logging-sensitive-data]
             )
             os.chmod(str(file), updated_mode)


### PR DESCRIPTION
The Output from --fix-ssl-permissions shows the current 'mode' not the 'updated_mode'.

So the output said that it is attempting to set the old ex: 644 mode instead of 600.

```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@             WARNING: UNPROTECTED SSL FILE!              @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for '/.chia/mainnet/config/ssl/ca/chia_ca.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/daemon/private_daemon.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/farmer/private_farmer.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/farmer/public_farmer.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/full_node/private_full_node.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/full_node/public_full_node.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/ca/chia_ca.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/ca/private_ca.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/harvester/private_harvester.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/full_node/public_full_node.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/ca/private_ca.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/timelord/private_timelord.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/timelord/public_timelord.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/daemon/private_daemon.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/wallet/private_wallet.key' are too open. Expected 0600
Permissions 0644 for '/.chia/mainnet/config/ssl/wallet/public_wallet.key' are too open. Expected 0600
One or more SSL files were found with permission issues.
Run `chia init --fix-ssl-permissions` to fix issues.
Chia directory /.chia/mainnet
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/ca/chia_ca.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/daemon/private_daemon.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/farmer/private_farmer.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/farmer/public_farmer.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/full_node/private_full_node.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/full_node/public_full_node.key
Attempting to set permissions 0600 on /.chia/mainnet/config/ssl/ca/chia_ca.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/ca/private_ca.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/harvester/private_harvester.key
Attempting to set permissions 0600 on /.chia/mainnet/config/ssl/full_node/public_full_node.key
Attempting to set permissions 0600 on /.chia/mainnet/config/ssl/ca/private_ca.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/timelord/private_timelord.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/timelord/public_timelord.key
Attempting to set permissions 0600 on /.chia/mainnet/config/ssl/daemon/private_daemon.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/wallet/private_wallet.key
Attempting to set permissions 0644 on /.chia/mainnet/config/ssl/wallet/public_wallet.key
Finished updating SSL file permissions
```