### PR TITLE
replaced "npm install" => "npm ci"

### DIFF
--- a/build_scripts/build_linux_deb.sh
+++ b/build_scripts/build_linux_deb.sh
@@ -46,7 +46,7 @@ cd .. || exit
 cd chia-blockchain-gui || exit
 
 echo "npm build"
-npm install
+npm ci
 npm audit fix
 npm run build
 LAST_EXIT_CODE=$?

--- a/build_scripts/build_linux_rpm.sh
+++ b/build_scripts/build_linux_rpm.sh
@@ -47,7 +47,7 @@ cd .. || exit
 cd chia-blockchain-gui || exit
 
 echo "npm build"
-npm install
+npm ci
 npm audit fix
 npm run build
 LAST_EXIT_CODE=$?

--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -38,7 +38,7 @@ cd .. || exit
 cd chia-blockchain-gui || exit
 
 echo "npm build"
-npm install
+npm ci
 npm audit fix
 npm run build
 LAST_EXIT_CODE=$?

--- a/build_scripts/build_macos_m1.sh
+++ b/build_scripts/build_macos_m1.sh
@@ -40,7 +40,7 @@ cd .. || exit
 cd chia-blockchain-gui || exit
 
 echo "npm build"
-npm install
+npm ci
 npm audit fix
 npm run build
 LAST_EXIT_CODE=$?

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -97,7 +97,7 @@ Write-Output "   ---"
 $Env:NODE_OPTIONS = "--max-old-space-size=3000"
 npm install --save-dev electron-winstaller
 npm install -g electron-packager
-npm install
+npm ci
 npm audit fix
 
 git status


### PR DESCRIPTION
used "npm ci" instead of "npm install" for build

"npm ci" will use packages from package-lock.json