### PR TITLE
harvester: Drop plot existance check in `lookup_challenge`

### DIFF
--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -172,21 +172,17 @@ class HarvesterAPI:
         total = 0
         with self.harvester.plot_manager:
             for try_plot_filename, try_plot_info in self.harvester.plot_manager.plots.items():
-                try:
-                    if try_plot_filename.exists():
-                        # Passes the plot filter (does not check sp filter yet though, since we have not reached sp)
-                        # This is being executed at the beginning of the slot
-                        total += 1
-                        if ProofOfSpace.passes_plot_filter(
-                            self.harvester.constants,
-                            try_plot_info.prover.get_id(),
-                            new_challenge.challenge_hash,
-                            new_challenge.sp_hash,
-                        ):
-                            passed += 1
-                            awaitables.append(lookup_challenge(try_plot_filename, try_plot_info))
-                except Exception as e:
-                    self.harvester.log.error(f"Error plot file {try_plot_filename} may no longer exist {e}")
+                # Passes the plot filter (does not check sp filter yet though, since we have not reached sp)
+                # This is being executed at the beginning of the slot
+                total += 1
+                if ProofOfSpace.passes_plot_filter(
+                    self.harvester.constants,
+                    try_plot_info.prover.get_id(),
+                    new_challenge.challenge_hash,
+                    new_challenge.sp_hash,
+                ):
+                    passed += 1
+                    awaitables.append(lookup_challenge(try_plot_filename, try_plot_info))
 
         # Concurrently executes all lookups on disk, to take advantage of multiple disk parallelism
         total_proofs_found = 0


### PR DESCRIPTION
Saves a `Path.exists()` call in each lookup which obviously can be more 
expensive in some setups + this is anyway the job of 
the `PlotManager` and the existance is already implied due to the plot 
being in `PlotManager.plots`.