### PR TITLE
Do not included reversed blocks in get_blocks response if flag is provided

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -281,6 +281,9 @@ class FullNodeRpcApi:
         exclude_hh = False
         if "exclude_header_hash" in request:
             exclude_hh = request["exclude_header_hash"]
+        exclude_reorged = False
+        if "exclude_reorged" in request:
+            exclude_reorged = request["exclude_reorged"]
 
         start = int(request["start"])
         end = int(request["end"])
@@ -291,7 +294,7 @@ class FullNodeRpcApi:
         json_blocks = []
         for block in blocks:
             hh: bytes32 = block.header_hash
-            if self.service.blockchain.height_to_hash(block.height) != hh:
+            if exclude_reorged and self.service.blockchain.height_to_hash(block.height) != hh:
                 # Don't include forked (reorged) blocks
                 continue
             json = block.to_json_dict()

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -290,9 +290,13 @@ class FullNodeRpcApi:
         blocks: List[FullBlock] = await self.service.block_store.get_full_blocks_at(block_range)
         json_blocks = []
         for block in blocks:
+            hh: bytes32 = block.header_hash
+            if self.service.blockchain.height_to_hash(block.height) != hh:
+                # Don't include forked (reorged) blocks
+                continue
             json = block.to_json_dict()
             if not exclude_hh:
-                json["header_hash"] = block.header_hash.hex()
+                json["header_hash"] = hh.hex()
             json_blocks.append(json)
         return {"blocks": json_blocks}
 

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -36,8 +36,10 @@ class FullNodeRpcClient(RpcClient):
             return None
         return FullBlock.from_json_dict(response["block"])
 
-    async def get_blocks(self, start: int, end: int) -> List[FullBlock]:
-        response = await self.fetch("get_blocks", {"start": start, "end": end, "exclude_header_hash": True})
+    async def get_blocks(self, start: int, end: int, exclude_reorged: bool = False) -> List[FullBlock]:
+        response = await self.fetch(
+            "get_blocks", {"start": start, "end": end, "exclude_header_hash": True, "exclude_reorged": exclude_reorged}
+        )
         return [FullBlock.from_json_dict(block) for block in response["blocks"]]
 
     async def get_block_record_by_height(self, height) -> Optional[BlockRecord]:

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -36,6 +36,10 @@ class FullNodeRpcClient(RpcClient):
             return None
         return FullBlock.from_json_dict(response["block"])
 
+    async def get_blocks(self, start: int, end: int) -> List[FullBlock]:
+        response = await self.fetch("get_blocks", {"start": start, "end": end, "exclude_header_hash": True})
+        return [FullBlock.from_json_dict(block) for block in response["blocks"]]
+
     async def get_block_record_by_height(self, height) -> Optional[BlockRecord]:
         try:
             response = await self.fetch("get_block_record_by_height", {"height": height})

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -209,8 +209,11 @@ class TestRpc:
             assert len(blocks) == 5
 
             await full_node_api_1.reorg_from_index_to_new_index(ReorgProtocol(2, 55, bytes([0x2] * 32)))
-            new_blocks: List[FullBlock] = await client.get_blocks(0, 5)
-            assert len(blocks) == 5
+            new_blocks_0: List[FullBlock] = await client.get_blocks(0, 5)
+            assert len(new_blocks_0) == 7
+
+            new_blocks: List[FullBlock] = await client.get_blocks(0, 5, exclude_reorged=True)
+            assert len(new_blocks) == 5
             assert blocks[0].header_hash == new_blocks[0].header_hash
             assert blocks[1].header_hash == new_blocks[1].header_hash
             assert blocks[2].header_hash == new_blocks[2].header_hash

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F811, F401
 import logging
+from typing import List
 
 import pytest
 from blspy import AugSchemeMPL
@@ -10,7 +11,8 @@ from chia.protocols import full_node_protocol
 from chia.rpc.full_node_rpc_api import FullNodeRpcApi
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.rpc.rpc_server import NodeType, start_rpc_server
-from chia.simulator.simulator_protocol import FarmNewBlockProtocol
+from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
+from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
 from tests.block_tools import get_signage_point
@@ -202,6 +204,18 @@ class TestRpc:
             assert len(await client.get_connections(NodeType.FARMER)) == 0
             await client.close_connection(connections[0]["node_id"])
             await time_out_assert(10, num_connections, 0)
+
+            blocks: List[FullBlock] = await client.get_blocks(0, 5)
+            assert len(blocks) == 5
+
+            await full_node_api_1.reorg_from_index_to_new_index(ReorgProtocol(2, 55, bytes([0x2] * 32)))
+            new_blocks: List[FullBlock] = await client.get_blocks(0, 5)
+            assert len(blocks) == 5
+            assert blocks[0].header_hash == new_blocks[0].header_hash
+            assert blocks[1].header_hash == new_blocks[1].header_hash
+            assert blocks[2].header_hash == new_blocks[2].header_hash
+            assert blocks[3].header_hash != new_blocks[3].header_hash
+
         finally:
             # Checks that the RPC manages to stop the node
             client.close()


### PR DESCRIPTION
This API was confusing: it was returning all blocks at the heights specified, so it can return potentially two blocks at the same height. I added an optional arg which allows getting only the confirmed block at each height.