### PR TITLE
cache height-to-hash and height-to-ses maps between runs

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -148,6 +148,8 @@ class Blockchain(BlockchainInterface):
 
         assert peak is not None
         self._peak_height = self.block_record(peak).height
+        assert self.__height_map.contains_height(self._peak_height)
+        assert not self.__height_map.contains_height(self._peak_height + 1)
 
     def get_peak(self) -> Optional[BlockRecord]:
         """

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -43,6 +43,7 @@ from chia.util.errors import Err, ConsensusError
 from chia.util.generator_tools import get_block_header, tx_removals_and_additions
 from chia.util.ints import uint16, uint32, uint64, uint128
 from chia.util.streamable import recurse_jsonify
+from chia.full_node.block_height_map import BlockHeightMap
 
 log = logging.getLogger(__name__)
 
@@ -71,11 +72,9 @@ class Blockchain(BlockchainInterface):
     __block_records: Dict[bytes32, BlockRecord]
     # all hashes of blocks in block_record by height, used for garbage collection
     __heights_in_cache: Dict[uint32, Set[bytes32]]
-    # Defines the path from genesis to the peak, no orphan blocks
-    __height_to_hash: Dict[uint32, bytes32]
-    # All sub-epoch summaries that have been included in the blockchain from the beginning until and including the peak
-    # (height_included, SubEpochSummary). Note: ONLY for the blocks in the path to the peak
-    __sub_epoch_summaries: Dict[uint32, SubEpochSummary] = {}
+    # maps block height (of the current heaviest chain) to block hash and sub
+    # epoch summaries
+    __height_map: BlockHeightMap
     # Unspent Store
     coin_store: CoinStore
     # Store
@@ -126,13 +125,11 @@ class Blockchain(BlockchainInterface):
         self._shut_down = True
         self.pool.shutdown(wait=True)
 
-    async def _load_chain_from_store(self) -> None:
+    async def _load_chain_from_store(self):
         """
         Initializes the state of the Blockchain class from the database.
         """
-        height_to_hash, sub_epoch_summaries = await self.block_store.get_peak_height_dicts()
-        self.__height_to_hash = height_to_hash
-        self.__sub_epoch_summaries = sub_epoch_summaries
+        self.__height_map = await BlockHeightMap.create(self.block_store.db)
         self.__block_records = {}
         self.__heights_in_cache = {}
         block_records, peak = await self.block_store.get_block_records_close_to_peak(self.constants.BLOCKS_CACHE_SIZE)
@@ -142,11 +139,10 @@ class Blockchain(BlockchainInterface):
         if len(block_records) == 0:
             assert peak is None
             self._peak_height = None
-            return None
+            return
 
         assert peak is not None
         self._peak_height = self.block_record(peak).height
-        assert len(self.__height_to_hash) == self._peak_height + 1
 
     def get_peak(self) -> Optional[BlockRecord]:
         """
@@ -279,11 +275,11 @@ class Blockchain(BlockchainInterface):
                 # Then update the memory cache. It is important that this task is not cancelled and does not throw
                 self.add_block_record(block_record)
                 for fetched_block_record in records:
-                    self.__height_to_hash[fetched_block_record.height] = fetched_block_record.header_hash
-                    if fetched_block_record.sub_epoch_summary_included is not None:
-                        self.__sub_epoch_summaries[
-                            fetched_block_record.height
-                        ] = fetched_block_record.sub_epoch_summary_included
+                    self.__height_map.update_height(
+                        fetched_block_record.height,
+                        fetched_block_record.header_hash,
+                        fetched_block_record.sub_epoch_summary_included,
+                    )
                 if peak_height is not None:
                     self._peak_height = peak_height
             except BaseException:
@@ -374,13 +370,7 @@ class Blockchain(BlockchainInterface):
                     lastest_coin_state[coin_record.name] = coin_record
 
             # Rollback sub_epoch_summaries
-            heights_to_delete = []
-            for ses_included_height in self.__sub_epoch_summaries.keys():
-                if ses_included_height > fork_height:
-                    heights_to_delete.append(ses_included_height)
-            for height in heights_to_delete:
-                log.info(f"delete ses at height {height}")
-                del self.__sub_epoch_summaries[height]
+            self.__height_map.rollback(fork_height)
 
             # Collect all blocks from fork point to new peak
             blocks_to_add: List[Tuple[FullBlock, BlockRecord]] = []
@@ -674,16 +664,16 @@ class Blockchain(BlockchainInterface):
         return self.block_record(header_hash)
 
     def get_ses_heights(self) -> List[uint32]:
-        return sorted(self.__sub_epoch_summaries.keys())
+        return self.__height_map.get_ses_heights()
 
     def get_ses(self, height: uint32) -> SubEpochSummary:
-        return self.__sub_epoch_summaries[height]
+        return self.__height_map.get_ses(height)
 
     def height_to_hash(self, height: uint32) -> Optional[bytes32]:
