### PR TITLE
plotting|tests|setup: Improve `PlotManager` cache

### DIFF
--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -48,8 +48,8 @@ class CacheEntry:
     plot_public_key: G1Element
     last_use: float
 
-    @staticmethod
-    def from_disk_prover(prover: DiskProver) -> "CacheEntry":
+    @classmethod
+    def from_disk_prover(cls, prover: DiskProver) -> "CacheEntry":
         (
             pool_public_key_or_puzzle_hash,
             farmer_public_key,
@@ -70,9 +70,7 @@ class CacheEntry:
             local_sk.get_g1(), farmer_public_key, pool_contract_puzzle_hash is not None
         )
 
-        return CacheEntry(
-            prover, farmer_public_key, pool_public_key, pool_contract_puzzle_hash, plot_public_key, time.time()
-        )
+        return cls(prover, farmer_public_key, pool_public_key, pool_contract_puzzle_hash, plot_public_key, time.time())
 
     def bump_last_use(self) -> None:
         self.last_use = time.time()

--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -1,0 +1,144 @@
+import logging
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, ItemsView, KeysView, List, Optional, Tuple, ValuesView
+
+from blspy import G1Element
+from chiapos import DiskProver
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint16, uint64
+from chia.util.path import mkdir
+from chia.util.streamable import Streamable, streamable
+
+log = logging.getLogger(__name__)
+
+CURRENT_VERSION: int = 1
+
+
+@streamable
+@dataclass(frozen=True)
+class DiskCacheEntry(Streamable):
+    prover_data: bytes
+    farmer_public_key: G1Element
+    pool_public_key: Optional[G1Element]
+    pool_contract_puzzle_hash: Optional[bytes32]
+    plot_public_key: G1Element
+    last_use: uint64
+
+
+@streamable
+@dataclass(frozen=True)
+class DiskCache(Streamable):
+    version: uint16
+    data: List[Tuple[str, DiskCacheEntry]]
+
+
+@dataclass
+class CacheEntry:
+    prover: DiskProver
+    farmer_public_key: G1Element
+    pool_public_key: Optional[G1Element]
+    pool_contract_puzzle_hash: Optional[bytes32]
+    plot_public_key: G1Element
+    last_use: float
+
+    def bump_last_use(self) -> None:
+        self.last_use = time.time()
+
+    def expired(self, expiry_seconds: int) -> bool:
+        return time.time() - self.last_use > expiry_seconds
+
+
+class Cache:
+    _changed: bool
+    _data: Dict[Path, CacheEntry]
+    expiry_seconds: int = 7 * 24 * 60 * 60  # Keep the cache entries alive for 7 days after its last access
+
+    def __init__(self, path: Path) -> None:
+        self._changed = False
+        self._data = {}
+        self._path = path
+        if not path.parent.exists():
+            mkdir(path.parent)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def update(self, path: Path, entry: CacheEntry) -> None:
+        self._data[path] = entry
+        self._changed = True
+
+    def remove(self, cache_keys: List[Path]) -> None:
+        for key in cache_keys:
+            if key in self._data:
+                del self._data[key]
+                self._changed = True
+
+    def save(self) -> None:
+        try:
+            disk_cache_entries: Dict[str, DiskCacheEntry] = {
+                str(path): DiskCacheEntry(
+                    bytes(cache_entry.prover),
+                    cache_entry.farmer_public_key,
+                    cache_entry.pool_public_key,
+                    cache_entry.pool_contract_puzzle_hash,
+                    cache_entry.plot_public_key,
+                    uint64(int(cache_entry.last_use)),
+                )
+                for path, cache_entry in self.items()
+            }
+            disk_cache: DiskCache = DiskCache(
+                uint16(CURRENT_VERSION), [(plot_id, cache_entry) for plot_id, cache_entry in disk_cache_entries.items()]
+            )
+            serialized: bytes = bytes(disk_cache)
+            self._path.write_bytes(serialized)
+            self._changed = False
+            log.info(f"Saved {len(serialized)} bytes of cached data")
+        except Exception as e:
+            log.error(f"Failed to save cache: {e}, {traceback.format_exc()}")
+
+    def load(self) -> None:
+        try:
+            serialized = self._path.read_bytes()
+            version = uint16.from_bytes(serialized[0:2])
+            log.info(f"Loaded {len(serialized)} bytes of cached data")
+            if version == CURRENT_VERSION:
+                stored_cache: DiskCache = DiskCache.from_bytes(serialized)
+                self._data = {
+                    Path(path): CacheEntry(
+                        DiskProver.from_bytes(cache_entry.prover_data),
+                        cache_entry.farmer_public_key,
+                        cache_entry.pool_public_key,
+                        cache_entry.pool_contract_puzzle_hash,
+                        cache_entry.plot_public_key,
+                        float(cache_entry.last_use),
+                    )
+                    for path, cache_entry in stored_cache.data
+                }
+            else:
+                raise ValueError(f"Invalid cache version {version}. Expected version {CURRENT_VERSION}.")
+        except FileNotFoundError:
+            log.debug(f"Cache {self._path} not found")
+        except Exception as e:
+            log.error(f"Failed to load cache: {e}, {traceback.format_exc()}")
+
+    def keys(self) -> KeysView[Path]:
+        return self._data.keys()
+
+    def values(self) -> ValuesView[CacheEntry]:
+        return self._data.values()
+
+    def items(self) -> ItemsView[Path, CacheEntry]:
+        return self._data.items()
+
+    def get(self, path: Path) -> Optional[CacheEntry]:
+        return self._data.get(path)
+
+    def changed(self) -> bool:
+        return self._changed
+
+    def path(self) -> Path:
+        return self._path

