### PR TITLE
In main chain

### DIFF
--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -232,6 +232,7 @@ async def run_add_block_benchmark(version: int):
                 full_block,
                 record,
             )
+            await block_store.set_in_chain([(header_hash,)])
             header_hashes.append(header_hash)
             await block_store.set_peak(header_hash)
             await db_wrapper.db.commit()

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -363,6 +363,7 @@ class Blockchain(BlockchainInterface):
                     )
                 else:
                     added, _ = [], []
+                await self.block_store.set_in_chain([(block_record.header_hash,)])
                 await self.block_store.set_peak(block_record.header_hash)
                 return uint32(0), uint32(0), [block_record], (added, {})
             return None, None, [], ([], {})
@@ -385,6 +386,7 @@ class Blockchain(BlockchainInterface):
 
             # Rollback sub_epoch_summaries
             self.__height_map.rollback(fork_height)
+            await self.block_store.rollback(fork_height)
 
             # Collect all blocks from fork point to new peak
             blocks_to_add: List[Tuple[FullBlock, BlockRecord]] = []
@@ -445,6 +447,8 @@ class Blockchain(BlockchainInterface):
                             if key not in hint_coin_state:
                                 hint_coin_state[key] = {}
                             hint_coin_state[key][coin_id] = lastest_coin_state[coin_id]
+
+            await self.block_store.set_in_chain([(br.header_hash,) for br in records_to_add])
 
             # Changes the peak to be the new peak
             await self.block_store.set_peak(block_record.header_hash)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -12,7 +12,7 @@ from blspy import AugSchemeMPL, G2Element
 from clvm.casts import int_to_bytes
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward
-from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.blockchain import ReceiveBlockResult, Blockchain
 from chia.consensus.coinbase import create_farmer_coin
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.bundle_tools import detect_potential_template_generator
@@ -1645,6 +1645,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -1674,6 +1675,7 @@ class TestBodyValidation:
             time_per_block=10,
         )
         assert (await b.receive_block(blocks[-1]))[0:-1] == expected
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -1710,6 +1712,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -1732,6 +1735,7 @@ class TestBodyValidation:
             time_per_block=10,
         )
         assert (await b.receive_block(blocks[-1]))[0] == expected
+        await check_block_store_invariant(b)
 
         if expected == ReceiveBlockResult.NEW_PEAK:
             # ensure coin1 was in fact spent
@@ -1749,10 +1753,12 @@ class TestBodyValidation:
         while blocks[-1].foliage_transaction_block is not None:
             assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
             blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
+        await check_block_store_invariant(b)
         original_block: FullBlock = blocks[-1]
 
         block = recursive_replace(original_block, "transactions_generator", SerializedProgram())
         assert (await b.receive_block(block))[1] == Err.NOT_BLOCK_BUT_HAS_DATA
+        await check_block_store_invariant(b)
         h = std_hash(b"")
         i = uint64(1)
         block = recursive_replace(
@@ -1761,9 +1767,11 @@ class TestBodyValidation:
             TransactionsInfo(h, h, G2Element(), uint64(1), uint64(1), []),
         )
         assert (await b.receive_block(block))[1] == Err.NOT_BLOCK_BUT_HAS_DATA
+        await check_block_store_invariant(b)
 
         block = recursive_replace(original_block, "transactions_generator_ref_list", [i])
         assert (await b.receive_block(block))[1] == Err.NOT_BLOCK_BUT_HAS_DATA
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_tx_block_missing_data(self, empty_blockchain):
@@ -1771,6 +1779,7 @@ class TestBodyValidation:
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
         block = recursive_replace(
             blocks[-1],
             "foliage_transaction_block",
@@ -1778,6 +1787,7 @@ class TestBodyValidation:
         )
         err = (await b.receive_block(block))[1]
         assert err == Err.IS_TRANSACTION_BLOCK_BUT_NO_DATA or err == Err.INVALID_FOLIAGE_BLOCK_PRESENCE
