### PR TITLE
[v2] remove unused counter column in hint table (for v2 schema)

### DIFF
--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -109,11 +109,9 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
                 "block_record blob)"
             )
             await out_db.execute(
-                "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3("
-                "ses_block_hash blob PRIMARY KEY,"
-                "challenge_segments blob)"
+                "CREATE TABLE sub_epoch_segments_v3(" "ses_block_hash blob PRIMARY KEY," "challenge_segments blob)"
             )
-            await out_db.execute("CREATE TABLE IF NOT EXISTS current_peak(key int PRIMARY KEY, hash blob)")
+            await out_db.execute("CREATE TABLE current_peak(key int PRIMARY KEY, hash blob)")
 
             peak_hash, peak_height = await store_v1.get_peak()
             print(f"peak: {peak_hash.hex()} height: {peak_height}")
@@ -237,7 +235,7 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
             commit_in = HINT_COMMIT_RATE
             hint_start_time = time()
             hint_values = []
-            await out_db.execute("CREATE TABLE IF NOT EXISTS hints(coin_id blob, hint blob, UNIQUE (coin_id, hint))")
+            await out_db.execute("CREATE TABLE hints(coin_id blob, hint blob, UNIQUE (coin_id, hint))")
             await out_db.commit()
             async with in_db.execute("SELECT coin_id, hint FROM hints") as cursor:
                 count = 0

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -237,22 +237,22 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
             commit_in = HINT_COMMIT_RATE
             hint_start_time = time()
             hint_values = []
-            await out_db.execute("CREATE TABLE hints(id INTEGER PRIMARY KEY AUTOINCREMENT, coin_id blob,  hint blob)")
+            await out_db.execute("CREATE TABLE IF NOT EXISTS hints(coin_id blob, hint blob, UNIQUE (coin_id, hint))")
             await out_db.commit()
             async with in_db.execute("SELECT coin_id, hint FROM hints") as cursor:
                 count = 0
                 await out_db.execute("begin transaction")
                 async for row in cursor:
-                    hint_values.append((None, row[0], row[1]))
+                    hint_values.append((row[0], row[1]))
                     commit_in -= 1
                     if commit_in == 0:
                         commit_in = HINT_COMMIT_RATE
-                        await out_db.executemany("INSERT INTO hints VALUES (?, ?, ?)", hint_values)
+                        await out_db.executemany("INSERT INTO hints VALUES(?, ?) ON CONFLICT DO NOTHING", hint_values)
                         await out_db.commit()
                         await out_db.execute("begin transaction")
                         hint_values = []
 
-            await out_db.executemany("INSERT INTO hints VALUES (?, ?, ?)", hint_values)
+            await out_db.executemany("INSERT INTO hints VALUES (?, ?)", hint_values)
             await out_db.commit()
 
             end_time = time()

--- a/chia/full_node/hint_store.py
+++ b/chia/full_node/hint_store.py
@@ -1,5 +1,4 @@
 from typing import List, Tuple
-import aiosqlite
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.db_wrapper import DBWrapper
 import logging
@@ -8,33 +7,43 @@ log = logging.getLogger(__name__)
 
 
 class HintStore:
-    coin_record_db: aiosqlite.Connection
     db_wrapper: DBWrapper
 
     @classmethod
     async def create(cls, db_wrapper: DBWrapper):
         self = cls()
         self.db_wrapper = db_wrapper
-        self.coin_record_db = db_wrapper.db
-        await self.coin_record_db.execute(
-            "CREATE TABLE IF NOT EXISTS hints(id INTEGER PRIMARY KEY AUTOINCREMENT, coin_id blob,  hint blob)"
-        )
-        await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS hint_index on hints(hint)")
-        await self.coin_record_db.commit()
+
+        if self.db_wrapper.db_version == 2:
+            await self.db_wrapper.db.execute(
+                "CREATE TABLE IF NOT EXISTS hints(coin_id blob, hint blob, UNIQUE (coin_id, hint))"
+            )
+        else:
+            await self.db_wrapper.db.execute(
+                "CREATE TABLE IF NOT EXISTS hints(id INTEGER PRIMARY KEY AUTOINCREMENT, coin_id blob, hint blob)"
+            )
+        await self.db_wrapper.db.execute("CREATE INDEX IF NOT EXISTS hint_index on hints(hint)")
+        await self.db_wrapper.db.commit()
         return self
 
     async def get_coin_ids(self, hint: bytes) -> List[bytes32]:
