### PR TITLE
Remove block records table

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -31,22 +31,20 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
 
+            # TODO: most data in block is duplicated in block_record. The only
+            # reason for this is that our parsing of a FullBlock is so slow,
+            # it's faster to store duplicate data to parse less when we just
+            # need the BlockRecord. Once we fix the parsing (and data structure)
+            # of FullBlock, this can use less space
             await self.db.execute(
                 "CREATE TABLE IF NOT EXISTS full_blocks("
                 "header_hash blob PRIMARY KEY,"
-                "height bigint,"
-                "is_fully_compactified tinyint,"
-                "block blob)"
-            )
-
-            # Block records
-            await self.db.execute(
-                "CREATE TABLE IF NOT EXISTS block_records("
-                "header_hash blob PRIMARY KEY,"
                 "prev_hash blob,"
                 "height bigint,"
+                "sub_epoch_summary blob,"
+                "is_fully_compactified tinyint,"
                 "block blob,"
-                "sub_epoch_summary blob)"
+                "block_record blob)"
             )
 
             # This is a single-row table containing the hash of the current
@@ -61,11 +59,10 @@ class BlockStore:
             )
 
             # Height index so we can look up in order of height for sync purposes
-            await self.db.execute("CREATE INDEX IF NOT EXISTS full_block_height on full_blocks(height)")
+            await self.db.execute("CREATE INDEX IF NOT EXISTS height on full_blocks(height)")
             await self.db.execute(
                 "CREATE INDEX IF NOT EXISTS is_fully_compactified on full_blocks(is_fully_compactified)"
             )
-            await self.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
 
         else:
 
@@ -135,30 +132,27 @@ class BlockStore:
         self.block_cache.put(header_hash, block)
 
         if self.db_wrapper.db_version == 2:
-            cursor_1 = await self.db.execute(
-                "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?)",
-                (
-                    header_hash,
-                    block.height,
-                    int(block.is_fully_compactified()),
-                    self.compress(block),
-                ),
-            )
-            await cursor_1.close()
 
