### PR TITLE
Move data layer fixtures to conftest

### DIFF
--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -17,12 +17,7 @@ from chia.data_layer.data_store import DataStore
 from chia.types.blockchain_format.tree_hash import bytes32
 from chia.util.db_wrapper import DBWrapper
 
-from tests.core.data_layer.util import (
-    add_0123_example,
-    add_01234567_example,
-    ChiaRoot,
-    Example,
-)
+from tests.core.data_layer.util import add_0123_example, add_01234567_example, ChiaRoot, Example
 
 
 # TODO: These are more general than the data layer and should either move elsewhere or

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -22,7 +22,6 @@ from tests.core.data_layer.util import (
     add_0123_example,
     add_01234567_example,
     ChiaRoot,
-    create_valid_node_values,
     Example,
 )
 
@@ -120,21 +119,3 @@ async def data_store_fixture(raw_data_store: DataStore, tree_id: bytes32) -> Asy
     await raw_data_store.check()
     yield raw_data_store
     await raw_data_store.check()
-
-
-@pytest.fixture(name="node_type", params=NodeType)
-def node_type_fixture(request: SubRequest) -> NodeType:
-    return request.param  # type: ignore[no-any-return]
-
-
-@pytest.fixture(name="valid_node_values")
-async def valid_node_values_fixture(
-    data_store: DataStore,
-    tree_id: bytes32,
-    node_type: NodeType,
-) -> Dict[str, Any]:
-    await add_01234567_example(data_store=data_store, tree_id=tree_id)
-    node_a = await data_store.get_node_by_key(key=b"\x02", tree_id=tree_id)
-    node_b = await data_store.get_node_by_key(key=b"\x04", tree_id=tree_id)
-
-    return create_valid_node_values(node_type=node_type, left_hash=node_a.hash, right_hash=node_b.hash)

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -5,16 +5,26 @@ import subprocess
 import sys
 import sysconfig
 import time
-from typing import Awaitable, Callable, Iterator, List
+from typing import Any, AsyncIterable, Awaitable, Callable, Dict, Iterator, List
+
+import aiosqlite
 
 # https://github.com/pytest-dev/pytest/issues/7469
 from _pytest.fixtures import SubRequest
 import pytest
 
+from chia.data_layer.data_layer_types import NodeType
 from chia.data_layer.data_store import DataStore
 from chia.types.blockchain_format.tree_hash import bytes32
+from chia.util.db_wrapper import DBWrapper
 
-from tests.core.data_layer.util import add_0123_example, add_01234567_example, ChiaRoot, Example
+from tests.core.data_layer.util import (
+    add_0123_example,
+    add_01234567_example,
+    ChiaRoot,
+    create_valid_node_values,
+    Example,
+)
 
 
 # TODO: These are more general than the data layer and should either move elsewhere or
