### PR TITLE
[v2] build indices last

### DIFF
--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -58,10 +58,10 @@ def db_upgrade_func(
     print(f"\n\nLEAVING PREVIOUS DB FILE UNTOUCHED {in_db_path}\n")
 
 
-BLOCK_COMMIT_RATE = 5000
-SES_COMMIT_RATE = 1000
-HINT_COMMIT_RATE = 1000
-COIN_COMMIT_RATE = 15000
+BLOCK_COMMIT_RATE = 10000
+SES_COMMIT_RATE = 2000
+HINT_COMMIT_RATE = 2000
+COIN_COMMIT_RATE = 30000
 
 
 async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -89,9 +89,8 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
         async with aiosqlite.connect(out_path) as out_db:
             await out_db.execute("pragma journal_mode=OFF")
             await out_db.execute("pragma synchronous=OFF")
-            await out_db.execute("pragma cache_size=1000000")
+            await out_db.execute("pragma cache_size=131072")
             await out_db.execute("pragma locking_mode=exclusive")
-            await out_db.execute("pragma temp_store=memory")
 
             print("initializing v2 version")
             await out_db.execute("CREATE TABLE database_version(version int)")


### PR DESCRIPTION
depends on https://github.com/Chia-Network/chia-blockchain/pull/9613

build indices at the end, rather than during insertion. This brings the runtime to ~80% of the original one, in my test.

BEFORE:

```
opening file for reading: /media/arvid/old-system/home/arvid/chia-backup/blockchain_v1_mainnet.sqlite
opening file for writing: test-before.sqlite
initializing v2 version
initializing v2 block store
peak: d5ffe115558c447077512be9897124e2a1c244d9522cafbfdaa6b2235fecc628 height: 1309628
[1/4] converting full_blocks
      511.58 seconds
[2/4] converting sub_epoch_segments_v3
      7.12 seconds
[3/4] converting hint_store
      0.83 seconds
[4/4] converting coin_store
      1045.44 seconds


LEAVING PREVIOUS DB FILE UNTOUCHED /media/arvid/old-system/home/arvid/chia-backup/blockchain_v1_mainnet.sqlite


real    26m6,645s
user    17m56,486s
sys     4m57,775s
```

AFTER:

```
opening file for reading: /media/arvid/old-system/home/arvid/chia-backup/blockchain_v1_mainnet.sqlite
opening file for writing: test-after.sqlite
initializing v2 version
initializing v2 block store
peak: d5ffe115558c447077512be9897124e2a1c244d9522cafbfdaa6b2235fecc628 height: 1309628
[1/5] converting full_blocks
      510.32 seconds
[2/5] converting sub_epoch_segments_v3
      6.42 seconds
[3/5] converting hint_store
      0.72 seconds
[4/5] converting coin_store
      645.37 seconds
[5/5] build indices
      block store
      coin store
      hint store
      95.52 seconds                             


LEAVING PREVIOUS DB FILE UNTOUCHED /media/arvid/old-system/home/arvid/chia-backup/blockchain_v1_mainnet.sqlite


real    20m59,234s
user    12m34,671s
sys     5m10,848s
```