### PR TITLE
create SizedBytes.secret(), substitute for bytes32(token_bytes(32))

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -2,7 +2,6 @@ import asyncio
 import dataclasses
 import time
 import traceback
-from secrets import token_bytes
 from typing import Callable, Dict, List, Optional, Tuple, Set
 
 from blspy import AugSchemeMPL, G2Element
@@ -199,13 +198,11 @@ class FullNodeAPI:
                     if task_id in full_node.full_node_store.tx_fetch_tasks:
                         full_node.full_node_store.tx_fetch_tasks.pop(task_id)
 
-            task_id = token_bytes()
+            task_id = bytes32.secret()
             fetch_task = asyncio.create_task(
                 tx_request_and_timeout(self.full_node, transaction.transaction_id, task_id)
             )
-            # TODO: address hint error and remove ignore
-            #       error: Invalid index type "bytes" for "Dict[bytes32, Task[Any]]"; expected type "bytes32"  [index]
-            self.full_node.full_node_store.tx_fetch_tasks[task_id] = fetch_task  # type: ignore[index]
+            self.full_node.full_node_store.tx_fetch_tasks[task_id] = fetch_task
             return None
         return None
 

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from secrets import token_bytes
 from typing import Dict, List, Optional, Tuple
 
 from blspy import AugSchemeMPL, G1Element, PrivateKey
