### PR TITLE
Catch errors in the build script for intel mac (match m1 script)

### DIFF
--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -euo pipefail
+
 pip install setuptools_scm
 # The environment variable CHIA_INSTALLER_VERSION needs to be defined.
 # If the env variable NOTARIZE and the username and password variables are


### PR DESCRIPTION
When notarization failed on Azure for the last release, the script kept going. This updates the script to be inline with error catching from m1 script, and should solve that problem.