### PR TITLE
plotting|tests: Extend the lifetime of plot data cache entries

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -4,7 +4,7 @@ import threading
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from concurrent.futures.thread import ThreadPoolExecutor
 
 from blspy import G1Element
@@ -22,7 +22,7 @@ from chia.plotting.util import (
     stream_plot_info_ph,
 )
 from chia.util.generator_tools import list_to_batches
-from chia.util.ints import uint16
+from chia.util.ints import uint16, uint64
 from chia.util.path import mkdir
 from chia.util.streamable import Streamable, streamable
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
@@ -31,12 +31,12 @@ from chia.wallet.derive_keys import master_sk_to_local_sk
 
 log = logging.getLogger(__name__)
 
-CURRENT_VERSION: uint16 = uint16(0)
+CURRENT_VERSION: int = 1
 
 
 @dataclass(frozen=True)
 @streamable
-class CacheEntry(Streamable):
+class CacheEntryVersion0(Streamable):
     pool_public_key: Optional[G1Element]
     pool_contract_puzzle_hash: Optional[bytes32]
     plot_public_key: G1Element
@@ -44,14 +44,45 @@ class CacheEntry(Streamable):
 
 @dataclass(frozen=True)
 @streamable
+class DiskCacheVersion0(Streamable):
+    version: uint16
+    data: List[Tuple[bytes32, CacheEntryVersion0]]
+
+
+@dataclass(frozen=True)
+@streamable
+class DiskCacheEntry(Streamable):
+    pool_public_key: Optional[G1Element]
+    pool_contract_puzzle_hash: Optional[bytes32]
+    plot_public_key: G1Element
+    last_use: uint64
+
+
+@dataclass(frozen=True)
+@streamable
 class DiskCache(Streamable):
     version: uint16
-    data: List[Tuple[bytes32, CacheEntry]]
+    data: List[Tuple[bytes32, DiskCacheEntry]]
+
+
+@dataclass
+class CacheEntry:
+    pool_public_key: Optional[G1Element]
+    pool_contract_puzzle_hash: Optional[bytes32]
+    plot_public_key: G1Element
+    last_use: float
+
+    def bump_last_use(self) -> None:
+        self.last_use = time.time()
+
+    def expired(self, expiry_seconds: int) -> bool:
+        return time.time() - self.last_use > expiry_seconds
 
 
 class Cache:
     _changed: bool
     _data: Dict[bytes32, CacheEntry]
+    expiry_seconds: int = 7 * 24 * 60 * 60  # Keep the cache entries alive for 7 days after its last access
 
     def __init__(self, path: Path):
         self._changed = False
@@ -73,11 +104,37 @@ class Cache:
                 del self._data[key]
                 self._changed = True
 
