### PR TITLE
Remove SpendableCC.genesis_coin_id

### DIFF
--- a/chia/wallet/cc_wallet/cc_utils.py
+++ b/chia/wallet/cc_wallet/cc_utils.py
@@ -30,7 +30,6 @@ ANYONE_CAN_SPEND_PUZZLE = Program.to(1)  # simply return the conditions
 @dataclasses.dataclass
 class SpendableCC:
     coin: Coin
-    genesis_coin_id: bytes32
     inner_puzzle: Program
     lineage_proof: Program
 
@@ -244,9 +243,7 @@ def spendable_cc_list_from_coin_spend(coin_spend: CoinSpend, hash_to_puzzle_f) -
 
         mod_hash, genesis_coin_checker, inner_puzzle = r
 
-        genesis_coin_id = genesis_coin_id_for_genesis_coin_checker(genesis_coin_checker)
-
-        cc_spend_info = SpendableCC(new_coin, genesis_coin_id, inner_puzzle, lineage_proof)
+        cc_spend_info = SpendableCC(new_coin, inner_puzzle, lineage_proof)
         spendable_cc_list.append(cc_spend_info)
 
     return spendable_cc_list

--- a/chia/wallet/cc_wallet/cc_utils.py
+++ b/chia/wallet/cc_wallet/cc_utils.py
@@ -12,7 +12,6 @@ from chia.util.condition_tools import conditions_dict_for_solution
 from chia.util.ints import uint64
 from chia.wallet.puzzles.cc_loader import CC_MOD, LOCK_INNER_PUZZLE
 from chia.wallet.puzzles.genesis_by_coin_id_with_0 import (
-    genesis_coin_id_for_genesis_coin_checker,
     lineage_proof_for_coin,
     lineage_proof_for_genesis,
     lineage_proof_for_zero,

--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -36,7 +36,6 @@ from chia.wallet.cc_wallet.cc_utils import (
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.puzzles.genesis_by_coin_id_with_0 import (
     create_genesis_or_zero_coin_checker,
-    genesis_coin_id_for_genesis_coin_checker,
     lineage_proof_for_genesis,
 )
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (

--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -615,8 +615,6 @@ class CCWallet:
         if self.cc_info.my_genesis_checker is None:
             raise ValueError("My genesis checker is None")
 
-        genesis_id = genesis_coin_id_for_genesis_coin_checker(self.cc_info.my_genesis_checker)
-
         spendable_cc_list = []
         innersol_list = []
         sigs: List[G2Element] = []
@@ -634,7 +632,7 @@ class CCWallet:
             innersol_list.append(innersol)
             lineage_proof = await self.get_lineage_proof_for_coin(coin)
             assert lineage_proof is not None
-            spendable_cc_list.append(SpendableCC(coin, genesis_id, inner_puzzle, lineage_proof))
+            spendable_cc_list.append(SpendableCC(coin, inner_puzzle, lineage_proof))
             sigs = sigs + await self.get_sigs(coin_inner_puzzle, innersol, coin.name())
 
         spend_bundle = spend_bundle_for_spendable_ccs(

--- a/chia/wallet/puzzles/genesis_by_coin_id_with_0.py
+++ b/chia/wallet/puzzles/genesis_by_coin_id_with_0.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/wallet/puzzles/genesis_by_coin_id_with_0.py
+++ b/chia/wallet/puzzles/genesis_by_coin_id_with_0.py
@@ -17,21 +17,6 @@ def create_genesis_or_zero_coin_checker(genesis_coin_id: bytes32) -> Program:
     return genesis_coin_mod.curry(genesis_coin_id)
 
 
-def genesis_coin_id_for_genesis_coin_checker(
-    genesis_coin_checker: Program,
-) -> Optional[bytes32]:
-    """
-    Given a `genesis_coin_checker` program, pull out the genesis coin id.
-    """
-    r = genesis_coin_checker.uncurry()
-    if r is None:
-        return r
-    f, args = r
-    if f != MOD:
-        return None
-    return args.first().as_atom()
-
-
 def lineage_proof_for_genesis(parent_coin: Coin) -> Program:
     return Program.to((0, [parent_coin.as_list(), 0]))
 

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -19,7 +19,6 @@ from chia.util.ints import uint32, uint64
 from chia.wallet.cc_wallet import cc_utils
 from chia.wallet.cc_wallet.cc_utils import CC_MOD, SpendableCC, spend_bundle_for_spendable_ccs, uncurry_cc
 from chia.wallet.cc_wallet.cc_wallet import CCWallet
-from chia.wallet.puzzles.genesis_by_coin_id_with_0 import genesis_coin_id_for_genesis_coin_checker
 from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.trading.trade_store import TradeStore

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -454,7 +454,6 @@ class TradeManager:
             my_output_coin = my_cc_spends.pop()
             spendable_cc_list = []
             innersol_list = []
-            genesis_id = genesis_coin_id_for_genesis_coin_checker(Program.from_bytes(bytes.fromhex(colour)))
             # Make the rest of the coins assert the output coin is consumed
             for coloured_coin in my_cc_spends:
                 inner_solution = self.wallet_state_manager.main_wallet.make_solution(consumed=[my_output_coin.name()])
@@ -466,7 +465,7 @@ class TradeManager:
                 aggsig = AugSchemeMPL.aggregate(sigs)
 
                 lineage_proof = await wallets[colour].get_lineage_proof_for_coin(coloured_coin)
-                spendable_cc_list.append(SpendableCC(coloured_coin, genesis_id, inner_puzzle, lineage_proof))
+                spendable_cc_list.append(SpendableCC(coloured_coin, inner_puzzle, lineage_proof))
                 innersol_list.append(inner_solution)
 
             # Create SpendableCC for each of the coloured coins received
@@ -480,7 +479,7 @@ class TradeManager:
                     mod_hash, genesis_coin_checker, inner_puzzle = r
                     inner_solution = solution.first()
                     lineage_proof = solution.rest().rest().first()
-                    spendable_cc_list.append(SpendableCC(cc_coinsol.coin, genesis_id, inner_puzzle, lineage_proof))
+                    spendable_cc_list.append(SpendableCC(cc_coinsol.coin, inner_puzzle, lineage_proof))
                     innersol_list.append(inner_solution)
 
             # Finish the output coin SpendableCC with new information
@@ -493,7 +492,7 @@ class TradeManager:
             assert inner_puzzle is not None
 
             lineage_proof = await wallets[colour].get_lineage_proof_for_coin(my_output_coin)
-            spendable_cc_list.append(SpendableCC(my_output_coin, genesis_id, inner_puzzle, lineage_proof))
+            spendable_cc_list.append(SpendableCC(my_output_coin, inner_puzzle, lineage_proof))
             innersol_list.append(inner_solution)
 
             sigs = await wallets[colour].get_sigs(inner_puzzle, inner_solution, my_output_coin.name())


### PR DESCRIPTION
Is this used somewhere secret?  Or otherwise being held onto for future use?  I noticed it while checking on a type hint complaint and noticed that I couldn't figure out what the correct hint was since it wasn't used anywhere.