### PR TITLE
Simplify FullNode._replace_proof

### DIFF
--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -227,7 +227,7 @@ async def run_add_block_benchmark(version: int):
             )
 
             start = time()
-            await block_store.add_full_block(header_hash, full_block, record, False)
+            await block_store.add_full_block(header_hash, full_block, record)
             await block_store.set_in_chain([(header_hash,)])
             header_hashes.append(header_hash)
             await block_store.set_peak(header_hash)

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -252,7 +252,7 @@ class Blockchain(BlockchainInterface):
                 header_hash: bytes32 = block.header_hash
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.db_wrapper.begin_transaction()
-                await self.block_store.add_full_block(header_hash, block, block_record, False)
+                await self.block_store.add_full_block(header_hash, block, block_record)
                 fork_height, peak_height, records, (coin_record_change, hint_changes) = await self._reconsider_peak(
                     block_record, genesis, fork_point_with_peak, npc_result
                 )

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -154,7 +154,7 @@ class BlockStore:
             (
                 block_bytes,
                 int(block.is_fully_compactified()),
-                header_hash,
+                self.maybe_to_hex(header_hash),
             ),
         )
 

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -170,7 +170,7 @@ class BlockStore:
             )
 
             await self.db.execute(
-                "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     header_hash,
                     block.prev_header_hash,
@@ -185,7 +185,7 @@ class BlockStore:
 
         else:
             await self.db.execute(
-                "INSERT OR REPLACE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
                 (
                     header_hash.hex(),
                     block.height,
@@ -196,7 +196,7 @@ class BlockStore:
             )
 
             await self.db.execute(
-                "INSERT OR REPLACE INTO block_records VALUES(?, ?, ?, ?,?, ?, ?)",
+                "INSERT OR IGNORE INTO block_records VALUES(?, ?, ?, ?,?, ?, ?)",
                 (
                     header_hash.hex(),
                     block.prev_header_hash.hex(),

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2133,6 +2133,7 @@ class FullNode:
             self.log.info(f"Duplicate compact proof. Height: {height}. Header hash: {header_hash}.")
         return is_new_proof
 
+    # returns True if we ended up replacing the proof, and False otherwise
     async def _replace_proof(
         self,
         vdf_info: VDFInfo,
@@ -2140,59 +2141,59 @@ class FullNode:
         height: uint32,
         field_vdf: CompressibleVDFField,
     ) -> bool:
-        full_blocks = await self.block_store.get_full_blocks_at([height])
-        assert len(full_blocks) > 0
-        replaced = False
-        expected_header_hash = self.blockchain.height_to_hash(height)
-        for block in full_blocks:
-            new_block = None
-            if block.header_hash != expected_header_hash:
-                continue
+        header_hash = self.blockchain.height_to_hash(height)
+        if not header_hash:
+            return False
 
-            if field_vdf == CompressibleVDFField.CC_EOS_VDF:
-                for index, sub_slot in enumerate(block.finished_sub_slots):
-                    if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
-                        new_proofs = dataclasses.replace(sub_slot.proofs, challenge_chain_slot_proof=vdf_proof)
-                        new_subslot = dataclasses.replace(sub_slot, proofs=new_proofs)
-                        new_finished_subslots = block.finished_sub_slots
-                        new_finished_subslots[index] = new_subslot
-                        new_block = dataclasses.replace(block, finished_sub_slots=new_finished_subslots)
-                        break
-            if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
-                for index, sub_slot in enumerate(block.finished_sub_slots):
-                    if (
-                        sub_slot.infused_challenge_chain is not None
-                        and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
-                    ):
-                        new_proofs = dataclasses.replace(sub_slot.proofs, infused_challenge_chain_slot_proof=vdf_proof)
-                        new_subslot = dataclasses.replace(sub_slot, proofs=new_proofs)
-                        new_finished_subslots = block.finished_sub_slots
-                        new_finished_subslots[index] = new_subslot
-                        new_block = dataclasses.replace(block, finished_sub_slots=new_finished_subslots)
-                        break
-            if field_vdf == CompressibleVDFField.CC_SP_VDF:
-                if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
-                    assert block.challenge_chain_sp_proof is not None
-                    new_block = dataclasses.replace(block, challenge_chain_sp_proof=vdf_proof)
-            if field_vdf == CompressibleVDFField.CC_IP_VDF:
-                if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
-                    new_block = dataclasses.replace(block, challenge_chain_ip_proof=vdf_proof)
-            if new_block is None:
-                continue
-            async with self.db_wrapper.lock:
-                try:
-                    await self.block_store.db_wrapper.begin_transaction()
-                    await self.block_store.replace_proof(new_block.header_hash, new_block)
-                    await self.block_store.db_wrapper.commit_transaction()
-                    replaced = True
-                except BaseException as e:
-                    await self.block_store.db_wrapper.rollback_transaction()
-                    self.log.error(
-                        f"_replace_proof error while adding block {block.header_hash} height {block.height},"
-                        f" rolling back: {e} {traceback.format_exc()}"
-                    )
-                    raise
-        return replaced
+        block = await self.block_store.get_full_block(header_hash)
+        if block is None:
+            return False
+
+        new_block = None
+
+        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+            for index, sub_slot in enumerate(block.finished_sub_slots):
+                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
+                    new_proofs = dataclasses.replace(sub_slot.proofs, challenge_chain_slot_proof=vdf_proof)
+                    new_subslot = dataclasses.replace(sub_slot, proofs=new_proofs)
+                    new_finished_subslots = block.finished_sub_slots
+                    new_finished_subslots[index] = new_subslot
+                    new_block = dataclasses.replace(block, finished_sub_slots=new_finished_subslots)
+                    break
+        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+            for index, sub_slot in enumerate(block.finished_sub_slots):
+                if (
+                    sub_slot.infused_challenge_chain is not None
+                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
+                ):
+                    new_proofs = dataclasses.replace(sub_slot.proofs, infused_challenge_chain_slot_proof=vdf_proof)
+                    new_subslot = dataclasses.replace(sub_slot, proofs=new_proofs)
+                    new_finished_subslots = block.finished_sub_slots
+                    new_finished_subslots[index] = new_subslot
+                    new_block = dataclasses.replace(block, finished_sub_slots=new_finished_subslots)
+                    break
+        if field_vdf == CompressibleVDFField.CC_SP_VDF:
+            if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
+                assert block.challenge_chain_sp_proof is not None
+                new_block = dataclasses.replace(block, challenge_chain_sp_proof=vdf_proof)
+        if field_vdf == CompressibleVDFField.CC_IP_VDF:
+            if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
+                new_block = dataclasses.replace(block, challenge_chain_ip_proof=vdf_proof)
+        if new_block is None:
+            return False
+        async with self.db_wrapper.lock:
+            try:
+                await self.block_store.db_wrapper.begin_transaction()
+                await self.block_store.replace_proof(new_block.header_hash, new_block)
+                await self.block_store.db_wrapper.commit_transaction()
+                return True
+            except BaseException as e:
+                await self.block_store.db_wrapper.rollback_transaction()
+                self.log.error(
+                    f"_replace_proof error while adding block {block.header_hash} height {block.height},"
+                    f" rolling back: {e} {traceback.format_exc()}"
+                )
+                raise
 
     async def respond_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime):
         field_vdf = CompressibleVDFField(int(request.field_vdf))

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2138,12 +2138,9 @@ class FullNode:
         self,
         vdf_info: VDFInfo,
         vdf_proof: VDFProof,
-        height: uint32,
+        header_hash: bytes32,
         field_vdf: CompressibleVDFField,
     ) -> bool:
-        header_hash = self.blockchain.height_to_hash(height)
-        if not header_hash:
-            return False
 
         block = await self.block_store.get_full_block(header_hash)
         if block is None:
@@ -2202,7 +2199,7 @@ class FullNode:
         ):
             return None
         async with self.blockchain.compact_proof_lock:
-            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.height, field_vdf)
+            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
         if not replaced:
             self.log.error(f"Could not replace compact proof: {request.height}")
             return None
