### PR TITLE
Fixed Offer history limit and GUI sorting

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -242,7 +242,9 @@ def make_offer_cmd(
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, make_offer))
 
 
-@wallet_cmd.command("get_offers", short_help="Get the status of existing offers")
+@wallet_cmd.command(
+    "get_offers", short_help="Get the status of existing offers. Displays only active/pending offers by default."
+)
 @click.option(
     "-wp",
     "--wallet-rpc-port",
@@ -253,17 +255,33 @@ def make_offer_cmd(
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-id", "--id", help="The ID of the offer that you wish to examine")
 @click.option("-p", "--filepath", help="The path to rewrite the offer file to (must be used in conjunction with --id)")
-@click.option("-ia", "--include-all", help="Include offers that have already been confirmed/cancelled", is_flag=True)
+@click.option("-em", "--exclude-my-offers", help="Exclude your own offers from the output", is_flag=True)
+@click.option("-et", "--exclude-taken-offers", help="Exclude offers that you've accepted from the output", is_flag=True)
+@click.option(
+    "-ic", "--include-completed", help="Include offers that have been confirmed/cancelled or failed", is_flag=True
+)
 @click.option("-s", "--summaries", help="Show the assets being offered and requested for each offer", is_flag=True)
+@click.option("-r", "--reverse", help="Reverse the order of the output", is_flag=True)
 def get_offers_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
     id: Optional[str],
     filepath: Optional[str],
-    include_all: bool,
+    exclude_my_offers: bool,
+    exclude_taken_offers: bool,
+    include_completed: bool,
     summaries: bool,
+    reverse: bool,
 ) -> None:
-    extra_params = {"id": id, "filepath": filepath, "include_all": include_all, "summaries": summaries}
+    extra_params = {
+        "id": id,
+        "filepath": filepath,
+        "exclude_my_offers": exclude_my_offers,
+        "exclude_taken_offers": exclude_taken_offers,
+        "include_completed": include_completed,
+        "summaries": summaries,
+        "reverse": reverse,
+    }
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_offers
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -451,7 +451,15 @@ class WalletRpcClient(RpcClient):
         return TradeRecord.from_json_dict_convenience(res["trade_record"], offer_str)
 
     async def get_all_offers(
-        self, start: int = 0, end: int = 50, sort_key: str = None, reverse: bool = False, file_contents: bool = False
+        self,
+        start: int = 0,
+        end: int = 50,
+        sort_key: str = None,
+        reverse: bool = False,
+        file_contents: bool = False,
+        exclude_my_offers: bool = False,
+        exclude_taken_offers: bool = False,
+        include_completed: bool = False,
     ) -> List[TradeRecord]:
         res = await self.fetch(
             "get_all_offers",
@@ -461,6 +469,9 @@ class WalletRpcClient(RpcClient):
                 "sort_key": sort_key,
                 "reverse": reverse,
                 "file_contents": file_contents,
+                "exclude_my_offers": exclude_my_offers,
+                "exclude_taken_offers": exclude_taken_offers,
+                "include_completed": include_completed,
             },
         )
 

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -118,7 +118,9 @@ class TradeStore:
             await self.db_wrapper.lock.acquire()
         try:
             cursor = await self.db_connection.execute(
-                "INSERT OR REPLACE INTO trade_records VALUES(?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR REPLACE INTO trade_records "
+                "(trade_record, trade_id, status, confirmed_at_index, created_at_time, sent, is_my_offer) "
+                "VALUES(?, ?, ?, ?, ?, ?, ?)",
                 (
                     bytes(record),
                     record.trade_id.hex(),

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -371,13 +371,13 @@ class TradeStore:
             # Custom sort order for statuses to separate out pending/completed offers
             ordered_statuses = [
                 # Pending statuses are grouped together and ordered by creation date/confirmation height
-                (TradeStatus.PENDING_ACCEPT.value, 0),
-                (TradeStatus.PENDING_CONFIRM.value, 0),
-                (TradeStatus.PENDING_CANCEL.value, 0),
+                (TradeStatus.PENDING_ACCEPT.value, 1 if reverse else 0),
+                (TradeStatus.PENDING_CONFIRM.value, 1 if reverse else 0),
+                (TradeStatus.PENDING_CANCEL.value, 1 if reverse else 0),
                 # Cancelled/Confirmed/Failed are grouped together and ordered by creation date/confirmation height
-                (TradeStatus.CANCELLED.value, 1),
-                (TradeStatus.CONFIRMED.value, 1),
-                (TradeStatus.FAILED.value, 1),
+                (TradeStatus.CANCELLED.value, 0 if reverse else 1),
+                (TradeStatus.CONFIRMED.value, 0 if reverse else 1),
+                (TradeStatus.FAILED.value, 0 if reverse else 1),
             ]
             if reverse:
                 ordered_statuses.reverse()

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -1,7 +1,9 @@
-from typing import List, Optional
+from time import perf_counter
+from typing import List, Optional, Tuple
 from operator import attrgetter
 
 import aiosqlite
+import logging
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
@@ -12,6 +14,37 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.trade_status import TradeStatus
 
 
+async def migrate_is_my_offer(log: logging.Logger, db_connection: aiosqlite.Connection) -> None:
+    """
+    Migrate the is_my_offer property contained in the serialized TradeRecord (trade_record column)
+    to the is_my_offer column in the trade_records table.
+    """
+    log.info("Beginning migration of is_my_offer property in trade_records")
+
+    start_time = perf_counter()
+    cursor = await db_connection.execute("SELECT trade_record, trade_id from trade_records")
+    rows = await cursor.fetchall()
+    await cursor.close()
+
+    updates: List[Tuple[int, str]] = []
+    for row in rows:
+        record = TradeRecord.from_bytes(row[0])
+        is_my_offer = 1 if record.is_my_offer else 0
+        updates.append((is_my_offer, row[1]))
+
+    try:
+        await db_connection.executemany(
+            "UPDATE trade_records SET is_my_offer=? WHERE trade_id=?",
+            updates,
+        )
+    except (aiosqlite.OperationalError, aiosqlite.IntegrityError):
+        log.exception("Failed to migrate is_my_offer property in trade_records")
+        raise
+
+    end_time = perf_counter()
+    log.info(f"Completed migration of {len(updates)} records in {end_time - start_time} seconds")
+
+
 class TradeStore:
     """
     TradeStore stores trading history.
@@ -20,10 +53,21 @@ class TradeStore:
     db_connection: aiosqlite.Connection
     cache_size: uint32
     db_wrapper: DBWrapper
+    log: logging.Logger
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper, cache_size: uint32 = uint32(600000)):
+    async def create(
+        cls,
+        db_wrapper: DBWrapper,
+        cache_size: uint32 = uint32(600000),
+        name: str = None,
+    ) -> "TradeStore":
         self = cls()
+
+        if name:
+            self.log = logging.getLogger(name)
+        else:
+            self.log = logging.getLogger(__name__)
 
         self.cache_size = cache_size
         self.db_wrapper = db_wrapper
@@ -36,9 +80,18 @@ class TradeStore:
                 " status int,"
                 " confirmed_at_index int,"
                 " created_at_time bigint,"
-                " sent int)"
+                " sent int,"
+                " is_my_offer tinyint)"
             )
         )
+
+        # Attempt to add the is_my_offer column. If successful, migrate is_my_offer to the new column.
+        needs_is_my_offer_migration: bool = False
+        try:
+            await self.db_connection.execute("ALTER TABLE trade_records ADD COLUMN is_my_offer tinyint")
+            needs_is_my_offer_migration = True
+        except aiosqlite.OperationalError:
+            pass  # ignore what is likely Duplicate column error
 
         await self.db_connection.execute(
             "CREATE INDEX IF NOT EXISTS trade_confirmed_index on trade_records(confirmed_at_index)"
@@ -47,6 +100,10 @@ class TradeStore:
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS trade_id on trade_records(trade_id)")
 
         await self.db_connection.commit()
+
+        if needs_is_my_offer_migration:
+            await migrate_is_my_offer(self.log, self.db_connection)
+
         return self
 
     async def _clear_database(self):
@@ -62,7 +119,7 @@ class TradeStore:
             await self.db_wrapper.lock.acquire()
         try:
             cursor = await self.db_connection.execute(
-                "INSERT OR REPLACE INTO trade_records VALUES(?, ?, ?, ?, ?, ?)",
+                "INSERT OR REPLACE INTO trade_records VALUES(?, ?, ?, ?, ?, ?, ?)",
                 (
                     bytes(record),
                     record.trade_id.hex(),
@@ -70,6 +127,7 @@ class TradeStore:
                     record.confirmed_at_index,
                     record.created_at_time,
                     record.sent,
+                    record.is_my_offer,
                 ),
             )
             await cursor.close()
@@ -171,6 +229,20 @@ class TradeStore:
 
         await self.add_trade_record(tx, False)
 
+    async def get_trades_count(self) -> Tuple[int, int, int]:
+        """
+        Returns the number of trades in the database broken down by is_my_offer status
+        """
+        # select count(*) as TOTAL, sum(case when is_my_offer=1 then 1 else 0 end) as my_offers, sum(case when is_my_offer=0 then 1 else 0 end) as taken_offers from trade_records;
+        query = "SELECT COUNT(*) AS total, "
+        query += "SUM(CASE WHEN is_my_offer=1 THEN 1 ELSE 0 END) AS my_offers, "
+        query += "SUM(CASE WHEN is_my_offer=0 THEN 1 ELSE 0 END) AS taken_offers "
+        query += "FROM trade_records"
+        cursor = await self.db_connection.execute(query)
+        row = await cursor.fetchone()
+        await cursor.close()
+        return row[0], row[1], row[2]
+
     async def get_trade_record(self, trade_id: bytes32) -> Optional[TradeRecord]:
         """
         Checks DB for TradeRecord with id: id and returns it.
@@ -251,38 +323,113 @@ class TradeStore:
         return records
 
     async def get_trades_between(
-        self, start: int, end: int, sort_key: Optional[str] = None, reverse: bool = False
+        self,
+        start: int,
+        end: int,
+        *,
+        sort_key: Optional[str] = None,
+        reverse: bool = False,
+        exclude_my_offers: bool = False,
+        exclude_taken_offers: bool = False,
+        include_completed: bool = False,
     ) -> List[TradeRecord]:
         """
         Return a list of trades sorted by a key and between a start and end index.
         """
-        records = await self.get_all_trades()
+        if start < 0:
+            raise ValueError("start must be >= 0")
 
-        # Sort
-        records = sorted(records, key=attrgetter("trade_id"))  # For determinism
+        if start > end:
+            raise ValueError("start must be less than or equal to end")
+
+        # If excluding everything, return an empty list
+        if exclude_my_offers and exclude_taken_offers:
+            return []
+
+        offset = start
+        limit = end - start
+        rows = []
+        where_status_clause: Optional[str] = None
+        order_by_clause: Optional[str] = None
+
+        if not include_completed:
+            # Construct a WHERE clause that only looks at active/pending statuses
+            where_status_clause = (
+                f"(status={TradeStatus.PENDING_ACCEPT.value} OR "
+                f"status={TradeStatus.PENDING_CONFIRM.value} OR "
+                f"status={TradeStatus.PENDING_CANCEL.value}) "
+            )
+
+        # Create an ORDER BY clause according to the desired sort type
         if sort_key is None or sort_key == "CONFIRMED_AT_HEIGHT":
-            records = sorted(records, key=attrgetter("confirmed_at_index"), reverse=(not reverse))
+            order_by_clause = (
+                f"ORDER BY confirmed_at_index {'ASC' if reverse else 'DESC'}, "
+                f"trade_id {'DESC' if reverse else 'ASC'} "
+            )
         elif sort_key == "RELEVANCE":
-            sorted_records = sorted(records, key=attrgetter("created_at_time"), reverse=(not reverse))
-            sorted_records = sorted(sorted_records, key=attrgetter("confirmed_at_index"), reverse=(not reverse))
-            # custom sort of the statuses here
-            records = []
-            statuses = ["PENDING", "CONFIRMED", "CANCELLED", "FAILED"]
+            # Custom sort order for statuses to separate out pending/completed offers
+            ordered_statuses = [
+                # Pending statuses are grouped together and ordered by creation date/confirmation height
+                (TradeStatus.PENDING_ACCEPT.value, 0),
+                (TradeStatus.PENDING_CONFIRM.value, 0),
+                (TradeStatus.PENDING_CANCEL.value, 0),
+                # Cancelled/Confirmed/Failed are grouped together and ordered by creation date/confirmation height
+                (TradeStatus.CANCELLED.value, 1),
+                (TradeStatus.CONFIRMED.value, 1),
+                (TradeStatus.FAILED.value, 1),
+            ]
             if reverse:
-                statuses.reverse()
-            statuses.append("")  # This is a catch all for any statuses we have not explicitly designated
-            for status in statuses:
-                for record in sorted_records:
-                    if status in TradeStatus(record.status).name and record not in records:
-                        records.append(record)
+                ordered_statuses.reverse()
+            # Create the "WHEN {status} THEN {index}" cases for the "CASE status" statement
+            ordered_status_clause = map(lambda x: f"WHEN {x[0]} THEN {x[1]}", ordered_statuses)
+            ordered_status_clause = "CASE status " + " ".join(ordered_status_clause) + " END,"
+            order_by_clause = (
+                f"ORDER BY "
+                f"{ordered_status_clause} "
+                f"created_at_time {'ASC' if reverse else 'DESC'}, "
+                f"confirmed_at_index {'ASC' if reverse else 'DESC'}, "
+                f"trade_id {'DESC' if reverse else 'ASC'} "
+            )
         else:
             raise ValueError(f"No known sort {sort_key}")
 
-        # Paginate
-        if start > len(records) - 1:
-            return []
+        query = "SELECT * from trade_records "
+        args = []
+
+        if exclude_my_offers or exclude_taken_offers:
+            # We check if exclude_my_offers == exclude_taken_offers earlier and return [] if so
+            is_my_offer_val = 0 if exclude_my_offers else 1
+            args.append(is_my_offer_val)
+
+            query += "WHERE is_my_offer=? "
+            # Include the additional WHERE status clause if we're filtering out certain statuses
+            if where_status_clause is not None:
+                query += "AND " + where_status_clause
         else:
-            return records[max(start, 0) : min(end, len(records))]
+            query = "SELECT * from trade_records "
+            # Include the additional WHERE status clause if we're filtering out certain statuses
+            if where_status_clause is not None:
+                query += "WHERE " + where_status_clause
+
+        # Include the ORDER BY clause
+        if order_by_clause is not None:
+            query += order_by_clause
+        # Include the LIMIT clause
+        query += "LIMIT ? OFFSET ?"
+
+        args.extend([limit, offset])
+
+        cursor = await self.db_connection.execute(query, tuple(args))
+        rows = await cursor.fetchall()
+        await cursor.close()
+
+        records = []
+
+        for row in rows:
+            record = TradeRecord.from_bytes(row[0])
+            records.append(record)
+
+        return records
 
     async def get_trades_above(self, height: uint32) -> List[TradeRecord]:
         cursor = await self.db_connection.execute("SELECT * from trade_records WHERE confirmed_at_index>?", (height,))

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -497,23 +497,25 @@ class TestWalletRpc:
                 return [t.trade_id for t in trades]
 
             trade_record = await client.get_offer(offer.name())
-            all_offers = await client.get_all_offers()  # confirmed at index descending
+            all_offers = await client.get_all_offers(include_completed=True)  # confirmed at index descending
             assert len(all_offers) == 2
             assert only_ids(all_offers) == only_ids([trade_record, new_trade_record])
-            all_offers = await client.get_all_offers(reverse=True)  # confirmed at index ascending
+            all_offers = await client.get_all_offers(
+                include_completed=True, reverse=True
+            )  # confirmed at index ascending
             assert only_ids(all_offers) == only_ids([new_trade_record, trade_record])
-            all_offers = await client.get_all_offers(sort_key="RELEVANCE")  # most relevant
+            all_offers = await client.get_all_offers(include_completed=True, sort_key="RELEVANCE")  # most relevant
             assert only_ids(all_offers) == only_ids([new_trade_record, trade_record])
-            all_offers = await client.get_all_offers(sort_key="RELEVANCE", reverse=True)  # least relevant
+            all_offers = await client.get_all_offers(
+                include_completed=True, sort_key="RELEVANCE", reverse=True
+            )  # least relevant
             assert only_ids(all_offers) == only_ids([trade_record, new_trade_record])
             # Test pagination
-            all_offers = await client.get_all_offers(start=0, end=1)
+            all_offers = await client.get_all_offers(include_completed=True, start=0, end=1)
             assert len(all_offers) == 1
-            all_offers = await client.get_all_offers(start=-1, end=1)
-            assert len(all_offers) == 1
-            all_offers = await client.get_all_offers(start=50)
+            all_offers = await client.get_all_offers(include_completed=True, start=50)
             assert len(all_offers) == 0
-            all_offers = await client.get_all_offers(start=0, end=50)
+            all_offers = await client.get_all_offers(include_completed=True, start=0, end=50)
             assert len(all_offers) == 2
 
             # Keys and addresses


### PR DESCRIPTION
trade_store: Migrated the is_my_offer property from the serialized
trade_record to a new `is_my_offer` column in the trade_records table.
Rewrote get_trades_between to move the query/sorting into the database.
This supports the presentation of offers in the GUI (two lists sorted by
relevance).

RPC: get_all_offers now accepts options to restrict the listing to
completed offers, my offers, taken offers. Added get_offers_count call
to return a breakdown of the number of offers (my offers, taken offers,
total).

CLI: Updated `chia wallet get_offers` to include options to exclude
created/taken offers, as well as an option to reverse the listing. The
-ia|--include-all option has been renamed -ic|--include-completed to
make sense in the context of the --exclude-[my-offers|taken-offers]
options. The full listing is now output, fixing the issue with hitting
the prior paging cap of 50 records.

Addresses bug #9954 