### PR TITLE
simplify cost calculation. It's already computed in rust

### DIFF
--- a/chia/consensus/cost_calculator.py
+++ b/chia/consensus/cost_calculator.py
@@ -1,10 +1,7 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import List, Optional
 
-from chia.consensus.condition_costs import ConditionCost
 from chia.types.blockchain_format.program import SerializedProgram
-from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.name_puzzle_condition import NPC
 from chia.util.ints import uint16, uint64
 from chia.util.streamable import Streamable, streamable
@@ -15,36 +12,12 @@ from chia.util.streamable import Streamable, streamable
 class NPCResult(Streamable):
     error: Optional[uint16]
     npc_list: List[NPC]
-    clvm_cost: uint64  # CLVM cost only, cost of conditions and tx size is not included
-
-
-def conditions_cost(conditions: Dict[ConditionOpcode, List[ConditionWithArgs]]) -> uint64:
-    total_cost = 0
-    for condition, cvp_list in conditions.items():
-        if condition is ConditionOpcode.AGG_SIG_UNSAFE or condition is ConditionOpcode.AGG_SIG_ME:
-            total_cost += len(cvp_list) * ConditionCost.AGG_SIG.value
-        elif condition is ConditionOpcode.CREATE_COIN:
-            total_cost += len(cvp_list) * ConditionCost.CREATE_COIN.value
-        else:
-            # all other conditions are free, and we ignore unknown conditions in
-            # order to allow for future soft forks
-            pass
-    return uint64(total_cost)
+    cost: uint64  # The total cost of the block, including CLVM cost, cost of
+    # conditions and cost of bytes
 
 
 def calculate_cost_of_program(program: SerializedProgram, npc_result: NPCResult, cost_per_byte: int) -> uint64:
     """
     This function calculates the total cost of either a block or a spendbundle
     """
-    total_cost = 0
-    total_cost += npc_result.clvm_cost
-    npc_list = npc_result.npc_list
-    # Add cost of conditions
-    npc: NPC
-    for npc in npc_list:
-        total_cost += conditions_cost(npc.condition_dict)
-
-    # Add raw size of the program
-    total_cost += len(bytes(program)) * cost_per_byte
-
-    return uint64(total_cost)
+    return npc_result.cost

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -771,7 +771,7 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
         result = full_node_1.full_node.full_node_store.get_unfinished_block_result(unf.partial_hash)
         assert result is not None
-        assert result.npc_result is not None and result.npc_result.clvm_cost > 0
+        assert result.npc_result is not None and result.npc_result.cost > 0
 
         assert not full_node_1.full_node.blockchain.contains_block(block.header_hash)
         assert block.transactions_generator is not None
@@ -887,7 +887,7 @@ class TestFullNodeProtocol:
             cost_result = await full_node_1.full_node.mempool_manager.pre_validate_spendbundle(
                 spend_bundle, None, spend_bundle.name()
             )
-            log.info(f"Cost result: {cost_result.clvm_cost}")
+            log.info(f"Cost result: {cost_result.cost}")
 
             new_transaction = fnp.NewTransaction(spend_bundle.get_hash(), uint64(100), uint64(100))
 

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -43,6 +43,7 @@ from tests.setup_nodes import bt, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.consensus.cost_calculator import NPCResult
+from chia.consensus.condition_costs import ConditionCost
 from chia.types.blockchain_format.program import SerializedProgram
 from clvm_tools import binutils
 from chia.types.generator_types import BlockGenerator
@@ -1890,15 +1891,15 @@ class TestGeneratorConditions:
 
         # this max cost is exactly enough for the create coin condition
         npc_result = generator_condition_tester(
-            f'(51 "{puzzle_hash}" 10) ', max_cost=20470 + 95 * COST_PER_BYTE + 1800000
+            f'(51 "{puzzle_hash}" 10) ', max_cost=20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value
         )
         assert npc_result.error is None
-        assert npc_result.clvm_cost == 20470
+        assert npc_result.cost == 20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value
         assert len(npc_result.npc_list) == 1
 
         # if we subtract one from max cost, this should fail
         npc_result = generator_condition_tester(
-            f'(51 "{puzzle_hash}" 10) ', max_cost=20470 + 95 * COST_PER_BYTE + 1800000 - 1
+            f'(51 "{puzzle_hash}" 10) ', max_cost=20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value - 1
         )
         assert npc_result.error in [Err.BLOCK_COST_EXCEEDS_MAX.value, Err.INVALID_BLOCK_COST.value]
 
