### PR TITLE
Backend changes to support passphrase hints and additional GUI passphrase support

### DIFF
--- a/chia/cmds/passphrase.py
+++ b/chia/cmds/passphrase.py
@@ -129,7 +129,7 @@ def hint_cmd(display: bool, set: Optional[str], remove: bool):
     if display is True:
         passphrase_hint = Keychain.get_master_passphrase_hint()
         if passphrase_hint is not None:
-            print(f"Passphrase hint: {passphrase_hint}")
+            print(f"Passphrase hint: {passphrase_hint}")  # lgtm [py/clear-text-logging-sensitive-data]
         else:
             print("Passphrase hint is not set")
     elif set is not None or remove is True:

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -466,7 +466,7 @@ class WebSocketServer:
         error: Optional[str] = None
         current_passphrase: Optional[str] = None
         new_passphrase: Optional[str] = None
-        passphrase_hint: Optional[str] = None
+        passphrase_hint: Optional[str] = request.get("passphrase_hint", None)
         save_passphrase: bool = request.get("save_passphrase", False)
 
         if using_default_passphrase():
@@ -485,8 +485,6 @@ class WebSocketServer:
             return {"success": False, "error": "passphrase doesn't satisfy requirements"}
 
         try:
-            passphrase_hint = request.get("passphrase_hint", None)
-
             assert new_passphrase is not None  # mypy, I love you
             Keychain.set_master_passphrase(
                 current_passphrase,

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -13,7 +13,7 @@ from functools import wraps
 from hashlib import pbkdf2_hmac
 from pathlib import Path
 from secrets import token_bytes
-from typing import Optional
+from typing import Any, Dict, Optional
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
@@ -108,6 +108,9 @@ class FileKeyring(FileSystemEventHandler):
         # that holds a dictionary of keys.
         data: <base64-encoded string of encrypted inner-payload>
 
+        # An optional passphrase hint
+        passphrase_hint: <cleartext string>
+
     The file is encrypted using ChaCha20Poly1305. The symmetric key is derived from the
     master passphrase using PBKDF2. The nonce is updated each time the file is written-to.
     The salt is updated each time the master passphrase is changed.
@@ -149,6 +152,9 @@ class FileKeyring(FileSystemEventHandler):
         self.payload_cache = {}  # This is used as a building block for adding keys etc if the keyring is empty
         self.load_keyring_lock = threading.RLock()
         self.keyring_last_mod_time = None
+
+        # Key/value pairs to set on the outer payload on the next write
+        self.outer_payload_properties_for_next_write: Dict[str, Any] = {}
 
         if not self.keyring_path.exists():
             # Super simple payload if starting from scratch
@@ -420,6 +426,10 @@ class FileKeyring(FileSystemEventHandler):
             "data": base64.b64encode(encrypted_inner_payload).decode("utf-8"),
         }
 
+        # Merge in other properties like "passphrase_hint"
+        outer_payload.update(self.outer_payload_properties_for_next_write)
+        self.outer_payload_properties_for_next_write = {}
+
         self.write_data_to_keyring(outer_payload)
 
         # Update our cached payload
@@ -442,3 +452,25 @@ class FileKeyring(FileSystemEventHandler):
 
         if not self.salt:
             self.salt = FileKeyring.generate_salt()
+
+    def get_passphrase_hint(self) -> Optional[str]:
+        """
+        Return the passphrase hint (if set). The hint data may not yet be written to the keyring, so we
+        return the hint data either from the staging dict (outer_payload_properties_for_next_write), or
+        from outer_payload_cache (loaded from the keyring)
+        """
+        passphrase_hint: Optional[str] = self.outer_payload_properties_for_next_write.get("passphrase_hint", None)
+        if passphrase_hint is None:
+            passphrase_hint = self.outer_payload_cache.get("passphrase_hint", None)
+        return passphrase_hint
+
+    def set_passphrase_hint(self, passphrase_hint: Optional[str]) -> None:
+        """
+        Store the new passphrase hint in the staging dict (outer_payload_properties_for_next_write) to
+        be written-out on the next write to the keyring.
+        """
+        assert self.outer_payload_properties_for_next_write is not None
+        if passphrase_hint is not None and len(passphrase_hint) > 0:
+            self.outer_payload_properties_for_next_write["passphrase_hint"] = passphrase_hint
+        elif "passphrase_hint" in self.outer_payload_properties_for_next_write:
+            del self.outer_payload_properties_for_next_write["passphrase_hint"]

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -475,13 +475,19 @@ class Keychain:
         KeyringWrapper.get_shared_instance().refresh_keyrings()
 
     @staticmethod
