### PR TITLE
Mypy issues on python 3.9.7

### DIFF
--- a/chia/cmds/start.py
+++ b/chia/cmds/start.py
@@ -5,7 +5,7 @@ from chia.util.service_groups import all_groups
 
 @click.command("start", short_help="Start service groups")
 @click.option("-r", "--restart", is_flag=True, type=bool, help="Restart running services")
-@click.argument("group", type=click.Choice(all_groups()), nargs=-1, required=True)
+@click.argument("group", type=click.Choice(list(all_groups())), nargs=-1, required=True)
 @click.pass_context
 def start_cmd(ctx: click.Context, restart: bool, group: str) -> None:
     import asyncio

--- a/chia/cmds/stop.py
+++ b/chia/cmds/stop.py
@@ -38,7 +38,7 @@ async def async_stop(root_path: Path, group: str, stop_daemon: bool) -> int:
 
 @click.command("stop", short_help="Stop services")
 @click.option("-d", "--daemon", is_flag=True, type=bool, help="Stop daemon")
-@click.argument("group", type=click.Choice(all_groups()), nargs=-1, required=True)
+@click.argument("group", type=click.Choice(list(all_groups())), nargs=-1, required=True)
 @click.pass_context
 def stop_cmd(ctx: click.Context, daemon: bool, group: str) -> None:
     import asyncio

--- a/run-py-tests.sh
+++ b/run-py-tests.sh
@@ -4,7 +4,6 @@ python3 -m venv venv
 # shellcheck disable=SC1091
 . ./activate
 pip3 install ".[dev]"
+mypy --install-types
 
-py.test ./tests/blockchain -s -v
-py.test ./tests/core -s -v
-py.test ./tests/wallet -s -v
+py.test ./tests -s -vtop

--- a/run-py-tests.sh
+++ b/run-py-tests.sh
@@ -6,4 +6,4 @@ python3 -m venv venv
 pip3 install ".[dev]"
 mypy --install-types
 
-py.test ./tests -s -vtop
+py.test ./tests -s -v

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ dev_dependencies = [
     "black",
     "aiohttp_cors",  # For blackd
     "ipython",  # For asyncio debugging
+    "types-setuptools",
 ]
 
 kwargs = dict(


### PR DESCRIPTION
Before this change, the following errors showed up on 3.9.7 when running mypy:

```
chia/__init__.py:1: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.9)
chia/__init__.py:1: note: Hint: "python3 -m pip install types-setuptools"
chia/__init__.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
chia/__init__.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
chia/util/config.py:7: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.9)
chia/util/config.py:8: error: Library stubs not installed for "yaml" (or incompatible with Python 3.9)
chia/wallet/puzzles/load_clvm.py:3: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.9)
chia/ssl/create_ssl.py:6: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.9)
chia/timelord/timelord_launcher.py:9: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.9)
tests/core/util/test_config.py:5: error: Library stubs not installed for "yaml" (or incompatible with Python 3.9)
chia/util/file_keyring.py:6: error: Library stubs not installed for "yaml" (or incompatible with Python 3.9)
chia/util/keychain.py:2: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.9)
chia/cmds/init_funcs.py:6: error: Library stubs not installed for "yaml" (or incompatible with Python 3.9)
chia/cmds/init_funcs.py:6: note: Hint: "python3 -m pip install types-PyYAML"
chia/cmds/stop.py:41: error: Argument 1 to "Choice" has incompatible type "KeysView[str]"; expected "Sequence[str]"
chia/cmds/start.py:8: error: Argument 1 to "Choice" has incompatible type "KeysView[str]"; expected "Sequence[str]"
Found 12 errors in 11 files (checked 415 source files)
```

Also, not all tests were being run with the script.
