### PR TITLE
Initialize FullNode._transaction_queue_task and avoid AttributeError on shutdown

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -97,6 +97,7 @@ class FullNode:
     _blockchain_lock_ultra_priority: LockClient
     _blockchain_lock_high_priority: LockClient
     _blockchain_lock_low_priority: LockClient
+    _transaction_queue_task: Optional[asyncio.Task]
 
     def __init__(
         self,
@@ -135,6 +136,7 @@ class FullNode:
         self.peer_puzzle_hash: Dict[bytes32, Set[bytes32]] = {}  # Peer ID: Set[puzzle_hash]
         self.peer_sub_counter: Dict[bytes32, int] = {}  # Peer ID: int (subscription count)
         mkdir(self.db_path.parent)
+        self._transaction_queue_task = None
 
     def _set_state_changed_callback(self, callback: Callable):
         self.state_changed_callback = callback
@@ -701,7 +703,8 @@ class FullNode:
             asyncio.create_task(self.full_node_peers.close())
         if self.uncompact_task is not None:
             self.uncompact_task.cancel()
-        self._transaction_queue_task.cancel()
+        if self._transaction_queue_task is not None:
+            self._transaction_queue_task.cancel()
         self._blockchain_lock_queue.close()
 
     async def _await_closed(self):


### PR DESCRIPTION
This occurred when I ran `chia stop -d all` soon after `chia start -r all` when I meant `farmer`.

```python-traceback
Traceback (most recent call last):
  File "/farm/chia-blockchain/venv/bin/chia_full_node", line 33, in <module>
    sys.exit(load_entry_point('chia-blockchain', 'console_scripts', 'chia_full_node')())
  File "/farm/chia-blockchain/chia/server/start_full_node.py", line 60, in main
    return run_service(**kwargs)
  File "/farm/chia-blockchain/chia/server/start_service.py", line 255, in run_service
    return asyncio.run(async_run_service(*args, **kwargs))
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 603, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.8/asyncio/base_events.py", line 570, in run_forever
    self._run_once()
  File "/usr/lib/python3.8/asyncio/base_events.py", line 1823, in _run_once
    event_list = self._selector.select(timeout)
  File "/usr/lib/python3.8/selectors.py", line 468, in select
    fd_event_list = self._selector.poll(timeout, max_ev)
  File "/farm/chia-blockchain/chia/server/start_service.py", line 193, in _accept_signal
    self.stop()
  File "/farm/chia-blockchain/chia/server/start_service.py", line 210, in stop
    self._node._close()
  File "/farm/chia-blockchain/chia/full_node/full_node.py", line 704, in _close
    self._transaction_queue_task.cancel()
AttributeError: 'FullNode' object has no attribute '_transaction_queue_task'
```