### PR TITLE
Use same CI triggers for super linter workflow as for tests

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -17,11 +17,13 @@ name: GitHub Super Linter
 #############################
 on:
   push:
-    branches-ignore:
-      - 'main'
+    branches:
+      - main
+    tags:
+        - '**'
   pull_request:
-    branches-ignore:
-      - ''
+    branches:
+      - '**'
 
 ###############
 # Set the Job #


### PR DESCRIPTION
The existing setup results in the super linter not being run on `main` and being run twice for PRs and once for non-PR branches.  The new setup runs for `main`, any tag, and any PR.  This is consistent with the existing test workflows.

Consider the following example.

https://github.com/Chia-Network/chia-blockchain/blob/54eb13c66d1e8c169cd241c129ddc60cd487871a/.github/workflows/build-test-ubuntu-core-ssl.yml#L6-L14