-        return self.__height_to_hash[height]
+        return self.__height_map.get_hash(height)
 
     def contains_height(self, height: uint32) -> bool:
-        return height in self.__height_to_hash
+        return self.__height_map.contains_height(height)
 
     def get_peak_height(self) -> Optional[uint32]:
         return self._peak_height

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -1,0 +1,96 @@
+import aiosqlite
+import logging
+from typing import Dict, List, Optional
+from chia.util.ints import uint32
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
+
+log = logging.getLogger(__name__)
+
+
+class BlockHeightMap:
+    db: aiosqlite.Connection
+
+    # Defines the path from genesis to the peak, no orphan blocks
+    __height_to_hash: Dict[uint32, bytes32]
+    # All sub-epoch summaries that have been included in the blockchain from the beginning until and including the peak
+    # (height_included, SubEpochSummary). Note: ONLY for the blocks in the path to the peak
+    __sub_epoch_summaries: Dict[uint32, SubEpochSummary]
+
+    @classmethod
+    async def create(cls, db: aiosqlite.Connection) -> "BlockHeightMap":
+        self = BlockHeightMap()
+        self.db = db
+
+        self.__height_to_hash = {}
+        self.__sub_epoch_summaries = {}
+
+        res = await self.db.execute("SELECT * from block_records WHERE is_peak = 1")
+        row = await res.fetchone()
+        await res.close()
+
+        if row is None:
+            return self
+
+        # TODO: it's unsustainable to dump all block records to RAM
+        # this takes a very long time where the DB is on a spinning disk
+        peak: bytes32 = bytes.fromhex(row[0])
+        cursor = await self.db.execute("SELECT header_hash,prev_hash,height,sub_epoch_summary from block_records")
+        rows = await cursor.fetchall()
+        await cursor.close()
+        hash_to_prev_hash: Dict[bytes32, bytes32] = {}
+        hash_to_height: Dict[bytes32, uint32] = {}
+        hash_to_summary: Dict[bytes32, SubEpochSummary] = {}
+
+        for row in rows:
+            hash_to_prev_hash[bytes.fromhex(row[0])] = bytes.fromhex(row[1])
+            hash_to_height[bytes.fromhex(row[0])] = row[2]
+            if row[3] is not None:
+                hash_to_summary[bytes.fromhex(row[0])] = SubEpochSummary.from_bytes(row[3])
+
+        height_to_hash: Dict[uint32, bytes32] = {}
+        sub_epoch_summaries: Dict[uint32, SubEpochSummary] = {}
+
+        curr_header_hash = peak
+        curr_height = hash_to_height[curr_header_hash]
+        while True:
+            height_to_hash[curr_height] = curr_header_hash
+            if curr_header_hash in hash_to_summary:
+                sub_epoch_summaries[curr_height] = hash_to_summary[curr_header_hash]
+            if curr_height == 0:
+                break
+            curr_header_hash = hash_to_prev_hash[curr_header_hash]
+            curr_height = hash_to_height[curr_header_hash]
+
+        self.__height_to_hash = height_to_hash
+        self.__sub_epoch_summaries = sub_epoch_summaries
+        return self
+
+    def update_height(self, height: uint32, header_hash: bytes32, ses: Optional[SubEpochSummary]):
+        self.__height_to_hash[height] = header_hash
+        if ses is not None:
+            self.__sub_epoch_summaries[height] = ses
+
+    def get_hash(self, height: uint32) -> bytes32:
+        return self.__height_to_hash[height]
+
+    def contains_height(self, height: uint32) -> bool:
+        return height in self.__height_to_hash
+
+    def rollback(self, fork_height: int):
+        # fork height may be -1, in which case all blocks are different and we
+        # should clear all sub epoch summaries
+        heights_to_delete = []
+        for ses_included_height in self.__sub_epoch_summaries.keys():
+            if ses_included_height > fork_height:
+                heights_to_delete.append(ses_included_height)
+        for height in heights_to_delete:
+            log.info(f"delete ses at height {height}")
+            del self.__sub_epoch_summaries[height]
+
+    def get_ses(self, height: uint32) -> SubEpochSummary:
+        return self.__sub_epoch_summaries[height]
+
+    # TODO: This function is not sustainable
+    def get_ses_heights(self) -> List[uint32]:
+        return sorted(self.__sub_epoch_summaries.keys())

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -1,81 +1,186 @@
 import aiosqlite
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from chia.util.ints import uint32
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
+from pathlib import Path
+import aiofiles
+from dataclasses import dataclass
+from chia.util.streamable import Streamable, streamable
+from chia.util.files import write_file_async
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+@streamable
+class SesCache(Streamable):
+    content: List[Tuple[uint32, bytes]]
 
 
 class BlockHeightMap:
     db: aiosqlite.Connection
 
