### PR TITLE
tests: Set `log_level` to `DEBUG` in `pytest.ini`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import logging
+
+
+def pytest_configure(config):
+    # Disable logging of the following modules to reduce log spam
+    for logger in ["aiosqlite", "fsevents", "watchdog"]:
+        logging.getLogger(logger).propagate = False

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 ; logging options
 log_cli = 1
-log_level = WARNING
+log_level = DEBUG
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s


### PR DESCRIPTION
I think this will help to better understand whats going on in failed CI tests. @mariano54 you set it to `WARNING` here 3f844fb65af6fd744bea5befb27cd36071ef0aec,  any objections about setting it to `DEBUG` now?