### PR TITLE
plotting|tests: Fix and test removal of invalid plots

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -244,6 +244,10 @@ class PlotManager:
                 def plot_removed(test_path: Path):
                     return not test_path.exists() or test_path.parent not in plot_directories
 
+                for path in list(self.failed_to_open_filenames.keys()):
+                    if plot_removed(path):
+                        del self.failed_to_open_filenames[path]
+
                 filenames_to_remove: List[str] = []
                 for plot_filename, paths_entry in self.plot_filename_paths.items():
                     loaded_path, duplicated_paths = paths_entry

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -370,6 +370,18 @@ async def test_invalid_plots(test_environment):
     await env.refresh_tester.run(expected_result)
     assert len(env.refresh_tester.plot_manager.failed_to_open_filenames) == 1
     assert retry_test_plot in env.refresh_tester.plot_manager.failed_to_open_filenames
+    # Give it a non .plot ending and make sure it gets removed from the invalid list on the next refresh
+    retry_test_plot_unload = Path(env.dir_1.path / ".unload").resolve()
+    move(retry_test_plot, retry_test_plot_unload)
+    expected_result.loaded = []
+    await env.refresh_tester.run(expected_result)
+    assert len(env.refresh_tester.plot_manager.failed_to_open_filenames) == 0
+    assert retry_test_plot not in env.refresh_tester.plot_manager.failed_to_open_filenames
+    # Recover the name and make sure it reappears in the invalid list
+    move(retry_test_plot_unload, retry_test_plot)
+    await env.refresh_tester.run(expected_result)
+    assert len(env.refresh_tester.plot_manager.failed_to_open_filenames) == 1
+    assert retry_test_plot in env.refresh_tester.plot_manager.failed_to_open_filenames
     # Make sure the file stays in `failed_to_open_filenames` and doesn't get loaded in the next refresh cycle
     expected_result.loaded = []
     expected_result.processed = len(env.dir_1)


### PR DESCRIPTION
Prior to this PR invalid plots were not dropped from the `failed_to_open_filenames` dict if there were just removed from the filesystem. They were only removed from there when they became valid.