### PR TITLE
Avoid exception on shutdown from RpcServer._state_changed()

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -65,6 +65,8 @@ class RpcServer:
         for payload in payloads:
             if "success" not in payload["data"]:
                 payload["data"]["success"] = True
+            if self.websocket is None:
+                return None
             try:
                 await self.websocket.send_str(dict_to_json_str(payload))
             except Exception:


### PR DESCRIPTION
```
2021-11-03T19:09:09.603 full_node chia.rpc.rpc_server     : WARNING  Sending data failed. Exception Traceback (most recent call last):
  File "/farm/chia-blockchain/chia/rpc/rpc_server.py", line 69, in _state_changed
    await self.websocket.send_str(dict_to_json_str(payload))
AttributeError: 'NoneType' object has no attribute 'send_str'
.
```