### PR TITLE
In rare cases where os.replace fails, retry using shutil.move. 

### DIFF
--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -25,7 +25,7 @@ def create_default_chia_config(root_path: Path, filenames=["config.yaml"]) -> No
             f.write(default_config_file_data)
         try:
             os.replace(str(tmp_path), str(path))
-        except Exception:
+        except PermissionError:
             shutil.move(str(tmp_path), str(path))
 
 
@@ -43,7 +43,7 @@ def save_config(root_path: Path, filename: Union[str, Path], config_data: Any):
         yaml.safe_dump(config_data, f)
     try:
         os.replace(str(tmp_path), path)
-    except Exception:
+    except PermissionError:
         shutil.move(str(tmp_path), str(path))
 
 

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
@@ -22,7 +23,10 @@ def create_default_chia_config(root_path: Path, filenames=["config.yaml"]) -> No
         mkdir(path.parent)
         with open(tmp_path, "w") as f:
             f.write(default_config_file_data)
-        os.replace(str(tmp_path), str(path))
+        try:
+            os.replace(str(tmp_path), str(path))
+        except Exception:
+            shutil.move(str(tmp_path), str(path))
 
 
 def config_path_for_filename(root_path: Path, filename: Union[str, Path]) -> Path:
@@ -37,7 +41,10 @@ def save_config(root_path: Path, filename: Union[str, Path], config_data: Any):
     tmp_path: Path = path.with_suffix("." + str(os.getpid()))
     with open(tmp_path, "w") as f:
         yaml.safe_dump(config_data, f)
-    os.replace(str(tmp_path), path)
+    try:
+        os.replace(str(tmp_path), path)
+    except Exception:
+        shutil.move(str(tmp_path), str(path))
 
 
 def load_config(

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -1,6 +1,7 @@
 import base64
 import fasteners
 import os
+import shutil
 import sys
 import threading
 import yaml
@@ -432,7 +433,10 @@ class FileKeyring(FileSystemEventHandler):
         temp_path: Path = self.keyring_path.with_suffix("." + str(os.getpid()))
         with open(os.open(str(temp_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600), "w") as f:
             _ = yaml.safe_dump(data, f)
-        os.replace(str(temp_path), self.keyring_path)
+        try:
+            os.replace(str(temp_path), self.keyring_path)
+        except Exception:
+            shutil.move(str(temp_path), str(self.keyring_path))
 
     def prepare_for_migration(self):
         if not self.payload_cache:

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -435,7 +435,7 @@ class FileKeyring(FileSystemEventHandler):
             _ = yaml.safe_dump(data, f)
         try:
             os.replace(str(temp_path), self.keyring_path)
-        except Exception:
+        except PermissionError:
             shutil.move(str(temp_path), str(self.keyring_path))
 
     def prepare_for_migration(self):


### PR DESCRIPTION
Some Windows installs were seeing test failures when writing to the keyring and then moving the keyring using os.replace(). Windows would raise the following exception:

PermissionError: [WinError 5] Access is denied: <src path> <dst path>

We'll now catch the exception and retry using shutil.move(), which was the method used previously.