### PR TITLE
Fix packaging failure with relative import when using --passphrase-file

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -56,7 +56,6 @@ def cli(
     passphrase_file: Optional[TextIOWrapper] = None,
 ) -> None:
     from pathlib import Path
-    from chia.cmds.passphrase_funcs import cache_passphrase, read_passphrase_from_file
 
     ctx.ensure_object(dict)
     ctx.obj["root_path"] = Path(root_path)
@@ -67,6 +66,8 @@ def cli(
         set_keys_root_path(Path(keys_root_path))
 
     if passphrase_file is not None:
+        from chia.cmds.passphrase_funcs import cache_passphrase, read_passphrase_from_file
+
         try:
             cache_passphrase(read_passphrase_from_file(passphrase_file))
         except Exception as e:

--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -56,6 +56,7 @@ def cli(
     passphrase_file: Optional[TextIOWrapper] = None,
 ) -> None:
     from pathlib import Path
+    from chia.cmds.passphrase_funcs import cache_passphrase, read_passphrase_from_file
 
     ctx.ensure_object(dict)
     ctx.obj["root_path"] = Path(root_path)
@@ -66,8 +67,6 @@ def cli(
         set_keys_root_path(Path(keys_root_path))
 
     if passphrase_file is not None:
-        from .passphrase_funcs import cache_passphrase, read_passphrase_from_file
-
         try:
             cache_passphrase(read_passphrase_from_file(passphrase_file))
         except Exception as e:


### PR DESCRIPTION
Pyinstaller didn't properly package a relative import used in `chia.py` when the `--passphrase-file` option was specified. This change updates the import to use its fully qualified module name `chia.cmds.passphrase_funcs` which is consistent with other uses of that module elsewhere.

Addresses issue #8967

Tested installers built for macOS and Windows