### PR TITLE
Archlinux: add missing dependencies in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ if [ "$(uname)" = "Linux" ]; then
 	elif type pacman && [ -f "/etc/arch-release" ]; then
 		# Arch Linux
 		echo "Installing on Arch Linux."
-		sudo pacman -S --needed python git
+		sudo pacman -S --needed python git cmake boost-libs
 	elif type yum && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
 		# AMZN 2
 		echo "Installing on Amazon Linux 2."


### PR DESCRIPTION
Hello,

After a fresh install on Archlinux, I got some compile errors when running the install.sh. 
Cmake was missing, as well as the boost library. Indeed, there are not installed by default on Arch.

This commit add these dependencies in the install script.