### PR TITLE
extend chia init to support initializing v2 blockchain db

### DIFF
--- a/chia/cmds/init.py
+++ b/chia/cmds/init.py
@@ -17,8 +17,11 @@ from chia.util.keychain import supports_keyring_passphrase
 )
 @click.option("--testnet", is_flag=True, help="Configure this chia install to connect to the testnet")
 @click.option("--set-passphrase", "-s", is_flag=True, help="Protect your keyring with a passphrase")
+@click.option("--experimental-v2-db", is_flag=True, help="Initialize the blockchain database in experimental v2 format")
 @click.pass_context
-def init_cmd(ctx: click.Context, create_certs: str, fix_ssl_permissions: bool, testnet: bool, **kwargs):
+def init_cmd(
+    ctx: click.Context, create_certs: str, fix_ssl_permissions: bool, testnet: bool, experimental_v2_db: bool, **kwargs
+):
     """
     Create a new configuration or migrate from previous versions to current
 
@@ -39,7 +42,13 @@ def init_cmd(ctx: click.Context, create_certs: str, fix_ssl_permissions: bool, t
     if set_passphrase:
         initialize_passphrase()
 
-    init(Path(create_certs) if create_certs is not None else None, ctx.obj["root_path"], fix_ssl_permissions, testnet)
+    init(
+        Path(create_certs) if create_certs is not None else None,
+        ctx.obj["root_path"],
+        fix_ssl_permissions,
+        testnet,
+        experimental_v2_db,
+    )
 
 
 if not supports_keyring_passphrase():

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -24,7 +24,7 @@ from chia.util.config import (
 )
 from chia.util.ints import uint32
 from chia.util.keychain import Keychain
-from chia.util.path import mkdir
+from chia.util.path import mkdir, path_from_root
 from chia.util.ssl_check import (
     DEFAULT_PERMISSIONS_CERT_FILE,
     DEFAULT_PERMISSIONS_KEY_FILE,
@@ -255,7 +255,13 @@ def copy_cert_files(cert_path: Path, new_path: Path):
         check_and_fix_permissions_for_ssl_file(new_path_child, RESTRICT_MASK_KEY_FILE, DEFAULT_PERMISSIONS_KEY_FILE)
 
 
-def init(create_certs: Optional[Path], root_path: Path, fix_ssl_permissions: bool = False, testnet: bool = False):
+def init(
+    create_certs: Optional[Path],
+    root_path: Path,
+    fix_ssl_permissions: bool = False,
+    testnet: bool = False,
+    experimental_v2_db: bool = False,
+):
     if create_certs is not None:
         if root_path.exists():
             if os.path.isdir(create_certs):
@@ -272,7 +278,13 @@ def init(create_certs: Optional[Path], root_path: Path, fix_ssl_permissions: boo
             print(f"** {root_path} does not exist. Executing core init **")
             # sanity check here to prevent infinite recursion
             if (
-                chia_init(root_path, fix_ssl_permissions=fix_ssl_permissions, testnet=testnet) == 0
+                chia_init(
+                    root_path,
+                    fix_ssl_permissions=fix_ssl_permissions,
+                    testnet=testnet,
+                    experimental_v2_db=experimental_v2_db,
+                )
+                == 0
                 and root_path.exists()
             ):
                 return init(create_certs, root_path, fix_ssl_permissions)
@@ -280,7 +292,9 @@ def init(create_certs: Optional[Path], root_path: Path, fix_ssl_permissions: boo
             print(f"** {root_path} was not created. Exiting **")
             return -1
     else:
-        return chia_init(root_path, fix_ssl_permissions=fix_ssl_permissions, testnet=testnet)
+        return chia_init(
+            root_path, fix_ssl_permissions=fix_ssl_permissions, testnet=testnet, experimental_v2_db=experimental_v2_db
+        )
 
 
 def chia_version_number() -> Tuple[str, str, str, str]:
@@ -343,7 +357,12 @@ def chia_full_version_str() -> str:
 
 
 def chia_init(
-    root_path: Path, *, should_check_keys: bool = True, fix_ssl_permissions: bool = False, testnet: bool = False
+    root_path: Path,
+    *,
+    should_check_keys: bool = True,
+    fix_ssl_permissions: bool = False,
+    testnet: bool = False,
+    experimental_v2_db: bool = False,
 ):
     """
     Standard first run initialization or migration steps. Handles config creation,
@@ -381,6 +400,18 @@ def chia_init(
         fix_ssl(root_path)
     if should_check_keys:
         check_keys(root_path)
+    if experimental_v2_db:
+        config: Dict = load_config(root_path, "config.yaml")["full_node"]
+        db_path_replaced: str = config["database_path"].replace("CHALLENGE", config["selected_network"])
+        db_path = path_from_root(root_path, db_path_replaced)
+        mkdir(db_path.parent)
+        import sqlite3
+
+        with sqlite3.connect(db_path) as connection:
+            connection.execute("CREATE TABLE database_version(version int)")
+            connection.execute("INSERT INTO database_version VALUES (2)")
+            connection.commit()
+
     print("")
     print("To see your keys, run 'chia keys show --show-mnemonic-seed'")
 


### PR DESCRIPTION
I'm open to better ways of doing this.

The intention is to make it easier to run tests with the v2 database schema. This new option will only take effect when running `chia init` for the first time (or after having cleared `~/.chia`). All it does is to create a table with a value indicating to the full node to use the v2 schema.