### PR TITLE
fix mempool issue with ASSERT_SECONDS_RELATIVE

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -343,14 +343,19 @@ class MempoolManager:
                 return None, MempoolInclusionStatus.FAILED, Err.UNKNOWN_UNSPENT
             elif name in additions_dict:
                 removal_coin = additions_dict[name]
-                # TODO(straya): what timestamp to use here?
+                # The timestamp and block-height of this coin being spent needs
+                # to be consistent with what we use to check time-lock
+                # conditions (below). All spends (including ephemeral coins) are
+                # spent simultaneously. Ephemeral coins with an
+                # ASSERT_SECONDS_RELATIVE 0 condition are still OK to spend in
+                # the same block.
                 assert self.peak.timestamp is not None
                 removal_record = CoinRecord(
                     removal_coin,
                     uint32(self.peak.height + 1),  # In mempool, so will be included in next height
                     uint32(0),
                     False,
-                    uint64(self.peak.timestamp + 1),
+                    self.peak.timestamp,
                 )
 
             assert removal_record is not None
@@ -361,7 +366,6 @@ class MempoolManager:
         removals: List[Coin] = [coin for coin in removal_coin_dict.values()]
 
         if addition_amount > removal_amount:
-            print(addition_amount, removal_amount)
             return None, MempoolInclusionStatus.FAILED, Err.MINTING_COIN
 
         fees = uint64(removal_amount - addition_amount)

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -77,6 +77,14 @@ def event_loop():
     yield loop
 
 
+# TODO: this fixture should really be at function scope, to make all tests
+# independent. Right now, TestMempool::test_basic_mempool initializes these
+# nodes, and the remaining tests just build on top of them. This means
+# test_basic_mempool must alwasy be run in order to have most of the other tests
+# pass.
+# The reason for this is that our simulators can't be destroyed correctly, which
+# means you can't instantiate more than one per process, so this is a hack until
+# that is fixed. For now, our tests are not independent
 @pytest.fixture(scope="module")
 async def two_nodes():
     async_gen = setup_simulators_and_wallets(2, 1, {})
@@ -246,6 +254,63 @@ class TestMempoolManager:
             spend_bundle,
             spend_bundle.name(),
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "opcode,lock_value,expected",
+        [
+            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -2, MempoolInclusionStatus.SUCCESS),
+            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -1, MempoolInclusionStatus.SUCCESS),
+            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0, MempoolInclusionStatus.SUCCESS),
+            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 1, MempoolInclusionStatus.FAILED),
+            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -2, MempoolInclusionStatus.SUCCESS),
+            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -1, MempoolInclusionStatus.SUCCESS),
+            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0, MempoolInclusionStatus.PENDING),
+            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 1, MempoolInclusionStatus.PENDING),
+            # the absolute height and seconds tests require fresh full nodes to
+            # run the test on. Right now, we just launch two simulations and all
+            # tests use the same ones. See comment at the two_nodes fixture
+            # (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 2, MempoolInclusionStatus.SUCCESS),
+            # (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 3, MempoolInclusionStatus.SUCCESS),
+            # (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 4, MempoolInclusionStatus.PENDING),
+            # (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 5, MempoolInclusionStatus.PENDING),
+            # genesis timestamp is 10000 and each block is 10 seconds
+            # (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10029, MempoolInclusionStatus.SUCCESS),
+            # (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10030, MempoolInclusionStatus.SUCCESS),
+            # (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10031, MempoolInclusionStatus.FAILED),
+            # (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10032, MempoolInclusionStatus.FAILED),
+        ],
+    )
+    async def test_ephemeral_timelock(self, two_nodes, opcode, lock_value, expected):
+        def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
+
+            conditions = {opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)])]}
+            tx1 = WALLET_A.generate_signed_transaction(
+                uint64(1000000), WALLET_A.get_new_puzzlehash(), coin_2, conditions.copy(), uint64(0)
+            )
+
+            ephemeral_coin: Coin = tx1.additions()[0]
+            tx2 = WALLET_A.generate_signed_transaction(
+                uint64(1000000), WALLET_A.get_new_puzzlehash(), ephemeral_coin, conditions.copy(), uint64(0)
+            )
+
+            bundle = SpendBundle.aggregate([tx1, tx2])
+            return bundle
+
+        full_node_1, _, server_1, _ = two_nodes
+        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
+
+        print(f"status: {status}")
+        print(f"error: {err}")
+
+        assert status == expected
+        if expected == MempoolInclusionStatus.SUCCESS:
+            assert mempool_bundle is bundle
+            assert err is None
+        else:
+            assert mempool_bundle is None
+            assert err is not None
 
     # this test makes sure that one spend successfully asserts the announce from
     # another spend, even though the assert condition is duplicated 100 times
@@ -527,7 +592,7 @@ class TestMempoolManager:
         bundle = test_fun(coin_1, coin_2)
 
         tx1: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(bundle)
-        status, err = await respond_transaction(full_node_1, tx1, peer)
+        status, err = await respond_transaction(full_node_1, tx1, peer, test=True)
 
         return blocks, bundle, status, err
 


### PR DESCRIPTION
Currently, the mempool rejects a spend bundle that spends an ephemeral coin with an ASSERT_SECONDS_RELATIVE 0 condition. Such condition is a no-op in the main blockchain validation (the consensus rules), so the mempool should also allow it.