### PR TITLE
avoid calling SpendBundle.fees() a second time

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1298,7 +1298,7 @@ class FullNode:
             new_tx = full_node_protocol.NewTransaction(
                 spend_name,
                 mempool_item.cost,
-                uint64(bundle.fees()),
+                fees,
             )
             msg = make_msg(ProtocolMessageTypes.new_transaction, new_tx)
             await self.server.send_to_all([msg], NodeType.FULL_NODE)


### PR DESCRIPTION
 in `peak_post_processing_2()`. This is an expensive function, that's why we cache its result.

I tracked this code back to here: 03d599d9accc182ea5fd0b8c35082bf66ea18507

@mariano54 does this look right to you?