### PR TITLE
Keep backwards compatibility on coin record RPCs

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -441,7 +441,14 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_puzzle_hash(**kwargs)
 
-        return {"coin_records": coin_records}
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
+        coin_records_with_spent = []
+        for cr in coin_records_as_json:
+            cr["spent"] = cr["spent_block_index"] > 0
+            coin_records_with_spent.append(cr)
+
+        return {"coin_records": coin_records_with_spent}
 
     async def get_coin_records_by_puzzle_hashes(self, request: Dict) -> Optional[Dict]:
         """
@@ -463,7 +470,14 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_puzzle_hashes(**kwargs)
 
-        return {"coin_records": coin_records}
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
+        coin_records_with_spent = []
+        for cr in coin_records_as_json:
+            cr["spent"] = cr["spent_block_index"] > 0
+            coin_records_with_spent.append(cr)
+
+        return {"coin_records": coin_records_with_spent}
 
     async def get_coin_record_by_name(self, request: Dict) -> Optional[Dict]:
         """
@@ -477,7 +491,11 @@ class FullNodeRpcApi:
         if coin_record is None:
             raise ValueError(f"Coin record 0x{name.hex()} not found")
 
-        return {"coin_record": coin_record}
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_record_json = coin_record.to_json_dict()
+        coin_record_json["spent"] = coin_record_json["spent_block_index"] > 0
+
+        return {"coin_record": coin_record_json}
 
     async def get_coin_records_by_names(self, request: Dict) -> Optional[Dict]:
         """
@@ -499,7 +517,14 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_names(**kwargs)
 
-        return {"coin_records": coin_records}
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
+        coin_records_with_spent = []
+        for cr in coin_records_as_json:
+            cr["spent"] = cr["spent_block_index"] > 0
+            coin_records_with_spent.append(cr)
+
+        return {"coin_records": coin_records_with_spent}
 
     async def get_coin_records_by_parent_ids(self, request: Dict) -> Optional[Dict]:
         """
@@ -521,7 +546,14 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_parent_ids(**kwargs)
 
-        return {"coin_records": coin_records}
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
+        coin_records_with_spent = []
+        for cr in coin_records_as_json:
+            cr["spent"] = cr["spent_block_index"] > 0
+            coin_records_with_spent.append(cr)
+
+        return {"coin_records": coin_records_with_spent}
 
     async def push_tx(self, request: Dict) -> Optional[Dict]:
         if "spend_bundle" not in request:

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -18,6 +18,11 @@ from chia.util.ints import uint32, uint64, uint128
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
 
 
+def coin_record_dict_backwards_compat(coin_record: Dict[str, Any]):
+    coin_record["spent"] = coin_record["spent_block_index"] > 0
+    return coin_record
+
+
 class FullNodeRpcApi:
     def __init__(self, service: FullNode):
         self.service = service
@@ -441,14 +446,7 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_puzzle_hash(**kwargs)
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
-        coin_records_with_spent = []
-        for cr in coin_records_as_json:
-            cr["spent"] = cr["spent_block_index"] > 0
-            coin_records_with_spent.append(cr)
-
-        return {"coin_records": coin_records_with_spent}
+        return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}
 
     async def get_coin_records_by_puzzle_hashes(self, request: Dict) -> Optional[Dict]:
         """
@@ -470,14 +468,7 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_puzzle_hashes(**kwargs)
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
-        coin_records_with_spent = []
-        for cr in coin_records_as_json:
-            cr["spent"] = cr["spent_block_index"] > 0
-            coin_records_with_spent.append(cr)
-
-        return {"coin_records": coin_records_with_spent}
+        return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}
 
     async def get_coin_record_by_name(self, request: Dict) -> Optional[Dict]:
         """
