### PR TITLE
V2 database framework

### DIFF
--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 from chia.util.db_wrapper import DBWrapper
-from chia.util.ints import uint64, uint8
+from chia.util.ints import uint128, uint64, uint32, uint8
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from utils import rewards, rand_hash, setup_db, rand_g1, rand_g2, rand_bytes
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
@@ -42,7 +42,7 @@ def rand_vdf_proof() -> VDFProof:
     )
 
 
-with open("clvm_generator.bin", "rb+") as f:
+with open("clvm_generator.bin", "rb") as f:
     clvm_generator = f.read()
 
 
@@ -52,7 +52,7 @@ async def run_add_block_benchmark():
     db_wrapper: DBWrapper = await setup_db("block-store-benchmark.db")
 
     # keep track of benchmark total time
-    all_test_time = 0
+    all_test_time = 0.0
 
     prev_block = bytes([0] * 32)
 
@@ -60,16 +60,16 @@ async def run_add_block_benchmark():
         block_store = await BlockStore.create(db_wrapper)
 
         block_height = 1
-        timestamp = 1631794488
-        weight = 10
-        iters = 123456
-        sp_index = 0
-        deficit = 0
-        sub_slot_iters = 10
-        required_iters = 100
+        timestamp = uint64(1631794488)
+        weight = uint128(10)
+        iters = uint128(123456)
+        sp_index = uint8(0)
+        deficit = uint8(0)
+        sub_slot_iters = uint64(10)
+        required_iters = uint64(100)
         transaction_block_counter = 0
         prev_transaction_block = bytes([0] * 32)
-        prev_transaction_height = 0
+        prev_transaction_height = uint32(0)
         total_time = 0.0
 
         if verbose:
@@ -79,8 +79,8 @@ async def run_add_block_benchmark():
 
             header_hash = rand_hash()
             is_transaction = transaction_block_counter == 0
-            fees = random.randint(0, 150000)
-            farmer_coin, pool_coin = rewards(height)
+            fees = uint64(random.randint(0, 150000))
+            farmer_coin, pool_coin = rewards(uint32(height))
             reward_claims_incorporated = [farmer_coin, pool_coin]
 
             # TODO: increase fidelity by setting these as well
@@ -92,7 +92,7 @@ async def run_add_block_benchmark():
             record = BlockRecord(
                 header_hash,
                 prev_block,
-                height,
+                uint32(height),
                 weight,
                 iters,
                 sp_index,
@@ -124,13 +124,13 @@ async def run_add_block_benchmark():
                 rand_g1() if has_pool_pk else None,
                 rand_hash() if not has_pool_pk else None,
                 rand_g1(),  # plot_public_key
-                32,
+                uint8(32),
                 rand_bytes(8 * 32),
             )
 
             reward_chain_block = RewardChainBlock(
                 weight,
-                height,
+                uint32(height),
                 iters,
                 sp_index,
                 rand_hash(),  # pos_ss_cc_challenge_hash
@@ -147,7 +147,7 @@ async def run_add_block_benchmark():
 
             pool_target = PoolTarget(
                 rand_hash(),  # puzzle_hash
-                0,  # max_height
+                uint32(0),  # max_height
             )
 
             foliage_block_data = FoliageBlockData(
@@ -188,7 +188,7 @@ async def run_add_block_benchmark():
                     rand_hash(),  # generator_refs_root
                     rand_g2(),  # aggregated_signature
                     fees,
-                    random.randint(0, 12000000000),  # cost
+                    uint64(random.randint(0, 12000000000)),  # cost
                     reward_claims_incorporated,
                 )
             )
@@ -220,11 +220,11 @@ async def run_add_block_benchmark():
             total_time += stop - start
 
             # 19 seconds per block
-            timestamp += 19
-            weight += 10
-            iters += 123456
-            sp_index = (sp_index + 1) % 64
-            deficit = (deficit + 3) % 17
+            timestamp = uint64(timestamp + 19)
+            weight = uint128(weight + 10)
+            iters = uint128(iters + 123456)
+            sp_index = uint8((sp_index + 1) % 64)
+            deficit = uint8((deficit + 3) % 17)
             prev_block = header_hash
 
             # every 33 blocks is a transaction block
