### PR TITLE
Fix streamable for Python 3.10

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -7,7 +7,7 @@ import io
 import pprint
 import sys
 from enum import Enum
-from typing import Any, BinaryIO, Dict, List, Tuple, Type, Callable, Optional, Iterator
+from typing import Any, BinaryIO, Dict, get_type_hints, List, Tuple, Type, Callable, Optional, Iterator
 
 from blspy import G1Element, G2Element, PrivateKey
 from typing_extensions import Literal
@@ -126,6 +126,7 @@ def recurse_jsonify(d):
 
 
 PARSE_FUNCTIONS_FOR_STREAMABLE_CLASS = {}
+FIELDS_FOR_STREAMABLE_CLASS = {}
 
 
 def streamable(cls: Any):
@@ -179,9 +180,12 @@ def streamable(cls: Any):
 
     parse_functions = []
     try:
-        fields = cls1.__annotations__  # pylint: disable=no-member
+        hints = get_type_hints(t)
+        fields = {field.name: hints.get(field.name, field.type) for field in dataclasses.fields(t)}
     except Exception:
         fields = {}
+
+    FIELDS_FOR_STREAMABLE_CLASS[t] = fields
 
     for _, f_type in fields.items():
         parse_functions.append(cls.function_to_parse_one_item(f_type))
@@ -295,7 +299,7 @@ class Streamable:
     def parse(cls: Type[cls.__name__], f: BinaryIO) -> cls.__name__:  # type: ignore
         # Create the object without calling __init__() to avoid unnecessary post-init checks in strictdataclass
         obj: Streamable = object.__new__(cls)
-        fields: Iterator[str] = iter(getattr(cls, "__annotations__", {}))
+        fields: Iterator[str] = iter(FIELDS_FOR_STREAMABLE_CLASS.get(cls, {}))
         values: Iterator = (parse_f(f) for parse_f in PARSE_FUNCTIONS_FOR_STREAMABLE_CLASS[cls])
         for field, value in zip(fields, values):
             object.__setattr__(obj, field, value)
@@ -347,7 +351,7 @@ class Streamable:
 
     def stream(self, f: BinaryIO) -> None:
         try:
-            fields = self.__annotations__  # pylint: disable=no-member
+            fields = FIELDS_FOR_STREAMABLE_CLASS[type(self)]
         except Exception:
             fields = {}
         for f_name, f_type in fields.items():


### PR DESCRIPTION
Use the `dataclasses.fields()` with a preference for the hints processed through `typing.get_type_hints()` to handle properly processing stringy hints to actual classes.  This makes `tests.core.util.test_streamable` pass locally with Python 3.10 while it fails without these changes.  Hopefully by using a couple higher level APIs this will be a bit less prone to detailed changes like this.

```python-console
Python 3.9.5 (default, Jun  3 2021, 15:18:23) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> class C:
...     x: int
... 
>>> class D(C):
...     pass
... 
>>> C.__annotations__
{'x': <class 'int'>}
>>> D.__annotations__
{'x': <class 'int'>}
```

```python-console
Python 3.10.1 (main, Jan 12 2022, 20:28:45) [GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> class C:
...     x: int
... 
>>> class D(C):
...     pass
... 
>>> C.__annotations__
{'x': <class 'int'>}
>>> D.__annotations__
{}
```