-    def migrate_legacy_keyring(passphrase: Optional[str] = None, cleanup_legacy_keyring: bool = False) -> None:
+    def migrate_legacy_keyring(
+        passphrase: Optional[str] = None, save_passphrase: bool = False, cleanup_legacy_keyring: bool = False
+    ) -> None:
         """
         Begins legacy keyring migration in a non-interactive manner
         """
         if passphrase is not None and passphrase != "":
             KeyringWrapper.get_shared_instance().set_master_passphrase(
-                current_passphrase=None, new_passphrase=passphrase, write_to_keyring=False, allow_migration=False
+                current_passphrase=None,
+                new_passphrase=passphrase,
+                write_to_keyring=False,
+                save_passphrase=save_passphrase,
+                allow_migration=False,
             )
 
         KeyringWrapper.get_shared_instance().migrate_legacy_keyring(cleanup_legacy_keyring=cleanup_legacy_keyring)

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -476,7 +476,10 @@ class Keychain:
 
     @staticmethod
     def migrate_legacy_keyring(
-        passphrase: Optional[str] = None, save_passphrase: bool = False, cleanup_legacy_keyring: bool = False
+        passphrase: Optional[str] = None,
+        passphrase_hint: Optional[str] = None,
+        save_passphrase: bool = False,
+        cleanup_legacy_keyring: bool = False,
     ) -> None:
         """
         Begins legacy keyring migration in a non-interactive manner
@@ -486,8 +489,9 @@ class Keychain:
                 current_passphrase=None,
                 new_passphrase=passphrase,
                 write_to_keyring=False,
-                save_passphrase=save_passphrase,
                 allow_migration=False,
+                passphrase_hint=passphrase_hint,
+                save_passphrase=save_passphrase,
             )
 
         KeyringWrapper.get_shared_instance().migrate_legacy_keyring(cleanup_legacy_keyring=cleanup_legacy_keyring)
@@ -566,6 +570,7 @@ class Keychain:
         new_passphrase: str,
         *,
         allow_migration: bool = True,
+        passphrase_hint: Optional[str] = None,
         save_passphrase: bool = False,
     ) -> None:
         """
@@ -573,7 +578,11 @@ class Keychain:
         passphrase can decrypt the contents
         """
         KeyringWrapper.get_shared_instance().set_master_passphrase(
-            current_passphrase, new_passphrase, allow_migration=allow_migration, save_passphrase=save_passphrase
+            current_passphrase,
+            new_passphrase,
+            allow_migration=allow_migration,
+            passphrase_hint=passphrase_hint,
+            save_passphrase=save_passphrase,
         )
 
     @staticmethod
@@ -584,3 +593,10 @@ class Keychain:
         default passphrase.
         """
         KeyringWrapper.get_shared_instance().remove_master_passphrase(current_passphrase)
+
+    @staticmethod
+    def get_master_passphrase_hint() -> Optional[str]:
+        """
+        Returns the passphrase hint from the keyring
+        """
+        return KeyringWrapper.get_shared_instance().get_master_passphrase_hint()

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -600,3 +600,11 @@ class Keychain:
         Returns the passphrase hint from the keyring
         """
         return KeyringWrapper.get_shared_instance().get_master_passphrase_hint()
+
+    @staticmethod
+    def set_master_passphrase_hint(current_passphrase: str, passphrase_hint: Optional[str]) -> None:
+        """
+        Convenience method for setting/removing the passphrase hint. Requires the current
+        passphrase, as the passphrase hint is written as part of a passphrase update.
+        """
+        Keychain.set_master_passphrase(current_passphrase, current_passphrase, passphrase_hint=passphrase_hint)

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -238,6 +238,7 @@ class KeyringWrapper:
         *,
         write_to_keyring: bool = True,
         allow_migration: bool = True,
+        passphrase_hint: Optional[str] = None,
         save_passphrase: bool = False,
     ) -> None:
         """
@@ -259,6 +260,8 @@ class KeyringWrapper:
             raise KeyringCurrentPassphraseIsInvalid("invalid current passphrase")
 
         self.set_cached_master_passphrase(new_passphrase, validated=True)
+
+        self.keyring.set_passphrase_hint(passphrase_hint)
 
         if write_to_keyring:
             # We'll migrate the legacy contents to the new keyring at this point
@@ -321,6 +324,9 @@ class KeyringWrapper:
                 if not warn_if_macos_errSecInteractionNotAllowed(e):
                     raise e
         return None
+
+    def get_master_passphrase_hint(self) -> Optional[str]:
+        return self.keyring.get_passphrase_hint()
 
     # Legacy keyring migration
 

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -326,7 +326,9 @@ class KeyringWrapper:
         return None
 
     def get_master_passphrase_hint(self) -> Optional[str]:
-        return self.keyring.get_passphrase_hint()
+        if self.keyring_supports_master_passphrase():
+            return self.keyring.get_passphrase_hint()
+        return None
 
     # Legacy keyring migration
 

