### PR TITLE
use pytest.fixture instead of pytest_asyncio.fixture in cmd test

### DIFF
--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import pytest_asyncio
 import re
 
 from chia.cmds.chia import cli
@@ -23,7 +22,7 @@ TEST_FINGERPRINT = 2877570395
 
 
 class TestKeysCommands:
-    @pytest_asyncio.fixture(scope="function")
+    @pytest.fixture(scope="function")
     def empty_keyring(self):
         with TempKeyring(user="user-chia-1.8", service="chia-user-chia-1.8") as keychain:
             yield keychain


### PR DESCRIPTION
running this test locally failed with:

```
tests/core/cmds/test_keys.py:25: in <module>
    class TestKeysCommands:
tests/core/cmds/test_keys.py:26: in TestKeysCommands
    @pytest_asyncio.fixture(scope="function")
E   AttributeError: module 'pytest_asyncio' has no attribute 'fixture'
```