+    # the below dictionaries are loaded from the database, from the peak
+    # and back in time on startup.
+
     # Defines the path from genesis to the peak, no orphan blocks
-    __height_to_hash: Dict[uint32, bytes32]
+    # this buffer contains all block hashes that are part of the current peak
+    # ordered by height. i.e. __height_to_hash[0..32] is the genesis hash
+    # __height_to_hash[32..64] is the hash for height 1 and so on
+    __height_to_hash: bytearray
+
     # All sub-epoch summaries that have been included in the blockchain from the beginning until and including the peak
     # (height_included, SubEpochSummary). Note: ONLY for the blocks in the path to the peak
-    __sub_epoch_summaries: Dict[uint32, SubEpochSummary]
+    # The value is a serialized SubEpochSummary object
+    __sub_epoch_summaries: Dict[uint32, bytes]
+
+    # count how many blocks have been added since the cache was last written to
+    # disk
+    __dirty: int
+
+    # the file we're saving the height-to-hash cache to
+    __height_to_hash_filename: Path
+
+    # the file we're saving the sub epoch summary cache to
+    __ses_filename: Path
 
     @classmethod
-    async def create(cls, db: aiosqlite.Connection) -> "BlockHeightMap":
+    async def create(cls, blockchain_dir: Path, db: aiosqlite.Connection) -> "BlockHeightMap":
         self = BlockHeightMap()
         self.db = db
 
-        self.__height_to_hash = {}
+        self.__dirty = 0
+        self.__height_to_hash = bytearray()
         self.__sub_epoch_summaries = {}
+        self.__height_to_hash_filename = blockchain_dir / "height-to-hash"
+        self.__ses_filename = blockchain_dir / "sub-epoch-summaries"
 
-        res = await self.db.execute("SELECT * from block_records WHERE is_peak = 1")
+        res = await self.db.execute(
+            "SELECT header_hash,prev_hash,height,sub_epoch_summary from block_records WHERE is_peak=1"
+        )
         row = await res.fetchone()
         await res.close()
 
         if row is None:
             return self
 
-        # TODO: it's unsustainable to dump all block records to RAM
-        # this takes a very long time where the DB is on a spinning disk
+        try:
+            async with aiofiles.open(self.__height_to_hash_filename, "rb") as f:
+                self.__height_to_hash = bytearray(await f.read())
+        except Exception:
+            # it's OK if this file doesn't exist, we can rebuild it
+            pass
+
+        try:
+            async with aiofiles.open(self.__ses_filename, "rb") as f:
+                self.__sub_epoch_summaries = {k: v for (k, v) in SesCache.from_bytes(await f.read()).content}
+        except Exception:
+            # it's OK if this file doesn't exist, we can rebuild it
+            pass
+
         peak: bytes32 = bytes.fromhex(row[0])
-        cursor = await self.db.execute("SELECT header_hash,prev_hash,height,sub_epoch_summary from block_records")
-        rows = await cursor.fetchall()
-        await cursor.close()
-        hash_to_prev_hash: Dict[bytes32, bytes32] = {}
-        hash_to_height: Dict[bytes32, uint32] = {}
-        hash_to_summary: Dict[bytes32, SubEpochSummary] = {}
+        prev_hash: bytes32 = bytes.fromhex(row[1])
+        height = row[2]
 
-        for row in rows:
-            hash_to_prev_hash[bytes.fromhex(row[0])] = bytes.fromhex(row[1])
-            hash_to_height[bytes.fromhex(row[0])] = row[2]
+        # allocate memory for height to hash map
+        # this may also truncate it, if thie file on disk had an invalid size
+        new_size = (height + 1) * 32
+        size = len(self.__height_to_hash)
+        if size > new_size:
+            del self.__height_to_hash[new_size:]
+        else:
+            self.__height_to_hash += bytearray([0] * (new_size - size))
+
+        # if the peak hash is already in the height-to-hash map, we don't need
+        # to load anything more from the DB
+        if self.get_hash(height) != peak:
+            self.__set_hash(height, peak)
+
             if row[3] is not None:
-                hash_to_summary[bytes.fromhex(row[0])] = SubEpochSummary.from_bytes(row[3])
+                self.__sub_epoch_summaries[height] = row[3]
 
-        height_to_hash: Dict[uint32, bytes32] = {}
-        sub_epoch_summaries: Dict[uint32, SubEpochSummary] = {}
+            # prepopulate the height -> hash mapping
+            await self._load_blocks_from(height, prev_hash)
 
-        curr_header_hash = peak
-        curr_height = hash_to_height[curr_header_hash]
-        while True:
-            height_to_hash[curr_height] = curr_header_hash
-            if curr_header_hash in hash_to_summary:
-                sub_epoch_summaries[curr_height] = hash_to_summary[curr_header_hash]
-            if curr_height == 0:
-                break
-            curr_header_hash = hash_to_prev_hash[curr_header_hash]
-            curr_height = hash_to_height[curr_header_hash]
+            await self.maybe_flush()
 