@@ -76,3 +86,55 @@ def chia_data_fixture(chia_root: ChiaRoot, chia_daemon: None, scripts_path: path
 @pytest.fixture(name="create_example", params=[add_0123_example, add_01234567_example])
 def create_example_fixture(request: SubRequest) -> Callable[[DataStore, bytes32], Awaitable[Example]]:
     return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture(name="db_connection", scope="function")
+async def db_connection_fixture() -> AsyncIterable[aiosqlite.Connection]:
+    async with aiosqlite.connect(":memory:") as connection:
+        # make sure this is on for tests even if we disable it at run time
+        await connection.execute("PRAGMA foreign_keys = ON")
+        yield connection
+
+
+@pytest.fixture(name="db_wrapper", scope="function")
+def db_wrapper_fixture(db_connection: aiosqlite.Connection) -> DBWrapper:
+    return DBWrapper(db_connection)
+
+
+@pytest.fixture(name="tree_id", scope="function")
+def tree_id_fixture() -> bytes32:
+    base = b"a tree id"
+    pad = b"." * (32 - len(base))
+    return bytes32(pad + base)
+
+
+@pytest.fixture(name="raw_data_store", scope="function")
+async def raw_data_store_fixture(db_wrapper: DBWrapper) -> DataStore:
+    return await DataStore.create(db_wrapper=db_wrapper)
+
+
+@pytest.fixture(name="data_store", scope="function")
+async def data_store_fixture(raw_data_store: DataStore, tree_id: bytes32) -> AsyncIterable[DataStore]:
+    await raw_data_store.create_tree(tree_id=tree_id)
+
+    await raw_data_store.check()
+    yield raw_data_store
+    await raw_data_store.check()
+
+
+@pytest.fixture(name="node_type", params=NodeType)
+def node_type_fixture(request: SubRequest) -> NodeType:
+    return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture(name="valid_node_values")
+async def valid_node_values_fixture(
+    data_store: DataStore,
+    tree_id: bytes32,
+    node_type: NodeType,
+) -> Dict[str, Any]:
+    await add_01234567_example(data_store=data_store, tree_id=tree_id)
+    node_a = await data_store.get_node_by_key(key=b"\x02", tree_id=tree_id)
+    node_b = await data_store.get_node_by_key(key=b"\x04", tree_id=tree_id)
+
+    return create_valid_node_values(node_type=node_type, left_hash=node_a.hash, right_hash=node_b.hash)

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import sysconfig
 import time
-from typing import Any, AsyncIterable, Awaitable, Callable, Dict, Iterator, List
+from typing import AsyncIterable, Awaitable, Callable, Iterator, List
 
 import aiosqlite
 
@@ -13,7 +13,6 @@ import aiosqlite
 from _pytest.fixtures import SubRequest
 import pytest
 
-from chia.data_layer.data_layer_types import NodeType
 from chia.data_layer.data_store import DataStore
 from chia.types.blockchain_format.tree_hash import bytes32
 from chia.util.db_wrapper import DBWrapper

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -1,6 +1,6 @@
 import itertools
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 
 import pytest
 

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -28,18 +28,6 @@ log = logging.getLogger(__name__)
 pytestmark = pytest.mark.data_layer
 
 
-@pytest.mark.asyncio
-async def test_valid_node_values_fixture_are_valid(data_store: DataStore, valid_node_values: Dict[str, Any]) -> None:
-    async with data_store.db_wrapper.locked_transaction():
-        await data_store.db.execute(
-            """
-            INSERT INTO node(hash, node_type, left, right, key, value)
-            VALUES(:hash, :node_type, :left, :right, :key, :value)
-            """,
-            valid_node_values,
-        )
-
-
 table_columns: Dict[str, List[str]] = {
     "node": ["hash", "node_type", "left", "right", "key", "value"],
     "root": ["tree_id", "generation", "node_hash", "status"],

--- a/tests/core/data_layer/util.py
+++ b/tests/core/data_layer/util.py
@@ -4,9 +4,9 @@ import functools
 import os
 import pathlib
 import subprocess
-from typing import Any, Iterator, IO, List, Optional, TYPE_CHECKING, Union
+from typing import Any, Dict, Iterator, IO, List, Optional, TYPE_CHECKING, Union
 
-from chia.data_layer.data_layer_types import Side
+from chia.data_layer.data_layer_types import NodeType, Side
 from chia.data_layer.data_store import DataStore
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.tree_hash import bytes32
@@ -173,3 +173,32 @@ class ChiaRoot:
             yield
         finally:
             self.print_log()
+
+
+def create_valid_node_values(
+    node_type: NodeType,
+    left_hash: Optional[bytes32] = None,
+    right_hash: Optional[bytes32] = None,
+) -> Dict[str, Any]:
+    if node_type == NodeType.INTERNAL:
+        return {
+            "hash": Program.to((left_hash, right_hash)).get_tree_hash(left_hash, right_hash).hex(),
+            "node_type": node_type,
+            "left": None if left_hash is None else left_hash.hex(),
+            "right": None if right_hash is None else right_hash.hex(),
+            "key": None,
+            "value": None,
+        }
+    elif node_type == NodeType.TERMINAL:
+        key = b""
+        value = b""
+        return {
+            "hash": Program.to((key, value)).get_tree_hash().hex(),
+            "node_type": node_type,
+            "left": None,
+            "right": None,
+            "key": key.hex(),
+            "value": value.hex(),
+        }
+
+    raise Exception(f"Unhandled node type: {node_type!r}")

--- a/tests/core/data_layer/util.py
+++ b/tests/core/data_layer/util.py
@@ -4,9 +4,9 @@ import functools
 import os
 import pathlib
 import subprocess
-from typing import Any, Dict, Iterator, IO, List, Optional, TYPE_CHECKING, Union
+from typing import Any, Iterator, IO, List, Optional, TYPE_CHECKING, Union
 
-from chia.data_layer.data_layer_types import NodeType, Side
+from chia.data_layer.data_layer_types import Side
 from chia.data_layer.data_store import DataStore
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.tree_hash import bytes32

--- a/tests/core/data_layer/util.py
+++ b/tests/core/data_layer/util.py
@@ -173,32 +173,3 @@ class ChiaRoot:
             yield
         finally:
             self.print_log()
-
-
-def create_valid_node_values(
-    node_type: NodeType,
-    left_hash: Optional[bytes32] = None,
-    right_hash: Optional[bytes32] = None,
-) -> Dict[str, Any]:
-    if node_type == NodeType.INTERNAL:
-        return {
-            "hash": Program.to((left_hash, right_hash)).get_tree_hash(left_hash, right_hash).hex(),
-            "node_type": node_type,
-            "left": None if left_hash is None else left_hash.hex(),
-            "right": None if right_hash is None else right_hash.hex(),
-            "key": None,
-            "value": None,
-        }
-    elif node_type == NodeType.TERMINAL:
-        key = b""
-        value = b""
-        return {
-            "hash": Program.to((key, value)).get_tree_hash().hex(),
-            "node_type": node_type,
-            "left": None,
-            "right": None,
-            "key": key.hex(),
-            "value": value.hex(),
-        }
-
-    raise Exception(f"Unhandled node type: {node_type!r}")


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/pull/9284 creates another test file that uses some of the same fixtures.  This PR just handles moving the fixtures to `conftest.py` separate from the other work in #9284.

Draft for:
- [x] Self review