@@ -232,7 +232,7 @@ async def run_add_block_benchmark():
 
             if is_transaction:
                 prev_transaction_block = header_hash
-                prev_transaction_height = height
+                prev_transaction_height = uint32(height)
 
             if verbose:
                 print(".", end="")

--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -46,10 +46,10 @@ with open("clvm_generator.bin", "rb") as f:
     clvm_generator = f.read()
 
 
-async def run_add_block_benchmark():
+async def run_add_block_benchmark(version: int):
 
     verbose: bool = "--verbose" in sys.argv
-    db_wrapper: DBWrapper = await setup_db("block-store-benchmark.db")
+    db_wrapper: DBWrapper = await setup_db("block-store-benchmark.db", version)
 
     # keep track of benchmark total time
     all_test_time = 0.0
@@ -254,4 +254,7 @@ async def run_add_block_benchmark():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_add_block_benchmark())
+    print("version 1")
+    asyncio.run(run_add_block_benchmark(1))
+    print("version 2")
+    asyncio.run(run_add_block_benchmark(2))

--- a/benchmarks/coin_store.py
+++ b/benchmarks/coin_store.py
@@ -10,7 +10,7 @@ import sys
 from chia.util.db_wrapper import DBWrapper
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.coin import Coin
-from chia.util.ints import uint64
+from chia.util.ints import uint64, uint32
 from utils import rewards, rand_hash, setup_db
 
 NUM_ITERS = 200
@@ -34,13 +34,13 @@ def make_coins(num: int) -> Tuple[List[Coin], List[bytes32]]:
     return additions, hashes
 
 
-async def run_new_block_benchmark():
+async def run_new_block_benchmark(version: int):
 
     verbose: bool = "--verbose" in sys.argv
-    db_wrapper: DBWrapper = await setup_db("coin-store-benchmark.db")
+    db_wrapper: DBWrapper = await setup_db("coin-store-benchmark.db", version)
 
     # keep track of benchmark total time
-    all_test_time = 0
+    all_test_time = 0.0
 
     try:
         coin_store = await CoinStore.create(db_wrapper)
@@ -58,7 +58,7 @@ async def run_new_block_benchmark():
             additions, hashes = make_coins(2000)
 
             # farm rewards
-            farmer_coin, pool_coin = rewards(height)
+            farmer_coin, pool_coin = rewards(uint32(height))
             all_coins += hashes
             all_unspent += hashes
             all_unspent += [pool_coin.name(), farmer_coin.name()]
@@ -85,9 +85,9 @@ async def run_new_block_benchmark():
                 sys.stdout.flush()
         block_height += NUM_ITERS
 
-        total_time = 0
-        total_add = 0
-        total_remove = 0
+        total_time = 0.0
+        total_add = 0.0
+        total_remove = 0.0
         print("")
         if verbose:
             print("Profiling mostly additions ", end="")
@@ -97,7 +97,7 @@ async def run_new_block_benchmark():
             additions, hashes = make_coins(2000)
             total_add += 2000
 
-            farmer_coin, pool_coin = rewards(height)
+            farmer_coin, pool_coin = rewards(uint32(height))
             all_coins += hashes
             all_unspent += hashes
             all_unspent += [pool_coin.name(), farmer_coin.name()]
@@ -148,7 +148,7 @@ async def run_new_block_benchmark():
             additions.append(c)
             total_add += 1
 
-            farmer_coin, pool_coin = rewards(height)
+            farmer_coin, pool_coin = rewards(uint32(height))
             all_coins += [c.get_hash()]
             all_unspent += [c.get_hash()]
             all_unspent += [pool_coin.name(), farmer_coin.name()]
@@ -198,7 +198,7 @@ async def run_new_block_benchmark():
             additions, hashes = make_coins(2000)
             total_add += 2000
 
-            farmer_coin, pool_coin = rewards(height)
+            farmer_coin, pool_coin = rewards(uint32(height))
             all_coins += hashes
             all_unspent += hashes
             all_unspent += [pool_coin.name(), farmer_coin.name()]
