### PR TITLE
Re-enabled legacy keyring test. Updated the world.

### DIFF
--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -193,7 +193,7 @@ class KeyringWrapper:
         return KeyringWrapper.__shared_instance
 
     @staticmethod
-    def set_shared_instance(instance: 'KeyringWrapper'):
+    def set_shared_instance(instance: "KeyringWrapper"):
         KeyringWrapper.__shared_instance = instance
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,12 +21,13 @@ class BlockToolsFixtureHelper:
     def __init__(self, block_tools: BlockTools, keyring: TempKeyring) -> None:
         self.block_tools: BlockTools = block_tools
         self.keyring: TempKeyring = keyring
+        self.cleaned_up: bool = False
 
     def cleanup(self) -> None:
+        assert self.cleaned_up is False
         if self.keyring is not None:
             self.keyring.cleanup()
-        self.block_tools = None
-        self.keyring = None
+        self.cleaned_up = True
 
 
 shared_block_tools_helper: Optional[BlockToolsFixtureHelper] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,50 +81,55 @@ async def empty_blockchain():
 block_format_version = "rc4"
 
 
-@pytest.fixture(scope="session")
-async def default_400_blocks():
+@pytest.fixture(scope="module")
+async def default_400_blocks(shared_b_tools):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", seed=b"alternate2")
+    return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", shared_b_tools, seed=b"alternate2")
 
 
-@pytest.fixture(scope="session")
-async def default_1000_blocks():
+@pytest.fixture(scope="module")
+async def default_1000_blocks(shared_b_tools):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db")
+    return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db", shared_b_tools)
 
 
-@pytest.fixture(scope="session")
-async def pre_genesis_empty_slots_1000_blocks():
+@pytest.fixture(scope="module")
+async def pre_genesis_empty_slots_1000_blocks(shared_b_tools):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        1000, f"pre_genesis_empty_slots_1000_blocks{block_format_version}.db", seed=b"alternate2", empty_sub_slots=1
+        1000,
+        f"pre_genesis_empty_slots_1000_blocks{block_format_version}.db",
+        shared_b_tools,
+        seed=b"alternate2",
+        empty_sub_slots=1,
     )
 
 
-@pytest.fixture(scope="session")
-async def default_10000_blocks():
+@pytest.fixture(scope="module")
+async def default_10000_blocks(shared_b_tools):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db")
+    return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db", shared_b_tools)
 
 
-@pytest.fixture(scope="session")
-async def default_20000_blocks():
+@pytest.fixture(scope="module")
+async def default_20000_blocks(shared_b_tools):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db")
+    return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db", shared_b_tools)
 
 
-@pytest.fixture(scope="session")
-async def default_10000_blocks_compact():
+@pytest.fixture(scope="module")
+async def default_10000_blocks_compact(shared_b_tools):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
         10000,
         f"test_blocks_10000_compact_{block_format_version}.db",
+        shared_b_tools,
         normalized_to_identity_cc_eos=True,
         normalized_to_identity_icc_eos=True,
         normalized_to_identity_cc_ip=True,

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -53,9 +53,13 @@ class TestDaemon:
             yield _
 
     @pytest.fixture(scope="function")
-    async def simulation(self, b_tools, b_tools_1):
+    async def simulation(self, b_tools, b_tools_1, shared_b_tools):
         async for _ in setup_full_system(
-            b_tools_1.constants, b_tools=b_tools, b_tools_1=b_tools_1, connect_to_daemon=True
+            b_tools_1.constants,
+            b_tools=b_tools,
+            b_tools_1=b_tools_1,
+            shared_b_tools=shared_b_tools,
+            connect_to_daemon=True,
         ):
             yield _
 

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -11,36 +11,49 @@ from tests.time_out_assert import time_out_assert, time_out_assert_custom_interv
 from tests.util.keyring import TempKeyring
 
 import asyncio
-import atexit
 import json
 
 import aiohttp
 import pytest
 
 
-def cleanup_keyring(keyring: TempKeyring):
-    keyring.cleanup()
-
-
-temp_keyring1 = TempKeyring()
-temp_keyring2 = TempKeyring()
-atexit.register(cleanup_keyring, temp_keyring1)
-atexit.register(cleanup_keyring, temp_keyring2)
-b_tools = create_block_tools(constants=test_constants_modified, keychain=temp_keyring1.get_keychain())
-b_tools_1 = create_block_tools(constants=test_constants_modified, keychain=temp_keyring2.get_keychain())
-new_config = b_tools._config
-new_config["daemon_port"] = 55401
-b_tools.change_config(new_config)
-
-
 class TestDaemon:
