### PR TITLE
Fixes for the --passphrase-file option

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -16,7 +16,12 @@ from chia.cmds.wallet import wallet_cmd
 from chia.cmds.plotnft import plotnft_cmd
 from chia.cmds.plotters import plotters_cmd
 from chia.util.default_root import DEFAULT_KEYS_ROOT_PATH, DEFAULT_ROOT_PATH
-from chia.util.keychain import set_keys_root_path, supports_keyring_passphrase
+from chia.util.keychain import (
+    Keychain,
+    KeyringCurrentPassphraseIsInvalid,
+    set_keys_root_path,
+    supports_keyring_passphrase,
+)
 from chia.util.ssl_check import check_ssl
 from typing import Optional
 
@@ -68,9 +73,20 @@ def cli(
 
     if passphrase_file is not None:
         from chia.cmds.passphrase_funcs import cache_passphrase, read_passphrase_from_file
+        from sys import exit
 
         try:
-            cache_passphrase(read_passphrase_from_file(passphrase_file))
+            passphrase = read_passphrase_from_file(passphrase_file)
+            if Keychain.master_passphrase_is_valid(passphrase):
+                cache_passphrase(passphrase)
+            else:
+                raise KeyringCurrentPassphraseIsInvalid("Invalid passphrase")
+        except KeyringCurrentPassphraseIsInvalid:
+            if Path(passphrase_file.name).is_file():
+                print(f"Invalid passphrase found in \"{passphrase_file.name}\"")
+            else:
+                print("Invalid passphrase")
+            exit(1)
         except Exception as e:
             print(f"Failed to read passphrase: {e}")
 

--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -83,7 +83,7 @@ def cli(
                 raise KeyringCurrentPassphraseIsInvalid("Invalid passphrase")
         except KeyringCurrentPassphraseIsInvalid:
             if Path(passphrase_file.name).is_file():
-                print(f"Invalid passphrase found in \"{passphrase_file.name}\"")
+                print(f'Invalid passphrase found in "{passphrase_file.name}"')
             else:
                 print("Invalid passphrase")
             exit(1)

--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -118,7 +118,7 @@ def prompt_for_new_passphrase() -> Tuple[str, bool]:
 
 
 def read_passphrase_from_file(passphrase_file: TextIOWrapper) -> str:
-    passphrase = passphrase_file.read()
+    passphrase = passphrase_file.read().rstrip("\r\n")
     passphrase_file.close()
     return passphrase
 

--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -1,5 +1,6 @@
 import click
 import colorama
+import os
 import sys
 
 from chia.daemon.client import acquire_connection_to_daemon
@@ -118,7 +119,7 @@ def prompt_for_new_passphrase() -> Tuple[str, bool]:
 
 
 def read_passphrase_from_file(passphrase_file: TextIOWrapper) -> str:
-    passphrase = passphrase_file.read().rstrip("\r\n")
+    passphrase = passphrase_file.read().rstrip(os.environ.get("CHIA_PASSPHRASE_STRIP_TRAILING_CHARS", "\r\n"))
     passphrase_file.close()
     return passphrase
 

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -35,9 +35,8 @@ async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProx
     if connection:
         passphrase = None
         if await connection.is_keyring_locked():
-            if Keychain.has_cached_passphrase():
-                passphrase = Keychain.get_cached_master_passphrase()
-            else:
+            passphrase = Keychain.get_cached_master_passphrase()
+            if not Keychain.master_passphrase_is_valid(passphrase):
                 passphrase = get_current_passphrase()
 
         if passphrase:

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from chia.cmds.passphrase_funcs import get_current_passphrase
 from chia.daemon.client import DaemonProxy, connect_to_daemon_and_validate
-from chia.util.keychain import KeyringMaxUnlockAttempts
+from chia.util.keychain import Keychain, KeyringMaxUnlockAttempts
 from chia.util.service_groups import services_for_groups
 
 
@@ -35,7 +35,10 @@ async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProx
     if connection:
         passphrase = None
         if await connection.is_keyring_locked():
-            passphrase = get_current_passphrase()
+            if Keychain.has_cached_passphrase():
+                passphrase = Keychain.get_cached_master_passphrase()
+            else:
+                passphrase = get_current_passphrase()
 
         if passphrase:
             print("Unlocking daemon keyring")


### PR DESCRIPTION
Fixed `chia --passphrase-file <file> start <process>` to properly use the provided passphrase. The start command was prompting interactively for the passphrase, despite having specified the use of a passphrase file.

Invalid passphrases specified using the `--passphrase-file` option will now cause the chia process to print "Invalid passphrase" and sys.exit(1).

Passphrases read from a passphrase file now have trailing CR/LFs stripped by default. We had similar sanitization in an earlier incarnation, but there was some concern that it would lower the entropy. Since passphrases coming from a file or process often have a trailing newline, we now strip just those trailing CR/LFs by default. If any existing users rely on their passphrase having trailing CR/LFs, the `CHIA_PASSPHRASE_STRIP_TRAILING_CHARS` environment variable can be set to an empty string to restore the prior non-stripping behavior.

Examples:
`$ CHIA_PASSPHRASE_STRIP_TRAILING_CHARS="" chia --passphrase-file chia.pw keys show`
`$ CHIA_PASSPHRASE_STRIP_TRAILING_CHARS="" chia passphrase remove --current-passphrase-file chia.pw`

Issue #9032
Thanks goes to @moonlitbugs for reporting the issues