### PR TITLE
zstd block compression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ dependencies = [
     "watchdog==2.1.6",  # Filesystem event watching - watches keyring.yaml
     "dnslib==0.9.14",  # dns lib
     "typing-extensions==4.0.1",  # typing backports like Protocol and TypedDict
+    "zstd==1.5.0.4",
 ]
 
 upnp_dependencies = [


### PR DESCRIPTION
This patch serializes and deserializes `FullBlock` objects through zstd compression. This has the following performance improvements (running the `block_store` benchmark):

new benchmark program. comparing v1 against v2 with this patch. v1 is pretty close to the commit prior to this one:

test  | v1 | v2 | v2 / v1
---|---|---|---
table size | 2418.156 MB | 352.260  MB | 14.6 %
Ryzen, fast SSD | 351.82s | 292.8s | 83.23%
Xeon, HDD | 709.4s | 485.9s | 68.5%
RPi, SD card | 1670.3s | 1383.4s | 82.8%
M1, SSD | 169.3s | 153.2s | 90.5%

old benchmark program (only measures inserts):

test  | before | after | after / before
---|---|---|---
table size | 2414.498 MB | 351.564 MB | 14.6%
fast computer, fast SSD |  83.4s | 47.8s | 57.2%
Xeon, HDD | 432.9s | 235.4s | 53.4%
RPi, SD card | 481.3s | 288.5s | 60.0%

The serialization format of full blocks could be made more sophisticated by using a more compact representation of the `Optional` types, and encoding knowledge of range limits of various fields, and known relationships of hashes and their values. For example, since we only store valid blocks in the database, we don't need to store the hashes of fields as well as the fields themselves. we can just recompute the hashes when deserializing the block.

The parent coin IDs of coinbase coins follow a pattern where they don't have a full 32 bytes of entropy, that could also be compressed quite simply.

The main field that compresses well with zstd is the clvm program.

I think it would be worth exploring *not* running zstd over the full block, since a lot of it is hashes (which presumably already have max entropy). This patch is just implementing the simplest possible compression though, as it's a lot better than nothing.

# raw benchmark outputs (new benchmark)

Ryzen, SSD:

```
version 1
98.5140s, add_full_block
53.5636s, get_full_block
5.3293s, get_full_block_bytes
52.5041s, get_full_blocks_at
6.5427s, get_block_records_by_hash
53.7630s, get_blocks_by_hash
7.2385s, get_block_record
0.6580s, get_block_records_in_range
0.0052s, get_block_records_close_to_peak
4.5506s, get_block_record
69.1535s, get_random_not_compactified
all tests completed in 351.8225s
database size: 2418.156 MB
version 2
50.5875s, add_full_block
51.3444s, get_full_block
5.1197s, get_full_block_bytes
50.5790s, get_full_blocks_at
6.9718s, get_block_records_by_hash
52.0592s, get_blocks_by_hash
5.8935s, get_block_record
0.6742s, get_block_records_in_range
0.0059s, get_block_records_close_to_peak
4.8292s, get_block_record
64.7609s, get_random_not_compactified
all tests completed in 292.8254s
database size: 352.260 MB
```

Xeon, HDD:

```
version 1
492.1105s, add_full_block
43.9318s, get_full_block
5.4029s, get_full_block_bytes
42.5088s, get_full_blocks_at
5.0055s, get_block_records_by_hash
44.1666s, get_blocks_by_hash
4.4127s, get_block_record
0.5884s, get_block_records_in_range
0.0048s, get_block_records_close_to_peak
3.3326s, get_block_record
67.9706s, get_random_not_compactified
all tests completed in 709.4351s
database size: 2418.156 MB
version 2
272.2345s, add_full_block
43.2803s, get_full_block
4.2043s, get_full_block_bytes
42.2039s, get_full_blocks_at
4.8922s, get_block_records_by_hash
43.4046s, get_blocks_by_hash
4.6990s, get_block_record
0.5772s, get_block_records_in_range
0.0051s, get_block_records_close_to_peak
3.3977s, get_block_record
66.9707s, get_random_not_compactified
all tests completed in 485.8695s
database size: 352.260 MB
```

RPi, SD  card:

```
version 1
554.1024s, add_full_block
218.2731s, get_full_block
31.1171s, get_full_block_bytes
213.0253s, get_full_blocks_at
24.0242s, get_block_records_by_hash
218.8347s, get_blocks_by_hash
23.7923s, get_block_record
2.8354s, get_block_records_in_range
0.0249s, get_block_records_close_to_peak
17.6003s, get_block_record
366.6486s, get_random_not_compactified
all tests completed in 1670.2782s
database size: 2418.156 MB
version 2
307.3411s, add_full_block
202.9720s, get_full_block
24.1217s, get_full_block_bytes
197.8950s, get_full_blocks_at
24.2797s, get_block_records_by_hash
202.9930s, get_blocks_by_hash
24.0559s, get_block_record
2.7699s, get_block_records_in_range
0.0281s, get_block_records_close_to_peak
17.6855s, get_block_record
379.2843s, get_random_not_compactified
all tests completed in 1383.4261s
database size: 352.260 MB
```

M1, SSD:

```
version 1
19.5985s, add_full_block
37.4404s, get_full_block
4.7455s, get_full_block_bytes
27.6017s, get_full_blocks_at
2.8609s, get_block_records_by_hash
27.8004s, get_blocks_by_hash
2.5919s, get_block_record
0.3049s, get_block_records_in_range
0.0027s, get_block_records_close_to_peak
2.0584s, get_block_record
44.3153s, get_random_not_compactified
all tests completed in 169.3207s
database size: 2418.156 MB
version 2
17.8897s, add_full_block
27.1563s, get_full_block
2.3777s, get_full_block_bytes
26.1375s, get_full_blocks_at
2.5869s, get_block_records_by_hash
27.0924s, get_blocks_by_hash
2.5805s, get_block_record
0.3015s, get_block_records_in_range
0.0028s, get_block_records_close_to_peak
2.0521s, get_block_record
44.9901s, get_random_not_compactified
all tests completed in 153.1677s
database size: 352.260 MB
```