### PR TITLE
colorlog apparently changed, tests fail on colorlog-6.6.0

### DIFF
--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import pytest
 from clvm.casts import int_to_bytes
-from colorlog import logging
+from colorlog import getLogger
 
 from chia.consensus.block_rewards import calculate_pool_reward, calculate_base_farmer_reward
 from chia.protocols import wallet_protocol, full_node_protocol
@@ -36,7 +36,7 @@ def wallet_height_at_least(wallet_node, h):
     return False
 
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 
 @pytest.fixture(scope="session")

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -2,7 +2,7 @@
 import asyncio
 
 import pytest
-from colorlog import logging
+from colorlog import getLogger
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.protocols import full_node_protocol
@@ -22,7 +22,7 @@ def wallet_height_at_least(wallet_node, h):
     return False
 
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Patch to avoid the logging fails to import error.