### PR TITLE
[v2] use binary fields in block_store table

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Any
 
 import aiosqlite
 
@@ -27,53 +27,106 @@ class BlockStore:
         # All full blocks which have been added to the blockchain. Header_hash -> block
         self.db_wrapper = db_wrapper
         self.db = db_wrapper.db
-        await self.db.execute(
-            "CREATE TABLE IF NOT EXISTS full_blocks(header_hash text PRIMARY KEY, height bigint,"
-            "  is_block tinyint, is_fully_compactified tinyint, block blob)"
-        )
 
-        # Block records
-        await self.db.execute(
-            "CREATE TABLE IF NOT EXISTS block_records(header_hash "
-            "text PRIMARY KEY, prev_hash text, height bigint,"
-            "block blob, sub_epoch_summary blob, is_peak tinyint, is_block tinyint)"
-        )
+        if self.db_wrapper.db_version == 2:
 
-        # todo remove in v1.2
-        await self.db.execute("DROP TABLE IF EXISTS sub_epoch_segments_v2")
-
-        # Sub epoch segments for weight proofs
-        await self.db.execute(
-            "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3(ses_block_hash text PRIMARY KEY, challenge_segments blob)"
-        )
-
-        # Height index so we can look up in order of height for sync purposes
-        await self.db.execute("CREATE INDEX IF NOT EXISTS full_block_height on full_blocks(height)")
-        await self.db.execute("CREATE INDEX IF NOT EXISTS is_fully_compactified on full_blocks(is_fully_compactified)")
-
-        await self.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
-
-        if self.db_wrapper.allow_upgrades:
-            await self.db.execute("DROP INDEX IF EXISTS hh")
-            await self.db.execute("DROP INDEX IF EXISTS is_block")
-            await self.db.execute("DROP INDEX IF EXISTS peak")
             await self.db.execute(
-                "CREATE INDEX IF NOT EXISTS is_peak_eq_1_idx on block_records(is_peak) where is_peak = 1"
+                "CREATE TABLE IF NOT EXISTS full_blocks("
+                "header_hash blob PRIMARY KEY,"
+                "height bigint,"
+                "is_block tinyint,"
+                "is_fully_compactified tinyint,"
+                "block blob)"
             )
-        else:
+
+            # Block records
+            await self.db.execute(
+                "CREATE TABLE IF NOT EXISTS block_records("
+                "header_hash blob PRIMARY KEY,"
+                "prev_hash blob,"
+                "height bigint,"
+                "block blob,"
+                "sub_epoch_summary blob,"
+                "is_peak tinyint,"
+                "is_block tinyint)"
+            )
+
+            # Sub epoch segments for weight proofs
+            await self.db.execute(
+                "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3("
+                "ses_block_hash blob PRIMARY KEY,"
+                "challenge_segments blob)"
+            )
+
+            # Height index so we can look up in order of height for sync purposes
+            await self.db.execute("CREATE INDEX IF NOT EXISTS full_block_height on full_blocks(height)")
+            await self.db.execute(
+                "CREATE INDEX IF NOT EXISTS is_fully_compactified on full_blocks(is_fully_compactified)"
+            )
+            await self.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
             await self.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak) where is_peak = 1")
