### PR TITLE
Set pools CI test timeout to 45 minutes

### DIFF
--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: MacOS pools Tests
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: Ubuntu pools Test
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/tests/pools/config.py
+++ b/tests/pools/config.py
@@ -1,0 +1,1 @@
+job_timeout = 45


### PR DESCRIPTION
There have been several timeout failures recently with successful runs right on the edge at 28 minutes and such.