### PR TITLE
Set reserved cores to 0

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -183,7 +183,7 @@ class FullNode:
         self.coin_store = await CoinStore.create(self.db_wrapper)
         self.log.info("Initializing blockchain from disk")
         start_time = time.time()
-        reserved_cores = self.config.get("reserved_cores", 2)
+        reserved_cores = self.config.get("reserved_cores", 0)
         self.blockchain = await Blockchain.create(
             self.coin_store, self.block_store, self.constants, self.hint_store, self.db_path.parent, reserved_cores
         )

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -342,7 +342,7 @@ full_node:
 
   # When creating process pools the process count will generally be the CPU count minus
   # this reserved core count.
-  reserved_cores: 2
+  reserved_cores: 0
 
   # How often to initiate outbound connections to other full nodes.
   peer_connect_interval: 30

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -472,7 +472,7 @@ wallet:
 
   # When creating process pools the process count will generally be the CPU count minus
   # this reserved core count.
-  reserved_cores: 2
+  reserved_cores: 0
 
   logging: *logging
   network_overrides: *network_overrides

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -470,10 +470,6 @@ wallet:
   wallet_peers_path: wallet/db/wallet_peers.sqlite
   wallet_peers_file_path: wallet/db/wallet_peers.dat
 
-  # When creating process pools the process count will generally be the CPU count minus
-  # this reserved core count.
-  reserved_cores: 0
-
   logging: *logging
   network_overrides: *network_overrides
   selected_network: *selected_network


### PR DESCRIPTION
The sync speed benefits when switching to zero are significant, and many users are switching to it. This is especially clear in machines with not many cores like the RPI. It also seems to have a greater effect when combined with the other PR (bls optimization). 

Data can be seen here: 
https://github.com/neurosis69/chia-sync-data

The initial reason for having 2 here was that linux was lagging for some people during sync. However this is anectdotal evidence and might not be related to this change, as this was a long time ago there were many bugs present in past versions. 

Furthermore, as pointed out by @altendky operating systems should not freeze even when under full CPU load. Chia sync also currently does not take advantage of all CPUs even after this change. 

EDIT: wallet config has been removed, since it's no longer in use after the recent merge.