### PR TITLE
Revert "pip==21.3.1 for now"

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -43,8 +43,7 @@ Write-Output "Python version is:" $pythonVersion
 
 py -m venv venv
 
-# TODO: unpin pip after fixing support for 22.0 with our pypi.chia.net
-venv\scripts\python -m pip install --upgrade pip==21.3.1 setuptools wheel
+venv\scripts\python -m pip install --upgrade pip setuptools wheel
 venv\scripts\pip install --extra-index-url https://pypi.chia.net/simple/ miniupnpc==2.2.2
 venv\scripts\pip install --editable . --extra-index-url https://pypi.chia.net/simple/
 

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -27,8 +27,7 @@ Write-Output "Create venv - python3.9 is required in PATH"
 Write-Output "   ---"
 python -m venv venv
 . .\venv\Scripts\Activate.ps1
-# TODO: unpin pip after fixing support for 22.0 with our pypi.chia.net
-python -m pip install --upgrade pip==21.3.1
+python -m pip install --upgrade pip
 pip install wheel pep517
 pip install pywin32
 pip install pyinstaller==4.5

--- a/install.sh
+++ b/install.sh
@@ -170,8 +170,7 @@ fi
 # shellcheck disable=SC1091
 . ./activate
 # pip 20.x+ supports Linux binary wheels
-# TODO: unpin pip after fixing support for 22.0 with our pypi.chia.net
-python -m pip install --upgrade pip==21.3.1
+python -m pip install --upgrade pip
 python -m pip install wheel
 #if [ "$INSTALL_PYTHON_VERSION" = "3.8" ]; then
 # This remains in case there is a diversion of binary wheels


### PR DESCRIPTION
Reverts Chia-Network/chia-blockchain#10035

pip released updates turning the failure into a deprecation warning.  We are working on fixing https://pypi.chia.net/simple.

```
DEPRECATION: The HTML index page being used (https://pypi.chia.net/simple/argon2-cffi/) is not a proper HTML 5 document. This is in violation of PEP 503 which requires these pages to be well-formed HTML 5 documents. Please reach out to the owners of this index page, and ask them to update this index page to a valid HTML 5 document. pip 22.2 will enforce this behaviour change. Discussion can be found at https://github.com/pypa/pip/issues/10825
```

When using the old pip you get a warning that it is out of date.  I considered permanently banning 22.0 but since it will work once our extra index gets fixed and 22.2+ will have the same issue, it doesn't seem particularly useful.