--- a/tests/core/util/test_keyring_wrapper.py
+++ b/tests/core/util/test_keyring_wrapper.py
@@ -394,3 +394,65 @@ class TestKeyringWrapper:
         # Expect: an invalid passphrase containing an non-ascii characters should fail validation
         assert KeyringWrapper.get_shared_instance().get_cached_master_passphrase() != ("私は幸せな農夫ではありません", True)
         assert KeyringWrapper.get_shared_instance().master_passphrase_is_valid("私は幸せな農夫ではありません") is False
+
+    @using_temp_file_keyring()
+    def test_passphrase_hint(self):
+        """
+        Setting and retrieving the passphrase hint
+        """
+        # Expect: no hint set by default
+        assert KeyringWrapper.get_shared_instance().get_master_passphrase_hint() is None
+
+        # When: setting the passphrase hint while setting the master passphrase
+        KeyringWrapper.get_shared_instance().set_master_passphrase(
+            None, "passphrase", passphrase_hint="rhymes with bassphrase"
+        )
+
+        # Expect: to retrieve the passphrase hint that was just set
+        assert KeyringWrapper.get_shared_instance().get_master_passphrase_hint() == "rhymes with bassphrase"
+
+    @using_temp_file_keyring()
+    def test_passphrase_hint_removal(self):
+        """
+        Removing a passphrase hint
+        """
+        # When: setting the passphrase hint while setting the master passphrase
+        KeyringWrapper.get_shared_instance().set_master_passphrase(
+            None, "12345", passphrase_hint="President Skroob's luggage combination"
+        )
+
+        # Expect: to retrieve the passphrase hint that was just set
+        assert (
+            KeyringWrapper.get_shared_instance().get_master_passphrase_hint()
+            == "President Skroob's luggage combination"
+        )
+
+        # When: removing the passphrase hint
+        KeyringWrapper.get_shared_instance().set_master_passphrase("12345", "12345", passphrase_hint=None)
+
+        # Expect: passphrase hint has been removed
+        assert KeyringWrapper.get_shared_instance().get_master_passphrase_hint() is None
+
+    @using_temp_file_keyring()
+    def test_passphrase_hint_update(self):
+        """
+        Updating a passphrase hint
+        """
+        # When: setting the passphrase hint while setting the master passphrase
+        KeyringWrapper.get_shared_instance().set_master_passphrase(
+            None, "i like turtles", passphrase_hint="My deepest darkest secret"
+        )
+
+        # Expect: to retrieve the passphrase hint that was just set
+        assert KeyringWrapper.get_shared_instance().get_master_passphrase_hint() == "My deepest darkest secret"
+
+        # When: updating the passphrase hint
+        KeyringWrapper.get_shared_instance().set_master_passphrase(
+            "i like turtles", "i like turtles", passphrase_hint="Something you wouldn't expect The Shredder to say"
+        )
+
+        # Expect: to retrieve the passphrase hint that was just set
+        assert (
+            KeyringWrapper.get_shared_instance().get_master_passphrase_hint()
+            == "Something you wouldn't expect The Shredder to say"
+        )

--- a/tests/core/util/test_keyring_wrapper.py
+++ b/tests/core/util/test_keyring_wrapper.py
@@ -395,6 +395,20 @@ class TestKeyringWrapper:
         assert KeyringWrapper.get_shared_instance().get_cached_master_passphrase() != ("私は幸せな農夫ではありません", True)
         assert KeyringWrapper.get_shared_instance().master_passphrase_is_valid("私は幸せな農夫ではありません") is False
 
+    # When: using a new empty keyring
+    @using_temp_file_keyring()
+    def test_set_master_passphrase_with_hint(self):
+        """
+        Setting a passphrase hint at the same time as setting the passphrase
+        """
+        # When: setting the master passphrase with a hint
+        KeyringWrapper.get_shared_instance().set_master_passphrase(
+            None, "new master passphrase", passphrase_hint="some passphrase hint"
+        )
+
+        # Expect: hint can be retrieved
+        assert KeyringWrapper.get_shared_instance().get_master_passphrase_hint() == "some passphrase hint"
+
     @using_temp_file_keyring()
     def test_passphrase_hint(self):
         """


### PR DESCRIPTION
Trello issue: https://trello.com/c/P4SmvQVs/1373-final-ux-for-passphrase-encryption-feature

These changes complement the requested GUI changes to finalize keyring passphrase support. The ability to save the passphrase to the macOS Keychain or Windows Credential Manager was previously implemented for the CLI, but is now exposed to the GUI.

Additionally, a passphrase hint can now be set by the user. The GUI will display the hint (if set) in the passphrase dialog. The passphrase hint is stored in the clear in keyring.yaml and is set at the same time a passphrase change is made. CLI options have been added to manage the passphrase hint:

`$ chia passphrase hint display # Displays the passphrase hint`

`$ chia passphrase hint set "my deepest darkest secret" # Sets the passphrase hint`

`$ chia passphrase hint remove # Removes the passphrase hint`

`$ chia passphrase set --hint "some hint" # Sets the passphrase and hint`