### PR TITLE
Limit server to TLS 1.2 and set cipher list

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -3,12 +3,12 @@ import json
 import logging
 import os
 import signal
+import ssl
 import subprocess
 import sys
 import time
 import traceback
 import uuid
-
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from pathlib import Path
@@ -153,6 +153,19 @@ class WebSocketServer:
 
     async def start(self):
         self.log.info("Starting Daemon Server")
+
+        if ssl.OPENSSL_VERSION_NUMBER < 0x10101000:
+            self.log.warning(
+                (
+                    "Deprecation Warning: Your version of openssl (%s) does not support TLS1.3. "
+                    "A future version of Chia will require TLS1.3."
+                ),
+                ssl.OPENSSL_VERSION,
+            )
+        else:
+            if self.ssl_context is not None:
+                # Daemon is internal connections, so override to TLS1.3 only
+                self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_3
 
         def master_close_cb():
             asyncio.create_task(self.stop())

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -48,7 +48,21 @@ def ssl_context_for_server(
 
     ssl_context = ssl._create_unverified_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=str(ca_cert))
     ssl_context.check_hostname = False
-    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_3
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+    ssl_context.set_ciphers(
+        (
+            "ECDHE-ECDSA-AES256-GCM-SHA384:"
+            "ECDHE-RSA-AES256-GCM-SHA384:"
+            "ECDHE-ECDSA-CHACHA20-POLY1305:"
+            "ECDHE-RSA-CHACHA20-POLY1305:"
+            "ECDHE-ECDSA-AES128-GCM-SHA256:"
+            "ECDHE-RSA-AES128-GCM-SHA256:"
+            "ECDHE-ECDSA-AES256-SHA384:"
+            "ECDHE-RSA-AES256-SHA384:"
+            "ECDHE-ECDSA-AES128-SHA256:"
+            "ECDHE-RSA-AES128-SHA256"
+        )
+    )
     ssl_context.load_cert_chain(certfile=str(private_cert_path), keyfile=str(private_key_path))
     ssl_context.verify_mode = ssl.CERT_REQUIRED
     return ssl_context

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -4,11 +4,12 @@ import ssl
 import time
 import traceback
 from collections import Counter
-from ipaddress import IPv6Address, ip_address, ip_network, IPv4Network, IPv6Network
+from ipaddress import IPv4Network, IPv6Address, IPv6Network, ip_address, ip_network
 from pathlib import Path
 from secrets import token_bytes
-from typing import Any, Callable, Dict, List, Optional, Union, Set, Tuple
+from typing import Any, Callable
 from typing import Counter as typing_Counter
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from aiohttp import ClientSession, ClientTimeout, ServerDisconnectedError, WSCloseCode, client_exceptions, web
 from aiohttp.web_app import Application
@@ -19,7 +20,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.protocol_state_machine import message_requires_reply
-from chia.protocols.protocol_timing import INVALID_PROTOCOL_BAN_SECONDS, API_EXCEPTION_BAN_SECONDS
+from chia.protocols.protocol_timing import API_EXCEPTION_BAN_SECONDS, INVALID_PROTOCOL_BAN_SECONDS
 from chia.protocols.shared_protocol import protocol_version
 from chia.server.introducer_peers import IntroducerPeers
 from chia.server.outbound_message import Message, NodeType
@@ -29,7 +30,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import Err, ProtocolError
 from chia.util.ints import uint16
-from chia.util.network import is_localhost, is_in_network
+from chia.util.network import is_in_network, is_localhost
 from chia.util.ssl_check import verify_ssl_certs_and_keys
 
 
@@ -47,6 +48,7 @@ def ssl_context_for_server(
 
     ssl_context = ssl._create_unverified_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=str(ca_cert))
     ssl_context.check_hostname = False
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_3
     ssl_context.load_cert_chain(certfile=str(private_cert_path), keyfile=str(private_key_path))
     ssl_context.verify_mode = ssl.CERT_REQUIRED
     return ssl_context


### PR DESCRIPTION
Use ssl_context.minimum_version and set the minimum to TLS 1.2
Set the ciphers for 1.2 to a limited and secure set.
Check the version of openssl in use and issue warning if less than 1.1.1 (TLS 1.3 support)
If using openssl>=1.1.1 then daemon restricts local connections to TLS1.3