+        await check_block_store_invariant(b)
 
         block = recursive_replace(
             blocks[-1],
@@ -1789,6 +1799,7 @@ class TestBodyValidation:
         except AssertionError:
             return None
         assert err == Err.IS_TRANSACTION_BLOCK_BUT_NO_DATA or err == Err.INVALID_FOLIAGE_BLOCK_PRESENCE
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_invalid_transactions_info_hash(self, empty_blockchain):
@@ -1796,6 +1807,7 @@ class TestBodyValidation:
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
         h = std_hash(b"")
         block = recursive_replace(
             blocks[-1],
@@ -1811,6 +1823,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block))[1]
         assert err == Err.INVALID_TRANSACTIONS_INFO_HASH
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_invalid_transactions_block_hash(self, empty_blockchain):
@@ -1818,6 +1831,7 @@ class TestBodyValidation:
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
         h = std_hash(b"")
         block = recursive_replace(blocks[-1], "foliage.foliage_transaction_block_hash", h)
         new_m = block.foliage.foliage_transaction_block_hash
@@ -1826,6 +1840,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block))[1]
         assert err == Err.INVALID_FOLIAGE_BLOCK_HASH
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_invalid_reward_claims(self, empty_blockchain):
@@ -1834,6 +1849,7 @@ class TestBodyValidation:
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         block: FullBlock = blocks[-1]
+        await check_block_store_invariant(b)
 
         # Too few
         assert block.transactions_info
@@ -1855,6 +1871,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_REWARD_COINS
+        await check_block_store_invariant(b)
 
         # Too many
         h = std_hash(b"")
