### PR TITLE
await peer.close() in WalletNode.validate_received_state_from_peer()

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1055,7 +1055,7 @@ class WalletNode:
         )
 
         if validate_additions_result is False:
-            peer.close(9999)
+            await peer.close(9999)
             return False
 
         # get blocks on top of this block
@@ -1085,7 +1085,7 @@ class WalletNode:
                 spent_state_block.foliage_transaction_block.removals_root,
             )
             if validate_removals_result is False:
-                peer.close(9999)
+                await peer.close(9999)
                 return False
             validated = await self.validate_block_inclusion(spent_state_block, peer, peer_request_cache)
             if not validated:
@@ -1110,7 +1110,7 @@ class WalletNode:
                 spent_state_block.foliage_transaction_block.removals_root,
             )
             if validate_removals_result is False:
-                peer.close(9999)
+                await peer.close(9999)
                 return False
             validated = await self.validate_block_inclusion(spent_state_block, peer, peer_request_cache)
             if not validated:


### PR DESCRIPTION
```
farm/chia-blockchain/chia/wallet/wallet_node.py:1058: RuntimeWarning: coroutine 'WSChiaConnection.close' was never awaited
peer.close(9999)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```