### PR TITLE
New clvm generator api

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -1,17 +1,18 @@
 import io
 from typing import List, Set, Tuple, Optional, Any
 
-from clvm import KEYWORD_FROM_ATOM, KEYWORD_TO_ATOM, SExp
+from clvm import SExp
 from clvm import run_program as default_run_program
 from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
-from clvm.operators import OP_REWRITE, OPERATOR_LOOKUP
+from clvm.operators import OPERATOR_LOOKUP
 from clvm.serialize import sexp_from_stream, sexp_to_stream
-from clvm_rs import STRICT_MODE as MEMPOOL_MODE, deserialize_and_run_program2, serialized_length, run_generator
+from clvm_rs import STRICT_MODE as MEMPOOL_MODE, run_chia_program, serialized_length, run_generator2
 from clvm_tools.curry import curry, uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.hash import std_hash
+from chia.util.ints import uint16
 from chia.util.byte_types import hexstr_to_bytes
 
 from .tree_hash import sha256_treehash
@@ -243,7 +244,9 @@ class SerializedProgram:
     def run_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
         return self._run(max_cost, 0, *args)
 
-    def run_as_generator(self, max_cost: int, flags: int, *args) -> Tuple[Optional[int], List[Any], int]:
+    # returns an optional error code and an optional PySpendBundleConditions (from clvm_rs)
+    # exactly one of those will hold a value
+    def run_as_generator(self, max_cost: int, flags: int, *args) -> Tuple[Optional[uint16], Optional[Any]]:
         serialized_args = b""
         if len(args) > 1:
             # when we have more than one argument, serialize them into a list
@@ -254,19 +257,12 @@ class SerializedProgram:
         else:
             serialized_args += _serialize(args[0])
 
-        native_opcode_names_by_opcode = dict(
-            ("op_%s" % OP_REWRITE.get(k, k), op) for op, k in KEYWORD_FROM_ATOM.items() if k not in "qa."
-        )
-        err, npc_list, cost = run_generator(
+        return run_generator2(
             self._buf,
             serialized_args,
-            KEYWORD_TO_ATOM["q"][0],
-            KEYWORD_TO_ATOM["a"][0],
-            native_opcode_names_by_opcode,
             max_cost,
             flags,
         )
-        return None if err == 0 else err, npc_list, cost
 
     def _run(self, max_cost: int, flags, *args) -> Tuple[int, Program]:
         # when multiple arguments are passed, concatenate them into a serialized
@@ -283,16 +279,9 @@ class SerializedProgram:
         else:
             serialized_args += _serialize(args[0])
 
-        # TODO: move this ugly magic into `clvm` "dialects"
-        native_opcode_names_by_opcode = dict(
-            ("op_%s" % OP_REWRITE.get(k, k), op) for op, k in KEYWORD_FROM_ATOM.items() if k not in "qa."
-        )
-        cost, ret = deserialize_and_run_program2(
+        cost, ret = run_chia_program(
             self._buf,
             serialized_args,
-            KEYWORD_TO_ATOM["q"][0],
-            KEYWORD_TO_ATOM["a"][0],
-            native_opcode_names_by_opcode,
             max_cost,
             flags,
         )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ dependencies = [
     "chiabip158==1.0",  # bip158-style wallet filters
     "chiapos==1.0.7",  # proof of space
     "clvm==0.9.7",
-    "clvm_rs==0.1.16",
+    "clvm_rs==0.1.17",
     "clvm_tools==0.4.3",
     "aiohttp==3.7.4",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -1872,7 +1872,7 @@ class TestGeneratorConditions:
             assert c.conditions == [
                 (
                     opcode.value,
-                    [ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([10]), b""])],
+                    [ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([10])])],
                 )
             ]
 
@@ -1886,11 +1886,11 @@ class TestGeneratorConditions:
         assert len(npc_result.npc_list) == 1
         opcode = ConditionOpcode.CREATE_COIN
         assert (
-            ConditionWithArgs(opcode, [puzzle_hash_1.encode("ascii"), bytes([5]), b""])
+            ConditionWithArgs(opcode, [puzzle_hash_1.encode("ascii"), bytes([5])])
             in npc_result.npc_list[0].conditions[0][1]
         )
         assert (
-            ConditionWithArgs(opcode, [puzzle_hash_2.encode("ascii"), bytes([5]), b""])
+            ConditionWithArgs(opcode, [puzzle_hash_2.encode("ascii"), bytes([5])])
             in npc_result.npc_list[0].conditions[0][1]
         )
 
@@ -1903,11 +1903,11 @@ class TestGeneratorConditions:
         assert len(npc_result.npc_list) == 1
         opcode = ConditionOpcode.CREATE_COIN
         assert (
-            ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([5]), b""])
+            ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([5])])
             in npc_result.npc_list[0].conditions[0][1]
         )
         assert (
-            ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([4]), b""])
+            ConditionWithArgs(opcode, [puzzle_hash.encode("ascii"), bytes([4])])
             in npc_result.npc_list[0].conditions[0][1]
         )
 

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -103,7 +103,7 @@ class TestROM:
         npc_result = get_name_puzzle_conditions(gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, mempool_mode=False)
         assert npc_result.error is None
         assert npc_result.clvm_cost == EXPECTED_COST
-        cond_1 = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bytes([0] * 31 + [1]), int_to_bytes(500), b""])
+        cond_1 = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bytes([0] * 31 + [1]), int_to_bytes(500)])
         CONDITIONS = [
             (ConditionOpcode.CREATE_COIN, [cond_1]),
         ]


### PR DESCRIPTION
It uses the more compact return value from `run_generator2()` and converts it to our internal (more verbose) conditions format.