### PR TITLE
Name coin fields

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -129,7 +129,7 @@ class CoinStore:
         if cached is not None:
             return cached
         cursor = await self.coin_record_db.execute(
-            "SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            "SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             "coin_parent, amount, timestamp FROM coin_record WHERE coin_name=?",
             (coin_name.hex(),),
         )
@@ -137,14 +137,14 @@ class CoinStore:
         await cursor.close()
         if row is not None:
             coin = self.row_to_coin(row)
-            record = CoinRecord(coin, row[1], row[2], row[3], row[4], row[8])
+            record = CoinRecord(coin, row[0], row[1], row[2], row[3], row[7])
             self.coin_record_cache.put(record.coin.name(), record)
             return record
         return None
 
     async def get_coins_added_at_height(self, height: uint32) -> List[CoinRecord]:
         cursor = await self.coin_record_db.execute(
-            "SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            "SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index=?",
             (height,),
         )
@@ -153,7 +153,7 @@ class CoinStore:
         coins = []
         for row in rows:
             coin = self.row_to_coin(row)
-            coins.append(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+            coins.append(CoinRecord(coin, row[0], row[1], row[2], row[3], row[7]))
         return coins
 
     async def get_coins_removed_at_height(self, height: uint32) -> List[CoinRecord]:
@@ -161,7 +161,7 @@ class CoinStore:
         if height == 0:
             return []
         cursor = await self.coin_record_db.execute(
-            "SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            "SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             "coin_parent, amount, timestamp FROM coin_record WHERE spent_index=?",
             (height,),
         )
@@ -169,10 +169,10 @@ class CoinStore:
         await cursor.close()
         coins = []
         for row in rows:
-            spent: bool = bool(row[3])
+            spent: bool = bool(row[2])
             if spent:
                 coin = self.row_to_coin(row)
-                coin_record = CoinRecord(coin, row[1], row[2], spent, row[4], row[8])
+                coin_record = CoinRecord(coin, row[0], row[1], spent, row[3], row[7])
                 coins.append(coin_record)
         return coins
 
@@ -187,7 +187,7 @@ class CoinStore:
 
         coins = set()
         cursor = await self.coin_record_db.execute(
-            f"SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            f"SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash=? "
             f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",
@@ -198,7 +198,7 @@ class CoinStore:
         await cursor.close()
         for row in rows:
             coin = self.row_to_coin(row)
-            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+            coins.add(CoinRecord(coin, row[0], row[1], row[2], row[3], row[7]))
         return list(coins)
 
     async def get_coin_records_by_puzzle_hashes(
@@ -214,7 +214,7 @@ class CoinStore:
         coins = set()
         puzzle_hashes_db = tuple([ph.hex() for ph in puzzle_hashes])
         cursor = await self.coin_record_db.execute(
-            f"SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            f"SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
             f'WHERE puzzle_hash in ({"?," * (len(puzzle_hashes) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
@@ -227,7 +227,7 @@ class CoinStore:
         await cursor.close()
         for row in rows:
             coin = self.row_to_coin(row)
-            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+            coins.add(CoinRecord(coin, row[0], row[1], row[2], row[3], row[7]))
         return list(coins)
 
     async def get_coin_records_by_names(
@@ -243,7 +243,7 @@ class CoinStore:
         coins = set()
         names_db = tuple([name.hex() for name in names])
         cursor = await self.coin_record_db.execute(
-            f"SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            f"SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             f'coin_parent, amount, timestamp FROM coin_record WHERE coin_name in ({"?," * (len(names) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",
@@ -254,19 +254,19 @@ class CoinStore:
         await cursor.close()
         for row in rows:
             coin = self.row_to_coin(row)
-            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+            coins.add(CoinRecord(coin, row[0], row[1], row[2], row[3], row[7]))
 
         return list(coins)
 
     def row_to_coin(self, row) -> Coin:
-        return Coin(bytes32(bytes.fromhex(row[6])), bytes32(bytes.fromhex(row[5])), uint64.from_bytes(row[7]))
+        return Coin(bytes32(bytes.fromhex(row[5])), bytes32(bytes.fromhex(row[4])), uint64.from_bytes(row[6]))
 
     def row_to_coin_state(self, row):
         coin = self.row_to_coin(row)
         spent_h = None
-        if row[3]:
-            spent_h = row[2]
-        return CoinState(coin, spent_h, row[1])
+        if row[2]:
+            spent_h = row[1]
+        return CoinState(coin, spent_h, row[0])
 
     async def get_coin_states_by_puzzle_hashes(
         self,
@@ -281,7 +281,7 @@ class CoinStore:
         coins = set()
         puzzle_hashes_db = tuple([ph.hex() for ph in puzzle_hashes])
         cursor = await self.coin_record_db.execute(
-            f"SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            f"SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
             f'WHERE puzzle_hash in ({"?," * (len(puzzle_hashes) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
@@ -310,7 +310,7 @@ class CoinStore:
         coins = set()
         parent_ids_db = tuple([pid.hex() for pid in parent_ids])
         cursor = await self.coin_record_db.execute(
-            f"SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            f"SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             f'coin_parent, amount, timestamp FROM coin_record WHERE coin_parent in ({"?," * (len(parent_ids) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",
@@ -322,7 +322,7 @@ class CoinStore:
         await cursor.close()
         for row in rows:
             coin = self.row_to_coin(row)
-            coins.add(CoinRecord(coin, row[1], row[2], row[3], row[4], row[8]))
+            coins.add(CoinRecord(coin, row[0], row[1], row[2], row[3], row[7]))
         return list(coins)
 
     async def get_coin_state_by_ids(
@@ -338,7 +338,7 @@ class CoinStore:
         coins = set()
         coin_ids_db = tuple([pid.hex() for pid in coin_ids])
         cursor = await self.coin_record_db.execute(
-            f"SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            f"SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             f'coin_parent, amount, timestamp FROM coin_record WHERE coin_name in ({"?," * (len(coin_ids) - 1)}?) '
             f"AND confirmed_index>=? AND confirmed_index<? "
             f"{'' if include_spent_coins else 'AND spent=0'}",
@@ -378,14 +378,14 @@ class CoinStore:
 
         coin_changes: Dict[bytes32, CoinRecord] = {}
         cursor_deleted = await self.coin_record_db.execute(
-            "SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            "SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
             (block_index,),
         )
         rows = await cursor_deleted.fetchall()
         for row in rows:
             coin = self.row_to_coin(row)
-            record = CoinRecord(coin, uint32(0), row[2], row[3], row[4], uint64(0))
+            record = CoinRecord(coin, uint32(0), row[1], row[2], row[3], uint64(0))
             coin_changes[record.name] = record
         await cursor_deleted.close()
 
@@ -394,14 +394,14 @@ class CoinStore:
         await c1.close()
 
         cursor_unspent = await self.coin_record_db.execute(
-            "SELECT coin_name, confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
+            "SELECT confirmed_index, spent_index, spent, coinbase, puzzle_hash, "
             "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
             (block_index,),
         )
         rows = await cursor_unspent.fetchall()
         for row in rows:
             coin = self.row_to_coin(row)
-            record = CoinRecord(coin, row[1], uint32(0), False, row[4], row[8])
+            record = CoinRecord(coin, row[0], uint32(0), False, row[3], row[7])
             if record.name not in coin_changes:
                 coin_changes[record.name] = record
         await cursor_unspent.close()


### PR DESCRIPTION
This PR makes two changes:

1. rather than `SELECT * FROM coin_record` each field name is specified in the query. This makes the values returned in `rows` tied to the query, rather than the schema. It makes it easier to verify the code being correct, as well as it makes the code tolerate schema changes.
2. since we never actually use the `coin_name`field in any of the queries, strip it from the query and shift down the row indices accordingly.

These changes are easier to review separately, so they are two separate commits.