@@ -1876,6 +1893,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_REWARD_COINS
+        await check_block_store_invariant(b)
 
         # Duplicates
         duplicate_reward_claims = block.transactions_info.reward_claims_incorporated + [
@@ -1896,6 +1914,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_REWARD_COINS
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_invalid_transactions_generator_hash(self, empty_blockchain):
@@ -1903,6 +1922,7 @@ class TestBodyValidation:
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         # No tx should have all zeroes
         block: FullBlock = blocks[-1]
@@ -1919,6 +1939,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_TRANSACTIONS_GENERATOR_HASH
+        await check_block_store_invariant(b)
 
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         blocks = bt.get_consecutive_blocks(
@@ -1930,6 +1951,7 @@ class TestBodyValidation:
         )
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[3]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
         tx: SpendBundle = wt.generate_signed_transaction(
@@ -1954,6 +1976,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_TRANSACTIONS_GENERATOR_HASH
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_invalid_transactions_ref_list(self, empty_blockchain):
@@ -1967,6 +1990,7 @@ class TestBodyValidation:
         )
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         block: FullBlock = blocks[-1]
         block_2 = recursive_replace(block, "transactions_info.generator_refs_root", bytes([0] * 32))
@@ -1982,15 +2006,18 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+        await check_block_store_invariant(b)
 
         # No generator should have no refs list
         block_2 = recursive_replace(block, "transactions_generator_ref_list", [uint32(0)])
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+        await check_block_store_invariant(b)
 
         # Hash should be correct when there is a ref list
         assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
         wt: WalletTool = bt.get_pool_wallet_tool()
         tx: SpendBundle = wt.generate_signed_transaction(
             10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
@@ -1998,11 +2025,13 @@ class TestBodyValidation:
         blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, guarantee_transaction_block=False)
         for block in blocks[-5:]:
             assert (await b.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
         assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
         generator_arg = detect_potential_template_generator(blocks[-1].height, blocks[-1].transactions_generator)
         assert generator_arg is not None
 
@@ -2029,12 +2058,14 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+        await check_block_store_invariant(b)
 
         # Too many heights
         block_2 = recursive_replace(block, "transactions_generator_ref_list", [block.height - 2, block.height - 1])
         err = (await b.receive_block(block_2))[1]
         assert err == Err.GENERATOR_REF_HAS_NO_GENERATOR
         assert (await b.pre_validate_blocks_multiprocessing([block_2], {})) is None
+        await check_block_store_invariant(b)
 
         # Not tx block
         for h in range(0, block.height - 1):
@@ -2042,6 +2073,7 @@ class TestBodyValidation:
             err = (await b.receive_block(block_2))[1]
             assert err == Err.GENERATOR_REF_HAS_NO_GENERATOR or err == Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
             assert (await b.pre_validate_blocks_multiprocessing([block_2], {})) is None
+            await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_cost_exceeds_max(self, empty_blockchain):
@@ -2056,6 +2088,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -2072,6 +2105,7 @@ class TestBodyValidation:
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
         assert (await b.receive_block(blocks[-1]))[1] in [Err.BLOCK_COST_EXCEEDS_MAX, Err.INVALID_BLOCK_COST]
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_clvm_must_not_fail(self, empty_blockchain):
@@ -2091,6 +2125,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -2119,6 +2154,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_BLOCK_COST
+        await check_block_store_invariant(b)
 
         # too low
         block_2: FullBlock = recursive_replace(block, "transactions_info.cost", uint64(1))
@@ -2135,6 +2171,7 @@ class TestBodyValidation:
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_BLOCK_COST
+        await check_block_store_invariant(b)
 
         # too high
         block_2: FullBlock = recursive_replace(block, "transactions_info.cost", uint64(1000000))
@@ -2154,9 +2191,11 @@ class TestBodyValidation:
         # when the CLVM program exceeds cost during execution, it will fail with
         # a general runtime error
         assert err == Err.GENERATOR_RUNTIME_ERROR
+        await check_block_store_invariant(b)
 
         err = (await b.receive_block(block))[1]
         assert err is None
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("db_version", [1, 2])
@@ -2221,6 +2260,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -2245,6 +2285,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.BAD_ADDITION_ROOT
+        await check_block_store_invariant(b)
 
         # removals
         merkle_set.add_already_hashed(std_hash(b"1"))
@@ -2258,6 +2299,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.BAD_REMOVAL_ROOT
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_invalid_filter(self, empty_blockchain):
@@ -2272,6 +2314,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -2293,6 +2336,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_TRANSACTIONS_FILTER_HASH
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_duplicate_outputs(self, empty_blockchain):
@@ -2307,6 +2351,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -2323,6 +2368,7 @@ class TestBodyValidation:
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
         assert (await b.receive_block(blocks[-1]))[1] == Err.DUPLICATE_OUTPUT
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_duplicate_removals(self, empty_blockchain):
@@ -2337,6 +2383,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -2352,6 +2399,7 @@ class TestBodyValidation:
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=agg
         )
         assert (await b.receive_block(blocks[-1]))[1] == Err.DOUBLE_SPEND
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_double_spent_in_coin_store(self, empty_blockchain):
@@ -2366,6 +2414,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
@@ -2377,6 +2426,7 @@ class TestBodyValidation:
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
         assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         tx_2: SpendBundle = wt.generate_signed_transaction(
             10, wt.get_new_puzzlehash(), list(blocks[-2].get_included_reward_coins())[0]
@@ -2386,6 +2436,7 @@ class TestBodyValidation:
         )
 
         assert (await b.receive_block(blocks[-1]))[1] == Err.DOUBLE_SPEND
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_double_spent_in_reorg(self, empty_blockchain):
@@ -2401,6 +2452,7 @@ class TestBodyValidation:
         assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
         assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
 
+        await check_block_store_invariant(b)
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
@@ -2410,6 +2462,7 @@ class TestBodyValidation:
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
         assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         new_coin: Coin = tx.additions()[0]
         tx_2: SpendBundle = wt.generate_signed_transaction(10, wt.get_new_puzzlehash(), new_coin)
@@ -2418,13 +2471,17 @@ class TestBodyValidation:
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx_2
         )
         assert (await b.receive_block(blocks[-1]))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
         blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, guarantee_transaction_block=True)
         for block in blocks[-5:]:
             assert (await b.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         blocks_reorg = bt.get_consecutive_blocks(2, block_list_input=blocks[:-7], guarantee_transaction_block=True)
         assert (await b.receive_block(blocks_reorg[-2]))[0] == ReceiveBlockResult.ADDED_AS_ORPHAN
+        await check_block_store_invariant(b)
         assert (await b.receive_block(blocks_reorg[-1]))[0] == ReceiveBlockResult.ADDED_AS_ORPHAN
+        await check_block_store_invariant(b)
 
         # Coin does not exist in reorg
         blocks_reorg = bt.get_consecutive_blocks(
@@ -2432,6 +2489,7 @@ class TestBodyValidation:
         )
 
         assert (await b.receive_block(blocks_reorg[-1]))[1] == Err.UNKNOWN_UNSPENT
+        await check_block_store_invariant(b)
 
         # Finally add the block to the fork (spending both in same bundle, this is ephemeral)
         agg = SpendBundle.aggregate([tx, tx_2])
@@ -2444,6 +2502,7 @@ class TestBodyValidation:
             1, block_list_input=blocks_reorg, guarantee_transaction_block=True, transaction_data=tx_2
         )
         assert (await b.receive_block(blocks_reorg[-1]))[1] == Err.DOUBLE_SPEND_IN_FORK
