### PR TITLE
tests: Initialize `expected_result` and `expected_result_matched`

### DIFF
--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -75,6 +75,8 @@ class PlotRefreshTester:
     expected_result_matched: bool
 
     def __init__(self, root_path: Path):
+        self.expected_result = PlotRefreshResult()
+        self.expected_result_matched = False
         self.plot_manager = PlotManager(root_path, self.refresh_callback)
         self.plot_manager.start_refreshing()
 


### PR DESCRIPTION
Just to avoid irritating error logs like 
`tests.plotting.test_plot_manager: ERROR 'PlotRefreshTester' object has 
no attribute 'expected_result'`