### PR TITLE
Make sure to fail CI when unable to get madMAx version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ steps:
     displayName: Create installer version number
 
   - script: |
-      set -o pipefail
+      set -o errexit -o pipefail
       MADMAX_VERSION=$(curl --fail --silent "https://api.github.com/repos/Chia-Network/chia-plotter-madmax/releases/latest" | jq -r '.tag_name')
 
       mkdir "$(System.DefaultWorkingDirectory)/madmax"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,8 @@ steps:
     displayName: Create installer version number
 
   - script: |
-      MADMAX_VERSION=$(curl --silent "https://api.github.com/repos/Chia-Network/chia-plotter-madmax/releases/latest" | jq -r '.tag_name')
+      set -o pipefail
+      MADMAX_VERSION=$(curl --fail --silent "https://api.github.com/repos/Chia-Network/chia-plotter-madmax/releases/latest" | jq -r '.tag_name')
 
       mkdir "$(System.DefaultWorkingDirectory)/madmax"
       wget -O "$(System.DefaultWorkingDirectory)/madmax/chia_plot" https://github.com/Chia-Network/chia-plotter-madmax/releases/download/${MADMAX_VERSION}/chia_plot-${MADMAX_VERSION}-macos-intel


### PR DESCRIPTION
`-o errexit` so that failed commands cause a failure.  `-o pipefail` so that failures mid-pipe cause an overall command failure.  `--fail` so that curl will return a failure code when it fails.

The flakey builds were failing much further down with an error from macholib saying `struct.error: unpack requires a buffer of 4 bytes`.  Full traceback below.  This happened because the madMAx executable was, in fact, zero length.  It was zero length because we tried to download the wrong file using a version `null`.  This happened because we hit rate limits on our GitHub API queries.  The changes here are an effort to make these failures cause CI failures at their locations rather than multiple steps later.  Actually fixing the rate limit situation will be handled separately.

```python-traceback
132551 INFO: Building COLLECT COLLECT-00.toc
Traceback (most recent call last):
  File "/Users/runner/work/1/s/venv/bin/pyinstaller", line 8, in <module>
    sys.exit(run())
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/__main__.py", line 126, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/__main__.py", line 65, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/building/build_main.py", line 813, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/building/build_main.py", line 760, in build
    exec(code, spec_namespace)
  File "/Users/runner/work/1/s/chia/pyinstaller.spec", line 198, in <module>
    coll = COLLECT(*COLLECT_ARGS, **COLLECT_KWARGS)
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/building/api.py", line 855, in __init__
    self.__postinit__()
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/building/datastruct.py", line 159, in __postinit__
    self.assemble()
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/building/api.py", line 890, in assemble
    fnm = checkCache(fnm, strip=self.strip_binaries,
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/building/utils.py", line 387, in checkCache
    osxutils.binary_to_target_arch(cachedfile, target_arch,
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/utils/osx.py", line 322, in binary_to_target_arch
    is_fat, archs = get_binary_architectures(filename)
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/PyInstaller/utils/osx.py", line 294, in get_binary_architectures
    executable = MachO(filename)
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/macholib/MachO.py", line 118, in __init__
    self.load(fp)
  File "/Users/runner/work/1/s/venv/lib/python3.9/site-packages/macholib/MachO.py", line 125, in load
    header = struct.unpack(">I", fh.read(4))[0]
struct.error: unpack requires a buffer of 4 bytes
```