### PR TITLE
Cache header hash to improve sync performance

### DIFF
--- a/chia/types/full_block.py
+++ b/chia/types/full_block.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import List, Optional, Set
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import Foliage, FoliageTransactionBlock, TransactionsInfo
@@ -46,6 +47,7 @@ class FullBlock(Streamable):
         return self.reward_chain_block.total_iters
 
     @property
+    @lru_cache(1)
     def header_hash(self):
         return self.foliage.get_hash()
 


### PR DESCRIPTION
This only needs to get executed once, and can be cached. It can take a while to perform these hashes, and they were done repeatedly in `multiproceess_validation.py`.