### PR TITLE
rename variable to avoid hint confusion

### DIFF
--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -130,22 +130,19 @@ async def show_async(
                 # Nodetype length is 9 because INTRODUCER will be deprecated
                 if NodeType(con["type"]) is NodeType.FULL_NODE:
                     peak_height = con["peak_height"]
-                    peak_hash = con["peak_hash"]
-                    if peak_hash is None:
-                        peak_hash = "No Info"
+                    connection_peak_hash = con["peak_hash"]
+                    if connection_peak_hash is None:
+                        connection_peak_hash = "No Info"
                     if peak_height is None:
                         peak_height = 0
-                    # TODO: address hint error and remove ignore
-                    #       error: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc'; use
-                    #       '{!r}'.format(b'abc') if this is desired behavior  [str-bytes-safe]
                     con_str = (
-                        f"{NodeType(con['type']).name:9} {host:38} "  # type: ignore[str-bytes-safe]
+                        f"{NodeType(con['type']).name:9} {host:38} "
                         f"{con['peer_port']:5}/{con['peer_server_port']:<5}"
                         f" {con['node_id'].hex()[:8]}... "
                         f"{last_connect}  "
                         f"{mb_up:7.1f}|{mb_down:<7.1f}"
                         f"\n                                                 "
-                        f"-SB Height: {peak_height:8.0f}    -Hash: {peak_hash[2:10]}..."
+                        f"-SB Height: {peak_height:8.0f}    -Hash: {connection_peak_hash[2:10]}..."
                     )
                 else:
                     con_str = (


### PR DESCRIPTION
Earlier in the function `peak_hash` is used and is detectible as `bytes32`.  At this location it is assigned from an `Any` hinted value thus leaving `bytes32` as a valid, although inaccurate, hint.  Renamed to avoid this collision of uses.  When we ban `Any` we will end up dealing with this.

Draft for:
- [x] Needs https://github.com/Chia-Network/chia-blockchain/pull/9457 merged for green CI
