### PR TITLE
remove the GeneratorArgs type

### DIFF
--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -130,7 +130,7 @@ def create_foliage(
 
         # Calculate the cost of transactions
         if block_generator is not None:
-            generator_block_heights_list = block_generator.block_height_list()
+            generator_block_heights_list = block_generator.block_height_list
             result: NPCResult = get_name_puzzle_conditions(
                 block_generator,
                 constants.MAX_BLOCK_COST_CLVM,
@@ -428,7 +428,7 @@ def create_unfinished_block(
         foliage_transaction_block,
         transactions_info,
         block_generator.program if block_generator else None,
-        block_generator.block_height_list() if block_generator else [],
+        block_generator.block_height_list if block_generator else [],
     )
 
 

--- a/chia/full_node/bundle_tools.py
+++ b/chia/full_node/bundle_tools.py
@@ -37,7 +37,7 @@ def simple_solution_generator(bundle: SpendBundle) -> BlockGenerator:
 
     block_program += b"\xff" + cse_list + b"\x80"
 
-    return BlockGenerator(SerializedProgram.from_bytes(block_program), [])
+    return BlockGenerator(SerializedProgram.from_bytes(block_program), [], [])
 
 
 STANDARD_TRANSACTION_PUZZLE_PREFIX = r"""ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01"""  # noqa

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -7,7 +7,6 @@ from clvm.casts import int_from_bytes, int_to_bytes
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.generator import create_generator_args, setup_generator_args
-from chia.types.blockchain_format.program import NIL
 from chia.types.coin_record import CoinRecord
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.generator_types import BlockGenerator
@@ -187,10 +186,7 @@ def get_name_puzzle_conditions(
 def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin_name: bytes, max_cost: int):
     try:
         block_program = generator.program
-        if not generator.generator_args:
-            block_program_args = [NIL]
-        else:
-            block_program_args = create_generator_args(generator.generator_refs())
+        block_program_args = create_generator_args(generator.generator_refs)
 
         cost, result = GENERATOR_FOR_SINGLE_COIN_MOD.run_with_cost(
             max_cost, block_program, block_program_args, coin_name

--- a/chia/types/generator_types.py
+++ b/chia/types/generator_types.py
@@ -12,15 +12,6 @@ class GeneratorBlockCacheInterface:
 
 
 @dataclass(frozen=True)
-@streamable
-class GeneratorArg(Streamable):
-    """`GeneratorArg` contains data from already-buried blocks in the blockchain"""
-
-    block_height: uint32
-    generator: SerializedProgram
-
-
-@dataclass(frozen=True)
 class CompressorArg:
     """`CompressorArg` is used as input to the Block Compressor"""
 
@@ -34,10 +25,7 @@ class CompressorArg:
 @streamable
 class BlockGenerator(Streamable):
     program: SerializedProgram
-    generator_args: List[GeneratorArg]
+    generator_refs: List[SerializedProgram]
 
-    def block_height_list(self) -> List[uint32]:
-        return [a.block_height for a in self.generator_args]
-
-    def generator_refs(self) -> List[SerializedProgram]:
-        return [a.generator for a in self.generator_args]
+    # the heights are only used when creating blocks, never when validating
+    block_height_list: List[uint32]

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -1698,7 +1698,7 @@ def create_test_foliage(
 
         # Calculate the cost of transactions
         if block_generator is not None:
-            generator_block_heights_list = block_generator.block_height_list()
+            generator_block_heights_list = block_generator.block_height_list
             err, cost = compute_cost_test(block_generator, constants.COST_PER_BYTE)
             assert err is None
 
@@ -2003,7 +2003,7 @@ def create_test_unfinished_block(
         foliage_transaction_block,
         transactions_info,
         block_generator.program if block_generator else None,
-        block_generator.block_height_list() if block_generator else [],
+        block_generator.block_height_list if block_generator else [],  # TODO: can block_generator ever be None?
     )
 
 

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -2193,7 +2193,7 @@ class TestBodyValidation:
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
 
-        block_generator: BlockGenerator = BlockGenerator(blocks[-1].transactions_generator, [])
+        block_generator: BlockGenerator = BlockGenerator(blocks[-1].transactions_generator, [], [])
         npc_result = get_name_puzzle_conditions(
             block_generator,
             b.constants.MAX_BLOCK_COST_CLVM * 1000,
@@ -2254,7 +2254,7 @@ class TestBodyValidation:
         new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
 
-        block_generator: BlockGenerator = BlockGenerator(block_2.transactions_generator, [])
+        block_generator: BlockGenerator = BlockGenerator(block_2.transactions_generator, [], [])
         npc_result = get_name_puzzle_conditions(
             block_generator,
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
@@ -2279,7 +2279,7 @@ class TestBodyValidation:
         new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
 
-        block_generator: BlockGenerator = BlockGenerator(block_2.transactions_generator, [])
+        block_generator: BlockGenerator = BlockGenerator(block_2.transactions_generator, [], [])
         npc_result = get_name_puzzle_conditions(
             block_generator,
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
@@ -2304,7 +2304,7 @@ class TestBodyValidation:
         new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
 
-        block_generator: BlockGenerator = BlockGenerator(block_2.transactions_generator, [])
+        block_generator: BlockGenerator = BlockGenerator(block_2.transactions_generator, [], [])
         npc_result = get_name_puzzle_conditions(
             block_generator,
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),

--- a/tests/core/full_node/test_coin_store.py
+++ b/tests/core/full_node/test_coin_store.py
@@ -101,7 +101,7 @@ class TestCoinStoreWithBlocks:
                 should_be_included.add(pool_coin)
                 if block.is_transaction_block():
                     if block.transactions_generator is not None:
-                        block_gen: BlockGenerator = BlockGenerator(block.transactions_generator, [])
+                        block_gen: BlockGenerator = BlockGenerator(block.transactions_generator, [], [])
                         npc_result = get_name_puzzle_conditions(
                             block_gen,
                             bt.constants.MAX_BLOCK_COST_CLVM,

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -1767,7 +1767,7 @@ def generator_condition_tester(
     prg = f"(q ((0x0101010101010101010101010101010101010101010101010101010101010101 {'(q ' if quote else ''} {conditions} {')' if quote else ''} 123 (() (q . ())))))"  # noqa
     print(f"program: {prg}")
     program = SerializedProgram.from_bytes(binutils.assemble(prg).as_bin())
-    generator = BlockGenerator(program, [])
+    generator = BlockGenerator(program, [], [])
     print(f"len: {len(bytes(program))}")
     npc_result: NPCResult = get_name_puzzle_conditions(
         generator, max_cost, cost_per_byte=COST_PER_BYTE, mempool_mode=mempool_mode, height=height
@@ -1963,7 +1963,7 @@ class TestGeneratorConditions:
                 f'(q ((0x0101010101010101010101010101010101010101010101010101010101010101 (q (51 "{puzzle_hash}" 10)) 123 (() (q . ())))(0x0101010101010101010101010101010101010101010101010101010101010102 (q (51 "{puzzle_hash}" 10)) 123 (() (q . ()))) ))'  # noqa
             ).as_bin()
         )
-        generator = BlockGenerator(program, [])
+        generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
             generator, MAX_BLOCK_COST_CLVM, cost_per_byte=COST_PER_BYTE, mempool_mode=False, height=softfork_height
         )

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -145,7 +145,7 @@ class TestCostCalculation:
                 f"  (() (q . ((65 '00000000000000000000000000000000' 0x0cbba106e000))) ()))))"
             ).as_bin()
         )
-        generator = BlockGenerator(program, [])
+        generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
             generator,
             test_constants.MAX_BLOCK_COST_CLVM,
@@ -178,7 +178,7 @@ class TestCostCalculation:
         # ("0xfe"). In mempool mode, this should fail, but in non-mempool
         # mode, the unknown operator should be treated as if it returns ().
         program = SerializedProgram.from_bytes(binutils.assemble(f"(i (0xfe (q . 0)) (q . ()) {disassembly})").as_bin())
-        generator = BlockGenerator(program, [])
+        generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
             generator,
             test_constants.MAX_BLOCK_COST_CLVM,
@@ -202,7 +202,7 @@ class TestCostCalculation:
         program = SerializedProgram.from_bytes(generator_bytes)
 
         start_time = time.time()
-        generator = BlockGenerator(program, [])
+        generator = BlockGenerator(program, [], [])
         npc_result = get_name_puzzle_conditions(
             generator,
             test_constants.MAX_BLOCK_COST_CLVM,
@@ -233,7 +233,7 @@ class TestCostCalculation:
         )
 
         # ensure we fail if the program exceeds the cost
-        generator = BlockGenerator(program, [])
+        generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
             generator,
             10000000,

--- a/tests/generator/test_compression.py
+++ b/tests/generator/test_compression.py
@@ -14,7 +14,7 @@ from chia.full_node.bundle_tools import (
 from chia.full_node.generator import run_generator_unsafe, create_generator_args
 from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
 from chia.types.blockchain_format.program import Program, SerializedProgram, INFINITE_COST
-from chia.types.generator_types import BlockGenerator, CompressorArg, GeneratorArg
+from chia.types.generator_types import BlockGenerator, CompressorArg
 from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint32
@@ -74,11 +74,15 @@ def create_multiple_ref_generator(args: MultipleCompressorArg, spend_bundle: Spe
     )
 
     # TODO aqk: Improve ergonomics of CompressorArg -> GeneratorArg conversion
-    generator_args = [
-        GeneratorArg(FAKE_BLOCK_HEIGHT1, args.arg[0].generator),
-        GeneratorArg(FAKE_BLOCK_HEIGHT2, args.arg[1].generator),
+    generator_list = [
+        args.arg[0].generator,
+        args.arg[1].generator,
     ]
-    return BlockGenerator(program, generator_args)
+    generator_heights = [
+        FAKE_BLOCK_HEIGHT1,
+        FAKE_BLOCK_HEIGHT2,
+    ]
+    return BlockGenerator(program, generator_list, generator_heights)
 
 
 def spend_bundle_to_coin_spend_entry_list(bundle: SpendBundle) -> List[Any]:

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -7,7 +7,7 @@ from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.name_puzzle_condition import NPC
-from chia.types.generator_types import BlockGenerator, GeneratorArg
+from chia.types.generator_types import BlockGenerator
 from chia.util.clvm import int_to_bytes
 from chia.util.condition_tools import ConditionOpcode
 from chia.util.ints import uint32
@@ -69,8 +69,9 @@ def to_sp(sexp) -> SerializedProgram:
 
 
 def block_generator() -> BlockGenerator:
-    generator_args = [GeneratorArg(uint32(0), to_sp(FIRST_GENERATOR)), GeneratorArg(uint32(1), to_sp(SECOND_GENERATOR))]
-    return BlockGenerator(to_sp(COMPILED_GENERATOR_CODE), generator_args)
+    generator_list = [to_sp(FIRST_GENERATOR), to_sp(SECOND_GENERATOR)]
+    generator_heights = [uint32(0), uint32(1)]
+    return BlockGenerator(to_sp(COMPILED_GENERATOR_CODE), generator_list, generator_heights)
 
 
 EXPECTED_ABBREVIATED_COST = 108379

--- a/tests/util/generator_tools_testing.py
+++ b/tests/util/generator_tools_testing.py
@@ -21,7 +21,7 @@ def run_and_get_removals_and_additions(
 
     if block.transactions_generator is not None:
         npc_result = get_name_puzzle_conditions(
-            BlockGenerator(block.transactions_generator, []),
+            BlockGenerator(block.transactions_generator, [], []),
             max_cost,
             cost_per_byte=cost_per_byte,
             mempool_mode=mempool_mode,

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -50,7 +50,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.full_block import FullBlock
-from chia.types.generator_types import BlockGenerator, GeneratorArg
+from chia.types.generator_types import BlockGenerator
 from chia.types.name_puzzle_condition import NPC
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
@@ -101,7 +101,7 @@ def run_generator(
     else:
         flags = 0
 
-    _, result = block_generator.program.run_with_cost(max_cost, flags, block_generator.generator_refs())
+    _, result = block_generator.program.run_with_cost(max_cost, flags, block_generator.generator_refs)
 
     coin_spends = result.first()
 
@@ -167,13 +167,12 @@ def run_generator(
     return cat_list
 
 
-def ref_list_to_args(ref_list: List[uint32]):
+def ref_list_to_args(ref_list: List[uint32]) -> List[SerializedProgram]:
     args = []
     for height in ref_list:
         with open(f"{height}.json", "r") as f:
             program_str = json.load(f)["block"]["transactions_generator"]
-            arg = GeneratorArg(height, SerializedProgram.fromhex(program_str))
-            args.append(arg)
+            args.append(SerializedProgram.fromhex(program_str))
     return args
 
 
@@ -181,7 +180,7 @@ def run_full_block(block: FullBlock, constants: ConsensusConstants) -> List[CAT]
     generator_args = ref_list_to_args(block.transactions_generator_ref_list)
     if block.transactions_generator is None or block.transactions_info is None:
         raise RuntimeError("transactions_generator of FullBlock is null")
-    block_generator = BlockGenerator(block.transactions_generator, generator_args)
+    block_generator = BlockGenerator(block.transactions_generator, generator_args, [])
     return run_generator(
         block_generator, constants, min(constants.MAX_BLOCK_COST_CLVM, block.transactions_info.cost), block.height
     )
@@ -189,7 +188,7 @@ def run_full_block(block: FullBlock, constants: ConsensusConstants) -> List[CAT]
 
 def run_generator_with_args(
     generator_program_hex: str,
-    generator_args: List[GeneratorArg],
+    generator_args: List[SerializedProgram],
     constants: ConsensusConstants,
     cost: uint64,
     height: uint32,
@@ -197,7 +196,7 @@ def run_generator_with_args(
     if not generator_program_hex:
         return []
     generator_program = SerializedProgram.fromhex(generator_program_hex)
-    block_generator = BlockGenerator(generator_program, generator_args)
+    block_generator = BlockGenerator(generator_program, generator_args, [])
     return run_generator(block_generator, constants, min(constants.MAX_BLOCK_COST_CLVM, cost), height)
 
 


### PR DESCRIPTION
Instead include the heights and generator programs as separate lists in BlockGenerator. The heights are not necessary when validating blocks, so this makes it easier to omit them in that case. The heights are only used when generating/farming a block.

The heights and the generator programs are always accessed independently, as separate lists, so this also means we don't have to construct those lists on the fly all the time.

The fundamental motivation for this change is to make it easier to move towards `Blockchain.get_block_generator()` looking up the generator programs from the DB, without having to worry about returning the list of heights. The heights are only used when generating a block, so it seems like unnecessary to handle it in the validation path.