### PR TITLE
[Easy] Consistent member variable type in `class RateLimiter`

### DIFF
--- a/chia/server/rate_limits.py
+++ b/chia/server/rate_limits.py
@@ -126,13 +126,13 @@ class RateLimiter:
         """
         The incoming parameter affects whether counters are incremented
         unconditionally or not. For incoming messages, the counters are always
-        incremeneted. For outgoing messages, the counters are only incremented
+        incremented. For outgoing messages, the counters are only incremented
         if they are allowed to be sent by the rate limiter, since we won't send
         the messages otherwise.
         """
         self.incoming = incoming
         self.reset_seconds = reset_seconds
-        self.current_minute = time.time() // reset_seconds
+        self.current_minute = int(time.time() // reset_seconds)
         self.message_counts = Counter()
         self.message_cumulative_sizes = Counter()
         self.percentage_of_limit = percentage_of_limit


### PR DESCRIPTION
Class `RateLimiter` member variable `current_minute` has a type hint on line 118 suggesting it is an integer. The `floordiv` (a.k.a. `//`) operator doesn't necessarily return an integer. Ensure this is the case.