### PR TITLE
Fix Install.ps1 check for msvcp140.dll

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -6,7 +6,7 @@ if ([Environment]::Is64BitOperatingSystem -eq $false)
     Exit 1
 }
 
-if ((Get-Item "$env:windir\System32\msvcp140.dll").Exists -eq $false)
+if (-not (Get-Item -ErrorAction SilentlyContinue "$env:windir\System32\msvcp140.dll").Exists)
 {
     Write-Output "Unable to find Visual C++ Runtime DLLs"
     Write-Output ""


### PR DESCRIPTION
The original resulted in the following error when `msvcp140.dll` was not present.

```console
PS C:\chia\chia-blockchain> ./install.ps1
Get-Item : Cannot find path 'C:\WINDOWS\System32\msvcp140.dll' because it does not exist.
At C:\chia\chia-blockchain\Install.ps1:9 char:6
+ if ((Get-Item "$env:windir\System32\msvcp140.dll").Exists -eq $false)
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\WINDOWS\System32\msvcp140.dll:String) [Get-Item], ItemNotFoundExcept
   ion
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand
```