### PR TITLE
use context managers for database cursor objects & stream results

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -493,8 +493,6 @@ class BlockStore:
             ) as cursor:
                 rows = await cursor.fetchall()
 
-            heights = []
-            for row in rows:
-                heights.append(int(row[0]))
+        heights = [int(row[0]) for row in rows]
 
         return heights

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -156,7 +156,7 @@ class BlockStore:
                 else bytes(block_record.sub_epoch_summary_included)
             )
 
-            cursor_1 = await self.db.execute(
+            await self.db.execute(
                 "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     header_hash,
@@ -169,10 +169,9 @@ class BlockStore:
                     bytes(block_record),
                 ),
             )
-            await cursor_1.close()
 
         else:
-            cursor_1 = await self.db.execute(
+            await self.db.execute(
                 "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
                 (
                     header_hash.hex(),
@@ -182,9 +181,8 @@ class BlockStore:
                     bytes(block),
                 ),
             )
-            await cursor_1.close()
 
-            cursor_2 = await self.db.execute(
+            await self.db.execute(
                 "INSERT OR REPLACE INTO block_records VALUES(?, ?, ?, ?,?, ?, ?)",
                 (
                     header_hash.hex(),
@@ -198,17 +196,15 @@ class BlockStore:
                     block.is_transaction_block(),
                 ),
             )
-            await cursor_2.close()
 
     async def persist_sub_epoch_challenge_segments(
         self, ses_block_hash: bytes32, segments: List[SubEpochChallengeSegment]
     ) -> None:
         async with self.db_wrapper.lock:
-            cursor_1 = await self.db.execute(
+            await self.db.execute(
                 "INSERT OR REPLACE INTO sub_epoch_segments_v3 VALUES(?, ?)",
                 (self.maybe_to_hex(ses_block_hash), bytes(SubEpochSegments(segments))),
             )
-            await cursor_1.close()
             await self.db.commit()
 
     async def get_sub_epoch_challenge_segments(
@@ -219,12 +215,12 @@ class BlockStore:
         if cached is not None:
             return cached
 
-        cursor = await self.db.execute(
+        async with self.db.execute(
             "SELECT challenge_segments from sub_epoch_segments_v3 WHERE ses_block_hash=?",
             (self.maybe_to_hex(ses_block_hash),),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        ) as cursor:
+            row = await cursor.fetchone()
+
         if row is not None:
             challenge_segments = SubEpochSegments.from_bytes(row[0]).challenge_segments
             self.ses_challenge_cache.put(ses_block_hash, challenge_segments)
@@ -245,11 +241,10 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return cached
         log.debug(f"cache miss for block {header_hash.hex()}")
-        cursor = await self.db.execute(
+        async with self.db.execute(
             "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        ) as cursor:
+            row = await cursor.fetchone()
         if row is not None:
             block = self.maybe_decompress(row[0])
             self.block_cache.put(header_hash, block)
@@ -262,11 +257,10 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return bytes(cached)
         log.debug(f"cache miss for block {header_hash.hex()}")
-        cursor = await self.db.execute(
+        async with self.db.execute(
             "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        ) as cursor:
+            row = await cursor.fetchone()
         if row is not None:
             if self.db_wrapper.db_version == 2:
                 return zstd.decompress(row[0])
@@ -281,10 +275,11 @@ class BlockStore:
 
         heights_db = tuple(heights)
         formatted_str = f'SELECT block from full_blocks WHERE height in ({"?," * (len(heights_db) - 1)}?)'
-        cursor = await self.db.execute(formatted_str, heights_db)
-        rows = await cursor.fetchall()
-        await cursor.close()
-        return [self.maybe_decompress(row[0]) for row in rows]
+        async with self.db.execute(formatted_str, heights_db) as cursor:
+            ret: List[FullBlock] = []
+            for row in await cursor.fetchall():
+                ret.append(self.maybe_decompress(row[0]))
+            return ret
 
     async def get_block_records_by_hash(self, header_hashes: List[bytes32]):
         """
@@ -296,24 +291,20 @@ class BlockStore:
 
         all_blocks: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
-            cursor = await self.db.execute(
+            async with self.db.execute(
                 "SELECT header_hash,block_record FROM full_blocks "
                 f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
                 tuple(header_hashes),
-            )
-            rows = await cursor.fetchall()
-            await cursor.close()
-            for row in rows:
-                header_hash = bytes32(row[0])
-                all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
+            ) as cursor:
+                for row in await cursor.fetchall():
+                    header_hash = bytes32(row[0])
+                    all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
         else:
             formatted_str = f'SELECT block from block_records WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)'
-            cursor = await self.db.execute(formatted_str, tuple([hh.hex() for hh in header_hashes]))
-            rows = await cursor.fetchall()
-            await cursor.close()
-            for row in rows:
-                block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
-                all_blocks[block_rec.header_hash] = block_rec
+            async with self.db.execute(formatted_str, tuple([hh.hex() for hh in header_hashes])) as cursor:
+                for row in await cursor.fetchall():
+                    block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
+                    all_blocks[block_rec.header_hash] = block_rec
 
         ret: List[BlockRecord] = []
         for hh in header_hashes:
@@ -339,17 +330,16 @@ class BlockStore:
         formatted_str = (
             f'SELECT header_hash, block from full_blocks WHERE header_hash in ({"?," * (len(header_hashes_db) - 1)}?)'
         )
-        cursor = await self.db.execute(formatted_str, header_hashes_db)
-        rows = await cursor.fetchall()
-        await cursor.close()
         all_blocks: Dict[bytes32, FullBlock] = {}
-        for row in rows:
-            header_hash = self.maybe_from_hex(row[0])
-            full_block: FullBlock = self.maybe_decompress(row[1])
-            # TODO: address hint error and remove ignore
-            #       error: Invalid index type "bytes" for "Dict[bytes32, FullBlock]"; expected type "bytes32"  [index]
-            all_blocks[header_hash] = full_block  # type: ignore[index]
-            self.block_cache.put(header_hash, full_block)
+        async with self.db.execute(formatted_str, header_hashes_db) as cursor:
+            for row in await cursor.fetchall():
+                header_hash = self.maybe_from_hex(row[0])
+                full_block: FullBlock = self.maybe_decompress(row[1])
+                # TODO: address hint error and remove ignore
+                #       error: Invalid index type "bytes" for "Dict[bytes32, FullBlock]";
+                # expected type "bytes32"  [index]
+                all_blocks[header_hash] = full_block  # type: ignore[index]
+                self.block_cache.put(header_hash, full_block)
         ret: List[FullBlock] = []
         for hh in header_hashes:
             if hh not in all_blocks:
@@ -361,22 +351,20 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
 
-            cursor = await self.db.execute(
+            async with self.db.execute(
                 "SELECT block_record FROM full_blocks WHERE header_hash=?",
                 (header_hash,),
-            )
-            row = await cursor.fetchone()
-            await cursor.close()
+            ) as cursor:
+                row = await cursor.fetchone()
             if row is not None:
                 return BlockRecord.from_bytes(row[0])
 
         else:
-            cursor = await self.db.execute(
+            async with self.db.execute(
                 "SELECT block from block_records WHERE header_hash=?",
                 (header_hash.hex(),),
-            )
-            row = await cursor.fetchone()
-            await cursor.close()
+            ) as cursor:
+                row = await cursor.fetchone()
             if row is not None:
                 return BlockRecord.from_bytes(row[0])
         return None
@@ -394,47 +382,40 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
 
-            cursor = await self.db.execute(
+            async with self.db.execute(
                 "SELECT header_hash, block_record FROM full_blocks WHERE height >= ? AND height <= ?",
                 (start, stop),
-            )
-            rows = await cursor.fetchall()
-            await cursor.close()
-            for row in rows:
-                header_hash = bytes32(row[0])
-                ret[header_hash] = BlockRecord.from_bytes(row[1])
+            ) as cursor:
+                for row in await cursor.fetchall():
+                    header_hash = bytes32(row[0])
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         else:
 
             formatted_str = f"SELECT header_hash, block from block_records WHERE height >= {start} and height <= {stop}"
 
-            cursor = await self.db.execute(formatted_str)
-            rows = await cursor.fetchall()
-            await cursor.close()
-            for row in rows:
-                header_hash = bytes32(self.maybe_from_hex(row[0]))
-                ret[header_hash] = BlockRecord.from_bytes(row[1])
+            async with await self.db.execute(formatted_str) as cursor:
+                for row in await cursor.fetchall():
+                    header_hash = bytes32(self.maybe_from_hex(row[0]))
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret
 
     async def get_peak(self) -> Optional[Tuple[bytes32, uint32]]:
 
         if self.db_wrapper.db_version == 2:
-            cursor = await self.db.execute("SELECT hash FROM current_peak WHERE key = 0")
-            peak_row = await cursor.fetchone()
-            await cursor.close()
+            async with self.db.execute("SELECT hash FROM current_peak WHERE key = 0") as cursor:
+                peak_row = await cursor.fetchone()
             if peak_row is None:
                 return None
-            cursor_2 = await self.db.execute("SELECT height FROM full_blocks WHERE header_hash=?", (peak_row[0],))
-            peak_height = await cursor_2.fetchone()
-            await cursor_2.close()
+            async with self.db.execute("SELECT height FROM full_blocks WHERE header_hash=?", (peak_row[0],)) as cursor:
+                peak_height = await cursor.fetchone()
             if peak_height is None:
                 return None
             return bytes32(peak_row[0]), uint32(peak_height[0])
         else:
-            res = await self.db.execute("SELECT header_hash, height from block_records WHERE is_peak = 1")
-            peak_row = await res.fetchone()
-            await res.close()
+            async with self.db.execute("SELECT header_hash, height from block_records WHERE is_peak = 1") as cursor:
+                peak_row = await cursor.fetchone()
             if peak_row is None:
                 return None
             return bytes32(bytes.fromhex(peak_row[0])), uint32(peak_row[1])
@@ -454,24 +435,20 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
 
-            cursor = await self.db.execute(
+            async with self.db.execute(
                 "SELECT header_hash, block_record FROM full_blocks WHERE height >= ?",
                 (peak[1] - blocks_n,),
-            )
-            rows = await cursor.fetchall()
-            await cursor.close()
-            for row in rows:
-                header_hash = bytes32(row[0])
-                ret[header_hash] = BlockRecord.from_bytes(row[1])
+            ) as cursor:
+                for row in await cursor.fetchall():
+                    header_hash = bytes32(row[0])
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         else:
             formatted_str = f"SELECT header_hash, block  from block_records WHERE height >= {peak[1] - blocks_n}"
-            cursor = await self.db.execute(formatted_str)
-            rows = await cursor.fetchall()
-            await cursor.close()
-            for row in rows:
-                header_hash = bytes32(self.maybe_from_hex(row[0]))
-                ret[header_hash] = BlockRecord.from_bytes(row[1])
+            async with self.db.execute(formatted_str) as cursor:
+                for row in await cursor.fetchall():
+                    header_hash = bytes32(self.maybe_from_hex(row[0]))
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret, peak[0]
 
@@ -481,23 +458,19 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
             # Note: we use the key field as 0 just to ensure all inserts replace the existing row
-            cursor = await self.db.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, header_hash))
-            await cursor.close()
+            await self.db.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, header_hash))
         else:
-            cursor_1 = await self.db.execute("UPDATE block_records SET is_peak=0 WHERE is_peak=1")
-            await cursor_1.close()
-            cursor_2 = await self.db.execute(
+            await self.db.execute("UPDATE block_records SET is_peak=0 WHERE is_peak=1")
+            await self.db.execute(
                 "UPDATE block_records SET is_peak=1 WHERE header_hash=?",
                 (self.maybe_to_hex(header_hash),),
             )
-            await cursor_2.close()
 
     async def is_fully_compactified(self, header_hash: bytes32) -> Optional[bool]:
-        cursor = await self.db.execute(
+        async with self.db.execute(
             "SELECT is_fully_compactified from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        ) as cursor:
+            row = await cursor.fetchone()
         if row is None:
             return None
         return bool(row[0])
@@ -505,24 +478,23 @@ class BlockStore:
     async def get_random_not_compactified(self, number: int) -> List[int]:
 
         if self.db_wrapper.db_version == 2:
-            cursor = await self.db.execute(
+            async with self.db.execute(
                 f"SELECT height FROM full_blocks WHERE in_main_chain=1 AND is_fully_compactified=0 "
                 f"ORDER BY RANDOM() LIMIT {number}"
-            )
+            ) as cursor:
+                rows = await cursor.fetchall()
         else:
             # Since orphan blocks do not get compactified, we need to check whether all blocks with a
             # certain height are not compact. And if we do have compact orphan blocks, then all that
             # happens is that the occasional chain block stays uncompact - not ideal, but harmless.
-            cursor = await self.db.execute(
+            async with self.db.execute(
                 f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 "
                 f"ORDER BY RANDOM() LIMIT {number}"
-            )
+            ) as cursor:
+                rows = await cursor.fetchall()
 
-        rows = await cursor.fetchall()
-        await cursor.close()
-
-        heights = []
-        for row in rows:
-            heights.append(int(row[0]))
+            heights = []
+            for row in rows:
+                heights.append(int(row[0]))
 
         return heights


### PR DESCRIPTION
To make sure this doesn't cause any performance regressions, I ran both the block_store and coin_store benchmarks.
I would have expected this patch to not be any worse, but maybe a little bit faster. using `async for` to stream the sqlite results back allows pipelining reading from disk and parsing.

Are these timings noise? Is the code change worth it anyway?

| test | before | after | after / before
---|---|---|---
| block_store v1 | 333.8625s | 339.1758s | 101.6 %
| block_store v2 | 306.5919s | 319.9539s | 104.4 %
| coin_store v1 | 228.9748s | 219.8814s | 96.0 %
| coin_store v2 | 193.9898s | 195.0622s | 100.6 %

## This patch

block_store
```
version 1
89.2887s, add_full_block
52.8452s, get_full_block
5.8553s, get_full_block_bytes
53.1792s, get_full_blocks_at
7.2331s, get_block_records_by_hash
54.2095s, get_blocks_by_hash
5.4857s, get_block_record
0.6965s, get_block_records_in_range
0.0057s, get_block_records_close_to_peak
4.2023s, get_block_record
66.1747s, get_random_not_compactified
all tests completed in 339.1758s
database size: 2418.156 MB
version 2
44.2622s, add_full_block
52.6760s, get_full_block
5.0684s, get_full_block_bytes
53.2927s, get_full_blocks_at
7.9133s, get_block_records_by_hash
53.9895s, get_blocks_by_hash
6.5078s, get_block_record
0.7906s, get_block_records_in_range
0.0066s, get_block_records_close_to_peak
4.4581s, get_block_record
90.9888s, get_random_not_compactified
all tests completed in 319.9539s
database size: 357.474 MB
```

coin_store
```
version 1
Building database 
49.3254s, MOSTLY ADDITIONS additions: 400400.0 removals: 20000.0
8.0602s, MOSTLY REMOVALS additions: 600 removals: 140000
67.6810s, FULLBLOCKS additions: 400400 removals: 400000
1.4604s, GET RECORDS BY NAMES with spent 200 lookups found 40000 coins in total
66.7356s, GET RECORDS BY NAMES without spent 200 lookups found 20641 coins in total
26.6187s, GET COINS REMOVED AT HEIGHT 800 blocks, found 580000 coins in total
all tests completed in 219.8814s
database size: 638.099 MB
version 2
Building database 
44.3007s, MOSTLY ADDITIONS additions: 400400.0 removals: 20000.0
7.6507s, MOSTLY REMOVALS additions: 600 removals: 140000
64.7445s, FULLBLOCKS additions: 400400 removals: 400000
2.3373s, GET RECORDS BY NAMES with spent 200 lookups found 40000 coins in total
51.2288s, GET RECORDS BY NAMES without spent 200 lookups found 20693 coins in total
24.8002s, GET COINS REMOVED AT HEIGHT 800 blocks, found 580000 coins in total
all tests completed in 195.0622s
database size: 353.669 MB
```

## Prior commit:

block_store:
```
version 1
91.3370s, add_full_block
52.0561s, get_full_block
5.4880s, get_full_block_bytes
50.7568s, get_full_blocks_at
5.7596s, get_block_records_by_hash
53.2185s, get_blocks_by_hash
7.0929s, get_block_record
0.6808s, get_block_records_in_range
0.0057s, get_block_records_close_to_peak
4.8409s, get_block_record
62.6261s, get_random_not_compactified
all tests completed in 333.8625s
database size: 2418.156 MB
version 2
45.1364s, add_full_block
51.2920s, get_full_block
5.7642s, get_full_block_bytes
49.4884s, get_full_blocks_at
6.8339s, get_block_records_by_hash
52.1692s, get_blocks_by_hash
6.5498s, get_block_record
0.6922s, get_block_records_in_range
0.0062s, get_block_records_close_to_peak
4.2534s, get_block_record
84.4062s, get_random_not_compactified
all tests completed in 306.5919s
database size: 357.474 MB
```

coin_store
```
version 1
Building database 
56.8906s, MOSTLY ADDITIONS additions: 400400.0 removals: 20000.0
8.2210s, MOSTLY REMOVALS additions: 600 removals: 140000
70.9838s, FULLBLOCKS additions: 400400 removals: 400000
1.3132s, GET RECORDS BY NAMES with spent 200 lookups found 40000 coins in total
67.1411s, GET RECORDS BY NAMES without spent 200 lookups found 20641 coins in total
24.4251s, GET COINS REMOVED AT HEIGHT 800 blocks, found 580000 coins in total
all tests completed in 228.9748s
database size: 638.091 MB
version 2
Building database 
44.5126s, MOSTLY ADDITIONS additions: 400400.0 removals: 20000.0
7.9520s, MOSTLY REMOVALS additions: 600 removals: 140000
63.4308s, FULLBLOCKS additions: 400400 removals: 400000
2.1089s, GET RECORDS BY NAMES with spent 200 lookups found 40000 coins in total
49.9227s, GET RECORDS BY NAMES without spent 200 lookups found 20693 coins in total
26.0627s, GET COINS REMOVED AT HEIGHT 800 blocks, found 580000 coins in total
all tests completed in 193.9898s
database size: 353.620 MB
```