@@ -2285,7 +2282,7 @@ class FullNode:
         async with self.blockchain.compact_proof_lock:
             if self.blockchain.seen_compact_proofs(request.vdf_info, request.height):
                 return None
-            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.height, field_vdf)
+            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
         if not replaced:
             self.log.error(f"Could not replace compact proof: {request.height}")
             return None

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import random
 import sqlite3
+import dataclasses
 
 import pytest
 
@@ -9,6 +10,8 @@ from chia.consensus.blockchain import Blockchain
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
+from chia.util.ints import uint8
+from chia.types.blockchain_format.vdf import VDFProof
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.util.db_connection import DBConnection
 from tests.setup_nodes import bt, test_constants
@@ -44,8 +47,8 @@ class TestBlockStore:
                 await _validate_and_add_block(bc, block)
                 block_record = bc.block_record(block.header_hash)
                 block_record_hh = block_record.header_hash
-                await store.add_full_block(block.header_hash, block, block_record, False)
-                await store.add_full_block(block.header_hash, block, block_record, False)
+                await store.add_full_block(block.header_hash, block, block_record)
+                await store.add_full_block(block.header_hash, block, block_record)
                 assert block == await store.get_full_block(block.header_hash)
                 assert block == await store.get_full_block(block.header_hash)
                 assert block_record == (await store.get_block_record(block_record_hh))
