### PR TITLE
github: Enable some missing tests with `build-workflows.py`

### DIFF
--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Test core-util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/util/test_keychain.py tests/core/util/test_lru_cache.py tests/core/util/test_significant_bits.py tests/core/util/test_streamable.py tests/core/util/test_type_checking.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/util/test_cached_bls.py tests/core/util/test_config.py tests/core/util/test_file_keyring_synchronization.py tests/core/util/test_keychain.py tests/core/util/test_keyring_wrapper.py tests/core/util/test_lru_cache.py tests/core/util/test_significant_bits.py tests/core/util/test_streamable.py tests/core/util/test_type_checking.py -s -v --durations 0
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Test core-util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/util/test_keychain.py tests/core/util/test_lru_cache.py tests/core/util/test_significant_bits.py tests/core/util/test_streamable.py tests/core/util/test_type_checking.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/util/test_cached_bls.py tests/core/util/test_config.py tests/core/util/test_file_keyring_synchronization.py tests/core/util/test_keychain.py tests/core/util/test_keyring_wrapper.py tests/core/util/test_lru_cache.py tests/core/util/test_significant_bits.py tests/core/util/test_streamable.py tests/core/util/test_type_checking.py -s -v --durations 0
 
 
 #


### PR DESCRIPTION
The following tests are currently not enabled in CI: 

- `test_cached_bls.py` from #8028
- `test_config.py` from #8379 
- `keyring_synchronization.py` and `test_keyring_wrapper.py` from #7249

This PR enables them but i get failures here locally for the following tests:

- `TestConfig.test_multiple_writers` (https://stackoverflow.com/a/69165563)
- `TestKeyringWrapper.test_using_legacy_keyring`

Creating this as draft for now to see what else happens on CI. 