### PR TITLE
unify the name we use for strict/safe mode

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -322,7 +322,7 @@ async def validate_block_body(
                     curr_block_generator,
                     min(constants.MAX_BLOCK_COST_CLVM, curr.transactions_info.cost),
                     cost_per_byte=constants.COST_PER_BYTE,
-                    safe_mode=False,
+                    mempool_mode=False,
                 )
                 removals_in_curr, additions_in_curr = tx_removals_and_additions(curr_npc_result.npc_list)
             else:

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -135,7 +135,7 @@ def create_foliage(
                 block_generator,
                 constants.MAX_BLOCK_COST_CLVM,
                 cost_per_byte=constants.COST_PER_BYTE,
-                safe_mode=True,
+                mempool_mode=True,
             )
             cost = calculate_cost_of_program(block_generator.program, result, constants.COST_PER_BYTE)
 

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -222,7 +222,7 @@ class Blockchain(BlockchainInterface):
                         block_generator,
                         min(self.constants.MAX_BLOCK_COST_CLVM, block.transactions_info.cost),
                         cost_per_byte=self.constants.COST_PER_BYTE,
-                        safe_mode=False,
+                        mempool_mode=False,
                     )
                     removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
                 else:
@@ -470,7 +470,7 @@ class Blockchain(BlockchainInterface):
                         block_generator,
                         self.constants.MAX_BLOCK_COST_CLVM,
                         cost_per_byte=self.constants.COST_PER_BYTE,
-                        safe_mode=False,
+                        mempool_mode=False,
                     )
                 tx_removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
                 return tx_removals, tx_additions, npc_result

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -82,7 +82,7 @@ def batch_pre_validate_blocks(
                         block_generator,
                         min(constants.MAX_BLOCK_COST_CLVM, block.transactions_info.cost),
                         cost_per_byte=constants.COST_PER_BYTE,
-                        safe_mode=False,
+                        mempool_mode=False,
                     )
                     removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
 
@@ -344,7 +344,7 @@ def _run_generator(
             block_generator,
             min(constants.MAX_BLOCK_COST_CLVM, unfinished_block.transactions_info.cost),
             cost_per_byte=constants.COST_PER_BYTE,
-            safe_mode=False,
+            mempool_mode=False,
         )
         if npc_result.error is not None:
             return Err(npc_result.error), None

