### PR TITLE
plotting|harvester|tests: Drop some parts of `PlotRefreshResult`

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -79,7 +79,6 @@ class Harvester:
     def _plot_refresh_callback(self, update_result: PlotRefreshResult):
         self.log.info(
             f"refresh_batch: loaded_plots {update_result.loaded_plots}, "
-            f"loaded_size {update_result.loaded_size / (1024 ** 4):.2f} TiB, "
             f"removed_plots {update_result.removed_plots}, processed_plots {update_result.processed_files}, "
             f"remaining_plots {update_result.remaining_files}, "
             f"duration: {update_result.duration:.2f} seconds"

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -78,12 +78,12 @@ class Harvester:
 
     def _plot_refresh_callback(self, update_result: PlotRefreshResult):
         self.log.info(
-            f"refresh_batch: loaded_plots {update_result.loaded_plots}, "
-            f"removed_plots {update_result.removed_plots}, processed_plots {update_result.processed_files}, "
-            f"remaining_plots {update_result.remaining_files}, "
+            f"refresh_batch: loaded {update_result.loaded}, "
+            f"removed {update_result.removed}, processed {update_result.processed}, "
+            f"remaining {update_result.remaining}, "
             f"duration: {update_result.duration:.2f} seconds"
         )
-        if update_result.loaded_plots > 0:
+        if update_result.loaded > 0:
             self.event_loop.call_soon_threadsafe(self._state_changed, "plots")
 
     def on_disconnect(self, connection: ws.WSChiaConnection):

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 def plot_refresh_callback(refresh_result: PlotRefreshResult):
-    log.info(f"loaded {refresh_result.loaded_plots} plots, {refresh_result.remaining_files} remaining")
+    log.info(f"loaded {refresh_result.loaded} plots, {refresh_result.remaining} remaining")
 
 
 def check_plots(root_path, num, challenge_start, grep_string, list_duplicates, debug_show_memo):

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -227,7 +227,7 @@ class PlotManager:
                 batch_result: PlotRefreshResult = self.refresh_batch(plot_paths, plot_directories)
                 total_result += batch_result
                 self._refresh_callback(batch_result)
-                if batch_result.remaining_files == 0:
+                if batch_result.remaining == 0:
                     break
                 batch_sleep = self.refresh_parameter.batch_sleep_milliseconds
                 self.log.debug(f"refresh_plots: Sleep {batch_sleep} milliseconds")
@@ -245,8 +245,8 @@ class PlotManager:
             self.last_refresh_time = time.time()
 
             self.log.debug(
-                f"_refresh_task: total_result.loaded_plots {total_result.loaded_plots}, "
-                f"total_result.removed_plots {total_result.removed_plots}, "
+                f"_refresh_task: total_result.loaded {total_result.loaded}, "
+                f"total_result.removed {total_result.removed}, "
                 f"total_duration {total_result.duration:.2f} seconds"
             )
 
@@ -289,10 +289,10 @@ class PlotManager:
                     return None
             try:
                 with counter_lock:
-                    if result.processed_files >= self.refresh_parameter.batch_size:
-                        result.remaining_files += 1
+                    if result.processed >= self.refresh_parameter.batch_size:
+                        result.remaining += 1
                         return None
-                    result.processed_files += 1
+                    result.processed += 1
 
                 prover = DiskProver(str(file_path))
 
@@ -371,7 +371,7 @@ class PlotManager:
                 )
 
                 with counter_lock:
-                    result.loaded_plots += 1
+                    result.loaded += 1
 
                 if file_path in self.failed_to_open_filenames:
                     del self.failed_to_open_filenames[file_path]
@@ -406,7 +406,7 @@ class PlotManager:
                     loaded_path, duplicated_paths = paths_entry
                     if plot_removed(Path(loaded_path) / Path(plot_filename)):
                         filenames_to_remove.append(plot_filename)
-                        result.removed_plots += 1
+                        result.removed += 1
                         # No need to check the duplicates here since we drop the whole entry
                         continue
 
@@ -414,7 +414,7 @@ class PlotManager:
                     for path in duplicated_paths:
                         if plot_removed(Path(path) / Path(plot_filename)):
                             paths_to_remove.append(path)
-                            result.removed_plots += 1
+                            result.removed += 1
                     for path in paths_to_remove:
                         duplicated_paths.remove(path)
 
