### PR TITLE
Added a /push_tx endpoint to the wallet RPC

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -13,6 +13,7 @@ from chia.server.outbound_message import NodeType, make_msg
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint32, uint64
@@ -62,6 +63,7 @@ class WalletRpcApi:
             # Wallet node
             "/get_sync_status": self.get_sync_status,
             "/get_height_info": self.get_height_info,
+            "/push_tx": self.push_tx,
             "/farm_block": self.farm_block,  # Only when node simulator is running
             # this function is just here for backwards-compatibility. It will probably
             # be removed in the future
@@ -361,6 +363,11 @@ class WalletRpcApi:
         network_name = self.service.config["selected_network"]
         address_prefix = self.service.config["network_overrides"]["config"][network_name]["address_prefix"]
         return {"network_name": network_name, "network_prefix": address_prefix}
+
+    async def push_tx(self, request: Dict):
+        assert self.service.wallet_state_manager is not None
+        await self.service.push_tx(SpendBundle.from_bytes(hexstr_to_bytes(request["spend_bundle"])))
+        return {}
 
     async def farm_block(self, request):
         raw_puzzle_hash = decode_puzzle_hash(request["address"])

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -365,7 +365,9 @@ class WalletRpcApi:
         return {"network_name": network_name, "network_prefix": address_prefix}
 
     async def push_tx(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
+        nodes = self.service.server.get_full_node_connections()
+        if len(nodes) == 0:
+            raise ValueError("Wallet is not currently connected to any full node peers")
         await self.service.push_tx(SpendBundle.from_bytes(hexstr_to_bytes(request["spend_bundle"])))
         return {}
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -87,6 +87,9 @@ class WalletRpcClient(RpcClient):
     async def get_height_info(self) -> uint32:
         return (await self.fetch("get_height_info", {}))["height"]
 
+    async def push_tx(self, spend_bundle):
+        return (await self.fetch("push_tx", {"spend_bundle": bytes(spend_bundle).hex()}))
+
     async def farm_block(self, address: str) -> None:
         return await self.fetch("farm_block", {"address": address})
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1389,3 +1389,13 @@ class WalletNode:
             return validated_states
 
         return response.coin_states
+
+    # For RPC only.  You should use wallet_state_manager.add_pending_transaction for normal wallet business.
+    async def push_tx(self, spend_bundle):
+        msg = make_msg(
+            ProtocolMessageTypes.send_transaction,
+            wallet_protocol.SendTransaction(spend_bundle),
+        )
+        full_nodes = self.server.get_full_node_connections()
+        for peer in full_nodes:
+            await peer.send_message(msg)

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -185,7 +185,7 @@ class TestWalletRpc:
             assert len(tx_res.additions) == 2  # The output and the change
             assert any([addition.amount == signed_tx_amount for addition in tx_res.additions])
 
-            push_res = await client_node.push_tx(tx_res.spend_bundle)
+            push_res = await client.push_tx(tx_res.spend_bundle)
             assert push_res["success"]
             assert (await client.get_wallet_balance("1"))[
                 "confirmed_wallet_balance"


### PR DESCRIPTION
We have this on the full node but there's no reason a standalone wallet shouldn't be able to pass on transactions for you as well.