### PR TITLE
Remove flaky mtime check for plots

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -272,8 +272,14 @@ class PlotManager:
                 except Exception as e:
                     log.error(f"Failed to open file {file_path}. {e}")
                     return None
-                if stat_info.st_mtime == self.plots[file_path].time_modified:
-                    return self.plots[file_path]
+                if stat_info.st_mtime != self.plots[file_path].time_modified:
+                    log.info(
+                        f"Ignoring modification time mismatch for {file_path}: "
+                        f"({stat_info.st_mtime}) vs ({self.plots[file_path].time_modified})"
+                    )
+
+                return self.plots[file_path]
+
             entry: Optional[Tuple[str, Set[str]]] = self.plot_filename_paths.get(file_path.name)
             if entry is not None:
                 loaded_parent, duplicates = entry

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -266,18 +266,8 @@ class PlotManager:
             ):
                 # Try once every `refresh_parameter.retry_invalid_seconds` seconds to open the file
                 return None
-            if file_path in self.plots:
-                try:
-                    stat_info = file_path.stat()
-                except Exception as e:
-                    log.error(f"Failed to open file {file_path}. {e}")
-                    return None
-                if stat_info.st_mtime != self.plots[file_path].time_modified:
-                    log.info(
-                        f"Ignoring modification time mismatch for {file_path}: "
-                        f"({stat_info.st_mtime}) vs ({self.plots[file_path].time_modified})"
-                    )
 
+            if file_path in self.plots:
                 return self.plots[file_path]
 
             entry: Optional[Tuple[str, Set[str]]] = self.plot_filename_paths.get(file_path.name)


### PR DESCRIPTION
I suspect this may be the cause for #8562 - creating PR to generate installers for testing