### PR TITLE
configurable max message size

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -141,6 +141,7 @@ class WebSocketServer:
         self.net_config = load_config(root_path, "config.yaml")
         self.self_hostname = self.net_config["self_hostname"]
         self.daemon_port = self.net_config["daemon_port"]
+        self.daemon_max_message_size = self.net_config.get("daemon_max_message_size", 50 * 1000 * 1000)
         self.websocket_server = None
         self.ssl_context = ssl_context_for_server(ca_crt_path, ca_key_path, crt_path, key_path, log=self.log)
         self.shut_down = False
@@ -163,7 +164,7 @@ class WebSocketServer:
             self.safe_handle,
             self.self_hostname,
             self.daemon_port,
-            max_size=50 * 1000 * 1000,
+            max_size=self.daemon_max_message_size,
             ping_interval=500,
             ping_timeout=300,
             ssl=self.ssl_context,

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -4,6 +4,7 @@ min_mainnet_k_size: 32
 ping_interval: 120
 self_hostname: &self_hostname "localhost"
 daemon_port: 55400
+daemon_max_message_size: 50000000 # maximum size of RPC message in bytes
 inbound_rate_limit_percent: 100
 outbound_rate_limit_percent: 30
 


### PR DESCRIPTION
possible workaround for extremely large farms where reporting plot information exceeds the maximum message size currently hard-coded. This makes the size configurable in config.yaml
See #8061