### PR TITLE
20210923 clvm tools rs

### DIFF
--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -30,7 +30,7 @@ if 'CLVM_TOOLS_RS' in os.environ:
 
         def rust_compile_clvm(full_path, output, search_paths=[]):
             treated_include_paths = list(map(translate_path, search_paths))
-            print('compile_clvm_rs',full_path, output, treated_include_paths)
+            print('compile_clvm_rs', full_path, output, treated_include_paths)
             compile_clvm_rs(str(full_path), str(output), treated_include_paths)
 
             if os.environ['CLVM_TOOLS_RS'] == 'check':
@@ -47,6 +47,7 @@ if 'CLVM_TOOLS_RS' in os.environ:
         compile_clvm = rust_compile_clvm
     finally:
         pass
+
 
 def load_serialized_clvm(clvm_filename, package_or_requirement=__name__) -> SerializedProgram:
     """

--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -1,3 +1,5 @@
+import importlib
+import inspect
 import os
 import pathlib
 
@@ -21,8 +23,6 @@ if 'CLVM_TOOLS_RS' in os.environ:
             if os.path.isdir(p):
                 return p
             else:
-                import importlib
-                import inspect
                 module_object = importlib.import_module(p)
                 return os.path.dirname(inspect.getfile(module_object))
 
@@ -42,8 +42,9 @@ if 'CLVM_TOOLS_RS' in os.environ:
                     print("Aborting compilation due to mismatch with rust")
                     assert orig256 == rs256
 
+
         compile_clvm = rust_compile_clvm
-    except:
+    except as _:
         pass
 
 from chia.types.blockchain_format.program import Program, SerializedProgram

--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -5,9 +5,11 @@ import pathlib
 
 import pkg_resources
 from clvm_tools.clvmc import compile_clvm as compile_clvm_py
+from chia.types.blockchain_format.program import Program, SerializedProgram
 
 compile_clvm = compile_clvm_py
 
+# Handle optional use of clvm_tools_rs if available and requested
 if 'CLVM_TOOLS_RS' in os.environ:
     try:
         def sha256file(f):
@@ -28,7 +30,7 @@ if 'CLVM_TOOLS_RS' in os.environ:
 
         def rust_compile_clvm(full_path, output, search_paths=[]):
             treated_include_paths = list(map(translate_path, search_paths))
-            print('compile_clvm_rs',full_path,output,treated_include_paths)
+            print('compile_clvm_rs',full_path, output, treated_include_paths)
             compile_clvm_rs(str(full_path), str(output), treated_include_paths)
 
             if os.environ['CLVM_TOOLS_RS'] == 'check':
@@ -42,12 +44,9 @@ if 'CLVM_TOOLS_RS' in os.environ:
                     print("Aborting compilation due to mismatch with rust")
                     assert orig256 == rs256
 
-
         compile_clvm = rust_compile_clvm
     finally:
         pass
-
-from chia.types.blockchain_format.program import Program, SerializedProgram
 
 def load_serialized_clvm(clvm_filename, package_or_requirement=__name__) -> SerializedProgram:
     """

--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -44,7 +44,7 @@ if 'CLVM_TOOLS_RS' in os.environ:
 
 
         compile_clvm = rust_compile_clvm
-    except as _:
+    finally:
         pass
 
 from chia.types.blockchain_format.program import Program, SerializedProgram

--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -16,8 +16,19 @@ if 'CLVM_TOOLS_RS' in os.environ:
 
         from clvm_tools_rs import compile_clvm as compile_clvm_rs
 
+        def translate_path(p_):
+            p = str(p_)
+            if os.path.isdir(p):
+                return p
+            else:
+                import importlib
+                import inspect
+                module_object = importlib.import_module(p)
+                return os.path.dirname(inspect.getfile(module_object))
+
         def rust_compile_clvm(full_path, output, search_paths=[]):
-            treated_include_paths = list(map(lambda x: str(x), search_paths))
+            treated_include_paths = list(map(translate_path, search_paths))
+            print('compile_clvm_rs',full_path,output,treated_include_paths)
             compile_clvm_rs(str(full_path), str(output), treated_include_paths)
 
             if os.environ['CLVM_TOOLS_RS'] == 'check':

--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -10,12 +10,14 @@ from chia.types.blockchain_format.program import Program, SerializedProgram
 compile_clvm = compile_clvm_py
 
 # Handle optional use of clvm_tools_rs if available and requested
-if 'CLVM_TOOLS_RS' in os.environ:
+if "CLVM_TOOLS_RS" in os.environ:
     try:
+
         def sha256file(f):
             import hashlib
+
             m = hashlib.sha256()
-            m.update(open(f).read().encode('utf8'))
+            m.update(open(f).read().encode("utf8"))
             return m.hexdigest()
 
         from clvm_tools_rs import compile_clvm as compile_clvm_rs
@@ -30,11 +32,11 @@ if 'CLVM_TOOLS_RS' in os.environ:
 
         def rust_compile_clvm(full_path, output, search_paths=[]):
             treated_include_paths = list(map(translate_path, search_paths))
-            print('compile_clvm_rs', full_path, output, treated_include_paths)
+            print("compile_clvm_rs", full_path, output, treated_include_paths)
             compile_clvm_rs(str(full_path), str(output), treated_include_paths)
 
-            if os.environ['CLVM_TOOLS_RS'] == 'check':
-                orig = str(output) + '.orig'
+            if os.environ["CLVM_TOOLS_RS"] == "check":
+                orig = str(output) + ".orig"
                 compile_clvm_py(full_path, orig, search_paths=search_paths)
                 orig256 = sha256file(orig)
                 rs256 = sha256file(output)


### PR DESCRIPTION
This allows optional use of clvm_tools_rs in chia-blockchain, and is off by default.

If clvm_tools_rs is installed in your python environment via maturin, you can set

    CLVM_TOOLS_RS=true

to use clvm_tools_rs' chialisp compiler rather than the python one.  If something seems to go wrong, you can use

    CLVM_TOOLS_RS=check

to compile with both and check the hashes.  an assertion will fail if their output is different before anything else happens.  Make sure to delete the .hex files in chia/wallet/puzzles first.