+    @pytest.fixture(scope="module")
+    def b_tools(self):
+        b_tools: BlockTools
+        try:
+            b_tools = self.b_tools_value
+        except AttributeError:
+            self.temp_keyring1 = TempKeyring()
+            self.b_tools_value = create_block_tools(
+                constants=test_constants_modified, keychain=self.temp_keyring1.get_keychain()
+            )
+            new_config = self.b_tools_value._config
+            new_config["daemon_port"] = 55401
+            self.b_tools_value.change_config(new_config)
+            b_tools = self.b_tools_value
+        return b_tools
+
+    @pytest.fixture(scope="module")
+    def b_tools_1(self):
+        b_tools_1: BlockTools
+        try:
+            b_tools_1 = self.b_tools_1_value
+        except AttributeError:
+            self.temp_keyring2 = TempKeyring()
+            self.b_tools_1_value = create_block_tools(
+                constants=test_constants_modified, keychain=self.temp_keyring2.get_keychain()
+            )
+            b_tools_1 = self.b_tools_1_value
+        return b_tools_1
+
     @pytest.fixture(scope="function")
-    async def get_daemon(self):
+    async def get_daemon(self, b_tools):
         async for _ in setup_daemon(btools=b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def simulation(self):
+    async def simulation(self, b_tools, b_tools_1):
         async for _ in setup_full_system(
             b_tools_1.constants, b_tools=b_tools, b_tools_1=b_tools_1, connect_to_daemon=True
         ):
@@ -65,7 +78,7 @@ class TestDaemon:
             yield get_b_tools
 
     @pytest.mark.asyncio
-    async def test_daemon_simulation(self, simulation, get_daemon):
+    async def test_daemon_simulation(self, simulation, get_daemon, b_tools):
         node1, node2, _, _, _, _, _, _, _, server1 = simulation
         await server1.start_client(PeerInfo(self_hostname, uint16(21238)))
 

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -12,7 +12,7 @@ from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
 from chia.util.db_wrapper import DBWrapper
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
 
 log = logging.getLogger(__name__)
 
@@ -25,9 +25,9 @@ def event_loop():
 
 class TestBlockStore:
     @pytest.mark.asyncio
-    async def test_block_store(self):
+    async def test_block_store(self, shared_b_tools):
         assert sqlite3.threadsafety == 1
-        blocks = bt.get_consecutive_blocks(10)
+        blocks = shared_b_tools.get_consecutive_blocks(10)
 
         db_filename = Path("blockchain_test.db")
         db_filename_2 = Path("blockchain_test2.db")
@@ -85,12 +85,12 @@ class TestBlockStore:
         db_filename_2.unlink()
 
     @pytest.mark.asyncio
-    async def test_deadlock(self):
+    async def test_deadlock(self, shared_b_tools):
         """
         This test was added because the store was deadlocking in certain situations, when fetching and
         adding blocks repeatedly. The issue was patched.
         """
-        blocks = bt.get_consecutive_blocks(10)
+        blocks = shared_b_tools.get_consecutive_blocks(10)
         db_filename = Path("blockchain_test.db")
         db_filename_2 = Path("blockchain_test2.db")
 

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -100,7 +100,9 @@ def event_loop():
 
 @pytest.fixture(scope="module")
 async def wallet_nodes(shared_b_tools):
-    async_gen = setup_simulators_and_wallets(2, 1, {"MEMPOOL_BLOCK_BUFFER": 2, "MAX_BLOCK_COST_CLVM": 400000000}, shared_b_tools)
+    async_gen = setup_simulators_and_wallets(
+        2, 1, {"MEMPOOL_BLOCK_BUFFER": 2, "MAX_BLOCK_COST_CLVM": 400000000}, shared_b_tools
+    )
     nodes, wallets = await async_gen.__anext__()
     full_node_1 = nodes[0]
     full_node_2 = nodes[1]
@@ -150,7 +152,9 @@ async def wallet_nodes_mainnet(shared_b_tools):
 
 class TestFullNodeBlockCompression:
     @pytest.mark.asyncio
-    async def do_test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, test_reorgs, shared_b_tools):
+    async def do_test_block_compression(
+        self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, test_reorgs, shared_b_tools
+    ):
         nodes, wallets = setup_two_nodes_and_wallet
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -397,7 +401,9 @@ class TestFullNodeBlockCompression:
 
     @pytest.mark.asyncio
     async def test_block_compression_2(self, setup_two_nodes_and_wallet, empty_blockchain, shared_b_tools):
-        await self.do_test_block_compression(setup_two_nodes_and_wallet, empty_blockchain, 3000000000000, False, shared_b_tools)
+        await self.do_test_block_compression(
+            setup_two_nodes_and_wallet, empty_blockchain, 3000000000000, False, shared_b_tools
+        )
 
 
 class TestFullNodeProtocol:
@@ -537,7 +543,9 @@ class TestFullNodeProtocol:
         blocks = await full_node_1.get_all_full_blocks()
         saved_seed = b""
         for i in range(0, 9999999):
