### PR TITLE
truncate_to_significant_bits : Fix edge case with negative input

### DIFF
--- a/chia/util/significant_bits.py
+++ b/chia/util/significant_bits.py
@@ -6,7 +6,7 @@ def truncate_to_significant_bits(input_x: int, num_significant_bits: int) -> int
     """
     x = abs(input_x)
     if num_significant_bits > x.bit_length():
-        return x
+        return input_x
     lower = x.bit_length() - num_significant_bits
     mask = (1 << (x.bit_length())) - 1 - ((1 << lower) - 1)
     if input_x < 0:

--- a/tests/core/util/test_significant_bits.py
+++ b/tests/core/util/test_significant_bits.py
@@ -17,6 +17,8 @@ class TestSignificantBits(unittest.TestCase):
         assert truncate_to_significant_bits(a, 0) == 0b0
         a = 0b1000000111
         assert truncate_to_significant_bits(a, 500) == a
+        a = -0b1000000111
+        assert truncate_to_significant_bits(a, 500) == a
         a = 0b10101
         assert truncate_to_significant_bits(a, 5) == a
         a = 0b10101


### PR DESCRIPTION
If I'm understanding the code correctly, `truncate_to_significant_bits` when passed a negative `input_x`  and a `num_significant_bits` > `input_x.bit_length()` returns the absolute value of `input_x`, when it should return the original, negative value of `input_x`. This PR fixes this behavior and adds a new test case.