### PR TITLE
add WalletWeightProofHandler._executor_shutdown_tempfile

### DIFF
--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1273,9 +1273,7 @@ def validate_recent_blocks(
             ses_blocks += 1
         prev_block_record = block_record
 
-        # TODO: Where do we really want to be checking this?
         if shutdown_file_path is not None and not shutdown_file_path.is_file():
-            # TODO: Should we pretend invalidity or raise an exception?
             log.info(f"cancelling block {block.header_hash} validation, shutdown requested")
             return False, []
 
@@ -1654,9 +1652,7 @@ def _validate_vdf_batch(
         if not vdf.is_valid(constants, class_group, vdf_info):
             return False
 
-        # TODO: Where do we really want to be checking this?
         if shutdown_file_path is not None and not shutdown_file_path.is_file():
-            # TODO: Should we pretend invalidity or raise an exception?
             log.info("cancelling VDF validation, shutdown requested")
             return False
 

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -2,6 +2,7 @@ import asyncio
 import dataclasses
 import logging
 import math
+import pathlib
 import random
 from concurrent.futures.process import ProcessPoolExecutor
 from typing import Dict, List, Optional, Tuple
@@ -1193,7 +1194,10 @@ def sub_slot_data_vdf_input(
 
 
 def validate_recent_blocks(
-    constants: ConsensusConstants, recent_chain: RecentChainData, summaries: List[SubEpochSummary]
+    constants: ConsensusConstants,
+    recent_chain: RecentChainData,
+    summaries: List[SubEpochSummary],
+    shutdown_file_path: Optional[pathlib.Path] = None,
 ) -> Tuple[bool, List[bytes]]:
     sub_blocks = BlockCache({})
     first_ses_idx = _get_ses_idx(recent_chain.recent_chain_data)
@@ -1273,6 +1277,12 @@ def validate_recent_blocks(
             ses_blocks += 1
         prev_block_record = block_record
 
+        # TODO: Where do we really want to be checking this?
+        if shutdown_file_path is not None and not shutdown_file_path.is_file():
+            # TODO: Should we pretend invalidity or raise an exception?
+            log.info(f"cancelling block {block.header_hash} validation, shutdown requested")
+            return False, []
+
     return True, [bytes(sub) for sub in sub_blocks._block_records.values()]
 
 
@@ -1284,11 +1294,14 @@ def _validate_recent_blocks(constants_dict: Dict, recent_chain_bytes: bytes, sum
 
 
 def _validate_recent_blocks_and_get_records(
-    constants_dict: Dict, recent_chain_bytes: bytes, summaries_bytes: List[bytes]
+    constants_dict: Dict,
+    recent_chain_bytes: bytes,
+    summaries_bytes: List[bytes],
+    shutdown_file_path: Optional[pathlib.Path] = None,
 ) -> Tuple[bool, List[bytes]]:
     constants, summaries = bytes_to_vars(constants_dict, summaries_bytes)
     recent_chain: RecentChainData = RecentChainData.from_bytes(recent_chain_bytes)
-    return validate_recent_blocks(constants, recent_chain, summaries)
+    return validate_recent_blocks(constants, recent_chain, summaries, shutdown_file_path)
 
 
 def _validate_pospace_recent_chain(
@@ -1633,7 +1646,9 @@ def validate_total_iters(
     return total_iters == sub_slot_data.total_iters
 
 
-def _validate_vdf_batch(constants_dict, vdf_list: List[Tuple[bytes, bytes, bytes]]):
+def _validate_vdf_batch(
+    constants_dict, vdf_list: List[Tuple[bytes, bytes, bytes]], shutdown_file_path: Optional[pathlib.Path] = None
+):
     constants: ConsensusConstants = dataclass_from_dict(ConsensusConstants, constants_dict)
 
     for vdf_proof_bytes, class_group_bytes, info in vdf_list:
@@ -1641,6 +1656,12 @@ def _validate_vdf_batch(constants_dict, vdf_list: List[Tuple[bytes, bytes, bytes
         class_group = ClassgroupElement.from_bytes(class_group_bytes)
         vdf_info = VDFInfo.from_bytes(info)
         if not vdf.is_valid(constants, class_group, vdf_info):
+            return False
+
+        # TODO: Where do we really want to be checking this?
+        if shutdown_file_path is not None and not shutdown_file_path.is_file():
+            # TODO: Should we pretend invalidity or raise an exception?
+            log.info("cancelling VDF validation, shutdown requested")
             return False
 
     return True

--- a/chia/wallet/wallet_weight_proof_handler.py
+++ b/chia/wallet/wallet_weight_proof_handler.py
@@ -98,15 +98,16 @@ class WalletWeightProofHandler:
             self._constants, summaries, weight_proof
         )
 
-        vdf_tasks = []
-        recent_blocks_validation_task = asyncio.get_running_loop().run_in_executor(
+        vdf_tasks: List[asyncio.Future] = []
+        # TODO: remove hint overrides after https://github.com/python/typeshed/pull/6187
+        recent_blocks_validation_task: asyncio.Future = asyncio.get_running_loop().run_in_executor(
             self._executor,
             _validate_recent_blocks_and_get_records,
             constants,
             wp_recent_chain_bytes,
             summary_bytes,
             pathlib.Path(self._executor_shutdown_tempfile.name),
-        )
+        )  # type: ignore[assignment]
         try:
             segments_validated, vdfs_to_validate = _validate_sub_epoch_segments(
                 constants, rng, wp_segment_bytes, summary_bytes
@@ -121,13 +122,14 @@ class WalletWeightProofHandler:
                 for vdf_proof, classgroup, vdf_info in chunk:
                     byte_chunks.append((bytes(vdf_proof), bytes(classgroup), bytes(vdf_info)))
 
-                vdf_task = asyncio.get_running_loop().run_in_executor(
+                # TODO: remove hint overrides after https://github.com/python/typeshed/pull/6187
+                vdf_task: asyncio.Future = asyncio.get_running_loop().run_in_executor(
                     self._executor,
                     _validate_vdf_batch,
                     constants,
                     byte_chunks,
                     pathlib.Path(self._executor_shutdown_tempfile.name),
-                )
+                )  # type: ignore[assignment]
                 vdf_tasks.append(vdf_task)
 
             for vdf_task in vdf_tasks:


### PR DESCRIPTION
This is a minimally intrusive change to trigger the long-running
wallet weight proof handler's executors to terminate when requested.