-            blocks = shared_b_tools.get_consecutive_blocks(5, block_list_input=blocks, skip_slots=1, seed=i.to_bytes(4, "big"))
+            blocks = shared_b_tools.get_consecutive_blocks(
+                5, block_list_input=blocks, skip_slots=1, seed=i.to_bytes(4, "big")
+            )
             if len(blocks[-1].finished_sub_slots) == 0:
                 saved_seed = i.to_bytes(4, "big")
                 break
@@ -753,7 +761,9 @@ class TestFullNodeProtocol:
         blocks = await full_node_1.get_all_full_blocks()
         blocks = shared_b_tools.get_consecutive_blocks(3, block_list_input=blocks)  # Alternate chain
 
-        blocks_reorg = shared_b_tools.get_consecutive_blocks(3, block_list_input=blocks[:-1], seed=b"214")  # Alternate chain
+        blocks_reorg = shared_b_tools.get_consecutive_blocks(
+            3, block_list_input=blocks[:-1], seed=b"214"
+        )  # Alternate chain
         for block in blocks[-3:]:
             new_peak = fnp.NewPeak(
                 block.header_hash,
@@ -1237,7 +1247,9 @@ class TestFullNodeProtocol:
             blocks[-1], "foliage_transaction_block.timestamp", unf.foliage_transaction_block.timestamp + 1
         )
         new_m = block_2.foliage.foliage_transaction_block_hash
-        new_fbh_sig = shared_b_tools.get_plot_signature(new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key)
+        new_fbh_sig = shared_b_tools.get_plot_signature(
+            new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key
+        )
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fbh_sig)
         block_2 = recursive_replace(block_2, "transactions_generator", None)
 

--- a/tests/core/full_node/test_hint_store.py
+++ b/tests/core/full_node/test_hint_store.py
@@ -11,7 +11,6 @@ from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.spend_bundle import SpendBundle
 from tests.util.db_connection import DBConnection
 from tests.wallet_tools import WalletTool
-from tests.setup_nodes import bt
 
 
 @pytest.fixture(scope="module")
@@ -51,20 +50,20 @@ class TestHintStore:
             assert coins_for_non_hint == []
 
     @pytest.mark.asyncio
-    async def test_hints_in_blockchain(self, empty_blockchain):  # noqa: F811
+    async def test_hints_in_blockchain(self, empty_blockchain, shared_b_tools):  # noqa: F811
         blockchain: Blockchain = empty_blockchain
 
-        blocks = bt.get_consecutive_blocks(
+        blocks = shared_b_tools.get_consecutive_blocks(
             5,
             block_list_input=[],
             guarantee_transaction_block=True,
-            farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
+            farmer_reward_puzzle_hash=shared_b_tools.pool_ph,
+            pool_reward_puzzle_hash=shared_b_tools.pool_ph,
         )
         for block in blocks:
             await blockchain.receive_block(block)
 
-        wt: WalletTool = bt.get_pool_wallet_tool()
+        wt: WalletTool = shared_b_tools.get_pool_wallet_tool()
         puzzle_hash = 32 * b"\0"
         amount = int_to_bytes(1)
         hint = 32 * b"\5"
@@ -79,7 +78,7 @@ class TestHintStore:
             condition_dic=condition_dict,
         )
 
-        blocks = bt.get_consecutive_blocks(
+        blocks = shared_b_tools.get_consecutive_blocks(
             10, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
 

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -11,7 +11,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 from chia.wallet.transaction_record import TransactionRecord
 from tests.connection_utils import connect_and_get_peer
-from tests.setup_nodes import bt, self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
 
@@ -33,13 +33,13 @@ def event_loop():
 
 class TestMempoolPerformance:
     @pytest.fixture(scope="module")
-    async def wallet_nodes(self):
-        key_seed = bt.farmer_master_sk_entropy
-        async for _ in setup_simulators_and_wallets(2, 1, {}, key_seed=key_seed):
+    async def wallet_nodes(self, shared_b_tools):
+        key_seed = shared_b_tools.farmer_master_sk_entropy
+        async for _ in setup_simulators_and_wallets(2, 1, {}, shared_b_tools, key_seed=key_seed):
             yield _
 
     @pytest.mark.asyncio
-    async def test_mempool_update_performance(self, wallet_nodes, default_400_blocks):
+    async def test_mempool_update_performance(self, wallet_nodes, default_400_blocks, shared_b_tools):
         blocks = default_400_blocks
         full_nodes, wallets = wallet_nodes
         wallet_node = wallets[0][0]
@@ -67,7 +67,7 @@ class TestMempoolPerformance:
         for con in cons:
             await con.close()
 
-        blocks = bt.get_consecutive_blocks(3, blocks)
+        blocks = shared_b_tools.get_consecutive_blocks(3, blocks)
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[-3]))
 
         for block in blocks[-2:]:

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -7,7 +7,7 @@ from chia.protocols import full_node_protocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 from tests.connection_utils import connect_and_get_peer
-from tests.setup_nodes import bt, self_hostname, setup_two_nodes, test_constants
+from tests.setup_nodes import self_hostname, setup_two_nodes, test_constants
 from tests.time_out_assert import time_out_assert
 
 
