### PR TITLE
Silence output along the "didn't compile" path since clvm_tools_rs is…

### DIFF
--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -32,7 +32,6 @@ if "CLVM_TOOLS_RS" in os.environ:
 
         def rust_compile_clvm(full_path, output, search_paths=[]):
             treated_include_paths = list(map(translate_path, search_paths))
-            print("compile_clvm_rs", full_path, output, treated_include_paths)
             compile_clvm_rs(str(full_path), str(output), treated_include_paths)
 
             if os.environ["CLVM_TOOLS_RS"] == "check":


### PR DESCRIPTION
… getting pulled in elsewhere

Trivial change just silencing spam that showed what was being evaluated by clvm_tools_rs.