### PR TITLE
fix DB conversion with duplicate hints in the v1 database

### DIFF
--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -245,12 +245,14 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
                     commit_in -= 1
                     if commit_in == 0:
                         commit_in = HINT_COMMIT_RATE
-                        await out_db.executemany("INSERT INTO hints VALUES(?, ?) ON CONFLICT DO NOTHING", hint_values)
+                        await out_db.executemany(
+                            "INSERT OR IGNORE INTO hints VALUES(?, ?) ON CONFLICT DO NOTHING", hint_values
+                        )
                         await out_db.commit()
                         await out_db.execute("begin transaction")
                         hint_values = []
 
-            await out_db.executemany("INSERT INTO hints VALUES (?, ?)", hint_values)
+            await out_db.executemany("INSERT OR IGNORE INTO hints VALUES (?, ?)", hint_values)
             await out_db.commit()
 
             end_time = time()

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -47,6 +47,22 @@ class TestDbUpgrade:
         for i in range(351):
             hints.append((bytes32(rand_bytes(32)), rand_bytes(20)))
 
+        # the v1 schema allows duplicates in the hints table
+        for i in range(10):
+            coin_id = bytes32(rand_bytes(32))
+            hint = rand_bytes(20)
+            hints.append((coin_id, hint))
+            hints.append((coin_id, hint))
+
+        for i in range(2000):
+            hints.append((bytes32(rand_bytes(32)), rand_bytes(20)))
+
+        for i in range(5):
+            coin_id = bytes32(rand_bytes(32))
+            hint = rand_bytes(20)
+            hints.append((coin_id, hint))
+            hints.append((coin_id, hint))
+
         with TempFile() as in_file, TempFile() as out_file:
 
             async with aiosqlite.connect(in_file) as conn:


### PR DESCRIPTION
There was a recent patch to the v2 database schema which deduplicates hints in the hints table. However, since the v1 schema allowes duplicates, the conversion can fail because it doesn't properly ignore duplicate inserts.