### PR TITLE
Add TLS version to collected crawler stats

### DIFF
--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -77,6 +77,7 @@ class Crawler:
 
     async def connect_task(self, peer):
         async def peer_action(peer: ws.WSChiaConnection):
+
             peer_info = peer.get_peer_info()
             version = peer.get_version()
             if peer_info is not None and version is not None:
@@ -136,6 +137,7 @@ class Crawler:
                     uint64(0),
                     "undefined",
                     uint64(0),
+                    tls_version="unknown",
                 )
                 new_peer_reliability = PeerReliability(peer)
                 self.crawl_store.maybe_add_peer(new_peer, new_peer_reliability)
@@ -184,6 +186,7 @@ class Crawler:
                                 uint64(response_peer.timestamp),
                                 "undefined",
                                 uint64(0),
+                                tls_version="unknown",
                             )
                             new_peer_reliability = PeerReliability(response_peer.host)
                             if self.crawl_store is not None:
@@ -303,11 +306,14 @@ class Crawler:
     async def new_peak(self, request: full_node_protocol.NewPeak, peer: ws.WSChiaConnection):
         try:
             peer_info = peer.get_peer_info()
+            tls_version = peer.get_tls_version()
+            if tls_version is None:
+                tls_version = "unknown"
             if peer_info is None:
                 return
             if request.height >= self.minimum_height:
                 if self.crawl_store is not None:
-                    await self.crawl_store.peer_connected_hostname(peer_info.host, True)
+                    await self.crawl_store.peer_connected_hostname(peer_info.host, True, tls_version)
             self.with_peak.add(peer_info)
         except Exception as e:
             self.log.error(f"Exception: {e}. Traceback: {traceback.format_exc()}.")

--- a/chia/seeder/peer_record.py
+++ b/chia/seeder/peer_record.py
@@ -20,6 +20,7 @@ class PeerRecord(Streamable):
     best_timestamp: uint64
     version: str
     handshake_time: uint64
+    tls_version: str
 
     def update_version(self, version, now):
         if version != "undefined":

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -57,6 +57,7 @@ class WSChiaConnection:
         self.peer_host = peer_host
 
         peername = self.ws._writer.transport.get_extra_info("peername")
+
         if peername is None:
             raise ValueError(f"Was not able to get peername from {self.peer_host}")
 
@@ -510,6 +511,13 @@ class WSChiaConnection:
     # Used by the Chia Seeder.
     def get_version(self):
         return self.version
+
+    def get_tls_version(self) -> str:
+        ssl_obj = self.ws._writer.transport.get_extra_info("ssl_object")
+        if ssl_obj is not None:
+            return ssl_obj.version()
+        else:
+            return "unknown"
 
     def get_peer_info(self) -> Optional[PeerInfo]:
         result = self.ws._writer.transport.get_extra_info("peername")


### PR DESCRIPTION
Add TLS version to crawler stats.
Add new column to record the value of the TLS version
This is only recorded for "connected" clients, which for the purposes of the crawler only happens if they respond with a NewPeak message