@@ -312,4 +312,7 @@ async def run_new_block_benchmark():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_new_block_benchmark())
+    print("version 1")
+    asyncio.run(run_new_block_benchmark(1))
+    print("version 2")
+    asyncio.run(run_new_block_benchmark(2))

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -44,7 +44,7 @@ def rand_g2() -> G2Element:
     return AugSchemeMPL.sign(sk, b"foobar")
 
 
-async def setup_db(name: str) -> DBWrapper:
+async def setup_db(name: str, db_version: int) -> DBWrapper:
     db_filename = Path(name)
     try:
         os.unlink(db_filename)
@@ -65,4 +65,4 @@ async def setup_db(name: str) -> DBWrapper:
     await connection.execute("pragma journal_mode=wal")
     await connection.execute("pragma synchronous=full")
 
-    return DBWrapper(connection)
+    return DBWrapper(connection, False, db_version)

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -134,7 +134,7 @@ class Blockchain(BlockchainInterface):
         """
         Initializes the state of the Blockchain class from the database.
         """
-        self.__height_map = await BlockHeightMap.create(blockchain_dir, self.block_store.db)
+        self.__height_map = await BlockHeightMap.create(blockchain_dir, self.block_store.db_wrapper)
         self.__block_records = {}
         self.__heights_in_cache = {}
         block_records, peak = await self.block_store.get_block_records_close_to_peak(self.constants.BLOCKS_CACHE_SIZE)

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -1,4 +1,3 @@
-import aiosqlite
 import logging
 from typing import Dict, List, Optional, Tuple
 from chia.util.ints import uint32
@@ -9,6 +8,7 @@ import aiofiles
 from dataclasses import dataclass
 from chia.util.streamable import Streamable, streamable
 from chia.util.files import write_file_async
+from chia.util.db_wrapper import DBWrapper
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class SesCache(Streamable):
 
 
 class BlockHeightMap:
-    db: aiosqlite.Connection
+    db: DBWrapper
 
     # the below dictionaries are loaded from the database, from the peak
     # and back in time on startup.
@@ -47,7 +47,7 @@ class BlockHeightMap:
     __ses_filename: Path
 
     @classmethod
-    async def create(cls, blockchain_dir: Path, db: aiosqlite.Connection) -> "BlockHeightMap":
+    async def create(cls, blockchain_dir: Path, db: DBWrapper) -> "BlockHeightMap":
         self = BlockHeightMap()
         self.db = db
 
@@ -57,7 +57,7 @@ class BlockHeightMap:
         self.__height_to_hash_filename = blockchain_dir / "height-to-hash"
         self.__ses_filename = blockchain_dir / "sub-epoch-summaries"
 
