### PR TITLE
Avoid activating venv in Install.ps1

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -42,13 +42,10 @@ if ([version]$pythonVersion -lt [version]"3.7.0")
 Write-Output "Python version is:" $pythonVersion
 
 py -m venv venv
-.\venv\Scripts\Activate.ps1
 
-py -m pip install pip --upgrade
-pip install --upgrade setuptools
-pip install --upgrade wheel
-pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2
-pip install --editable . --extra-index-url https://pypi.chia.net/simple/
+venv\scripts\python -m pip install --upgrade pip setuptools wheel
+venv\scripts\pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2
+venv\scripts\pip install --editable . --extra-index-url https://pypi.chia.net/simple/
 
 Write-Output ""
 Write-Output "Chia blockchain .\Install.ps1 complete."


### PR DESCRIPTION
PowerShell scripts, as well as batch files, operate in the callers environment which is unlike bash where you have to `source` (or `.`) scripts for that to happen.  As such, this script returned control to the user with the venv still activated which was somewhat counter to the instructions that were printed out.  I suggest this route of leaving the environment not activated on exit for the sake of consistency with `install.sh`.  I chose to simply not activate the venv to begin with since then there's no deactivation "cleanup" to manage.