### PR TITLE
Make the hard coded 2 reserved cores configurable

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -100,6 +100,7 @@ class Blockchain(BlockchainInterface):
         consensus_constants: ConsensusConstants,
         hint_store: HintStore,
         blockchain_dir: Path,
+        reserved_cores: int,
     ):
         """
         Initializes a blockchain with the BlockRecords from disk, assuming they have all been
@@ -112,7 +113,7 @@ class Blockchain(BlockchainInterface):
         cpu_count = multiprocessing.cpu_count()
         if cpu_count > 61:
             cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
-        num_workers = max(cpu_count - 2, 1)
+        num_workers = max(cpu_count - reserved_cores, 1)
         self.pool = ProcessPoolExecutor(max_workers=num_workers)
         log.info(f"Started {num_workers} processes for block validation")
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -185,8 +185,9 @@ class FullNode:
         self.coin_store = await CoinStore.create(self.db_wrapper)
         self.log.info("Initializing blockchain from disk")
         start_time = time.time()
+        reserved_cores = self.config.get("reserved_cores", 2)
         self.blockchain = await Blockchain.create(
-            self.coin_store, self.block_store, self.constants, self.hint_store, self.db_path.parent
+            self.coin_store, self.block_store, self.constants, self.hint_store, self.db_path.parent, reserved_cores
         )
         self.mempool_manager = MempoolManager(self.coin_store, self.constants)
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -333,6 +333,10 @@ full_node:
   # If node is more than these blocks behind, will do a short batch-sync, if it's less, will do a backtrack sync
   short_sync_blocks_behind_threshold: 20
 
+  # When creating process pools the process count will generally be the CPU count minus
+  # this reserved core count.
+  reserved_cores: 2
+
   # How often to initiate outbound connections to other full nodes.
   peer_connect_interval: 30
   # How long to wait for a peer connection
@@ -458,6 +462,10 @@ wallet:
   # wallet_peers_path is deprecated and has been replaced by wallet_peers_file_path
   wallet_peers_path: wallet/db/wallet_peers.sqlite
   wallet_peers_file_path: wallet/db/wallet_peers.dat
+
+  # When creating process pools the process count will generally be the CPU count minus
+  # this reserved core count.
+  reserved_cores: 2
 
   logging: *logging
   network_overrides: *network_overrides

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -88,6 +88,7 @@ class WalletBlockchain(BlockchainInterface):
         new_transaction_block_callback: Callable,  # f(removals: List[Coin], additions: List[Coin], height: uint32)
         reorg_rollback: Callable,
         lock: asyncio.Lock,
+        reserved_cores: int,
     ):
         """
         Initializes a blockchain with the BlockRecords from disk, assuming they have all been
@@ -102,7 +103,7 @@ class WalletBlockchain(BlockchainInterface):
         cpu_count = multiprocessing.cpu_count()
         if cpu_count > 61:
             cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
-        num_workers = max(cpu_count - 2, 1)
+        num_workers = max(cpu_count - reserved_cores, 1)
         self.pool = ProcessPoolExecutor(max_workers=num_workers)
         log.info(f"Started {num_workers} processes for block validation")
         self.constants = consensus_constants

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -156,6 +156,8 @@ class WalletStateManager:
         self.interested_store = await WalletInterestedStore.create(self.db_wrapper)
         self.pool_store = await WalletPoolStore.create(self.db_wrapper)
 
+        reserved_cores = self.config.get("reserved_cores", 2)
+
         self.blockchain = await WalletBlockchain.create(
             self.block_store,
             self.coin_store,
@@ -165,6 +167,7 @@ class WalletStateManager:
             self.new_transaction_block_callback,
             self.reorg_rollback,
             self.lock,
+            reserved_cores,
         )
         self.weight_proof_handler = WeightProofHandler(self.constants, self.blockchain)
 

--- a/tests/core/full_node/ram_db.py
+++ b/tests/core/full_node/ram_db.py
@@ -17,5 +17,5 @@ async def create_ram_blockchain(consensus_constants: ConsensusConstants) -> Tupl
     block_store = await BlockStore.create(db_wrapper)
     coin_store = await CoinStore.create(db_wrapper)
     hint_store = await HintStore.create(db_wrapper)
