### PR TITLE
when validating blocks in the blockchain, we don't use strict-mode

### DIFF
--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -82,7 +82,7 @@ def batch_pre_validate_blocks(
                         block_generator,
                         min(constants.MAX_BLOCK_COST_CLVM, block.transactions_info.cost),
                         cost_per_byte=constants.COST_PER_BYTE,
-                        safe_mode=True,
+                        safe_mode=False,
                     )
                     removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
 


### PR DESCRIPTION
aka safe mode