### PR TITLE
added get_coin_records_by_parent_ids to spend_sim

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -218,6 +218,21 @@ class SimClient:
     async def get_coin_record_by_name(self, name: bytes32) -> CoinRecord:
         return await self.service.mempool_manager.coin_store.get_coin_record(name)
 
+    async def get_coin_records_by_parent_ids(
+        self,
+        parent_ids: List[bytes32],
+        start_height: Optional[int] = None,
+        end_height: Optional[int] = None,
+        include_spent_coins: bool = False,
+    ) -> List[CoinRecord]:
+
+        kwargs: Dict[str, Any] = {"include_spent_coins": include_spent_coins, "parent_ids": parent_ids, }
+        if start_height is not None:
+            kwargs["start_height"] = start_height
+        if end_height is not None:
+            kwargs["end_height"] = end_height
+        return await self.service.mempool_manager.coin_store.get_coin_records_by_parent_ids(**kwargs)
+
     async def get_coin_records_by_puzzle_hash(
         self,
         puzzle_hash: bytes32,

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -225,8 +225,7 @@ class SimClient:
         end_height: Optional[int] = None,
         include_spent_coins: bool = False,
     ) -> List[CoinRecord]:
-
-        kwargs: Dict[str, Any] = {"include_spent_coins": include_spent_coins, "parent_ids": parent_ids, }
+        kwargs: Dict[str, Any] = {"include_spent_coins": include_spent_coins, "parent_ids": parent_ids}
         if start_height is not None:
             kwargs["start_height"] = start_height
         if end_height is not None:

--- a/tests/clvm/test_spend_sim.py
+++ b/tests/clvm/test_spend_sim.py
@@ -74,7 +74,7 @@ class TestSimClient:
 
             # get_coin_record_by_name
             assert await sim_client.get_coin_record_by_name(coin_record_name)
-            
+
             # get_block_records
             block_records = await sim_client.get_block_records(0, 5)
             assert len(block_records) == 5
@@ -139,10 +139,9 @@ class TestSimClient:
             assert coin_solution
 
             # get_coin_records_by_parent_ids
-            new_coin = next(x.coin for x in additions if x.coin.puzzle_hash==puzzle_hash)
+            new_coin = next(x.coin for x in additions if x.coin.puzzle_hash == puzzle_hash)
             coin_records = await sim_client.get_coin_records_by_parent_ids([spendable_coin.name()])
             assert coin_records[0].coin.name() == new_coin.name()
-     
-            
+
         finally:
             await sim.close()

--- a/tests/clvm/test_spend_sim.py
+++ b/tests/clvm/test_spend_sim.py
@@ -74,7 +74,7 @@ class TestSimClient:
 
             # get_coin_record_by_name
             assert await sim_client.get_coin_record_by_name(coin_record_name)
-
+            
             # get_block_records
             block_records = await sim_client.get_block_records(0, 5)
             assert len(block_records) == 5
@@ -137,5 +137,12 @@ class TestSimClient:
             # get_puzzle_and_solution
             coin_solution = await sim_client.get_puzzle_and_solution(spendable_coin.name(), latest_block.height)
             assert coin_solution
+
+            # get_coin_records_by_parent_ids
+            new_coin = next(x.coin for x in additions if x.coin.puzzle_hash==puzzle_hash)
+            coin_records = await sim_client.get_coin_records_by_parent_ids([spendable_coin.name()])
+            assert coin_records[0].coin.name() == new_coin.name()
+     
+            
         finally:
             await sim.close()


### PR DESCRIPTION
Added an endpoint and test so spend_sim can use `get_coin_records_by_parent_ids`, bringing it more in line with the full node rpc