### PR TITLE
Ms.full node race

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1623,6 +1623,9 @@ class FullNode:
     ) -> Tuple[Optional[Message], bool]:
 
         fetched_ss = self.full_node_store.get_sub_slot(request.end_of_slot_bundle.challenge_chain.get_hash())
+
+        # We are not interested in sub-slots which have the same challenge chain but different reward chain. If there
+        # is a reorg, we will find out through the broadcast of blocks instead.
         if fetched_ss is not None:
             # Already have the sub-slot
             return None, True

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -284,6 +284,14 @@ class FullNodeStore:
 
         if peak is not None and peak.total_iters > last_slot_iters:
             # Peak is in this slot
+
+            # Note: Adding an end of subslot does not lock the blockchain, for performance reasons. Only the
+            # timelord_lock is used. Therefore, it's possible that we add a new peak at the same time as seeing
+            # the finished subslot, and the peak is not fully added yet, so it looks like we still need the subslot.
+            # In that case, we will exit here, and let the new_peak code add the subslot.
+            if total_iters < peak.total_iters:
+                return None
+
             rc_challenge = eos.reward_chain.end_of_slot_vdf.challenge
             cc_start_element = peak.challenge_vdf_output
             iters = uint64(total_iters - peak.total_iters)

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -288,7 +288,7 @@ class FullNodeStore:
             # Note: Adding an end of subslot does not lock the blockchain, for performance reasons. Only the
             # timelord_lock is used. Therefore, it's possible that we add a new peak at the same time as seeing
             # the finished subslot, and the peak is not fully added yet, so it looks like we still need the subslot.
-            # In that case, we will exit here, and let the new_peak code add the subslot.
+            # In that case, we will exit here and let the new_peak code add the subslot.
             if total_iters < peak.total_iters:
                 return None
 

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -524,6 +524,44 @@ class TestFullNodeProtocol:
         )
 
     @pytest.mark.asyncio
+    async def test_respond_end_of_sub_slot_no_reorg(self, wallet_nodes):
+        full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
+
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
+        expected_requests = 0
+        if await full_node_1.full_node.synced():
+            expected_requests = 1
+        await time_out_assert(10, time_out_messages(incoming_queue, "request_mempool_transactions", expected_requests))
+
+        peer = await connect_and_get_peer(server_1, server_2)
+
+        # First get two blocks in the same sub slot
+        blocks = await full_node_1.get_all_full_blocks()
+        saved_seed = b""
+        for i in range(0, 9999999):
+            blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, skip_slots=1, seed=i.to_bytes(4, "big"))
+            if len(blocks[-1].finished_sub_slots) == 0:
+                saved_seed = i.to_bytes(4, "big")
+                break
+
+        # Then create a fork after the first block.
+        blocks_alt_1 = bt.get_consecutive_blocks(1, block_list_input=blocks[:-1], skip_slots=1)
+        for slot in blocks[-1].finished_sub_slots[:-2]:
+            await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
+
+        # Add all blocks
+        for block in blocks:
+            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
+
+        original_ss = full_node_1.full_node.full_node_store.finished_sub_slots[:]
+
+        # Add subslot for first alternative
+        for slot in blocks_alt_1[-1].finished_sub_slots:
+            await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
+
+        assert full_node_1.full_node.full_node_store.finished_sub_slots == original_ss
+
+    @pytest.mark.asyncio
     async def test_respond_unfinished(self, wallet_nodes):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 


### PR DESCRIPTION
The issue we were seeing in the race condition was an exception due to negative number, found by arvid.

```
Traceback (most recent call last):
  File "/home/arvid/dev/chia-blockchain/chia/server/server.py", line 559, in wrapped_coroutine
    result = await coroutine
  File "/home/arvid/dev/chia-blockchain/chia/full_node/full_node_api.py", line 624, in respond_end_of_sub_slot
    msg, _ = await self.full_node.respond_end_of_sub_slot(request, peer)
  File "/home/arvid/dev/chia-blockchain/chia/full_node/full_node.py", line 1659, in respond_end_of_sub_slot
    new_infusions = self.full_node_store.new_finished_sub_slot(
  File "/home/arvid/dev/chia-blockchain/chia/full_node/full_node_store.py", line 289, in new_finished_sub_slot
    iters = uint64(total_iters - peak.total_iters)
  File "/home/arvid/dev/chia-blockchain/chia/util/struct_stream.py", line 21, in __new__
    raise ValueError(
ValueError: Value -14071390 of size 24 does not fit into uint64 of size 64
```
This would cause a disconnect to the peer who sent this.