@@ -192,7 +191,7 @@ async def create_plots(
             assert len(test_private_keys) == num
             sk: PrivateKey = test_private_keys[i]
         else:
-            sk = AugSchemeMPL.key_gen(token_bytes(32))
+            sk = AugSchemeMPL.key_gen(bytes32.secret())
 
         # The plot public key is the combination of the harvester and farmer keys
         # New plots will also include a taproot of the keys, for extensibility

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -6,7 +6,6 @@ import traceback
 from collections import Counter
 from ipaddress import IPv6Address, ip_address, ip_network, IPv4Network, IPv6Network
 from pathlib import Path
-from secrets import token_bytes
 from typing import Any, Callable, Dict, List, Optional, Union, Set, Tuple
 from typing import Counter as typing_Counter
 
@@ -611,16 +610,12 @@ class ChiaServer:
                     if task_id in self.execute_tasks:
                         self.execute_tasks.remove(task_id)
 
-            task_id = token_bytes()
+            task_id = bytes32.secret()
             api_task = asyncio.create_task(api_call(payload_inc, connection_inc, task_id))
-            # TODO: address hint error and remove ignore
-            #       error: Invalid index type "bytes" for "Dict[bytes32, Task[Any]]"; expected type "bytes32"  [index]
-            self.api_tasks[task_id] = api_task  # type: ignore[index]
+            self.api_tasks[task_id] = api_task
             if connection_inc.peer_node_id not in self.tasks_from_peer:
                 self.tasks_from_peer[connection_inc.peer_node_id] = set()
-            # TODO: address hint error and remove ignore
-            #       error: Argument 1 to "add" of "set" has incompatible type "bytes"; expected "bytes32"  [arg-type]
-            self.tasks_from_peer[connection_inc.peer_node_id].add(task_id)  # type: ignore[arg-type]
+            self.tasks_from_peer[connection_inc.peer_node_id].add(task_id)
 
     async def send_to_others(
         self,

--- a/chia/util/byte_types.py
+++ b/chia/util/byte_types.py
@@ -1,4 +1,5 @@
 import io
+from secrets import token_bytes
 from typing import BinaryIO, Type, TypeVar
 
 _T_SizedBytes = TypeVar("_T_SizedBytes", bound="SizedBytes")
@@ -26,6 +27,10 @@ class SizedBytes(bytes):
         if not isinstance(v, bytes) or len(v) != cls._size:
             raise ValueError("bad %s initializer %s" % (cls.__name__, v))
         return bytes.__new__(cls, v)
+
+    @classmethod
+    def secret(cls: Type[_T_SizedBytes]) -> _T_SizedBytes:
+        return cls(token_bytes(cls._size))
 
     @classmethod
     def parse(cls: Type[_T_SizedBytes], f: BinaryIO) -> _T_SizedBytes:

--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import replace
-from secrets import token_bytes
 from typing import Any, Dict, List, Optional, Set
 
 from blspy import AugSchemeMPL, G2Element
@@ -115,9 +114,6 @@ class CCWallet:
         if cc_coin is None:
             raise ValueError("Internal Error, unable to generate new coloured coin")
 
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         regular_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -133,11 +129,8 @@ class CCWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         cc_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -153,7 +146,7 @@ class CCWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.INCOMING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
         await self.standard_wallet.push_transaction(regular_record)
         await self.standard_wallet.push_transaction(cc_record)
@@ -440,7 +433,7 @@ class CCWallet:
                 sent_to=[],
                 trade_id=None,
                 type=uint32(TransactionType.INCOMING_TX.value),
-                name=token_bytes(),  # type: ignore[arg-type]
+                name=bytes32.secret(),
             )
             cc_record = TransactionRecord(
                 confirmed_at_height=uint32(0),

--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -415,9 +415,6 @@ class CCWallet:
         await self.add_lineage(eve_coin.parent_coin_info, Program.to((0, [origin.as_list(), 1])))
 
         if send:
-            # TODO: address hint error and remove ignore
-            #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-            #       [arg-type]
             regular_record = TransactionRecord(
                 confirmed_at_height=uint32(0),
                 created_at_time=uint64(int(time.time())),

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -5,7 +5,6 @@ import json
 from typing import Dict, Optional, List, Any, Set, Tuple, Union
 
 from blspy import AugSchemeMPL, G1Element
-from secrets import token_bytes
 from chia.protocols import wallet_protocol
 from chia.protocols.wallet_protocol import RespondAdditions, RejectAdditionsRequest
 from chia.server.outbound_message import NodeType
@@ -97,9 +96,6 @@ class DIDWallet:
             self.did_info.current_inner, self.did_info.origin_coin.name()
         ).get_tree_hash()
 
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -115,11 +111,8 @@ class DIDWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.INCOMING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         regular_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -135,7 +128,7 @@ class DIDWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
         await self.standard_wallet.push_transaction(regular_record)
         await self.standard_wallet.push_transaction(did_record)
@@ -521,7 +514,7 @@ class DIDWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
-            name=token_bytes(),
+            name=bytes32.secret(),
         )
         await self.standard_wallet.push_transaction(did_record)
         return spend_bundle
@@ -574,9 +567,6 @@ class DIDWallet:
         aggsig = AugSchemeMPL.aggregate(sigs)
         spend_bundle = SpendBundle(list_of_solutions, aggsig)
 
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -592,7 +582,7 @@ class DIDWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
         await self.standard_wallet.push_transaction(did_record)
         return spend_bundle
@@ -643,9 +633,6 @@ class DIDWallet:
         aggsig = AugSchemeMPL.aggregate(sigs)
         spend_bundle = SpendBundle(list_of_solutions, aggsig)
 
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -661,7 +648,7 @@ class DIDWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
         await self.standard_wallet.push_transaction(did_record)
         return spend_bundle
@@ -714,9 +701,6 @@ class DIDWallet:
         signature = AugSchemeMPL.sign(private, message)
         # assert signature.validate([signature.PkMessagePair(pubkey, message)])
         spend_bundle = SpendBundle(list_of_solutions, signature)
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -732,7 +716,7 @@ class DIDWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.INCOMING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
         await self.standard_wallet.push_transaction(did_record)
         if filename is not None:
@@ -857,9 +841,6 @@ class DIDWallet:
         else:
             spend_bundle = spend_bundle.aggregate([spend_bundle, SpendBundle(list_of_solutions, aggsig)])
 
-        # TODO: address hint error and remove ignore
-        #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-        #       [arg-type]
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -875,7 +856,7 @@ class DIDWallet:
             sent_to=[],
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
-            name=token_bytes(),  # type: ignore[arg-type]
+            name=bytes32.secret(),
         )
         await self.standard_wallet.push_transaction(did_record)
         new_did_info = DIDInfo(

--- a/chia/wallet/rl_wallet/rl_wallet.py
+++ b/chia/wallet/rl_wallet/rl_wallet.py
@@ -3,7 +3,6 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass
-from secrets import token_bytes
 from typing import Any, List, Optional, Tuple
 
 from blspy import AugSchemeMPL, G1Element, PrivateKey
@@ -81,7 +80,7 @@ class RLWallet:
             [
                 DerivationRecord(
                     unused,
-                    bytes32(token_bytes(32)),
+                    bytes32.secret(),
                     pubkey,
                     WalletType.RATE_LIMITED,
                     wallet_info.id,
@@ -122,7 +121,7 @@ class RLWallet:
                 [
                     DerivationRecord(
                         unused,
-                        bytes32(token_bytes(32)),
+                        bytes32.secret(),
                         pubkey,
                         WalletType.RATE_LIMITED,
                         wallet_info.id,

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -2,7 +2,6 @@ import logging
 import time
 import traceback
 from pathlib import Path
-from secrets import token_bytes
 from typing import Any, Dict, List, Optional, Tuple
 
 from blspy import AugSchemeMPL
@@ -544,13 +543,10 @@ class TradeManager:
         if chia_spend_bundle is not None:
             spend_bundle = SpendBundle.aggregate([spend_bundle, chia_spend_bundle])
             if chia_discrepancy < 0:
-                # TODO: address hint error and remove ignore
-                #       error: Argument "to_puzzle_hash" to "TransactionRecord" has incompatible type "bytes"; expected
-                #       "bytes32"  [arg-type]
                 tx_record = TransactionRecord(
                     confirmed_at_height=uint32(0),
                     created_at_time=now,
-                    to_puzzle_hash=token_bytes(),  # type: ignore[arg-type]
+                    to_puzzle_hash=bytes32.secret(),
                     amount=uint64(abs(chia_discrepancy)),
                     fee_amount=uint64(0),
                     confirmed=False,
@@ -565,13 +561,10 @@ class TradeManager:
                     name=chia_spend_bundle.name(),
                 )
             else:
-                # TODO: address hint error and remove ignore
-                #       error: Argument "to_puzzle_hash" to "TransactionRecord" has incompatible type "bytes"; expected
-                #       "bytes32"  [arg-type]
                 tx_record = TransactionRecord(
                     confirmed_at_height=uint32(0),
                     created_at_time=uint64(int(time.time())),
-                    to_puzzle_hash=token_bytes(),  # type: ignore[arg-type]
+                    to_puzzle_hash=bytes32.secret(),
                     amount=uint64(abs(chia_discrepancy)),
                     fee_amount=uint64(0),
                     confirmed=False,
@@ -590,13 +583,10 @@ class TradeManager:
         for colour, amount in cc_discrepancies.items():
             wallet = wallets[colour]
             if chia_discrepancy > 0:
-                # TODO: address hint error and remove ignore
-                #       error: Argument "to_puzzle_hash" to "TransactionRecord" has incompatible type "bytes"; expected
-                #       "bytes32"  [arg-type]
                 tx_record = TransactionRecord(
                     confirmed_at_height=uint32(0),
                     created_at_time=uint64(int(time.time())),
-                    to_puzzle_hash=token_bytes(),  # type: ignore[arg-type]
+                    to_puzzle_hash=bytes32.secret(),
                     amount=uint64(abs(amount)),
                     fee_amount=uint64(0),
                     confirmed=False,
@@ -611,15 +601,10 @@ class TradeManager:
                     name=spend_bundle.name(),
                 )
             else:
-                # TODO: address hint errors and remove ignores
-                #       error: Argument "to_puzzle_hash" to "TransactionRecord" has incompatible type "bytes"; expected
-                #       "bytes32"  [arg-type]
-                #       error: Argument "name" to "TransactionRecord" has incompatible type "bytes"; expected "bytes32"
-                #       [arg-type]
                 tx_record = TransactionRecord(
                     confirmed_at_height=uint32(0),
                     created_at_time=uint64(int(time.time())),
-                    to_puzzle_hash=token_bytes(),  # type: ignore[arg-type]
+                    to_puzzle_hash=bytes32.secret(),
                     amount=uint64(abs(amount)),
                     fee_amount=uint64(0),
                     confirmed=False,
@@ -631,17 +616,14 @@ class TradeManager:
                     sent_to=[],
                     trade_id=std_hash(spend_bundle.name() + bytes(now)),
                     type=uint32(TransactionType.INCOMING_TRADE.value),
-                    name=token_bytes(),  # type: ignore[arg-type]
+                    name=bytes32.secret(),
                 )
             my_tx_records.append(tx_record)
 
-        # TODO: address hint error and remove ignore
-        #       error: Argument "to_puzzle_hash" to "TransactionRecord" has incompatible type "bytes"; expected
-        #       "bytes32"  [arg-type]
         tx_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
-            to_puzzle_hash=token_bytes(),  # type: ignore[arg-type]
+            to_puzzle_hash=bytes32.secret(),
             amount=uint64(0),
             fee_amount=uint64(0),
             confirmed=False,


### PR DESCRIPTION
I could be swayed, but I chose `.secret()` to refer to the `secrets` module being used as opposed to `.random()` which would relate to the `random` module.  Maybe `.token()` would be better?  I don't necessarily know the implications of these words in the field, as opposed to just in Python.

Draft for:
- [x] Needs https://github.com/Chia-Network/chia-blockchain/pull/9457 merged for green CI
- [ ] Reconsideration based on comments