+
+        else:
+
+            await self.db.execute(
+                "CREATE TABLE IF NOT EXISTS full_blocks(header_hash text PRIMARY KEY, height bigint,"
+                "  is_block tinyint, is_fully_compactified tinyint, block blob)"
+            )
+
+            # Block records
+            await self.db.execute(
+                "CREATE TABLE IF NOT EXISTS block_records(header_hash "
+                "text PRIMARY KEY, prev_hash text, height bigint,"
+                "block blob, sub_epoch_summary blob, is_peak tinyint, is_block tinyint)"
+            )
+
+            # Sub epoch segments for weight proofs
+            await self.db.execute(
+                "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3(ses_block_hash text PRIMARY KEY,"
+                "challenge_segments blob)"
+            )
+
+            # Height index so we can look up in order of height for sync purposes
+            await self.db.execute("CREATE INDEX IF NOT EXISTS full_block_height on full_blocks(height)")
+            await self.db.execute(
+                "CREATE INDEX IF NOT EXISTS is_fully_compactified on full_blocks(is_fully_compactified)"
+            )
+
+            await self.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
+
+            if self.db_wrapper.allow_upgrades:
+                await self.db.execute("DROP INDEX IF EXISTS hh")
+                await self.db.execute("DROP INDEX IF EXISTS is_block")
+                await self.db.execute("DROP INDEX IF EXISTS peak")
+                await self.db.execute(
+                    "CREATE INDEX IF NOT EXISTS is_peak_eq_1_idx on block_records(is_peak) where is_peak = 1"
+                )
+            else:
+                await self.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak) where is_peak = 1")
 
         await self.db.commit()
         self.block_cache = LRUCache(1000)
         self.ses_challenge_cache = LRUCache(50)
         return self
 
