### PR TITLE
plotting: Reduce `Path.exists` calls

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -320,8 +320,6 @@ class PlotManager:
             filename_str = str(file_path)
             if self.match_str is not None and self.match_str not in filename_str:
                 return None
-            if not file_path.exists():
-                return None
             if (
                 file_path in self.failed_to_open_filenames
                 and (time.time() - self.failed_to_open_filenames[file_path])
@@ -340,6 +338,9 @@ class PlotManager:
                     log.debug(f"Skip duplicated plot {str(file_path)}")
                     return None
             try:
+                if not file_path.exists():
+                    return None
+
                 prover = DiskProver(str(file_path))
 
                 log.debug(f"process_file {str(file_path)}")

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -172,7 +172,6 @@ class BlockTools:
 
             if event == PlotRefreshEvents.batch_processed:
                 self.total_result.loaded += update_result.loaded
-                self.total_result.removed += update_result.removed
                 self.total_result.processed += update_result.processed
                 self.total_result.duration += update_result.duration
                 assert update_result.remaining == len(self.expected_plots) - self.total_result.processed
@@ -180,7 +179,6 @@ class BlockTools:
 
             if event == PlotRefreshEvents.done:
                 assert self.total_result.loaded == update_result.loaded
-                assert self.total_result.removed == update_result.removed
                 assert self.total_result.processed == update_result.processed
                 assert self.total_result.duration == update_result.duration
                 assert update_result.remaining == 0


### PR DESCRIPTION
This checks obviously can be quite expensive depending on how/where the plots are stored so this PR should noticeably improve refresh times in slow setups and large farms even for the initial refresh cycle.

Moving the checks down in 20518249f3e2da77568c58d21295fedfb5776476 avoids some redundant calls for already loaded plots in repeated refresh cycles. 
 
Moving checks up in the trace (49d2bf3af98d09c6bfd732948b0fe9c2a3655dbf) so that it only runs once for each refresh cycle reduces `plot_removed` (which calls `Path.exists`) calls per cycle from `batch_count * plot_count` to `plot_count` only.

**Note**: This has become an issue now (e.g. in #8972) because prior to #8385 which is part of `1.2.10` the batch processing was broken in a way, that it only really processed in batches for the very first run after a restart. For each repeated refresh cycle it just walked through all files in one `refresh_batch` call. Now after #8385 fixed this behavior the "removed checks" are called  `batch_count * plot_count` for all refresh cycles, even for each repeated cycle where it was `plot_count` before.