--- a/chia/full_node/generator.py
+++ b/chia/full_node/generator.py
@@ -62,9 +62,9 @@ def setup_generator_args(self: BlockGenerator) -> Tuple[SerializedProgram, Progr
     return self.program, args
 
 
-def run_generator(self: BlockGenerator, max_cost: int) -> Tuple[int, SerializedProgram]:
+def run_generator_mempool(self: BlockGenerator, max_cost: int) -> Tuple[int, SerializedProgram]:
     program, args = setup_generator_args(self)
-    return GENERATOR_MOD.run_safe_with_cost(max_cost, program, args)
+    return GENERATOR_MOD.run_mempool_with_cost(max_cost, program, args)
 
 
 def run_generator_unsafe(self: BlockGenerator, max_cost: int) -> Tuple[int, SerializedProgram]:

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -18,7 +18,7 @@ from chia.wallet.puzzles.generator_loader import GENERATOR_FOR_SINGLE_COIN_MOD
 from chia.wallet.puzzles.rom_bootstrap_generator import get_generator
 
 GENERATOR_MOD = get_generator()
-
+MEMPOOL_MODE = STRICT_MODE
 
 log = logging.getLogger(__name__)
 
@@ -89,14 +89,14 @@ def mempool_assert_relative_time_exceeds(
 
 
 def get_name_puzzle_conditions(
-    generator: BlockGenerator, max_cost: int, *, cost_per_byte: int, safe_mode: bool
+    generator: BlockGenerator, max_cost: int, *, cost_per_byte: int, mempool_mode: bool
 ) -> NPCResult:
     block_program, block_program_args = setup_generator_args(generator)
     max_cost -= len(bytes(generator.program)) * cost_per_byte
     if max_cost < 0:
         return NPCResult(uint16(Err.INVALID_BLOCK_COST.value), [], uint64(0))
 
-    flags = STRICT_MODE if safe_mode else 0
+    flags = MEMPOOL_MODE if mempool_mode else 0
     try:
         err, result, clvm_cost = GENERATOR_MOD.run_as_generator(max_cost, flags, block_program, block_program_args)
         if err is not None:

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from typing import Dict, List, Optional
-from clvm_rs import STRICT_MODE
+from clvm_rs import STRICT_MODE as MEMPOOL_MODE
 
 from chia.consensus.cost_calculator import NPCResult
 from chia.full_node.generator import create_generator_args, setup_generator_args
@@ -18,7 +18,6 @@ from chia.wallet.puzzles.generator_loader import GENERATOR_FOR_SINGLE_COIN_MOD
 from chia.wallet.puzzles.rom_bootstrap_generator import get_generator
 
 GENERATOR_MOD = get_generator()
-MEMPOOL_MODE = STRICT_MODE
 
 log = logging.getLogger(__name__)
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -50,7 +50,9 @@ def validate_clvm_and_signature(
         bundle: SpendBundle = SpendBundle.from_bytes(spend_bundle_bytes)
         program = simple_solution_generator(bundle)
         # npc contains names of the coins removed, puzzle_hashes and their spend conditions
-        result: NPCResult = get_name_puzzle_conditions(program, max_cost, cost_per_byte=cost_per_byte, safe_mode=True)
+        result: NPCResult = get_name_puzzle_conditions(
+            program, max_cost, cost_per_byte=cost_per_byte, mempool_mode=True
+        )
 
         if result.error is not None:
             return Err(result.error), b"", {}

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -7,7 +7,7 @@ from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
 from clvm.operators import OP_REWRITE, OPERATOR_LOOKUP
 from clvm.serialize import sexp_from_stream, sexp_to_stream
-from clvm_rs import STRICT_MODE, deserialize_and_run_program2, serialized_length, run_generator
+from clvm_rs import STRICT_MODE as MEMPOOL_MODE, deserialize_and_run_program2, serialized_length, run_generator
 from clvm_tools.curry import curry, uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -34,7 +34,6 @@ def run_program(
 
 
 INFINITE_COST = 0x7FFFFFFFFFFFFFFF
-MEMPOOL_MODE = STRICT_MODE
 
 
 class Program(SExp):

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -34,6 +34,7 @@ def run_program(
 
 
 INFINITE_COST = 0x7FFFFFFFFFFFFFFF
+MEMPOOL_MODE = STRICT_MODE
 
 
 class Program(SExp):
@@ -237,8 +238,8 @@ class SerializedProgram:
         tmp = sexp_from_stream(io.BytesIO(self._buf), SExp.to)
         return _tree_hash(tmp, set(args))
 
-    def run_safe_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
-        return self._run(max_cost, STRICT_MODE, *args)
+    def run_mempool_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
+        return self._run(max_cost, MEMPOOL_MODE, *args)
 
     def run_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
         return self._run(max_cost, 0, *args)

--- a/chia/wallet/cc_wallet/cc_wallet.py
+++ b/chia/wallet/cc_wallet/cc_wallet.py
@@ -261,7 +261,7 @@ class CCWallet:
                 program,
                 self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM,
                 cost_per_byte=self.wallet_state_manager.constants.COST_PER_BYTE,
-                safe_mode=True,
+                mempool_mode=True,
             )
             cost_result: uint64 = calculate_cost_of_program(
                 program.program, result, self.wallet_state_manager.constants.COST_PER_BYTE

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -81,7 +81,7 @@ class Wallet:
                 program,
                 self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM,
                 cost_per_byte=self.wallet_state_manager.constants.COST_PER_BYTE,
-                safe_mode=True,
+                mempool_mode=True,
             )
             cost_result: uint64 = calculate_cost_of_program(
                 program.program, result, self.wallet_state_manager.constants.COST_PER_BYTE

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -1568,7 +1568,7 @@ def get_full_block_and_block_record(
 def compute_cost_test(generator: BlockGenerator, cost_per_byte: int) -> Tuple[Optional[uint16], uint64]:
     try:
         block_program, block_program_args = setup_generator_args(generator)
-        clvm_cost, result = GENERATOR_MOD.run_safe_with_cost(INFINITE_COST, block_program, block_program_args)
+        clvm_cost, result = GENERATOR_MOD.run_mempool_with_cost(INFINITE_COST, block_program, block_program_args)
         size_cost = len(bytes(generator.program)) * cost_per_byte
         condition_cost = 0
 

--- a/tests/clvm/coin_store.py
+++ b/tests/clvm/coin_store.py
@@ -64,7 +64,9 @@ class CoinStore:
         # this should use blockchain consensus code
 
         program = simple_solution_generator(spend_bundle)
-        result: NPCResult = get_name_puzzle_conditions(program, max_cost, cost_per_byte=cost_per_byte, safe_mode=True)
+        result: NPCResult = get_name_puzzle_conditions(
+            program, max_cost, cost_per_byte=cost_per_byte, mempool_mode=True
+        )
         if result.error is not None:
             raise BadSpendBundleError(f"condition validation failure {Err(result.error)}")
 

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -106,7 +106,7 @@ class TestCoinStoreWithBlocks:
                             block_gen,
                             bt.constants.MAX_BLOCK_COST_CLVM,
                             cost_per_byte=bt.constants.COST_PER_BYTE,
-                            safe_mode=False,
+                            mempool_mode=False,
                         )
                         tx_removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
                     else:

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -1688,7 +1688,7 @@ MAX_BLOCK_COST_CLVM = 11000000000
 def generator_condition_tester(
     conditions: str,
     *,
-    safe_mode: bool = False,
+    mempool_mode: bool = False,
     quote: bool = True,
     max_cost: int = MAX_BLOCK_COST_CLVM,
 ) -> NPCResult:
@@ -1698,7 +1698,7 @@ def generator_condition_tester(
     generator = BlockGenerator(program, [])
     print(f"len: {len(bytes(program))}")
     npc_result: NPCResult = get_name_puzzle_conditions(
-        generator, max_cost, cost_per_byte=COST_PER_BYTE, safe_mode=safe_mode
+        generator, max_cost, cost_per_byte=COST_PER_BYTE, mempool_mode=mempool_mode
     )
     return npc_result
 
@@ -1863,7 +1863,7 @@ class TestGeneratorConditions:
         )
         generator = BlockGenerator(program, [])
         npc_result: NPCResult = get_name_puzzle_conditions(
-            generator, MAX_BLOCK_COST_CLVM, cost_per_byte=COST_PER_BYTE, safe_mode=False
+            generator, MAX_BLOCK_COST_CLVM, cost_per_byte=COST_PER_BYTE, mempool_mode=False
         )
         assert npc_result.error is None
         assert len(npc_result.npc_list) == 2
@@ -1924,14 +1924,14 @@ class TestGeneratorConditions:
         )
 
     @pytest.mark.parametrize(
-        "safe_mode",
+        "mempool_mode",
         [True, False],
     )
-    def test_unknown_condition(self, safe_mode):
+    def test_unknown_condition(self, mempool_mode):
         for c in ['(1 100 "foo" "bar")', "(100)", "(1 1) (2 2) (3 3)", '("foobar")']:
-            npc_result = generator_condition_tester(c, safe_mode=safe_mode)
+            npc_result = generator_condition_tester(c, mempool_mode=mempool_mode)
             print(npc_result)
-            if safe_mode:
+            if mempool_mode:
                 assert npc_result.error == Err.INVALID_CONDITION.value
                 assert npc_result.npc_list == []
             else:

--- a/tests/generator/test_compression.py
+++ b/tests/generator/test_compression.py
@@ -11,7 +11,7 @@ from chia.full_node.bundle_tools import (
     simple_solution_generator,
     spend_bundle_to_serialized_coin_spend_entry_list,
 )
-from chia.full_node.generator import run_generator, create_generator_args
+from chia.full_node.generator import run_generator_unsafe, create_generator_args
 from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
 from chia.types.blockchain_format.program import Program, SerializedProgram, INFINITE_COST
 from chia.types.generator_types import BlockGenerator, CompressorArg, GeneratorArg
@@ -117,7 +117,7 @@ class TestCompression(TestCase):
             gen_args = MultipleCompressorArg([ca1, ca2], split_offset)
             spend_bundle: SpendBundle = make_spend_bundle(1)
             multi_gen = create_multiple_ref_generator(gen_args, spend_bundle)
-            cost, result = run_generator(multi_gen, INFINITE_COST)
+            cost, result = run_generator_unsafe(multi_gen, INFINITE_COST)
             results.append(result)
             assert result is not None
             assert cost > 0
@@ -130,8 +130,8 @@ class TestCompression(TestCase):
         c = compressed_spend_bundle_solution(ca, sb)
         s = simple_solution_generator(sb)
         assert c != s
-        cost_c, result_c = run_generator(c, INFINITE_COST)
-        cost_s, result_s = run_generator(s, INFINITE_COST)
+        cost_c, result_c = run_generator_unsafe(c, INFINITE_COST)
+        cost_s, result_s = run_generator_unsafe(s, INFINITE_COST)
         print(result_c)
         assert result_c is not None
         assert result_s is not None

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -1,7 +1,7 @@
 from clvm_tools import binutils
 from clvm_tools.clvmc import compile_clvm_text
 
-from chia.full_node.generator import run_generator
+from chia.full_node.generator import run_generator_unsafe
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -97,10 +97,10 @@ class TestROM:
         # this tests that extra block or coin data doesn't confuse `get_name_puzzle_conditions`
 
         gen = block_generator()
-        cost, r = run_generator(gen, max_cost=MAX_COST)
+        cost, r = run_generator_unsafe(gen, max_cost=MAX_COST)
         print(r)
 
-        npc_result = get_name_puzzle_conditions(gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, safe_mode=False)
+        npc_result = get_name_puzzle_conditions(gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, mempool_mode=False)
         assert npc_result.error is None
         assert npc_result.clvm_cost == EXPECTED_COST
         cond_1 = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bytes([0] * 31 + [1]), int_to_bytes(500), b""])
@@ -120,7 +120,7 @@ class TestROM:
         # the ROM supports extra data after a coin. This test checks that it actually gets passed through
 
         gen = block_generator()
-        cost, r = run_generator(gen, max_cost=MAX_COST)
+        cost, r = run_generator_unsafe(gen, max_cost=MAX_COST)
         coin_spends = r.first()
         for coin_spend in coin_spends.as_iter():
             extra_data = coin_spend.rest().rest().rest().rest()
@@ -130,6 +130,6 @@ class TestROM:
         # the ROM supports extra data after the coin spend list. This test checks that it actually gets passed through
 
         gen = block_generator()
-        cost, r = run_generator(gen, max_cost=MAX_COST)
+        cost, r = run_generator_unsafe(gen, max_cost=MAX_COST)
         extra_block_data = r.rest()
         assert extra_block_data.as_atom_list() == b"extra data for block".split()

--- a/tests/util/generator_tools_testing.py
+++ b/tests/util/generator_tools_testing.py
@@ -9,7 +9,7 @@ from chia.util.generator_tools import additions_for_npc
 
 
 def run_and_get_removals_and_additions(
-    block: FullBlock, max_cost: int, cost_per_byte: int, safe_mode=False
+    block: FullBlock, max_cost: int, cost_per_byte: int, mempool_mode=False
 ) -> Tuple[List[bytes32], List[Coin]]:
     removals: List[bytes32] = []
     additions: List[Coin] = []
@@ -23,7 +23,7 @@ def run_and_get_removals_and_additions(
             BlockGenerator(block.transactions_generator, []),
             max_cost,
             cost_per_byte=cost_per_byte,
-            safe_mode=safe_mode,
+            mempool_mode=mempool_mode,
         )
         # build removals list
         for npc in npc_result.npc_list:


### PR DESCRIPTION
We currently call this, strict mode, safe mode, safe and unsafe. Neither of these names are very descriptive. This patch renames this mode to mempool-mode.

I think "unsafe" is especially misleading. It should probably be just removed (and just be implied), but it might make sense to have an explicit name for non-mempool or maybe blockchain.