-            cursor_2 = await self.db.execute(
-                "INSERT OR REPLACE INTO block_records VALUES(?, ?, ?, ?, ?)",
+            ses: Optional[bytes] = (
+                None
+                if block_record.sub_epoch_summary_included is None
+                else bytes(block_record.sub_epoch_summary_included)
+            )
+
+            cursor_1 = await self.db.execute(
+                "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?)",
                 (
                     header_hash,
                     block.prev_header_hash,
                     block.height,
+                    ses,
+                    int(block.is_fully_compactified()),
+                    self.compress(block),
                     bytes(block_record),
-                    None
-                    if block_record.sub_epoch_summary_included is None
-                    else bytes(block_record.sub_epoch_summary_included),
                 ),
             )
-            await cursor_2.close()
+            await cursor_1.close()
+
         else:
             cursor_1 = await self.db.execute(
                 "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
@@ -282,19 +276,27 @@ class BlockStore:
         if len(header_hashes) == 0:
             return []
 
-        header_hashes_db: Tuple[Any, ...]
-        if self.db_wrapper.db_version == 2:
-            header_hashes_db = tuple(header_hashes)
-        else:
-            header_hashes_db = tuple([hh.hex() for hh in header_hashes])
-        formatted_str = f'SELECT block from block_records WHERE header_hash in ({"?," * (len(header_hashes_db) - 1)}?)'
-        cursor = await self.db.execute(formatted_str, header_hashes_db)
-        rows = await cursor.fetchall()
-        await cursor.close()
         all_blocks: Dict[bytes32, BlockRecord] = {}
-        for row in rows:
-            block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
-            all_blocks[block_rec.header_hash] = block_rec
+        if self.db_wrapper.db_version == 2:
+            cursor = await self.db.execute(
+                "SELECT header_hash,block_record FROM full_blocks "
+                f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
+                tuple(header_hashes),
+            )
+            rows = await cursor.fetchall()
+            await cursor.close()
+            for row in rows:
+                header_hash = bytes32(row[0])
+                all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
+        else:
+            formatted_str = f'SELECT block from block_records WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)'
+            cursor = await self.db.execute(formatted_str, tuple([hh.hex() for hh in header_hashes]))
+            rows = await cursor.fetchall()
+            await cursor.close()
+            for row in rows:
+                block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
+                all_blocks[block_rec.header_hash] = block_rec
+
         ret: List[BlockRecord] = []
         for hh in header_hashes:
             if hh not in all_blocks:
@@ -338,14 +340,27 @@ class BlockStore:
         return ret
 
     async def get_block_record(self, header_hash: bytes32) -> Optional[BlockRecord]:
-        cursor = await self.db.execute(
-            "SELECT block from block_records WHERE header_hash=?",
-            (self.maybe_to_hex(header_hash),),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
-        if row is not None:
-            return BlockRecord.from_bytes(row[0])
+
+        if self.db_wrapper.db_version == 2:
+
+            cursor = await self.db.execute(
+                "SELECT block_record FROM full_blocks WHERE header_hash=?",
+                (header_hash,),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
+            if row is not None:
+                return BlockRecord.from_bytes(row[0])
+
+        else:
+            cursor = await self.db.execute(
+                "SELECT block from block_records WHERE header_hash=?",
+                (header_hash.hex(),),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
+            if row is not None:
+                return BlockRecord.from_bytes(row[0])
         return None
 
     async def get_block_records_in_range(
@@ -358,17 +373,29 @@ class BlockStore:
         if present.
         """
 
-        formatted_str = f"SELECT header_hash, block from block_records WHERE height >= {start} and height <= {stop}"
-
-        cursor = await self.db.execute(formatted_str)
-        rows = await cursor.fetchall()
-        await cursor.close()
         ret: Dict[bytes32, BlockRecord] = {}
-        for row in rows:
-            # TODO: address hint error and remove ignore
-            #       error: Invalid index type "bytes" for "Dict[bytes32, BlockRecord]"; expected type "bytes32"  [index]
-            header_hash = self.maybe_from_hex(row[0])
-            ret[header_hash] = BlockRecord.from_bytes(row[1])  # type: ignore[index]
+        if self.db_wrapper.db_version == 2:
+
+            cursor = await self.db.execute(
+                "SELECT header_hash, block_record FROM full_blocks WHERE height >= ? AND height <= ?",
+                (start, stop),
+            )
+            rows = await cursor.fetchall()
+            await cursor.close()
+            for row in rows:
+                header_hash = bytes32(row[0])
+                ret[header_hash] = BlockRecord.from_bytes(row[1])
+
+        else:
+
+            formatted_str = f"SELECT header_hash, block from block_records WHERE height >= {start} and height <= {stop}"
+
+            cursor = await self.db.execute(formatted_str)
+            rows = await cursor.fetchall()
+            await cursor.close()
+            for row in rows:
+                header_hash = bytes32(self.maybe_from_hex(row[0]))
+                ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret
 
@@ -406,14 +433,27 @@ class BlockStore:
         if peak is None:
             return {}, None
 
-        formatted_str = f"SELECT header_hash, block  from block_records WHERE height >= {peak[1] - blocks_n}"
-        cursor = await self.db.execute(formatted_str)
-        rows = await cursor.fetchall()
-        await cursor.close()
         ret: Dict[bytes32, BlockRecord] = {}
-        for row in rows:
-            header_hash = bytes32(self.maybe_from_hex(row[0]))
-            ret[header_hash] = BlockRecord.from_bytes(row[1])
+        if self.db_wrapper.db_version == 2:
+
+            cursor = await self.db.execute(
+                "SELECT header_hash, block_record FROM full_blocks WHERE height >= ?",
+                (peak[1] - blocks_n,),
+            )
+            rows = await cursor.fetchall()
+            await cursor.close()
+            for row in rows:
+                header_hash = bytes32(row[0])
+                ret[header_hash] = BlockRecord.from_bytes(row[1])
+
+        else:
+            formatted_str = f"SELECT header_hash, block  from block_records WHERE height >= {peak[1] - blocks_n}"
+            cursor = await self.db.execute(formatted_str)
+            rows = await cursor.fetchall()
+            await cursor.close()
+            for row in rows:
+                header_hash = bytes32(self.maybe_from_hex(row[0]))
+                ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret, peak[0]
 


### PR DESCRIPTION
The rationale for this patch is to simplify the database and make it smaller. The key (`header_hash`) in both `block_records` and `full_blocks` tables are 32 bytes, and by storing the block_records in the same table as the full blocks, we only need a single copy of those keys.

The first version of this patch removed the serialization of the BlockRecord object entirely, and rebuilt it, on demand, from the FullBlock object. However, until we fix parsing the FullBlock performance issue, that takes too long. It made the benchmark take a lot longer.

This patch, instead, stores the BlockRecord in the same table as the full block, meaning it can use the same header_hash key as the full block.

It's hard to explain why this makes the table slightly larger. If anything it should make it smaller. Perhaps there's some sqlite implementation detail or a scale issue (perhaps the difference is only observed at a larger scale than the benchmark).

Note that the main contributor to slowing down the benchmarks is the `get_random_not_compactified` test. I have another patch to improve this, by adding a column to indicate whether a block is part of the main chain or not.

test  | before | after | after / before
---|---|---|---
table size | 352.5 MB | 357.4 MB | 101.4%
Ryzen, fast SSD | 308.8 s | 317.5 s | 102.8%
RPi, SD card | 1614.2s | 1381.3s | 116.9 %

# raw benchmark output

this patch:

Ryzen, fast SSD:

```
version 2
46.2831s, add_full_block
52.6006s, get_full_block
5.3804s, get_full_block_bytes
51.5568s, get_full_blocks_at
6.3655s, get_block_records_by_hash
52.9810s, get_blocks_by_hash
5.6967s, get_block_record
0.6920s, get_block_records_in_range
0.0064s, get_block_records_close_to_peak
4.2865s, get_block_record
91.6701s, get_random_not_compactified
all tests completed in 317.5190s
database size: 357.372 MB
```

RPi, SD card:

```
version 2
262.1600s, add_full_block
202.8422s, get_full_block
23.8295s, get_full_block_bytes
198.1242s, get_full_blocks_at
26.1504s, get_block_records_by_hash
203.2471s, get_blocks_by_hash
25.6698s, get_block_record
3.4417s, get_block_records_in_range
0.0343s, get_block_records_close_to_peak
17.4574s, get_block_record
651.2877s, get_random_not_compactified
all tests completed in 1614.2444s
database size: 357.372 MB
```

previous commit:

Ryzen, fast SSD:

```
version 2
56.3806s, add_full_block
53.0442s, get_full_block
5.1803s, get_full_block_bytes
50.1041s, get_full_blocks_at
6.8339s, get_block_records_by_hash
52.6259s, get_blocks_by_hash
6.3245s, get_block_record
0.6537s, get_block_records_in_range
0.0056s, get_block_records_close_to_peak
4.9460s, get_block_record
72.6523s, get_random_not_compactified
all tests completed in 308.7509s
database size: 352.473 MB
```

RPi, SD card:

```
version 2
305.0027s, add_full_block
204.0082s, get_full_block
24.1904s, get_full_block_bytes
198.7703s, get_full_blocks_at
24.1730s, get_block_records_by_hash
204.2618s, get_blocks_by_hash
24.6884s, get_block_record
2.8021s, get_block_records_in_range
0.0261s, get_block_records_close_to_peak
18.0473s, get_block_record
375.3662s, get_random_not_compactified
all tests completed in 1381.3366s
database size: 352.473 MB

```
