### PR TITLE
Install .[dev] in CI tests

### DIFF
--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test blockchain code with pytest
       run: |

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test blockchain code with pytest
       run: |

--- a/.github/workflows/build-test-macos-clvm.yml
+++ b/.github/workflows/build-test-macos-clvm.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test clvm code with pytest
       run: |

--- a/.github/workflows/build-test-macos-clvm.yml
+++ b/.github/workflows/build-test-macos-clvm.yml
@@ -71,14 +71,9 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
 # Omitted installing Timelord
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test clvm code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-consensus.yml
+++ b/.github/workflows/build-test-macos-core-consensus.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-consensus code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-consensus.yml
+++ b/.github/workflows/build-test-macos-core-consensus.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-consensus code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-custom_types.yml
+++ b/.github/workflows/build-test-macos-core-custom_types.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-custom_types code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-custom_types.yml
+++ b/.github/workflows/build-test-macos-core-custom_types.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-custom_types code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-daemon code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-daemon code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node-full_sync code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node-full_sync code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-server code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-server code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-ssl code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-ssl code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-util code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-util code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core code with pytest
       run: |

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core code with pytest
       run: |

--- a/.github/workflows/build-test-macos-generator.yml
+++ b/.github/workflows/build-test-macos-generator.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test generator code with pytest
       run: |

--- a/.github/workflows/build-test-macos-generator.yml
+++ b/.github/workflows/build-test-macos-generator.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test generator code with pytest
       run: |

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -84,14 +84,9 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
 # Omitted installing Timelord
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
 
     - name: Test plotting code with pytest
       run: |

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test pools code with pytest
       run: |

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test pools code with pytest
       run: |

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test simulation code with pytest
       run: |

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test simulation code with pytest
       run: |

--- a/.github/workflows/build-test-macos-util.yml
+++ b/.github/workflows/build-test-macos-util.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test util code with pytest
       run: |

--- a/.github/workflows/build-test-macos-util.yml
+++ b/.github/workflows/build-test-macos-util.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test util code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-cc_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cc_wallet.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-cc_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-cc_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cc_wallet.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-cc_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-did_wallet.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-did_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-did_wallet.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-did_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-rl_wallet.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rl_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-rl_wallet.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rl_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rpc code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rpc code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-simple_sync code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-simple_sync code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-sync code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-sync code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet code with pytest
       run: |

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -84,18 +84,13 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test weight_proof code with pytest
       run: |

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test weight_proof code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test blockchain code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test blockchain code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-clvm.yml
+++ b/.github/workflows/build-test-ubuntu-clvm.yml
@@ -76,14 +76,9 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
 # Omitted installing Timelord
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test clvm code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-clvm.yml
+++ b/.github/workflows/build-test-ubuntu-clvm.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test clvm code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-consensus code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-consensus code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-custom_types code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-custom_types code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-daemon code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-daemon code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node-full_sync code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node-full_sync code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-full_node code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-server code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-server code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-ssl code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-ssl code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-util code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core-util code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test core code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test generator code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test generator code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -89,14 +89,9 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
 # Omitted installing Timelord
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
 
     - name: Test plotting code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test pools code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test pools code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test simulation code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test simulation code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test util code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test util code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-cc_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cc_wallet.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-cc_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-cc_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cc_wallet.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-cc_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-did_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-did_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rl_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rl_wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rpc code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-rpc code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-simple_sync code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-simple_sync code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-sync code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet-sync code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test wallet code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -89,18 +89,13 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
     - name: Install timelord
       run: |
         . ./activate
         sh install-timelord.sh
         ./vdf_bench square_asm 400000
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test weight_proof code with pytest
       run: |

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test weight_proof code with pytest
       run: |

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 set -e
+
+EXTRAS=
+
+while getopts d flag
+do
+    case "${flag}" in
+        # development
+        d) EXTRAS=${EXTRAS}dev,;;
+    esac
+done
+
 UBUNTU=false
 DEBIAN=false
 if [ "$(uname)" = "Linux" ]; then