-        self.__height_to_hash = height_to_hash
-        self.__sub_epoch_summaries = sub_epoch_summaries
         return self
 
     def update_height(self, height: uint32, header_hash: bytes32, ses: Optional[SubEpochSummary]):
-        self.__height_to_hash[height] = header_hash
+        # we're only updating the last hash. If we've reorged, we already rolled
+        # back, making this the new peak
+        idx = height * 32
+        assert idx <= len(self.__height_to_hash)
+        self.__height_to_hash[idx : idx + 32] = header_hash
         if ses is not None:
-            self.__sub_epoch_summaries[height] = ses
+            self.__sub_epoch_summaries[height] = bytes(ses)
+
+    async def maybe_flush(self):
+        if self.__dirty < 1000:
+            return
+
+        assert (len(self.__height_to_hash) % 32) == 0
+        map_buf = self.__height_to_hash.copy()
+
+        ses_buf = bytes(SesCache([(k, v) for (k, v) in self.__sub_epoch_summaries.items()]))
+
+        self.__dirty = 0
+
+        await write_file_async(self.__height_to_hash_filename, map_buf)
+        await write_file_async(self.__ses_filename, ses_buf)
+
+    # load height-to-hash map entries from the DB starting at height back in
+    # time until we hit a match in the existing map, at which point we can
+    # assume all previous blocks have already been populated
+    async def _load_blocks_from(self, height: uint32, prev_hash: bytes32):
+
+        while height > 0:
+            # load 5000 blocks at a time
+            window_end = max(0, height - 5000)
+            cursor = await self.db.execute(
+                "SELECT header_hash,prev_hash,height,sub_epoch_summary from block_records "
+                "INDEXED BY height WHERE height>=? AND height <?",
+                (window_end, height),
+            )
+
+            rows = await cursor.fetchall()
+            await cursor.close()
+
+            # maps block-hash -> (height, prev-hash, sub-epoch-summary)
+            ordered: Dict[bytes32, Tuple[uint32, bytes32, Optional[bytes]]] = {}
+            for r in rows:
+                ordered[bytes.fromhex(r[0])] = (r[2], bytes.fromhex(r[1]), r[3])
+
+            while height > window_end:
+                entry = ordered[prev_hash]
+                assert height == entry[0] + 1
+                height = entry[0]
+                if entry[2] is not None:
+
+                    if (
+                        self.get_hash(height) == prev_hash
+                        and height in self.__sub_epoch_summaries
+                        and self.__sub_epoch_summaries[height] == entry[2]
+                    ):
+                        return
+                    self.__sub_epoch_summaries[height] = entry[2]
+                self.__set_hash(height, prev_hash)
+                prev_hash = entry[1]
+
+    def __set_hash(self, height: int, block_hash: bytes32):
+        idx = height * 32
+        self.__height_to_hash[idx : idx + 32] = block_hash
+        self.__dirty += 1
 
     def get_hash(self, height: uint32) -> bytes32:
-        return self.__height_to_hash[height]
+        idx = height * 32
+        assert idx + 32 <= len(self.__height_to_hash)
+        return bytes(self.__height_to_hash[idx : idx + 32])
 
     def contains_height(self, height: uint32) -> bool:
-        return height in self.__height_to_hash
+        return height * 32 < len(self.__height_to_hash)
 
     def rollback(self, fork_height: int):
         # fork height may be -1, in which case all blocks are different and we
@@ -85,12 +190,10 @@ class BlockHeightMap:
             if ses_included_height > fork_height:
                 heights_to_delete.append(ses_included_height)
         for height in heights_to_delete:
-            log.info(f"delete ses at height {height}")
             del self.__sub_epoch_summaries[height]
 
     def get_ses(self, height: uint32) -> SubEpochSummary:
-        return self.__sub_epoch_summaries[height]
+        return SubEpochSummary.from_bytes(self.__sub_epoch_summaries[height])
 
-    # TODO: This function is not sustainable
     def get_ses_heights(self) -> List[uint32]:
         return sorted(self.__sub_epoch_summaries.keys())

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -5,7 +5,6 @@ import aiosqlite
 
 from chia.consensus.block_record import BlockRecord
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.full_block import FullBlock
 from chia.types.weight_proof import SubEpochChallengeSegment, SubEpochSegments
 from chia.util.db_wrapper import DBWrapper
@@ -285,47 +284,6 @@ class BlockStore:
             header_hash = bytes.fromhex(row[0])
             ret[header_hash] = BlockRecord.from_bytes(row[1])
         return ret, bytes.fromhex(peak_row[0])