-        res = await self.db.execute(
+        res = await self.db.db.execute(
             "SELECT header_hash,prev_hash,height,sub_epoch_summary from block_records WHERE is_peak=1"
         )
         row = await res.fetchone()
@@ -139,7 +139,7 @@ class BlockHeightMap:
         while height > 0:
             # load 5000 blocks at a time
             window_end = max(0, height - 5000)
-            cursor = await self.db.execute(
+            cursor = await self.db.db.execute(
                 "SELECT header_hash,prev_hash,height,sub_epoch_summary from block_records "
                 "INDEXED BY height WHERE height>=? AND height <?",
                 (window_end, height),

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -71,6 +71,7 @@ from chia.util.safe_cancel_task import cancel_task_safe
 from chia.util.profiler import profile_task
 from datetime import datetime
 from chia.util.db_synchronous import db_synchronous_on
+from chia.util.db_version import lookup_db_version
 
 
 class FullNode:
@@ -172,7 +173,12 @@ class FullNode:
                 log.close()
 
             await self.connection.set_trace_callback(sql_trace_callback)
-        self.db_wrapper = DBWrapper(self.connection, self.config.get("allow_database_upgrades", False))
+
+        db_version: int = await lookup_db_version(self.connection)
+
+        self.db_wrapper = DBWrapper(
+            self.connection, self.config.get("allow_database_upgrades", False), db_version=db_version
+        )
         self.block_store = await BlockStore.create(self.db_wrapper)
         self.sync_store = await SyncStore.create()
         self.hint_store = await HintStore.create(self.db_wrapper)

--- a/chia/util/db_version.py
+++ b/chia/util/db_version.py
@@ -1,0 +1,14 @@
+import aiosqlite
+
+
+async def lookup_db_version(db: aiosqlite.Connection) -> int:
+    try:
+        cursor = await db.execute("SELECT * from database_version")
+        row = await cursor.fetchone()
+        if row is not None and row[0] == 2:
+            return 2
+        else:
+            return 1
+    except aiosqlite.OperationalError:
+        # expects OperationalError('no such table: database_version')
+        return 1

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -10,11 +10,14 @@ class DBWrapper:
 
     db: aiosqlite.Connection
     lock: asyncio.Lock
+    allow_upgrades: bool
+    db_version: int
 
-    def __init__(self, connection: aiosqlite.Connection, allow_upgrades: bool = False):
+    def __init__(self, connection: aiosqlite.Connection, allow_upgrades: bool = False, db_version: int = 1):
         self.db = connection
         self.allow_upgrades = allow_upgrades
         self.lock = asyncio.Lock()
+        self.db_version = db_version
 
     async def begin_transaction(self):
         cursor = await self.db.execute("BEGIN TRANSACTION")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,15 +14,15 @@ from pathlib import Path
 #       fixtures avoids the issue.
 
 
-@pytest.fixture(scope="function")
-async def empty_blockchain():
+@pytest.fixture(scope="function", params=[1, 2])
+async def empty_blockchain(request):
     """
     Provides a list of 10 valid blocks, as well as a blockchain with 9 blocks added to it.
     """
     from tests.util.blockchain import create_blockchain
     from tests.setup_nodes import test_constants
 
-    bc1, connection, db_path = await create_blockchain(test_constants)
+    bc1, connection, db_path = await create_blockchain(test_constants, request.param)
     yield bc1
 
     await connection.close()

--- a/tests/core/full_node/test_block_height_map.py
+++ b/tests/core/full_node/test_block_height_map.py
@@ -1,8 +1,8 @@
-import aiosqlite
 import pytest
 import struct
 from chia.full_node.block_height_map import BlockHeightMap
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
+from chia.util.db_wrapper import DBWrapper
 
 from tests.util.db_connection import DBConnection
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -23,14 +23,14 @@ def gen_ses(height: int) -> SubEpochSummary:
 
 
 async def new_block(
-    db: aiosqlite.Connection,
+    db: DBWrapper,
     block_hash: bytes32,
     parent: bytes32,
     height: int,
     is_peak: bool,
     ses: Optional[SubEpochSummary],
 ):
-    cursor = await db.execute(
+    cursor = await db.db.execute(
         "INSERT INTO block_records VALUES(?, ?, ?, ?, ?)",
         (
             block_hash.hex(),
@@ -44,8 +44,8 @@ async def new_block(
     await cursor.close()
 
 
-async def setup_db(db: aiosqlite.Connection):
-    await db.execute(
+async def setup_db(db: DBWrapper):
+    await db.db.execute(
         "CREATE TABLE IF NOT EXISTS block_records("
         "header_hash text PRIMARY KEY,"
         "prev_hash text,"
@@ -53,16 +53,16 @@ async def setup_db(db: aiosqlite.Connection):
         "sub_epoch_summary blob,"
         "is_peak tinyint)"
     )
-    await db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
-    await db.execute("CREATE INDEX IF NOT EXISTS hh on block_records(header_hash)")
-    await db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
+    await db.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
+    await db.db.execute("CREATE INDEX IF NOT EXISTS hh on block_records(header_hash)")
+    await db.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
 
 
 # if chain_id != 0, the last block in the chain won't be considered the peak,
 # and the chain_id will be mixed in to the hashes, to form a separate chain at
 # the same heights as the main chain
 async def setup_chain(
-    db: aiosqlite.Connection, length: int, *, chain_id: int = 0, ses_every: Optional[int] = None, start_height=0
+    db: DBWrapper, length: int, *, chain_id: int = 0, ses_every: Optional[int] = None, start_height=0
 ):
     height = start_height
     peak_hash = gen_block_hash(height + chain_id * 65536)
@@ -83,13 +83,14 @@ async def setup_chain(
 
 class TestBlockHeightMap:
     @pytest.mark.asyncio
-    async def test_height_to_hash(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_height_to_hash(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             assert not height_map.contains_height(11)
             for height in reversed(range(10)):
@@ -99,13 +100,14 @@ class TestBlockHeightMap:
                 assert height_map.get_hash(height) == gen_block_hash(height)
 
     @pytest.mark.asyncio
-    async def test_height_to_hash_long_chain(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_height_to_hash_long_chain(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10000)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10000)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             for height in reversed(range(1000)):
                 assert height_map.contains_height(height)
@@ -114,13 +116,14 @@ class TestBlockHeightMap:
                 assert height_map.get_hash(height) == gen_block_hash(height)
 
     @pytest.mark.asyncio
-    async def test_save_restore(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_save_restore(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10000, ses_every=20)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10000, ses_every=20)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             for height in reversed(range(10000)):
                 assert height_map.contains_height(height)
@@ -141,9 +144,9 @@ class TestBlockHeightMap:
             # and sub epoch summary. In this test we have a sub epoch summary
             # every 20 blocks, so we generate the 30 last blocks only
             await db_wrapper.db.execute("DROP TABLE block_records")
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10000, ses_every=20, start_height=9970)
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10000, ses_every=20, start_height=9970)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             for height in reversed(range(10000)):
                 assert height_map.contains_height(height)
@@ -155,16 +158,17 @@ class TestBlockHeightMap:
                         height_map.get_ses(height)
 
     @pytest.mark.asyncio
-    async def test_restore_extend(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_restore_extend(self, tmp_dir, db_version):
 
         # test the case where the cache has fewer blocks than the DB, and that
         # we correctly load all the missing blocks from the DB to update the
         # cache
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 2000, ses_every=20)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 2000, ses_every=20)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             for height in reversed(range(2000)):
                 assert height_map.contains_height(height)
@@ -179,11 +183,11 @@ class TestBlockHeightMap:
 
             del height_map
 
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
             # add 2000 blocks to the chain
-            await setup_chain(db_wrapper.db, 4000, ses_every=20)
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            await setup_chain(db_wrapper, 4000, ses_every=20)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             # now make sure we have the complete chain, height 0 -> 4000
             for height in reversed(range(4000)):
@@ -196,32 +200,34 @@ class TestBlockHeightMap:
                         height_map.get_ses(height)
 
     @pytest.mark.asyncio
-    async def test_height_to_hash_with_orphans(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_height_to_hash_with_orphans(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10)
 
             # set up two separate chains, but without the peak
-            await setup_chain(db_wrapper.db, 10, chain_id=1)
-            await setup_chain(db_wrapper.db, 10, chain_id=2)
+            await setup_chain(db_wrapper, 10, chain_id=1)
+            await setup_chain(db_wrapper, 10, chain_id=2)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             for height in range(10):
                 assert height_map.get_hash(height) == gen_block_hash(height)
 
     @pytest.mark.asyncio
-    async def test_height_to_hash_update(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_height_to_hash_update(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10)
 
             # orphan blocks
-            await setup_chain(db_wrapper.db, 10, chain_id=1)
+            await setup_chain(db_wrapper, 10, chain_id=1)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             for height in range(10):
                 assert height_map.get_hash(height) == gen_block_hash(height)
@@ -234,16 +240,17 @@ class TestBlockHeightMap:
             assert height_map.get_hash(10) == gen_block_hash(100)
 
     @pytest.mark.asyncio
-    async def test_update_ses(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_update_ses(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10)
+        async with DBConnection(db_version) as db_wrapper:
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10)
 
             # orphan blocks
-            await setup_chain(db_wrapper.db, 10, chain_id=1)
+            await setup_chain(db_wrapper, 10, chain_id=1)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             with pytest.raises(KeyError) as _:
                 height_map.get_ses(10)
@@ -254,14 +261,15 @@ class TestBlockHeightMap:
             assert height_map.get_hash(10) == gen_block_hash(10)
 
     @pytest.mark.asyncio
-    async def test_height_to_ses(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_height_to_ses(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
+        async with DBConnection(db_version) as db_wrapper:
 
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10, ses_every=2)
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10, ses_every=2)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             assert height_map.get_ses(0) == gen_ses(0)
             assert height_map.get_ses(2) == gen_ses(2)
@@ -281,14 +289,15 @@ class TestBlockHeightMap:
                 height_map.get_ses(9)
 
     @pytest.mark.asyncio
-    async def test_rollback(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_rollback(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
+        async with DBConnection(db_version) as db_wrapper:
 
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10, ses_every=2)
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10, ses_every=2)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             assert height_map.get_ses(0) == gen_ses(0)
             assert height_map.get_ses(2) == gen_ses(2)
@@ -311,14 +320,15 @@ class TestBlockHeightMap:
                 height_map.get_ses(8)
 
     @pytest.mark.asyncio
-    async def test_rollback2(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_rollback2(self, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
+        async with DBConnection(db_version) as db_wrapper:
 
-            await setup_db(db_wrapper.db)
-            await setup_chain(db_wrapper.db, 10, ses_every=2)
+            await setup_db(db_wrapper)
+            await setup_chain(db_wrapper, 10, ses_every=2)
 
-            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper.db)
+            height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
 
             assert height_map.get_ses(0) == gen_ses(0)
             assert height_map.get_ses(2) == gen_ses(2)

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -25,7 +25,8 @@ def event_loop():
 
 class TestBlockStore:
     @pytest.mark.asyncio
-    async def test_block_store(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_block_store(self, tmp_dir, db_version):
         assert sqlite3.threadsafety == 1
         blocks = bt.get_consecutive_blocks(10)
 
@@ -39,8 +40,8 @@ class TestBlockStore:
 
         connection = await aiosqlite.connect(db_filename)
         connection_2 = await aiosqlite.connect(db_filename_2)
-        db_wrapper = DBWrapper(connection)
-        db_wrapper_2 = DBWrapper(connection_2)
+        db_wrapper = DBWrapper(connection, False, db_version)
+        db_wrapper_2 = DBWrapper(connection_2, False, db_version)
 
         # Use a different file for the blockchain
         coin_store_2 = await CoinStore.create(db_wrapper_2)
@@ -85,7 +86,8 @@ class TestBlockStore:
         db_filename_2.unlink()
 
     @pytest.mark.asyncio
-    async def test_deadlock(self, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_deadlock(self, tmp_dir, db_version):
         """
         This test was added because the store was deadlocking in certain situations, when fetching and
         adding blocks repeatedly. The issue was patched.
@@ -101,8 +103,8 @@ class TestBlockStore:
 
         connection = await aiosqlite.connect(db_filename)
         connection_2 = await aiosqlite.connect(db_filename_2)
-        wrapper = DBWrapper(connection)
-        wrapper_2 = DBWrapper(connection_2)
+        wrapper = DBWrapper(connection, False, db_version)
+        wrapper_2 = DBWrapper(connection_2, False, db_version)
 
         store = await BlockStore.create(wrapper)
         coin_store_2 = await CoinStore.create(wrapper_2)

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -57,7 +57,8 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 class TestCoinStoreWithBlocks:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0])
-    async def test_basic_coin_store(self, cache_size: uint32):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_basic_coin_store(self, cache_size: uint32, db_version):
         wallet_a = WALLET_A
         reward_ph = wallet_a.get_new_puzzlehash()
 
@@ -80,7 +81,7 @@ class TestCoinStoreWithBlocks:
             uint64(1000), wallet_a.get_new_puzzlehash(), coins_to_spend[0]
         )
 
-        async with DBConnection() as db_wrapper:
+        async with DBConnection(db_version) as db_wrapper:
             coin_store = await CoinStore.create(db_wrapper, cache_size=cache_size)
 
             blocks = bt.get_consecutive_blocks(
@@ -154,10 +155,11 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_set_spent(self, cache_size: uint32):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_set_spent(self, cache_size: uint32, db_version):
         blocks = bt.get_consecutive_blocks(9, [])
 
-        async with DBConnection() as db_wrapper:
+        async with DBConnection(db_version) as db_wrapper:
             coin_store = await CoinStore.create(db_wrapper, cache_size=cache_size)
 
             # Save/get block
@@ -188,10 +190,11 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_rollback(self, cache_size: uint32):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_rollback(self, cache_size: uint32, db_version):
         blocks = bt.get_consecutive_blocks(20)
 
-        async with DBConnection() as db_wrapper:
+        async with DBConnection(db_version) as db_wrapper:
             coin_store = await CoinStore.create(db_wrapper, cache_size=uint32(cache_size))
 
             records: List[CoinRecord] = []
@@ -240,9 +243,10 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_basic_reorg(self, cache_size: uint32, tmp_dir):
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_basic_reorg(self, cache_size: uint32, tmp_dir, db_version):
 
-        async with DBConnection() as db_wrapper:
+        async with DBConnection(db_version) as db_wrapper:
             initial_block_count = 30
             reorg_length = 15
             blocks = bt.get_consecutive_blocks(initial_block_count)
@@ -300,8 +304,9 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_get_puzzle_hash(self, cache_size: uint32, tmp_dir):
-        async with DBConnection() as db_wrapper:
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_get_puzzle_hash(self, cache_size: uint32, tmp_dir, db_version):
+        async with DBConnection(db_version) as db_wrapper:
             num_blocks = 20
             farmer_ph = 32 * b"0"
             pool_ph = 32 * b"1"

--- a/tests/core/full_node/test_full_node_store.py
+++ b/tests/core/full_node/test_full_node_store.py
@@ -45,18 +45,18 @@ def event_loop():
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="function")
-async def empty_blockchain():
-    bc1, connection, db_path = await create_blockchain(test_constants)
+@pytest.fixture(scope="function", params=[1, 2])
+async def empty_blockchain(request):
+    bc1, connection, db_path = await create_blockchain(test_constants, request.param)
     yield bc1
     await connection.close()
     bc1.shut_down()
     db_path.unlink()
 
 
-@pytest.fixture(scope="function")
-async def empty_blockchain_original():
-    bc1, connection, db_path = await create_blockchain(test_constants_original)
+@pytest.fixture(scope="function", params=[1, 2])
+async def empty_blockchain_original(request):
+    bc1, connection, db_path = await create_blockchain(test_constants_original, request.param)
     yield bc1
     await connection.close()
     bc1.shut_down()

--- a/tests/core/full_node/test_hint_store.py
+++ b/tests/core/full_node/test_hint_store.py
@@ -25,8 +25,9 @@ log = logging.getLogger(__name__)
 
 class TestHintStore:
     @pytest.mark.asyncio
-    async def test_basic_store(self):
-        async with DBConnection() as db_wrapper:
+    @pytest.mark.parametrize("db_version", [1, 2])
+    async def test_basic_store(self, db_version):
+        async with DBConnection(db_version) as db_wrapper:
             hint_store = await HintStore.create(db_wrapper)
             hint_0 = 32 * b"\0"
             hint_1 = 32 * b"\1"

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -19,14 +19,14 @@ from tests.setup_nodes import bt
 blockchain_db_counter: int = 0
 
 
-async def create_blockchain(constants: ConsensusConstants):
+async def create_blockchain(constants: ConsensusConstants, db_version: int):
     global blockchain_db_counter
     db_path = Path(f"blockchain_test-{blockchain_db_counter}.db")
     if db_path.exists():
         db_path.unlink()
     blockchain_db_counter += 1
     connection = await aiosqlite.connect(db_path)
-    wrapper = DBWrapper(connection)
+    wrapper = DBWrapper(connection, False, db_version)
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
     hint_store = await HintStore.create(wrapper)

--- a/tests/util/db_connection.py
+++ b/tests/util/db_connection.py
@@ -5,12 +5,15 @@ import aiosqlite
 
 
 class DBConnection:
+    def __init__(self, db_version):
+        self.db_version = db_version
+
     async def __aenter__(self) -> DBWrapper:
         self.db_path = Path(tempfile.NamedTemporaryFile().name)
         if self.db_path.exists():
             self.db_path.unlink()
         self.connection = await aiosqlite.connect(self.db_path)
-        return DBWrapper(self.connection)
+        return DBWrapper(self.connection, False, self.db_version)
 
     async def __aexit__(self, exc_t, exc_v, exc_tb):
         await self.connection.close()


### PR DESCRIPTION
This patch intends to lay the foundation for developing a v2 database schema for the blockchain as well as an upgrade path. It does not implement any changes to the schema, it enables updates to a future v2 schema without affecting the current v1 schema.

The idea is that the v2 schema is not set in stone until we say it is. For now we just have an ability to alter it and make improvements until we at some point reach diminishing returns and set it in stone and release it.

The changes can be summarized as:

* extend the `DBWrapper` with a version number, to let any user of the database know which schema version is being used
* switch some classes and test facilities to use `DBWrapper` rather than `aiosqlite.Connection` directly, to enable access to the version number (most classes already use `DBWrapper`)
* introduce a protocol for asking a database for its schema version. Namely a single-row table called `database_version` containing the version number. Note that there is no code anywhere that creates this table nor populates it with a version number. The idea is that a conversion program that converts a database from v1 to v2 would create and set the version via this table.
* Parameterize tests to run with both v1 and v2 (which is redundant for now, but won't be once we make changes to the v2 schema). This ensures changes to v2 will still be covered by the tests.
* Make the coin store and block store benchmarks run twice, both with v1 and v2 schemas. This provides a metric for how changes to v2 may improve performance.

One thing to keep in mind is that this patch (most likely) will make CI take longer to run, since it will run a lot of tests twice.

Somehow there were some lint issues in the block_store benchmark I had to fix to get CI green. That's the first commit in this patch-set. I would recommend reviewing the commits individually.

# Future direction

I have a few additional patches that changes the v2 schema for improved performance that builds on top of this patch. I'm happy to share those, but I think it's more expedient to review and land them individually. This patch is already rather big.

My list of v2 improvements (some of which I have implemented) are:

* remove the `spent` field from `coin_record` table. This field is redundant since we can use `spent_index` (removing use of this field has already landed in `main`)
* encode all fields that are currently hex-encoded, as binary fields. This makes the tables smaller and saves on conversions to and from text. This applies to all tables.
* encode the `amount` fields as an 8-byte blob of little-endian uint64, rather than a CLVM-encoded blob. This is a minor change that mostly simplifies the encoding. It enables faster and simpler parsing.
* compress full blocks. The lowest-hanging fruit here is to just run the encoded form of a full block through zstd. It's primarily the clvm code that's compressible. The encoding of full blocks adds about 2-3% of inefficiency that can be compressed away. The CLVM generator (which is the bulk of the bytes for transaction blocks) compresses quite well, reducing the size by about 80%.
* remove the `is_block` field from full_blocks table. This field indicates whether a block is a transaction block or not, It is not used.
* remove the `is_peak` field from full_blocks and block_records (along with its index). This field is a space-wasting way of just having a single pointer to the current peak block.
* The whole block_records table can probably be removed. All information in this table is duplicated in full_blocks and sub_epoch_segments_v3 tables. It seems having this table at all was an optimization because parsing the full block into python to pick out the relevant fields is very slow. It's possible we might have to make that fast before removing this table.
* add a field to full_blocks indicating whether this block is part of the main chain or not. This helps with picking random blocks to consider for blue boxing, but also generally makes it possible to map a height to a single block in the main chain in a sql query, rather than having to maintain this mapping in memory (although, this in-memory mapping is not trivial to get rid of).
* There are more improvements on encoding the full block into the database blob that could be both more compact and more efficient to parse.

I expect community members will contribute ideas of improvements to the v2 schema as well.

Here's a teaser of the block_store benchmark with (some of) the above improvements implemented:

```
version 1
476.9038s, add_full_blocks
all tests completed in 476.9038s
database size: 2420.711 MB

version 2
240.2757s, add_full_blocks
all tests completed in 240.2757s
database size: 351.539 MB
```