@@ -87,9 +90,7 @@ class TestBlockStore:
                 if random.random() < 0.5:
                     tasks.append(
                         asyncio.create_task(
-                            store.add_full_block(
-                                blocks[rand_i].header_hash, blocks[rand_i], block_records[rand_i], False
-                            )
+                            store.add_full_block(blocks[rand_i].header_hash, blocks[rand_i], block_records[rand_i])
                         )
                     )
                 if random.random() < 0.5:
@@ -176,3 +177,41 @@ class TestBlockStore:
 
             count = await block_store.count_uncompactified_blocks()
             assert count == 10
+
+    @pytest.mark.asyncio
+    async def test_replace_proof(self, tmp_dir, db_version):
+        blocks = bt.get_consecutive_blocks(10)
+
+        def rand_bytes(num) -> bytes:
+            ret = bytearray(num)
+            for i in range(num):
+                ret[i] = random.getrandbits(8)
+            return bytes(ret)
+
+        def rand_vdf_proof() -> VDFProof:
+            return VDFProof(
+                uint8(1),  # witness_type
+                rand_bytes(32),  # witness
+                bool(random.randint(0, 1)),  # normalized_to_identity
+            )
+
+        async with DBConnection(db_version) as db_wrapper:
+            coin_store = await CoinStore.create(db_wrapper)
+            block_store = await BlockStore.create(db_wrapper)
+            hint_store = await HintStore.create(db_wrapper)
+            bc = await Blockchain.create(coin_store, block_store, test_constants, hint_store, tmp_dir, 2)
+            for block in blocks:
+                await _validate_and_add_block(bc, block)
+
+            replaced = []
+
+            for block in blocks:
+                assert block.challenge_chain_ip_proof is not None
+                proof = rand_vdf_proof()
+                replaced.append(proof)
+                new_block = dataclasses.replace(block, challenge_chain_ip_proof=proof)
+                await block_store.replace_proof(block.header_hash, new_block)
+
+            for block, proof in zip(blocks, replaced):
+                b = await block_store.get_full_block(block.header_hash)
+                assert b.challenge_chain_ip_proof == proof

--- a/tests/core/full_node/test_block_store.py
+++ b/tests/core/full_node/test_block_store.py
@@ -215,3 +215,9 @@ class TestBlockStore:
             for block, proof in zip(blocks, replaced):
                 b = await block_store.get_full_block(block.header_hash)
                 assert b.challenge_chain_ip_proof == proof
+
+                # make sure we get the same result when we hit the database
+                # itself (and not just the block cache)
+                block_store.rollback_cache_block(block.header_hash)
+                b = await block_store.get_full_block(block.header_hash)
+                assert b.challenge_chain_ip_proof == proof


### PR DESCRIPTION
Currently, `_replace_proof()` asks the `BlockStore` for all blocks at the specific height followed by a linear search for the one with the correct header hash. This patch proposes that we, instead, simply lookup the correct header hash directly (since we need to perform the height-to-hash mapping either way). This simplifies the logic by dropping the loop over the blocks.