@@ -24,10 +24,10 @@ class TestNodeLoad:
             yield _
 
     @pytest.mark.asyncio
-    async def test_blocks_load(self, two_nodes):
+    async def test_blocks_load(self, two_nodes, shared_b_tools):
         num_blocks = 50
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        blocks = bt.get_consecutive_blocks(num_blocks)
+        blocks = shared_b_tools.get_consecutive_blocks(num_blocks)
         peer = await connect_and_get_peer(server_1, server_2)
         await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[0]), peer)
 

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -23,18 +23,18 @@ def event_loop():
 
 class TestTransactions:
     @pytest.fixture(scope="function")
-    async def wallet_node(self):
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
+    async def wallet_node(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 1, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def two_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
+    async def two_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def three_nodes_two_wallets(self):
-        async for _ in setup_simulators_and_wallets(3, 2, {}):
+    async def three_nodes_two_wallets(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(3, 2, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -39,8 +39,8 @@ def event_loop():
 
 
 @pytest.fixture(scope="function")
-async def setup_two_nodes():
-    async for _ in setup_simulators_and_wallets(2, 0, {}, starting_port=60000):
+async def setup_two_nodes(shared_b_tools):
+    async for _ in setup_simulators_and_wallets(2, 0, {}, shared_b_tools, starting_port=60000):
         yield _
 
 

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -51,18 +51,18 @@ async def establish_connection(server: ChiaServer, dummy_port: int, ssl_context)
 
 class TestSSL:
     @pytest.fixture(scope="function")
-    async def harvester_farmer(self):
-        async for _ in setup_farmer_harvester(test_constants):
+    async def harvester_farmer(self, shared_b_tools):
+        async for _ in setup_farmer_harvester(test_constants, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def wallet_node(self):
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
+    async def wallet_node(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 1, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def introducer(self):
-        async for _ in setup_introducer(21233):
+    async def introducer(self, shared_b_tools):
+        async for _ in setup_introducer(21233, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -12,7 +12,6 @@ from chia.types.peer_info import PeerInfo
 from tests.block_tools import test_constants
 from chia.util.ints import uint16
 from tests.setup_nodes import (
-    bt,
     self_hostname,
     setup_farmer_harvester,
     setup_introducer,
@@ -67,8 +66,8 @@ class TestSSL:
             yield _
 
     @pytest.fixture(scope="function")
-    async def timelord(self):
-        async for _ in setup_timelord(21236, 21237, False, test_constants, bt):
+    async def timelord(self, shared_b_tools):
+        async for _ in setup_timelord(21236, 21237, False, test_constants, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -13,7 +13,7 @@ from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, 
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.generator_types import BlockGenerator
 from chia.wallet.puzzles import p2_delegated_puzzle_or_hidden_puzzle
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
 
 from .make_block_generator import make_block_generator
 
@@ -54,11 +54,11 @@ def large_block_generator(size):
 
 class TestCostCalculation:
     @pytest.mark.asyncio
-    async def test_basics(self):
-        wallet_tool = bt.get_pool_wallet_tool()
+    async def test_basics(self, shared_b_tools):
+        wallet_tool = shared_b_tools.get_pool_wallet_tool()
         ph = wallet_tool.get_new_puzzlehash()
         num_blocks = 3
-        blocks = bt.get_consecutive_blocks(
+        blocks = shared_b_tools.get_consecutive_blocks(
             num_blocks, [], guarantee_transaction_block=True, pool_reward_puzzle_hash=ph, farmer_reward_puzzle_hash=ph
         )
         coinbase = None
@@ -105,12 +105,12 @@ class TestCostCalculation:
         )
 
     @pytest.mark.asyncio
-    async def test_strict_mode(self):
-        wallet_tool = bt.get_pool_wallet_tool()
+    async def test_strict_mode(self, shared_b_tools):
+        wallet_tool = shared_b_tools.get_pool_wallet_tool()
         ph = wallet_tool.get_new_puzzlehash()
 
         num_blocks = 3
-        blocks = bt.get_consecutive_blocks(
+        blocks = shared_b_tools.get_consecutive_blocks(
             num_blocks, [], guarantee_transaction_block=True, pool_reward_puzzle_hash=ph, farmer_reward_puzzle_hash=ph
         )
 

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -4,7 +4,7 @@ from typing import List
 import pytest
 from chiabip158 import PyBIP158
 
-from tests.setup_nodes import setup_simulators_and_wallets, bt
+from tests.setup_nodes import setup_simulators_and_wallets
 
 
 @pytest.fixture(scope="module")
@@ -15,19 +15,19 @@ def event_loop():
 
 class TestFilter:
     @pytest.fixture(scope="function")
-    async def wallet_and_node(self):
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
+    async def wallet_and_node(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 1, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio
-    async def test_basic_filter_test(self, wallet_and_node):
+    async def test_basic_filter_test(self, wallet_and_node, shared_b_tools):
         full_nodes, wallets = wallet_and_node
         wallet_node, server_2 = wallets[0]
         wallet = wallet_node.wallet_state_manager.main_wallet
 
         num_blocks = 2
         ph = await wallet.get_new_puzzlehash()
-        blocks = bt.get_consecutive_blocks(
+        blocks = shared_b_tools.get_consecutive_blocks(
             10,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=ph,

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -67,7 +67,9 @@ class TestRpc:
             assert state["sub_slot_iters"] > 0
 
             blocks = shared_b_tools.get_consecutive_blocks(num_blocks)
-            blocks = shared_b_tools.get_consecutive_blocks(num_blocks, block_list_input=blocks, guarantee_transaction_block=True)
+            blocks = shared_b_tools.get_consecutive_blocks(
+                num_blocks, block_list_input=blocks, guarantee_transaction_block=True
+            )
 
             assert len(await client.get_unfinished_block_headers()) == 0
             assert len((await client.get_block_records(0, 100))) == 0
@@ -258,7 +260,9 @@ class TestRpc:
             for block in blocks:
                 await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-            blocks = shared_b_tools.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1, force_overflow=True)
+            blocks = shared_b_tools.get_consecutive_blocks(
+                1, block_list_input=blocks, skip_slots=1, force_overflow=True
+            )
 
             blockchain = full_node_api_1.full_node.blockchain
             second_blockchain = empty_blockchain

--- a/tests/core/test_merkle_set.py
+++ b/tests/core/test_merkle_set.py
@@ -4,7 +4,6 @@ import itertools
 import pytest
 
 from chia.util.merkle_set import MerkleSet, confirm_included_already_hashed
-from tests.setup_nodes import bt
 
 
 @pytest.fixture(scope="module")
@@ -15,9 +14,9 @@ def event_loop():
 
 class TestMerkleSet:
     @pytest.mark.asyncio
-    async def test_basics(self):
+    async def test_basics(self, shared_b_tools):
         num_blocks = 20
-        blocks = bt.get_consecutive_blocks(num_blocks)
+        blocks = shared_b_tools.get_consecutive_blocks(num_blocks)
 
         merkle_set = MerkleSet()
         merkle_set_reverse = MerkleSet()

--- a/tests/core/util/test_keyring_wrapper.py
+++ b/tests/core/util/test_keyring_wrapper.py
@@ -38,7 +38,6 @@ class TestKeyringWrapper:
 
     # When: creating a new file keyring with a legacy keyring in place
     @using_temp_file_keyring_and_cryptfilekeyring()
-    @pytest.mark.skip(reason="Does only work if `test_keyring_wrapper.py` gets called separately.")
     def test_using_legacy_cryptfilekeyring(self):
         """
         In the case that an existing CryptFileKeyring (legacy) keyring exists and we're

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -26,10 +26,10 @@ from chia.util.streamable import (
     parse_size_hints,
     parse_str,
 )
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
 
 
-class TestStreamable(unittest.TestCase):
+class TestStreamable:
     def test_basic(self):
         @dataclass(frozen=True)
         @streamable
@@ -68,8 +68,8 @@ class TestStreamable(unittest.TestCase):
         except NotImplementedError:
             pass
 
-    def test_json(self):
-        block = bt.create_genesis_block(test_constants, bytes([0] * 32), b"0")
+    def test_json(self, shared_b_tools):
+        block = shared_b_tools.create_genesis_block(test_constants, bytes([0] * 32), b"0")
 
         dict_block = block.to_json_dict()
         assert FullBlock.from_json_dict(dict_block) == block

--- a/tests/pools/test_pool_wallet.py
+++ b/tests/pools/test_pool_wallet.py
@@ -28,8 +28,8 @@ def event_loop():
 
 class TestPoolWallet2:
     @pytest.fixture(scope="function")
-    async def one_wallet_node(self):
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
+    async def one_wallet_node(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 1, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -27,12 +27,6 @@ from tests.time_out_assert import time_out_assert_custom_interval
 from typing import Tuple
 
 
-# temp_keyring = TempKeyring()
-# keychain = temp_keyring.get_keychain()
-# atexit.register(cleanup_keyring, temp_keyring)  # Attempt to cleanup the temp keychain
-# bt = create_block_tools(constants=test_constants, keychain=keychain)
-
-# self_hostname = bt.config["self_hostname"]
 self_hostname = "localhost"
 
 
@@ -43,7 +37,7 @@ def constants_for_dic(dic):
 def setup_shared_block_tools_and_keyring(
     consensus_constants: ConsensusConstants = test_constants,
 ) -> Tuple[BlockTools, TempKeyring]:
-    temp_keyring = TempKeyring()
+    temp_keyring = TempKeyring(populate=True)
     bt = create_block_tools(constants=consensus_constants, keychain=temp_keyring.get_keychain())
     return bt, temp_keyring
 
@@ -137,7 +131,7 @@ async def setup_wallet_node(
     key_seed=None,
     starting_height=None,
 ):
-    with TempKeyring() as keychain:
+    with TempKeyring(populate=True) as keychain:
         config = shared_b_tools.config["wallet"]
         config["port"] = port
         config["rpc_port"] = port + 1000
@@ -333,7 +327,7 @@ async def setup_two_nodes(consensus_constants: ConsensusConstants):
     Setup and teardown of two full nodes, with blockchains and separate DBs.
     """
 
-    with TempKeyring() as keychain1, TempKeyring() as keychain2:
+    with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         node_iters = [
             setup_full_node(
                 consensus_constants,
@@ -367,7 +361,7 @@ async def setup_n_nodes(consensus_constants: ConsensusConstants, n: int):
     node_iters = []
     keyrings_to_cleanup = []
     for i in range(n):
-        keyring = TempKeyring()
+        keyring = TempKeyring(populate=True)
         keyrings_to_cleanup.append(keyring)
         node_iters.append(
             setup_full_node(
@@ -393,7 +387,7 @@ async def setup_n_nodes(consensus_constants: ConsensusConstants, n: int):
 async def setup_node_and_wallet(
     consensus_constants: ConsensusConstants, shared_b_tools: BlockTools, starting_height=None, key_seed=None
 ):
-    with TempKeyring() as keychain:
+    with TempKeyring(populate=True) as keychain:
         btools = await create_block_tools_async(constants=test_constants, keychain=keychain)
         node_iters = [
             setup_full_node(consensus_constants, "blockchain_test.db", 21234, btools, simulator=False),
@@ -425,7 +419,7 @@ async def setup_simulators_and_wallets(
     key_seed=None,
     starting_port=50000,
 ):
-    with TempKeyring() as keychain1, TempKeyring() as keychain2:
+    with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         simulators: List[FullNodeAPI] = []
         wallets = []
         node_iters = []
@@ -490,7 +484,7 @@ async def setup_farmer_harvester(consensus_constants: ConsensusConstants, shared
 async def setup_full_system(
     consensus_constants: ConsensusConstants, b_tools=None, b_tools_1=None, shared_b_tools=None, connect_to_daemon=False
 ):
-    with TempKeyring() as keychain1, TempKeyring() as keychain2:
+    with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         if b_tools is None:
             b_tools = await create_block_tools_async(constants=test_constants, keychain=keychain1)
         if b_tools_1 is None:

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -33,8 +33,8 @@ class TestSimulation:
                 yield _
 
     @pytest.fixture(scope="function")
-    async def simulation(self):
-        async for _ in setup_full_system(test_constants_modified):
+    async def simulation(self, shared_b_tools):
+        async for _ in setup_full_system(test_constants_modified, shared_b_tools=shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -13,8 +13,7 @@ from chia.full_node.hint_store import HintStore
 from chia.types.full_block import FullBlock
 from chia.util.db_wrapper import DBWrapper
 from chia.util.path import mkdir
-
-from tests.setup_nodes import bt
+from tests.block_tools import BlockTools
 
 blockchain_db_counter: int = 0
 
@@ -38,6 +37,7 @@ async def create_blockchain(constants: ConsensusConstants):
 def persistent_blocks(
     num_of_blocks: int,
     db_name: str,
+    shared_b_tools: BlockTools,
     seed: bytes = b"",
     empty_sub_slots=0,
     normalized_to_identity_cc_eos: bool = False,
@@ -71,6 +71,7 @@ def persistent_blocks(
         num_of_blocks,
         seed,
         empty_sub_slots,
+        shared_b_tools,
         normalized_to_identity_cc_eos,
         normalized_to_identity_icc_eos,
         normalized_to_identity_cc_sp,
@@ -83,13 +84,14 @@ def new_test_db(
     num_of_blocks: int,
     seed: bytes,
     empty_sub_slots: int,
+    shared_b_tools: BlockTools,
     normalized_to_identity_cc_eos: bool = False,  # CC_EOS,
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
 ):
     print(f"create {path} with {num_of_blocks} blocks with ")
-    blocks: List[FullBlock] = bt.get_consecutive_blocks(
+    blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
         num_of_blocks,
         seed=seed,
         skip_slots=empty_sub_slots,

--- a/tests/wallet/cc_wallet/test_cc_wallet.py
+++ b/tests/wallet/cc_wallet/test_cc_wallet.py
@@ -34,18 +34,18 @@ async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32):
 
 class TestCCWallet:
     @pytest.fixture(scope="function")
-    async def wallet_node(self):
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
+    async def wallet_node(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 1, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def two_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
+    async def two_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def three_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 3, {}):
+    async def three_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 3, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/wallet/cc_wallet/test_trades.py
+++ b/tests/wallet/cc_wallet/test_trades.py
@@ -22,8 +22,8 @@ def event_loop():
 
 
 @pytest.fixture(scope="module")
-async def two_wallet_nodes():
-    async for _ in setup_simulators_and_wallets(1, 2, {}):
+async def two_wallet_nodes(shared_b_tools):
+    async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
         yield _
 
 

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -22,28 +22,28 @@ def event_loop():
 
 class TestDIDWallet:
     @pytest.fixture(scope="function")
-    async def wallet_node(self):
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
+    async def wallet_node(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 1, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def two_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
+    async def two_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def three_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 3, {}):
+    async def three_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 3, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def two_wallet_nodes_five_freeze(self):
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
+    async def two_wallet_nodes_five_freeze(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def three_sim_two_wallets(self):
-        async for _ in setup_simulators_and_wallets(3, 2, {}):
+    async def three_sim_two_wallets(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(3, 2, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/wallet/did_wallet/test_did_rpc.py
+++ b/tests/wallet/did_wallet/test_did_rpc.py
@@ -9,7 +9,7 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
 from chia.wallet.util.wallet_types import WalletType
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets, bt
+from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 
@@ -32,7 +32,7 @@ class TestDIDWallet:
             yield _
 
     @pytest.mark.asyncio
-    async def test_create_did(self, three_wallet_nodes):
+    async def test_create_did(self, three_wallet_nodes, shared_b_tools):
         num_blocks = 4
         full_nodes, wallets = three_wallet_nodes
         full_node_api = full_nodes[0]
@@ -54,18 +54,20 @@ class TestDIDWallet:
         log.info("Waiting for initial money in Wallet 0 ...")
 
         api_one = WalletRpcApi(wallet_node_0)
-        config = bt.config
+        config = shared_b_tools.config
         daemon_port = config["daemon_port"]
         test_rpc_port = uint16(21529)
         await wallet_server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
-        client = await WalletRpcClient.create(self_hostname, test_rpc_port, bt.root_path, bt.config)
+        client = await WalletRpcClient.create(
+            self_hostname, test_rpc_port, shared_b_tools.root_path, shared_b_tools.config
+        )
         rpc_server_cleanup = await start_rpc_server(
             api_one,
             self_hostname,
             daemon_port,
             test_rpc_port,
             lambda x: None,
-            bt.root_path,
+            shared_b_tools.root_path,
             config,
             connect_to_daemon=False,
         )

--- a/tests/wallet/did_wallet/test_did_rpc.py
+++ b/tests/wallet/did_wallet/test_did_rpc.py
@@ -27,8 +27,8 @@ def event_loop():
 
 class TestDIDWallet:
     @pytest.fixture(scope="function")
-    async def three_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 3, {}):
+    async def three_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 3, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/wallet/rl_wallet/test_rl_rpc.py
+++ b/tests/wallet/rl_wallet/test_rl_rpc.py
@@ -52,8 +52,8 @@ async def check_balance(api, wallet_id):
 
 class TestRLWallet:
     @pytest.fixture(scope="function")
-    async def three_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 3, {}):
+    async def three_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 3, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/wallet/rl_wallet/test_rl_wallet.py
+++ b/tests/wallet/rl_wallet/test_rl_wallet.py
@@ -18,8 +18,8 @@ def event_loop():
 
 class TestCCWallet:
     @pytest.fixture(scope="function")
-    async def two_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
+    async def two_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -96,7 +96,9 @@ class TestWalletRpc:
         await time_out_assert(5, wallet.get_unconfirmed_balance, initial_funds)
 
         client = await WalletRpcClient.create(self_hostname, test_rpc_port, shared_b_tools.root_path, config)
-        client_node = await FullNodeRpcClient.create(self_hostname, test_rpc_port_node, shared_b_tools.root_path, config)
+        client_node = await FullNodeRpcClient.create(
+            self_hostname, test_rpc_port_node, shared_b_tools.root_path, config
+        )
         try:
             addr = encode_puzzle_hash(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), "xch")
             tx_amount = 15600000

--- a/tests/wallet/test_singleton_lifecycle.py
+++ b/tests/wallet/test_singleton_lifecycle.py
@@ -16,7 +16,7 @@ from chia.util.condition_tools import ConditionOpcode
 from chia.util.ints import uint64
 from chia.wallet.puzzles.load_clvm import load_clvm
 
-from tests.core.full_node.test_conditions import bt, check_spend_bundle_validity, initial_blocks
+from tests.core.full_node.test_conditions import check_spend_bundle_validity, initial_blocks
 
 
 SINGLETON_MOD = load_clvm("singleton_top_layer.clvm")
@@ -96,7 +96,7 @@ def p2_singleton_puzzle_hash(launcher_id: Program, launcher_puzzle_hash: bytes32
     return p2_singleton_puzzle(launcher_id, launcher_puzzle_hash).get_tree_hash()
 
 
-def test_only_odd_coins_0():
+def test_only_odd_coins_0(shared_b_tools):
     blocks = initial_blocks()
     farmed_coin = list(blocks[-1].get_included_reward_coins())[0]
 
@@ -114,7 +114,7 @@ def test_only_odd_coins_0():
     coin_spend = CoinSpend(farmed_coin, ANYONE_CAN_SPEND_PUZZLE, conditions)
     spend_bundle = SpendBundle.aggregate([launcher_spend_bundle, SpendBundle([coin_spend], G2Element())])
     run = asyncio.get_event_loop().run_until_complete
-    coins_added, coins_removed = run(check_spend_bundle_validity(bt.constants, blocks, spend_bundle))
+    coins_added, coins_removed = run(check_spend_bundle_validity(shared_b_tools.constants, blocks, spend_bundle))
 
     coin_set_added = set([_.coin for _ in coins_added])
     coin_set_removed = set([_.coin for _ in coins_removed])

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -24,23 +24,23 @@ def event_loop():
 
 class TestWalletSimulator:
     @pytest.fixture(scope="function")
-    async def wallet_node(self):
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
+    async def wallet_node(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 1, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def two_wallet_nodes(self):
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
+    async def two_wallet_nodes(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def two_wallet_nodes_five_freeze(self):
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
+    async def two_wallet_nodes_five_freeze(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(1, 2, {}, shared_b_tools):
             yield _
 
     @pytest.fixture(scope="function")
-    async def three_sim_two_wallets(self):
-        async for _ in setup_simulators_and_wallets(3, 2, {}):
+    async def three_sim_two_wallets(self, shared_b_tools):
+        async for _ in setup_simulators_and_wallets(3, 2, {}, shared_b_tools):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/weight_proof/test_weight_proof.py
+++ b/tests/weight_proof/test_weight_proof.py
@@ -22,7 +22,6 @@ from tests.block_tools import test_constants
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.generator_tools import get_block_header
-from tests.setup_nodes import bt
 
 try:
     from reprlib import repr
@@ -194,57 +193,57 @@ class TestWeightProof:
         assert wp is not None
 
     @pytest.mark.asyncio
-    async def test_weight_proof_edge_cases(self, default_400_blocks):
+    async def test_weight_proof_edge_cases(self, default_400_blocks, shared_b_tools):
         blocks: List[FullBlock] = default_400_blocks
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=2
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=1
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=2
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
@@ -253,14 +252,14 @@ class TestWeightProof:
             normalized_to_identity_cc_eos=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             10,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
@@ -269,14 +268,14 @@ class TestWeightProof:
             normalized_to_identity_icc_eos=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             10,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
@@ -285,14 +284,14 @@ class TestWeightProof:
             normalized_to_identity_cc_ip=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             10,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             seed=b"asdfghjkl",
@@ -301,18 +300,18 @@ class TestWeightProof:
             normalized_to_identity_cc_sp=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             1, block_list_input=blocks, seed=b"asdfghjkl", force_overflow=True, skip_slots=4
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             10,
             block_list_input=blocks,
             seed=b"asdfghjkl",
             force_overflow=True,
         )
 
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             300,
             block_list_input=blocks,
             seed=b"asdfghjkl",
@@ -370,8 +369,8 @@ class TestWeightProof:
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof1000_partial_blocks_compact(self, default_10000_blocks_compact):
-        blocks: List[FullBlock] = bt.get_consecutive_blocks(
+    async def test_weight_proof1000_partial_blocks_compact(self, default_10000_blocks_compact, shared_b_tools):
+        blocks: List[FullBlock] = shared_b_tools.get_consecutive_blocks(
             100,
             block_list_input=default_10000_blocks_compact,
             seed=b"asdfghjkl",


### PR DESCRIPTION
This set of changes fixes some issues with globals created during testing, which can interfere with some KeyringWrapper tests.

The KeyringWrapper class is currently configured as a singleton. Normally this works just fine, but when running in the automated test environment, tests often create one or more BlockTools instances, each with a distinct keyring. With KeyringWrapper tests that mock/monkeypatch methods, having the global `bt` BlockTools instance created in the same test session AND before running the tests in `test_keyring_wrapper.py`, has led to test failures, notably `test_using_legacy_cryptfilekeyring`.

KeyringWrapper has been updated a bit to better handle cleanup between tests (though it's still a singleton, as this would be a much larger change to move away from). Additionally, during testing, mock patches are now applied to KeyringWrapper instances instead of the class itself.

The global `bt` BlockTools instance has been replaced by a `shared_b_tools` pytest fixture. The fixture is configured to automatically cleanup the instance when the testing of each module has been completed. Most of the updates in this set of changes are to tests that previously used `bt` directly, and now must go through the shared_b_tools fixture.
