### PR TITLE
remove unnecessary index in CoinStore & add additional benchmarks 

### DIFF
--- a/benchmarks/coin_store.py
+++ b/benchmarks/coin_store.py
@@ -3,7 +3,7 @@ import random
 from time import time
 from pathlib import Path
 from chia.full_node.coin_store import CoinStore
-from typing import List
+from typing import List, Tuple
 import os
 import sys
 
@@ -13,10 +13,13 @@ from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.coin import Coin
-from chia.util.ints import uint64
+from chia.util.ints import uint64, uint32
 
 
 NUM_ITERS = 200
+
+# farmer puzzle hash
+ph = bytes32(b"a" * 32)
 
 
 async def setup_db() -> DBWrapper:
@@ -39,46 +42,57 @@ def make_coin() -> Coin:
     return Coin(rand_hash(), rand_hash(), uint64(1))
 
 
+def make_coins(num: int) -> Tuple[List[Coin], List[bytes32]]:
+    additions: List[Coin] = []
+    hashes: List[bytes32] = []
+    for i in range(num):
+        c = make_coin()
+        additions.append(c)
+        hashes.append(c.get_hash())
+
+    return additions, hashes
+
+
+def rewards(height: uint32) -> Tuple[Coin, Coin]:
+    farmer_coin = create_farmer_coin(height, ph, uint64(250000000), DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
+    pool_coin = create_pool_coin(height, ph, uint64(1750000000), DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
+    return farmer_coin, pool_coin
+
+
 async def run_new_block_benchmark():
 
     db_wrapper: DBWrapper = await setup_db()
 
     try:
         coin_store = await CoinStore.create(db_wrapper)
-        # farmer puzzle hash
-        ph = bytes32(b"a" * 32)
 
-        all_added: List[bytes32] = []
+        all_unspent: List[bytes32] = []
+        all_coins: List[bytes32] = []
 
         block_height = 1
         timestamp = 1631794488
 
         print("Building database ", end="")
         for height in range(block_height, block_height + NUM_ITERS):
-            additions = []
-            removals = []
 
             # add some new coins
-            for i in range(2000):
-                c = make_coin()
-                additions.append(c)
-                all_added.append(c.get_hash())
+            additions, hashes = make_coins(2000)
 
             # farm rewards
-            farmer_coin = create_farmer_coin(height, ph, 250000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            pool_coin = create_pool_coin(height, ph, 1750000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            reward_coins = [pool_coin, farmer_coin]
-            all_added += [pool_coin.name(), farmer_coin.name()]
+            farmer_coin, pool_coin = rewards(height)
+            all_coins += hashes
+            all_unspent += hashes
+            all_unspent += [pool_coin.name(), farmer_coin.name()]
 
             # remove some coins we've added previously
-            random.shuffle(all_added)
-            removals = all_added[:100]
-            all_added = all_added[100:]
+            random.shuffle(all_unspent)
+            removals = all_unspent[:100]
+            all_unspent = all_unspent[100:]
 
             await coin_store.new_block(
                 height,
                 timestamp,
-                set(reward_coins),
+                set([pool_coin, farmer_coin]),
                 additions,
                 removals,
             )
@@ -96,33 +110,28 @@ async def run_new_block_benchmark():
         total_remove = 0
         print("\nProfiling mostly additions ", end="")
         for height in range(block_height, block_height + NUM_ITERS):
-            additions = []
-            removals = []
 
             # add some new coins
-            for i in range(2000):
-                c = make_coin()
-                additions.append(c)
-                all_added.append(c.get_hash())
+            additions, hashes = make_coins(2000)
             total_add += 2000
 
-            farmer_coin = create_farmer_coin(height, ph, 250000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            pool_coin = create_pool_coin(height, ph, 1750000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            reward_coins = [pool_coin, farmer_coin]
-            all_added += [pool_coin.name(), farmer_coin.name()]
+            farmer_coin, pool_coin = rewards(height)
+            all_coins += hashes
+            all_unspent += hashes
+            all_unspent += [pool_coin.name(), farmer_coin.name()]
             total_add += 2
 
             # remove some coins we've added previously
-            random.shuffle(all_added)
-            removals = all_added[:100]
-            all_added = all_added[100:]
+            random.shuffle(all_unspent)
+            removals = all_unspent[:100]
+            all_unspent = all_unspent[100:]
             total_remove += 100
 
             start = time()
             await coin_store.new_block(
                 height,
                 timestamp,
-                set(reward_coins),
+                set([pool_coin, farmer_coin]),
                 additions,
                 removals,
             )
@@ -146,31 +155,29 @@ async def run_new_block_benchmark():
         total_time = 0
         for height in range(block_height, block_height + NUM_ITERS):
             additions = []
-            removals = []
 
             # add one new coins
             c = make_coin()
             additions.append(c)
-            all_added.append(c.get_hash())
             total_add += 1
 
-            farmer_coin = create_farmer_coin(height, ph, 250000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            pool_coin = create_pool_coin(height, ph, 1750000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            reward_coins = [pool_coin, farmer_coin]
-            all_added += [pool_coin.name(), farmer_coin.name()]
+            farmer_coin, pool_coin = rewards(height)
+            all_coins += [c.get_hash()]
+            all_unspent += [c.get_hash()]
+            all_unspent += [pool_coin.name(), farmer_coin.name()]
             total_add += 2
 
             # remove some coins we've added previously
-            random.shuffle(all_added)
-            removals = all_added[:700]
-            all_added = all_added[700:]
+            random.shuffle(all_unspent)
+            removals = all_unspent[:700]
+            all_unspent = all_unspent[700:]
             total_remove += 700
 
             start = time()
             await coin_store.new_block(
                 height,
                 timestamp,
-                set(reward_coins),
+                set([pool_coin, farmer_coin]),
                 additions,
                 removals,
             )
@@ -194,33 +201,28 @@ async def run_new_block_benchmark():
         total_remove = 0
         total_time = 0
         for height in range(block_height, block_height + NUM_ITERS):
-            additions = []
-            removals = []
 
             # add some new coins
-            for i in range(2000):
-                c = make_coin()
-                additions.append(c)
-                all_added.append(c.get_hash())
+            additions, hashes = make_coins(2000)
             total_add += 2000
 
-            farmer_coin = create_farmer_coin(height, ph, 250000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            pool_coin = create_pool_coin(height, ph, 1750000000, DEFAULT_CONSTANTS.GENESIS_CHALLENGE)
-            reward_coins = [pool_coin, farmer_coin]
-            all_added += [pool_coin.name(), farmer_coin.name()]
+            farmer_coin, pool_coin = rewards(height)
+            all_coins += hashes
+            all_unspent += hashes
+            all_unspent += [pool_coin.name(), farmer_coin.name()]
             total_add += 2
 
             # remove some coins we've added previously
-            random.shuffle(all_added)
-            removals = all_added[:2000]
-            all_added = all_added[2000:]
+            random.shuffle(all_unspent)
+            removals = all_unspent[:2000]
+            all_unspent = all_unspent[2000:]
             total_remove += 2000
 
             start = time()
             await coin_store.new_block(
                 height,
                 timestamp,
-                set(reward_coins),
+                set([pool_coin, farmer_coin]),
                 additions,
                 removals,
             )
@@ -234,7 +236,61 @@ async def run_new_block_benchmark():
             print(".", end="")
             sys.stdout.flush()
 
+        block_height += NUM_ITERS
+
         print(f"\nFULLBLOCKS, time: {total_time:0.4f}s additions: {total_add} removals: {total_remove}")
+
+        print("profiling get_coin_records_by_names, include_spent ", end="")
+        total_time = 0
+        found_coins = 0
+        for i in range(NUM_ITERS):
+            lookup = random.sample(all_coins, 200)
+            start = time()
+            records = await coin_store.get_coin_records_by_names(True, lookup)
+            total_time += time() - start
+            assert len(records) == 200
+            found_coins += len(records)
+            print(".", end="")
+            sys.stdout.flush()
+
+        print(
+            f"\nGET RECORDS BY NAMES with spent, time: {total_time:0.4f}s {NUM_ITERS} "
+            f"lookups found {found_coins} coins in total"
+        )
+
+        print("profiling get_coin_records_by_names, without spent coins ", end="")
+        total_time = 0
+        found_coins = 0
+        for i in range(NUM_ITERS):
+            lookup = random.sample(all_coins, 200)
+            start = time()
+            records = await coin_store.get_coin_records_by_names(False, lookup)
+            total_time += time() - start
+            assert len(records) <= 200
+            found_coins += len(records)
+            print(".", end="")
+            sys.stdout.flush()
+
+        print(
+            f"\nGET RECORDS BY NAMES without spent, time: {total_time:0.4f}s {NUM_ITERS} "
+            f"lookups found {found_coins} coins in total"
+        )
+
+        print("profiling get_coin_removed_at_height ", end="")
+        total_time = 0
+        found_coins = 0
+        for i in range(1, block_height):
+            start = time()
+            records = await coin_store.get_coins_removed_at_height(i)
+            total_time += time() - start
+            found_coins += len(records)
+            print(".", end="")
+            sys.stdout.flush()
+
+        print(
+            f"\nGET COINS REMOVED AT HEIGHT, time: {total_time:0.4f}s {block_height-1} blocks, "
+            f"found {found_coins} coins in total"
+        )
 
     finally:
         await db_wrapper.db.close()

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -55,7 +55,10 @@ class CoinStore:
 
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent_index on coin_record(spent_index)")
 
-        await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent on coin_record(spent)")
+        # earlier versions of chia created this index despite no lookups needing
+        # it. For now, just don't create it for new installs. In the future we
+        # may remove the index from existing installations as well
+        # await self.coin_record_db.execute("DROP INDEX IF EXISTS coin_spent")
 
         await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_puzzle_hash on coin_record(puzzle_hash)")
 


### PR DESCRIPTION
this extends the benchmark a bit and improves performance by deleting an unused index in the sqlite coin store table.

As far as I can tell there are no queries that requires an index on whether a coin is spent or not. In fact, the mere existence of this index made the query planner mistakenly use it, causing a significant performance issue (as demonstrated by the benchmark).

My main attempt with this patch was to improve insertion performance, by removing the index and thus reducing the amount of work for insertions. This had a small effect in insertion performance, but more noticeable impact on the lookup speed of coins by name, excluding spent coins. The problem was (presumably) that sqlite chose to use the `coin_spent`  index *first*, followed by looking up the coin ID. By removing the index, the query instead looks up the coin ID first, and then discards it if the coin is spent, this is significantly faster.

I ran this benchmark on a fast machine with an SSD (Apple M1) as well as an older machine with spinning disk (Ubuntu amd64).

# summary

* `get_records_by_name()` filtering spent coins improved from 49s -> 2s on SSD and from 70s -> 1s on HDD. This is most likely due to the query planner using the wrong index.
* On SSD the additions timings improved somewhat. from 35s -> 30s

# SSD

Before:

```
MOSTLY ADDITIONS, time: 35.6544s additions: 400400 removals: 20000
MOSTLY REMOVALS, time: 8.8911s additions: 600 removals: 140000
FULLBLOCKS, time: 69.9725s additions: 400400 removals: 400000
GET RECORDS BY NAMES with spent, time: 0.7952s 200 lookups found 40000 coins in total
GET RECORDS BY NAMES without spent, time: 49.0541s 200 lookups found 20747 coins in total
GET COINS REMOVED AT HIGHT, time: 15.5742s 800 blocks, found 580000 coins in total
```

After:

```
MOSTLY ADDITIONS, time: 29.9418s additions: 400400 removals: 20000
MOSTLY REMOVALS, time: 10.9705s additions: 600 removals: 140000
FULLBLOCKS, time: 54.4167s additions: 400400 removals: 400000
GET RECORDS BY NAMES with spent, time: 0.9823s 200 lookups found 40000 coins in total
GET RECORDS BY NAMES without spent, time: 2.0775s 200 lookups found 20773 coins in total
GET COINS REMOVED AT HIGHT, time: 15.3979s 800 blocks, found 580000 coins in total
```

# Spinning disk

Before:

```
MOSTLY ADDITIONS, time: 51.8249s additions: 400400 removals: 20000
MOSTLY REMOVALS, time: 6.6823s additions: 600 removals: 140000
FULLBLOCKS, time: 76.4455s additions: 400400 removals: 400000
GET RECORDS BY NAMES with spent, time: 1.2238s 200 lookups found 40000 coins in total
GET RECORDS BY NAMES without spent, time: 70.1104s 200 lookups found 20730 coins in total
GET COINS REMOVED AT HIGHT, time: 22.4741s 800 blocks, found 580000 coins in total
```

After:

```
MOSTLY ADDITIONS, time: 51.6045s additions: 400400 removals: 20000
MOSTLY REMOVALS, time: 4.5481s additions: 600 removals: 140000
FULLBLOCKS, time: 71.1832s additions: 400400 removals: 400000
GET RECORDS BY NAMES with spent, time: 1.2226s 200 lookups found 40000 coins in total
GET RECORDS BY NAMES without spent, time: 0.9238s 200 lookups found 20732 coins in total
GET COINS REMOVED AT HEIGHT, time: 22.4992s 800 blocks, found 580000 coins in total
```