### PR TITLE
full_node: remove pending timeout tasks to save memory

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -362,6 +362,7 @@ class WSChiaConnection:
         await event.wait()
 
         self.pending_requests.pop(message.id)
+        self.pending_timeouts.pop(message.id)
         result: Optional[Message] = None
         if message.id in self.request_results:
             result = self.request_results[message.id]


### PR DESCRIPTION
From @altendky :

>  if you search for pending_timeouts i think we don't drop references to those until we drop the whole connection?  i think it can go away entirely by using the asyncio.wait_for() option, though i haven't tried to think of corner cases.  anyways, since you were noting memory 'leaks'.  sys.getsizeof(some_random_task_i_made) gives 200 bytes (though who knows what more is hidden behind that in references) so that's ballpark 1MB/day/peer.  400MB for an average of holding a peer for five days with 80 peers