@@ -1908,15 +1909,15 @@ class TestGeneratorConditions:
 
         # this max cost is exactly enough for the AGG_SIG condition
         npc_result = generator_condition_tester(
-            f'(49 "{pubkey}" "foobar") ', max_cost=20512 + 117 * COST_PER_BYTE + 1200000
+            f'(49 "{pubkey}" "foobar") ', max_cost=20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value
         )
         assert npc_result.error is None
-        assert npc_result.clvm_cost == 20512
+        assert npc_result.cost == 20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value
         assert len(npc_result.npc_list) == 1
 
         # if we subtract one from max cost, this should fail
         npc_result = generator_condition_tester(
-            f'(49 "{pubkey}" "foobar") ', max_cost=20512 + 117 * COST_PER_BYTE + 1200000 - 1
+            f'(49 "{pubkey}" "foobar") ', max_cost=20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value - 1
         )
         assert npc_result.error in [Err.BLOCK_COST_EXCEEDS_MAX.value, Err.INVALID_BLOCK_COST.value]
 

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -93,7 +93,13 @@ class TestCostCalculation:
         )
         assert error is None
 
-        assert npc_result.clvm_cost == 404560
+        assert (
+            npc_result.cost
+            == 404560
+            + ConditionCost.CREATE_COIN.value
+            + ConditionCost.AGG_SIG.value
+            + len(bytes(program.program)) * test_constants.COST_PER_BYTE
+        )
 
         # Create condition + agg_sig_condition + length + cpu_cost
         assert (
@@ -101,7 +107,7 @@ class TestCostCalculation:
             == ConditionCost.CREATE_COIN.value
             + ConditionCost.AGG_SIG.value
             + len(bytes(program.program)) * test_constants.COST_PER_BYTE
-            + 404560  # clvm_cost
+            + 404560  # clvm cost
         )
 
     @pytest.mark.asyncio
@@ -226,14 +232,14 @@ class TestCostCalculation:
         npc_result: NPCResult = get_name_puzzle_conditions(generator, 10000000, cost_per_byte=0, mempool_mode=False)
 
         assert npc_result.error is not None
-        assert npc_result.clvm_cost == 0
+        assert npc_result.cost == 0
 
         # raise the max cost to make sure this passes
         # ensure we pass if the program does not exceeds the cost
         npc_result = get_name_puzzle_conditions(generator, 20000000, cost_per_byte=0, mempool_mode=False)
 
         assert npc_result.error is None
-        assert npc_result.clvm_cost > 10000000
+        assert npc_result.cost > 10000000
 
     @pytest.mark.asyncio
     async def test_standard_tx(self):

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -12,6 +12,7 @@ from chia.util.clvm import int_to_bytes
 from chia.util.condition_tools import ConditionOpcode
 from chia.util.ints import uint32
 from chia.wallet.puzzles.load_clvm import load_clvm
+from chia.consensus.condition_costs import ConditionCost
 
 MAX_COST = int(1e15)
 COST_PER_BYTE = int(12000)
@@ -102,7 +103,9 @@ class TestROM:
 
         npc_result = get_name_puzzle_conditions(gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, mempool_mode=False)
         assert npc_result.error is None
-        assert npc_result.clvm_cost == EXPECTED_COST
+        assert npc_result.cost == EXPECTED_COST + ConditionCost.CREATE_COIN.value + (
+            len(bytes(gen.program)) * COST_PER_BYTE
+        )
         cond_1 = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bytes([0] * 31 + [1]), int_to_bytes(500)])
         CONDITIONS = [
             (ConditionOpcode.CREATE_COIN, [cond_1]),


### PR DESCRIPTION
the rust `run_generator` function already computes the cost of the clvm + conditions. It needs to in order to terminate parsing of conditions as early as possible if it exceeds the cost limit.

Right now, for backwards compatibility reasons, we subtract the cost of the conditions in the returned `NPCResult`, because it has a field counting *just* the cost of CLVM (for historical reasons).

This patch replaces the `clvm_cost` field with a `cost` field, that counts the total cost of the generator. Including clvm, conditions and the size. This turns `compute_cost_of_program()` into a no-op. I intend to remove it in a separate patch.