-
-    async def get_peak_height_dicts(self) -> Tuple[Dict[uint32, bytes32], Dict[uint32, SubEpochSummary]]:
-        """
-        Returns a dictionary with all blocks, as well as the header hash of the peak,
-        if present.
-        """
-
-        res = await self.db.execute("SELECT * from block_records WHERE is_peak = 1")
-        row = await res.fetchone()
-        await res.close()
-        if row is None:
-            return {}, {}
-
-        peak: bytes32 = bytes.fromhex(row[0])
-        cursor = await self.db.execute("SELECT header_hash,prev_hash,height,sub_epoch_summary from block_records")
-        rows = await cursor.fetchall()
-        await cursor.close()
-        hash_to_prev_hash: Dict[bytes32, bytes32] = {}
-        hash_to_height: Dict[bytes32, uint32] = {}
-        hash_to_summary: Dict[bytes32, SubEpochSummary] = {}
-
-        for row in rows:
-            hash_to_prev_hash[bytes.fromhex(row[0])] = bytes.fromhex(row[1])
-            hash_to_height[bytes.fromhex(row[0])] = row[2]
-            if row[3] is not None:
-                hash_to_summary[bytes.fromhex(row[0])] = SubEpochSummary.from_bytes(row[3])
-
-        height_to_hash: Dict[uint32, bytes32] = {}
-        sub_epoch_summaries: Dict[uint32, SubEpochSummary] = {}
-
-        curr_header_hash = peak
-        curr_height = hash_to_height[curr_header_hash]
-        while True:
-            height_to_hash[curr_height] = curr_header_hash
-            if curr_header_hash in hash_to_summary:
-                sub_epoch_summaries[curr_height] = hash_to_summary[curr_header_hash]
-            if curr_height == 0:
-                break
-            curr_header_hash = hash_to_prev_hash[curr_header_hash]
-            curr_height = hash_to_height[curr_header_hash]
-        return height_to_hash, sub_epoch_summaries
 
     async def set_peak(self, header_hash: bytes32) -> None:
         # We need to be in a sqlite transaction here.

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -179,7 +179,9 @@ class FullNode:
         self.coin_store = await CoinStore.create(self.db_wrapper)
         self.log.info("Initializing blockchain from disk")
         start_time = time.time()
-        self.blockchain = await Blockchain.create(self.coin_store, self.block_store, self.constants, self.hint_store)
+        self.blockchain = await Blockchain.create(
+            self.coin_store, self.block_store, self.constants, self.hint_store, self.db_path.parent
+        )
         self.mempool_manager = MempoolManager(self.coin_store, self.constants)
 
         # Blocks are validated under high priority, and transactions under low priority. This guarantees blocks will

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import tempfile
+from pathlib import Path
 
 
 # TODO: tests.setup_nodes (which is also imported by tests.util.blockchain) creates a
@@ -80,3 +82,9 @@ async def default_10000_blocks_compact():
         normalized_to_identity_cc_ip=True,
         normalized_to_identity_cc_sp=True,
     )
+
+
+@pytest.fixture(scope="function")
+async def tmp_dir():
+    with tempfile.TemporaryDirectory() as folder:
+        yield Path(folder)

--- a/tests/core/full_node/ram_db.py
+++ b/tests/core/full_node/ram_db.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+from pathlib import Path
 
 import aiosqlite
 
@@ -16,5 +17,5 @@ async def create_ram_blockchain(consensus_constants: ConsensusConstants) -> Tupl
     block_store = await BlockStore.create(db_wrapper)
     coin_store = await CoinStore.create(db_wrapper)
     hint_store = await HintStore.create(db_wrapper)
-    blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, hint_store)
+    blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, hint_store, Path("."))
     return connection, blockchain

