### PR TITLE
tests: Don't drop the test plot directory if the test gets interrupted

### DIFF
--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -265,7 +265,7 @@ class BlockTools:
         args.num = 1
         args.buffer = 100
         args.tmp_dir = self.temp_dir
-        args.tmp2_dir = final_dir
+        args.tmp2_dir = self.temp_dir
         args.final_dir = final_dir
         args.plotid = None
         args.memo = None
@@ -320,7 +320,7 @@ class BlockTools:
             return plot_id_new
 
         except KeyboardInterrupt:
-            shutil.rmtree(self.plot_dir, ignore_errors=True)
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
             sys.exit(1)
 
     async def refresh_plots(self):


### PR DESCRIPTION
If you currently cancel the test during the plot setup phase it just removes the whole directory and with it all the test plots for no good reason. At least in my opinion its just annoying. Sure, you can clone the `test-cache` repo and copy them over if this happens but i still think its better to just merge this PR :)