### PR TITLE
Rate limits for new protocol

### DIFF
--- a/chia/server/rate_limits.py
+++ b/chia/server/rate_limits.py
@@ -102,6 +102,10 @@ rate_limits_other = {
     ProtocolMessageTypes.respond_to_ph_update: RLSettings(1000, 100 * 1024 * 1024),
     ProtocolMessageTypes.register_interest_in_coin: RLSettings(1000, 100 * 1024 * 1024),
     ProtocolMessageTypes.respond_to_coin_update: RLSettings(1000, 100 * 1024 * 1024),
+    ProtocolMessageTypes.request_ses_hashes: RLSettings(2000, 1 * 1024 * 1024),
+    ProtocolMessageTypes.respond_ses_hashes: RLSettings(2000, 1 * 1024 * 1024),
+    ProtocolMessageTypes.request_children: RLSettings(2000, 1024 * 1024),
+    ProtocolMessageTypes.respond_children: RLSettings(2000, 1 * 1024 * 1024),
 }
 
 


### PR DESCRIPTION
This needs to go in, to prevent going over the rate limits when syncing wallets in new protocol, if you have many coins.