### PR TITLE
Improve and fix outdated messages in CLI.

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -118,7 +118,7 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
     if updated_target:
         print(
             f"To change the XCH destination addresses, edit the `xch_target_address` entries in"
-            f" {(new_root / 'config.yaml').absolute()}."
+            f" {(new_root / 'config' / 'config.yaml').absolute()}."
         )
 
     # Set the pool pks in the farmer

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -88,10 +88,14 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
             if all_targets[-1] == config["pool"].get("xch_target_address"):
                 stop_searching_for_pool = True
 
-    # Set the destinations
+    # Set the destinations, if necessary
+    updated_target: bool = False
     if "xch_target_address" not in config["farmer"]:
-        print(f"Setting the xch destination address for coinbase fees reward to {all_targets[0]}")
+        print(
+            f"Setting the xch destination for the farmer reward (1/8 plus fees, solo and pooling) to {all_targets[0]}"
+        )
         config["farmer"]["xch_target_address"] = all_targets[0]
+        updated_target = True
     elif config["farmer"]["xch_target_address"] not in all_targets:
         print(
             f"WARNING: using a farmer address which we don't have the private"
@@ -102,13 +106,19 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
     if "pool" not in config:
         config["pool"] = {}
     if "xch_target_address" not in config["pool"]:
-        print(f"Setting the xch destination address for coinbase reward to {all_targets[0]}")
+        print(f"Setting the xch destination address for pool reward (7/8 for solo only) to {all_targets[0]}")
         config["pool"]["xch_target_address"] = all_targets[0]
+        updated_target = True
     elif config["pool"]["xch_target_address"] not in all_targets:
         print(
             f"WARNING: using a pool address which we don't have the private"
             f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
             f"{config['pool']['xch_target_address']} with {all_targets[0]}"
+        )
+    if updated_target:
+        print(
+            f"To change the XCH destination addresses, edit the `xch_target_address` entries in"
+            f" {(new_root / 'config.yaml').absolute()}."
         )
 
     # Set the pool pks in the farmer

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -72,7 +72,7 @@ def show_all_keys(show_mnemonic: bool):
     if len(private_keys) == 0:
         print("There are no saved private keys")
         return None
-    msg = "Showing all public keys derived from your private keys:"
+    msg = "Showing all public keys derived from your master seed and private key:"
     if show_mnemonic:
         msg = "Showing all public and private keys"
     print(msg)


### PR DESCRIPTION
Previously (Before new consensus in late 2020), the name of the two coinbase coins were "fees coin" and "farmer coin". They are now "farmer coin" and "pool coin" respectively. Very confusing. 