### PR TITLE
Avoid issue with Ubuntu 21.04+ setuptools>=60

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,7 @@ if $UBUNTU; then
 	# Mint 20.04 repsonds with 20 here so 20 instead of 20.04
 	UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20" | bc)
 	UBUNTU_2100=$(echo "$LSB_RELEASE>=21" | bc)
+	UBUNTU_2110_PLUS=$(echo "$LSB_RELEASE>=21.10" | bc)
 fi
 
 # Manage npm and other install requirements on an OS specific basis
@@ -166,8 +167,16 @@ fi
 # shellcheck disable=SC1091
 . ./activate
 # pip 20.x+ supports Linux binary wheels
-python -m pip install --upgrade pip
-python -m pip install wheel
+
+if [ "$UBUNTU_2110_PLUS" = "true" ]; then
+	# https://github.com/pypa/setuptools/issues/2956
+	SETUPTOOLS_FOR_PIP='setuptools<60'
+else
+	SETUPTOOLS_FOR_PIP='setuptools'
+fi
+
+python -m pip install --upgrade pip wheel "${SETUPTOOLS_FOR_PIP}"
+
 #if [ "$INSTALL_PYTHON_VERSION" = "3.8" ]; then
 # This remains in case there is a diversion of binary wheels
 python -m pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,6 @@ if $UBUNTU; then
 	# Mint 20.04 repsonds with 20 here so 20 instead of 20.04
 	UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20" | bc)
 	UBUNTU_2100=$(echo "$LSB_RELEASE>=21" | bc)
-	UBUNTU_2110_PLUS=$(echo "$LSB_RELEASE>=21.10" | bc)
 fi
 
 # Manage npm and other install requirements on an OS specific basis
@@ -168,7 +167,7 @@ fi
 . ./activate
 # pip 20.x+ supports Linux binary wheels
 
-if [ "$UBUNTU_2110_PLUS" = "true" ]; then
+if [ "$UBUNTU_2100" = "1" ]; then
 	# https://github.com/pypa/setuptools/issues/2956
 	SETUPTOOLS_FOR_PIP='setuptools<60'
 else


### PR DESCRIPTION
https://github.com/pypa/setuptools/issues/2956
https://gist.github.com/altendky/b852296ac520b343890c55eabc90c880

```python-traceback
      File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 290, in set_undefined_options
        setattr(self, dst_option, getattr(src_cmd_obj, src_option))
      File "/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py", line 103, in __getattr__
        raise AttributeError(attr)
    AttributeError: install_layout
```

Draft for:
- [ ] Self testing
- [ ] Add install tests across an array of docker images