### PR TITLE
Make WalletPuzzleStore.get_derivation_record_for_puzzle_hash() take bytes32

### DIFF
--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -565,7 +565,7 @@ class CCWallet:
 
     async def inner_puzzle_for_cc_puzhash(self, cc_hash: bytes32) -> Program:
         record: DerivationRecord = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
-            cc_hash.hex()
+            cc_hash
         )
         inner_puzzle: Program = self.standard_wallet.puzzle_for_pk(bytes(record.pubkey))
         return inner_puzzle

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -890,7 +890,7 @@ class DIDWallet:
 
     async def inner_puzzle_for_did_puzzle(self, did_hash: bytes32) -> Program:
         record: DerivationRecord = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
-            did_hash.hex()
+            did_hash
         )
         inner_puzzle: Program = did_wallet_puzzles.create_innerpuz(
             bytes(record.pubkey),

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -323,7 +323,7 @@ class TradeManager:
         return get_discrepancies_for_spend_bundle(trade_offer.spend_bundle)
 
     async def get_inner_puzzle_for_puzzle_hash(self, puzzle_hash) -> Program:
-        info = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(puzzle_hash.hex())
+        info = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(puzzle_hash)
         assert info is not None
         puzzle = self.wallet_state_manager.main_wallet.puzzle_for_pk(bytes(info.pubkey))
         return puzzle

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -968,7 +968,7 @@ class WalletNode:
         for coin in additions:
             puzzle_store = self.wallet_state_manager.puzzle_store
             record_info: Optional[DerivationRecord] = await puzzle_store.get_derivation_record_for_puzzle_hash(
-                coin.puzzle_hash.hex()
+                coin.puzzle_hash
             )
             if record_info is not None and record_info.wallet_type == WalletType.COLOURED_COIN:
                 # TODO why ?

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -135,13 +135,13 @@ class WalletPuzzleStore:
 
         return None
 
-    async def get_derivation_record_for_puzzle_hash(self, puzzle_hash: str) -> Optional[DerivationRecord]:
+    async def get_derivation_record_for_puzzle_hash(self, puzzle_hash: bytes32) -> Optional[DerivationRecord]:
         """
         Returns the derivation record by index and wallet id.
         """
         cursor = await self.db_connection.execute(
             "SELECT * FROM derivation_paths WHERE puzzle_hash=?;",
-            (puzzle_hash,),
+            (puzzle_hash.hex(),),
         )
         row = await cursor.fetchone()
         await cursor.close()


### PR DESCRIPTION
Since the line of the actual issue ends up untouched in this PR, here it is.  `removal.puzzle_hash` was missing the `.hex()` it should have had.  This would have resulted in something like a seven character string `b'abcd'` in the db rather than `61626364`.  Instead of adding the `.hex()` to this line this PR removes it from all other calls to `.get_derivation_record_for_puzzle_hash()` and handles the `.hex()` inside.

https://github.com/Chia-Network/chia-blockchain/blob/ec8d3ae2f9c96c880b0ab32d912aa30c67b4121c/chia/wallet/wallet_state_manager.py#L975