--- a/tests/core/full_node/test_block_height_map.py
+++ b/tests/core/full_node/test_block_height_map.py
@@ -1,0 +1,340 @@
+import aiosqlite
+import pytest
+import struct
+from chia.full_node.block_height_map import BlockHeightMap
+from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
+
+from tests.util.db_connection import DBConnection
+from chia.types.blockchain_format.sized_bytes import bytes32
+from typing import Optional
+from chia.util.ints import uint8
+
+# from tests.conftest import tmp_dir
+
+
+def gen_block_hash(height: int) -> bytes32:
+    return struct.pack(">I", height + 1) * (32 // 4)
+
+
+def gen_ses(height: int) -> SubEpochSummary:
+    prev_ses = gen_block_hash(height + 0xFA0000)
+    reward_chain_hash = gen_block_hash(height + 0xFC0000)
+    return SubEpochSummary(prev_ses, reward_chain_hash, uint8(0), None, None)
+
+
+async def new_block(
+    db: aiosqlite.Connection,
+    block_hash: bytes32,
+    parent: bytes32,
+    height: int,
+    is_peak: bool,
+    ses: Optional[SubEpochSummary],
+):
+    cursor = await db.execute(
+        "INSERT INTO block_records VALUES(?, ?, ?, ?, ?)",
+        (
+            block_hash.hex(),
+            parent.hex(),
+            height,
+            # sub epoch summary
+            None if ses is None else bytes(ses),
+            is_peak,
+        ),
+    )
+    await cursor.close()
+
+
+async def setup_db(db: aiosqlite.Connection):
+    await db.execute(
+        "CREATE TABLE IF NOT EXISTS block_records("
+        "header_hash text PRIMARY KEY,"
+        "prev_hash text,"
+        "height bigint,"
+        "sub_epoch_summary blob,"
+        "is_peak tinyint)"
+    )
+    await db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
+    await db.execute("CREATE INDEX IF NOT EXISTS hh on block_records(header_hash)")
+    await db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
+
+
+# if chain_id != 0, the last block in the chain won't be considered the peak,
+# and the chain_id will be mixed in to the hashes, to form a separate chain at
+# the same heights as the main chain
+async def setup_chain(
+    db: aiosqlite.Connection, length: int, *, chain_id: int = 0, ses_every: Optional[int] = None, start_height=0
+):
+    height = start_height
+    peak_hash = gen_block_hash(height + chain_id * 65536)
+    parent_hash = bytes32([0] * 32)
+    while height < length:
+        ses = None
+        if ses_every is not None and height % ses_every == 0:
+            ses = gen_ses(height)
+
+        await new_block(db, peak_hash, parent_hash, height, False, ses)
+        height += 1
+        parent_hash = peak_hash
+        peak_hash = gen_block_hash(height + chain_id * 65536)
+
+    # we only set is_peak=1 for chain_id 0
+    await new_block(db, peak_hash, parent_hash, height, chain_id == 0, None)
+
+
+class TestBlockHeightMap:
+    @pytest.mark.asyncio
+    async def test_height_to_hash(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            assert not height_map.contains_height(11)
+            for height in reversed(range(10)):
+                assert height_map.contains_height(height)
+
+            for height in reversed(range(10)):
+                assert height_map.get_hash(height) == gen_block_hash(height)
+
+    @pytest.mark.asyncio
+    async def test_height_to_hash_long_chain(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10000)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            for height in reversed(range(1000)):
+                assert height_map.contains_height(height)
+
+            for height in reversed(range(10000)):
+                assert height_map.get_hash(height) == gen_block_hash(height)
+
+    @pytest.mark.asyncio
+    async def test_save_restore(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10000, ses_every=20)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            for height in reversed(range(10000)):
+                assert height_map.contains_height(height)
+                assert height_map.get_hash(height) == gen_block_hash(height)
+                if (height % 20) == 0:
+                    assert height_map.get_ses(height) == gen_ses(height)
+                else:
+                    with pytest.raises(KeyError) as _:
+                        height_map.get_ses(height)
+
+            await height_map.maybe_flush()
+
+            del height_map
+
+            # To ensure we're actually loading from cache, and not the DB, clear
+            # the table (but we still need the peak). We need at least 20 blocks
+            # in the DB since we keep loading until we find a match of both hash
+            # and sub epoch summary. In this test we have a sub epoch summary
+            # every 20 blocks, so we generate the 30 last blocks only
+            await db_wrapper.db.execute("DROP TABLE block_records")
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10000, ses_every=20, start_height=9970)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            for height in reversed(range(10000)):
+                assert height_map.contains_height(height)
+                assert height_map.get_hash(height) == gen_block_hash(height)
+                if (height % 20) == 0:
+                    assert height_map.get_ses(height) == gen_ses(height)
+                else:
+                    with pytest.raises(KeyError) as _:
+                        height_map.get_ses(height)
+
+    @pytest.mark.asyncio
+    async def test_restore_extend(self, tmp_dir):
+
+        # test the case where the cache has fewer blocks than the DB, and that
+        # we correctly load all the missing blocks from the DB to update the
+        # cache
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 2000, ses_every=20)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            for height in reversed(range(2000)):
+                assert height_map.contains_height(height)
+                assert height_map.get_hash(height) == gen_block_hash(height)
+                if (height % 20) == 0:
+                    assert height_map.get_ses(height) == gen_ses(height)
+                else:
+                    with pytest.raises(KeyError) as _:
+                        height_map.get_ses(height)
+
+            await height_map.maybe_flush()
+
+            del height_map
+
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            # add 2000 blocks to the chain
+            await setup_chain(db_wrapper.db, 4000, ses_every=20)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            # now make sure we have the complete chain, height 0 -> 4000
+            for height in reversed(range(4000)):
+                assert height_map.contains_height(height)
+                assert height_map.get_hash(height) == gen_block_hash(height)
+                if (height % 20) == 0:
+                    assert height_map.get_ses(height) == gen_ses(height)
+                else:
+                    with pytest.raises(KeyError) as _:
+                        height_map.get_ses(height)
+
+    @pytest.mark.asyncio
+    async def test_height_to_hash_with_orphans(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10)
+
+            # set up two separate chains, but without the peak
+            await setup_chain(db_wrapper.db, 10, chain_id=1)
+            await setup_chain(db_wrapper.db, 10, chain_id=2)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            for height in range(10):
+                assert height_map.get_hash(height) == gen_block_hash(height)
+
+    @pytest.mark.asyncio
+    async def test_height_to_hash_update(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10)
+
+            # orphan blocks
+            await setup_chain(db_wrapper.db, 10, chain_id=1)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            for height in range(10):
+                assert height_map.get_hash(height) == gen_block_hash(height)
+
+            height_map.update_height(10, gen_block_hash(100), None)
+
+            for height in range(9):
+                assert height_map.get_hash(height) == gen_block_hash(height)
+
+            assert height_map.get_hash(10) == gen_block_hash(100)
+
+    @pytest.mark.asyncio
+    async def test_update_ses(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10)
+
+            # orphan blocks
+            await setup_chain(db_wrapper.db, 10, chain_id=1)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(10)
+
+            height_map.update_height(10, gen_block_hash(10), gen_ses(10))
+
+            assert height_map.get_ses(10) == gen_ses(10)
+            assert height_map.get_hash(10) == gen_block_hash(10)
+
+    @pytest.mark.asyncio
+    async def test_height_to_ses(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10, ses_every=2)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            assert height_map.get_ses(0) == gen_ses(0)
+            assert height_map.get_ses(2) == gen_ses(2)
+            assert height_map.get_ses(4) == gen_ses(4)
+            assert height_map.get_ses(6) == gen_ses(6)
+            assert height_map.get_ses(8) == gen_ses(8)
+
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(1)
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(3)
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(5)
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(7)
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(9)
+
+    @pytest.mark.asyncio
+    async def test_rollback(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10, ses_every=2)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            assert height_map.get_ses(0) == gen_ses(0)
+            assert height_map.get_ses(2) == gen_ses(2)
+            assert height_map.get_ses(4) == gen_ses(4)
+            assert height_map.get_ses(6) == gen_ses(6)
+            assert height_map.get_ses(8) == gen_ses(8)
+
+            assert height_map.get_hash(5) == gen_block_hash(5)
+
+            height_map.rollback(5)
+
+            assert height_map.get_hash(5) == gen_block_hash(5)
+
+            assert height_map.get_ses(0) == gen_ses(0)
+            assert height_map.get_ses(2) == gen_ses(2)
+            assert height_map.get_ses(4) == gen_ses(4)
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(6)
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(8)
+
+    @pytest.mark.asyncio
+    async def test_rollback2(self, tmp_dir):
+
+        async with DBConnection() as db_wrapper:
+
+            await setup_db(db_wrapper.db)
+            await setup_chain(db_wrapper.db, 10, ses_every=2)
+
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+
+            assert height_map.get_ses(0) == gen_ses(0)
+            assert height_map.get_ses(2) == gen_ses(2)
+            assert height_map.get_ses(4) == gen_ses(4)
+            assert height_map.get_ses(6) == gen_ses(6)
+            assert height_map.get_ses(8) == gen_ses(8)
+
+            assert height_map.get_hash(6) == gen_block_hash(6)
+
+            height_map.rollback(6)
+
+            assert height_map.get_hash(6) == gen_block_hash(6)
+
+            assert height_map.get_ses(0) == gen_ses(0)
+            assert height_map.get_ses(2) == gen_ses(2)
+            assert height_map.get_ses(4) == gen_ses(4)
+            assert height_map.get_ses(6) == gen_ses(6)
+            with pytest.raises(KeyError) as _:
+                height_map.get_ses(8)

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -25,7 +25,7 @@ def event_loop():
 
 class TestBlockStore:
     @pytest.mark.asyncio
