### PR TITLE
Remove unneeded 's from stale issue message

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -21,17 +21,17 @@ jobs:
           stale-issue-label: stale-issue
           stale-pr-label: stale-pr
           remove-stale-when-updated: true
-          stale-issue-message: >
-            'This issue has been flagged as stale, as there has been no
+          stale-issue-message: >-
+            This issue has been flagged as stale, as there has been no
             activity on it in the last 14 days. If this issue is still
             affecting you and in need of further review, please comment
-            on it with an update to keep it open.'
-          close-issue-message: >
-            'This issue was automatically closed because it has been flagged
+            on it with an update to keep it open.
+          close-issue-message: >-
+            This issue was automatically closed because it has been flagged
             as stale, and subsequently passed 7 days with no further activity
-            from the submitter or watchers.'
-          stale-pr-message: >
-            'This PR has been flagged as stale due to no activity for over 60
+            from the submitter or watchers.
+          stale-pr-message: >-
+            This PR has been flagged as stale due to no activity for over 60
             days. It will not be automatically closed, but it has been given a
             stale-pr label and should be manually reviewed by the relevant
-            parties.'
+            parties.


### PR DESCRIPTION
When the `>` approach was used the `'` became part of the text.  Note https://github.com/Chia-Network/chia-blockchain/issues/8344#issuecomment-938552667 vs. https://github.com/Chia-Network/chia-blockchain/issues/8629#issuecomment-943250731.

```console
$ python -c 'import yaml; f = open(".github/workflows/stale-issue.yml"); x = yaml.safe_load(f); print(x)'
{'name': 'Close stale issues', True: {'schedule': [{'cron': '0 11 * * *'}]}, 'jobs': {'stale': {'runs-on': 'ubuntu-latest', 'steps': [{'uses': 'chia-network/stale@main', 'with': {'operations-per-run': 10000, 'ascending': True, 'days-before-issue-stale': 14, 'days-before-issue-close': 7, 'days-before-pr-stale': 60, 'days-before-pr-close': -1, 'exempt-all-pr-milestones': True, 'exempt-all-issue-milestones': True, 'exempt-all-assignees': True, 'stale-issue-label': 'stale-issue', 'stale-pr-label': 'stale-pr', 'remove-stale-when-updated': True, 'stale-issue-message': "'This issue has been flagged as stale, as there has been no activity on it in the last 14 days. If this issue is still affecting you and in need of further review, please comment on it with an update to keep it open.'\n", 'close-issue-message': "'This issue was automatically closed because it has been flagged as stale, and subsequently passed 7 days with no further activity from the submitter or watchers.'\n", 'stale-pr-message': "'This PR has been flagged as stale due to no activity for over 60 days. It will not be automatically closed, but it has been given a stale-pr label and should be manually reviewed by the relevant parties.'\n"}}]}}}
```

```console
$ git diff
diff --git a/.github/workflows/stale-issue.yml b/.github/workflows/stale-issue.yml
index 2c7c5839a..1ddb819c6 100644
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -22,16 +22,16 @@ jobs:
           stale-pr-label: stale-pr
           remove-stale-when-updated: true
           stale-issue-message: >
-            'This issue has been flagged as stale, as there has been no
+            This issue has been flagged as stale, as there has been no
             activity on it in the last 14 days. If this issue is still
             affecting you and in need of further review, please comment
-            on it with an update to keep it open.'
+            on it with an update to keep it open.
           close-issue-message: >
-            'This issue was automatically closed because it has been flagged
+            This issue was automatically closed because it has been flagged
             as stale, and subsequently passed 7 days with no further activity
-            from the submitter or watchers.'
+            from the submitter or watchers.
           stale-pr-message: >
-            'This PR has been flagged as stale due to no activity for over 60
+            This PR has been flagged as stale due to no activity for over 60
             days. It will not be automatically closed, but it has been given a
             stale-pr label and should be manually reviewed by the relevant
-            parties.'
+            parties.
```

