### PR TITLE
CLI fixes for plotting with madmax

### DIFF
--- a/chia/plotters/madmax.py
+++ b/chia/plotters/madmax.py
@@ -214,8 +214,8 @@ def plot_madmax(args, chia_root_path: Path, plotters_root_path: Path):
     call_args.append(str(args.buckets))
     call_args.append("-v")
     call_args.append(str(args.buckets3))
-    call_args.append("-w")
-    call_args.append(str(int(args.waitforcopy)))
+    if args.waitforcopy:
+        call_args.append("-w")
     call_args.append("-K")
     call_args.append(str(args.rmulti2))
     if args.size != 32:

--- a/chia/plotters/madmax.py
+++ b/chia/plotters/madmax.py
@@ -216,6 +216,8 @@ def plot_madmax(args, chia_root_path: Path, plotters_root_path: Path):
     call_args.append(str(args.buckets3))
     if args.waitforcopy:
         call_args.append("-w")
+    if args.tmptoggle:
+        call_args.append("-G")
     call_args.append("-K")
     call_args.append(str(args.rmulti2))
     if args.size != 32:

--- a/chia/plotters/madmax.py
+++ b/chia/plotters/madmax.py
@@ -199,8 +199,9 @@ def plot_madmax(args, chia_root_path: Path, plotters_root_path: Path):
     call_args.append("-t")
     # s if s[-1] == os.path.sep else s + os.path.sep
     call_args.append(dir_with_trailing_slash(args.tmpdir))
-    call_args.append("-2")
-    call_args.append(dir_with_trailing_slash(args.tmpdir2))
+    if len(args.tmpdir2) > 0:
+        call_args.append("-2")
+        call_args.append(dir_with_trailing_slash(args.tmpdir2))
     call_args.append("-d")
     call_args.append(dir_with_trailing_slash(args.finaldir))
     if plot_keys.pool_contract_address is not None:

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -142,7 +142,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
                 type=str,
                 dest="tmpdir2",
                 help="Temporary directory 2.",
-                default=str(root_path) + "/",
+                default="",
             )
         if option is Options.FINAL_DIR:
             parser.add_argument(

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -133,7 +133,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
                 type=str,
                 dest="tmpdir",
                 help="Temporary directory 1.",
-                default=str(root_path) + "/",
+                required=True,
             )
         if option is Options.TMP_DIR2:
             parser.add_argument(
@@ -151,7 +151,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
                 type=str,
                 dest="finaldir",
                 help="Final directory.",
-                default=str(root_path) + "/",
+                required=True,
             )
         if option is Options.BUFF:
             parser.add_argument(


### PR DESCRIPTION
When plotting with madmax using the `chia plotters` CLI, the following options were not handled properly:

`-w` was not treated as a flag, and instead was passing a 0 or 1 value along to madmax. As a result, madmax was always running with the waitforcopy option set. The `-w` flag is now only passed along to madmax when True.

`-G` was omitted from the CLI args. The tmptoggle option was functional when plotting from the GUI, but that was only because its behavior was being implemented at a higher level (-G wasn't actually passed into madmax). The `-G` option is now passed along to madmax when True.

`-2` `-t` and `-d` options were all configured to use a default value rooted in $CHIA_ROOT/plotters. Default values have been removed for these options, and `-t` and `-d` have been marked as required options.

Thanks to @randomisresistance and @lasers8oclockday1 for the bug reports
Issue #9163 