@@ -109,6 +120,11 @@ if [ ! -f "activate" ]; then
 	ln -s venv/bin/activate .
 fi
 
+EXTRAS=${EXTRAS%,}
+if [ -n "${EXTRAS}" ]; then
+  EXTRAS=[${EXTRAS}]
+fi
+
 # shellcheck disable=SC1091
 . ./activate
 # pip 20.x+ supports Linux binary wheels
@@ -117,7 +133,7 @@ python -m pip install wheel
 #if [ "$INSTALL_PYTHON_VERSION" = "3.8" ]; then
 # This remains in case there is a diversion of binary wheels
 python -m pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2
-python -m pip install -e . --extra-index-url https://pypi.chia.net/simple/
+python -m pip install -e ."${EXTRAS}" --extra-index-url https://pypi.chia.net/simple/
 
 echo ""
 echo "Chia blockchain install.sh complete."

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,27 @@
 #!/bin/bash
 set -e
 
+USAGE_TEXT="\
+Usage: $0 [-d]
+
+  -d                          install development dependencies
+  -h                          display this help and exit
+"
+
+usage() {
+  echo "${USAGE_TEXT}"
+}
+
 EXTRAS=
 
-while getopts d flag
+while getopts dh flag
 do
-    case "${flag}" in
-        # development
-        d) EXTRAS=${EXTRAS}dev,;;
-    esac
+  case "${flag}" in
+    # development
+    d) EXTRAS=${EXTRAS}dev,;;
+    h) usage; exit 0;;
+    *) echo; usage; exit 1;;
+  esac
 done
 
 UBUNTU=false

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ upnp_dependencies = [
 dev_dependencies = [
     "pytest",
     "pytest-asyncio",
+    "pytest-monitor",
+    "pytest-xdist",
     "flake8",
     "mypy",
     "black",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ upnp_dependencies = [
 dev_dependencies = [
     "pytest",
     "pytest-asyncio",
-    "pytest-monitor",
+    "pytest-monitor; sys_platform == 'linux'",
     "pytest-xdist",
     "flake8",
     "mypy",

--- a/tests/runner-templates/build-test-macos
+++ b/tests/runner-templates/build-test-macos
@@ -71,14 +71,9 @@ CHECKOUT_TEST_BLOCKS_AND_PLOTS
         BUILD_VDF_CLIENT: "N"
       run: |
         brew install boost
-        sh install.sh
+        sh install.sh -d
 
 INSTALL_TIMELORD
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test TEST_NAME code with pytest
       run: |

--- a/tests/runner-templates/build-test-macos
+++ b/tests/runner-templates/build-test-macos
@@ -78,7 +78,7 @@ INSTALL_TIMELORD
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test TEST_NAME code with pytest
       run: |

--- a/tests/runner-templates/build-test-ubuntu
+++ b/tests/runner-templates/build-test-ubuntu
@@ -83,7 +83,7 @@ INSTALL_TIMELORD
     - name: Install developer requirements
       run: |
         . ./activate
-        venv/bin/python -m pip install pytest pytest-asyncio pytest-xdist pytest-monitor
+        venv/bin/python -m pip install -e .[dev]
 
     - name: Test TEST_NAME code with pytest
       run: |

--- a/tests/runner-templates/build-test-ubuntu
+++ b/tests/runner-templates/build-test-ubuntu
@@ -76,14 +76,9 @@ CHECKOUT_TEST_BLOCKS_AND_PLOTS
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
-        sh install.sh
+        sh install.sh -d
 
 INSTALL_TIMELORD
-
-    - name: Install developer requirements
-      run: |
-        . ./activate
-        venv/bin/python -m pip install -e .[dev]
 
     - name: Test TEST_NAME code with pytest
       run: |


### PR DESCRIPTION
This way we don't have to duplicate the dev dependency list in multiple places.

* Add a `-d` option to `install.sh` to allow for installing `dev` extra
* Add `-h`, invalid option rejection, and usage reporting to go with above
* Use `-d` in CI instead of a separate step with it's own dev dependency list
* Move the dependencies in the workflows to the dev extra list
* Install the dev extras in CI