### PR TITLE
Update pre-commit mypy to 0.930

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.921
+    rev: v0.930
     hooks:
     - id: mypy
       additional_dependencies: [types-aiofiles, types-click, types-setuptools, types-PyYAML]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.921
     hooks:
     - id: mypy
       additional_dependencies: [types-aiofiles, types-click, types-setuptools, types-PyYAML]


### PR DESCRIPTION
Just keeping up.  Our other use of mypy isn't pinned at all so this is just setting it to match what we get there.

Draft for:
- [x] https://github.com/pre-commit/mirrors-mypy releasing 0.930