### PR TITLE
Atari test utility changes

### DIFF
--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -267,7 +267,7 @@ class FullNodeSimulator(FullNodeAPI):
         ids_to_check: Set[bytes32] = set()
         for record in records:
             if record.spend_bundle is None:
-                raise ValueError(f"Transaction record has no spend bundle: {record!r}")
+                continue
 
             ids_to_check.add(record.spend_bundle.name())
 

--- a/tests/core/data_layer/util.py
+++ b/tests/core/data_layer/util.py
@@ -132,6 +132,11 @@ class ChiaRoot:
         # TODO: --root-path doesn't seem to work here...
         kwargs.setdefault("env", {})
         kwargs["env"]["CHIA_ROOT"] = os.fspath(self.path)
+        kwargs["env"]["CHIA_KEYS_ROOT"] = os.fspath(self.path)
+
+        # This is for windows
+        if "SYSTEMROOT" in os.environ:
+            kwargs["env"]["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
 
         modified_args: List[Union[str, os_PathLike_str]] = [
             self.scripts_path.joinpath("chia"),


### PR DESCRIPTION
These are two small fixes.  One to handle transactions without a spend bundle and one to handle an error that was ocurring on Windows.