### PR TITLE
Fix long load times when selecting the default key from the GUI.

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -236,7 +236,10 @@ class WalletNode:
         self.peer_task = asyncio.create_task(self._periodically_check_full_node())
         self.sync_event = asyncio.Event()
         self.sync_task = asyncio.create_task(self.sync_job())
-        self.logged_in_fingerprint = fingerprint
+        if fingerprint is None:
+            self.logged_in_fingerprint = private_key.get_g1().get_fingerprint()
+        else:
+            self.logged_in_fingerprint = fingerprint
         self.logged_in = True
         return True
 


### PR DESCRIPTION
When creating a new WalletNode at launch, the fingerprint will be set to None. After a lengthy initialization task, the logged-in fingerprint was set to None instead of the default private key's fingerprint. If the user then selected that same key in the key selection screen, the same lengthy initialization task would be repeated. This fix will set the logged-in fingerprint to the default key's fingerprint if the fingerprint wasn't originally specified.