### PR TITLE
Restore peer_db_path and wallet_peers_path config keys/values for downgrading from a newer install.

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -312,8 +312,12 @@ full_node:
 
   # Run multiple nodes with different databases by changing the database_path
   database_path: db/blockchain_v1_CHALLENGE.sqlite
+  # peer_db_path is deprecated and has been replaced by peers_file_path
+  peer_db_path: db/peer_table_node.sqlite
   peers_file_path: db/peers.dat
   simulator_database_path: sim_db/simulator_blockchain_v1_CHALLENGE.sqlite
+  # simulator_peer_db_path is deprecated and has been replaced by simulator_peers_file_path
+  simulator_peer_db_path: sim_db/peer_table_node.sqlite
   simulator_peers_file_path: sim_db/peer_table_node.dat
 
   # If True, starts an RPC server at the following port
@@ -451,6 +455,8 @@ wallet:
 
   testing: False
   database_path: wallet/db/blockchain_wallet_v1_CHALLENGE_KEY.sqlite
+  # wallet_peers_path is deprecated and has been replaced by wallet_peers_file_path
+  wallet_peers_path: wallet/db/wallet_peers.sqlite
   wallet_peers_file_path: wallet/db/wallet_peers.dat
 
   logging: *logging

--- a/tests/core/full_node/test_peer_store_resolver.py
+++ b/tests/core/full_node/test_peer_store_resolver.py
@@ -101,6 +101,58 @@ class TestPeerStoreResolver:
         # Expect: the config doesn't add a legacy peer_db_path value
         assert config.get("peer_db_path") is None
 
+    def test_resolve_both_peers_file_path_and_legacy_peer_db_path_exist(self, tmp_path: Path):
+        """
+        When the config has values for both the legacy peer_db_path and peer_files_path, the
+        peers_file_path value should take precedence.
+        """
+
+        root_path: Path = tmp_path
+        config: Dict[str, str] = {
+            "peer_db_path": "db/peer_table_node.sqlite",
+            "peers_file_path": "db/peers.dat",
+        }
+        resolver: PeerStoreResolver = PeerStoreResolver(
+            root_path,
+            config,
+            selected_network="mainnet",
+            peers_file_path_key="peers_file_path",
+            legacy_peer_db_path_key="peer_db_path",
+            default_peers_file_path="db/peers.dat",
+        )
+        # Expect: peers.dat path is the same as the location specified in the config
+        assert resolver.peers_file_path == root_path / Path("db/peers.dat")
+        # Expect: the config is updated with the new value
+        assert config["peers_file_path"] == "db/peers.dat"
+        # Expect: the config retains the legacy peer_db_path value
+        assert config["peer_db_path"] == "db/peer_table_node.sqlite"
+
+    def test_resolve_modified_both_peers_file_path_and_legacy_peer_db_path_exist(self, tmp_path: Path):
+        """
+        When the config has modified values for both the peers_file_path and legacy peer_db_path,
+        the resolver should use the peers_file_path value.
+        """
+
+        root_path: Path = tmp_path
+        config: Dict[str, str] = {
+            "peer_db_path": "some/modified/db/path/peer_table_node.sqlite",
+            "peers_file_path": "some/modified/db/path/peers.dat",
+        }
+        resolver: PeerStoreResolver = PeerStoreResolver(
+            root_path,
+            config,
+            selected_network="mainnet",
+            peers_file_path_key="peers_file_path",
+            legacy_peer_db_path_key="peer_db_path",
+            default_peers_file_path="db/peers.dat",
+        )
+        # Expect: peers.dat path is the same as the location specified in the config
+        assert resolver.peers_file_path == root_path / Path("some/modified/db/path/peers.dat")
+        # Expect: the config is updated with the new value
+        assert config["peers_file_path"] == "some/modified/db/path/peers.dat"
+        # Expect: the config retains the legacy peer_db_path value
+        assert config["peer_db_path"] == "some/modified/db/path/peer_table_node.sqlite"
+
     # use tmp_path pytest fixture to create a temporary directory
     def test_resolve_missing_keys(self, tmp_path: Path):
         """


### PR DESCRIPTION
PROBLEM

When downgrading from a clean new install, full_node.py would hit a KeyError exception when attempting to read `peer_db_path` from the config dictionary.

SOLUTION

While the original intent was to omit `peer_db_path` and `wallet_peers_path` (replaced by `peers_file_path` and `wallet_peers_file_path` respectively) from the config on a fresh install, those keys/values are now reinstated in `initial-config.yaml` to support a client downgrade. Functionality didn't need any changes as the PeerStoreResolver already handled this scenario.

TESTING

Tests have been added to account for the case where both sets of keys/values are present in the config. Manually tested to ensure that the proper peer db/file is used depending on which values are found in config.yaml