### PR TITLE
Properly assign keyring observer to instance field

### DIFF
--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -167,12 +167,10 @@ class FileKeyring(FileSystemEventHandler):
         self.setup_keyring_file_watcher()
 
     def setup_keyring_file_watcher(self):
-        observer = Observer()
-        # recursive=True necessary for macOS support
-        observer.schedule(self, self.keyring_path.parent, recursive=True)
-        observer.start()
-
         self.keyring_observer = Observer()
+        # recursive=True necessary for macOS support
+        self.keyring_observer.schedule(self, self.keyring_path.parent, recursive=True)
+        self.keyring_observer.start()
 
     def cleanup_keyring_file_watcher(self):
         if getattr(self, "keyring_observer"):


### PR DESCRIPTION
Basically just a one-line change of what looks like a typo: `self.keyring_observer = Observer()` should probably have been `self.keyring_observer = observer`, that is: assign the previously set-up observer, instead of creating a new one. (The actual patch also removes the local variable, while at it.)