### PR TITLE
Update pre-commit black to latest 21.12b0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     -   id: check-ast
     -   id: debug-statements
 -   repo: https://github.com/psf/black
-    rev: 21.8b0
+    rev: 21.12b0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -115,7 +115,6 @@ if getattr(sys, "frozen", False):
             path = f"{application_path}/{name_map[service_name]}"
             return path
 
-
 else:
     application_path = os.path.dirname(__file__)
 

--- a/chia/seeder/util/service.py
+++ b/chia/seeder/util/service.py
@@ -95,7 +95,6 @@ if getattr(sys, "frozen", False):
             path = f"{application_path}/{name_map[service_name]}"
             return path
 
-
 else:
     application_path = os.path.dirname(__file__)
 

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -23,7 +23,6 @@ if sys.version_info < (3, 8):
     def get_args(t: Type[Any]) -> Tuple[Any, ...]:
         return getattr(t, "__args__", ())
 
-
 else:
 
     from typing import get_args

--- a/chia/util/type_checking.py
+++ b/chia/util/type_checking.py
@@ -10,7 +10,6 @@ if sys.version_info < (3, 8):
     def get_origin(t: Type[Any]) -> Optional[Type[Any]]:
         return getattr(t, "__origin__", None)
 
-
 else:
 
     from typing import get_args, get_origin


### PR DESCRIPTION
Draft for:
- [ ] Latest black isn't yet used by the GitHub super-linter.  Waiting for https://github.com/github/super-linter/commit/fc6c5b34d9cde631aff9bc918947b5e69ff146af to be released so we can update to that here.