-    blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, hint_store, Path("."))
+    blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, hint_store, Path("."), 2)
     return connection, blockchain

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -34,7 +34,7 @@ class TestBlockStore:
             coin_store_2 = await CoinStore.create(db_wrapper_2)
             store_2 = await BlockStore.create(db_wrapper_2)
             hint_store = await HintStore.create(db_wrapper_2)
-            bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
+            bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir, 2)
 
             store = await BlockStore.create(db_wrapper)
             await BlockStore.create(db_wrapper_2)
@@ -76,7 +76,7 @@ class TestBlockStore:
             coin_store_2 = await CoinStore.create(wrapper_2)
             store_2 = await BlockStore.create(wrapper_2)
             hint_store = await HintStore.create(wrapper_2)
-            bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir)
+            bc = await Blockchain.create(coin_store_2, store_2, test_constants, hint_store, tmp_dir, 2)
             block_records = []
             for block in blocks:
                 await bc.receive_block(block)
@@ -105,7 +105,7 @@ class TestBlockStore:
             coin_store = await CoinStore.create(db_wrapper)
             block_store = await BlockStore.create(db_wrapper)
             hint_store = await HintStore.create(db_wrapper)
-            bc = await Blockchain.create(coin_store, block_store, test_constants, hint_store, tmp_dir)
+            bc = await Blockchain.create(coin_store, block_store, test_constants, hint_store, tmp_dir, 2)
 
             # insert all blocks
             count = 0

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -253,7 +253,7 @@ class TestCoinStoreWithBlocks:
             coin_store = await CoinStore.create(db_wrapper, cache_size=uint32(cache_size))
             store = await BlockStore.create(db_wrapper)
             hint_store = await HintStore.create(db_wrapper)
-            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store, tmp_dir)
+            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store, tmp_dir, 2)
             try:
 
                 records: List[Optional[CoinRecord]] = []
@@ -324,7 +324,7 @@ class TestCoinStoreWithBlocks:
             coin_store = await CoinStore.create(db_wrapper, cache_size=uint32(cache_size))
             store = await BlockStore.create(db_wrapper)
             hint_store = await HintStore.create(db_wrapper)
-            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store, tmp_dir)
+            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, hint_store, tmp_dir, 2)
             for block in blocks:
                 res, err, _, _ = await b.receive_block(block)
                 assert err is None

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -30,7 +30,7 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int):
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
     hint_store = await HintStore.create(wrapper)
-    bc1 = await Blockchain.create(coin_store, store, constants, hint_store, Path("."))
+    bc1 = await Blockchain.create(coin_store, store, constants, hint_store, Path("."), 2)
     assert bc1.get_peak() is None
     return bc1, connection, db_path
 


### PR DESCRIPTION
Removing the hard coded `- 2` took my 4-core RPi4 from 2 full cores and 14k BPH (Blocks Per Hour) sync rate to closer to 4 full cores and 23k BPH.  Linux anyways is pretty good about not starving user interaction from CPU time so attempting to use all cores should be fine in that regard anyways.  I don't know how well Windows handles this these days.  If there is concern, perhaps process priority would be better than forgoing entire cores all the time?  For example, there were some number of weeks where I had a full plotting load on my laptop with plotman's priority adjustment on them and I was also working full time on the laptop.  I only really bothered to pause the plotting when on video calls or otherwise wanting my system to focus on other loads.  In general, just working in PyCharm etc was still fine.

(gratuitous `htop` screenshot from around block 105k)
![image](https://user-images.githubusercontent.com/543719/147895621-91f65c0e-5fee-455a-b972-324660d19252.png)

Draft for:
- [x] Self testing
  - [x] blockchain
  - [x] wallet
- [x] Discussion of the reasons for the existing value of 2
  - 2 specifically accounts for a 'real core' when dealing with hyperthreading.
- [x] Discussion of the reasons for not using all cores
  - The interest was in leaving a processor available for the OS to use for other things including remote connections etc.
- [x] Discussion of what the default value should be for this change
  - We're going to leave the default behavior unchanged for now.  Future changes to the default can be discussed including maybe after public feedback on the effects in various cases.
- [ ] ~Testing responsiveness on Windows with 0 reserved cores~
  - Not applicable since we are not changing the default
- [ ] ~Testing responsiveness on older macOS systems with 0 reserved cores~
  - Not applicable since we are not changing the default
- [x] Consider if we want to saturate to non-negative or maybe fail on negative values
  - Maybe it's just ok for someone to request the pool be larger than their core count if they decide to specify negative?