### PR TITLE
add SizedBytes.zeros() and use for some defaults

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -109,10 +109,7 @@ class SpendSim:
             return None
         return simple_solution_generator(bundle)
 
-    # TODO: address hint error and remove ignore
-    #       error: Incompatible default for argument "puzzle_hash" (default has type "bytes", argument has type
-    #       "bytes32")  [assignment]
-    async def farm_block(self, puzzle_hash: bytes32 = (b"0" * 32)):  # type: ignore[assignment]
+    async def farm_block(self, puzzle_hash: bytes32 = bytes32.zeros()):
         # Fees get calculated
         fees = uint64(0)
         if self.mempool_manager.mempool.spends:

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -35,9 +35,6 @@ from chia.util.recursive_replace import recursive_replace
 log = logging.getLogger(__name__)
 
 
-# TODO: address hint error and remove ignore
-#       error: Incompatible default for argument "seed" (default has type "bytes", argument has type "bytes32")
-#       [assignment]
 def create_foliage(
     constants: ConsensusConstants,
     reward_block_unfinished: RewardChainBlockUnfinished,
@@ -53,7 +50,7 @@ def create_foliage(
     pool_target: PoolTarget,
     get_plot_signature: Callable[[bytes32, G1Element], G2Element],
     get_pool_signature: Callable[[PoolTarget, Optional[G1Element]], Optional[G2Element]],
-    seed: bytes32 = b"",  # type: ignore[assignment]
+    seed: bytes32 = bytes32.zeros(),
 ) -> Tuple[Foliage, Optional[FoliageTransactionBlock], Optional[TransactionsInfo]]:
     """
     Creates a foliage for a given reward chain block. This may or may not be a tx block. In the case of a tx block,
@@ -298,9 +295,6 @@ def create_foliage(
     return foliage, foliage_transaction_block, transactions_info
 
 
-# TODO: address hint error and remove ignore
-#       error: Incompatible default for argument "seed" (default has type "bytes", argument has type "bytes32")
-#       [assignment]
 def create_unfinished_block(
     constants: ConsensusConstants,
     sub_slot_start_total_iters: uint128,
@@ -317,7 +311,7 @@ def create_unfinished_block(
     signage_point: SignagePoint,
     timestamp: uint64,
     blocks: BlockchainInterface,
-    seed: bytes32 = b"",  # type: ignore[assignment]
+    seed: bytes32 = bytes32.zeros(),
     block_generator: Optional[BlockGenerator] = None,
     aggregate_sig: G2Element = G2Element(),
     additions: Optional[List[Coin]] = None,

--- a/chia/util/byte_types.py
+++ b/chia/util/byte_types.py
@@ -28,6 +28,10 @@ class SizedBytes(bytes):
         return bytes.__new__(cls, v)
 
     @classmethod
+    def zeros(cls: Type[_T_SizedBytes]) -> _T_SizedBytes:
+        return cls([0] * cls._size)
+
+    @classmethod
     def parse(cls: Type[_T_SizedBytes], f: BinaryIO) -> _T_SizedBytes:
         b = f.read(cls._size)
         assert len(b) == cls._size


### PR DESCRIPTION
Note that these new default values are distinctly different.  Given that they were not valid `bytes32` objects before, perhaps this is fine.  Or, perhaps we have created a dependence on these invalid values and the hinting issues must be addressed differently.

Draft for:
- [x] Needs https://github.com/Chia-Network/chia-blockchain/pull/9457 merged to fix hints
- [ ] Consideration of whether tests should be updated or if they indicate that the new values are problematic.