### PR TITLE
Set the permissions of chrome-sandbox

### DIFF
--- a/build_scripts/build_linux_rpm.sh
+++ b/build_scripts/build_linux_rpm.sh
@@ -50,7 +50,6 @@ echo "npm build"
 npm install
 npm audit fix
 npm run build
-chmod 4755 node_modules/electron/dist/chrome-sandbox
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 	echo >&2 "npm run build failed!"
@@ -86,6 +85,11 @@ if [ "$REDHAT_PLATFORM" = "x86_64" ]; then
 	# Disables build links from the generated rpm so that we dont conflict with other packages. See https://github.com/Chia-Network/chia-blockchain/issues/3846
 	# shellcheck disable=SC2086
 	sed -i '1s/^/%define _build_id_links none\n%global _enable_debug_package 0\n%global debug_package %{nil}\n%global __os_install_post \/usr\/lib\/rpm\/brp-compress %{nil}\n/' "$NODE_ROOT/lib/node_modules/electron-installer-redhat/resources/spec.ejs"
+	
+	# Use attr feature of RPM to set the chrome-sandbox permissions
+	# adds a %attr line after the %files line
+	# The location is based on the existing location inside spec.ej
+	sed -i '/^%files/a %attr(4755, root, root) /usr/lib/<%= name %>/chrome-sandbox' "$NODE_ROOT/lib/node_modules/electron-installer-redhat/resources/spec.ejs"
 
 	# Updates the requirements for building an RPM on Centos 7 to allow older version of rpm-build and not use the boolean dependencies
 	# See https://github.com/electron-userland/electron-installer-redhat/issues/157

--- a/build_scripts/build_linux_rpm.sh
+++ b/build_scripts/build_linux_rpm.sh
@@ -50,6 +50,7 @@ echo "npm build"
 npm install
 npm audit fix
 npm run build
+chmod 4755 node_modules/electron/dist/chrome-sandbox
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 	echo >&2 "npm run build failed!"

--- a/build_scripts/build_linux_rpm.sh
+++ b/build_scripts/build_linux_rpm.sh
@@ -85,7 +85,7 @@ if [ "$REDHAT_PLATFORM" = "x86_64" ]; then
 	# Disables build links from the generated rpm so that we dont conflict with other packages. See https://github.com/Chia-Network/chia-blockchain/issues/3846
 	# shellcheck disable=SC2086
 	sed -i '1s/^/%define _build_id_links none\n%global _enable_debug_package 0\n%global debug_package %{nil}\n%global __os_install_post \/usr\/lib\/rpm\/brp-compress %{nil}\n/' "$NODE_ROOT/lib/node_modules/electron-installer-redhat/resources/spec.ejs"
-	
+
 	# Use attr feature of RPM to set the chrome-sandbox permissions
 	# adds a %attr line after the %files line
 	# The location is based on the existing location inside spec.ej


### PR DESCRIPTION
Uses the RPM attr option to make sure chrome-sandbox is installed with proper permissions when installing the RPM.
This change only effects the RPM package

Note: The Ubuntu DEB package seems to set the permissions correctly as is