### PR TITLE
plotting: Return `None` in `process_file` if the plot exists

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -341,7 +341,7 @@ class PlotManager:
                 return None
 
             if file_path in self.plots:
-                return self.plots[file_path]
+                return None
 
             entry: Optional[Tuple[str, Set[str]]] = self.plot_filename_paths.get(file_path.name)
             if entry is not None:


### PR DESCRIPTION
This avoids redundant insertions of the existing plots here 
https://github.com/Chia-Network/chia-blockchain/blob/0ba838b7a8ea2b5410d438ac70295df699a30dae/chia/plotting/manager.py#L463 
and avoids having them in the update call here 
https://github.com/Chia-Network/chia-blockchain/blob/0ba838b7a8ea2b5410d438ac70295df699a30dae/chia/plotting/manager.py#L464.