+    def maybe_from_hex(self, field: Any) -> bytes:
+        if self.db_wrapper.db_version == 2:
+            return field
+        else:
+            return bytes.fromhex(field)
+
+    def maybe_to_hex(self, field: bytes) -> Any:
+        if self.db_wrapper.db_version == 2:
+            return field
+        else:
+            return field.hex()
+
     async def add_full_block(self, header_hash: bytes32, block: FullBlock, block_record: BlockRecord) -> None:
         self.block_cache.put(header_hash, block)
         cursor_1 = await self.db.execute(
             "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
             (
-                header_hash.hex(),
+                self.maybe_to_hex(header_hash),
                 block.height,
                 int(block.is_transaction_block()),
                 int(block.is_fully_compactified()),
@@ -86,8 +139,8 @@ class BlockStore:
         cursor_2 = await self.db.execute(
             "INSERT OR REPLACE INTO block_records VALUES(?, ?, ?, ?,?, ?, ?)",
             (
-                header_hash.hex(),
-                block.prev_header_hash.hex(),
+                self.maybe_to_hex(header_hash),
+                self.maybe_to_hex(block.prev_header_hash),
                 block.height,
                 bytes(block_record),
                 None
@@ -105,7 +158,7 @@ class BlockStore:
         async with self.db_wrapper.lock:
             cursor_1 = await self.db.execute(
                 "INSERT OR REPLACE INTO sub_epoch_segments_v3 VALUES(?, ?)",
-                (ses_block_hash.hex(), bytes(SubEpochSegments(segments))),
+                (self.maybe_to_hex(ses_block_hash), bytes(SubEpochSegments(segments))),
             )
             await cursor_1.close()
             await self.db.commit()
@@ -117,8 +170,10 @@ class BlockStore:
         cached = self.ses_challenge_cache.get(ses_block_hash)
         if cached is not None:
             return cached
+
         cursor = await self.db.execute(
-            "SELECT challenge_segments from sub_epoch_segments_v3 WHERE ses_block_hash=?", (ses_block_hash.hex(),)
+            "SELECT challenge_segments from sub_epoch_segments_v3 WHERE ses_block_hash=?",
+            (self.maybe_to_hex(ses_block_hash),),
         )
         row = await cursor.fetchone()
         await cursor.close()
@@ -142,7 +197,9 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return cached
         log.debug(f"cache miss for block {header_hash.hex()}")
-        cursor = await self.db.execute("SELECT block from full_blocks WHERE header_hash=?", (header_hash.hex(),))
+        cursor = await self.db.execute(
+            "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
+        )
         row = await cursor.fetchone()
         await cursor.close()
         if row is not None:
@@ -157,7 +214,9 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return bytes(cached)
         log.debug(f"cache miss for block {header_hash.hex()}")
-        cursor = await self.db.execute("SELECT block from full_blocks WHERE header_hash=?", (header_hash.hex(),))
+        cursor = await self.db.execute(
+            "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
+        )
         row = await cursor.fetchone()
         await cursor.close()
         if row is not None:
@@ -183,7 +242,11 @@ class BlockStore:
         if len(header_hashes) == 0:
             return []
 
-        header_hashes_db = tuple([hh.hex() for hh in header_hashes])
+        header_hashes_db: Tuple[Any, ...]
+        if self.db_wrapper.db_version == 2:
+            header_hashes_db = tuple(header_hashes)
+        else:
+            header_hashes_db = tuple([hh.hex() for hh in header_hashes])
         formatted_str = f'SELECT block from block_records WHERE header_hash in ({"?," * (len(header_hashes_db) - 1)}?)'
         cursor = await self.db.execute(formatted_str, header_hashes_db)
         rows = await cursor.fetchall()
@@ -208,7 +271,11 @@ class BlockStore:
         if len(header_hashes) == 0:
             return []
 
-        header_hashes_db = tuple([hh.hex() for hh in header_hashes])
+        header_hashes_db: Tuple[Any, ...]
+        if self.db_wrapper.db_version == 2:
+            header_hashes_db = tuple(header_hashes)
+        else:
+            header_hashes_db = tuple([hh.hex() for hh in header_hashes])
         formatted_str = (
             f'SELECT header_hash, block from full_blocks WHERE header_hash in ({"?," * (len(header_hashes_db) - 1)}?)'
         )
@@ -217,7 +284,7 @@ class BlockStore:
         await cursor.close()
         all_blocks: Dict[bytes32, FullBlock] = {}
         for row in rows:
-            header_hash = bytes.fromhex(row[0])
+            header_hash = self.maybe_from_hex(row[0])
             full_block: FullBlock = FullBlock.from_bytes(row[1])
             # TODO: address hint error and remove ignore
             #       error: Invalid index type "bytes" for "Dict[bytes32, FullBlock]"; expected type "bytes32"  [index]
@@ -233,7 +300,7 @@ class BlockStore:
     async def get_block_record(self, header_hash: bytes32) -> Optional[BlockRecord]:
         cursor = await self.db.execute(
             "SELECT block from block_records WHERE header_hash=?",
-            (header_hash.hex(),),
+            (self.maybe_to_hex(header_hash),),
         )
         row = await cursor.fetchone()
         await cursor.close()
@@ -258,9 +325,9 @@ class BlockStore:
         await cursor.close()
         ret: Dict[bytes32, BlockRecord] = {}
         for row in rows:
-            header_hash = bytes.fromhex(row[0])
             # TODO: address hint error and remove ignore
             #       error: Invalid index type "bytes" for "Dict[bytes32, BlockRecord]"; expected type "bytes32"  [index]
+            header_hash = self.maybe_from_hex(row[0])
             ret[header_hash] = BlockRecord.from_bytes(row[1])  # type: ignore[index]
 
         return ret
@@ -285,14 +352,15 @@ class BlockStore:
         await cursor.close()
         ret: Dict[bytes32, BlockRecord] = {}
         for row in rows:
-            header_hash = bytes.fromhex(row[0])
+            header_hash = self.maybe_from_hex(row[0])
             # TODO: address hint error and remove ignore
             #       error: Invalid index type "bytes" for "Dict[bytes32, BlockRecord]"; expected type "bytes32"  [index]
             ret[header_hash] = BlockRecord.from_bytes(row[1])  # type: ignore[index]
+
         # TODO: address hint error and remove ignore
         #       error: Incompatible return value type (got "Tuple[Dict[bytes32, BlockRecord], bytes]", expected
         #       "Tuple[Dict[bytes32, BlockRecord], Optional[bytes32]]")  [return-value]
-        return ret, bytes.fromhex(peak_row[0])  # type: ignore[return-value]
+        return ret, self.maybe_from_hex(peak_row[0])  # type: ignore[return-value]
 
     async def set_peak(self, header_hash: bytes32) -> None:
         # We need to be in a sqlite transaction here.
@@ -301,13 +369,13 @@ class BlockStore:
         await cursor_1.close()
         cursor_2 = await self.db.execute(
             "UPDATE block_records SET is_peak=1 WHERE header_hash=?",
-            (header_hash.hex(),),
+            (self.maybe_to_hex(header_hash),),
         )
         await cursor_2.close()
 
     async def is_fully_compactified(self, header_hash: bytes32) -> Optional[bool]:
         cursor = await self.db.execute(
-            "SELECT is_fully_compactified from full_blocks WHERE header_hash=?", (header_hash.hex(),)
+            "SELECT is_fully_compactified from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
         )
         row = await cursor.fetchone()
         await cursor.close()

--- a/tests/core/full_node/test_block_height_map.py
+++ b/tests/core/full_node/test_block_height_map.py
@@ -32,32 +32,60 @@ async def new_block(
     is_peak: bool,
     ses: Optional[SubEpochSummary],
 ):
-    cursor = await db.db.execute(
-        "INSERT INTO block_records VALUES(?, ?, ?, ?, ?)",
-        (
-            block_hash.hex(),
-            parent.hex(),
-            height,
-            # sub epoch summary
-            None if ses is None else bytes(ses),
-            is_peak,
-        ),
-    )
-    await cursor.close()
+    if db.db_version == 2:
+        cursor = await db.db.execute(
+            "INSERT INTO block_records VALUES(?, ?, ?, ?, ?)",
+            (
+                block_hash,
+                parent,
+                height,
+                # sub epoch summary
+                None if ses is None else bytes(ses),
+                is_peak,
+            ),
+        )
+        await cursor.close()
+    else:
+        cursor = await db.db.execute(
+            "INSERT INTO block_records VALUES(?, ?, ?, ?, ?)",
+            (
+                block_hash.hex(),
+                parent.hex(),
+                height,
+                # sub epoch summary
+                None if ses is None else bytes(ses),
+                is_peak,
+            ),
+        )
+        await cursor.close()
 
 
 async def setup_db(db: DBWrapper):
-    await db.db.execute(
-        "CREATE TABLE IF NOT EXISTS block_records("
-        "header_hash text PRIMARY KEY,"
-        "prev_hash text,"
-        "height bigint,"
-        "sub_epoch_summary blob,"
-        "is_peak tinyint)"
-    )
-    await db.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
-    await db.db.execute("CREATE INDEX IF NOT EXISTS hh on block_records(header_hash)")
-    await db.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
+
+    if db.db_version == 2:
+        await db.db.execute(
+            "CREATE TABLE IF NOT EXISTS block_records("
+            "header_hash blob PRIMARY KEY,"
+            "prev_hash blob,"
+            "height bigint,"
+            "sub_epoch_summary blob,"
+            "is_peak tinyint)"
+        )
+        await db.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
+        await db.db.execute("CREATE INDEX IF NOT EXISTS hh on block_records(header_hash)")
+        await db.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
+    else:
+        await db.db.execute(
+            "CREATE TABLE IF NOT EXISTS block_records("
+            "header_hash text PRIMARY KEY,"
+            "prev_hash text,"
+            "height bigint,"
+            "sub_epoch_summary blob,"
+            "is_peak tinyint)"
+        )
+        await db.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
+        await db.db.execute("CREATE INDEX IF NOT EXISTS hh on block_records(header_hash)")
+        await db.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
 
 
 # if chain_id != 0, the last block in the chain won't be considered the peak,


### PR DESCRIPTION
This patch updates the v2 database schema to use binary fields instead if hex in the `block_store` table. This reduces the size of the table a little bit. Most of this table is made up of serialized clvm code, which is already stored as binary.

These changes are best reviewed hiding white space changes.

test  | v1 | v2 | v2 / v1
---|---|---|---
table size | 2420 MB | 2413 MB | 99.7%

This change in size may seem insignificant relative to the size of the change. however, most of the code change is mostly related to making *any* distinction between v1 and v2, and there are more significant changes to be made where it's required to distinguish v1 from v2.