-    async def test_block_store(self):
+    async def test_block_store(self, tmp_dir):
         assert sqlite3.threadsafety == 1
         blocks = bt.get_consecutive_blocks(10)
 
@@ -46,7 +46,7 @@ class TestBlockStore:
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2)
         hint_store = await HintStore.create(db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store)
+        bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
 
         store = await BlockStore.create(db_wrapper)
         await BlockStore.create(db_wrapper_2)
@@ -85,7 +85,7 @@ class TestBlockStore:
         db_filename_2.unlink()
 
     @pytest.mark.asyncio
-    async def test_deadlock(self):
+    async def test_deadlock(self, tmp_dir):
         """
         This test was added because the store was deadlocking in certain situations, when fetching and
         adding blocks repeatedly. The issue was patched.
@@ -108,7 +108,7 @@ class TestBlockStore:
         coin_store_2 = await CoinStore.create(wrapper_2)
         store_2 = await BlockStore.create(wrapper_2)
         hint_store = await HintStore.create(wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store)
+        bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
         block_records = []
         for block in blocks:
             await bc.receive_block(block)

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -240,7 +240,7 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_basic_reorg(self, cache_size: uint32):
+    async def test_basic_reorg(self, cache_size: uint32, tmp_dir):
 
         async with DBConnection() as db_wrapper:
             initial_block_count = 30
@@ -249,7 +249,7 @@ class TestCoinStoreWithBlocks:
             coin_store = await CoinStore.create(db_wrapper, cache_size=uint32(cache_size))
             store = await BlockStore.create(db_wrapper)
             hint_store = await HintStore.create(db_wrapper)
-            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store)
+            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store, tmp_dir)
             try:
 
                 records: List[Optional[CoinRecord]] = []
@@ -300,7 +300,7 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_get_puzzle_hash(self, cache_size: uint32):
+    async def test_get_puzzle_hash(self, cache_size: uint32, tmp_dir):
         async with DBConnection() as db_wrapper:
             num_blocks = 20
             farmer_ph = 32 * b"0"
@@ -314,7 +314,7 @@ class TestCoinStoreWithBlocks:
             coin_store = await CoinStore.create(db_wrapper, cache_size=uint32(cache_size))
             store = await BlockStore.create(db_wrapper)
             hint_store = await HintStore.create(db_wrapper)
-            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store)
+            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store, tmp_dir)
             for block in blocks:
                 res, err, _, _ = await b.receive_block(block)
                 assert err is None

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -73,8 +73,8 @@ async def check_spend_bundle_validity(
     `SpendBundle`, and then invokes `receive_block` to ensure that it's accepted (if `expected_err=None`)
     or fails with the correct error code.
     """
