### PR TITLE
Fixup a couple data layer wallet tests

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -274,7 +274,7 @@ class DataLayerWallet:
         # await self.wallet_state_manager.update_wallet_puzzle_hashes(self.wallet_info.id)
         next_full_puz = create_host_fullpuz(new_inner_inner_puzzle, root_hash, self.dl_info.origin_coin.name())
         await self.wallet_state_manager.interested_store.add_interested_puzzle_hash(
-            next_full_puz.get_tree_hash(), self.wallet_id, True
+            next_full_puz.get_tree_hash(), self.wallet_id
         )
         dl_record = TransactionRecord(
             confirmed_at_height=uint32(0),

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -203,6 +203,9 @@ class TestDLWallet:
 
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
+            await asyncio.sleep(0.2)
+            if await wallet_2.get_unconfirmed_balance() == 200:
+                break
 
         await time_out_assert(15, wallet_2.get_confirmed_balance, 200)
         await time_out_assert(15, wallet_2.get_unconfirmed_balance, 200)

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -109,6 +109,9 @@ class TestDLWallet:
 
         for i in range(1, num_blocks * 2):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+            await asyncio.sleep(0.2)
+            if await dl_wallet_0.get_unconfirmed_balance() == 101:
+                break
 
         await time_out_assert(15, dl_wallet_0.get_confirmed_balance, 101)
         await time_out_assert(15, dl_wallet_0.get_unconfirmed_balance, 101)


### PR DESCRIPTION
With this:
```
=========================== short test summary info ============================
FAILED tests/wallet/db_wallet/test_dl_wallet.py::TestDLWallet::test_dlo_wallet
```

Without:
```
=========================== short test summary info ============================
FAILED tests/wallet/db_wallet/test_dl_wallet.py::TestDLWallet::test_update_coin
FAILED tests/wallet/db_wallet/test_dl_wallet.py::TestDLWallet::test_announce_coin
FAILED tests/wallet/db_wallet/test_dl_wallet.py::TestDLWallet::test_dlo_wallet
```

The sleeps seemed to make it both take fewer loop cycles and also make it overall faster.