### PR TITLE
Safer check for pool_list in config

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -584,10 +584,12 @@ class Farmer:
             if launcher_id == pool_state_dict["pool_config"].launcher_id:
                 config = load_config(self._root_path, "config.yaml")
                 new_list = []
-                for list_element in config["pool"]["pool_list"]:
-                    if hexstr_to_bytes(list_element["launcher_id"]) == bytes(launcher_id):
-                        list_element["payout_instructions"] = payout_instructions
-                    new_list.append(list_element)
+                pool_list = config["pool"].get("pool_list", [])
+                if pool_list is not None:
+                    for list_element in pool_list:
+                        if hexstr_to_bytes(list_element["launcher_id"]) == bytes(launcher_id):
+                            list_element["payout_instructions"] = payout_instructions
+                        new_list.append(list_element)
 
                 config["pool"]["pool_list"] = new_list
                 save_config(self._root_path, "config.yaml", config)

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -41,8 +41,9 @@ class PoolWalletConfig(Streamable):
 def load_pool_config(root_path: Path) -> List[PoolWalletConfig]:
     config = load_config(root_path, "config.yaml")
     ret_list: List[PoolWalletConfig] = []
-    if "pool_list" in config["pool"]:
-        for pool_config_dict in config["pool"]["pool_list"]:
+    pool_list = config["pool"].get("pool_list", [])
+    if pool_list is not None:
+        for pool_config_dict in pool_list:
             try:
                 pool_config = PoolWalletConfig(
                     bytes32.from_hexstr(pool_config_dict["launcher_id"]),


### PR DESCRIPTION
Safer check for pool_list in config. Sometimes users can end up with `pool_list: null` in config.yaml - this may be because they were manually deleting items from the list, but left in the `pool_list:` line. It may also occur in other unknown circumstances.

In this case `load_pool_config` will throw a `TypeError: 'NoneType' object is not iterable` which can cause the wallet to stop syncing. This happens during a new sync when the wallet hits a plotNFT of interest on the chain and tries to add it to the pool_list in config.yaml 

See the initial report in #9672