### PR TITLE
tests|farmer: Attempt to make `test_farmer_harvester_rpc.py` more reliable

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -78,11 +78,11 @@ class HarvesterCacheEntry:
         self.data = data
         self.bump_last_update()
 
-    def needs_update(self):
-        return time.time() - self.last_update > UPDATE_HARVESTER_CACHE_INTERVAL
+    def needs_update(self, update_interval: int):
+        return time.time() - self.last_update > update_interval
 
-    def expired(self):
-        return time.time() - self.last_update > UPDATE_HARVESTER_CACHE_INTERVAL * 10
+    def expired(self, update_interval: int):
+        return time.time() - self.last_update > update_interval * 10
 
 
 class Farmer:
@@ -114,6 +114,9 @@ class Farmer:
         # A dictionary of keys to time added. These keys refer to keys in the above 4 dictionaries. This is used
         # to periodically clear the memory
         self.cache_add_time: Dict[bytes32, uint64] = {}
+
+        # Interval to request plots from connected harvesters
+        self.update_harvester_cache_interval = UPDATE_HARVESTER_CACHE_INTERVAL
 
         self.cache_clear_task: asyncio.Task
         self.update_pool_state_task: asyncio.Task
@@ -591,7 +594,7 @@ class Farmer:
             remove_peers = []
             for peer_id, peer_cache in host_cache.items():
                 # If the peer cache is expired it means the harvester didn't respond for too long
-                if peer_cache.expired():
+                if peer_cache.expired(self.update_harvester_cache_interval):
                     remove_peers.append(peer_id)
             for key in remove_peers:
                 del host_cache[key]
@@ -604,11 +607,11 @@ class Farmer:
         updated = False
         for connection in self.server.get_connections(NodeType.HARVESTER):
             cache_entry = await self.get_cached_harvesters(connection)
-            if cache_entry.needs_update():
+            if cache_entry.needs_update(self.update_harvester_cache_interval):
                 self.log.debug(f"update_cached_harvesters update harvester: {connection.peer_node_id}")
                 cache_entry.bump_last_update()
                 response = await connection.request_plots(
-                    harvester_protocol.RequestPlots(), timeout=UPDATE_HARVESTER_CACHE_INTERVAL
+                    harvester_protocol.RequestPlots(), timeout=self.update_harvester_cache_interval
                 )
                 if response is not None:
                     if isinstance(response, harvester_protocol.RespondPlots):

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -177,6 +177,8 @@ class TestRpc:
 
             # Test farmer get_harvesters
             async def test_get_harvesters():
+                harvester.plot_manager.trigger_refresh()
+                await time_out_assert(5, harvester.plot_manager.needs_refresh, value=False)
                 farmer_res = await client.get_harvesters()
                 if len(list(farmer_res["harvesters"])) != 1:
                     log.error(f"test_get_harvesters: invalid harvesters {list(farmer_res['harvesters'])}")

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -179,8 +179,10 @@ class TestRpc:
             async def test_get_harvesters():
                 farmer_res = await client.get_harvesters()
                 if len(list(farmer_res["harvesters"])) != 1:
+                    log.error(f"test_get_harvesters: invalid harvesters {list(farmer_res['harvesters'])}")
                     return False
                 if len(list(farmer_res["harvesters"][0]["plots"])) != num_plots:
+                    log.error(f"test_get_harvesters: invalid plots {list(farmer_res['harvesters'])}")
                     return False
                 return True
 

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -170,6 +170,11 @@ class TestRpc:
             res_2 = await client_2.get_plots()
             assert len(res_2["plots"]) == num_plots
 
+            # Reset cache and force updates cache every second to make sure the farmer gets the most recent data
+            update_interval_before = farmer_api.farmer.update_harvester_cache_interval
+            farmer_api.farmer.update_harvester_cache_interval = 1
+            farmer_api.farmer.harvester_cache = {}
+
             # Test farmer get_harvesters
             async def test_get_harvesters():
                 farmer_res = await client.get_harvesters()
@@ -180,6 +185,10 @@ class TestRpc:
                 return True
 
             await time_out_assert(30, test_get_harvesters)
+
+            # Reset cache and reset update interval to avoid hitting the rate limit
+            farmer_api.farmer.update_harvester_cache_interval = update_interval_before
+            farmer_api.farmer.harvester_cache = {}
 
             expected_result: PlotRefreshResult = PlotRefreshResult()
 

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -28,7 +28,7 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_pooling_authentication_sk
 from tests.setup_nodes import bt, self_hostname, setup_farmer_harvester, test_constants
-from tests.time_out_assert import time_out_assert
+from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 
 log = logging.getLogger(__name__)
 
@@ -184,7 +184,7 @@ class TestRpc:
                     return False
                 return True
 
-            await time_out_assert(30, test_get_harvesters)
+            await time_out_assert_custom_interval(30, 1, test_get_harvesters)
 
             # Reset cache and reset update interval to avoid hitting the rate limit
             farmer_api.farmer.update_harvester_cache_interval = update_interval_before


### PR DESCRIPTION
This fails a lot on CI but i am not exactly sure yet whats going on that it fails. One guess is that the cache update happens before the harvester loaded its plots so that the next update won't happen in time so this PR forces an cache update and triggers extra harvester plot refreshing.