### PR TITLE
Remove mempool checking for exact replacement set

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -199,6 +199,13 @@ class MempoolManager:
         # 0.00001 XCH
         return 10000000
 
+    ###
+    # There used to be logic in this function that banned replacements if the new item wasn't a superset of the old item
+    # That logic was removed because when spendbundles are distributed outside of the mempool there's a possible
+    # minor attack in which someone could push your spend bundle with an additional coin of their own and a
+    # low or zero fee.  This would mean you can never replace-by-fee your own coins because you can never spend a
+    # superset and your coins would remain locked until the low fee transaction goes through.
+    ###
     def can_replace(
         self,
         conflicting_items: Dict[bytes32, MempoolItem],

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -212,13 +212,6 @@ class MempoolManager:
             conflicting_fees += item.fee
             conflicting_cost += item.cost
 
-            # All coins spent in all conflicting items must also be spent in
-            # the new item
-            for coin in item.removals:
-                if coin.name() not in removals:
-                    log.debug(f"Rejecting conflicting tx as it does not spend conflicting coin {coin.name()}")
-                    return False
-
         # New item must have higher fee per cost
         conflicting_fees_per_cost = conflicting_fees / conflicting_cost
         if fees_per_cost <= conflicting_fees_per_cost:

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -407,14 +407,13 @@ class TestMempoolManager:
         sb23 = SpendBundle.aggregate((sb2, sb3))
         await self.send_sb(full_node_1, sb23)
 
-        # sb23 must not replace existing sb12 as the former does not spend all
-        # coins that are spent in the latter (specifically, coin1)
-        self.assert_sb_in_pool(full_node_1, sb12)
-        self.assert_sb_not_in_pool(full_node_1, sb23)
+        # sb23 should replace existing sb12 even though it is not a superset
+        self.assert_sb_not_in_pool(full_node_1, sb12)
+        self.assert_sb_in_pool(full_node_1, sb23)
 
-        await self.send_sb(full_node_1, sb3)
-        # Adding non-conflicting sb3 should succeed
-        self.assert_sb_in_pool(full_node_1, sb3)
+        sb1_4 = await self.gen_and_send_sb(full_node_1, peer, coin1, fee=uint64(min_fee_increase))
+        # Adding non-conflicting sb1_4 should succeed
+        self.assert_sb_in_pool(full_node_1, sb1_4)
 
         sb4_1 = generate_test_spend_bundle(coin4, fee=uint64(min_fee_increase))
         sb1234_1 = SpendBundle.aggregate((sb12, sb3, sb4_1))


### PR DESCRIPTION
Right now the mempool checks that a spend bundle that is meant to replace another spend bundle has the exact same coins being spent within it.  I'm not sure what the reason for this is, but it creates a problem when thinking about offers:

If someone (maker) makes an offer, they create a partial spend bundle.  If someone (taker) then takes the offer, they fill the spend bundle in with their own coins in addition to the coins of the maker.  The taker could push the now complete offer into the mempool with zero fee and have it sit there for potentially hours.  Meanwhile, the maker sees a drop in the price of the asset they were requesting, so they go to create a transaction which cancels their offer at all cost (a fee of 1XCH we'll say).  The maker's cancellation spend bundle can never make it into the mempool with the current logic.  They can only cancel their coins, not the ones the taker added, and they are therefore ineligible to replace the slow transaction because they cannot spend the exact set of coins. 