### PR TITLE
collect streamable metadata early, allow ignored fields

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -364,7 +364,7 @@ class Streamable:
         #       itself?
         post_init = getattr(cls, "__post_init__", None)
         if post_init is not None:
-            post_init(obj)
+            post_init(obj, parsed=True)
 
         # Use -1 as a sentinel value as it's not currently serializable
         if next(fields, -1) != -1:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -70,7 +70,11 @@ def dataclass_from_dict(klass, d):
         return tuple(klass_properties)
     elif dataclasses.is_dataclass(klass):
         # Type is a dataclass, data is a dictionary
-        fieldtypes = {f.name: f.annotation for f in klass._chia_streamable.fields}
+        metadata = getattr(klass, "_chia_streamable", None)
+        if metadata is not None:
+            fieldtypes = {f.name: f.annotation for f in metadata.fields}
+        else:
+            fieldtypes = {f.name: f.type for f in dataclasses.fields(klass)}
         return klass(**{f: dataclass_from_dict(fieldtypes[f], d[f]) for f in d})
     elif is_type_List(klass):
         # Type is a list, data is a list

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -364,7 +364,7 @@ class Streamable:
         #       itself?
         post_init = getattr(cls, "__post_init__", None)
         if post_init is not None:
-            post_init(obj, parsed=True)
+            post_init(obj, parsed=True)  # pylint: disable=E1102
 
         # Use -1 as a sentinel value as it's not currently serializable
         if next(fields, -1) != -1:

--- a/chia/util/streamablemetadata.py
+++ b/chia/util/streamablemetadata.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import dataclasses
+import functools
+from typing import Any, Tuple, Type, TypeVar
+
+
+_field_metadata_key = "_chia_streamable"
+
+
+@dataclasses.dataclass(frozen=True)
+class _FieldMetadata:
+    ignore: bool = False
+
+
+@functools.wraps(wrapped=dataclasses.field)
+def unstreamed_field(*args, **kwargs):
+    metadata = kwargs.setdefault("metadata", {})
+    metadata[_field_metadata_key] = _FieldMetadata(ignore=True)
+
+    return dataclasses.field(*args, **kwargs)
+
+
+_T_Field = TypeVar("_T_Field", bound="_Field")
+
+
+@dataclasses.dataclass(frozen=True)
+class _Field:
+    name: str
+    annotation: Any
+
+    @classmethod
+    def from_dataclass_field(cls: Type[_T_Field], field: dataclasses.Field) -> _T_Field:
+        return cls(name=field.name, annotation=field.type)
+
+
+_T_ClassMetadata = TypeVar("_T_ClassMetadata", bound="_ClassMetadata")
+
+
+@dataclasses.dataclass(frozen=True)
+class _ClassMetadata:
+    fields: Tuple[_Field, ...] = ()
+
+    @classmethod
+    def from_dataclass(cls: Type[_T_ClassMetadata], dataclass) -> _T_ClassMetadata:
+        fields = []
+        for dataclass_field in dataclasses.fields(dataclass):
+            metadata = dataclass_field.metadata.get(_field_metadata_key, _FieldMetadata())
+            if metadata.ignore:
+                continue
+            fields.append(_Field.from_dataclass_field(field=dataclass_field))
+
+        return cls(fields=tuple(fields))

--- a/chia/util/type_checking.py
+++ b/chia/util/type_checking.py
@@ -80,7 +80,10 @@ def strictdataclass(cls: Any):
                 raise ValueError(f"Wrong type for {f_name}")
             return item
 
-        def __post_init__(self):
+        def __post_init__(self, parsed=False):
+            if parsed:
+                return
+
             metadata = getattr(self, "_chia_streamable", None)
             if metadata is not None:
                 fields = {field.name: field.annotation for field in metadata.fields}

--- a/chia/util/type_checking.py
+++ b/chia/util/type_checking.py
@@ -1,6 +1,10 @@
 import dataclasses
 import sys
-from typing import Any, List, Optional, Tuple, Type, Union
+from typing import Any, List, Optional, Tuple, Type, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from chia.util.streamable import Streamable
+
 
 if sys.version_info < (3, 8):
 
@@ -31,7 +35,7 @@ def is_type_Tuple(f_type: Type) -> bool:
     return (get_origin(f_type) is not None and get_origin(f_type) == tuple) or f_type == tuple
 
 
