### PR TITLE
pool_wallet: Deterministic derivation of auth key, and only count poo…

### DIFF
--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -52,9 +52,6 @@ def get_login_link_cmd(launcher_id: str) -> None:
 
 
 @plotnft_cmd.command("create", short_help="Create a plot NFT")
-@click.option(
-    "--override_limit", help="Override Default Limit of 20 PlotNFT's.", type=bool, required=False, default=False
-)
 @click.option("-y", "--yes", help="No prompts", is_flag=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-u", "--pool_url", help="HTTPS host:port of the pool to join", type=str, required=False)
@@ -83,7 +80,6 @@ def create_cmd(
     state: str,
     fee: int,
     yes: bool,
-    override_limit: bool,
 ) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet
@@ -101,7 +97,6 @@ def create_cmd(
         "state": valid_initial_states[state],
         "fee": fee,
         "yes": yes,
-        "override_limit": override_limit,
     }
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, create))
 

--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -26,7 +26,6 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint16, uint32, uint64
-from chia.wallet.derive_keys import MAX_POOL_WALLETS
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.wallet_types import WalletType
 
@@ -59,10 +58,6 @@ async def create(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -
     prompt = not args.get("yes", False)
     fee = Decimal(args.get("fee", 0))
     fee_mojos = uint64(int(fee * units["chia"]))
-    override_limit = args.get("override_limit", False)
-    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    self_hostname = config["self_hostname"]
-    farmer_rpc_port = config["farmer"]["rpc_port"]
     target_puzzle_hash: Optional[bytes32]
     # Could use initial_pool_state_from_dict to simplify
     if state == "SELF_POOLING":

--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -26,6 +26,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint16, uint32, uint64
+from chia.wallet.derive_keys import MAX_POOL_WALLETS
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.wallet_types import WalletType
 
@@ -68,9 +69,9 @@ async def create(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -
     farmer_client.close()
     await farmer_client.await_closed()
 
-    if total_plot_nfts >= 18 and not override_limit:
+    if total_plot_nfts >= (MAX_POOL_WALLETS - 2) and not override_limit:
         raise Exception(
-            "18 or more PlotNFT's already exist. "
+            f"{total_plot_nfts} or more PlotNFT's already exist. "
             "If you need to override this limit (most users should not) use '--override_limit'."
         )
 

--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -63,18 +63,6 @@ async def create(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     self_hostname = config["self_hostname"]
     farmer_rpc_port = config["farmer"]["rpc_port"]
-    # get total amount of plotnft's
-    farmer_client = await FarmerRpcClient.create(self_hostname, uint16(farmer_rpc_port), DEFAULT_ROOT_PATH, config)
-    total_plot_nfts = len((await farmer_client.get_pool_state())["pool_state"])
-    farmer_client.close()
-    await farmer_client.await_closed()
-
-    if total_plot_nfts >= (MAX_POOL_WALLETS - 2) and not override_limit:
-        raise Exception(
-            f"{total_plot_nfts} or more PlotNFT's already exist. "
-            "If you need to override this limit (most users should not) use '--override_limit'."
-        )
-
     target_puzzle_hash: Optional[bytes32]
     # Could use initial_pool_state_from_dict to simplify
     if state == "SELF_POOLING":

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -408,7 +408,6 @@ class Farmer:
     def get_authentication_sk(self, pool_config: PoolWalletConfig) -> Optional[PrivateKey]:
         if pool_config.p2_singleton_puzzle_hash in self.authentication_keys:
             return self.authentication_keys[pool_config.p2_singleton_puzzle_hash]
-        self.log.error(f"FINDING AUTH SKS: {self.all_root_sks}. {[pool_config]}")
         auth_sk: Optional[PrivateKey] = find_authentication_sk(self.all_root_sks, pool_config.owner_public_key)
         if auth_sk is not None:
             self.authentication_keys[pool_config.p2_singleton_puzzle_hash] = auth_sk

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -177,7 +177,7 @@ class Farmer:
         # From p2_singleton_puzzle_hash to pool state dict
         self.pool_state: Dict[bytes32, Dict] = {}
 
-        # From p2_singleton PrivateKey
+        # From p2_singleton to auth PrivateKey
         self.authentication_keys: Dict[bytes32, PrivateKey] = {}
 
         # Last time we updated pool_state based on the config file
@@ -328,10 +328,12 @@ class Farmer:
     async def _pool_post_farmer(
         self, pool_config: PoolWalletConfig, authentication_token_timeout: uint8, owner_sk: PrivateKey
     ) -> Optional[Dict]:
+        auth_sk: Optional[PrivateKey] = await self.get_authentication_sk(pool_config)
+        assert auth_sk is not None
         post_farmer_payload: PostFarmerPayload = PostFarmerPayload(
             pool_config.launcher_id,
             get_current_authentication_token(authentication_token_timeout),
-            pool_config.authentication_public_key,
+            auth_sk.get_g1(),
             pool_config.payout_instructions,
             None,
         )
@@ -366,10 +368,12 @@ class Farmer:
     async def _pool_put_farmer(
         self, pool_config: PoolWalletConfig, authentication_token_timeout: uint8, owner_sk: PrivateKey
     ) -> Optional[Dict]:
+        auth_sk: Optional[PrivateKey] = await self.get_authentication_sk(pool_config)
+        assert auth_sk is not None
         put_farmer_payload: PutFarmerPayload = PutFarmerPayload(
             pool_config.launcher_id,
             get_current_authentication_token(authentication_token_timeout),
-            pool_config.authentication_public_key,
+            auth_sk.get_g1(),
             pool_config.payout_instructions,
             None,
         )
@@ -401,6 +405,14 @@ class Farmer:
             )
         return None
 
+    async def get_authentication_sk(self, pool_config: PoolWalletConfig) -> Optional[PrivateKey]:
+        if pool_config.p2_singleton_puzzle_hash in self.authentication_keys:
+            return self.authentication_keys[pool_config.p2_singleton_puzzle_hash]
+        auth_sk: Optional[PrivateKey] = await find_authentication_sk(self.all_root_sks, pool_config.owner_public_key)
+        if auth_sk is not None:
+            self.authentication_keys[pool_config.p2_singleton_puzzle_hash] = auth_sk
+        return auth_sk
+
     async def update_pool_state(self):
         config = load_config(self._root_path, "config.yaml")
         pool_config_list: List[PoolWalletConfig] = load_pool_config(self._root_path)
@@ -408,14 +420,12 @@ class Farmer:
             p2_singleton_puzzle_hash = pool_config.p2_singleton_puzzle_hash
 
             try:
-                authentication_sk: Optional[PrivateKey] = await find_authentication_sk(
-                    self.all_root_sks, pool_config.owner_public_key
-                )
+                authentication_sk: Optional[PrivateKey] = await self.get_authentication_sk(pool_config)
+
                 if authentication_sk is None:
                     self.log.error(f"Could not find authentication sk for {p2_singleton_puzzle_hash}")
                     continue
                 if p2_singleton_puzzle_hash not in self.pool_state:
-                    self.authentication_keys[p2_singleton_puzzle_hash] = authentication_sk
                     self.pool_state[p2_singleton_puzzle_hash] = {
                         "points_found_since_start": 0,
                         "points_found_24h": [],
@@ -608,11 +618,10 @@ class Farmer:
         for pool_state in self.pool_state.values():
             pool_config: PoolWalletConfig = pool_state["pool_config"]
             if pool_config.launcher_id == launcher_id:
-                authentication_sk: Optional[PrivateKey] = await find_authentication_sk(
-                    self.all_root_sks, pool_config.owner_public_key
-                )
+
+                authentication_sk: Optional[PrivateKey] = await self.get_authentication_sk(pool_config)
                 if authentication_sk is None:
-                    self.log.error(f"Could not find authentication sk for pk: {pool_config.authentication_public_key}")
+                    self.log.error(f"Could not find authentication sk for {pool_config.p2_singleton_puzzle_hash}")
                     continue
                 authentication_token_timeout = pool_state["authentication_token_timeout"]
                 authentication_token = get_current_authentication_token(authentication_token_timeout)

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -177,8 +177,8 @@ class Farmer:
         # From p2_singleton_puzzle_hash to pool state dict
         self.pool_state: Dict[bytes32, Dict] = {}
 
-        # From public key bytes to PrivateKey
-        self.authentication_keys: Dict[bytes, PrivateKey] = {}
+        # From p2_singleton PrivateKey
+        self.authentication_keys: Dict[bytes32, PrivateKey] = {}
 
         # Last time we updated pool_state based on the config file
         self.last_config_access_time: uint64 = uint64(0)
@@ -289,7 +289,6 @@ class Farmer:
     async def _pool_get_farmer(
         self, pool_config: PoolWalletConfig, authentication_token_timeout: uint8, authentication_sk: PrivateKey
     ) -> Optional[Dict]:
-        assert authentication_sk.get_g1() == pool_config.authentication_public_key
         authentication_token = get_current_authentication_token(authentication_token_timeout)
         message: bytes32 = std_hash(
             AuthenticationPayload(
@@ -410,13 +409,13 @@ class Farmer:
 
             try:
                 authentication_sk: Optional[PrivateKey] = await find_authentication_sk(
-                    self.all_root_sks, pool_config.authentication_public_key
+                    self.all_root_sks, pool_config.owner_public_key
                 )
                 if authentication_sk is None:
-                    self.log.error(f"Could not find authentication sk for pk: {pool_config.authentication_public_key}")
+                    self.log.error(f"Could not find authentication sk for {p2_singleton_puzzle_hash}")
                     continue
                 if p2_singleton_puzzle_hash not in self.pool_state:
-                    self.authentication_keys[bytes(pool_config.authentication_public_key)] = authentication_sk
+                    self.authentication_keys[p2_singleton_puzzle_hash] = authentication_sk
                     self.pool_state[p2_singleton_puzzle_hash] = {
                         "points_found_since_start": 0,
                         "points_found_24h": [],
@@ -483,9 +482,12 @@ class Farmer:
                         farmer_info, farmer_is_known = await update_pool_farmer_info()
                         if farmer_info is None and farmer_is_known is not None and not farmer_is_known:
                             # Make the farmer known on the pool with a POST /farmer
-                            owner_sk = await find_owner_sk(self.all_root_sks, pool_config.owner_public_key)
+                            owner_sk_and_index: Optional[PrivateKey, uint32] = await find_owner_sk(
+                                self.all_root_sks, pool_config.owner_public_key
+                            )
+                            assert owner_sk_and_index is not None
                             post_response = await self._pool_post_farmer(
-                                pool_config, authentication_token_timeout, owner_sk
+                                pool_config, authentication_token_timeout, owner_sk_and_index[0]
                             )
                             if post_response is not None and "error_code" not in post_response:
                                 self.log.info(
@@ -502,9 +504,12 @@ class Farmer:
                             farmer_info is not None
                             and pool_config.payout_instructions.lower() != farmer_info.payout_instructions.lower()
                         ):
-                            owner_sk = await find_owner_sk(self.all_root_sks, pool_config.owner_public_key)
+                            owner_sk_and_index: Optional[PrivateKey, uint32] = await find_owner_sk(
+                                self.all_root_sks, pool_config.owner_public_key
+                            )
+                            assert owner_sk_and_index is not None
                             put_farmer_response_dict = await self._pool_put_farmer(
-                                pool_config, authentication_token_timeout, owner_sk
+                                pool_config, authentication_token_timeout, owner_sk_and_index[0]
                             )
                             try:
                                 # put_farmer_response: PutFarmerResponse = PutFarmerResponse.from_json_dict(
@@ -604,12 +609,11 @@ class Farmer:
             pool_config: PoolWalletConfig = pool_state["pool_config"]
             if pool_config.launcher_id == launcher_id:
                 authentication_sk: Optional[PrivateKey] = await find_authentication_sk(
-                    self.all_root_sks, pool_config.authentication_public_key
+                    self.all_root_sks, pool_config.owner_public_key
                 )
                 if authentication_sk is None:
                     self.log.error(f"Could not find authentication sk for pk: {pool_config.authentication_public_key}")
                     continue
-                assert authentication_sk.get_g1() == pool_config.authentication_public_key
                 authentication_token_timeout = pool_state["authentication_token_timeout"]
                 authentication_token = get_current_authentication_token(authentication_token_timeout)
                 message: bytes32 = std_hash(

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -211,7 +211,13 @@ class FarmerAPI:
                         )
                         assert AugSchemeMPL.verify(agg_pk, m_to_sign, plot_signature)
 
-                authentication_sk: PrivateKey = self.farmer.authentication_keys[p2_singleton_puzzle_hash]
+                authentication_sk: Optional[PrivateKey] = await self.farmer.get_authentication_sk(
+                    pool_state_dict["pool_config"]
+                )
+                if authentication_sk is None:
+                    self.farmer.log.error(f"No authentication sk for {p2_singleton_puzzle_hash}")
+                    return
+
                 authentication_signature = AugSchemeMPL.sign(authentication_sk, m_to_sign)
 
                 assert plot_signature is not None

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -211,7 +211,7 @@ class FarmerAPI:
                         )
                         assert AugSchemeMPL.verify(agg_pk, m_to_sign, plot_signature)
 
-                authentication_sk: Optional[PrivateKey] = await self.farmer.get_authentication_sk(
+                authentication_sk: Optional[PrivateKey] = self.farmer.get_authentication_sk(
                     pool_state_dict["pool_config"]
                 )
                 if authentication_sk is None:

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -210,11 +210,8 @@ class FarmerAPI:
                             [sig_farmer, response.message_signatures[0][1], taproot_sig]
                         )
                         assert AugSchemeMPL.verify(agg_pk, m_to_sign, plot_signature)
-                authentication_pk = pool_state_dict["pool_config"].authentication_public_key
-                if bytes(authentication_pk) is None:
-                    self.farmer.log.error(f"No authentication sk for {authentication_pk}")
-                    return
-                authentication_sk: PrivateKey = self.farmer.authentication_keys[bytes(authentication_pk)]
+
+                authentication_sk: PrivateKey = self.farmer.authentication_keys[p2_singleton_puzzle_hash]
                 authentication_signature = AugSchemeMPL.sign(authentication_sk, m_to_sign)
 
                 assert plot_signature is not None

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -15,7 +15,6 @@ Config example
 This is what goes into the user's config file, to communicate between the wallet and the farmer processes.
 pool_list:
     launcher_id: ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa
-    authentication_public_key: 970e181ae45435ae696508a78012dc80548c334cf29676ea6ade7049eb9d2b9579cc30cb44c3fd68d35a250cfbc69e29
     owner_public_key: 84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5
     payout_instructions: c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8
     pool_url: localhost
@@ -35,7 +34,6 @@ class PoolWalletConfig(Streamable):
     target_puzzle_hash: bytes32
     p2_singleton_puzzle_hash: bytes32
     owner_public_key: G1Element
-    authentication_public_key: G1Element
 
 
 def load_pool_config(root_path: Path) -> List[PoolWalletConfig]:
@@ -52,7 +50,6 @@ def load_pool_config(root_path: Path) -> List[PoolWalletConfig]:
                     bytes32.from_hexstr(pool_config_dict["target_puzzle_hash"]),
                     bytes32.from_hexstr(pool_config_dict["p2_singleton_puzzle_hash"]),
                     G1Element.from_bytes(hexstr_to_bytes(pool_config_dict["owner_public_key"])),
-                    G1Element.from_bytes(hexstr_to_bytes(pool_config_dict["authentication_public_key"])),
                 )
                 ret_list.append(pool_config)
             except Exception as e:

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -448,7 +448,7 @@ class PoolWallet:
         if self._pool_wallet_index_cache is not None:
             return self._pool_wallet_index_cache
 
-        owner_sk_and_index: Optional[Tuple[PrivateKey, uint32]] = await find_owner_sk(
+        owner_sk_and_index: Optional[Tuple[PrivateKey, uint32]] = find_owner_sk(
             [self.wallet_state_manager.private_key], (await self.get_current_state()).current.owner_pubkey
         )
         assert owner_sk_and_index is not None
@@ -457,7 +457,7 @@ class PoolWallet:
 
     async def sign(self, coin_spend: CoinSpend) -> SpendBundle:
         async def pk_to_sk(pk: G1Element) -> PrivateKey:
-            owner_sk_and_index: Optional[Tuple[PrivateKey, uint32]] = await find_owner_sk(
+            owner_sk_and_index: Optional[Tuple[PrivateKey, uint32]] = find_owner_sk(
                 [self.wallet_state_manager.private_key], pk
             )
             assert owner_sk_and_index is not None

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -44,7 +44,6 @@ from chia.pools.pool_puzzles import (
 
 from chia.util.ints import uint8, uint32, uint64
 from chia.wallet.derive_keys import (
-    master_sk_to_pooling_authentication_sk,
     find_owner_sk,
 )
 from chia.wallet.sign_coin_spends import sign_coin_spends
@@ -235,13 +234,8 @@ class PoolWallet:
         existing_config: Optional[PoolWalletConfig] = pool_config_dict.get(current_state.launcher_id, None)
 
         if make_new_authentication_key or existing_config is None:
-            new_auth_sk: PrivateKey = master_sk_to_pooling_authentication_sk(
-                self.wallet_state_manager.private_key, await self.get_pool_wallet_index(), uint32(0)
-            )
-            auth_pk: G1Element = new_auth_sk.get_g1()
             payout_instructions: str = (await self.standard_wallet.get_new_puzzlehash(in_transaction=True)).hex()
         else:
-            auth_pk = existing_config.authentication_public_key
             payout_instructions = existing_config.payout_instructions
 
         new_config: PoolWalletConfig = PoolWalletConfig(
@@ -251,7 +245,6 @@ class PoolWallet:
             current_state.current.target_puzzle_hash,
             current_state.p2_singleton_puzzle_hash,
             current_state.current.owner_pubkey,
-            auth_pk,
         )
         pool_config_dict[new_config.launcher_id] = new_config
         await update_pool_config(self.wallet_state_manager.root_path, list(pool_config_dict.values()))

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -526,9 +526,11 @@ class WalletRpcApi:
                 from chia.pools.pool_wallet_info import initial_pool_state_from_dict
 
                 async with self.service.wallet_state_manager.lock:
-                    # We assign a unique id to each pool wallet, so that each one gets it's own deterministic owner
-                    # and auth keys. The public keys will go on the blockchain, and the private keys can be found
-                    # using the root SK and trying each index from zero.
+                    # We assign a pseudo unique id to each pool wallet, so that each one gets its own deterministic
+                    # owner and auth keys. The public keys will go on the blockchain, and the private keys can be found
+                    # using the root SK and trying each index from zero. The indexes are not fully unique though,
+                    # because the PoolWallet is not created until the tx gets confirmed on chain. Therefore if we
+                    # make multiple pool wallets at the same time, they will have the same ID.
                     max_pwi = 1
                     for _, wallet in self.service.wallet_state_manager.wallets.items():
                         if wallet.type() == WalletType.POOLING_WALLET:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -23,7 +23,7 @@ from chia.util.path import path_from_root
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
 from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
-from chia.wallet.derive_keys import master_sk_to_singleton_owner_sk, master_sk_to_wallet_sk_unhardened
+from chia.wallet.derive_keys import master_sk_to_singleton_owner_sk, master_sk_to_wallet_sk_unhardened, MAX_POOL_WALLETS
 from chia.wallet.rl_wallet.rl_wallet import RLWallet
 from chia.wallet.derive_keys import master_sk_to_farmer_sk, master_sk_to_pool_sk, master_sk_to_wallet_sk
 from chia.wallet.did_wallet.did_wallet import DIDWallet
@@ -537,6 +537,10 @@ class WalletRpcApi:
                             pool_wallet_index = await wallet.get_pool_wallet_index()
                             if pool_wallet_index > max_pwi:
                                 max_pwi = pool_wallet_index
+
+                    if max_pwi + 1 >= (MAX_POOL_WALLETS - 1):
+                        raise ValueError(f"Too many pool wallets ({max_pwi}), cannot create any more on this key.")
+
                     owner_sk: PrivateKey = master_sk_to_singleton_owner_sk(
                         self.service.wallet_state_manager.private_key, uint32(max_pwi + 1)
                     )

--- a/chia/wallet/derive_keys.py
+++ b/chia/wallet/derive_keys.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from blspy import AugSchemeMPL, PrivateKey, G1Element
 
@@ -9,6 +9,9 @@ from chia.util.ints import uint32
 # 12381 = bls spec number
 # 8444 = Chia blockchain number and port number
 # 0, 1, 2, 3, 4, 5, 6 farmer, pool, wallet, local, backup key, singleton, pooling authentication key numbers
+
+# Allows up to 100 pool wallets (plot NFTs)
+MAX_POOL_WALLETS = 100
 
 
 def _derive_path(sk: PrivateKey, path: List[int]) -> PrivateKey:
@@ -57,38 +60,38 @@ def master_sk_to_backup_sk(master: PrivateKey) -> PrivateKey:
     return _derive_path(master, [12381, 8444, 4, 0])
 
 
-def master_sk_to_singleton_owner_sk(master: PrivateKey, wallet_id: uint32) -> PrivateKey:
+def master_sk_to_singleton_owner_sk(master: PrivateKey, pool_wallet_index: uint32) -> PrivateKey:
     """
     This key controls a singleton on the blockchain, allowing for dynamic pooling (changing pools)
     """
-    return _derive_path(master, [12381, 8444, 5, wallet_id])
+    return _derive_path(master, [12381, 8444, 5, pool_wallet_index])
 
 
-def master_sk_to_pooling_authentication_sk(master: PrivateKey, wallet_id: uint32, index: uint32) -> PrivateKey:
+def master_sk_to_pooling_authentication_sk(master: PrivateKey, pool_wallet_index: uint32, index: uint32) -> PrivateKey:
     """
     This key is used for the farmer to authenticate to the pool when sending partials
     """
     assert index < 10000
-    assert wallet_id < 10000
-    return _derive_path(master, [12381, 8444, 6, wallet_id * 10000 + index])
+    assert pool_wallet_index < 10000
+    return _derive_path(master, [12381, 8444, 6, pool_wallet_index * 10000 + index])
 
 
-async def find_owner_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[G1Element]:
-    for wallet_id in range(50):
+async def find_owner_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[Tuple[G1Element, uint32]]:
+    for pool_wallet_index in range(MAX_POOL_WALLETS):
         for sk in all_sks:
-            auth_sk = master_sk_to_singleton_owner_sk(sk, uint32(wallet_id))
+            auth_sk = master_sk_to_singleton_owner_sk(sk, uint32(pool_wallet_index))
             if auth_sk.get_g1() == owner_pk:
-                return auth_sk
+                return auth_sk, uint32(pool_wallet_index)
     return None
 
 
-async def find_authentication_sk(all_sks: List[PrivateKey], authentication_pk: G1Element) -> Optional[PrivateKey]:
+async def find_authentication_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[PrivateKey]:
     # NOTE: might need to increase this if using a large number of wallets, or have switched authentication keys
     # many times.
-    for auth_key_index in range(20):
-        for wallet_id in range(20):
-            for sk in all_sks:
-                auth_sk = master_sk_to_pooling_authentication_sk(sk, uint32(wallet_id), uint32(auth_key_index))
-                if auth_sk.get_g1() == authentication_pk:
-                    return auth_sk
+    for pool_wallet_index in range(MAX_POOL_WALLETS):
+        for sk in all_sks:
+            auth_sk = master_sk_to_singleton_owner_sk(sk, uint32(pool_wallet_index))
+            if auth_sk.get_g1() == owner_pk:
+                # NOTE: ONLY use 0 for authentication key index to ensure compatibility
+                return await master_sk_to_pooling_authentication_sk(sk, uint32(pool_wallet_index), uint32(0))
     return None

--- a/chia/wallet/derive_keys.py
+++ b/chia/wallet/derive_keys.py
@@ -76,22 +76,22 @@ def master_sk_to_pooling_authentication_sk(master: PrivateKey, pool_wallet_index
     return _derive_path(master, [12381, 8444, 6, pool_wallet_index * 10000 + index])
 
 
-async def find_owner_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[Tuple[G1Element, uint32]]:
+def find_owner_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[Tuple[G1Element, uint32]]:
     for pool_wallet_index in range(MAX_POOL_WALLETS):
         for sk in all_sks:
-            auth_sk = master_sk_to_singleton_owner_sk(sk, uint32(pool_wallet_index))
-            if auth_sk.get_g1() == owner_pk:
-                return auth_sk, uint32(pool_wallet_index)
+            try_owner_sk = master_sk_to_singleton_owner_sk(sk, uint32(pool_wallet_index))
+            if try_owner_sk.get_g1() == owner_pk:
+                return try_owner_sk, uint32(pool_wallet_index)
     return None
 
 
-async def find_authentication_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[PrivateKey]:
+def find_authentication_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[PrivateKey]:
     # NOTE: might need to increase this if using a large number of wallets, or have switched authentication keys
     # many times.
     for pool_wallet_index in range(MAX_POOL_WALLETS):
         for sk in all_sks:
-            auth_sk = master_sk_to_singleton_owner_sk(sk, uint32(pool_wallet_index))
-            if auth_sk.get_g1() == owner_pk:
+            try_owner_sk = master_sk_to_singleton_owner_sk(sk, uint32(pool_wallet_index))
+            if try_owner_sk.get_g1() == owner_pk:
                 # NOTE: ONLY use 0 for authentication key index to ensure compatibility
-                return await master_sk_to_pooling_authentication_sk(sk, uint32(pool_wallet_index), uint32(0))
+                return master_sk_to_pooling_authentication_sk(sk, uint32(pool_wallet_index), uint32(0))
     return None

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -21,7 +21,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, save_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
-from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_pooling_authentication_sk
+from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from tests.setup_nodes import bt, self_hostname, setup_farmer_harvester, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.rpc import validate_get_routes
@@ -236,12 +236,9 @@ class TestRpc:
                 await client.set_reward_targets(None, replaced_char)
 
             assert len((await client.get_pool_state())["pool_state"]) == 0
-            all_sks = farmer_api.farmer.local_keychain.get_all_private_keys()
-            auth_sk = master_sk_to_pooling_authentication_sk(all_sks[0][0], 0, 1)
             pool_list = [
                 {
                     "launcher_id": "ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa",
-                    "authentication_public_key": bytes(auth_sk.get_g1()).hex(),
                     "owner_public_key": "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5",  # noqa
                     "payout_instructions": "c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
                     "pool_url": "localhost",

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -237,7 +237,7 @@ class TestRpc:
 
             assert len((await client.get_pool_state())["pool_state"]) == 0
             all_sks = farmer_api.farmer.local_keychain.get_all_private_keys()
-            auth_sk = master_sk_to_pooling_authentication_sk(all_sks[0][0], 2, 1)
+            auth_sk = master_sk_to_pooling_authentication_sk(all_sks[0][0], 0, 1)
             pool_list = [
                 {
                     "launcher_id": "ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa",

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -3,7 +3,7 @@ from secrets import token_bytes
 import time
 
 import pytest
-from blspy import AugSchemeMPL
+from blspy import AugSchemeMPL, G1Element
 from chiapos import DiskPlotter
 
 from chia.consensus.coinbase import create_puzzlehash_for_pk
@@ -21,7 +21,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, save_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
-from chia.wallet.derive_keys import master_sk_to_wallet_sk
+from chia.wallet.derive_keys import master_sk_to_wallet_sk, find_owner_sk, master_sk_to_singleton_owner_sk
 from tests.setup_nodes import bt, self_hostname, setup_farmer_harvester, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.rpc import validate_get_routes
@@ -239,7 +239,7 @@ class TestRpc:
             pool_list = [
                 {
                     "launcher_id": "ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa",
-                    "owner_public_key": "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5",  # noqa
+                    "owner_public_key": "aa11e92274c0f6a2449fd0c7cfab4a38f943289dbe2214c808b36390c34eacfaa1d4c8f3c6ec582ac502ff32228679a0",  # noqa
                     "payout_instructions": "c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
                     "pool_url": "localhost",
                     "p2_singleton_puzzle_hash": "16e4bac26558d315cded63d4c5860e98deb447cc59146dd4de06ce7394b14f17",
@@ -248,6 +248,7 @@ class TestRpc:
             ]
             config["pool"]["pool_list"] = pool_list
             save_config(root_path, "config.yaml", config)
+
             await farmer_api.farmer.update_pool_state()
 
             pool_state = (await client.get_pool_state())["pool_state"]

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -3,7 +3,7 @@ from secrets import token_bytes
 import time
 
 import pytest
-from blspy import AugSchemeMPL, G1Element
+from blspy import AugSchemeMPL
 from chiapos import DiskPlotter
 
 from chia.consensus.coinbase import create_puzzlehash_for_pk
@@ -21,7 +21,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, save_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
-from chia.wallet.derive_keys import master_sk_to_wallet_sk, find_owner_sk, master_sk_to_singleton_owner_sk
+from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from tests.setup_nodes import bt, self_hostname, setup_farmer_harvester, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.rpc import validate_get_routes

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -248,7 +248,6 @@ class TestRpc:
             ]
             config["pool"]["pool_list"] = pool_list
             save_config(root_path, "config.yaml", config)
-
             await farmer_api.farmer.update_pool_state()
 
             pool_state = (await client.get_pool_state())["pool_state"]

--- a/tests/pools/test_pool_config.py
+++ b/tests/pools/test_pool_config.py
@@ -20,7 +20,6 @@ def test_pool_config():
 
     auth_sk: PrivateKey = AugSchemeMPL.key_gen(b"1" * 32)
     d = {
-        "authentication_public_key": bytes(auth_sk.get_g1()).hex(),
         "owner_public_key": "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5",
         "p2_singleton_puzzle_hash": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
         "payout_instructions": "c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -206,9 +206,10 @@ class TestPoolWalletRpc:
         assert len(pool_list) == 1
         pool_config = pool_list[0]
         assert (
-            pool_config["authentication_public_key"]
-            == "0xb3c4b513600729c6b2cf776d8786d620b6acc88f86f9d6f489fa0a0aff81d634262d5348fb7ba304db55185bb4c5c8a4"
+            pool_config["owner_public_key"]
+            == "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
         )
+
         # It can be one of multiple launcher IDs, due to selecting a different coin
         launcher_id = None
         for addition in creation_tx.additions:
@@ -282,8 +283,8 @@ class TestPoolWalletRpc:
         assert len(pool_list) == 1
         pool_config = pool_list[0]
         assert (
-            pool_config["authentication_public_key"]
-            == "0xb3c4b513600729c6b2cf776d8786d620b6acc88f86f9d6f489fa0a0aff81d634262d5348fb7ba304db55185bb4c5c8a4"
+            pool_config["owner_public_key"]
+            == "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
         )
         # It can be one of multiple launcher IDs, due to selecting a different coin
         launcher_id = None

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -375,8 +375,6 @@ class TestPoolWalletRpc:
             await client.pw_status(3)
 
         def wallet_is_synced():
-            print(wallet_node_0.wallet_state_manager.blockchain.get_peak_height())
-            print(full_node_api.full_node.blockchain.get_peak_height())
             return (
                 wallet_node_0.wallet_state_manager.blockchain.get_peak_height()
                 == full_node_api.full_node.blockchain.get_peak_height()
@@ -396,8 +394,9 @@ class TestPoolWalletRpc:
             bal_0 = await client.get_wallet_balance(cat_0_id)
             assert bal_0["confirmed_wallet_balance"] == 20
 
-        # Test creation of many pool wallets
-        if not trusted:
+        # Test creation of many pool wallets. Use untrusted since that is the more complicated protocol, but don't
+        # run this code more than once, since it's slow.
+        if fee == 0 and not trusted:
             for i in range(22):
                 creation_tx_3: TransactionRecord = await client.create_new_pool_wallet(
                     our_ph_1, "localhost", 5, "localhost:5000", "new", "FARMING_TO_POOL", fee

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -420,7 +420,6 @@ class TestPoolWalletRpc:
                     for wallet in wallet_node_0.wallet_state_manager.wallets.values():
                         if wallet.type() == WalletType.POOLING_WALLET:
                             status: PoolWalletInfo = (await client.pw_status(wallet.id()))[0]
-                            print(await wallet.get_pool_wallet_index())
                             assert (await wallet.get_pool_wallet_index()) < 5
                             auth_sk = find_authentication_sk(
                                 [wallet_0.wallet_state_manager.private_key], status.current.owner_pubkey

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -210,7 +210,6 @@ class TestPoolWalletRpc:
             pool_config["owner_public_key"]
             == "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
         )
-
         # It can be one of multiple launcher IDs, due to selecting a different coin
         launcher_id = None
         for addition in creation_tx.additions:
@@ -415,8 +414,6 @@ class TestPoolWalletRpc:
                 assert len(pool_list) == i + 3
                 if i == 0:
                     # Ensures that the CAT creation does not cause pool wallet IDs to increment
-                    summaries_response = await client.get_wallets()
-                    print(summaries_response)
                     for wallet in wallet_node_0.wallet_state_manager.wallets.values():
                         if wallet.type() == WalletType.POOLING_WALLET:
                             status: PoolWalletInfo = (await client.pw_status(wallet.id()))[0]
@@ -430,9 +427,6 @@ class TestPoolWalletRpc:
                             )
                             assert owner_sk is not None
                             assert owner_sk != auth_sk
-
-                            summaries_response = await client.get_wallets()
-            print(summaries_response)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True])

--- a/tests/wallet/test_wallet_user_store.py
+++ b/tests/wallet/test_wallet_user_store.py
@@ -1,0 +1,57 @@
+import asyncio
+from pathlib import Path
+import aiosqlite
+import pytest
+
+from chia.util.db_wrapper import DBWrapper
+from chia.wallet.util.wallet_types import WalletType
+
+from chia.wallet.wallet_user_store import WalletUserStore
+
+
+@pytest.fixture(scope="module")
+def event_loop():
+    loop = asyncio.get_event_loop()
+    yield loop
+
+
+class TestWalletUserStore:
+    @pytest.mark.asyncio
+    async def test_store(self):
+        db_filename = Path("wallet_user_store_test.db")
+
+        if db_filename.exists():
+            db_filename.unlink()
+
+        db_connection = await aiosqlite.connect(db_filename)
+        db_wrapper = DBWrapper(db_connection)
+        store = await WalletUserStore.create(db_wrapper)
+        try:
+            await store.init_wallet()
+            assert (await store.get_last_wallet()).id == 1
+            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
+            assert wallet is not None
+            assert (await store.get_last_wallet()).id == 2
+            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
+            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
+            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
+            assert (await store.get_last_wallet()).id == 5
+
+            print(await store.get_all_wallet_info_entries())
+            for i in range(2, 6):
+                await store.delete_wallet(i, in_transaction=False)
+
+            print(await store.get_all_wallet_info_entries())
+            assert (await store.get_last_wallet()).id == 1
+            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
+            # Due to autoincrement, we don't reuse IDs
+            assert (await store.get_last_wallet()).id == 6
+            assert wallet.id == 6
+
+            assert (await store.get_wallet_by_id(7)) is None
+            assert (await store.get_wallet_by_id(6)) == wallet
+            assert store.get_last_wallet() == wallet
+
+        finally:
+            await db_connection.close()
+            db_filename.unlink()

--- a/tests/wallet/test_wallet_user_store.py
+++ b/tests/wallet/test_wallet_user_store.py
@@ -8,39 +8,38 @@ from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_user_store import WalletUserStore
 
 
-class TestWalletUserStore:
-    @pytest.mark.asyncio
-    async def test_store(self):
-        db_filename = Path("wallet_user_store_test.db")
+@pytest.mark.asyncio
+async def test_store(self):
+    db_filename = Path("wallet_user_store_test.db")
 
-        if db_filename.exists():
-            db_filename.unlink()
+    if db_filename.exists():
+        db_filename.unlink()
 
-        db_connection = await aiosqlite.connect(db_filename)
-        db_wrapper = DBWrapper(db_connection)
-        store = await WalletUserStore.create(db_wrapper)
-        try:
-            await store.init_wallet()
-            wallet = None
-            for i in range(1, 5):
-                assert (await store.get_last_wallet()).id == i
-                wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
-                assert wallet.id == i + 1
-            assert wallet.id == 5
-
-            for i in range(2, 6):
-                await store.delete_wallet(i, in_transaction=False)
-
-            assert (await store.get_last_wallet()).id == 1
+    db_connection = await aiosqlite.connect(db_filename)
+    db_wrapper = DBWrapper(db_connection)
+    store = await WalletUserStore.create(db_wrapper)
+    try:
+        await store.init_wallet()
+        wallet = None
+        for i in range(1, 5):
+            assert (await store.get_last_wallet()).id == i
             wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
-            # Due to autoincrement, we don't reuse IDs
-            assert (await store.get_last_wallet()).id == 6
-            assert wallet.id == 6
+            assert wallet.id == i + 1
+        assert wallet.id == 5
 
-            assert (await store.get_wallet_by_id(7)) is None
-            assert (await store.get_wallet_by_id(6)) == wallet
-            assert await store.get_last_wallet() == wallet
+        for i in range(2, 6):
+            await store.delete_wallet(i, in_transaction=False)
 
-        finally:
-            await db_connection.close()
-            db_filename.unlink()
+        assert (await store.get_last_wallet()).id == 1
+        wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
+        # Due to autoincrement, we don't reuse IDs
+        assert (await store.get_last_wallet()).id == 6
+        assert wallet.id == 6
+
+        assert (await store.get_wallet_by_id(7)) is None
+        assert (await store.get_wallet_by_id(6)) == wallet
+        assert await store.get_last_wallet() == wallet
+
+    finally:
+        await db_connection.close()
+        db_filename.unlink()

--- a/tests/wallet/test_wallet_user_store.py
+++ b/tests/wallet/test_wallet_user_store.py
@@ -50,7 +50,7 @@ class TestWalletUserStore:
 
             assert (await store.get_wallet_by_id(7)) is None
             assert (await store.get_wallet_by_id(6)) == wallet
-            assert store.get_last_wallet() == wallet
+            assert await store.get_last_wallet() == wallet
 
         finally:
             await db_connection.close()

--- a/tests/wallet/test_wallet_user_store.py
+++ b/tests/wallet/test_wallet_user_store.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 import aiosqlite
 import pytest
@@ -7,12 +6,6 @@ from chia.util.db_wrapper import DBWrapper
 from chia.wallet.util.wallet_types import WalletType
 
 from chia.wallet.wallet_user_store import WalletUserStore
-
-
-@pytest.fixture(scope="module")
-def event_loop():
-    loop = asyncio.get_event_loop()
-    yield loop
 
 
 class TestWalletUserStore:
@@ -28,20 +21,16 @@ class TestWalletUserStore:
         store = await WalletUserStore.create(db_wrapper)
         try:
             await store.init_wallet()
-            assert (await store.get_last_wallet()).id == 1
-            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
-            assert wallet is not None
-            assert (await store.get_last_wallet()).id == 2
-            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
-            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
-            wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
-            assert (await store.get_last_wallet()).id == 5
+            wallet = None
+            for i in range(1, 5):
+                assert (await store.get_last_wallet()).id == i
+                wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
+                assert wallet.id == i + 1
+            assert wallet.id == 5
 
-            print(await store.get_all_wallet_info_entries())
             for i in range(2, 6):
                 await store.delete_wallet(i, in_transaction=False)
 
-            print(await store.get_all_wallet_info_entries())
             assert (await store.get_last_wallet()).id == 1
             wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
             # Due to autoincrement, we don't reuse IDs

--- a/tests/wallet/test_wallet_user_store.py
+++ b/tests/wallet/test_wallet_user_store.py
@@ -9,7 +9,7 @@ from chia.wallet.wallet_user_store import WalletUserStore
 
 
 @pytest.mark.asyncio
-async def test_store(self):
+async def test_store():
     db_filename = Path("wallet_user_store_test.db")
 
     if db_filename.exists():


### PR DESCRIPTION
…lWallets for indeces.

Problem: we have a hardcoded limit of 20 wallets/plotNFTs, and this includes CATs.  The reason is for syncing a 2nd machine and looking for keys: that we try index 0 to 19 for every possible wallet ID, so it's a lot of BLS operations which take time. There are two ways we can improve this. The first is just hardcoding the use of index 0 for all authentication keys. We are not rotating them anyway, and if we did, 20 wouldn't be enough. The second is to only increment indeces for pooling wallets. There is no need to skip index 3 if index 3 is a CAT wallet or something else. 

This change is fully backwards compatible, and will start assigning indeces from the highest pool wallet index the user has. The limit has been increased to 100 from 20 due to the auth key optimization. Also this can allow the user to have many CAT wallets but not have any effect on plotNFT limits

The auth key optimization also means that we will hopefully not have any more auth key errors while pooling, because the auth key can be found deterministically from the owner key.

TODO:

- [x] self review
- [x] add an automated test
- [x] manually test with real farmers
- [x] potentially remove auth key from configuration altogether.
- [ ] consider catching invalid auth key and doing a PUT farmer
- [x] test plotNFT limit on CLI and GUI