### PR TITLE
Timed assertion output simplification

### DIFF
--- a/tests/time_out_assert.py
+++ b/tests/time_out_assert.py
@@ -9,6 +9,7 @@ log = logging.getLogger(__name__)
 
 
 async def time_out_assert_custom_interval(timeout: int, interval, function, value=True, *args, **kwargs):
+    __tracebackhide__ = True
     start = time.time()
     while time.time() - start < timeout:
         if asyncio.iscoroutinefunction(function):
@@ -22,6 +23,7 @@ async def time_out_assert_custom_interval(timeout: int, interval, function, valu
 
 
 async def time_out_assert(timeout: int, function, value=True, *args, **kwargs):
+    __tracebackhide__ = True
     await time_out_assert_custom_interval(timeout, 0.05, function, value, *args, **kwargs)
 
 

--- a/tests/time_out_assert.py
+++ b/tests/time_out_assert.py
@@ -18,7 +18,7 @@ async def time_out_assert_custom_interval(timeout: int, interval, function, valu
         if value == f_res:
             return None
         await asyncio.sleep(interval)
-    assert False, "Timed assertion timed out"
+    assert False, f"Timed assertion timed out after {timeout} seconds: expected {value!r}, got {f_res!r}"
 
 
 async def time_out_assert(timeout: int, function, value=True, *args, **kwargs):


### PR DESCRIPTION
Get:

```
>       await time_out_assert(15, dl_wallet_0.get_unconfirmed_balance, 101)
E       AssertionError: Timed assertion timed out after 15 seconds: expected 101, got 0
```

Instead of:
```
>       await time_out_assert(15, dl_wallet_0.get_unconfirmed_balance, 101)

tests/wallet/db_wallet/test_dl_wallet.py:114:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/time_out_assert.py:25: in time_out_assert
    await time_out_assert_custom_interval(timeout, 0.05, function, value, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

timeout = 15, interval = 0.05
function = <bound method DataLayerWallet.get_unconfirmed_balance of <chia.data_layer.data_layer_wallet.DataLayerWallet object at 0x7fbcbc35c7c0>>
value = 101, args = (), kwargs = {}, start = 1637077216.2218025, f_res = 0

    async def time_out_assert_custom_interval(timeout: int, interval, function, value=True, *args, **kwargs):
        start = time.time()
        while time.time() - start < timeout:
            if asyncio.iscoroutinefunction(function):
                f_res = await function(*args, **kwargs)
            else:
                f_res = function(*args, **kwargs)
            if value == f_res:
                return None
            await asyncio.sleep(interval)
>       assert False, "Timed assertion timed out"
E       AssertionError: Timed assertion timed out

tests/time_out_assert.py:21: AssertionError
```