-def strictdataclass(cls: Any):
+def strictdataclass(cls: Type["Streamable"]) -> Type["Streamable"]:
     class _Local:
         """
         Dataclass where all fields must be type annotated, and type checking is performed
@@ -81,19 +85,23 @@ def strictdataclass(cls: Any):
 
         def __post_init__(self):
             try:
-                fields = self.__annotations__  # pylint: disable=no-member
+                fields = self._chia_streamable.fields
             except Exception:
-                fields = {}
+                fields = []
             data = self.__dict__
-            for (f_name, f_type) in fields.items():
-                if f_name not in data:
-                    raise ValueError(f"Field {f_name} not present")
+            for field in fields:
+                if field.name not in data:
+                    raise ValueError(f"Field {field.name} not present")
                 try:
-                    if not isinstance(data[f_name], f_type):
-                        object.__setattr__(self, f_name, self.parse_item(data[f_name], f_name, f_type))
+                    if not isinstance(data[field.name], field.annotation):
+                        object.__setattr__(
+                            self, field.name, self.parse_item(data[field.name], field.name, field.annotation)
+                        )
                 except TypeError:
                     # Throws a TypeError because we cannot call isinstance for subscripted generics like Optional[int]
-                    object.__setattr__(self, f_name, self.parse_item(data[f_name], f_name, f_type))
+                    object.__setattr__(
+                        self, field.name, self.parse_item(data[field.name], field.name, field.annotation)
+                    )
 
     class NoTypeChecking:
         __no_type_check__ = True

--- a/chia/util/type_checking.py
+++ b/chia/util/type_checking.py
@@ -2,7 +2,6 @@ import dataclasses
 import sys
 from typing import Any, List, Optional, Tuple, Type, Union
 
-
 if sys.version_info < (3, 8):
 
     def get_args(t: Type[Any]) -> Tuple[Any, ...]:
@@ -81,6 +80,8 @@ def strictdataclass(cls: Any):
             return item
 
         def __post_init__(self, parsed=False):
+            # TODO: rework to avoid attaching all this expensive work we only sometimes
+            #       want such that it is outside of the .__init__() path.
             if parsed:
                 return
 

--- a/chia/util/type_checking.py
+++ b/chia/util/type_checking.py
@@ -1,9 +1,6 @@
 import dataclasses
 import sys
-from typing import Any, List, Optional, Tuple, Type, TYPE_CHECKING, Union
-
-if TYPE_CHECKING:
-    from chia.util.streamable import Streamable
+from typing import Any, List, Optional, Tuple, Type, Union
 
 
 if sys.version_info < (3, 8):

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -16,7 +16,6 @@ from chia.util.ints import uint8, uint32
 from chia.util.streamable import (
     Streamable,
     streamable,
-    unstreamed_field,
     parse_bool,
     parse_uint32,
     write_uint32,
@@ -27,6 +26,7 @@ from chia.util.streamable import (
     parse_size_hints,
     parse_str,
 )
+from chia.util.streamablemetadata import unstreamed_field
 from tests.setup_nodes import bt, test_constants
 
 
@@ -373,64 +373,6 @@ class TestStreamable(unittest.TestCase):
         # EOF off by one
         with raises(AssertionError):
             parse_str(io.BytesIO(b"\x00\x00\x02\x01" + b"a" * 512))
-
-    def test_ignored_field(self):
-        @dataclass(frozen=True)
-        @streamable
-        class Bare(Streamable):
-            a: uint32
-            b: uint32
-            c: List[uint32]
-            d: List[List[uint32]]
-            e: Optional[uint32]
-            f: Optional[uint32]
-            g: Tuple[uint32, str, bytes]
-
-        bare = Bare(a=24, b=352, c=[1, 2, 4], d=[[1, 2, 3], [3, 4]], e=728, f=None, g=(383, "hello", b"goodbye"))
-
-        bare_bytes = bytes(bare)
-        assert bare == Bare.from_bytes(bare_bytes)
-
-        @dataclass(frozen=True)
-        @streamable
-        class Ignored(Streamable):
-            a: uint32
-            b: uint32
-            c: List[uint32]
-            d: List[List[uint32]]
-            e: Optional[uint32]
-            f: Optional[uint32]
-            g: Tuple[uint32, str, bytes]
-            m: uint32 = unstreamed_field(init=False)
-            n: List[uint32] = unstreamed_field(init=False)
-            o: Optional[uint32] = unstreamed_field(init=False)
-
-            def __post_init__(self, parsed=False):
-                super().__post_init__(parsed=parsed)  # pylint: disable=E1101
-                super().__setattr__("m", self.a + uint32(1))
-                super().__setattr__("n", self.c + [uint32(2)])
-                super().__setattr__("o", self.e + uint32(3))
-
-            # TODO: can we reasonably use this form?
-            # @classmethod
-            # def create(
-            #     cls,
-            #     a: uint32,
-            #     b: uint32,
-            #     c: List[uint32],
-            #     d: List[List[uint32]],
-            #     e: Optional[uint32],
-            #     f: Optional[uint32],
-            #     g: Tuple[uint32, str, bytes],
-            # ):
-            #     return cls(a=a, b=b, c=c, d=d, e=e, f=f, g=g, m=a + 1, n=c + [uint32(2)], o=e + uint32(3))
-
-        ignored = Ignored(a=24, b=352, c=[1, 2, 4], d=[[1, 2, 3], [3, 4]], e=728, f=None, g=(383, "hello", b"goodbye"))
-
-        ignored_bytes = bytes(ignored)
-        assert ignored == Ignored.from_bytes(ignored_bytes)
-
-        assert ignored_bytes == bare_bytes
 
 
 if __name__ == "__main__":

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -406,7 +406,7 @@ class TestStreamable(unittest.TestCase):
             o: Optional[uint32] = unstreamed_field(init=False)
 
             def __post_init__(self, parsed=False):
-                super().__post_init__(parsed=parsed)
+                super().__post_init__(parsed=parsed)  # pylint: disable=E1101
                 super().__setattr__("m", self.a + uint32(1))
                 super().__setattr__("n", self.c + [uint32(2)])
                 super().__setattr__("o", self.e + uint32(3))

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -16,6 +16,7 @@ from chia.util.ints import uint8, uint32
 from chia.util.streamable import (
     Streamable,
     streamable,
+    unstreamed_field,
     parse_bool,
     parse_uint32,
     write_uint32,
@@ -372,6 +373,64 @@ class TestStreamable(unittest.TestCase):
         # EOF off by one
         with raises(AssertionError):
             parse_str(io.BytesIO(b"\x00\x00\x02\x01" + b"a" * 512))
+
+    def test_ignored_field(self):
+        @dataclass(frozen=True)
+        @streamable
+        class Bare(Streamable):
+            a: uint32
+            b: uint32
+            c: List[uint32]
+            d: List[List[uint32]]
+            e: Optional[uint32]
+            f: Optional[uint32]
+            g: Tuple[uint32, str, bytes]
+
+        bare = Bare(a=24, b=352, c=[1, 2, 4], d=[[1, 2, 3], [3, 4]], e=728, f=None, g=(383, "hello", b"goodbye"))
+
+        bare_bytes = bytes(bare)
+        assert bare == Bare.from_bytes(bare_bytes)
+
+        @dataclass(frozen=True)
+        @streamable
+        class Ignored(Streamable):
+            a: uint32
+            b: uint32
+            c: List[uint32]
+            d: List[List[uint32]]
+            e: Optional[uint32]
+            f: Optional[uint32]
+            g: Tuple[uint32, str, bytes]
+            m: uint32 = unstreamed_field(init=False)
+            n: List[uint32] = unstreamed_field(init=False)
+            o: Optional[uint32] = unstreamed_field(init=False)
+
+            def __post_init__(self):
+                super().__post_init__()
+                super().__setattr__("m", self.a + uint32(1))
+                super().__setattr__("n", self.c + [uint32(2)])
+                super().__setattr__("o", self.e + uint32(3))
+
+            # TODO: can we reasonably use this form?
+            # @classmethod
+            # def create(
+            #     cls,
+            #     a: uint32,
+            #     b: uint32,
+            #     c: List[uint32],
+            #     d: List[List[uint32]],
+            #     e: Optional[uint32],
+            #     f: Optional[uint32],
+            #     g: Tuple[uint32, str, bytes],
+            # ):
+            #     return cls(a=a, b=b, c=c, d=d, e=e, f=f, g=g, m=a + 1, n=c + [uint32(2)], o=e + uint32(3))
+
+        ignored = Ignored(a=24, b=352, c=[1, 2, 4], d=[[1, 2, 3], [3, 4]], e=728, f=None, g=(383, "hello", b"goodbye"))
+
+        ignored_bytes = bytes(ignored)
+        assert ignored == Ignored.from_bytes(ignored_bytes)
+
+        assert ignored_bytes == bare_bytes
 
 
 if __name__ == "__main__":

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -26,7 +26,6 @@ from chia.util.streamable import (
     parse_size_hints,
     parse_str,
 )
-from chia.util.streamablemetadata import unstreamed_field
 from tests.setup_nodes import bt, test_constants
 
 

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -405,8 +405,8 @@ class TestStreamable(unittest.TestCase):
             n: List[uint32] = unstreamed_field(init=False)
             o: Optional[uint32] = unstreamed_field(init=False)
 
-            def __post_init__(self):
-                super().__post_init__()
+            def __post_init__(self, parsed=False):
+                super().__post_init__(parsed=parsed)
                 super().__setattr__("m", self.a + uint32(1))
                 super().__setattr__("n", self.c + [uint32(2)])
                 super().__setattr__("o", self.e + uint32(3))

--- a/tests/core/util/test_streamablemetadata.py
+++ b/tests/core/util/test_streamablemetadata.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from chia.util.ints import uint32
+from chia.util.streamable import Streamable, streamable
+from chia.util.streamablemetadata import unstreamed_field
+
+
+def test_ignored_field():
+    @dataclass(frozen=True)
+    @streamable
+    class Bare(Streamable):
+        a: uint32
+        b: uint32
+        c: List[uint32]
+        d: List[List[uint32]]
+        e: Optional[uint32]
+        f: Optional[uint32]
+        g: Tuple[uint32, str, bytes]
+
+    bare = Bare(a=24, b=352, c=[1, 2, 4], d=[[1, 2, 3], [3, 4]], e=728, f=None, g=(383, "hello", b"goodbye"))
+
+    bare_bytes = bytes(bare)
+    assert bare == Bare.from_bytes(bare_bytes)
+
+    @dataclass(frozen=True)
+    @streamable
+    class Ignored(Streamable):
+        a: uint32
+        b: uint32
+        c: List[uint32]
+        d: List[List[uint32]]
+        e: Optional[uint32]
+        f: Optional[uint32]
+        g: Tuple[uint32, str, bytes]
+        m: uint32 = unstreamed_field(init=False)
+        n: List[uint32] = unstreamed_field(init=False)
+        o: Optional[uint32] = unstreamed_field(init=False)
+
+        def __post_init__(self, parsed=False):
+            super().__post_init__(parsed=parsed)  # pylint: disable=E1101
+            super().__setattr__("m", self.a + uint32(1))
+            super().__setattr__("n", self.c + [uint32(2)])
+            super().__setattr__("o", self.e + uint32(3))
+
+        # TODO: can we reasonably use this form?
+        # @classmethod
+        # def create(
+        #     cls,
+        #     a: uint32,
+        #     b: uint32,
+        #     c: List[uint32],
+        #     d: List[List[uint32]],
+        #     e: Optional[uint32],
+        #     f: Optional[uint32],
+        #     g: Tuple[uint32, str, bytes],
+        # ):
+        #     return cls(a=a, b=b, c=c, d=d, e=e, f=f, g=g, m=a + 1, n=c + [uint32(2)], o=e + uint32(3))
+
+    ignored = Ignored(a=24, b=352, c=[1, 2, 4], d=[[1, 2, 3], [3, 4]], e=728, f=None, g=(383, "hello", b"goodbye"))
+
+    ignored_bytes = bytes(ignored)
+    assert ignored == Ignored.from_bytes(ignored_bytes)
+
+    assert ignored_bytes == bare_bytes


### PR DESCRIPTION
Mariano was interested in caching the `HeaderBlock.header_hash` property but we couldn't add it as a dataclass field/attribute because then the streamable system would pick up on it.  There were various other options but they all felt to me like workarounds for streamable presuming that every annotation or field (depending which bit of streamable you consider) must be part of what gets streamed.  With this change we will be able to calculate the header hash one time at the time of creation and assign it as an attribute such that all other uses will avoid both recalculation and traversal through the descriptor/property protocols and function calls.

https://github.com/Chia-Network/chia-blockchain/blob/9cc908678b1255c9a520c322302ba35084676e08/chia/types/header_block.py#L43-L45

Draft for:
- [ ] Consider being able to indicate to streamable what callable to use for building an object when parsing.  Maybe this can help avoid `.__post_init__()` and the `.__setattr__()` games inside.  This will likely run into some issues with inheritance and avoiding the skipping of the `strictdataclass()`-added type checking.
- [x] Check for performance effects using `benchmarks/coin_store.py`