### PR TITLE
Test installers in Dockers

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -50,43 +50,53 @@ jobs:
         sh install-gui.sh
 
   test_scripts_in_docker:
-    name: Test Install Scripts
+    name: Test Install Scripts ${{ matrix.distribution.name }}
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.docker.url }}
+    container: ${{ matrix.distribution.url }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        docker:
-        - type: arch
+        distribution:
+        - name: arch:latest
+          type: arch
           url: "docker://archlinux:latest"
         # TODO: what CentOS version provides Python3.7-3.9?
-        - type: debian
+        - name: debian:buster
+          type: debian
           # https://packages.debian.org/buster/python/python3 (3.7)
           url: "docker://debian:buster"
-        - type: debian
+        - name: debian:bullseye
+          type: debian
           # https://packages.debian.org/bullseye/python/python3 (3.9)
           url: "docker://debian:bullseye"
-        - type: debian
+        - name: debian:bookworm
+          type: debian
           # https://packages.debian.org/bookworm/python/python3 (3.9)
           url: "docker://debian:bookworm"
-        - type: ubuntu
-          # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
-          url: "docker://ubuntu:focal"
-        - type: fedora
+        - name: fedora:33
+          type: fedora
           # (33, 3.9)
           url: "docker://fedora:33"
-        - type: fedora
+        - name: fedora:34
+          type: fedora
           # (34, 3.9) https://packages.fedoraproject.org/search?query=python3&releases=Fedora+34&start=0
           url: "docker://fedora:34"
-#        - type: fedora
+#        - name: fedora:35
+#          type: fedora
 #          # (35, 3.10) https://packages.fedoraproject.org/search?query=python3&releases=Fedora+35&start=0
 #          url: "docker://fedora:35"
-        - type: ubuntu
+        - name: ubuntu:focal
+          type: ubuntu
+          # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
+          url: "docker://ubuntu:focal"
+        - name: ubuntu:hirsute (21.04)
+          type: ubuntu
           # https://packages.ubuntu.com/hirsute/python3 (21.04, 3.9)
           url: "docker://ubuntu:hirsute"
-        - type: ubuntu
+        - name: ubuntu:impish (21.10)
+          type: ubuntu
           # https://packages.ubuntu.com/impish/python3 (21.10, 3.9)
           url: "docker://ubuntu:impish"
 
@@ -98,12 +108,12 @@ jobs:
         access_token: ${{ github.token }}
 
     - name: Prepare Arch
-      if: ${{ matrix.docker.type == 'arch' }}
+      if: ${{ matrix.distribution.type == 'arch' }}
       run: |
         pacman --noconfirm --refresh base --sync git sudo
 
     - name: Prepare Debian
-      if: ${{ matrix.docker.type == 'debian' }}
+      if: ${{ matrix.distribution.type == 'debian' }}
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
@@ -111,12 +121,12 @@ jobs:
         apt-get install --yes git lsb-release sudo
 
     - name: Prepare Fedora
-      if: ${{ matrix.docker.type == 'fedor' }}
+      if: ${{ matrix.distribution.type == 'fedor' }}
       run: |
         yum install --assumeyes git
 
     - name: Prepare Ubuntu
-      if: ${{ matrix.docker.type == 'ubuntu' }}
+      if: ${{ matrix.distribution.type == 'ubuntu' }}
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -148,3 +148,8 @@ jobs:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
         BUILD_VDF_CLIENT: "N"
       run: sh install.sh -a
+
+    - name: Run chia --help
+      run: |
+        source ./activate
+        chia --help

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -52,25 +52,31 @@ jobs:
   test_scripts_in_docker:
     name: Test Install Scripts
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.docker }}
+    container: ${{ matrix.docker.url }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
         docker:
-        # https://packages.debian.org/buster/python/python3 (3.7)
-        - "docker://debian:buster"
-        # https://packages.debian.org/bullseye/python/python3 (3.9)
-        - "docker://debian:bullseye"
-        # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
-        - "docker://ubuntu:focal"
-        # https://packages.ubuntu.com/hirsute/python3 (21.04, 3.9)
-        - "docker://ubuntu:hirsute"
-        # https://packages.ubuntu.com/impish/python3 (21.10, 3.9)
-        - "docker://ubuntu:impish"
+        - type: arch
+          url: "docker://archlinux:latest"
         # TODO: what CentOS version provides Python3.7-3.9?
-        - "docker://arch:latest"
+        - type: debian
+          # https://packages.debian.org/buster/python/python3 (3.7)
+          url: "docker://debian:buster"
+        - type: debian
+          # https://packages.debian.org/bullseye/python/python3 (3.9)
+          url: "docker://debian:bullseye"
+        - type: ubuntu
+          # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
+          url: "docker://ubuntu:focal"
+        - type: ubuntu
+          # https://packages.ubuntu.com/hirsute/python3 (21.04, 3.9)
+          url: "docker://ubuntu:hirsute"
+        - type: ubuntu
+          # https://packages.ubuntu.com/impish/python3 (21.10, 3.9)
+          url: "docker://ubuntu:impish"
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -83,6 +89,27 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: Prepare Arch
+      if: ${{ matrix.docker.type == 'arch' }}
+      run: |
+        pacman --sync --refresh base git sudo
+
+    - name: Prepare Debian
+      if: ${{ matrix.docker.type == 'debian' }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get --yes update
+        apt-get install --yes git lsb-release sudo
+
+    - name: Prepare Ubuntu
+      if: ${{ matrix.docker.type == 'ubuntu' }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get --yes update
+        apt-get install --yes git lsb-release sudo
 
     - name: Run install script
       env:

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Prepare Amazon Linux
       if: ${{ matrix.distribution.type == 'amazon' }}
       run: |
-        yum install --assumeyes git
+        yum install --assumeyes git sudo
 
     - name: Prepare Arch
       if: ${{ matrix.distribution.type == 'arch' }}

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -121,7 +121,7 @@ jobs:
         apt-get install --yes git lsb-release sudo
 
     - name: Prepare Fedora
-      if: ${{ matrix.distribution.type == 'fedor' }}
+      if: ${{ matrix.distribution.type == 'fedora' }}
       run: |
         yum install --assumeyes git
 

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -143,6 +143,8 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         # for bionic
+        apt-get --yes update
+        apt-get install --yes software-properties-common
         add-apt-repository --yes ppa:git-core/ppa
         apt-get --yes update
         apt-get install --yes git lsb-release sudo

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -142,6 +142,8 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
+        # for bionic
+        sudo add-apt-repository --yes ppa:git-core/ppa
         apt-get --yes update
         apt-get install --yes git lsb-release sudo
 

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -117,6 +117,6 @@ jobs:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
         BUILD_VDF_CLIENT: "N"
       run: |
-        pwd
-        ls -l
-        sh install.sh
+      pwd
+      ls -l
+      sh install.sh

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -116,6 +116,6 @@ jobs:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
         BUILD_VDF_CLIENT: "N"
       run: |
-      pwd
-      ls -l
-      sh install.sh
+        pwd
+        ls -l
+        sh install.sh

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -118,5 +118,5 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         pwd
-        ls -la
+        ls -l
         sh install.sh

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Prepare Arch
       if: ${{ matrix.docker.type == 'arch' }}
       run: |
-        pacman --no-confirm --refresh base --sync sudo
+        pacman --no-confirm --refresh base --sync git sudo
 
     - name: Prepare Debian
       if: ${{ matrix.docker.type == 'debian' }}
@@ -101,7 +101,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         apt-get --yes update
-        apt-get install --yes lsb-release sudo
+        apt-get install --yes git lsb-release sudo
 
     - name: Prepare Ubuntu
       if: ${{ matrix.docker.type == 'ubuntu' }}
@@ -109,7 +109,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         apt-get --yes update
-        apt-get install --yes lsb-release sudo
+        apt-get install --yes git lsb-release sudo
 
     - name: Run install script
       env:

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -85,11 +85,6 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - name: Checkout Code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
     - name: Prepare Arch
       if: ${{ matrix.docker.type == 'arch' }}
       run: |
@@ -110,6 +105,12 @@ jobs:
       run: |
         apt-get --yes update
         apt-get install --yes git lsb-release sudo
+
+    # after installing git so we use that copy
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Run install script
       env:

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -143,7 +143,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         # for bionic
-        sudo add-apt-repository --yes ppa:git-core/ppa
+        add-apt-repository --yes ppa:git-core/ppa
         apt-get --yes update
         apt-get install --yes git lsb-release sudo
 

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -87,7 +87,11 @@ jobs:
 #          type: fedora
 #          # (35, 3.10) https://packages.fedoraproject.org/search?query=python3&releases=Fedora+35&start=0
 #          url: "docker://fedora:35"
-        - name: ubuntu:focal
+        - name: ubuntu:bionic (18.04)
+          type: ubuntu
+          # https://packages.ubuntu.com/bionic/python3.7 (18.04, 3.7)
+          url: "docker://ubuntu:bionic"
+        - name: ubuntu:focal (20.04)
           type: ubuntu
           # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
           url: "docker://ubuntu:focal"

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -48,3 +48,44 @@ jobs:
       run: |
         . ./activate
         sh install-gui.sh
+
+  test_scripts_in_docker:
+    name: Test Install Scripts
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.docker }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest]
+        docker:
+        # https://packages.debian.org/buster/python/python3 (3.7)
+        - "docker://debian:buster"
+        # https://packages.debian.org/bullseye/python/python3 (3.9)
+        - "docker://debian:bullseye"
+        # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
+        - "docker://ubuntu:focal"
+        # https://packages.ubuntu.com/hirsute/python3 (21.04, 3.9)
+        - "docker://ubuntu:hirsute"
+        # https://packages.ubuntu.com/impish/python3 (21.10, 3.9)
+        - "docker://ubuntu:impish"
+        # TODO: what CentOS version provides Python3.7-3.9?
+        - "docker://arch:latest"
+
+    steps:
+    - name: Cancel previous runs on the same branch
+      if: ${{ github.ref != 'refs/heads/main' }}
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Run install script
+      env:
+        INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
+        BUILD_VDF_CLIENT: "N"
+      run: sh install.sh

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Prepare Arch
       if: ${{ matrix.docker.type == 'arch' }}
       run: |
-        pacman --sync --refresh base git sudo
+        pacman --no-confirm --refresh base --sync git sudo
 
     - name: Prepare Debian
       if: ${{ matrix.docker.type == 'debian' }}

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -117,5 +117,5 @@ jobs:
         BUILD_VDF_CLIENT: "N"
       run: |
         pwd
-        ls -l
+        ls -la
         sh install.sh

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Prepare Arch
       if: ${{ matrix.docker.type == 'arch' }}
       run: |
-        pacman --no-confirm --refresh base --sync git sudo
+        pacman --no-confirm --refresh base --sync sudo
 
     - name: Prepare Debian
       if: ${{ matrix.docker.type == 'debian' }}
@@ -101,7 +101,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         apt-get --yes update
-        apt-get install --yes git lsb-release sudo
+        apt-get install --yes lsb-release sudo
 
     - name: Prepare Ubuntu
       if: ${{ matrix.docker.type == 'ubuntu' }}
@@ -109,7 +109,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         apt-get --yes update
-        apt-get install --yes git lsb-release sudo
+        apt-get install --yes lsb-release sudo
 
     - name: Run install script
       env:

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Prepare Arch
       if: ${{ matrix.docker.type == 'arch' }}
       run: |
-        pacman --no-confirm --refresh base --sync git sudo
+        pacman --noconfirm --refresh base --sync git sudo
 
     - name: Prepare Debian
       if: ${{ matrix.docker.type == 'debian' }}

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -68,6 +68,9 @@ jobs:
         - type: debian
           # https://packages.debian.org/bullseye/python/python3 (3.9)
           url: "docker://debian:bullseye"
+        - type: debian
+          # https://packages.debian.org/bookworm/python/python3 (3.9)
+          url: "docker://debian:bookworm"
         - type: ubuntu
           # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
           url: "docker://ubuntu:focal"

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -116,7 +116,4 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
         BUILD_VDF_CLIENT: "N"
-      run: |
-      pwd
-      ls -l
-      sh install.sh
+      run: sh install.sh

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -115,4 +115,7 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
         BUILD_VDF_CLIENT: "N"
-      run: sh install.sh
+      run: |
+      pwd
+      ls -l
+      sh install.sh

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -119,4 +119,4 @@ jobs:
       env:
         INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
         BUILD_VDF_CLIENT: "N"
-      run: sh install.sh
+      run: sh install.sh -a

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -74,6 +74,15 @@ jobs:
         - type: ubuntu
           # https://packages.ubuntu.com/focal/python3 (20.04, 3.8)
           url: "docker://ubuntu:focal"
+        - type: fedora
+          # (33, 3.9)
+          url: "docker://fedora:33"
+        - type: fedora
+          # (34, 3.9) https://packages.fedoraproject.org/search?query=python3&releases=Fedora+34&start=0
+          url: "docker://fedora:34"
+#        - type: fedora
+#          # (35, 3.10) https://packages.fedoraproject.org/search?query=python3&releases=Fedora+35&start=0
+#          url: "docker://fedora:35"
         - type: ubuntu
           # https://packages.ubuntu.com/hirsute/python3 (21.04, 3.9)
           url: "docker://ubuntu:hirsute"
@@ -100,6 +109,11 @@ jobs:
       run: |
         apt-get --yes update
         apt-get install --yes git lsb-release sudo
+
+    - name: Prepare Fedora
+      if: ${{ matrix.docker.type == 'fedor' }}
+      run: |
+        yum install --assumeyes git
 
     - name: Prepare Ubuntu
       if: ${{ matrix.docker.type == 'ubuntu' }}

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -59,6 +59,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         distribution:
+        - name: amazonlinux:2
+          type: amazon
+          url: "docker://amazonlinux:2"
         - name: arch:latest
           type: arch
           url: "docker://archlinux:latest"
@@ -110,6 +113,11 @@ jobs:
       uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
+
+    - name: Prepare Amazon Linux
+      if: ${{ matrix.distribution.type == 'amazon' }}
+      run: |
+        yum install --assumeyes git
 
     - name: Prepare Arch
       if: ${{ matrix.distribution.type == 'arch' }}

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -159,5 +159,5 @@ jobs:
 
     - name: Run chia --help
       run: |
-        source ./activate
+        . ./activate
         chia --help

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -e
 USAGE_TEXT="\
 Usage: $0 [-d]
 
+  -a                          automated install, no questions
   -d                          install development dependencies
   -h                          display this help and exit
 "
@@ -12,11 +13,14 @@ usage() {
   echo "${USAGE_TEXT}"
 }
 
+PACMAN_AUTOMATED=
 EXTRAS=
 
 while getopts dh flag
 do
   case "${flag}" in
+    # automated
+    a) PACMAN_AUTOMATED=--noconfirm
     # development
     d) EXTRAS=${EXTRAS}dev,;;
     h) usage; exit 0;;
