### PR TITLE
azure|build_macos: Always export `NOTARIZE` and check its value

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,8 @@ steps:
       export APPLE_NOTARIZE_USERNAME
       APPLE_NOTARIZE_PASSWORD="$(APPLE_NOTARIZE_PASSWORD)"
       export APPLE_NOTARIZE_PASSWORD
-      if [ "$(APPLE_NOTARIZE_PASSWORD)" ]; then NOTARIZE="true"; export NOTARIZE; fi
+      if [ "$(APPLE_NOTARIZE_PASSWORD)" ]; then NOTARIZE="true"; else NOTARIZE="false"; fi
+      export NOTARIZE
       cd build_scripts || exit
       sh build_macos.sh
     displayName: "Build DMG with build_scripts/build_macos.sh"

--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -65,7 +65,7 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 	exit $LAST_EXIT_CODE
 fi
 
-if [ "$NOTARIZE" ]; then
+if [ "$NOTARIZE" == true ]; then
   electron-osx-sign Chia-darwin-x64/Chia.app --platform=darwin \
   --hardened-runtime=true --provisioning-profile=chiablockchain.provisionprofile \
   --entitlements=entitlements.mac.plist --entitlements-inherit=entitlements.mac.plist \
@@ -91,7 +91,7 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 	exit $LAST_EXIT_CODE
 fi
 
-if [ "$NOTARIZE" ]; then
+if [ "$NOTARIZE" == true ]; then
 	echo "Notarize $DMG_NAME on ci"
 	cd final_installer || exit
   notarize-cli --file=$DMG_NAME --bundle-id net.chia.blockchain \


### PR DESCRIPTION
This *should* fix failures like 
https://dev.azure.com/chianetwork/Build%20MacOS%20Mojave%20chia-blockchain/_build/results?buildId=15533&view=logs&j=69944193-f126-526b-b021-abb6fb4b38ee&t=fa98ba94-cfb8-59e8-e95b-1eee1a49caed&l=906