### PR TITLE
set BUILD_VDF_CLIENT=n as default on Darwin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,7 @@ if [ "$(uname)" = "Linux" ]; then
 	fi
 elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
 	echo "Installation currently requires brew on MacOS - https://brew.sh/"
+	export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}
 elif [ "$(uname)" = "OpenBSD" ]; then
 	export MAKE=${MAKE:-gmake}
 	export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}


### PR DESCRIPTION
BUILD_VDF_CLIENT does not have a default on Darwin which causes it to build and fail on M1.