### PR TITLE
Added harvesters info to farmer logging

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -626,7 +626,8 @@ class Farmer:
                         )
                 else:
                     self.log.error(
-                        "Harvester did not respond. You might need to update harvester to the latest version"
+                        f"Harvester '{connection.peer_host}/{connection.peer_node_id}' did not respond: "
+                        f"(version mismatch or time out {UPDATE_HARVESTER_CACHE_INTERVAL}s)"
                     )
         return updated
 

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -487,5 +487,6 @@ class FarmerAPI:
         )
 
     @api_request
-    async def respond_plots(self, _: harvester_protocol.RespondPlots):
-        self.farmer.log.warning("Respond plots came too late")
+    @peer_required
+    async def respond_plots(self, _: harvester_protocol.RespondPlots, peer: ws.WSChiaConnection):
+        self.farmer.log.warning(f"Respond plots came too late from: {peer.get_peer_logging()}")


### PR DESCRIPTION
Small updates to Farmer logging when something goes wrong with the harvesters - now includes the harvester peer information for improved troubleshooting of remote harvesters