### PR TITLE
Improve cache

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1607,15 +1607,12 @@ class FullNode:
 
             npc_result = await self.blockchain.run_generator(block_bytes, block_generator)
             pre_validation_time = time.time() - pre_validation_start
-            start_t = time.time()
+
             pairs_pks, pairs_msgs = pkm_pairs(npc_result.npc_list, self.constants.AGG_SIG_ME_ADDITIONAL_DATA)
-            self.log.warning(f"PKM_PAIRS: {time.time() - start_t}")
-            start_t = time.time()
             if not cached_bls.aggregate_verify(
                 pairs_pks, pairs_msgs, block.transactions_info.aggregated_signature, True
             ):
                 raise ConsensusError(Err.BAD_AGGREGATE_SIGNATURE)
-            self.log.warning(f"BLS: {time.time() - start_t}")
 
         async with self._blockchain_lock_high_priority:
             # TODO: pre-validate VDFs outside of lock

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1607,12 +1607,15 @@ class FullNode:
 
             npc_result = await self.blockchain.run_generator(block_bytes, block_generator)
             pre_validation_time = time.time() - pre_validation_start
-
+            start_t = time.time()
             pairs_pks, pairs_msgs = pkm_pairs(npc_result.npc_list, self.constants.AGG_SIG_ME_ADDITIONAL_DATA)
+            self.log.warning(f"PKM_PAIRS: {time.time() - start_t}")
+            start_t = time.time()
             if not cached_bls.aggregate_verify(
                 pairs_pks, pairs_msgs, block.transactions_info.aggregated_signature, True
             ):
                 raise ConsensusError(Err.BAD_AGGREGATE_SIGNATURE)
+            self.log.warning(f"BLS: {time.time() - start_t}")
 
         async with self._blockchain_lock_high_priority:
             # TODO: pre-validate VDFs outside of lock

--- a/chia/util/cached_bls.py
+++ b/chia/util/cached_bls.py
@@ -2,15 +2,17 @@ import functools
 from typing import List, Optional
 
 from blspy import AugSchemeMPL, G1Element, G2Element, GTElement
+
+from chia.types.blockchain_format.sized_bytes import bytes48
 from chia.util.hash import std_hash
 from chia.util.lru_cache import LRUCache
 
 
-def get_pairings(cache: LRUCache, pks: List[G1Element], msgs: List[bytes], force_cache: bool) -> List[GTElement]:
+def get_pairings(cache: LRUCache, pks: List[bytes48], msgs: List[bytes], force_cache: bool) -> List[GTElement]:
     pairings: List[Optional[GTElement]] = []
     missing_count: int = 0
     for pk, msg in zip(pks, msgs):
-        aug_msg: bytes = bytes(pk) + msg
+        aug_msg: bytes = pk + msg
         h: bytes = bytes(std_hash(aug_msg))
         pairing: Optional[GTElement] = cache.get(h)
         if not force_cache and pairing is None:
