### PR TITLE
Use hex-strings at the interface between the RPC client and API

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -5,13 +5,10 @@ from typing import Any, Callable, Dict, List, Optional
 import aiosqlite
 
 from chia.consensus.constants import ConsensusConstants
-from chia.data_layer.data_layer_types import Side
 from chia.data_layer.data_layer_wallet import DataLayerWallet
 from chia.data_layer.data_store import DataStore
 from chia.server.server import ChiaServer
-from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.byte_types import hexstr_to_bytes
 from chia.util.db_wrapper import DBWrapper
 from chia.util.path import mkdir, path_from_root
 

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -11,6 +11,7 @@ from chia.data_layer.data_store import DataStore
 from chia.server.server import ChiaServer
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.byte_types import hexstr_to_bytes
 from chia.util.db_wrapper import DBWrapper
 from chia.util.path import mkdir, path_from_root
 
@@ -95,20 +96,16 @@ class DataLayer:
     ) -> bool:
         for change in changelist:
             if change["action"] == "insert":
-                key = bytes32(change["key"])
-                value = bytes32(change["value"])
-                reference_node_hash = None
-                if "reference_node_hash" in change:
-                    reference_node_hash = Program.from_bytes(change["reference_node_hash"])
-                side = None
-                if side in change:
-                    side = Side(change["side"])
+                key = change["key"]
+                value = change["value"]
+                reference_node_hash = change.get("reference_node_hash")
+                side = change.get("side")
                 if reference_node_hash or side:
                     await self.data_store.insert(key, value, tree_id, reference_node_hash, side)
                 await self.data_store.autoinsert(key, value, tree_id)
             else:
                 assert change["action"] == "delete"
-                key = bytes32(change["key"])
+                key = change["key"]
                 await self.data_store.delete(key, tree_id)
 
         # state = await self.data_store.get_table_state(table)

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -115,7 +115,7 @@ class DataStore:
 
         return node_hash
 
-    async def _insert_terminal_node(self, key: bytes32, value: bytes32) -> bytes32:
+    async def _insert_terminal_node(self, key: bytes, value: bytes) -> bytes32:
         # TODO: maybe verify a transaction is active
 
         node_hash = Program.to((key, value)).get_tree_hash()
