### PR TITLE
Enable keyring passphrase support by default. 

### DIFF
--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -44,11 +44,8 @@ class KeyringMaxUnlockAttempts(Exception):
 
 
 def supports_keyring_passphrase() -> bool:
-    # TODO: Enable once all platforms are supported and GUI work is finalized (including migration)
-    return False or os.environ.get("CHIA_PASSPHRASE_SUPPORT", "").lower() in ["1", "true"]
-    # from sys import platform
-
-    # return platform == "linux"
+    # Support can be disabled by setting CHIA_PASSPHRASE_SUPPORT to 0/false
+    return os.environ.get("CHIA_PASSPHRASE_SUPPORT", "true").lower() in ["1", "true"]
 
 
 def supports_os_passphrase_storage() -> bool:


### PR DESCRIPTION
Can be disabled by setting the CHIA_PASSPHRASE_SUPPORT env variable to "false".