### PR TITLE
simplify test_block_store

### DIFF
--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -2,16 +2,14 @@ import asyncio
 import logging
 import random
 import sqlite3
-from pathlib import Path
 
-import aiosqlite
 import pytest
 
 from chia.consensus.blockchain import Blockchain
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
-from chia.util.db_wrapper import DBWrapper
+from tests.util.db_connection import DBConnection
 from tests.setup_nodes import bt, test_constants
 
 log = logging.getLogger(__name__)
@@ -30,28 +28,17 @@ class TestBlockStore:
         assert sqlite3.threadsafety == 1
         blocks = bt.get_consecutive_blocks(10)
 
-        db_filename = Path("blockchain_test.db")
-        db_filename_2 = Path("blockchain_test2.db")
+        async with DBConnection(db_version) as db_wrapper, DBConnection(db_version) as db_wrapper_2:
 
-        if db_filename.exists():
-            db_filename.unlink()
-        if db_filename_2.exists():
-            db_filename_2.unlink()
+            # Use a different file for the blockchain
+            coin_store_2 = await CoinStore.create(db_wrapper_2)
+            store_2 = await BlockStore.create(db_wrapper_2)
+            hint_store = await HintStore.create(db_wrapper_2)
+            bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
 
-        connection = await aiosqlite.connect(db_filename)
-        connection_2 = await aiosqlite.connect(db_filename_2)
-        db_wrapper = DBWrapper(connection, False, db_version)
-        db_wrapper_2 = DBWrapper(connection_2, False, db_version)
+            store = await BlockStore.create(db_wrapper)
+            await BlockStore.create(db_wrapper_2)
 
-        # Use a different file for the blockchain
-        coin_store_2 = await CoinStore.create(db_wrapper_2)
-        store_2 = await BlockStore.create(db_wrapper_2)
-        hint_store = await HintStore.create(db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
-
-        store = await BlockStore.create(db_wrapper)
-        await BlockStore.create(db_wrapper_2)
-        try:
             # Save/get block
             for block in blocks:
                 await bc.receive_block(block)
@@ -73,18 +60,6 @@ class TestBlockStore:
             block_record_records = await store.get_block_records_in_range(0, 0xFFFFFFFF)
             assert len(block_record_records) == len(blocks)
 
-        except Exception:
-            await connection.close()
-            await connection_2.close()
-            db_filename.unlink()
-            db_filename_2.unlink()
-            raise
-
-        await connection.close()
-        await connection_2.close()
-        db_filename.unlink()
-        db_filename_2.unlink()
-
     @pytest.mark.asyncio
     @pytest.mark.parametrize("db_version", [1, 2])
     async def test_deadlock(self, tmp_dir, db_version):
@@ -93,42 +68,28 @@ class TestBlockStore:
         adding blocks repeatedly. The issue was patched.
         """
         blocks = bt.get_consecutive_blocks(10)
-        db_filename = Path("blockchain_test.db")
-        db_filename_2 = Path("blockchain_test2.db")
 
-        if db_filename.exists():
-            db_filename.unlink()
-        if db_filename_2.exists():
-            db_filename_2.unlink()
+        async with DBConnection(db_version) as wrapper, DBConnection(db_version) as wrapper_2:
 
-        connection = await aiosqlite.connect(db_filename)
-        connection_2 = await aiosqlite.connect(db_filename_2)
-        wrapper = DBWrapper(connection, False, db_version)
-        wrapper_2 = DBWrapper(connection_2, False, db_version)
+            store = await BlockStore.create(wrapper)
+            coin_store_2 = await CoinStore.create(wrapper_2)
+            store_2 = await BlockStore.create(wrapper_2)
+            hint_store = await HintStore.create(wrapper_2)
+            bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
+            block_records = []
+            for block in blocks:
+                await bc.receive_block(block)
+                block_records.append(bc.block_record(block.header_hash))
+            tasks = []
 
-        store = await BlockStore.create(wrapper)
-        coin_store_2 = await CoinStore.create(wrapper_2)
-        store_2 = await BlockStore.create(wrapper_2)
-        hint_store = await HintStore.create(wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
-        block_records = []
-        for block in blocks:
-            await bc.receive_block(block)
-            block_records.append(bc.block_record(block.header_hash))
-        tasks = []
-
-        for i in range(10000):
-            rand_i = random.randint(0, 9)
-            if random.random() < 0.5:
-                tasks.append(
-                    asyncio.create_task(
-                        store.add_full_block(blocks[rand_i].header_hash, blocks[rand_i], block_records[rand_i])
+            for i in range(10000):
+                rand_i = random.randint(0, 9)
+                if random.random() < 0.5:
+                    tasks.append(
+                        asyncio.create_task(
+                            store.add_full_block(blocks[rand_i].header_hash, blocks[rand_i], block_records[rand_i])
+                        )
                     )
-                )
-            if random.random() < 0.5:
-                tasks.append(asyncio.create_task(store.get_full_block(blocks[rand_i].header_hash)))
-        await asyncio.gather(*tasks)
-        await connection.close()
-        await connection_2.close()
-        db_filename.unlink()
-        db_filename_2.unlink()
+                if random.random() < 0.5:
+                    tasks.append(asyncio.create_task(store.get_full_block(blocks[rand_i].header_hash)))
+            await asyncio.gather(*tasks)


### PR DESCRIPTION
use the `DBConnection` utility context manager to set up and tear down a test database and `DBWrapper` object.

best reviewed with white-space changes disabled