@@ -413,8 +413,8 @@ class DataStore:
 
     async def autoinsert(
         self,
-        key: bytes32,
-        value: bytes32,
+        key: bytes,
+        value: bytes,
         tree_id: bytes32,
         *,
         lock: bool = True,
@@ -440,8 +440,8 @@ class DataStore:
 
     async def insert(
         self,
-        key: bytes32,
-        value: bytes32,
+        key: bytes,
+        value: bytes,
         tree_id: bytes32,
         reference_node_hash: Optional[bytes32],
         side: Optional[Side],
@@ -514,7 +514,7 @@ class DataStore:
 
         return new_terminal_node_hash
 
-    async def delete(self, key: bytes32, tree_id: bytes32, *, lock: bool = True) -> None:
+    async def delete(self, key: bytes, tree_id: bytes32, *, lock: bool = True) -> None:
         async with self.db_wrapper.locked_transaction(lock=lock):
             node = await self.get_node_by_key(key=key, tree_id=tree_id, lock=False)
             ancestors = await self.get_ancestors(node_hash=node.hash, tree_id=tree_id, lock=False)
@@ -558,7 +558,7 @@ class DataStore:
 
         return
 
-    async def get_node_by_key(self, key: bytes32, tree_id: bytes32, *, lock: bool = True) -> TerminalNode:
+    async def get_node_by_key(self, key: bytes, tree_id: bytes32, *, lock: bool = True) -> TerminalNode:
         async with self.db_wrapper.locked_transaction(lock=lock):
             nodes = await self.get_pairs(tree_id=tree_id, lock=False)
 
@@ -569,7 +569,7 @@ class DataStore:
         # TODO: fill out the exception
         raise Exception("node not found")
 
-    async def get_node_by_key_bytes(self, key: bytes32, tree_id: bytes32, *, lock: bool = True) -> TerminalNode:
+    async def get_node_by_key_bytes(self, key: bytes, tree_id: bytes32, *, lock: bool = True) -> TerminalNode:
         async with self.db_wrapper.locked_transaction(lock=lock):
             nodes = await self.get_pairs(tree_id=tree_id, lock=False)
 

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -7,7 +7,9 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.data_layer.data_layer import DataLayer
 from chia.data_layer.data_store import DataStore
 from chia.rpc.data_layer_rpc_api import DataLayerRpcApi
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.program import Program
+from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config
 from chia.util.db_wrapper import DBWrapper
 from chia.util.hash import std_hash
@@ -27,18 +29,18 @@ async def test_create_insert_get(chia_root: ChiaRoot) -> None:
     data_layer.data_store = await DataStore.create(data_layer.db_wrapper)
     data_layer.initialized = True
     rpc_api = DataLayerRpcApi(data_layer)
-    key = std_hash(b"a")
-    value = std_hash(Program.to([1, 2]))
-    changelist: List[Dict[str, str]] = [{"action": "insert", "key": key, "value": value}]
+    key = b"a"
+    value = b"\x00\x01"
+    changelist: List[Dict[str, str]] = [{"action": "insert", "key": key.hex(), "value": value.hex()}]
     res = await rpc_api.create_kv_store()
-    store_id = res["id"]
-    await rpc_api.update_kv_store({"id": store_id, "changelist": changelist})
-    res = await rpc_api.get_value({"id": store_id, "key": key})
-    assert res["data"] == value
-    changelist = [{"action": "delete", "key": key}]
-    await rpc_api.update_kv_store({"id": store_id, "changelist": changelist})
+    store_id = bytes32(hexstr_to_bytes(res["id"]))
+    await rpc_api.update_kv_store({"id": store_id.hex(), "changelist": changelist})
+    res = await rpc_api.get_value({"id": store_id.hex(), "key": key.hex()})
+    assert hexstr_to_bytes(res["data"]) == value
+    changelist = [{"action": "delete", "key": key.hex()}]
+    await rpc_api.update_kv_store({"id": store_id.hex(), "changelist": changelist})
     with pytest.raises(Exception):
-        val = await rpc_api.get_value({"id": store_id, "key": key.as_bin()})
+        val = await rpc_api.get_value({"id": store_id.hex(), "key": key.hex()})
     await connection.close()
 
 
@@ -54,26 +56,26 @@ async def test_create_double_insert(chia_root: ChiaRoot) -> None:
     data_layer.data_store = await DataStore.create(data_layer.db_wrapper)
     data_layer.initialized = True
     rpc_api = DataLayerRpcApi(data_layer)
-    key1 = std_hash(b"a")
-    value1 = std_hash(Program.to([1, 2]))
-    key2 = std_hash(b"b")
-    value2 = std_hash(Program.to([1, 23]))
-    changelist: List[Dict[str, str]] = [{"action": "insert", "key": key1, "value": value1}]
+    key1 = b"a"
+    value1 = b"\x01\x02"
+    key2 = b"b"
+    value2 = b"\x01\x23"
+    changelist: List[Dict[str, str]] = [{"action": "insert", "key": key1.hex(), "value": value1.hex()}]
     res = await rpc_api.create_kv_store()
-    store_id = res["id"]
-    await rpc_api.update_kv_store({"id": store_id, "changelist": changelist})
-    res = await rpc_api.get_value({"id": store_id, "key": key1})
-    assert res["data"] == value1
+    store_id = bytes32(hexstr_to_bytes(res["id"]))
+    await rpc_api.update_kv_store({"id": store_id.hex(), "changelist": changelist})
+    res = await rpc_api.get_value({"id": store_id.hex(), "key": key1.hex()})
+    assert hexstr_to_bytes(res["data"]) == value1
 
-    changelist = [{"action": "insert", "key": key2, "value": value2}]
-    await rpc_api.update_kv_store({"id": store_id, "changelist": changelist})
-    res = await rpc_api.get_value({"id": store_id, "key": key2})
-    assert res["data"] == value2
+    changelist = [{"action": "insert", "key": key2.hex(), "value": value2.hex()}]
+    await rpc_api.update_kv_store({"id": store_id.hex(), "changelist": changelist})
+    res = await rpc_api.get_value({"id": store_id.hex(), "key": key2.hex()})
+    assert hexstr_to_bytes(res["data"]) == value2
 
-    changelist = [{"action": "delete", "key": key1}]
-    await rpc_api.update_kv_store({"id": store_id, "changelist": changelist})
+    changelist = [{"action": "delete", "key": key1.hex()}]
+    await rpc_api.update_kv_store({"id": store_id.hex(), "changelist": changelist})
     with pytest.raises(Exception):
-        val = await rpc_api.get_value({"id": store_id, "key": key1})
+        val = await rpc_api.get_value({"id": store_id.hex(), "key": key1.hex()})
     await connection.close()
 
 
@@ -89,29 +91,29 @@ async def test_get_pairs(chia_root: ChiaRoot) -> None:
     data_layer.data_store = await DataStore.create(data_layer.db_wrapper)
     data_layer.initialized = True
     rpc_api = DataLayerRpcApi(data_layer)
-    key1 = std_hash(b"a")
-    value1 = std_hash(Program.to([1, 2]))
-    changelist: List[Dict[str, str]] = [{"action": "insert", "key": key1, "value": value1}]
-    key2 = std_hash(b"b")
-    value2 = std_hash(Program.to([3, 2]))
-    changelist.append({"action": "insert", "key": key2, "value": value2})
-    key3 = std_hash(b"c")
-    value3 = std_hash(Program.to([4, 5]))
-    changelist.append({"action": "insert", "key": key3, "value": value3})
-    key4 = std_hash(b"d")
-    value4 = std_hash(Program.to([6, 3]))
-    changelist.append({"action": "insert", "key": key4, "value": value4})
-    key5 = std_hash(b"e")
-    value5 = std_hash(Program.to([7, 1]))
-    changelist.append({"action": "insert", "key": key5, "value": value5})
+    key1 = b"a"
+    value1 = b"\x01\x02"
+    changelist: List[Dict[str, str]] = [{"action": "insert", "key": key1.hex(), "value": value1.hex()}]
+    key2 = b"b"
+    value2 = b"\x03\x02"
+    changelist.append({"action": "insert", "key": key2.hex(), "value": value2.hex()})
+    key3 = b"c"
+    value3 = b"\x04\x05"
+    changelist.append({"action": "insert", "key": key3.hex(), "value": value3.hex()})
+    key4 = b"d"
+    value4 = b"\x06\x03"
+    changelist.append({"action": "insert", "key": key4.hex(), "value": value4.hex()})
+    key5 = b"e"
+    value5 = b"\x07\x01"
+    changelist.append({"action": "insert", "key": key5.hex(), "value": value5.hex()})
     res = await rpc_api.create_kv_store()
-    tree_id = res["id"]
-    await rpc_api.update_kv_store({"id": tree_id, "changelist": changelist})
-    val = await rpc_api.get_value({"id": tree_id, "key": key1})
-    assert val["data"] == value1
-    val = await rpc_api.get_value({"id": tree_id, "key": key1})
-    changelist = [{"action": "delete", "key": key1}]
-    await rpc_api.update_kv_store({"id": tree_id, "changelist": changelist})
+    tree_id = bytes32(hexstr_to_bytes(res["id"]))
+    await rpc_api.update_kv_store({"id": tree_id.hex(), "changelist": changelist})
+    val = await rpc_api.get_value({"id": tree_id.hex(), "key": key1.hex()})
+    assert hexstr_to_bytes(val["data"]) == value1
+    val = await rpc_api.get_value({"id": tree_id.hex(), "key": key1.hex()})
+    changelist = [{"action": "delete", "key": key1.hex()}]
+    await rpc_api.update_kv_store({"id": tree_id.hex(), "changelist": changelist})
     with pytest.raises(Exception):
-        val = await rpc_api.get_value({"id": tree_id, "key": key1})
+        val = await rpc_api.get_value({"id": tree_id.hex(), "key": key1.hex()})
     await connection.close()


### PR DESCRIPTION
In real usage they interact through JSON and thus cannot use
bytes objects between them.  Rather, we tend to use .hex() and
hexstr_to_bytes() for the [de]serialization.