### PR TITLE
[Easy] Fix typo, and display overlap if applicable

### DIFF
--- a/chia/protocols/protocol_state_machine.py
+++ b/chia/protocols/protocol_state_machine.py
@@ -38,7 +38,7 @@ def static_check_sent_message_response() -> None:
     # Reply and non-reply sets should not overlap: This check should be static
     overlap = set(NO_REPLY_EXPECTED).intersection(set(VALID_REPLY_MESSAGE_MAP.keys()))
     if len(overlap) != 0:
-        raise AssertionError("Overlapping NO_REPLY_EXPECTED and VALID_REPLY_MESSAGE_MAP values: {}")
+        raise AssertionError(f'Overlapping NO_REPLY_EXPECTED and VALID_REPLY_MESSAGE_MAP values: {overlap}')
 
 
 def message_requires_reply(sent: ProtocolMessageTypes) -> bool:

--- a/chia/protocols/protocol_state_machine.py
+++ b/chia/protocols/protocol_state_machine.py
@@ -38,7 +38,7 @@ def static_check_sent_message_response() -> None:
     # Reply and non-reply sets should not overlap: This check should be static
     overlap = set(NO_REPLY_EXPECTED).intersection(set(VALID_REPLY_MESSAGE_MAP.keys()))
     if len(overlap) != 0:
-        raise AssertionError(f'Overlapping NO_REPLY_EXPECTED and VALID_REPLY_MESSAGE_MAP values: {overlap}')
+        raise AssertionError(f"Overlapping NO_REPLY_EXPECTED and VALID_REPLY_MESSAGE_MAP values: {overlap}")
 
 
 def message_requires_reply(sent: ProtocolMessageTypes) -> bool:

--- a/chia/protocols/protocol_state_machine.py
+++ b/chia/protocols/protocol_state_machine.py
@@ -12,13 +12,13 @@ NO_REPLY_EXPECTED = [
 ]
 
 """
-VAILD_REPLY_MESSAGE_MAP:
+VALID_REPLY_MESSAGE_MAP:
 key: sent message type.
 value: valid reply message types, from the view of the requester.
 A state machine can be built from this message map.
 """
 
-VAILD_REPLY_MESSAGE_MAP = {
+VALID_REPLY_MESSAGE_MAP = {
     # messages for all services
     # pmt.handshake is handled in WSChiaConnection.perform_handshake
     # full_node -> full_node protocol messages
@@ -36,15 +36,15 @@ VAILD_REPLY_MESSAGE_MAP = {
 def static_check_sent_message_response() -> None:
     """Check that allowed message data structures VALID_REPLY_MESSAGE_MAP and NO_REPLY_EXPECTED are consistent."""
     # Reply and non-reply sets should not overlap: This check should be static
-    overlap = set(NO_REPLY_EXPECTED).intersection(set(VAILD_REPLY_MESSAGE_MAP.keys()))
+    overlap = set(NO_REPLY_EXPECTED).intersection(set(VALID_REPLY_MESSAGE_MAP.keys()))
     if len(overlap) != 0:
-        raise AssertionError("Overlapping NO_REPLY_EXPECTED and VAILD_REPLY_MESSAGE_MAP values: {}")
+        raise AssertionError("Overlapping NO_REPLY_EXPECTED and VALID_REPLY_MESSAGE_MAP values: {}")
 
 
 def message_requires_reply(sent: ProtocolMessageTypes) -> bool:
     """Return True if message has an entry in the full node P2P message map"""
     # If we knew the peer NodeType is FULL_NODE, we could also check `sent not in NO_REPLY_EXPECTED`
-    return sent in VAILD_REPLY_MESSAGE_MAP
+    return sent in VALID_REPLY_MESSAGE_MAP
 
 
 def message_response_ok(sent: ProtocolMessageTypes, received: ProtocolMessageTypes) -> bool:
@@ -53,8 +53,8 @@ def message_response_ok(sent: ProtocolMessageTypes, received: ProtocolMessageTyp
     Call with received == None to indicate that we do not expect a specific reply message type.
     """
     # Errors below are runtime protocol message mismatches from peers
-    if sent in VAILD_REPLY_MESSAGE_MAP:
-        if received not in VAILD_REPLY_MESSAGE_MAP[sent]:
+    if sent in VALID_REPLY_MESSAGE_MAP:
+        if received not in VALID_REPLY_MESSAGE_MAP[sent]:
             return False
 
     return True


### PR DESCRIPTION
Nits encountered during code spelunking.