### PR TITLE
_blockchain_lock_queue is not always initialized by the time we shut down

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -713,7 +713,8 @@ class FullNode:
             self.uncompact_task.cancel()
         if self._transaction_queue_task is not None:
             self._transaction_queue_task.cancel()
-        self._blockchain_lock_queue.close()
+        if hasattr(self, "_blockchain_lock_queue"):
+            self._blockchain_lock_queue.close()
 
     async def _await_closed(self):
         cancel_task_safe(self._sync_task, self.log)
@@ -722,7 +723,8 @@ class FullNode:
         await self.connection.close()
         if self._init_weight_proof is not None:
             await asyncio.wait([self._init_weight_proof])
-        await self._blockchain_lock_queue.await_closed()
+        if hasattr(self, "_blockchain_lock_queue"):
+            await self._blockchain_lock_queue.await_closed()
 
     async def _sync(self):
         """


### PR DESCRIPTION
This is an attempt to fix this shutdown error:

```
Traceback (most recent call last):
  File "/home/arvid/dev/chia-blockchain/venv/bin/chia_full_node", line 33, in <module>
    sys.exit(load_entry_point('chia-blockchain', 'console_scripts', 'chia_full_node')())
  File "/home/arvid/dev/chia-blockchain/chia/server/start_full_node.py", line 60, in main
    return run_service(**kwargs)
  File "/home/arvid/dev/chia-blockchain/chia/server/start_service.py", line 255, in run_service
    return asyncio.run(async_run_service(*args, **kwargs))
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 629, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.9/asyncio/base_events.py", line 596, in run_forever
    self._run_once()
  File "/usr/lib/python3.9/asyncio/base_events.py", line 1854, in _run_once
    event_list = self._selector.select(timeout)
  File "/usr/lib/python3.9/selectors.py", line 469, in select
    fd_event_list = self._selector.poll(timeout, max_ev)
  File "/home/arvid/dev/chia-blockchain/chia/server/start_service.py", line 193, in _accept_signal
    self.stop()
  File "/home/arvid/dev/chia-blockchain/chia/server/start_service.py", line 210, in stop
    self._node._close()
  File "/home/arvid/dev/chia-blockchain/chia/full_node/full_node.py", line 718, in _close
    self._blockchain_lock_queue.close()
AttributeError: 'FullNode' object has no attribute '_blockchain_lock_queue'
```