### PR TITLE
plotting: Fix log output for duplicated plots

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -351,15 +351,13 @@ class PlotManager:
                     self.cache.update(prover.get_id(), cache_entry)
 
                 with self.plot_filename_paths_lock:
-                    if file_path.name not in self.plot_filename_paths:
-                        self.plot_filename_paths[file_path.name] = (str(Path(prover.get_filename()).parent), set())
+                    paths: Optional[Tuple[str, Set[str]]] = self.plot_filename_paths.get(file_path.name)
+                    if paths is None:
+                        paths = (str(Path(prover.get_filename()).parent), set())
+                        self.plot_filename_paths[file_path.name] = paths
                     else:
-                        self.plot_filename_paths[file_path.name][1].add(str(Path(prover.get_filename()).parent))
-                    if len(self.plot_filename_paths[file_path.name][1]) > 0:
-                        log.warning(
-                            f"Have multiple copies of the plot {file_path} in "
-                            f"{self.plot_filename_paths[file_path.name][1]}."
-                        )
+                        paths[1].add(str(Path(prover.get_filename()).parent))
+                        log.warning(f"Have multiple copies of the plot {file_path.name} in {[paths[0], *paths[1]]}.")
                         return None
 
                 new_plot_info: PlotInfo = PlotInfo(


### PR DESCRIPTION
The first replacement of the log output contained `file_path` which is the full path to the actual duplicate and should have rather been something like `Path(self.plot_filename_paths[file_path.name][0]) / file_path.name` to contain the full path to the loaded plot. I refactored this part a bit and slightly modified the log message. Output now looks like:

```
Have multiple copies of the plot plot-k32-2021-07-05-22-19-xx...xx.plot in ('/test', '/test/duplicated', '/test/duplicated-copy')
```