### PR TITLE
Crawler retry db on lock

### DIFF
--- a/chia/seeder/crawl_store.py
+++ b/chia/seeder/crawl_store.py
@@ -269,16 +269,19 @@ class CrawlStore:
         return self.reliable_peers
 
     async def load_to_db(self):
+        log.error("Saving peers to DB...")
         for peer_id in list(self.host_to_reliability.keys()):
             if peer_id in self.host_to_reliability and peer_id in self.host_to_records:
                 reliability = self.host_to_reliability[peer_id]
                 record = self.host_to_records[peer_id]
                 await self.add_peer(record, reliability, True)
         await self.crawl_db.commit()
+        log.error(" - Done saving peers to DB")
 
     async def unload_from_db(self):
         self.host_to_records = {}
         self.host_to_reliability = {}
+        log.error("Loading peer reliability records...")
         cursor = await self.crawl_db.execute(
             "SELECT * from peer_reliability",
         )
@@ -308,6 +311,8 @@ class CrawlStore:
                 row[19],
             )
             self.host_to_reliability[row[0]] = reliability
+        log.error("  - Done loading peer reliability records...")
+        log.error("Loading peer records...")
         cursor = await self.crawl_db.execute(
             "SELECT * from peer_records",
         )
@@ -318,6 +323,7 @@ class CrawlStore:
                 row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11]
             )
             self.host_to_records[row[0]] = peer
+        log.error("  - Done loading peer records...")
 
     # Crawler -> DNS.
     async def load_reliable_peers_to_db(self):
@@ -327,10 +333,13 @@ class CrawlStore:
             if reliability.is_reliable():
                 peers.append(peer_id)
         self.reliable_peers = len(peers)
+        log.error("Deleting old good_peers from DB...")
         cursor = await self.crawl_db.execute(
             "DELETE from good_peers",
         )
         await cursor.close()
+        log.error(" - Done deleting old good_peers...")
+        log.error("Saving new good_peers to DB...")
         for peer in peers:
             cursor = await self.crawl_db.execute(
                 "INSERT OR REPLACE INTO good_peers VALUES(?)",
@@ -338,6 +347,7 @@ class CrawlStore:
             )
             await cursor.close()
         await self.crawl_db.commit()
+        log.error(" - Done saving new good_peers to DB...")
 
     def load_host_to_version(self):
         versions = {}

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -228,8 +228,18 @@ class Crawler:
                 self.server.banned_peers = {}
                 if len(peers_to_crawl) == 0:
                     continue
-                await self.crawl_store.load_to_db()
-                await self.crawl_store.load_reliable_peers_to_db()
+
+                # Try up to 5 times to write to the DB in case there is a lock that causes a timeout
+                for i in range(1, 5):
+                    try:
+                        await self.crawl_store.load_to_db()
+                        await self.crawl_store.load_reliable_peers_to_db()
+                    except Exception as e:
+                        self.log.error(f"Exception while saving to DB: {e}.")
+                        self.log.error("Waiting 5 seconds before retry...")
+                        await asyncio.sleep(5)
+                        continue
+                    break
                 total_records = self.crawl_store.get_total_records()
                 ipv6_count = self.crawl_store.get_ipv6_peers()
                 self.log.error("***")

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -118,8 +118,6 @@ class Crawler:
             self.connection = await aiosqlite.connect(self.db_path)
             self.crawl_store = await CrawlStore.create(self.connection)
             self.log.info("Started")
-            await self.crawl_store.load_to_db()
-            await self.crawl_store.load_reliable_peers_to_db()
             t_start = time.time()
             total_nodes = 0
             self.seen_nodes = set()


### PR DESCRIPTION
Removes initial DB write that is right after loading from the DB (so not writing anything new).
Adds additional logging
Retries writing to the DB in case something else has a DB lock that causes a timeout/exception