@@ -89,17 +93,17 @@ if [ "$(uname)" = "Linux" ]; then
 		echo "Python <= 3.9.9 is required. Installing python-3.9.9-1"
 		case $(uname -m) in
 			x86_64)
-				sudo pacman -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
+				sudo pacman ${PACMAN_AUTOMATED} -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
 				;;
 			aarch64)
-				sudo pacman -U --needed http://tardis.tiny-vps.com/aarm/packages/p/python/python-3.9.9-1-aarch64.pkg.tar.xz
+				sudo pacman ${PACMAN_AUTOMATED} -U --needed http://tardis.tiny-vps.com/aarm/packages/p/python/python-3.9.9-1-aarch64.pkg.tar.xz
 				;;
 			*)
 				echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
 				exit 1
 				;;
 			esac
-		sudo pacman -S --needed git
+		sudo pacman ${PACMAN_AUTOMATED} -S --needed git
 	elif type yum && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
 		# AMZN 2
 		echo "Installing on Amazon Linux 2."

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,7 @@ if $UBUNTU; then
 	# Mint 20.04 repsonds with 20 here so 20 instead of 20.04
 	UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20" | bc)
 	UBUNTU_2100=$(echo "$LSB_RELEASE>=21" | bc)
+	UBUNTU_2110_PLUS=$(echo "$LSB_RELEASE>=21.10" | bc)
 fi
 
 # Manage npm and other install requirements on an OS specific basis
