### PR TITLE
remove CoinStore's dependency on FullBlock

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -310,7 +310,15 @@ class Blockchain(BlockchainInterface):
                     tx_removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
                 else:
                     tx_removals, tx_additions = [], []
-                await self.coin_store.new_block(block, tx_additions, tx_removals)
+                if block.is_transaction_block():
+                    assert block.foliage_transaction_block is not None
+                    await self.coin_store.new_block(
+                        block.height,
+                        block.foliage_transaction_block.timestamp,
+                        block.get_included_reward_coins(),
+                        tx_additions,
+                        tx_removals,
+                    )
                 await self.block_store.set_peak(block_record.header_hash)
                 return uint32(0), uint32(0), [block_record]
             return None, None, []
@@ -362,7 +370,16 @@ class Blockchain(BlockchainInterface):
                         )
                     else:
                         tx_removals, tx_additions = await self.get_tx_removals_and_additions(fetched_full_block, None)
-                    await self.coin_store.new_block(fetched_full_block, tx_additions, tx_removals)
+
+                    if fetched_full_block.is_transaction_block():
+                        assert fetched_full_block.foliage_transaction_block is not None
+                        await self.coin_store.new_block(
+                            fetched_full_block.height,
+                            fetched_full_block.foliage_transaction_block.timestamp,
+                            fetched_full_block.get_included_reward_coins(),
+                            tx_additions,
+                            tx_removals,
+                        )
 
             # Changes the peak to be the new peak
             await self.block_store.set_peak(block_record.header_hash)


### PR DESCRIPTION
Just pass in the parts of the block necessary to add the block. Even though this is a net increase in lines of code (for now), it improves encapsulation of the CoinStore class and enables simpler tests of it. My main motivation is that it simplifies writing a benchmark for the `CoinStore` class, since I don't have to construct full blocks.

Here's Koan from Tony Van Eerd to further justify this:

> Master, I am honoured by your visit.
> I was out walking my dog. Your function, why does it take BigCommonStruct instead of just x and y?
> BCS is where we keep x and y, master.
> Bark
> He's hungry.
> Shall I prepare him food?
> No, just open the fridge, let him take what he wants.
> #CppKoan