+    connection, blockchain = await create_ram_blockchain(constants)
     try:
-        connection, blockchain = await create_ram_blockchain(constants)
         for block in blocks:
             received_block_result, err, fork_height, coin_changes = await blockchain.receive_block(block)
             assert err is None

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -30,7 +30,7 @@ async def create_blockchain(constants: ConsensusConstants):
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
     hint_store = await HintStore.create(wrapper)
-    bc1 = await Blockchain.create(coin_store, store, constants, hint_store)
+    bc1 = await Blockchain.create(coin_store, store, constants, hint_store, Path("."))
     assert bc1.get_peak() is None
     return bc1, connection, db_path
 


### PR DESCRIPTION
This patch addresses a serious startup issue when running with the blockchain DB on a spinning disk. This patch shortens my startup time from:

# 26 minutes -> 1.5 seconds

The current startup time is a great impediment for me to upgrade Chia, and I expect it is for other people too.

# what's going on

When starting the full node, one of the first things we do is to build a map of block height -> block hash as well as as block-height -> SubEpochSummary map. In order to build these maps, we have to traverse the whole chain, from the peak to the genesis, and record the hash and SeS.

The SQL statement to dump the whole blockchain takes a long time when the DB is on a spinning disk. It's a little bit surprising as one would think the entries would come back unordered anyway, and sqlite could just read the table sequentially. However, even if it could, holding the whole table in memory is also problematic going forward, as it ends up with a pretty high peak memory usage.

# this change

This patch makes two main changes:

* alters the in-memory data structure for the height-to-hash to be a lot more efficient. In this patch the map is kept in a single buffer, rather than in a dense dict, each with individual 32 byte heap allocations.
* Periodically save these two maps to disk in simple flat-files and recover them on startup again. This is very quick (at least for now, these files will also grow over time). The height-to-hash map is currently ~ 35 MB.

How can it be safe to save these to disk? what about corruption or getting out of sync with the main DB?

The files are not used as the authoritative state on startup. We load them to **initialize** our maps, but then we still go through the same procedure to traverse the authoritative DB to build these maps. The traversal happens from the peak block, going backwards in time, as soon as we encounter a match in our existing map, we have connected them and we can safely assume our maps are complete.

One quirk about this is that since the height-to-hash and height-to-ses maps are saved in different files, they too can be out of sync. Therefore, it's not sufficient to have a match in just one of them. We need to keep traversing until we have a match in *both* the block hash and the sub epoch summary.

Since the normal DB traversal is still taking place, that also means these two files can be removed or truncated and will be rebuilt on the startup. However, if these files have holes punched in them, there will be no validation on startup to catch that. However, this seems quite unlikely to happen unintentionally. We could protect against this by simply adding a checksum to the end of the files.

Another thing to note, in order to avoid loading the entire chain on startup, the current version of this patch loads windows of 5000 blocks at a time. This slows down the initial loading compared to loading the whole chain in a single SQL statement.

# test machine

I'm testing this on a relatively powerful machine running Ubuntu-5.4. 14GiB RAM, Xeon 4 cores @ 3.40GHz.
The clear issue that I only have hard drives in this machine. It's clear from the noise the hard drive makes for about 30 minutes when I start up the chia node.