@@ -166,8 +167,16 @@ fi
 # shellcheck disable=SC1091
 . ./activate
 # pip 20.x+ supports Linux binary wheels
-python -m pip install --upgrade pip
-python -m pip install wheel
+
+if [ "$UBUNTU_2110_PLUS" = "true" ]; then
+	# https://github.com/pypa/setuptools/issues/2956
+	SETUPTOOLS_FOR_PIP='setuptools<60'
+else
+	SETUPTOOLS_FOR_PIP='setuptools'
+fi
+
+python -m pip install --upgrade pip wheel "${SETUPTOOLS_FOR_PIP}"
+
 #if [ "$INSTALL_PYTHON_VERSION" = "3.8" ]; then
 # This remains in case there is a diversion of binary wheels
 python -m pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,6 @@ if $UBUNTU; then
 	# Mint 20.04 repsonds with 20 here so 20 instead of 20.04
 	UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20" | bc)
 	UBUNTU_2100=$(echo "$LSB_RELEASE>=21" | bc)
-	UBUNTU_2110_PLUS=$(echo "$LSB_RELEASE>=21.10" | bc)
 fi
 
 # Manage npm and other install requirements on an OS specific basis
@@ -168,7 +167,7 @@ fi
 . ./activate
 # pip 20.x+ supports Linux binary wheels
 