@@ -430,9 +430,9 @@ class PlotManager:
         result.duration = time.time() - start_time
 
         self.log.debug(
-            f"refresh_batch: loaded_plots {result.loaded_plots}, "
-            f"removed_plots {result.removed_plots}, processed_plots {result.processed_files}, "
-            f"remaining_plots {result.remaining_files}, batch_size {self.refresh_parameter.batch_size}, "
+            f"refresh_batch: loaded {result.loaded}, "
+            f"removed {result.removed}, processed {result.processed}, "
+            f"remaining {result.remaining}, batch_size {self.refresh_parameter.batch_size}, "
             f"duration: {result.duration:.2f} seconds"
         )
         return result

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -225,7 +225,11 @@ class PlotManager:
             total_result: PlotRefreshResult = PlotRefreshResult()
             while self.needs_refresh() and self._refreshing_enabled:
                 batch_result: PlotRefreshResult = self.refresh_batch(plot_paths, plot_directories)
-                total_result += batch_result
+                total_result.loaded += batch_result.loaded
+                total_result.removed += batch_result.removed
+                total_result.processed += batch_result.processed
+                total_result.remaining = batch_result.remaining
+                total_result.duration += batch_result.duration
                 self._refresh_callback(batch_result)
                 if batch_result.remaining == 0:
                     break

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -247,7 +247,6 @@ class PlotManager:
             self.log.debug(
                 f"_refresh_task: total_result.loaded_plots {total_result.loaded_plots}, "
                 f"total_result.removed_plots {total_result.removed_plots}, "
-                f"total_result.loaded_size {total_result.loaded_size / (1024 ** 4):.2f} TiB, "
                 f"total_duration {total_result.duration:.2f} seconds"
             )
 
@@ -373,7 +372,6 @@ class PlotManager:
 
                 with counter_lock:
                     result.loaded_plots += 1
-                    result.loaded_size += stat_info.st_size
 
                 if file_path in self.failed_to_open_filenames:
                     del self.failed_to_open_filenames[file_path]
