### PR TITLE
make synchronous mode in sqlite database connections configurable

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -62,6 +62,7 @@ from chia.util.path import mkdir, path_from_root
 from chia.util.safe_cancel_task import cancel_task_safe
 from chia.util.profiler import profile_task
 from datetime import datetime
+from chia.util.db_synchronous import db_synchronous_on
 
 
 class FullNode:
@@ -131,7 +132,12 @@ class FullNode:
         # create the store (db) and full node instance
         self.connection = await aiosqlite.connect(self.db_path)
         await self.connection.execute("pragma journal_mode=wal")
-        await self.connection.execute("pragma synchronous=OFF")
+
+        if db_synchronous_on(self.config.get("db_sync", "auto"), self.db_path):
+            await self.connection.execute("pragma synchronous=NORMAL")
+        else:
+            await self.connection.execute("pragma synchronous=OFF")
+
         if self.config.get("log_sqlite_cmds", False):
             sql_log_path = path_from_root(self.root_path, "log/sql.log")
             self.log.info(f"logging SQL commands to {sql_log_path}")

--- a/chia/util/db_synchronous.py
+++ b/chia/util/db_synchronous.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+def db_synchronous_on(setting: str, db_path: Path) -> bool:
+    if setting == "on":
+        return True
+    if setting == "off":
+        return False
+
+    # for now, default to synchronous=NORMAL mode. This can be made more
+    # sohpisticated in the future. There are still material performance
+    # improvements to be had in cases where the risks are low.
+
+    # e.g.
+    # type = GetDriveTypeW(db_path)
+    # if type == DRIVE_FIXED or type == DRIVE_RAMDISK:
+    #     return False
+
+    return True

--- a/chia/util/db_synchronous.py
+++ b/chia/util/db_synchronous.py
@@ -8,7 +8,7 @@ def db_synchronous_on(setting: str, db_path: Path) -> bool:
         return False
 
     # for now, default to synchronous=NORMAL mode. This can be made more
-    # sohpisticated in the future. There are still material performance
+    # sophisticated in the future. There are still material performance
     # improvements to be had in cases where the risks are low.
 
     # e.g.

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -255,6 +255,16 @@ full_node:
   # The full node server (if run) will run on this port
   port: 8444
 
+  # controls the sync-to-disk behavior of the database connection. Can be one of:
+  # "on"    enables syncing to disk, minimizes risk of corrupting the DB in
+  #         power-loss, disk failure or kernel panics
+  # "off"   disables syncing, lightens disk load and improves performance.
+  #         increases risk of corrupting DB in power-loss, disk failure or
+  #         kernel panics
+  # "auto"  on/off is decided based on a heuristic of how likely a failure is on
+  #         the particular system we're running on
+  db_sync: auto
+
   # Run multiple nodes with different databases by changing the database_path
   database_path: db/blockchain_v1_CHALLENGE.sqlite
   peer_db_path: db/peer_table_node.sqlite
@@ -378,6 +388,9 @@ wallet:
   rpc_port: 9256
 
   enable_profiler: False
+
+  # see description for full_node.db_sync
+  db_fsync: auto
 
   # The minimum height that we care about for our transactions. Set to zero
   # If we are restoring from private key and don't know the height.

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -390,7 +390,7 @@ wallet:
   enable_profiler: False
 
   # see description for full_node.db_sync
-  db_fsync: auto
+  db_sync: auto
 
   # The minimum height that we care about for our transactions. Set to zero
   # If we are restoring from private key and don't know the height.


### PR DESCRIPTION
Default to enabling synchronous mode, leaving the door open for a more sophisticated heuristic in the future