### PR TITLE
Add data to wallet RPCs to support metrics (+ update log_exceptions helper)

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -345,13 +345,13 @@ class FullNodeRpcApi:
     async def get_block_count_metrics(self, request: Dict):
         compact_blocks = 0
         uncompact_blocks = 0
-        with log_exceptions(self.service.log):
+        with log_exceptions(self.service.log, consume=True):
             compact_blocks = await self.service.block_store.count_compactified_blocks()
             uncompact_blocks = await self.service.block_store.count_uncompactified_blocks()
 
         hint_count = 0
         if self.service.hint_store is not None:
-            with log_exceptions(self.service.log):
+            with log_exceptions(self.service.log, consume=True):
                 hint_count = await self.service.hint_store.count_hints()
 
         return {

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -601,6 +601,8 @@ class WalletRpcApi:
                     "unspent_coin_count": 0,
                     "pending_coin_removal_count": 0,
                 }
+                if self.service.logged_in_fingerprint is not None:
+                    wallet_balance["fingerprint"] = self.service.logged_in_fingerprint
         else:
             async with self.service.wallet_state_manager.lock:
                 unspent_records = await self.service.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(
@@ -625,6 +627,8 @@ class WalletRpcApi:
                     "unspent_coin_count": len(unspent_records),
                     "pending_coin_removal_count": len(unconfirmed_removals),
                 }
+                if self.service.logged_in_fingerprint is not None:
+                    wallet_balance["fingerprint"] = self.service.logged_in_fingerprint
                 self.balance_cache[wallet_id] = wallet_balance
 
         return {"wallet_balance": wallet_balance}

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -134,7 +134,13 @@ class WalletRpcApi:
             data["wallet_id"] = args[1]
         if args[2] is not None:
             data["additional_data"] = args[2]
-        return [create_payload_dict("state_changed", data, "chia_wallet", "wallet_ui")]
+
+        payloads = [create_payload_dict("state_changed", data, self.service_name, "wallet_ui")]
+
+        if args[0] == "coin_added":
+            payloads.append(create_payload_dict(args[0], data, self.service_name, "metrics"))
+
+        return payloads
 
     async def _stop_wallet(self):
         """

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -124,6 +124,10 @@ class WalletRpcApi:
         Called by the WalletNode or WalletStateManager when something has changed in the wallet. This
         gives us an opportunity to send notifications to all connected clients via WebSocket.
         """
+        if args[0] is not None and args[0] == "sync_changed":
+            # Metrics is the only current consumer for this event
+            return [create_payload_dict(args[0], {}, self.service_name, "metrics")]
+
         if len(args) < 2:
             return []
 

--- a/chia/util/log_exceptions.py
+++ b/chia/util/log_exceptions.py
@@ -4,8 +4,10 @@ import traceback
 
 
 @contextmanager
-def log_exceptions(log: logging.Logger):
+def log_exceptions(log: logging.Logger, *, consume: bool = False):
     try:
         yield
     except Exception as e:
         log.error(f"Caught Exception: {e}. Traceback: {traceback.format_exc()}")
+        if not consume:
+            raise e

--- a/chia/util/log_exceptions.py
+++ b/chia/util/log_exceptions.py
@@ -10,4 +10,4 @@ def log_exceptions(log: logging.Logger, *, consume: bool = False):
     except Exception as e:
         log.error(f"Caught Exception: {e}. Traceback: {traceback.format_exc()}")
         if not consume:
-            raise e
+            raise


### PR DESCRIPTION
Data required for the initial batch of wallet metrics was mostly already present - just needed a few small additions.

Also updated the `log_exceptions()` util introduced in the last (full node) metrics data PR to _not_ consume the exception by default, per @altendky 's suggestion, so adding him to take a look here as well. In all cases calling log_exceptions() for metrics (only use at the moment), I'm still setting `consume=True` so nothing related to metrics that might throw an exception causes any adverse side effects.