```console
$ venv/bin/python -c 'import yaml; f = open(".github/workflows/stale-issue.yml"); x = yaml.safe_load(f); print(x)'
{'name': 'Close stale issues', True: {'schedule': [{'cron': '0 11 * * *'}]}, 'jobs': {'stale': {'runs-on': 'ubuntu-latest', 'steps': [{'uses': 'chia-network/stale@main', 'with': {'operations-per-run': 10000, 'ascending': True, 'days-before-issue-stale': 14, 'days-before-issue-close': 7, 'days-before-pr-stale': 60, 'days-before-pr-close': -1, 'exempt-all-pr-milestones': True, 'exempt-all-issue-milestones': True, 'exempt-all-assignees': True, 'stale-issue-label': 'stale-issue', 'stale-pr-label': 'stale-pr', 'remove-stale-when-updated': True, 'stale-issue-message': 'This issue has been flagged as stale, as there has been no activity on it in the last 14 days. If this issue is still affecting you and in need of further review, please comment on it with an update to keep it open.\n', 'close-issue-message': 'This issue was automatically closed because it has been flagged as stale, and subsequently passed 7 days with no further activity from the submitter or watchers.\n', 'stale-pr-message': 'This PR has been flagged as stale due to no activity for over 60 days. It will not be automatically closed, but it has been given a stale-pr label and should be manually reviewed by the relevant parties.\n'}}]}}}
```

Adding the `-` after the `>` additionally avoids the trailing newline.

```console
$ git diff
diff --git a/.github/workflows/stale-issue.yml b/.github/workflows/stale-issue.yml
index 2c7c5839a..1bee15516 100644
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -21,17 +21,17 @@ jobs:
           stale-issue-label: stale-issue
           stale-pr-label: stale-pr
           remove-stale-when-updated: true
-          stale-issue-message: >
-            'This issue has been flagged as stale, as there has been no
+          stale-issue-message: >-
+            This issue has been flagged as stale, as there has been no
             activity on it in the last 14 days. If this issue is still
             affecting you and in need of further review, please comment
-            on it with an update to keep it open.'
-          close-issue-message: >
-            'This issue was automatically closed because it has been flagged
+            on it with an update to keep it open.
+          close-issue-message: >-
+            This issue was automatically closed because it has been flagged
             as stale, and subsequently passed 7 days with no further activity
-            from the submitter or watchers.'
-          stale-pr-message: >
-            'This PR has been flagged as stale due to no activity for over 60
+            from the submitter or watchers.
+          stale-pr-message: >-
+            This PR has been flagged as stale due to no activity for over 60
             days. It will not be automatically closed, but it has been given a
             stale-pr label and should be manually reviewed by the relevant
-            parties.'
+            parties.
```

```console
$ python -c 'import yaml; f = open(".github/workflows/stale-issue.yml"); x = yaml.safe_load(f); print(x)'
{'name': 'Close stale issues', True: {'schedule': [{'cron': '0 11 * * *'}]}, 'jobs': {'stale': {'runs-on': 'ubuntu-latest', 'steps': [{'uses': 'chia-network/stale@main', 'with': {'operations-per-run': 10000, 'ascending': True, 'days-before-issue-stale': 14, 'days-before-issue-close': 7, 'days-before-pr-stale': 60, 'days-before-pr-close': -1, 'exempt-all-pr-milestones': True, 'exempt-all-issue-milestones': True, 'exempt-all-assignees': True, 'stale-issue-label': 'stale-issue', 'stale-pr-label': 'stale-pr', 'remove-stale-when-updated': True, 'stale-issue-message': 'This issue has been flagged as stale, as there has been no activity on it in the last 14 days. If this issue is still affecting you and in need of further review, please comment on it with an update to keep it open.', 'close-issue-message': 'This issue was automatically closed because it has been flagged as stale, and subsequently passed 7 days with no further activity from the submitter or watchers.', 'stale-pr-message': 'This PR has been flagged as stale due to no activity for over 60 days. It will not be automatically closed, but it has been given a stale-pr label and should be manually reviewed by the relevant parties.'}}]}}}
```