### PR TITLE
Pick TX type even when added coin has been spent

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -695,10 +695,15 @@ class WalletStateManager:
                 if record is None:
                     farmer_reward = False
                     pool_reward = False
+                    tx_type: int
                     if self.is_farmer_reward(coin_state.created_height, coin_state.coin.parent_coin_info):
                         farmer_reward = True
+                        tx_type = TransactionType.FEE_REWARD.value
                     elif self.is_pool_reward(coin_state.created_height, coin_state.coin.parent_coin_info):
                         pool_reward = True
+                        tx_type = TransactionType.COINBASE_REWARD.value
+                    else:
+                        tx_type = TransactionType.INCOMING_TX.value
                     record = WalletCoinRecord(
                         coin_state.coin,
                         coin_state.created_height,
@@ -734,7 +739,7 @@ class WalletStateManager:
                             wallet_id=wallet_id,
                             sent_to=[],
                             trade_id=None,
-                            type=uint32(TransactionType.INCOMING_TX.value),
+                            type=uint32(tx_type),
                             name=bytes32(token_bytes()),
                             memos=[],
                         )


### PR DESCRIPTION
While my wallet balance was correct but the reported farming rewards were low.  Several rewards were being categorized as regular transactions.  The code path for coins that had been spent assumed they were regular incoming transactions instead of considering whether they were rewards.  It doesn't seem great to have to duplicate this functionality between the two cases but this form seemed like the minimally intrusive change.  Given my limited experience here that seemed like a good way to share a fix.

This fix applies to syncing as far as I know so it will not correct incorrectly categorized transactions that were already processed into the db.