+        await check_block_store_invariant(b)
 
         rewards_ph = wt.get_new_puzzlehash()
         blocks_reorg = bt.get_consecutive_blocks(
@@ -2455,6 +2514,7 @@ class TestBodyValidation:
         for block in blocks_reorg[-10:]:
             r, e, _, _ = await b.receive_block(block)
             assert e is None
+            await check_block_store_invariant(b)
 
         # ephemeral coin is spent
         first_coin = await b.coin_store.get_coin_record(new_coin.name())
@@ -2558,6 +2618,7 @@ class TestBodyValidation:
 
         err = (await b.receive_block(block_2))[1]
         assert err == Err.INVALID_BLOCK_FEE_AMOUNT
+        await check_block_store_invariant(b)
 
 
 class TestReorgs:
@@ -2569,10 +2630,12 @@ class TestReorgs:
         for block in blocks:
             assert (await b.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
         assert b.get_peak().height == 14
+        await check_block_store_invariant(b)
 
         blocks_reorg_chain = bt.get_consecutive_blocks(7, blocks[:10], seed=b"2")
         for reorg_block in blocks_reorg_chain:
             result, error_code, fork_height, _ = await b.receive_block(reorg_block)
+            await check_block_store_invariant(b)
             if reorg_block.height < 10:
                 assert result == ReceiveBlockResult.ALREADY_HAVE_BLOCK
             elif reorg_block.height < 14:
@@ -2596,6 +2659,7 @@ class TestReorgs:
 
         for block in blocks:
             assert (await b.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
         chain_1_height = b.get_peak().height
         chain_1_weight = b.get_peak().weight
         assert chain_1_height == (num_blocks_chain_1 - 1)
@@ -2611,6 +2675,7 @@ class TestReorgs:
         found_orphan = False
         for reorg_block in blocks_reorg_chain:
             result, error_code, fork_height, _ = await b.receive_block(reorg_block)
+            await check_block_store_invariant(b)
             if reorg_block.height < num_blocks_chain_2_start:
                 assert result == ReceiveBlockResult.ALREADY_HAVE_BLOCK
             if reorg_block.weight <= chain_1_weight:
@@ -2633,6 +2698,7 @@ class TestReorgs:
         for block in default_10000_blocks_compact:
             assert (await b.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
         assert b.get_peak().height == len(default_10000_blocks_compact) - 1
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_reorg_from_genesis(self, empty_blockchain):
@@ -2646,6 +2712,8 @@ class TestReorgs:
             assert (await b.receive_block(block))[0] == ReceiveBlockResult.NEW_PEAK
         assert b.get_peak().height == 14
 
+        await check_block_store_invariant(b)
+
         # Reorg to alternate chain that is 1 height longer
         found_orphan = False
         blocks_reorg_chain = bt.get_consecutive_blocks(16, [], seed=b"2")
@@ -2658,20 +2726,24 @@ class TestReorgs:
             elif reorg_block.height >= 15:
                 assert result == ReceiveBlockResult.NEW_PEAK
             assert error_code is None
+            await check_block_store_invariant(b)
 
         # Back to original chain
         blocks_reorg_chain_2 = bt.get_consecutive_blocks(3, blocks, seed=b"3")
 
         result, error_code, fork_height, _ = await b.receive_block(blocks_reorg_chain_2[-3])
         assert result == ReceiveBlockResult.ADDED_AS_ORPHAN
+        await check_block_store_invariant(b)
 
         result, error_code, fork_height, _ = await b.receive_block(blocks_reorg_chain_2[-2])
         assert result == ReceiveBlockResult.NEW_PEAK
+        await check_block_store_invariant(b)
 
         result, error_code, fork_height, _ = await b.receive_block(blocks_reorg_chain_2[-1])
         assert result == ReceiveBlockResult.NEW_PEAK
         assert found_orphan
         assert b.get_peak().height == 17
+        await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_reorg_transaction(self, empty_blockchain):
@@ -2715,10 +2787,12 @@ class TestReorgs:
         for block in blocks:
             result, error_code, _, _ = await b.receive_block(block)
             assert error_code is None and result == ReceiveBlockResult.NEW_PEAK
+            await check_block_store_invariant(b)
 
         for block in blocks_fork:
             result, error_code, _, _ = await b.receive_block(block)
             assert error_code is None
+            await check_block_store_invariant(b)
 
     @pytest.mark.asyncio
     async def test_get_header_blocks_in_range_tx_filter(self, empty_blockchain):
@@ -2762,8 +2836,37 @@ class TestReorgs:
             heights.append(block.height)
             result, error_code, _, _ = await b.receive_block(block)
             assert error_code is None and result == ReceiveBlockResult.NEW_PEAK
+            await check_block_store_invariant(b)
 
         blocks = await b.get_block_records_at(heights, batch_size=2)
         assert blocks
         assert len(blocks) == 200
         assert blocks[-1].height == 199
+
+
+async def check_block_store_invariant(bc: Blockchain):
+    db_wrapper = bc.block_store.db_wrapper
+
+    if db_wrapper.db_version == 1:
+        return
+
+    in_chain = set()
+    max_height = 0
+    async with db_wrapper.db.execute("SELECT height, in_main_chain FROM full_blocks") as cursor:
+        rows = await cursor.fetchall()
+        for row in rows:
+            height = row[0]
+
+            # if this block is in-chain, ensure we haven't found another block
+            # at this height that's also in chain. That would be an invariant
+            # violation
+            if row[1]:
+                # make sure we don't have any duplicate heights. Each block
+                # height can only have a single block with in_main_chain set
+                assert height not in in_chain
+                in_chain.add(height)
+                if height > max_height:
+                    max_height = height
+
+        # make sure every height is represented in the set
+        assert len(in_chain) == max_height + 1

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -49,6 +49,11 @@ class TestBlockStore:
                 assert block == await store.get_full_block(block.header_hash)
                 assert block == await store.get_full_block(block.header_hash)
                 assert block_record == (await store.get_block_record(block_record_hh))
+                await store.set_in_chain(
+                    [
+                        (block_record.header_hash),
+                    ]
+                )
                 await store.set_peak(block_record.header_hash)
                 await store.set_peak(block_record.header_hash)
 
@@ -93,3 +98,46 @@ class TestBlockStore:
                 if random.random() < 0.5:
                     tasks.append(asyncio.create_task(store.get_full_block(blocks[rand_i].header_hash)))
             await asyncio.gather(*tasks)
+
+    @pytest.mark.asyncio
+    async def test_rollback(self, tmp_dir):
+        blocks = bt.get_consecutive_blocks(10)
+
+        async with DBConnection(2) as db_wrapper:
+
+            # Use a different file for the blockchain
+            coin_store = await CoinStore.create(db_wrapper)
+            block_store = await BlockStore.create(db_wrapper)
+            hint_store = await HintStore.create(db_wrapper)
+            bc = await Blockchain.create(coin_store, block_store, test_constants, hint_store, tmp_dir)
+
+            # insert all blocks
+            count = 0
+            for block in blocks:
+                await bc.receive_block(block)
+                count += 1
+                ret = await block_store.get_random_not_compactified(count)
+                assert len(ret) == count
+                # make sure all block heights are unique
+                assert len(set(ret)) == count
+
+            for block in blocks:
+                async with db_wrapper.db.execute(
+                    "SELECT in_main_chain FROM full_blocks WHERE header_hash=?", (block.header_hash,)
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                    assert len(rows) == 1
+                    assert rows[0][0]
+
+            await block_store.rollback(5)
+
+            count = 0
+            for block in blocks:
+                async with db_wrapper.db.execute(
+                    "SELECT in_main_chain FROM full_blocks WHERE header_hash=? ORDER BY height", (block.header_hash,)
+                ) as cursor:
+                    rows = await cursor.fetchall()
+                    print(count, rows)
+                    assert len(rows) == 1
+                    assert rows[0][0] == (count <= 5)
+                count += 1

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -49,11 +49,7 @@ class TestBlockStore:
                 assert block == await store.get_full_block(block.header_hash)
                 assert block == await store.get_full_block(block.header_hash)
                 assert block_record == (await store.get_block_record(block_record_hh))
-                await store.set_in_chain(
-                    [
-                        (block_record.header_hash),
-                    ]
-                )
+                await store.set_in_chain([(block_record.header_hash,)])
                 await store.set_peak(block_record.header_hash)
                 await store.set_peak(block_record.header_hash)
 


### PR DESCRIPTION
This patch introduces a new `in_main_chain` column in the `full_blocks` table, indicating whether this block is part of the current heaviest chain or not.

I'm not 100% confident I'm setting this field correctly, so the only thing relying on it right now is picking a randon non-compactified block. It does improve the performance of picking this block quite significantly.

The comparison is not from the immediately prior commit (since it introduced a regression of the get_random_not_compactified() function).

The key timing metric is the `get_random_not_compactified()` function:

test  | before | after | after / before
---|---|---|---
table size | 352.5 MB | 358.8 MB | 101.8 %
Ryzen, fast SSD | 72.7s | 19.3s | 26.6 %
RPi, SD card | 376.8s  | 82.0s | 21.8 %
Xeon, HDD | 67.7s | 17.3s | 25.6 %

## raw benchmark output

This patch:

Ryzen, fast SSD:

```
version 2
50.0260s, add_full_block
53.3180s, get_full_block
5.2007s, get_full_block_bytes
52.0012s, get_full_blocks_at
7.1181s, get_block_records_by_hash
53.3044s, get_blocks_by_hash
6.2934s, get_block_record
0.7631s, get_block_records_in_range
0.0065s, get_block_records_close_to_peak
4.3690s, get_block_record
19.3385s, get_random_not_compactified
all tests completed in 251.7388s
database size: 358.810 MB
```

RPi, SD card:

```
version 2
290.5492s, add_full_block
203.2999s, get_full_block
23.6671s, get_full_block_bytes
198.3695s, get_full_blocks_at
25.9796s, get_block_records_by_hash
203.3476s, get_blocks_by_hash
25.5381s, get_block_record
3.4463s, get_block_records_in_range
0.0322s, get_block_records_close_to_peak
17.2408s, get_block_record
82.0613s, get_random_not_compactified
all tests completed in 1073.5315s
database size: 358.810 MB
```

Xeon, HDD:

```
version 2
230.2963s, add_full_block
42.8371s, get_full_block
4.0482s, get_full_block_bytes
41.6950s, get_full_blocks_at
5.0723s, get_block_records_by_hash
43.0111s, get_blocks_by_hash
4.8511s, get_block_record
0.6462s, get_block_records_in_range
0.0055s, get_block_records_close_to_peak
3.3385s, get_block_record
17.3130s, get_random_not_compactified
all tests completed in 393.1144s
database size: 358.810 MB
```

prior commit:

Ryzen, fast SSD:

```
version 2
56.3806s, add_full_block
53.0442s, get_full_block
5.1803s, get_full_block_bytes
50.1041s, get_full_blocks_at
6.8339s, get_block_records_by_hash
52.6259s, get_blocks_by_hash
6.3245s, get_block_record
0.6537s, get_block_records_in_range
0.0056s, get_block_records_close_to_peak
4.9460s, get_block_record
72.6523s, get_random_not_compactified
all tests completed in 308.7509s
database size: 352.473 MB
```

RPi, SD Card:

```
version 2
311.0953s, add_full_block
204.2302s, get_full_block
24.0304s, get_full_block_bytes
199.0710s, get_full_blocks_at
24.2053s, get_block_records_by_hash
204.2228s, get_blocks_by_hash
24.8648s, get_block_record
2.8389s, get_block_records_in_range
0.0268s, get_block_records_close_to_peak
17.6518s, get_block_record
376.7793s, get_random_not_compactified
all tests completed in 1389.0169s
database size: 352.473 MB
```

Xeon, HDD:

```
version 2
245.2260s, add_full_block
42.9780s, get_full_block
4.0179s, get_full_block_bytes
41.8684s, get_full_blocks_at
4.8848s, get_block_records_by_hash
43.1449s, get_blocks_by_hash
4.4390s, get_block_record
0.5681s, get_block_records_in_range
0.0050s, get_block_records_close_to_peak
3.3432s, get_block_record
67.6903s, get_random_not_compactified
all tests completed in 458.1655s
database size: 352.473 MB
```