### PR TITLE
Strip IPv6 [] correctly even with non-4-character segments

### DIFF
--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -118,8 +118,7 @@ async def show_async(
 
                 host = con["peer_host"]
                 # Strip IPv6 brackets
-                if host[0] == "[":
-                    host = host[1:39]
+                host = host.lstrip("[").rstrip("]")
                 # Nodetype length is 9 because INTRODUCER will be deprecated
                 if NodeType(con["type"]) is NodeType.FULL_NODE:
                     peak_height = con["peak_height"]

--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -118,7 +118,7 @@ async def show_async(
 
                 host = con["peer_host"]
                 # Strip IPv6 brackets
-                host = host.lstrip("[").rstrip("]")
+                host = host.strip("[]")
                 # Nodetype length is 9 because INTRODUCER will be deprecated
                 if NodeType(con["type"]) is NodeType.FULL_NODE:
                     peak_height = con["peak_height"]


### PR DESCRIPTION
For example, the existing code failed to properly strip
`[____:____:____:600:____:a2:____:____]` resulting in the trailing `]`
below.  (four character segments and node id redacted with `_`)

```
FULL_NODE ____:____:____:600:____:a2:____:____]   8444/8444  ________... Nov 12 20:46:47      1.5|18.9
                                                 -SB Height:  1131954    -Hash: 344cbef3...
```