@@ -491,11 +482,7 @@ class FullNodeRpcApi:
         if coin_record is None:
             raise ValueError(f"Coin record 0x{name.hex()} not found")
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_record_json = coin_record.to_json_dict()
-        coin_record_json["spent"] = coin_record_json["spent_block_index"] > 0
-
-        return {"coin_record": coin_record_json}
+        return {"coin_record": coin_record_dict_backwards_compat(coin_record.to_json_dict())}
 
     async def get_coin_records_by_names(self, request: Dict) -> Optional[Dict]:
         """
@@ -517,14 +504,7 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_names(**kwargs)
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
-        coin_records_with_spent = []
-        for cr in coin_records_as_json:
-            cr["spent"] = cr["spent_block_index"] > 0
-            coin_records_with_spent.append(cr)
-
-        return {"coin_records": coin_records_with_spent}
+        return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}
 
     async def get_coin_records_by_parent_ids(self, request: Dict) -> Optional[Dict]:
         """
@@ -546,14 +526,7 @@ class FullNodeRpcApi:
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_parent_ids(**kwargs)
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_as_json = [cr.to_json_dict() for cr in coin_records]
-        coin_records_with_spent = []
-        for cr in coin_records_as_json:
-            cr["spent"] = cr["spent_block_index"] > 0
-            coin_records_with_spent.append(cr)
-
-        return {"coin_records": coin_records_with_spent}
+        return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}
 
     async def push_tx(self, request: Dict) -> Optional[Dict]:
         if "spend_bundle" not in request:

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -14,6 +14,11 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint32, uint64
 
 
+def coin_record_dict_backwards_compat(coin_record: Dict[str, Any]):
+    del coin_record["spent"]
+    return coin_record
+
+
 class FullNodeRpcClient(RpcClient):
     """
     Client to Chia RPC, connects to a local full node. Uses HTTP/JSON, and converts back from
@@ -87,10 +92,7 @@ class FullNodeRpcClient(RpcClient):
         except Exception:
             return None
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_record_no_spent = response["coin_record"]
-        del coin_record_no_spent["spent"]
-        return CoinRecord.from_json_dict(coin_record_no_spent)
+        return CoinRecord.from_json_dict(coin_record_dict_backwards_compat(response["coin_record"]))
 
     async def get_coin_records_by_names(
         self,
@@ -106,13 +108,8 @@ class FullNodeRpcClient(RpcClient):
         if end_height is not None:
             d["end_height"] = end_height
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_no_spent = []
-        for coin in (await self.fetch("get_coin_records_by_names", d))["coin_records"]:
-            del coin["spent"]
-            coin_records_no_spent.append(coin)
-
-        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
+        response = await self.fetch("get_coin_records_by_names", d)
+        return [CoinRecord.from_json_dict(coin_record_dict_backwards_compat(coin)) for coin in response["coin_records"]]
 
     async def get_coin_records_by_puzzle_hash(
         self,
@@ -127,13 +124,8 @@ class FullNodeRpcClient(RpcClient):
         if end_height is not None:
             d["end_height"] = end_height
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_no_spent = []
-        for coin in (await self.fetch("get_coin_records_by_puzzle_hash", d))["coin_records"]:
-            del coin["spent"]
-            coin_records_no_spent.append(coin)
-
-        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
+        response = await self.fetch("get_coin_records_by_puzzle_hash", d)
+        return [CoinRecord.from_json_dict(coin_record_dict_backwards_compat(coin)) for coin in response["coin_records"]]
 
     async def get_coin_records_by_puzzle_hashes(
         self,
@@ -149,13 +141,8 @@ class FullNodeRpcClient(RpcClient):
         if end_height is not None:
             d["end_height"] = end_height
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_no_spent = []
-        for coin in (await self.fetch("get_coin_records_by_puzzle_hashes", d))["coin_records"]:
-            del coin["spent"]
-            coin_records_no_spent.append(coin)
-
-        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
+        response = await self.fetch("get_coin_records_by_puzzle_hashes", d)
+        return [CoinRecord.from_json_dict(coin_record_dict_backwards_compat(coin)) for coin in response["coin_records"]]
 
     async def get_coin_records_by_parent_ids(
         self,
@@ -171,13 +158,8 @@ class FullNodeRpcClient(RpcClient):
         if end_height is not None:
             d["end_height"] = end_height
 
-        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
-        coin_records_no_spent = []
-        for coin in (await self.fetch("get_coin_records_by_parent_ids", d))["coin_records"]:
-            del coin["spent"]
-            coin_records_no_spent.append(coin)
-
-        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
+        response = await self.fetch("get_coin_records_by_parent_ids", d)
+        return [CoinRecord.from_json_dict(coin_record_dict_backwards_compat(coin)) for coin in response["coin_records"]]
 
     async def get_additions_and_removals(self, header_hash: bytes32) -> Tuple[List[CoinRecord], List[CoinRecord]]:
         try:

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -86,7 +86,11 @@ class FullNodeRpcClient(RpcClient):
             response = await self.fetch("get_coin_record_by_name", {"name": coin_id.hex()})
         except Exception:
             return None
-        return CoinRecord.from_json_dict(response["coin_record"])
+
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_record_no_spent = response["coin_record"]
+        del coin_record_no_spent["spent"]
+        return CoinRecord.from_json_dict(coin_record_no_spent)
 
     async def get_coin_records_by_names(
         self,
@@ -101,10 +105,14 @@ class FullNodeRpcClient(RpcClient):
             d["start_height"] = start_height
         if end_height is not None:
             d["end_height"] = end_height
-        return [
-            CoinRecord.from_json_dict(coin)
-            for coin in (await self.fetch("get_coin_records_by_names", d))["coin_records"]
-        ]
+
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_no_spent = []
+        for coin in (await self.fetch("get_coin_records_by_names", d))["coin_records"]:
+            del coin["spent"]
+            coin_records_no_spent.append(coin)
+
+        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
 
     async def get_coin_records_by_puzzle_hash(
         self,
@@ -118,10 +126,14 @@ class FullNodeRpcClient(RpcClient):
             d["start_height"] = start_height
         if end_height is not None:
             d["end_height"] = end_height
-        return [
-            CoinRecord.from_json_dict(coin)
-            for coin in (await self.fetch("get_coin_records_by_puzzle_hash", d))["coin_records"]
-        ]
+
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_no_spent = []
+        for coin in (await self.fetch("get_coin_records_by_puzzle_hash", d))["coin_records"]:
+            del coin["spent"]
+            coin_records_no_spent.append(coin)
+
+        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
 
     async def get_coin_records_by_puzzle_hashes(
         self,
@@ -136,10 +148,14 @@ class FullNodeRpcClient(RpcClient):
             d["start_height"] = start_height
         if end_height is not None:
             d["end_height"] = end_height
-        return [
-            CoinRecord.from_json_dict(coin)
-            for coin in (await self.fetch("get_coin_records_by_puzzle_hashes", d))["coin_records"]
-        ]
+
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_no_spent = []
+        for coin in (await self.fetch("get_coin_records_by_puzzle_hashes", d))["coin_records"]:
+            del coin["spent"]
+            coin_records_no_spent.append(coin)
+
+        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
 
     async def get_coin_records_by_parent_ids(
         self,
@@ -154,10 +170,14 @@ class FullNodeRpcClient(RpcClient):
             d["start_height"] = start_height
         if end_height is not None:
             d["end_height"] = end_height
-        return [
-            CoinRecord.from_json_dict(coin)
-            for coin in (await self.fetch("get_coin_records_by_parent_ids", d))["coin_records"]
-        ]
+
+        # The following lines are for backwards compatibility after `spent` was removed as a field on CoinRecord
+        coin_records_no_spent = []
+        for coin in (await self.fetch("get_coin_records_by_parent_ids", d))["coin_records"]:
+            del coin["spent"]
+            coin_records_no_spent.append(coin)
+
+        return [CoinRecord.from_json_dict(coin) for coin in coin_records_no_spent]
 
     async def get_additions_and_removals(self, header_hash: bytes32) -> Tuple[List[CoinRecord], List[CoinRecord]]:
         try:


### PR DESCRIPTION
When the `spent` field was removed from `CoinRecord` it changed the JSON output of the RPCs that return coin records.  This patch forces a spent field onto responses from the full node api as well as strips those spent responses when parsing in the api client.