### PR TITLE
plotting|tests|github: Fix and test re-loading/removal of plots where we missed the keys

### DIFF
--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-consensus.yml
+++ b/.github/workflows/build-test-macos-core-consensus.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-custom_types.yml
+++ b/.github/workflows/build-test-macos-core-custom_types.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-generator.yml
+++ b/.github/workflows/build-test-macos-generator.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-util.yml
+++ b/.github/workflows/build-test-macos-util.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet-cc_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cc_wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-did_wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-rl_wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet-cc_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cc_wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -395,6 +395,9 @@ class PlotManager:
                         if not self.open_no_key_filenames:
                             return None
 
+                    if file_path in self.no_key_filenames:
+                        self.no_key_filenames.remove(file_path)
+
                     local_sk = master_sk_to_local_sk(local_master_sk)
 
                     plot_public_key: G1Element = ProofOfSpace.generate_plot_public_key(

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -247,7 +247,7 @@ class PlotManager:
                     if plot_removed(path):
                         del self.failed_to_open_filenames[path]
 
-                for path in list(self.no_key_filenames):
+                for path in self.no_key_filenames.copy():
                     if plot_removed(path):
                         self.no_key_filenames.remove(path)
 

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -399,6 +399,8 @@ class PlotManager:
                         if not self.open_no_key_filenames:
                             return None
 
+                    # If a plot is in `no_key_filenames` the keys were missing in earlier refresh cycles. We can remove
+                    # the current plot from that list if its in there since we passed the key checks above.
                     if file_path in self.no_key_filenames:
                         self.no_key_filenames.remove(file_path)
 

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -247,6 +247,10 @@ class PlotManager:
                     if plot_removed(path):
                         del self.failed_to_open_filenames[path]
 
+                for path in list(self.no_key_filenames):
+                    if plot_removed(path):
+                        self.no_key_filenames.remove(path)
+
                 filenames_to_remove: List[str] = []
                 for plot_filename, paths_entry in self.plot_filename_paths.items():
                     loaded_path, duplicated_paths = paths_entry

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -240,7 +240,10 @@ class BlockTools:
         await self.refresh_plots()
 
     async def new_plot(
-        self, pool_contract_puzzle_hash: Optional[bytes32] = None, path: Path = None
+        self,
+        pool_contract_puzzle_hash: Optional[bytes32] = None,
+        path: Path = None,
+        plot_keys: Optional[PlotKeys] = None,
     ) -> Optional[bytes32]:
         final_dir = self.plot_dir
         if path is not None:
@@ -264,18 +267,19 @@ class BlockTools:
         args.exclude_final_dir = False
         args.list_duplicates = False
         try:
-            pool_pk: Optional[G1Element] = None
-            pool_address: Optional[str] = None
-            if pool_contract_puzzle_hash is None:
-                pool_pk = self.pool_pk
-            else:
-                pool_address = encode_puzzle_hash(pool_contract_puzzle_hash, "xch")
+            if plot_keys is None:
+                pool_pk: Optional[G1Element] = None
+                pool_address: Optional[str] = None
+                if pool_contract_puzzle_hash is None:
+                    pool_pk = self.pool_pk
+                else:
+                    pool_address = encode_puzzle_hash(pool_contract_puzzle_hash, "xch")
 
-            keys = PlotKeys(self.farmer_pk, pool_pk, pool_address)
+                plot_keys = PlotKeys(self.farmer_pk, pool_pk, pool_address)
             # No datetime in the filename, to get deterministic filenames and not re-plot
             created, existed = await create_plots(
                 args,
-                keys,
+                plot_keys,
                 self.root_path,
                 use_datetime=False,
                 test_private_keys=[AugSchemeMPL.key_gen(std_hash(len(self.expected_plots).to_bytes(2, "big")))],

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -237,6 +237,14 @@ class BlockTools:
         # Pool Plots
         for i in range(5):
             await self.new_plot(self.pool_ph)
+        # Some plots with keys that are not in the keychain
+        for i in range(3):
+            await self.new_plot(
+                path=self.plot_dir / "not_in_keychain",
+                plot_keys=PlotKeys(G1Element(), G1Element(), None),
+                exclude_final_dir=True,
+            )
+
         await self.refresh_plots()
 
     async def new_plot(
@@ -244,6 +252,7 @@ class BlockTools:
         pool_contract_puzzle_hash: Optional[bytes32] = None,
         path: Path = None,
         plot_keys: Optional[PlotKeys] = None,
+        exclude_final_dir: bool = False,
     ) -> Optional[bytes32]:
         final_dir = self.plot_dir
         if path is not None:
@@ -266,6 +275,7 @@ class BlockTools:
         args.nobitfield = False
         args.exclude_final_dir = False
         args.list_duplicates = False
+        args.exclude_final_dir = exclude_final_dir
         try:
             if plot_keys is None:
                 pool_pk: Optional[G1Element] = None
@@ -296,10 +306,11 @@ class BlockTools:
                 assert len(created) == 0
                 plot_id_new, path_new = list(existed.items())[0]
 
-            # TODO: address hint error and remove ignore
-            #       error: Invalid index type "Optional[bytes32]" for "Dict[bytes32, Path]"; expected type "bytes32"
-            #       [index]
-            self.expected_plots[plot_id_new] = path_new  # type: ignore[index]
+            if not exclude_final_dir:
+                # TODO: address hint error and remove ignore
+                #       error: Invalid index type "Optional[bytes32]" for "Dict[bytes32, Path]"; expected type "bytes32"
+                #       [index]
+                self.expected_plots[plot_id_new] = path_new  # type: ignore[index]
 
             # create_plots() updates plot_directories. Ensure we refresh our config to reflect the updated value
             self._config["harvester"]["plot_directories"] = load_config(self.root_path, "config.yaml", "harvester")[

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from shutil import copy, move
 from typing import Callable, Iterator, List, Optional
 import pytest
+from blspy import G1Element
 
 from dataclasses import dataclass
 from chia.plotting.util import (
@@ -19,6 +20,7 @@ from chia.util.config import create_default_chia_config
 from chia.util.path import mkdir
 from chia.plotting.manager import PlotManager
 from tests.block_tools import get_plot_dir
+from tests.plotting.util import get_test_plots
 from tests.setup_nodes import bt
 from tests.time_out_assert import time_out_assert
 
@@ -135,7 +137,7 @@ class TestEnvironment:
 def test_environment(tmp_path) -> Iterator[TestEnvironment]:
     dir_1_count: int = 7
     dir_2_count: int = 3
-    plots: List[Path] = list(sorted(get_plot_dir().glob("*.plot")))
+    plots: List[Path] = get_test_plots()
     assert len(plots) >= dir_1_count + dir_2_count
 
     dir_1: TestDirectory = TestDirectory(tmp_path / "plots" / "1", plots[0:dir_1_count])
@@ -400,6 +402,43 @@ async def test_invalid_plots(test_environment):
     await env.refresh_tester.run(expected_result)
     assert len(env.refresh_tester.plot_manager.failed_to_open_filenames) == 0
     assert retry_test_plot not in env.refresh_tester.plot_manager.failed_to_open_filenames
+
+
+@pytest.mark.asyncio
+async def test_keys_missing(test_environment: TestEnvironment) -> None:
+    env: TestEnvironment = test_environment
+    not_in_keychain_plots: List[Path] = get_test_plots("not_in_keychain")
+    dir_not_in_keychain: TestDirectory = TestDirectory(
+        env.root_path / "plots" / "not_in_keychain", not_in_keychain_plots
+    )
+    expected_result = PlotRefreshResult()
+    # The plots in "not_in_keychain" directory have infinity g1 elements as farmer/pool key so they should be plots
+    # with missing keys for now
+    add_plot_directory(env.root_path, str(dir_not_in_keychain.path))
+    expected_result.loaded = []
+    expected_result.removed = []
+    expected_result.processed = len(dir_not_in_keychain)
+    expected_result.remaining = 0
+    for i in range(2):
+        await env.refresh_tester.run(expected_result)
+        assert len(env.refresh_tester.plot_manager.no_key_filenames) == len(dir_not_in_keychain)
+        for path in env.refresh_tester.plot_manager.no_key_filenames:
+            assert path in dir_not_in_keychain.plots
+    # Delete one of the plots and make sure it gets dropped from the no key filenames list
+    drop_plot = dir_not_in_keychain.path_list()[0]
+    dir_not_in_keychain.drop(drop_plot)
+    drop_plot.unlink()
+    assert drop_plot in env.refresh_tester.plot_manager.no_key_filenames
+    await env.refresh_tester.run(expected_result)
+    assert drop_plot not in env.refresh_tester.plot_manager.no_key_filenames
+    # Now add the missing keys to the plot manager's key lists and make sure the plots are getting loaded
+    env.refresh_tester.plot_manager.farmer_public_keys.append(G1Element())
+    env.refresh_tester.plot_manager.pool_public_keys.append(G1Element())
+    expected_result.loaded = dir_not_in_keychain.plot_info_list()  # type: ignore[assignment]
+    expected_result.processed = len(dir_not_in_keychain)
+    await env.refresh_tester.run(expected_result)
+    # And make sure they are dropped from the list of plots with missing keys
+    assert len(env.refresh_tester.plot_manager.no_key_filenames) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -429,6 +429,7 @@ async def test_keys_missing(test_environment: TestEnvironment) -> None:
     dir_not_in_keychain.drop(drop_plot)
     drop_plot.unlink()
     assert drop_plot in env.refresh_tester.plot_manager.no_key_filenames
+    expected_result.processed -= 1
     await env.refresh_tester.run(expected_result)
     assert drop_plot not in env.refresh_tester.plot_manager.no_key_filenames
     # Now add the missing keys to the plot manager's key lists and make sure the plots are getting loaded

--- a/tests/plotting/util.py
+++ b/tests/plotting/util.py
@@ -1,0 +1,10 @@
+from typing import List
+from pathlib import Path
+from tests.block_tools import get_plot_dir
+
+
+def get_test_plots(sub_dir: str = "") -> List[Path]:
+    path = get_plot_dir()
+    if sub_dir != "":
+        path = path / sub_dir
+    return list(sorted(path.glob("*.plot")))

--- a/tests/runner_templates/checkout-test-plots.include.yml
+++ b/tests/runner_templates/checkout-test-plots.include.yml
@@ -3,7 +3,7 @@
       with:
         repository: 'Chia-Network/test-cache'
         path: '.chia'
-        ref: '0.27.0'
+        ref: '0.28.0'
         fetch-depth: 1
 
     - name: Link home directory


### PR DESCRIPTION
Fixes are 6493bf5 and 47de8b7.

Note that 74fcf8f bumps the test cache (requires `0.28.0` release in the test-cache repo after the https://github.com/Chia-Network/test-cache/pull/1 was merged).

The rest is preparation for tests and actual tests in 677a261.

~Based on #9567~