### PR TITLE
Restore original CWD in Install-gui.ps1

### DIFF
--- a/Install-gui.ps1
+++ b/Install-gui.ps1
@@ -17,15 +17,20 @@ Write-Output "Running 'git submodule update --init --recursive'."
 Write-Output ""
 git submodule update --init --recursive
 
-Set-Location chia-blockchain-gui
+Push-Location
+try {
+    Set-Location chia-blockchain-gui
 
-$ErrorActionPreference = "SilentlyContinue"
-npm install --loglevel=error
-npm audit fix
-npm run build
-py ..\installhelper.py
+    $ErrorActionPreference = "SilentlyContinue"
+    npm install --loglevel=error
+    npm audit fix
+    npm run build
+    py ..\installhelper.py
 
-Write-Output ""
-Write-Output "Chia blockchain Install-gui.ps1 completed."
-Write-Output ""
-Write-Output "Type 'cd chia-blockchain-gui' and then 'npm run electron' to start the GUI."
+    Write-Output ""
+    Write-Output "Chia blockchain Install-gui.ps1 completed."
+    Write-Output ""
+    Write-Output "Type 'cd chia-blockchain-gui' and then 'npm run electron' to start the GUI."
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
The original script left the user in the `chia-blockchain-gui/` directory and despite the instructions to `cd chia-blockchain-gui`.