### PR TITLE
plotting|tests: Fix try/except in `PlotManager._refresh_task`

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -220,9 +220,8 @@ class PlotManager:
         self.last_refresh_time = 0
 
     def _refresh_task(self):
-        try:
-            while self._refreshing_enabled:
-
+        while self._refreshing_enabled:
+            try:
                 while not self.needs_refresh() and self._refreshing_enabled:
                     time.sleep(1)
 
@@ -305,9 +304,9 @@ class PlotManager:
                     f"total_result.removed {len(total_result.removed)}, "
                     f"total_duration {total_result.duration:.2f} seconds"
                 )
-        except Exception as e:
-            log.error(f"_refresh_callback raised: {e} with the traceback: {traceback.format_exc()}")
-            self.reset()
+            except Exception as e:
+                log.error(f"_refresh_callback raised: {e} with the traceback: {traceback.format_exc()}")
+                self.reset()
 
     def refresh_batch(self, plot_paths: List[Path], plot_directories: Set[Path]) -> PlotRefreshResult:
         start_time: float = time.time()

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -76,6 +76,7 @@ class PlotRefreshTester:
 
     def __init__(self, root_path: Path):
         self.plot_manager = PlotManager(root_path, self.refresh_callback)
+        self.plot_manager.start_refreshing()
 
     def refresh_callback(self, event: PlotRefreshEvents, refresh_result: PlotRefreshResult):
         if event != PlotRefreshEvents.done:
@@ -115,7 +116,6 @@ class PlotRefreshTester:
     async def run(self, expected_result: PlotRefreshResult):
         self.expected_result = expected_result
         self.expected_result_matched = False
-        self.plot_manager.start_refreshing()
         self.plot_manager.trigger_refresh()
         await time_out_assert(5, self.plot_manager.needs_refresh, value=False)
         assert self.expected_result_matched


### PR DESCRIPTION
The `try`/`except` should be inside the loop to let it do what it's supposed to do. This was introduced in #9409 and not detected because of e8a003fa90a025f32fd6cdce93f9bd018d45d5fa.