### PR TITLE
Removed excessive from "excessive trolling" 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,7 +24,7 @@ Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
  advances
-* Insulting/derogatory comments, and personal or political attacks, or excessive trolling.
+* Insulting/derogatory comments, and personal or political attacks, or trolling.
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
  address, without explicit permission


### PR DESCRIPTION
To improve and further clarify the Chia code of conduct.