--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import traceback
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, ItemsView, KeysView, List, Optional, Tuple, ValuesView
 
@@ -81,17 +81,15 @@ class CacheEntry:
         return time.time() - self.last_use > expiry_seconds
 
 
+@dataclass
 class Cache:
-    _changed: bool
-    _data: Dict[Path, CacheEntry]
+    _path: Path
+    _changed: bool = False
+    _data: Dict[Path, CacheEntry] = field(default_factory=dict)
     expiry_seconds: int = 7 * 24 * 60 * 60  # Keep the cache entries alive for 7 days after its last access
 
-    def __init__(self, path: Path) -> None:
-        self._changed = False
-        self._data = {}
-        self._path = path
-        if not path.parent.exists():
-            mkdir(path.parent)
+    def __post_init__(self) -> None:
+        mkdir(self._path.parent)
 
     def __len__(self) -> int:
         return len(self._data)

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -35,6 +35,8 @@ CURRENT_VERSION: int = 1
 @streamable
 @dataclass(frozen=True)
 class DiskCacheEntry(Streamable):
+    prover_data: bytes
+    farmer_public_key: G1Element
     pool_public_key: Optional[G1Element]
     pool_contract_puzzle_hash: Optional[bytes32]
     plot_public_key: G1Element
@@ -45,11 +47,13 @@ class DiskCacheEntry(Streamable):
 @dataclass(frozen=True)
 class DiskCache(Streamable):
     version: uint16
-    data: List[Tuple[bytes32, DiskCacheEntry]]
+    data: List[Tuple[str, DiskCacheEntry]]
 
 
 @dataclass
 class CacheEntry:
+    prover: DiskProver
+    farmer_public_key: G1Element
     pool_public_key: Optional[G1Element]
     pool_contract_puzzle_hash: Optional[bytes32]
     plot_public_key: G1Element
@@ -64,7 +68,7 @@ class CacheEntry:
 
 class Cache:
     _changed: bool
-    _data: Dict[bytes32, CacheEntry]
+    _data: Dict[Path, CacheEntry]
     expiry_seconds: int = 7 * 24 * 60 * 60  # Keep the cache entries alive for 7 days after its last access
 
     def __init__(self, path: Path):
@@ -77,11 +81,11 @@ class Cache:
     def __len__(self):
         return len(self._data)
 
