### PR TITLE
github|setup: Introduce `pre-commit.yml` to force `pre-commit` to pass

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -22,16 +22,16 @@ jobs:
           stale-pr-label: stale-pr
           remove-stale-when-updated: true
           stale-issue-message: >
-            'This issue has been flagged as stale, as there has been no 
-            activity on it in the last 14 days. If this issue is still 
+            'This issue has been flagged as stale, as there has been no
+            activity on it in the last 14 days. If this issue is still
             affecting you and in need of further review, please comment
             on it with an update to keep it open.'
           close-issue-message: >
-            'This issue was automatically closed because it has been flagged 
+            'This issue was automatically closed because it has been flagged
             as stale, and subsequently passed 7 days with no further activity
             from the submitter or watchers.'
           stale-pr-message: >
-            'This PR has been flagged as stale due to no activity for over 60 
-            days. It will not be automatically closed, but it has been given a 
-            stale-pr label and should be manually reviewed by the relevant 
+            'This PR has been flagged as stale due to no activity for over 60
+            days. It will not be automatically closed, but it has been given a
+            stale-pr label and should be manually reviewed by the relevant
             parties.'

--- a/setup.py
+++ b/setup.py
@@ -120,4 +120,4 @@ kwargs = dict(
 
 
 if __name__ == "__main__":
-    setup(**kwargs)
+    setup(**kwargs)  # type: ignore


### PR DESCRIPTION
1ac1ff2 and 198abe8 are part of #8728. I moved them into this PR now to get it merged faster to avoid repeatedly occurring trailing whitespace failures introduces in `main`. The commits in here enable ` pre-commit` as CI step / Github Action so that all checks are enforced now for all PRs.