@@ -24,9 +26,9 @@ def get_pairings(cache: LRUCache, pks: List[G1Element], msgs: List[bytes], force
 
     for i, pairing in enumerate(pairings):
         if pairing is None:
-            aug_msg = bytes(pks[i]) + msgs[i]
+            aug_msg = pks[i] + msgs[i]
             aug_hash: G2Element = AugSchemeMPL.g2_from_message(aug_msg)
-            pairing = pks[i].pair(aug_hash)
+            pairing = G1Element.from_bytes(pks[i]).pair(aug_hash)
 
             h = bytes(std_hash(aug_msg))
             cache.put(h, pairing)
@@ -39,11 +41,12 @@ LOCAL_CACHE: LRUCache = LRUCache(50000)
 
 
 def aggregate_verify(
-    pks: List[G1Element], msgs: List[bytes], sig: G2Element, force_cache: bool = False, cache: LRUCache = LOCAL_CACHE
+    pks: List[bytes48], msgs: List[bytes], sig: G2Element, force_cache: bool = False, cache: LRUCache = LOCAL_CACHE
 ):
     pairings: List[GTElement] = get_pairings(cache, pks, msgs, force_cache)
     if len(pairings) == 0:
-        return AugSchemeMPL.aggregate_verify(pks, msgs, sig)
+        pks_objects: List[G1Element] = [G1Element.from_bytes(pk) for pk in pks]
+        return AugSchemeMPL.aggregate_verify(pks_objects, msgs, sig)
 
     pairings_prod: GTElement = functools.reduce(GTElement.__mul__, pairings)
     return pairings_prod == sig.pair(G1Element.generator())

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -1,12 +1,10 @@
 from typing import Dict, List, Optional, Tuple, Set
 
-from blspy import G1Element
-
 from chia.types.announcement import Announcement
 from chia.types.name_puzzle_condition import NPC
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program, SerializedProgram
-from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.util.clvm import int_from_bytes
@@ -66,8 +64,8 @@ def conditions_by_opcode(
     return d
 
 
-def pkm_pairs(npc_list: List[NPC], additional_data: bytes) -> Tuple[List[G1Element], List[bytes]]:
-    ret: Tuple[List[G1Element], List[bytes]] = ([], [])
+def pkm_pairs(npc_list: List[NPC], additional_data: bytes) -> Tuple[List[bytes48], List[bytes]]:
+    ret: Tuple[List[bytes48], List[bytes]] = ([], [])
 
     for npc in npc_list:
         for opcode, l in npc.conditions:
@@ -76,35 +74,35 @@ def pkm_pairs(npc_list: List[NPC], additional_data: bytes) -> Tuple[List[G1Eleme
                     assert len(cwa.vars) == 2
                     assert len(cwa.vars[0]) == 48 and len(cwa.vars[1]) <= 1024
                     assert cwa.vars[0] is not None and cwa.vars[1] is not None
-                    ret[0].append(G1Element.from_bytes(cwa.vars[0]))
+                    ret[0].append(bytes48(cwa.vars[0]))
                     ret[1].append(cwa.vars[1])
             elif opcode == ConditionOpcode.AGG_SIG_ME:
                 for cwa in l:
                     assert len(cwa.vars) == 2
                     assert len(cwa.vars[0]) == 48 and len(cwa.vars[1]) <= 1024
                     assert cwa.vars[0] is not None and cwa.vars[1] is not None
-                    ret[0].append(G1Element.from_bytes(cwa.vars[0]))
+                    ret[0].append(bytes48(cwa.vars[0]))
                     ret[1].append(cwa.vars[1] + npc.coin_name + additional_data)
     return ret
 
 
 def pkm_pairs_for_conditions_dict(
     conditions_dict: Dict[ConditionOpcode, List[ConditionWithArgs]], coin_name: bytes32, additional_data: bytes
-) -> List[Tuple[G1Element, bytes]]:
+) -> List[Tuple[bytes48, bytes]]:
     assert coin_name is not None
-    ret: List[Tuple[G1Element, bytes]] = []
+    ret: List[Tuple[bytes48, bytes]] = []
 
     for cwa in conditions_dict.get(ConditionOpcode.AGG_SIG_UNSAFE, []):
         assert len(cwa.vars) == 2
         assert len(cwa.vars[0]) == 48 and len(cwa.vars[1]) <= 1024
         assert cwa.vars[0] is not None and cwa.vars[1] is not None
-        ret.append((G1Element.from_bytes(cwa.vars[0]), cwa.vars[1]))
+        ret.append((bytes48(cwa.vars[0]), cwa.vars[1]))
 
     for cwa in conditions_dict.get(ConditionOpcode.AGG_SIG_ME, []):
         assert len(cwa.vars) == 2
         assert len(cwa.vars[0]) == 48 and len(cwa.vars[1]) <= 1024
         assert cwa.vars[0] is not None and cwa.vars[1] is not None
-        ret.append((G1Element.from_bytes(cwa.vars[0]), cwa.vars[1] + coin_name + additional_data))
+        ret.append((bytes48(cwa.vars[0]), cwa.vars[1] + coin_name + additional_data))
     return ret
 
 

--- a/chia/wallet/sign_coin_spends.py
+++ b/chia/wallet/sign_coin_spends.py
@@ -28,8 +28,11 @@ async def sign_coin_spends(
             raise ValueError(error_msg)
 
         # Create signature
-        for pk, msg in pkm_pairs_for_conditions_dict(conditions_dict, bytes(coin_spend.coin.name()), additional_data):
-            pk_list.append(blspy.G1Element.from_bytes(pk))
+        for pk_bytes, msg in pkm_pairs_for_conditions_dict(
+            conditions_dict, bytes(coin_spend.coin.name()), additional_data
+        ):
+            pk = blspy.G1Element.from_bytes(pk_bytes)
+            pk_list.append(pk)
             msg_list.append(msg)
             if inspect.iscoroutinefunction(secret_key_for_public_key_f):
                 secret_key = await secret_key_for_public_key_f(pk)
@@ -40,7 +43,7 @@ async def sign_coin_spends(
                 raise ValueError(e_msg)
             assert bytes(secret_key.get_g1()) == bytes(pk)
             signature = AugSchemeMPL.sign(secret_key, msg)
-            assert AugSchemeMPL.verify(pk_list[-1], msg, signature)
+            assert AugSchemeMPL.verify(pk, msg, signature)
             signatures.append(signature)
 
     # Aggregate signatures

--- a/chia/wallet/sign_coin_spends.py
+++ b/chia/wallet/sign_coin_spends.py
@@ -40,7 +40,7 @@ async def sign_coin_spends(
                 raise ValueError(e_msg)
             assert bytes(secret_key.get_g1()) == bytes(pk)
             signature = AugSchemeMPL.sign(secret_key, msg)
-            assert AugSchemeMPL.verify(pk, msg, signature)
+            assert AugSchemeMPL.verify(pk_list[-1], msg, signature)
             signatures.append(signature)
 
     # Aggregate signatures

--- a/chia/wallet/sign_coin_spends.py
+++ b/chia/wallet/sign_coin_spends.py
@@ -29,7 +29,7 @@ async def sign_coin_spends(
 
         # Create signature
         for pk, msg in pkm_pairs_for_conditions_dict(conditions_dict, bytes(coin_spend.coin.name()), additional_data):
-            pk_list.append(pk)
+            pk_list.append(blspy.G1Element.from_bytes(pk))
             msg_list.append(msg)
             if inspect.iscoroutinefunction(secret_key_for_public_key_f):
                 secret_key = await secret_key_for_public_key_f(pk)

--- a/chia/wallet/util/debug_spend_bundle.py
+++ b/chia/wallet/util/debug_spend_bundle.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 
-from blspy import AugSchemeMPL
+from blspy import AugSchemeMPL, G1Element
 from clvm import KEYWORD_FROM_ATOM
 from clvm_tools.binutils import disassemble as bu_disassemble
 
@@ -77,7 +77,7 @@ def debug_spend_bundle(spend_bundle, agg_sig_additional_data=DEFAULT_CONSTANTS.A
             print(f"*** error {error}")
         elif conditions is not None:
             for pk, m in pkm_pairs_for_conditions_dict(conditions, coin_name, agg_sig_additional_data):
-                pks.append(pk)
+                pks.append(G1Element.from_bytes(pk))
                 msgs.append(m)
             print()
             cost, r = puzzle_reveal.run_with_cost(INFINITE_COST, solution)  # type: ignore

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -2305,7 +2305,7 @@ class TestPkmPairs:
             )
         ]
         pks, msgs = pkm_pairs(npc_list, b"foobar")
-        assert pks == [self.pk1, self.pk2]
+        assert pks == [bytes(self.pk1), bytes(self.pk2)]
         assert msgs == [b"msg1" + self.h1 + b"foobar", b"msg2" + self.h1 + b"foobar"]
 
     def test_agg_sig_unsafe(self):
@@ -2325,7 +2325,7 @@ class TestPkmPairs:
             )
         ]
         pks, msgs = pkm_pairs(npc_list, b"foobar")
-        assert pks == [self.pk1, self.pk2]
+        assert pks == [bytes(self.pk1), bytes(self.pk2)]
         assert msgs == [b"msg1", b"msg2"]
 
     def test_agg_sig_mixed(self):
@@ -2334,5 +2334,5 @@ class TestPkmPairs:
             NPC(self.h1, self.h2, [(self.ASU, [ConditionWithArgs(self.ASU, [bytes(self.pk2), b"msg2"])])]),
         ]
         pks, msgs = pkm_pairs(npc_list, b"foobar")
-        assert pks == [self.pk1, self.pk2]
+        assert pks == [bytes(self.pk1), bytes(self.pk2)]
         assert msgs == [b"msg1" + self.h1 + b"foobar", b"msg2"]

--- a/tests/core/util/test_cached_bls.py
+++ b/tests/core/util/test_cached_bls.py
@@ -1,5 +1,5 @@
 import unittest
-from blspy import AugSchemeMPL
+from blspy import AugSchemeMPL, G1Element
 from chia.util import cached_bls
 from chia.util.lru_cache import LRUCache
 
@@ -9,7 +9,7 @@ class TestCachedBLS(unittest.TestCase):
         n_keys = 10
         seed = b"a" * 31
         sks = [AugSchemeMPL.key_gen(seed + bytes([i])) for i in range(n_keys)]
-        pks = [sk.get_g1() for sk in sks]
+        pks = [bytes(sk.get_g1()) for sk in sks]
 
         msgs = [("msg-%d" % (i,)).encode() for i in range(n_keys)]
         sigs = [AugSchemeMPL.sign(sk, msg) for sk, msg in zip(sks, msgs)]
@@ -20,7 +20,7 @@ class TestCachedBLS(unittest.TestCase):
         sigs_half = sigs[: n_keys // 2]
         agg_sig_half = AugSchemeMPL.aggregate(sigs_half)
 
-        assert AugSchemeMPL.aggregate_verify(pks, msgs, agg_sig)
+        assert AugSchemeMPL.aggregate_verify([G1Element.from_bytes(pk) for pk in pks], msgs, agg_sig)
 
         # Verify with empty cache and populate it
         assert cached_bls.aggregate_verify(pks_half, msgs_half, agg_sig_half, True)

--- a/tests/util/key_tool.py
+++ b/tests/util/key_tool.py
@@ -35,6 +35,6 @@ class KeyTool(dict):
         for public_key, message_hash in pkm_pairs_for_conditions_dict(
             conditions_dict, coin_spend.coin.name(), additional_data
         ):
-            signature = self.sign(bytes(public_key), message_hash)
+            signature = self.sign(public_key, message_hash)
             signatures.append(signature)
         return AugSchemeMPL.aggregate(signatures)


### PR DESCRIPTION
Reduces the time for pkm_pairs by waiting until later to convert to G1Element (since it's not necessary to do when using the cache).

On RPI, a full block can take 1.3 seconds for `pkm_pairs`, this reduces it to essentially 0 when the cache is used.