-    def save(self):
-        try:
-            disk_cache: DiskCache = DiskCache(
-                CURRENT_VERSION, [(plot_id, cache_entry) for plot_id, cache_entry in self.items()]
+    def save(self, version: int = CURRENT_VERSION):
+        disk_cache: Union[DiskCache, DiskCacheVersion0]
+        if version == CURRENT_VERSION:
+            disk_cache_entries: Dict[bytes32, DiskCacheEntry] = {
+                plot_id: DiskCacheEntry(
+                    cache_entry.pool_public_key,
+                    cache_entry.pool_contract_puzzle_hash,
+                    cache_entry.plot_public_key,
+                    uint64(int(cache_entry.last_use)),
+                )
+                for plot_id, cache_entry in self.items()
+            }
+            disk_cache = DiskCache(
+                uint16(version), [(plot_id, cache_entry) for plot_id, cache_entry in disk_cache_entries.items()]
             )
+        elif version == 0:
+            # Support saving with older versions to test the upgrade
+            disk_cache_entries_v0: Dict[bytes32, CacheEntryVersion0] = {
+                plot_id: CacheEntryVersion0(
+                    cache_entry.pool_public_key,
+                    cache_entry.pool_contract_puzzle_hash,
+                    cache_entry.plot_public_key,
+                )
+                for plot_id, cache_entry in self.items()
+            }
+            disk_cache = DiskCacheVersion0(
+                uint16(version), [(plot_id, cache_entry) for plot_id, cache_entry in disk_cache_entries_v0.items()]
+            )
+        else:
+            raise ValueError(f"Invalid cache version {version}.")
+        try:
             serialized: bytes = bytes(disk_cache)
             self._path.write_bytes(serialized)
             self._changed = False
@@ -88,12 +145,36 @@ class Cache:
     def load(self):
         try:
             serialized = self._path.read_bytes()
+            version = uint16.from_bytes(serialized[0:2])
             log.info(f"Loaded {len(serialized)} bytes of cached data")
-            stored_cache: DiskCache = DiskCache.from_bytes(serialized)
-            if stored_cache.version != CURRENT_VERSION:
-                # TODO, Migrate or drop current cache if the version changes.
-                raise ValueError(f"Invalid cache version {stored_cache.version}. Expected version {CURRENT_VERSION}.")
-            self._data = {plot_id: cache_entry for plot_id, cache_entry in stored_cache.data}
+            if version == CURRENT_VERSION:
+                stored_cache: DiskCache = DiskCache.from_bytes(serialized)
+                self._data = {
+                    plot_id: CacheEntry(
+                        cache_entry.pool_public_key,
+                        cache_entry.pool_contract_puzzle_hash,
+                        cache_entry.plot_public_key,
+                        float(cache_entry.last_use),
+                    )
+                    for plot_id, cache_entry in stored_cache.data
+                }
+            elif version == 0:
+                log.info(f"Upgrading cache from {version} to {CURRENT_VERSION}")
+                old_cache: DiskCacheVersion0 = DiskCacheVersion0.from_bytes(serialized)
+                upgrade_time: float = time.time()
+                self._data = {
+                    plot_id: CacheEntry(
+                        cache_entry.pool_public_key,
+                        cache_entry.pool_contract_puzzle_hash,
+                        cache_entry.plot_public_key,
+                        upgrade_time,
+                    )
+                    for plot_id, cache_entry in old_cache.data
+                }
+                # Save the migrated data
+                self.save()
+            else:
+                raise ValueError(f"Invalid cache version {version}. Expected version {CURRENT_VERSION}.")
         except FileNotFoundError:
             log.debug(f"Cache {self._path} not found")
         except Exception as e:
@@ -101,6 +182,9 @@ class Cache:
 
     def keys(self):
         return self._data.keys()
+
+    def values(self):
+        return self._data.values()
 
     def items(self):
         return self._data.items()
@@ -297,10 +381,16 @@ class PlotManager:
                     self._refresh_callback(PlotRefreshEvents.done, total_result)
 
                 # Cleanup unused cache
+                self.log.debug(f"_refresh_task: cached entries before cleanup: {len(self.cache)}")
                 available_ids = set([plot_info.prover.get_id() for plot_info in self.plots.values()])
-                invalid_cache_keys = [plot_id for plot_id in self.cache.keys() if plot_id not in available_ids]
-                self.cache.remove(invalid_cache_keys)
-                self.log.debug(f"_refresh_task: cached entries removed: {len(invalid_cache_keys)}")
+                remove_ids: List[bytes32] = []
+                for plot_id, cache_entry in self.cache.items():
+                    if cache_entry.expired(Cache.expiry_seconds) and plot_id not in available_ids:
+                        remove_ids.append(plot_id)
+                    elif plot_id in available_ids:
+                        cache_entry.bump_last_use()
+                self.cache.remove(remove_ids)
+                self.log.debug(f"_refresh_task: cached entries removed: {len(remove_ids)}")
 
                 if self.cache.changed():
                     self.cache.save()
@@ -410,7 +500,7 @@ class PlotManager:
                         local_sk.get_g1(), farmer_public_key, pool_contract_puzzle_hash is not None
                     )
 
-                    cache_entry = CacheEntry(pool_public_key, pool_contract_puzzle_hash, plot_public_key)
+                    cache_entry = CacheEntry(pool_public_key, pool_contract_puzzle_hash, plot_public_key, time.time())
                     self.cache.update(prover.get_id(), cache_entry)
 
                 with self.plot_filename_paths_lock:
@@ -431,6 +521,8 @@ class PlotManager:
                     stat_info.st_size,
                     stat_info.st_mtime,
                 )
+
+                cache_entry.bump_last_use()
 
                 with counter_lock:
                     result.loaded.append(new_plot_info)


### PR DESCRIPTION
This PR extends the lifetime of plot data cache entries to 7 days. On current `main` cache entries are instantly dropped if a plot is not longer available. This is annoying because it needs to reload the cache data if you for example detach a drive (e.g. for some maintenance) longer than the refresh interval. 