### PR TITLE
fix query transaction_record sql statement logic error

### DIFF
--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -341,7 +341,7 @@ class WalletTransactionStore:
         cursor = await self.db_connection.execute(
             f"SELECT * from transaction_record where wallet_id=? and confirmed_at_height not in"
             f" (select confirmed_at_height from transaction_record order by confirmed_at_height"
-            f" ASC LIMIT {start})"
+            f" DESC LIMIT {start})"
             f" order by confirmed_at_height DESC LIMIT {limit}",
             (wallet_id,),
         )


### PR DESCRIPTION
if I have 10 records in transaction_record table,and their confirmed_at_height is[1,2,3,4,5,6,7,8,9,10].

call http rpc of get_transactions 

- with parameter start=0,end=50, return : [1,2,3,4,5,6,7,8,9,10]

- with parameter start=0,end=5,return:[1,2,3,4,5] 

until now the result is correct.

but **when start is greater than 0,will return a unexpected results**.
for example,start=3,end=6, the [4,5,6] is expected,but the chia get_transactions rpc will retuen [1,2,3].