@@ -433,7 +431,6 @@ class PlotManager:
 
         self.log.debug(
             f"refresh_batch: loaded_plots {result.loaded_plots}, "
-            f"loaded_size {result.loaded_size / (1024 ** 4):.2f} TiB, "
             f"removed_plots {result.removed_plots}, processed_plots {result.processed_files}, "
             f"remaining_plots {result.remaining_files}, batch_size {self.refresh_parameter.batch_size}, "
             f"duration: {result.duration:.2f} seconds"

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -39,15 +39,6 @@ class PlotRefreshResult:
     remaining: int = 0
     duration: float = 0
 
-    def __add__(self, other):
-        result: PlotRefreshResult = PlotRefreshResult()
-        result.loaded = self.loaded + other.loaded
-        result.removed = self.removed + other.removed
-        result.processed = self.processed + other.processed
-        result.remaining = other.remaining
-        result.duration = self.duration + other.duration
-        return result
-
 
 def get_plot_directories(root_path: Path, config: Dict = None) -> List[str]:
     if config is None:

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -34,7 +34,6 @@ class PlotInfo:
 @dataclass
 class PlotRefreshResult:
     loaded_plots: int = 0
-    loaded_size: float = 0
     removed_plots: int = 0
     processed_files: int = 0
     remaining_files: int = 0
@@ -43,7 +42,6 @@ class PlotRefreshResult:
     def __add__(self, other):
         result: PlotRefreshResult = PlotRefreshResult()
         result.loaded_plots = self.loaded_plots + other.loaded_plots
-        result.loaded_size = self.loaded_size + other.loaded_size
         result.removed_plots = self.removed_plots + other.removed_plots
         result.processed_files = self.processed_files + other.processed_files
         result.remaining_files = other.remaining_files

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -33,18 +33,18 @@ class PlotInfo:
 
 @dataclass
 class PlotRefreshResult:
-    loaded_plots: int = 0
-    removed_plots: int = 0
-    processed_files: int = 0
-    remaining_files: int = 0
+    loaded: int = 0
+    removed: int = 0
+    processed: int = 0
+    remaining: int = 0
     duration: float = 0
 
     def __add__(self, other):
         result: PlotRefreshResult = PlotRefreshResult()
-        result.loaded_plots = self.loaded_plots + other.loaded_plots
-        result.removed_plots = self.removed_plots + other.removed_plots
-        result.processed_files = self.processed_files + other.processed_files
-        result.remaining_files = other.remaining_files
+        result.loaded = self.loaded + other.loaded
+        result.removed = self.removed + other.removed
+        result.processed = self.processed + other.processed
+        result.remaining = other.remaining
         result.duration = self.duration + other.duration
         return result
 

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -165,11 +165,11 @@ class BlockTools:
         self.expected_plots: Dict[bytes32, Path] = {}
 
         def test_callback(update_result: PlotRefreshResult):
-            if update_result.remaining_files == 0:
+            if update_result.remaining == 0:
                 assert len(self.plot_manager.plots) == len(self.expected_plots)
             else:
-                assert 0 < update_result.loaded_plots <= self.refresh_parameter.batch_size
-                assert update_result.loaded_plots == update_result.processed_files
+                assert 0 < update_result.loaded <= self.refresh_parameter.batch_size
+                assert update_result.loaded == update_result.processed
                 assert 0 < update_result.duration < 5
 
         self.plot_manager: PlotManager = PlotManager(

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -170,7 +170,6 @@ class BlockTools:
             else:
                 assert 0 < update_result.loaded_plots <= self.refresh_parameter.batch_size
                 assert update_result.loaded_plots == update_result.processed_files
-                assert update_result.loaded_size > 0
                 assert 0 < update_result.duration < 5
 
         self.plot_manager: PlotManager = PlotManager(

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -211,10 +211,10 @@ class TestRpc:
                         log.error(f"{error}")
                         expected_result_matched = False
 
-                test_value("loaded_plots", refresh_result, expected_result)
-                test_value("removed_plots", refresh_result, expected_result)
-                test_value("processed_files", refresh_result, expected_result)
-                test_value("remaining_files", refresh_result, expected_result)
+                test_value("loaded", refresh_result, expected_result)
+                test_value("removed", refresh_result, expected_result)
+                test_value("processed", refresh_result, expected_result)
+                test_value("remaining", refresh_result, expected_result)
 
             harvester.plot_manager.set_refresh_callback(test_refresh_callback)
 
@@ -238,9 +238,9 @@ class TestRpc:
                 expect_total_plots,
             ):
                 nonlocal expected_result_matched
-                expected_result.loaded_plots = expect_loaded
-                expected_result.removed_plots = expect_removed
-                expected_result.processed_files = expect_processed
+                expected_result.loaded = expect_loaded
+                expected_result.removed = expect_removed
+                expected_result.processed = expect_processed
                 await trigger
                 assert len(await client_2.get_plot_directories()) == expected_directories
                 await test_refresh_results(harvester.plot_manager)
@@ -373,11 +373,10 @@ class TestRpc:
             # Manually trigger `save_cache` and make sure it creates a new cache file
             harvester.plot_manager.cache.save()
             assert harvester.plot_manager.cache.path().exists()
-
-            expected_result.loaded_plots = 20
-            expected_result.removed_plots = 0
-            expected_result.processed_files = 20
-            expected_result.remaining_files = 0
+            expected_result.loaded = 20
+            expected_result.removed = 0
+            expected_result.processed = 20
+            expected_result.remaining = 0
             plot_manager: PlotManager = PlotManager(harvester.root_path, test_refresh_callback)
             plot_manager.cache.load()
             assert len(harvester.plot_manager.cache) == len(plot_manager.cache)
@@ -408,10 +407,10 @@ class TestRpc:
             plot_manager.set_public_keys(
                 harvester.plot_manager.farmer_public_keys, harvester.plot_manager.pool_public_keys
             )
-            expected_result.loaded_plots = 20
-            expected_result.removed_plots = 0
-            expected_result.processed_files = 20
-            expected_result.remaining_files = 0
+            expected_result.loaded = 20
+            expected_result.removed = 0
+            expected_result.processed = 20
+            expected_result.remaining = 0
             await test_refresh_results(plot_manager, start_refreshing=True)
             assert len(plot_manager.plots) == len(harvester.plot_manager.plots)
             plot_manager.stop_refreshing()
@@ -426,23 +425,23 @@ class TestRpc:
                 file.write(bytes(100))
             # Add it and validate it fails to load
             await harvester.add_plot_directory(str(plot_dir_sub))
-            expected_result.loaded_plots = 0
-            expected_result.removed_plots = 0
-            expected_result.processed_files = 1
-            expected_result.remaining_files = 0
+            expected_result.loaded = 0
+            expected_result.removed = 0
+            expected_result.processed = 1
+            expected_result.remaining = 0
             await test_refresh_results(harvester.plot_manager, start_refreshing=True)
             assert retry_test_plot in harvester.plot_manager.failed_to_open_filenames
             # Make sure the file stays in `failed_to_open_filenames` and doesn't get loaded or processed in the next
             # update round
-            expected_result.loaded_plots = 0
-            expected_result.processed_files = 0
+            expected_result.loaded = 0
+            expected_result.processed = 0
             await test_refresh_results(harvester.plot_manager)
             assert retry_test_plot in harvester.plot_manager.failed_to_open_filenames
             # Now decrease the re-try timeout, restore the valid plot file and make sure it properly loads now
             harvester.plot_manager.refresh_parameter.retry_invalid_seconds = 0
             move(retry_test_plot_save, retry_test_plot)
-            expected_result.loaded_plots = 1
-            expected_result.processed_files = 1
+            expected_result.loaded = 1
+            expected_result.processed = 1
             await test_refresh_results(harvester.plot_manager)
             assert retry_test_plot not in harvester.plot_manager.failed_to_open_filenames
 


### PR DESCRIPTION
See commit messages.

~Currently based on #8749.~