-    def update(self, plot_id: bytes32, entry: CacheEntry):
-        self._data[plot_id] = entry
+    def update(self, path: Path, entry: CacheEntry):
+        self._data[path] = entry
         self._changed = True
 
-    def remove(self, cache_keys: List[bytes32]):
+    def remove(self, cache_keys: List[Path]):
         for key in cache_keys:
             if key in self._data:
                 del self._data[key]
@@ -89,14 +93,16 @@ class Cache:
 
     def save(self):
         try:
-            disk_cache_entries: Dict[bytes32, DiskCacheEntry] = {
-                plot_id: DiskCacheEntry(
+            disk_cache_entries: Dict[str, DiskCacheEntry] = {
+                str(path): DiskCacheEntry(
+                    bytes(cache_entry.prover),
+                    cache_entry.farmer_public_key,
                     cache_entry.pool_public_key,
                     cache_entry.pool_contract_puzzle_hash,
                     cache_entry.plot_public_key,
                     uint64(int(cache_entry.last_use)),
                 )
-                for plot_id, cache_entry in self.items()
+                for path, cache_entry in self.items()
             }
             disk_cache: DiskCache = DiskCache(
                 uint16(CURRENT_VERSION), [(plot_id, cache_entry) for plot_id, cache_entry in disk_cache_entries.items()]
@@ -116,13 +122,15 @@ class Cache:
             if version == CURRENT_VERSION:
                 stored_cache: DiskCache = DiskCache.from_bytes(serialized)
                 self._data = {
-                    plot_id: CacheEntry(
+                    Path(path): CacheEntry(
+                        DiskProver.from_bytes(cache_entry.prover_data),
+                        cache_entry.farmer_public_key,
                         cache_entry.pool_public_key,
                         cache_entry.pool_contract_puzzle_hash,
                         cache_entry.plot_public_key,
                         float(cache_entry.last_use),
                     )
-                    for plot_id, cache_entry in stored_cache.data
+                    for path, cache_entry in stored_cache.data
                 }
             else:
                 raise ValueError(f"Invalid cache version {version}. Expected version {CURRENT_VERSION}.")
@@ -140,8 +148,8 @@ class Cache:
     def items(self):
         return self._data.items()
 
-    def get(self, plot_id):
-        return self._data.get(plot_id)
+    def get(self, path: Path):
+        return self._data.get(path)
 
     def changed(self):
         return self._changed
@@ -337,15 +345,14 @@ class PlotManager:
 
                 # Cleanup unused cache
                 self.log.debug(f"_refresh_task: cached entries before cleanup: {len(self.cache)}")
-                available_ids = set([plot_info.prover.get_id() for plot_info in self.plots.values()])
-                remove_ids: List[bytes32] = []
-                for plot_id, cache_entry in self.cache.items():
-                    if cache_entry.expired(Cache.expiry_seconds) and plot_id not in available_ids:
-                        remove_ids.append(plot_id)
-                    elif plot_id in available_ids:
+                remove_paths: List[Path] = []
+                for path, cache_entry in self.cache.items():
+                    if cache_entry.expired(Cache.expiry_seconds) and path not in self.plots:
+                        remove_paths.append(path)
+                    elif path in self.plots:
                         cache_entry.bump_last_use()
-                self.cache.remove(remove_ids)
-                self.log.debug(f"_refresh_task: cached entries removed: {len(remove_ids)}")
+                self.cache.remove(remove_paths)
+                self.log.debug(f"_refresh_task: cached entries removed: {len(remove_paths)}")
 
                 if self.cache.changed():
                     self.cache.save()
@@ -398,37 +405,32 @@ class PlotManager:
                 if not file_path.exists():
                     return None
 
-                prover = DiskProver(str(file_path))
-
-                log.debug(f"process_file {str(file_path)}")
-
-                expected_size = _expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR
                 stat_info = file_path.stat()
 
-                # TODO: consider checking if the file was just written to (which would mean that the file is still
-                # being copied). A segfault might happen in this edge case.
+                cache_entry = self.cache.get(file_path)
+                cache_hit = cache_entry is not None
+                if not cache_hit:
+                    prover = DiskProver(str(file_path))
 
-                if prover.get_size() >= 30 and stat_info.st_size < 0.98 * expected_size:
-                    log.warning(
-                        f"Not farming plot {file_path}. Size is {stat_info.st_size / (1024**3)} GiB, but expected"
-                        f" at least: {expected_size / (1024 ** 3)} GiB. We assume the file is being copied."
-                    )
-                    return None
+                    log.debug(f"process_file {str(file_path)}")
 
-                cache_entry = self.cache.get(prover.get_id())
-                if cache_entry is None:
+                    expected_size = _expected_plot_size(prover.get_size()) * UI_ACTUAL_SPACE_CONSTANT_FACTOR
+
+                    # TODO: consider checking if the file was just written to (which would mean that the file is still
+                    # being copied). A segfault might happen in this edge case.
+
+                    if prover.get_size() >= 30 and stat_info.st_size < 0.98 * expected_size:
+                        log.warning(
+                            f"Not farming plot {file_path}. Size is {stat_info.st_size / (1024 ** 3)} GiB, but expected"
+                            f" at least: {expected_size / (1024 ** 3)} GiB. We assume the file is being copied."
+                        )
+                        return None
+
                     (
                         pool_public_key_or_puzzle_hash,
                         farmer_public_key,
                         local_master_sk,
                     ) = parse_plot_info(prover.get_memo())
-
-                    # Only use plots that correct keys associated with them
-                    if farmer_public_key not in self.farmer_public_keys:
-                        log.warning(f"Plot {file_path} has a farmer public key that is not in the farmer's pk list.")
-                        self.no_key_filenames.add(file_path)
-                        if not self.open_no_key_filenames:
-                            return None
 
                     pool_public_key: Optional[G1Element] = None
                     pool_contract_puzzle_hash: Optional[bytes32] = None
@@ -438,38 +440,52 @@ class PlotManager:
                         assert isinstance(pool_public_key_or_puzzle_hash, bytes32)
                         pool_contract_puzzle_hash = pool_public_key_or_puzzle_hash
 
-                    if pool_public_key is not None and pool_public_key not in self.pool_public_keys:
-                        log.warning(f"Plot {file_path} has a pool public key that is not in the farmer's pool pk list.")
-                        self.no_key_filenames.add(file_path)
-                        if not self.open_no_key_filenames:
-                            return None
-
-                    # If a plot is in `no_key_filenames` the keys were missing in earlier refresh cycles. We can remove
-                    # the current plot from that list if its in there since we passed the key checks above.
-                    if file_path in self.no_key_filenames:
-                        self.no_key_filenames.remove(file_path)
-
                     local_sk = master_sk_to_local_sk(local_master_sk)
 
                     plot_public_key: G1Element = ProofOfSpace.generate_plot_public_key(
                         local_sk.get_g1(), farmer_public_key, pool_contract_puzzle_hash is not None
                     )
 
-                    cache_entry = CacheEntry(pool_public_key, pool_contract_puzzle_hash, plot_public_key, time.time())
-                    self.cache.update(prover.get_id(), cache_entry)
+                    cache_entry = CacheEntry(
+                        prover,
+                        farmer_public_key,
+                        pool_public_key,
+                        pool_contract_puzzle_hash,
+                        plot_public_key,
+                        time.time(),
+                    )
+                    self.cache.update(file_path, cache_entry)
+
+                # Only use plots that correct keys associated with them
+                if cache_entry.farmer_public_key not in self.farmer_public_keys:
+                    log.warning(f"Plot {file_path} has a farmer public key that is not in the farmer's pk list.")
+                    self.no_key_filenames.add(file_path)
+                    if not self.open_no_key_filenames:
+                        return None
+
+                if cache_entry.pool_public_key is not None and cache_entry.pool_public_key not in self.pool_public_keys:
+                    log.warning(f"Plot {file_path} has a pool public key that is not in the farmer's pool pk list.")
+                    self.no_key_filenames.add(file_path)
+                    if not self.open_no_key_filenames:
+                        return None
+
+                # If a plot is in `no_key_filenames` the keys were missing in earlier refresh cycles. We can remove
+                # the current plot from that list if its in there since we passed the key checks above.
+                if file_path in self.no_key_filenames:
+                    self.no_key_filenames.remove(file_path)
 
                 with self.plot_filename_paths_lock:
                     paths: Optional[Tuple[str, Set[str]]] = self.plot_filename_paths.get(file_path.name)
                     if paths is None:
-                        paths = (str(Path(prover.get_filename()).parent), set())
+                        paths = (str(Path(cache_entry.prover.get_filename()).parent), set())
                         self.plot_filename_paths[file_path.name] = paths
                     else:
-                        paths[1].add(str(Path(prover.get_filename()).parent))
+                        paths[1].add(str(Path(cache_entry.prover.get_filename()).parent))
                         log.warning(f"Have multiple copies of the plot {file_path.name} in {[paths[0], *paths[1]]}.")
                         return None
 
                 new_plot_info: PlotInfo = PlotInfo(
-                    prover,
+                    cache_entry.prover,
                     cache_entry.pool_public_key,
                     cache_entry.pool_contract_puzzle_hash,
                     cache_entry.plot_public_key,
@@ -490,7 +506,8 @@ class PlotManager:
                 log.error(f"Failed to open file {file_path}. {e} {tb}")
                 self.failed_to_open_filenames[file_path] = int(time.time())
                 return None
-            log.info(f"Found plot {file_path} of size {new_plot_info.prover.get_size()}")
+            log.info(f"Found plot {file_path} of size {new_plot_info.prover.get_size()}, cache_hit: {cache_hit}")
+
             return new_plot_info
 
         with self, ThreadPoolExecutor() as executor:

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -1,16 +1,16 @@
-from dataclasses import dataclass
 import logging
 import threading
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, ItemsView, ValuesView, KeysView
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 from concurrent.futures.thread import ThreadPoolExecutor
 
 from blspy import G1Element
 from chiapos import DiskProver
 
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR, _expected_plot_size
+from chia.plotting.cache import Cache, CacheEntry
 from chia.plotting.util import (
     PlotInfo,
     PlotRefreshResult,
@@ -20,142 +20,11 @@ from chia.plotting.util import (
     parse_plot_info,
 )
 from chia.util.generator_tools import list_to_batches
-from chia.util.ints import uint16, uint64
-from chia.util.path import mkdir
-from chia.util.streamable import Streamable, streamable
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.derive_keys import master_sk_to_local_sk
 
 log = logging.getLogger(__name__)
-
-CURRENT_VERSION: int = 1
-
-
-@streamable
-@dataclass(frozen=True)
-class DiskCacheEntry(Streamable):
-    prover_data: bytes
-    farmer_public_key: G1Element
-    pool_public_key: Optional[G1Element]
-    pool_contract_puzzle_hash: Optional[bytes32]
-    plot_public_key: G1Element
-    last_use: uint64
-
-
-@streamable
-@dataclass(frozen=True)
-class DiskCache(Streamable):
-    version: uint16
-    data: List[Tuple[str, DiskCacheEntry]]
-
-
-@dataclass
-class CacheEntry:
-    prover: DiskProver
-    farmer_public_key: G1Element
-    pool_public_key: Optional[G1Element]
-    pool_contract_puzzle_hash: Optional[bytes32]
-    plot_public_key: G1Element
-    last_use: float
-
-    def bump_last_use(self) -> None:
-        self.last_use = time.time()
-
-    def expired(self, expiry_seconds: int) -> bool:
-        return time.time() - self.last_use > expiry_seconds
-
-
-class Cache:
-    _changed: bool
-    _data: Dict[Path, CacheEntry]
-    expiry_seconds: int = 7 * 24 * 60 * 60  # Keep the cache entries alive for 7 days after its last access
-
-    def __init__(self, path: Path) -> None:
-        self._changed = False
-        self._data = {}
-        self._path = path
-        if not path.parent.exists():
-            mkdir(path.parent)
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-    def update(self, path: Path, entry: CacheEntry) -> None:
-        self._data[path] = entry
-        self._changed = True
-
-    def remove(self, cache_keys: List[Path]) -> None:
-        for key in cache_keys:
-            if key in self._data:
-                del self._data[key]
-                self._changed = True
-
-    def save(self) -> None:
-        try:
-            disk_cache_entries: Dict[str, DiskCacheEntry] = {
-                str(path): DiskCacheEntry(
-                    bytes(cache_entry.prover),
-                    cache_entry.farmer_public_key,
-                    cache_entry.pool_public_key,
-                    cache_entry.pool_contract_puzzle_hash,
-                    cache_entry.plot_public_key,
-                    uint64(int(cache_entry.last_use)),
-                )
-                for path, cache_entry in self.items()
-            }
-            disk_cache: DiskCache = DiskCache(
-                uint16(CURRENT_VERSION), [(plot_id, cache_entry) for plot_id, cache_entry in disk_cache_entries.items()]
-            )
-            serialized: bytes = bytes(disk_cache)
-            self._path.write_bytes(serialized)
-            self._changed = False
-            log.info(f"Saved {len(serialized)} bytes of cached data")
-        except Exception as e:
-            log.error(f"Failed to save cache: {e}, {traceback.format_exc()}")
-
-    def load(self) -> None:
-        try:
-            serialized = self._path.read_bytes()
-            version = uint16.from_bytes(serialized[0:2])
-            log.info(f"Loaded {len(serialized)} bytes of cached data")
-            if version == CURRENT_VERSION:
-                stored_cache: DiskCache = DiskCache.from_bytes(serialized)
-                self._data = {
-                    Path(path): CacheEntry(
-                        DiskProver.from_bytes(cache_entry.prover_data),
-                        cache_entry.farmer_public_key,
-                        cache_entry.pool_public_key,
-                        cache_entry.pool_contract_puzzle_hash,
-                        cache_entry.plot_public_key,
-                        float(cache_entry.last_use),
-                    )
-                    for path, cache_entry in stored_cache.data
-                }
-            else:
-                raise ValueError(f"Invalid cache version {version}. Expected version {CURRENT_VERSION}.")
-        except FileNotFoundError:
-            log.debug(f"Cache {self._path} not found")
-        except Exception as e:
-            log.error(f"Failed to load cache: {e}, {traceback.format_exc()}")
-
-    def keys(self) -> KeysView[Path]:
-        return self._data.keys()
-
-    def values(self) -> ValuesView[CacheEntry]:
-        return self._data.values()
-
-    def items(self) -> ItemsView[Path, CacheEntry]:
-        return self._data.items()
-
-    def get(self, path: Path) -> Optional[CacheEntry]:
-        return self._data.get(path)
-
-    def changed(self) -> bool:
-        return self._changed
-
-    def path(self) -> Path:
-        return self._path
 
 
 class PlotManager:

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -17,12 +17,8 @@ from chia.plotting.util import (
     PlotsRefreshParameter,
     PlotRefreshEvents,
     get_plot_filenames,
-    parse_plot_info,
 )
 from chia.util.generator_tools import list_to_batches
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace
-from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.wallet.derive_keys import master_sk_to_local_sk
 
 log = logging.getLogger(__name__)
 
@@ -295,34 +291,7 @@ class PlotManager:
                         )
                         return None
 
-                    (
-                        pool_public_key_or_puzzle_hash,
-                        farmer_public_key,
-                        local_master_sk,
-                    ) = parse_plot_info(prover.get_memo())
-
-                    pool_public_key: Optional[G1Element] = None
-                    pool_contract_puzzle_hash: Optional[bytes32] = None
-                    if isinstance(pool_public_key_or_puzzle_hash, G1Element):
-                        pool_public_key = pool_public_key_or_puzzle_hash
-                    else:
-                        assert isinstance(pool_public_key_or_puzzle_hash, bytes32)
-                        pool_contract_puzzle_hash = pool_public_key_or_puzzle_hash
-
-                    local_sk = master_sk_to_local_sk(local_master_sk)
-
-                    plot_public_key: G1Element = ProofOfSpace.generate_plot_public_key(
-                        local_sk.get_g1(), farmer_public_key, pool_contract_puzzle_hash is not None
-                    )
-
-                    cache_entry = CacheEntry(
-                        prover,
-                        farmer_public_key,
-                        pool_public_key,
-                        pool_contract_puzzle_hash,
-                        plot_public_key,
-                        time.time(),
-                    )
+                    cache_entry = CacheEntry.from_disk_prover(prover)
                     self.cache.update(file_path, cache_entry)
 
                 assert cache_entry is not None

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -4,7 +4,7 @@ import threading
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, ItemsView, ValuesView, KeysView
 from concurrent.futures.thread import ThreadPoolExecutor
 
 from blspy import G1Element
@@ -71,27 +71,27 @@ class Cache:
     _data: Dict[Path, CacheEntry]
     expiry_seconds: int = 7 * 24 * 60 * 60  # Keep the cache entries alive for 7 days after its last access
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
         self._changed = False
         self._data = {}
         self._path = path
         if not path.parent.exists():
             mkdir(path.parent)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._data)
 
-    def update(self, path: Path, entry: CacheEntry):
+    def update(self, path: Path, entry: CacheEntry) -> None:
         self._data[path] = entry
         self._changed = True
 
-    def remove(self, cache_keys: List[Path]):
+    def remove(self, cache_keys: List[Path]) -> None:
         for key in cache_keys:
             if key in self._data:
                 del self._data[key]
                 self._changed = True
 
-    def save(self):
+    def save(self) -> None:
         try:
             disk_cache_entries: Dict[str, DiskCacheEntry] = {
                 str(path): DiskCacheEntry(
@@ -114,7 +114,7 @@ class Cache:
         except Exception as e:
             log.error(f"Failed to save cache: {e}, {traceback.format_exc()}")
 
-    def load(self):
+    def load(self) -> None:
         try:
             serialized = self._path.read_bytes()
             version = uint16.from_bytes(serialized[0:2])
@@ -139,22 +139,22 @@ class Cache:
         except Exception as e:
             log.error(f"Failed to load cache: {e}, {traceback.format_exc()}")
 
-    def keys(self):
+    def keys(self) -> KeysView[Path]:
         return self._data.keys()
 
-    def values(self):
+    def values(self) -> ValuesView[CacheEntry]:
         return self._data.values()
 
-    def items(self):
+    def items(self) -> ItemsView[Path, CacheEntry]:
         return self._data.items()
 
-    def get(self, path: Path):
+    def get(self, path: Path) -> Optional[CacheEntry]:
         return self._data.get(path)
 
-    def changed(self):
+    def changed(self) -> bool:
         return self._changed
 
-    def path(self):
+    def path(self) -> Path:
         return self._path
 
 
@@ -456,6 +456,7 @@ class PlotManager:
                     )
                     self.cache.update(file_path, cache_entry)
 
+                assert cache_entry is not None
                 # Only use plots that correct keys associated with them
                 if cache_entry.farmer_public_key not in self.farmer_public_keys:
                     log.warning(f"Plot {file_path} has a farmer public key that is not in the farmer's pk list.")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ dependencies = [
     "blspy==1.0.9",  # Signature library
     "chiavdf==1.0.5",  # timelord and vdf verification
     "chiabip158==1.1",  # bip158-style wallet filters
-    "chiapos==1.0.9",  # proof of space
+    "chiapos==1.0.10",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.4",  # Currying, Program.to, other conveniences
     "chia_rs==0.1.1",

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -477,10 +477,13 @@ async def test_plot_info_caching(test_plot_environment, bt):
     assert env.refresh_tester.plot_manager.cache.path().exists()
     refresh_tester: PlotRefreshTester = PlotRefreshTester(env.root_path)
     plot_manager = refresh_tester.plot_manager
+    plot_manager.set_public_keys(bt.plot_manager.farmer_public_keys, bt.plot_manager.pool_public_keys)
     plot_manager.cache.load()
     assert len(plot_manager.cache) == len(env.refresh_tester.plot_manager.cache)
-    for plot_id, cache_entry in env.refresh_tester.plot_manager.cache.items():
-        cache_entry_new = plot_manager.cache.get(plot_id)
+    for path, cache_entry in env.refresh_tester.plot_manager.cache.items():
+        cache_entry_new = plot_manager.cache.get(path)
+        assert bytes(cache_entry_new.prover) == bytes(cache_entry.prover)
+        assert cache_entry_new.farmer_public_key == cache_entry.farmer_public_key
         assert cache_entry_new.pool_public_key == cache_entry.pool_public_key
         assert cache_entry_new.pool_contract_puzzle_hash == cache_entry.pool_contract_puzzle_hash
         assert cache_entry_new.plot_public_key == cache_entry.plot_public_key

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -19,7 +19,7 @@ from chia.plotting.util import (
 )
 from chia.util.config import create_default_chia_config
 from chia.util.path import mkdir
-from chia.plotting.manager import PlotManager
+from chia.plotting.manager import Cache, PlotManager
 from tests.block_tools import get_plot_dir
 from tests.plotting.util import get_test_plots
 from tests.time_out_assert import time_out_assert
@@ -185,7 +185,6 @@ async def test_plot_refreshing(test_plot_environment):
         assert len(get_plot_directories(env.root_path)) == expected_directories
         await env.refresh_tester.run(expected_result)
         assert len(env.refresh_tester.plot_manager.plots) == expect_total_plots
-        assert len(env.refresh_tester.plot_manager.cache) == expect_total_plots
         assert len(env.refresh_tester.plot_manager.get_duplicates()) == expect_duplicates
         assert len(env.refresh_tester.plot_manager.failed_to_open_filenames) == 0
 
@@ -513,6 +512,40 @@ async def test_plot_info_caching(test_plot_environment, bt):
     await refresh_tester.run(expected_result)
     assert len(plot_manager.plots) == len(plot_manager.plots)
     plot_manager.stop_refreshing()
+
+
+@pytest.mark.asyncio
+async def test_cache_lifetime(test_plot_environment: TestEnvironment) -> None:
+    # Load a directory to produce a cache file
+    env: TestEnvironment = test_plot_environment
+    expected_result = PlotRefreshResult()
+    add_plot_directory(env.root_path, str(env.dir_1.path))
+    expected_result.loaded = env.dir_1.plot_info_list()  # type: ignore[assignment]
+    expected_result.removed = []
+    expected_result.processed = len(env.dir_1)
+    expected_result.remaining = 0
+    await env.refresh_tester.run(expected_result)
+    expected_result.loaded = []
+    cache_v1: Cache = env.refresh_tester.plot_manager.cache
+    assert len(cache_v1) > 0
+    count_before = len(cache_v1)
+    # Remove half of the plots in dir1
+    for path in env.dir_1.path_list()[0 : int(len(env.dir_1) / 2)]:
+        expected_result.processed -= 1
+        expected_result.removed.append(path)
+        unlink(path)
+    # Modify the `last_use` timestamp of all cache entries to let them expire
+    last_use_before = time.time() - Cache.expiry_seconds - 1
+    for cache_entry in cache_v1.values():
+        cache_entry.last_use = last_use_before
+        assert cache_entry.expired(Cache.expiry_seconds)
+    # The next refresh cycle will now lead to half of the cache entries being removed because they are expired and
+    # the related plots do not longer exist.
+    await env.refresh_tester.run(expected_result)
+    assert len(cache_v1) == count_before - len(expected_result.removed)
+    # The other half of the cache entries should have a different `last_use` value now.
+    for cache_entry in cache_v1.values():
+        assert cache_entry.last_use != last_use_before
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Extend the lifetime of the cache entries, see https://github.com/Chia-Network/chia-blockchain/pull/9688
- Add the `DiskProver` and the farmer public key to the cache which leads to much faster cached loading because the plot files don't need to be reloaded at all.

This PR requires https://github.com/Chia-Network/chiapos/pull/323 and #9932 to be merged + a `chiapos` 1.0.10 release to allow `DiskProver` byte conversions.