### PR TITLE
build_scripts: Only copy `win_code_sign_cert.p12` if we have secrets

### DIFF
--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -89,7 +89,9 @@ Write-Output "   ---"
 Copy-Item "dist\daemon" -Destination "..\chia-blockchain-gui\packages\gui\" -Recurse
 Set-Location -Path "..\chia-blockchain-gui" -PassThru
 # We need the code sign cert in the gui subdirectory so we can actually sign the UI package
-Copy-Item "win_code_sign_cert.p12" -Destination "packages\gui\"
+If ($env:HAS_SECRET) {
+    Copy-Item "win_code_sign_cert.p12" -Destination "packages\gui\"
+}
 
 git status
 


### PR DESCRIPTION
PRs from forked `chia-blockchain` repos don't have the cert available which leads to the installer step to fail, see  https://github.com/Chia-Network/chia-blockchain/runs/4465950001

Follow-up for #9506.