-        cursor = await self.coin_record_db.execute("SELECT * from hints WHERE hint=?", (hint,))
+        cursor = await self.db_wrapper.db.execute("SELECT coin_id from hints WHERE hint=?", (hint,))
         rows = await cursor.fetchall()
         await cursor.close()
         coin_ids = []
         for row in rows:
-            coin_ids.append(row[1])
+            coin_ids.append(row[0])
         return coin_ids
 
     async def add_hints(self, coin_hint_list: List[Tuple[bytes32, bytes]]) -> None:
-        cursor = await self.coin_record_db.executemany(
-            "INSERT INTO hints VALUES(?, ?, ?)",
-            [(None,) + record for record in coin_hint_list],
-        )
+        if self.db_wrapper.db_version == 2:
+            cursor = await self.db_wrapper.db.executemany(
+                "INSERT INTO hints VALUES(?, ?) ON CONFLICT DO NOTHING",
+                coin_hint_list,
+            )
+        else:
+            cursor = await self.db_wrapper.db.executemany(
+                "INSERT INTO hints VALUES(?, ?, ?)",
+                [(None,) + record for record in coin_hint_list],
+            )
         await cursor.close()

--- a/tests/core/full_node/test_hint_store.py
+++ b/tests/core/full_node/test_hint_store.py
@@ -50,6 +50,68 @@ class TestHintStore:
             coins_for_non_hint = await hint_store.get_coin_ids(not_existing_hint)
             assert coins_for_non_hint == []
 
+    async def test_duplicate_coins(self, db_version):
+        async with DBConnection(db_version) as db_wrapper:
+            hint_store = await HintStore.create(db_wrapper)
+            hint_0 = 32 * b"\0"
+            hint_1 = 32 * b"\1"
+
+            coin_id_0 = 32 * b"\4"
+
+            hints = [(coin_id_0, hint_0), (coin_id_0, hint_1)]
+            await hint_store.add_hints(hints)
+            await db_wrapper.commit_transaction()
+            coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
+            assert coin_id_0 in coins_for_hint_0
+
+            coins_for_hint_1 = await hint_store.get_coin_ids(hint_1)
+            assert coin_id_0 in coins_for_hint_1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_hints(self, db_version):
+        async with DBConnection(db_version) as db_wrapper:
+            hint_store = await HintStore.create(db_wrapper)
+            hint_0 = 32 * b"\0"
+            hint_1 = 32 * b"\1"
+
+            coin_id_0 = 32 * b"\4"
+            coin_id_1 = 32 * b"\5"
+
+            hints = [(coin_id_0, hint_0), (coin_id_1, hint_0)]
+            await hint_store.add_hints(hints)
+            await db_wrapper.commit_transaction()
+            coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
+            assert coin_id_0 in coins_for_hint_0
+            assert coin_id_1 in coins_for_hint_0
+
+            coins_for_hint_1 = await hint_store.get_coin_ids(hint_1)
+            assert coins_for_hint_1 == []
+
+    @pytest.mark.asyncio
+    async def test_duplicates(self, db_version):
+        async with DBConnection(db_version) as db_wrapper:
+            hint_store = await HintStore.create(db_wrapper)
+            hint_0 = 32 * b"\0"
+            coin_id_0 = 32 * b"\4"
+
+            for i in range(0, 2):
+                hints = [(coin_id_0, hint_0), (coin_id_0, hint_0)]
+                await hint_store.add_hints(hints)
+                await db_wrapper.commit_transaction()
+            coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
+            assert coin_id_0 in coins_for_hint_0
+
+            cursor = await db_wrapper.db.execute("SELECT COUNT(*) FROM hints")
+            rows = await cursor.fetchall()
+
+            if db_wrapper.db_version == 2:
+                # even though we inserted the pair multiple times, there's only one
+                # entry in the DB
+                assert rows[0][0] == 1
+            else:
+                # we get one copy for each duplicate
+                assert rows[0][0] == 4
+
     @pytest.mark.asyncio
     async def test_hints_in_blockchain(self, empty_blockchain):  # noqa: F811
         blockchain: Blockchain = empty_blockchain


### PR DESCRIPTION
apart from removing the index column, this also adds a constraint preventing duplicate (coin_id, hint) pairs in the table. Such duplicates probably don't come up a lot in real-life, but might during reorgs. We don't reverse and replay into the hints table.