-if [ "$UBUNTU_2110_PLUS" = "true" ]; then
+if [ "$UBUNTU_2100" = "1" ]; then
 	# https://github.com/pypa/setuptools/issues/2956
 	SETUPTOOLS_FOR_PIP='setuptools<60'
 else

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ if [ "$(uname)" = "Linux" ]; then
 	elif [ "$DEBIAN" = "true" ]; then
 		echo "Installing on Debian."
 		sudo apt-get update
-		sudo apt-get install -y python3-venv=3.9*
+		sudo apt-get install -y python3-venv
 	elif type pacman && [ -f "/etc/arch-release" ]; then
 		# Arch Linux
 		echo "Installing on Arch Linux."

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ while getopts dh flag
 do
   case "${flag}" in
     # automated
-    a) PACMAN_AUTOMATED=--noconfirm
+    a) PACMAN_AUTOMATED=--noconfirm;;
     # development
     d) EXTRAS=${EXTRAS}dev,;;
     h) usage; exit 0;;

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ usage() {
 PACMAN_AUTOMATED=
 EXTRAS=
 
-while getopts dh flag
+while getopts adh flag
 do
   case "${flag}" in
     # automated

--- a/install.sh
+++ b/install.sh
@@ -170,16 +170,8 @@ fi
 # shellcheck disable=SC1091
 . ./activate
 # pip 20.x+ supports Linux binary wheels
-
-if [ "$UBUNTU_2100" = "1" ]; then
-	# https://github.com/pypa/setuptools/issues/2956
-	SETUPTOOLS_FOR_PIP='setuptools<60'
-else
-	SETUPTOOLS_FOR_PIP='setuptools'
-fi
-
-python -m pip install --upgrade pip wheel "${SETUPTOOLS_FOR_PIP}"
-
+python -m pip install --upgrade pip
+python -m pip install wheel
 #if [ "$INSTALL_PYTHON_VERSION" = "3.8" ]; then
 # This remains in case there is a diversion of binary wheels
 python -m pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2


### PR DESCRIPTION
This introduces testing across the Linux distributions that our `install.sh` explicitly covers with the exception of CentOS and Redhat.  I don't know if we have an explicitly supported version list for each but I picked a few that seemed to make sense.  This also reverts the addition of `=3.9*` on the `python3-venv` install for Debian added in https://github.com/Chia-Network/chia-blockchain/pull/9633/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR85 since it does not work. When `python3-venv` on Debian is 3.10 you will have to `python3.9-venv` to get 3.9.  `python3-venv=3.9*` will do nothing when `python3-venv` is 3.9 and it will fail when it is anything else, such as in Debian Buster.  Additionally, a `-a` flag was added to `install.sh` to allow for automated installs.  For now, this is only used with `pacman` to pass `--noconfirm`.

Draft for:
- [x] Self reflection