### PR TITLE
ARM64 installer updates (#9120)

### DIFF
--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -14,14 +14,14 @@ on:
 jobs:
   build:
     name: Linux ARM64 installer on Python 3.8
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    runs-on: [ARM64]
+    container: chianetwork/ubuntu-18.04-builder:latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
         python-version: [3.8]
-        os: [ARM64]
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -29,6 +29,8 @@ jobs:
       uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
+
+    - uses: Chia-Network/actions/clean-workspace@main
 
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -40,7 +42,7 @@ jobs:
       run: bash build_scripts/clean-runner.sh || true
 
     # Create our own venv outside of the git directory JUST for getting the ACTUAL version so that install can't break it
-    - name: Create installer version number
+    - name: Get version number
       id: version_number
       run: |
         python3 -m venv ../venv
@@ -59,47 +61,27 @@ jobs:
       env:
         SECRET: "${{ secrets.INSTALLER_UPLOAD_SECRET }}"
 
-    - name: Build ARM64 Installer
+    - name: Run install script
+      env:
+        INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
+        BUILD_VDF_CLIENT: "N"
       run: |
-        podman run --rm=true \
-          -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-          docker.io/library/ubuntu:18.04 \
-          bash -exc '\
-            echo $PATH && \
-            apt update && \
-            apt upgrade -y && \
-            apt -y install software-properties-common build-essential \
-            curl git dialog apt-utils zlib1g-dev && \
-            add-apt-repository ppa:deadsnakes/ppa -y && \
-            curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
-            apt -y install nodejs fakeroot jq \
-            python3.8 python3.8-venv libpython3.8-dev python3.8-distutils && \
-            rm -rf venv && \
-            python3 --version && \
-            python3.8 -m venv venv && \
-            source venv/bin/activate && \
-            echo "Should be Python 3.8.x" && \
-            python --version && \
-            echo "Emulating install.sh" && \
-            pip install --upgrade pip && \
-            pip install wheel && \
-            pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2 && \
-            pip install . --extra-index-url https://pypi.chia.net/simple/ && \
-            ldd --version && \
-            cd build_scripts && \
-            sh build_linux_deb.sh arm64 \
-          '
+        sh install.sh
+
+    - name: Build arm64 .deb package
+      run: |
+        . ./activate
+        ldd --version
+        cd ./chia-blockchain-gui
+        git status
+        cd ../build_scripts
+        sh build_linux_deb.sh arm64
 
     - name: Upload Linux artifacts
       uses: actions/upload-artifact@v2
       with:
         name: Linux-ARM-64-Installer
         path: ${{ github.workspace }}/build_scripts/final_installer/
-
-    - name: Install AWS CLI
-      if: steps.check_secrets.outputs.HAS_SECRET
-      run: |
-          sudo apt-get install -y awscli
 
     - name: Configure AWS Credentials
       if: steps.check_secrets.outputs.HAS_SECRET
@@ -114,17 +96,17 @@ jobs:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       if: steps.check_secrets.outputs.HAS_SECRET
       run: |
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download-chia-net/builds/
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download-chia-net/protocol_and_cats_rebased/
+          aws s3 cp "$GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb" s3://download-chia-net/builds/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download-chia-net/protocol_and_cats_rebased/
 
     - name: Create Checksums
       if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        ls ${{ github.workspace }}/build_scripts/final_installer/
-        sha256sum ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb > ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256
-        ls ${{ github.workspace }}/build_scripts/final_installer/
+        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
+        sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256
+        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
 
     - name: Install py3createtorrent
       if: startsWith(github.ref, 'refs/tags/')
@@ -136,26 +118,26 @@ jobs:
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb -o ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent --webseed https://download-chia-net.s3.us-west-2.amazonaws.com/install/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb
-        ls ${{ github.workspace }}/build_scripts/final_installer/
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent --webseed https://download-chia-net.s3.us-west-2.amazonaws.com/install/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb
+        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
 
     - name: Upload Beta Installer
       if: steps.check_secrets.outputs.HAS_SECRET && github.ref == 'refs/heads/main'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download-chia-net/beta/chia-blockchain_arm64_latest_beta.deb
-        aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download-chia-net/beta/chia-blockchain_arm64_latest_beta.deb.sha256
+        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download-chia-net/beta/chia-blockchain_arm64_latest_beta.deb
+        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download-chia-net/beta/chia-blockchain_arm64_latest_beta.deb.sha256
 
     - name: Upload Release Files
       if: steps.check_secrets.outputs.HAS_SECRET && startsWith(github.ref, 'refs/tags/')
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-          ls ${{ github.workspace }}/build_scripts/final_installer/
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download-chia-net/install/
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download-chia-net/install/
-          aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent s3://download-chia-net/torrents/
+          ls $GITHUB_WORKSPACE/build_scripts/final_installer/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download-chia-net/install/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download-chia-net/install/
+          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent s3://download-chia-net/torrents/
 
     - name: Get tag name
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
* Refactor the whole workflow to run in a container rather than just one step

* Update to chianetwork/ubuntu-18.04-builder:latest image

* Remove some steps that install things that are now pre-baked to the container

* Remove caches for now

* Update path to github workspace

* Add clean workspace action

* Fix linux installer artifact path