### PR TITLE
Start plotting the next valid item in the queue, not the last

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -833,6 +833,7 @@ class WebSocketServer:
         for item in self.plots_queue:
             if item["queue"] == queue and item["state"] is PlotState.SUBMITTED and item["parallel"] is False:
                 next_plot_id = item["id"]
+                break
 
         if next_plot_id is not None:
             loop.create_task(self._start_plotting(next_plot_id, loop, queue))


### PR DESCRIPTION
When creating multiple plots from the GUI, after first plot task completes, new tasks are plucked from the end of the queue instead of the front. This is a bit confusing in the GUI as the active plotting job jumps from the top of the list (the first item in the queue), to an item further down the list, or even on another page.

This change causes us to pick the first available task in the queue when looking for the next plotting task to start.