### PR TITLE
Refactor generate_signed_transaction methods and CAT support in tx RPCs

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -185,14 +185,10 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
 
     final_fee = uint64(int(fee * units["chia"]))
     final_amount: uint64
-    if typ == WalletType.STANDARD_WALLET:
-        final_amount = uint64(int(amount * units["chia"]))
+    if typ in [WalletType.STANDARD_WALLET, WalletType.CAT]:
+        final_amount = uint64(int(amount * get_mojo_per_unit(typ)))
         print("Submitting transaction...")
         res = await wallet_client.send_transaction(str(wallet_id), final_amount, address, final_fee, memos)
-    elif typ == WalletType.CAT:
-        final_amount = uint64(int(amount * units["cat"]))
-        print("Submitting transaction...")
-        res = await wallet_client.cat_spend(str(wallet_id), final_amount, address, final_fee, memos)
     else:
         print("Only standard wallet and CAT wallets are supported")
         return

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -485,7 +485,6 @@ class PoolWallet:
             fee=fee,
             origin_id=None,
             coins=None,
-            primaries=None,
             ignore_max_send_amount=False,
             coin_announcements_to_consume=coin_announcements,
         )

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -480,9 +480,8 @@ class PoolWallet:
         )
 
     async def generate_fee_transaction(self, fee: uint64, coin_announcements=None) -> TransactionRecord:
-        fee_tx = await self.standard_wallet.generate_signed_transaction(
-            uint64(0),
-            (await self.standard_wallet.get_new_puzzlehash()),
+        [fee_tx] = await self.standard_wallet.generate_signed_transaction(
+            [Payment((await self.standard_wallet.get_new_puzzlehash()), uint64(0), [])],
             fee=fee,
             origin_id=None,
             coins=None,

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -656,7 +656,7 @@ class PoolWallet:
         announcement_message = Program.to([puzzle_hash, amount, pool_state_bytes]).get_tree_hash()
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
-        create_launcher_tx_record: Optional[TransactionRecord] = await standard_wallet.generate_signed_transaction(
+        create_launcher_tx_record: TransactionRecord = (await standard_wallet.generate_signed_transaction(
             amount,
             genesis_launcher_puz.get_tree_hash(),
             fee,
@@ -665,7 +665,7 @@ class PoolWallet:
             None,
             False,
             announcement_set,
-        )
+        ))[0]
         assert create_launcher_tx_record is not None and create_launcher_tx_record.spend_bundle is not None
 
         genesis_launcher_solution: Program = Program.to([puzzle_hash, amount, pool_state_bytes])

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -51,6 +51,7 @@ from chia.wallet.sign_coin_spends import sign_coin_spends
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
+from chia.wallet.payment import Payment
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 
 from chia.wallet.wallet_info import WalletInfo
@@ -657,8 +658,7 @@ class PoolWallet:
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
         create_launcher_tx_record: TransactionRecord = (await standard_wallet.generate_signed_transaction(
-            amount,
-            genesis_launcher_puz.get_tree_hash(),
+            [Payment(genesis_launcher_puz.get_tree_hash(), amount, [])],
             fee,
             launcher_parent.name(),
             coins,

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -657,15 +657,16 @@ class PoolWallet:
         announcement_message = Program.to([puzzle_hash, amount, pool_state_bytes]).get_tree_hash()
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
-        create_launcher_tx_record: TransactionRecord = (await standard_wallet.generate_signed_transaction(
-            [Payment(genesis_launcher_puz.get_tree_hash(), amount, [])],
-            fee,
-            launcher_parent.name(),
-            coins,
-            None,
-            False,
-            announcement_set,
-        ))[0]
+        create_launcher_tx_record: TransactionRecord = (
+            await standard_wallet.generate_signed_transaction(
+                [Payment(genesis_launcher_puz.get_tree_hash(), amount, [])],
+                fee,
+                launcher_parent.name(),
+                coins,
+                False,
+                announcement_set,
+            )
+        )[0]
         assert create_launcher_tx_record is not None and create_launcher_tx_record.spend_bundle is not None
 
         genesis_launcher_solution: Program = Program.to([puzzle_hash, amount, pool_state_bytes])

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -33,7 +33,7 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
-from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
+from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_node import WalletNode
 from chia.util.config import load_config
@@ -777,9 +777,6 @@ class WalletRpcApi:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before sending transactions")
 
-        wallet_id = uint32(request["wallet_id"])
-        wallet = self.service.wallet_state_manager.wallets[wallet_id]
-
         async with self.service.wallet_state_manager.lock:
             transaction: Dict = (await self.create_signed_transaction(request, hold_lock=False))["signed_tx"]
             tr: TransactionRecord = TransactionRecord.from_json_dict_convenience(transaction)
@@ -1228,9 +1225,9 @@ class WalletRpcApi:
         if len(puzzle_hash_0) != 32:
             raise ValueError(f"Address must be 32 bytes. {puzzle_hash_0.hex()}")
 
-        memos_0 = None if "memos" not in additions[0] else [mem.encode("utf-8") for mem in additions[0]["memos"]]
+        memos_0 = [] if "memos" not in additions[0] else [mem.encode("utf-8") for mem in additions[0]["memos"]]
 
-        additional_outputs: List[AmountWithPuzzlehash] = []
+        additional_outputs: List[Payment] = []
         for addition in additions[1:]:
             receiver_ph = bytes32.from_hexstr(addition["puzzle_hash"])
             if len(receiver_ph) != 32:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -721,11 +721,8 @@ class WalletRpcApi:
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
         selected = self.service.config["selected_network"]
         prefix = self.service.config["network_overrides"]["config"][selected]["address_prefix"]
-        if wallet.type() == WalletType.STANDARD_WALLET:
+        if wallet.type() in [WalletType.STANDARD_WALLET, WalletType.CAT]:
             raw_puzzle_hash = await wallet.get_puzzle_hash(create_new)
-            address = encode_puzzle_hash(raw_puzzle_hash, prefix)
-        elif wallet.type() == WalletType.CAT:
-            raw_puzzle_hash = await wallet.standard_wallet.get_puzzle_hash(create_new)
             address = encode_puzzle_hash(raw_puzzle_hash, prefix)
         else:
             raise ValueError(f"Wallet type {wallet.type()} cannot create puzzle hashes")
@@ -743,9 +740,6 @@ class WalletRpcApi:
 
         wallet_id = int(request["wallet_id"])
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
-
-        if wallet.type() == WalletType.CAT:
-            raise ValueError("send_transaction does not work for CAT wallets")
 
         if not isinstance(request["amount"], int) or not isinstance(request["fee"], int):
             raise ValueError("An integer amount or fee is required (too many decimals)")

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -761,7 +761,7 @@ class WalletRpcApi:
         else:
             fee = uint64(0)
         async with self.service.wallet_state_manager.lock:
-            tx: TransactionRecord = await wallet.generate_signed_transaction(amount, puzzle_hash, fee, memos=memos)
+            tx: TransactionRecord = (await wallet.generate_signed_transaction(amount, puzzle_hash, fee, memos=memos))[0]
             await wallet.push_transaction(tx)
 
         # Transaction may not have been included in the mempool yet. Use get_transaction to check.
@@ -847,7 +847,7 @@ class WalletRpcApi:
         else:
             fee = uint64(0)
         async with self.service.wallet_state_manager.lock:
-            txs: TransactionRecord = await wallet.generate_signed_transaction(
+            txs: List[TransactionRecord] = await wallet.generate_signed_transaction(
                 [amount], [puzzle_hash], fee, memos=[memos]
             )
             for tx in txs:
@@ -1282,7 +1282,7 @@ class WalletRpcApi:
 
         if hold_lock:
             async with self.service.wallet_state_manager.lock:
-                signed_tx = await self.service.wallet_state_manager.main_wallet.generate_signed_transaction(
+                [signed_tx] = await self.service.wallet_state_manager.main_wallet.generate_signed_transaction(
                     amount_0,
                     bytes32(puzzle_hash_0),
                     fee,
@@ -1294,7 +1294,7 @@ class WalletRpcApi:
                     puzzle_announcements_to_consume=puzzle_announcements,
                 )
         else:
-            signed_tx = await self.service.wallet_state_manager.main_wallet.generate_signed_transaction(
+            [signed_tx] = await self.service.wallet_state_manager.main_wallet.generate_signed_transaction(
                 amount_0,
                 bytes32(puzzle_hash_0),
                 fee,

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -236,7 +236,7 @@ class CATWallet:
         spendable.sort(reverse=True, key=lambda record: record.coin.amount)
         if self.cost_of_single_tx is None:
             coin = spendable[0].coin
-            txs = await self.generate_signed_transaction(
+            txs: List[TransactionRecord] = await self.generate_signed_transaction(
                 [coin.amount], [coin.puzzle_hash], coins={coin}, ignore_max_send_amount=True
             )
             program: BlockGenerator = simple_solution_generator(txs[0].spend_bundle)
@@ -512,7 +512,7 @@ class CATWallet:
         if fee > amount_to_claim:
             chia_coins = await self.standard_wallet.select_coins(fee)
             origin_id = list(chia_coins)[0].name()
-            chia_tx = await self.standard_wallet.generate_signed_transaction(
+            [chia_tx] = await self.standard_wallet.generate_signed_transaction(
                 uint64(0),
                 (await self.standard_wallet.get_new_puzzlehash()),
                 fee=uint64(fee - amount_to_claim),
@@ -536,7 +536,7 @@ class CATWallet:
         else:
             chia_coins = await self.standard_wallet.select_coins(fee)
             selected_amount = sum([c.amount for c in chia_coins])
-            chia_tx = await self.standard_wallet.generate_signed_transaction(
+            [chia_tx] = await self.standard_wallet.generate_signed_transaction(
                 uint64(selected_amount + amount_to_claim - fee),
                 (await self.standard_wallet.get_new_puzzlehash()),
                 coins=chia_coins,

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -44,7 +44,7 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
 )
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
-from chia.wallet.util.wallet_types import WalletType, AmountWithPuzzlehash
+from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
@@ -536,7 +536,13 @@ class CATWallet:
             chia_coins = await self.standard_wallet.select_coins(fee)
             selected_amount = sum([c.amount for c in chia_coins])
             [chia_tx] = await self.standard_wallet.generate_signed_transaction(
-                [Payment((await self.standard_wallet.get_new_puzzlehash()), uint64(selected_amount + amount_to_claim - fee), [])],
+                [
+                    Payment(
+                        (await self.standard_wallet.get_new_puzzlehash()),
+                        uint64(selected_amount + amount_to_claim - fee),
+                        [],
+                    )
+                ],
                 coins=chia_coins,
                 negative_change_allowed=True,
                 coin_announcements_to_consume={announcement_to_assert} if announcement_to_assert is not None else None,

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -22,6 +22,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.wallet import Wallet
+from chia.wallet.payment import Payment
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.derivation_record import DerivationRecord
@@ -942,7 +943,7 @@ class DIDWallet:
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
         tx_record: TransactionRecord = (await self.standard_wallet.generate_signed_transaction(
-            amount, genesis_launcher_puz.get_tree_hash(), uint64(0), origin.name(), coins, None, False, announcement_set
+            [Payment(genesis_launcher_puz.get_tree_hash(), amount, [])], uint64(0), origin.name(), coins, False, announcement_set
         ))[0]
 
         genesis_launcher_solution = Program.to([did_puzzle_hash, amount, bytes(0x80)])

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -941,9 +941,9 @@ class DIDWallet:
         announcement_message = Program.to([did_puzzle_hash, amount, bytes(0x80)]).get_tree_hash()
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
-        tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
+        tx_record: TransactionRecord = (await self.standard_wallet.generate_signed_transaction(
             amount, genesis_launcher_puz.get_tree_hash(), uint64(0), origin.name(), coins, None, False, announcement_set
-        )
+        ))[0]
 
         genesis_launcher_solution = Program.to([did_puzzle_hash, amount, bytes(0x80)])
 

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -942,9 +942,16 @@ class DIDWallet:
         announcement_message = Program.to([did_puzzle_hash, amount, bytes(0x80)]).get_tree_hash()
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
-        tx_record: TransactionRecord = (await self.standard_wallet.generate_signed_transaction(
-            [Payment(genesis_launcher_puz.get_tree_hash(), amount, [])], uint64(0), origin.name(), coins, False, announcement_set
-        ))[0]
+        tx_record: TransactionRecord = (
+            await self.standard_wallet.generate_signed_transaction(
+                [Payment(genesis_launcher_puz.get_tree_hash(), amount, [])],
+                uint64(0),
+                origin.name(),
+                coins,
+                False,
+                announcement_set,
+            )
+        )[0]
 
         genesis_launcher_solution = Program.to([did_puzzle_hash, amount, bytes(0x80)])
 

--- a/chia/wallet/puzzles/genesis_checkers.py
+++ b/chia/wallet/puzzles/genesis_checkers.py
@@ -79,9 +79,9 @@ class GenesisById(LimitationsProgram):
             CAT_MOD, genesis_coin_checker.get_tree_hash(), cc_inner
         ).get_tree_hash()
 
-        tx_record: TransactionRecord = await wallet.standard_wallet.generate_signed_transaction(
+        tx_record: TransactionRecord = (await wallet.standard_wallet.generate_signed_transaction(
             amount, minted_cc_puzzle_hash, uint64(0), origin_id, coins
-        )
+        ))[0]
         assert tx_record.spend_bundle is not None
 
         inner_solution = wallet.standard_wallet.add_condition_to_solution(

--- a/chia/wallet/puzzles/genesis_checkers.py
+++ b/chia/wallet/puzzles/genesis_checkers.py
@@ -79,9 +79,11 @@ class GenesisById(LimitationsProgram):
             CAT_MOD, genesis_coin_checker.get_tree_hash(), cc_inner
         ).get_tree_hash()
 
-        tx_record: TransactionRecord = (await wallet.standard_wallet.generate_signed_transaction(
-            amount, minted_cc_puzzle_hash, uint64(0), origin_id, coins
-        ))[0]
+        tx_record: TransactionRecord = (
+            await wallet.standard_wallet.generate_signed_transaction(
+                amount, minted_cc_puzzle_hash, uint64(0), origin_id, coins
+            )
+        )[0]
         assert tx_record.spend_bundle is not None
 
         inner_solution = wallet.standard_wallet.add_condition_to_solution(

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -6,6 +6,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
 from chia.util.byte_types import hexstr_to_bytes
 from chia.wallet.lineage_proof import LineageProof
+from chia.wallet.payment import Payment
 from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.wallet.cat_wallet.cat_utils import (
     CAT_MOD,
@@ -78,14 +79,14 @@ class GenesisById(LimitationsProgram):
         minted_cat_puzzle_hash: bytes32 = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), cat_inner).get_tree_hash()
 
         tx_record: TransactionRecord = (await wallet.standard_wallet.generate_signed_transaction(
-            amount, minted_cat_puzzle_hash, uint64(0), origin_id, coins
+            [Payment(minted_cat_puzzle_hash, amount, [])], uint64(0), origin_id, coins
         ))[0]
         assert tx_record.spend_bundle is not None
 
         inner_solution = wallet.standard_wallet.add_condition_to_solution(
             Program.to([51, 0, -113, tail, []]),
             wallet.standard_wallet.make_solution(
-                primaries=[{"puzzlehash": cat_inner.get_tree_hash(), "amount": amount}],
+                payments=[Payment(cat_inner.get_tree_hash(), amount, [])],
             ),
         )
         eve_spend = unsigned_spend_bundle_for_spendable_cats(

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -78,9 +78,11 @@ class GenesisById(LimitationsProgram):
 
         minted_cat_puzzle_hash: bytes32 = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), cat_inner).get_tree_hash()
 
-        tx_record: TransactionRecord = (await wallet.standard_wallet.generate_signed_transaction(
-            [Payment(minted_cat_puzzle_hash, amount, [])], uint64(0), origin_id, coins
-        ))[0]
+        tx_record: TransactionRecord = (
+            await wallet.standard_wallet.generate_signed_transaction(
+                [Payment(minted_cat_puzzle_hash, amount, [])], uint64(0), origin_id, coins
+            )
+        )[0]
         assert tx_record.spend_bundle is not None
 
         inner_solution = wallet.standard_wallet.add_condition_to_solution(

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -77,9 +77,9 @@ class GenesisById(LimitationsProgram):
 
         minted_cat_puzzle_hash: bytes32 = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), cat_inner).get_tree_hash()
 
-        tx_record: TransactionRecord = await wallet.standard_wallet.generate_signed_transaction(
+        tx_record: TransactionRecord = (await wallet.standard_wallet.generate_signed_transaction(
             amount, minted_cat_puzzle_hash, uint64(0), origin_id, coins
-        )
+        ))[0]
         assert tx_record.spend_bundle is not None
 
         inner_solution = wallet.standard_wallet.add_condition_to_solution(

--- a/chia/wallet/rl_wallet/rl_wallet.py
+++ b/chia/wallet/rl_wallet/rl_wallet.py
@@ -17,6 +17,7 @@ from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk
+from chia.wallet.payment import Payment
 from chia.wallet.rl_wallet.rl_wallet_puzzles import (
     make_clawback_solution,
     rl_make_aggregation_puzzle,
@@ -194,7 +195,7 @@ class RLWallet:
         )
         await self.wallet_state_manager.puzzle_store.add_derivation_paths([record])
 
-        [spend_bundle] = await self.main_wallet.generate_signed_transaction(amount, rl_puzzle_hash, fee, origin_id, coins)
+        [spend_bundle] = await self.main_wallet.generate_signed_transaction([Payment(rl_puzzle_hash, amount, [])], fee, origin_id, coins)
         if spend_bundle is None:
             return False
 
@@ -685,7 +686,7 @@ class RLWallet:
         return puzzle_hash
 
     async def rl_add_funds(self, amount, puzzle_hash, fee):
-        [spend_bundle] = await self.main_wallet.generate_signed_transaction(amount, puzzle_hash, fee)
+        [spend_bundle] = await self.main_wallet.generate_signed_transaction([Payment(puzzle_hash, amount, [])], fee)
         if spend_bundle is None:
             return False
 

--- a/chia/wallet/rl_wallet/rl_wallet.py
+++ b/chia/wallet/rl_wallet/rl_wallet.py
@@ -195,7 +195,9 @@ class RLWallet:
         )
         await self.wallet_state_manager.puzzle_store.add_derivation_paths([record])
 
-        [spend_bundle] = await self.main_wallet.generate_signed_transaction([Payment(rl_puzzle_hash, amount, [])], fee, origin_id, coins)
+        [spend_bundle] = await self.main_wallet.generate_signed_transaction(
+            [Payment(rl_puzzle_hash, amount, [])], fee, origin_id, coins
+        )
         if spend_bundle is None:
             return False
 

--- a/chia/wallet/rl_wallet/rl_wallet.py
+++ b/chia/wallet/rl_wallet/rl_wallet.py
@@ -194,7 +194,7 @@ class RLWallet:
         )
         await self.wallet_state_manager.puzzle_store.add_derivation_paths([record])
 
-        spend_bundle = await self.main_wallet.generate_signed_transaction(amount, rl_puzzle_hash, fee, origin_id, coins)
+        [spend_bundle] = await self.main_wallet.generate_signed_transaction(amount, rl_puzzle_hash, fee, origin_id, coins)
         if spend_bundle is None:
             return False
 
@@ -685,7 +685,7 @@ class RLWallet:
         return puzzle_hash
 
     async def rl_add_funds(self, amount, puzzle_hash, fee):
-        spend_bundle = await self.main_wallet.generate_signed_transaction(amount, puzzle_hash, fee)
+        [spend_bundle] = await self.main_wallet.generate_signed_transaction(amount, puzzle_hash, fee)
         if spend_bundle is None:
             return False
 

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -22,7 +22,6 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
-from chia.wallet.payment import Payment
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 
 
@@ -300,7 +299,7 @@ class TradeManager:
             for wallet_id, selected_coins in coins_to_offer.items():
                 wallet = self.wallet_state_manager.wallets[wallet_id]
                 txs = await wallet.generate_signed_transaction(
-                    [Payment(Offer.ph(), abs(offer_dict[int(wallet_id)]), [])],
+                    [Payment(Offer.ph(), uint64(abs(offer_dict[int(wallet_id)])), [])],
                     fee=fee_left_to_pay,
                     coins=set(selected_coins),
                     puzzle_announcements_to_consume=announcements_to_assert,

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -22,6 +22,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
+from chia.wallet.payment import Payment
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 
 
@@ -190,7 +191,7 @@ class TradeManager:
             # This should probably not switch on whether or not we're spending a CAT but it has to for now
             if wallet.type() == WalletType.CAT:
                 txs = await wallet.generate_signed_transaction(
-                    [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
+                    [Payment(new_ph, coin.amount, [])], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
                 )
                 all_txs.extend(txs)
             else:
@@ -203,8 +204,7 @@ class TradeManager:
                 else:
                     selected_coins = {coin}
                 [tx] = await wallet.generate_signed_transaction(
-                    uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
-                    new_ph,
+                    [Payment(new_ph, uint64(sum([c.amount for c in selected_coins]) - fee_to_pay), [])],
                     fee=fee_to_pay,
                     coins=selected_coins,
                     ignore_max_send_amount=True,
@@ -300,8 +300,7 @@ class TradeManager:
             for wallet_id, selected_coins in coins_to_offer.items():
                 wallet = self.wallet_state_manager.wallets[wallet_id]
                 txs = await wallet.generate_signed_transaction(
-                    [abs(offer_dict[int(wallet_id)])],
-                    [Offer.ph()],
+                    [Payment(Offer.ph(), abs(offer_dict[int(wallet_id)]), [])],
                     fee=fee_left_to_pay,
                     coins=set(selected_coins),
                     puzzle_announcements_to_consume=announcements_to_assert,

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -299,26 +299,14 @@ class TradeManager:
             fee_left_to_pay: uint64 = fee
             for wallet_id, selected_coins in coins_to_offer.items():
                 wallet = self.wallet_state_manager.wallets[wallet_id]
-                # This should probably not switch on whether or not we're spending a CAT but it has to for now
-
-                if wallet.type() == WalletType.CAT:
-                    txs = await wallet.generate_signed_transaction(
-                        [abs(offer_dict[int(wallet_id)])],
-                        [Offer.ph()],
-                        fee=fee_left_to_pay,
-                        coins=set(selected_coins),
-                        puzzle_announcements_to_consume=announcements_to_assert,
-                    )
-                    all_transactions.extend(txs)
-                else:
-                    [tx] = await wallet.generate_signed_transaction(
-                        abs(offer_dict[int(wallet_id)]),
-                        Offer.ph(),
-                        fee=fee_left_to_pay,
-                        coins=set(selected_coins),
-                        puzzle_announcements_to_consume=announcements_to_assert,
-                    )
-                    all_transactions.append(tx)
+                txs = await wallet.generate_signed_transaction(
+                    [abs(offer_dict[int(wallet_id)])],
+                    [Offer.ph()],
+                    fee=fee_left_to_pay,
+                    coins=set(selected_coins),
+                    puzzle_announcements_to_consume=announcements_to_assert,
+                )
+                all_transactions.extend(txs)
 
                 fee_left_to_pay = uint64(0)
 

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -202,7 +202,7 @@ class TradeManager:
                     selected_coins.add(coin)
                 else:
                     selected_coins = {coin}
-                tx = await wallet.generate_signed_transaction(
+                [tx] = await wallet.generate_signed_transaction(
                     uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
                     new_ph,
                     fee=fee_to_pay,
@@ -311,7 +311,7 @@ class TradeManager:
                     )
                     all_transactions.extend(txs)
                 else:
-                    tx = await wallet.generate_signed_transaction(
+                    [tx] = await wallet.generate_signed_transaction(
                         abs(offer_dict[int(wallet_id)]),
                         Offer.ph(),
                         fee=fee_left_to_pay,

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 import time
 from typing import Any, Dict, List, Optional, Set
@@ -38,7 +37,7 @@ from chia.wallet.secret_key_store import SecretKeyStore
 from chia.wallet.sign_coin_spends import sign_coin_spends
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
-from chia.wallet.util.wallet_types import WalletType, AmountWithPuzzlehash
+from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.payment import Payment
 from chia.wallet.wallet_info import WalletInfo
@@ -348,7 +347,7 @@ class Wallet:
                 origin_id = coin.name()
                 if change > 0:
                     change_puzzle_hash: bytes32 = await self.get_new_puzzlehash()
-                    payments.append(Payment(change_puzzle_hash, change, []))
+                    payments.append(Payment(change_puzzle_hash, uint64(change), []))
                 message_list: List[bytes32] = [c.name() for c in coins]
                 for payment in payments:
                     message_list.append(Coin(coin.name(), payment.puzzle_hash, payment.amount).name())
@@ -443,24 +442,26 @@ class Wallet:
         else:
             assert output_amount == input_amount
 
-        return [TransactionRecord(
-            confirmed_at_height=uint32(0),
-            created_at_time=now,
-            to_puzzle_hash=payments[0].puzzle_hash,
-            amount=sum(p.amount for p in payments),
-            fee_amount=uint64(fee),
-            confirmed=False,
-            sent=uint32(0),
-            spend_bundle=spend_bundle,
-            additions=add_list,
-            removals=rem_list,
-            wallet_id=self.id(),
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_TX.value),
-            name=spend_bundle.name(),
-            memos=list(compute_memos(spend_bundle).items()),
-        )]
+        return [
+            TransactionRecord(
+                confirmed_at_height=uint32(0),
+                created_at_time=now,
+                to_puzzle_hash=payments[0].puzzle_hash,
+                amount=uint64(sum(p.amount for p in payments)),
+                fee_amount=uint64(fee),
+                confirmed=False,
+                sent=uint32(0),
+                spend_bundle=spend_bundle,
+                additions=add_list,
+                removals=rem_list,
+                wallet_id=self.id(),
+                sent_to=[],
+                trade_id=None,
+                type=uint32(TransactionType.OUTGOING_TX.value),
+                name=spend_bundle.name(),
+                memos=list(compute_memos(spend_bundle).items()),
+            )
+        ]
 
     async def push_transaction(self, tx: TransactionRecord) -> None:
         """Use this API to send transactions."""

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -73,7 +73,7 @@ class Wallet:
         spendable.sort(reverse=True, key=lambda record: record.coin.amount)
         if self.cost_of_single_tx is None:
             coin = spendable[0].coin
-            tx = await self.generate_signed_transaction(
+            [tx] = await self.generate_signed_transaction(
                 coin.amount, coin.puzzle_hash, coins={coin}, ignore_max_send_amount=True
             )
             program: BlockGenerator = simple_solution_generator(tx.spend_bundle)
@@ -434,7 +434,7 @@ class Wallet:
         puzzle_announcements_to_consume: Set[Announcement] = None,
         memos: Optional[List[bytes]] = None,
         negative_change_allowed: bool = False,
-    ) -> TransactionRecord:
+    ) -> List[TransactionRecord]:
         """
         Use this to generate transaction.
         Note: this must be called under a wallet state manager lock
@@ -480,7 +480,7 @@ class Wallet:
         else:
             assert output_amount == input_amount
 
-        return TransactionRecord(
+        return [TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=now,
             to_puzzle_hash=puzzle_hash,
@@ -497,7 +497,7 @@ class Wallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=spend_bundle.name(),
             memos=list(compute_memos(spend_bundle).items()),
-        )
+        )]
 
     async def push_transaction(self, tx: TransactionRecord) -> None:
         """Use this API to send transactions."""

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -191,10 +191,10 @@ class TestFullNodeBlockCompression:
         await time_out_assert(30, wallet_is_synced, True, wallet_node_1, full_node_1)
 
         # Send a transaction to mempool
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             tx_size,
             ph,
-        )
+        ))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -224,10 +224,10 @@ class TestFullNodeBlockCompression:
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         # Send another tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             20000,
             ph,
-        )
+        ))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -261,10 +261,10 @@ class TestFullNodeBlockCompression:
         await time_out_assert(30, wallet_is_synced, True, wallet_node_1, full_node_1)
 
         # Send another 2 tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             30000,
             ph,
-        )
+        ))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -272,10 +272,10 @@ class TestFullNodeBlockCompression:
             tr.spend_bundle,
             tr.name,
         )
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             40000,
             ph,
-        )
+        ))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -284,10 +284,10 @@ class TestFullNodeBlockCompression:
             tr.name,
         )
 
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             50000,
             ph,
-        )
+        ))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -296,10 +296,10 @@ class TestFullNodeBlockCompression:
             tr.name,
         )
 
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             3000000000000,
             ph,
-        )
+        ))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -325,10 +325,10 @@ class TestFullNodeBlockCompression:
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
 
         # Creates a standard_transaction and an anyone-can-spend tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             30000,
             Program.to(1).get_tree_hash(),
-        )
+        ))[0]
         extra_spend = SpendBundle(
             [
                 CoinSpend(
@@ -371,10 +371,10 @@ class TestFullNodeBlockCompression:
         assert len(all_blocks[-1].transactions_generator_ref_list) == 0
 
         # Make a standard transaction and an anyone-can-spend transaction
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        tr: TransactionRecord = (await wallet.generate_signed_transaction(
             30000,
             Program.to(1).get_tree_hash(),
-        )
+        ))[0]
         extra_spend = SpendBundle(
             [
                 CoinSpend(

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -48,6 +48,7 @@ from tests.blockchain.blockchain_test_utils import (
 from tests.pools.test_pool_rpc import wallet_is_synced
 from tests.wallet_tools import WalletTool
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
+from chia.wallet.payment import Payment
 from chia.wallet.transaction_record import TransactionRecord
 
 from tests.connection_utils import add_dummy_connection, connect_and_get_peer
@@ -191,10 +192,7 @@ class TestFullNodeBlockCompression:
         await time_out_assert(30, wallet_is_synced, True, wallet_node_1, full_node_1)
 
         # Send a transaction to mempool
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            tx_size,
-            ph,
-        ))[0]
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, tx_size, [])]))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -224,10 +222,7 @@ class TestFullNodeBlockCompression:
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         # Send another tx
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            20000,
-            ph,
-        ))[0]
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, 20000, [])]))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -261,10 +256,7 @@ class TestFullNodeBlockCompression:
         await time_out_assert(30, wallet_is_synced, True, wallet_node_1, full_node_1)
 
         # Send another 2 tx
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            30000,
-            ph,
-        ))[0]
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, 30000, [])]))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -272,22 +264,7 @@ class TestFullNodeBlockCompression:
             tr.spend_bundle,
             tr.name,
         )
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            40000,
-            ph,
-        ))[0]
-        await wallet.push_transaction(tx=tr)
-        await time_out_assert(
-            10,
-            full_node_2.full_node.mempool_manager.get_spendbundle,
-            tr.spend_bundle,
-            tr.name,
-        )
-
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            50000,
-            ph,
-        ))[0]
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, 40000, [])]))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -296,10 +273,16 @@ class TestFullNodeBlockCompression:
             tr.name,
         )
 
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            3000000000000,
-            ph,
-        ))[0]
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, 50000, [])]))[0]
+        await wallet.push_transaction(tx=tr)
+        await time_out_assert(
+            10,
+            full_node_2.full_node.mempool_manager.get_spendbundle,
+            tr.spend_bundle,
+            tr.name,
+        )
+
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, 3000000000000, [])]))[0]
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -325,10 +308,7 @@ class TestFullNodeBlockCompression:
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
 
         # Creates a standard_transaction and an anyone-can-spend tx
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            30000,
-            Program.to(1).get_tree_hash(),
-        ))[0]
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(Program.to(1).get_tree_hash(), 30000, [])]))[0]
         extra_spend = SpendBundle(
             [
                 CoinSpend(
@@ -371,10 +351,7 @@ class TestFullNodeBlockCompression:
         assert len(all_blocks[-1].transactions_generator_ref_list) == 0
 
         # Make a standard transaction and an anyone-can-spend transaction
-        tr: TransactionRecord = (await wallet.generate_signed_transaction(
-            30000,
-            Program.to(1).get_tree_hash(),
-        ))[0]
+        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(Program.to(1).get_tree_hash(), 30000, [])]))[0]
         extra_spend = SpendBundle(
             [
                 CoinSpend(
@@ -450,7 +427,6 @@ class TestFullNodeBlockCompression:
             for block in reog_blocks:
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
             assert full_node_1.full_node.full_node_store.previous_generator is None
-
 
 class TestFullNodeProtocol:
     @pytest.mark.asyncio

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -308,7 +308,9 @@ class TestFullNodeBlockCompression:
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
 
         # Creates a standard_transaction and an anyone-can-spend tx
-        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(Program.to(1).get_tree_hash(), 30000, [])]))[0]
+        tr: TransactionRecord = (
+            await wallet.generate_signed_transaction([Payment(Program.to(1).get_tree_hash(), 30000, [])])
+        )[0]
         extra_spend = SpendBundle(
             [
                 CoinSpend(
@@ -351,7 +353,9 @@ class TestFullNodeBlockCompression:
         assert len(all_blocks[-1].transactions_generator_ref_list) == 0
 
         # Make a standard transaction and an anyone-can-spend transaction
-        tr: TransactionRecord = (await wallet.generate_signed_transaction([Payment(Program.to(1).get_tree_hash(), 30000, [])]))[0]
+        tr: TransactionRecord = (
+            await wallet.generate_signed_transaction([Payment(Program.to(1).get_tree_hash(), 30000, [])])
+        )[0]
         extra_spend = SpendBundle(
             [
                 CoinSpend(
@@ -427,6 +431,7 @@ class TestFullNodeBlockCompression:
             for block in reog_blocks:
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
             assert full_node_1.full_node.full_node_store.previous_generator is None
+
 
 class TestFullNodeProtocol:
     @pytest.mark.asyncio

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -12,6 +12,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_node import WalletNode
+from chia.wallet.payment import Payment
 from tests.connection_utils import connect_and_get_peer
 from tests.setup_nodes import bt, self_hostname, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
@@ -70,7 +71,7 @@ class TestMempoolPerformance:
         fee_amount = 2213
         await time_out_assert(60, wallet_balance_at_least, True, wallet_node, send_amount + fee_amount)
 
-        big_transaction: TransactionRecord = (await wallet.generate_signed_transaction(send_amount, ph, fee_amount))[0]
+        big_transaction: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, send_amount, [])], fee_amount))[0]
 
         peer = await connect_and_get_peer(server_1, server_2)
         await full_node_api_1.respond_transaction(

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -70,7 +70,7 @@ class TestMempoolPerformance:
         fee_amount = 2213
         await time_out_assert(60, wallet_balance_at_least, True, wallet_node, send_amount + fee_amount)
 
-        big_transaction: TransactionRecord = await wallet.generate_signed_transaction(send_amount, ph, fee_amount)
+        big_transaction: TransactionRecord = (await wallet.generate_signed_transaction(send_amount, ph, fee_amount))[0]
 
         peer = await connect_and_get_peer(server_1, server_2)
         await full_node_api_1.respond_transaction(

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -71,7 +71,9 @@ class TestMempoolPerformance:
         fee_amount = 2213
         await time_out_assert(60, wallet_balance_at_least, True, wallet_node, send_amount + fee_amount)
 
-        big_transaction: TransactionRecord = (await wallet.generate_signed_transaction([Payment(ph, send_amount, [])], fee_amount))[0]
+        big_transaction: TransactionRecord = (
+            await wallet.generate_signed_transaction([Payment(ph, send_amount, [])], fee_amount)
+        )[0]
 
         peer = await connect_and_get_peer(server_1, server_2)
         await full_node_api_1.respond_transaction(

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -12,6 +12,7 @@ from chia.protocols import full_node_protocol
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32
+from chia.wallet.payment import Payment
 from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
@@ -103,7 +104,7 @@ class TestTransactions:
         await time_out_assert(10, peak_height, num_blocks, full_node_api_1)
         await time_out_assert(10, peak_height, num_blocks, full_node_api_2)
 
-        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, ph1, 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction([Payment(ph1, 10, [])], 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(
@@ -175,7 +176,7 @@ class TestTransactions:
         )
         await time_out_assert(10, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
-        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, token_bytes(), 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction([Payment(token_bytes(), 10, [])], 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -103,7 +103,7 @@ class TestTransactions:
         await time_out_assert(10, peak_height, num_blocks, full_node_api_1)
         await time_out_assert(10, peak_height, num_blocks, full_node_api_2)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, ph1, 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, ph1, 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(
@@ -175,7 +175,7 @@ class TestTransactions:
         )
         await time_out_assert(10, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, token_bytes(), 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, token_bytes(), 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -176,7 +176,9 @@ class TestTransactions:
         )
         await time_out_assert(10, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
-        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction([Payment(token_bytes(), 10, [])], 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+            [Payment(token_bytes(), 10, [])], 0
+        )
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -359,7 +359,9 @@ class TestCATWallet:
         await time_out_assert(15, cat_wallet_2.get_unconfirmed_balance, 60)
 
         cc2_ph = await cat_wallet_2.get_new_cat_puzzle_hash()
-        [tx_record] = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction([Payment(cc2_ph, uint64(10), [])])
+        [tx_record] = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(
+            [Payment(cc2_ph, uint64(10), [])]
+        )
         await wallet.wallet_state_manager.add_pending_transaction(tx_record)
         await time_out_assert(
             15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()
@@ -450,7 +452,9 @@ class TestCATWallet:
         cat_1_hash = await cat_wallet_1.get_new_inner_hash()
         cat_2_hash = await cat_wallet_2.get_new_inner_hash()
 
-        tx_records = await cat_wallet_0.generate_signed_transaction([Payment(cat_1_hash, uint64(60), []), Payment(cat_2_hash, uint64(20), [])])
+        tx_records = await cat_wallet_0.generate_signed_transaction(
+            [Payment(cat_1_hash, uint64(60), []), Payment(cat_2_hash, uint64(20), [])]
+        )
         for tx_record in tx_records:
             await wallet_0.wallet_state_manager.add_pending_transaction(tx_record)
             await time_out_assert(
@@ -499,7 +503,9 @@ class TestCATWallet:
         txs = await wallet_1.wallet_state_manager.tx_store.get_transactions_between(cat_wallet_1.id(), 0, 100000)
         print(len(txs))
         # Test with Memo
-        tx_records_3: TransactionRecord = await cat_wallet_1.generate_signed_transaction([Payment(cat_hash, uint64(30), [b"Markus Walburg"])])
+        tx_records_3: TransactionRecord = await cat_wallet_1.generate_signed_transaction(
+            [Payment(cat_hash, uint64(30), [b"Markus Walburg"])]
+        )
 
         for tx_record in tx_records_3:
             await wallet_1.wallet_state_manager.add_pending_transaction(tx_record)

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -358,7 +358,7 @@ class TestCATWallet:
         await time_out_assert(15, cat_wallet_2.get_unconfirmed_balance, 60)
 
         cc2_ph = await cat_wallet_2.get_new_cat_puzzle_hash()
-        tx_record = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(10, cc2_ph, 0)
+        [tx_record] = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(10, cc2_ph, 0)
         await wallet.wallet_state_manager.add_pending_transaction(tx_record)
         await time_out_assert(
             15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -421,9 +421,7 @@ class TestWalletRpc:
             assert bal_0["pending_coin_removal_count"] == 0
             assert bal_0["unspent_coin_count"] == 1
 
-            cat_tx_res: TransactionRecord = await client.create_signed_transaction(
-                [{"amount": 1, "puzzle_hash": ph_2}]
-            )
+            cat_tx_res: TransactionRecord = await client.create_signed_transaction([{"amount": 1, "puzzle_hash": ph_2}])
 
             assert cat_tx_res.fee_amount == 0
             assert cat_tx_res.amount == 1

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -421,6 +421,15 @@ class TestWalletRpc:
             assert bal_0["pending_coin_removal_count"] == 0
             assert bal_0["unspent_coin_count"] == 1
 
+            cat_tx_res: TransactionRecord = await client.create_signed_transaction(
+                [{"amount": 1, "puzzle_hash": ph_2}]
+            )
+
+            assert cat_tx_res.fee_amount == 0
+            assert cat_tx_res.amount == 1
+            assert len(cat_tx_res.additions) == 2  # The output and the change
+            assert any([addition.amount == 1 for addition in cat_tx_res.additions])
+
             # Creates a second wallet with the same CAT
             res = await client_2.create_wallet_for_existing_cat(asset_id)
             assert res["success"]
@@ -440,7 +449,7 @@ class TestWalletRpc:
 
             assert addr_0 != addr_1
 
-            await client.cat_spend(cat_0_id, 4, addr_1, 0, ["the cat memo"])
+            await client.send_transaction(cat_0_id, 4, addr_1, 0, ["the cat memo"])
 
             await asyncio.sleep(1)
             for i in range(0, 5):

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -217,7 +217,9 @@ class TestSimpleSyncProtocol:
         from chia.wallet.puzzles.singleton_top_layer import SINGLETON_LAUNCHER_HASH
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        [tx_record] = await wallet.generate_signed_transaction([Payment(SINGLETON_LAUNCHER_HASH, uint64(10), [])], uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction(
+            [Payment(SINGLETON_LAUNCHER_HASH, uint64(10), [])], uint64(0)
+        )
         await wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -295,7 +297,9 @@ class TestSimpleSyncProtocol:
 
         coins = set()
         coins.add(coin_to_spend)
-        [tx_record] = await standard_wallet.generate_signed_transaction([Payment(puzzle_hash, uint64(10), [])], uint64(0), coins=coins)
+        [tx_record] = await standard_wallet.generate_signed_transaction(
+            [Payment(puzzle_hash, uint64(10), [])], uint64(0), coins=coins
+        )
         await standard_wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -320,7 +324,9 @@ class TestSimpleSyncProtocol:
 
         # Test getting notification for coin that is about to be created
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        [tx_record] = await standard_wallet.generate_signed_transaction([Payment(puzzle_hash, uint64(10), [])], uint64(0))
+        [tx_record] = await standard_wallet.generate_signed_transaction(
+            [Payment(puzzle_hash, uint64(10), [])], uint64(0)
+        )
 
         tx_record.spend_bundle.additions()
 

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -198,7 +198,7 @@ class TestSimpleSyncProtocol:
         assert len(data_response_1.coin_states) == 2 * num_blocks  # 2 per height farmer / pool reward
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        tx_record = await wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
         assert len(tx_record.spend_bundle.removals()) == 1
         spent_coin = tx_record.spend_bundle.removals()[0]
         assert spent_coin.puzzle_hash == puzzle_hash
@@ -216,7 +216,7 @@ class TestSimpleSyncProtocol:
         from chia.wallet.puzzles.singleton_top_layer import SINGLETON_LAUNCHER_HASH
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        tx_record = await wallet.generate_signed_transaction(uint64(10), SINGLETON_LAUNCHER_HASH, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction(uint64(10), SINGLETON_LAUNCHER_HASH, uint64(0))
         await wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -229,7 +229,7 @@ class TestSimpleSyncProtocol:
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
 
         # Send a transaction to make sure the wallet is still running
-        tx_record = await wallet.generate_signed_transaction(uint64(10), junk_ph, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction(uint64(10), junk_ph, uint64(0))
         await wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -294,7 +294,7 @@ class TestSimpleSyncProtocol:
 
         coins = set()
         coins.add(coin_to_spend)
-        tx_record = await standard_wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0), coins=coins)
+        [tx_record] = await standard_wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0), coins=coins)
         await standard_wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -319,7 +319,7 @@ class TestSimpleSyncProtocol:
 
         # Test getting notification for coin that is about to be created
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        tx_record = await standard_wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
+        [tx_record] = await standard_wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
 
         tx_record.spend_bundle.additions()
 

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -21,6 +21,7 @@ from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.peer_info import PeerInfo
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint16, uint32, uint64
+from chia.wallet.payment import Payment
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_state_manager import WalletStateManager
 from tests.connection_utils import add_dummy_connection
@@ -198,7 +199,7 @@ class TestSimpleSyncProtocol:
         assert len(data_response_1.coin_states) == 2 * num_blocks  # 2 per height farmer / pool reward
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        [tx_record] = await wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction([Payment(puzzle_hash, uint64(10), [])], uint64(0))
         assert len(tx_record.spend_bundle.removals()) == 1
         spent_coin = tx_record.spend_bundle.removals()[0]
         assert spent_coin.puzzle_hash == puzzle_hash
@@ -216,7 +217,7 @@ class TestSimpleSyncProtocol:
         from chia.wallet.puzzles.singleton_top_layer import SINGLETON_LAUNCHER_HASH
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        [tx_record] = await wallet.generate_signed_transaction(uint64(10), SINGLETON_LAUNCHER_HASH, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction([Payment(SINGLETON_LAUNCHER_HASH, uint64(10), [])], uint64(0))
         await wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -229,7 +230,7 @@ class TestSimpleSyncProtocol:
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
 
         # Send a transaction to make sure the wallet is still running
-        [tx_record] = await wallet.generate_signed_transaction(uint64(10), junk_ph, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction([Payment(junk_ph, uint64(10), [])], uint64(0))
         await wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -294,7 +295,7 @@ class TestSimpleSyncProtocol:
 
         coins = set()
         coins.add(coin_to_spend)
-        [tx_record] = await standard_wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0), coins=coins)
+        [tx_record] = await standard_wallet.generate_signed_transaction([Payment(puzzle_hash, uint64(10), [])], uint64(0), coins=coins)
         await standard_wallet.push_transaction(tx_record)
 
         await time_out_assert(
@@ -319,7 +320,7 @@ class TestSimpleSyncProtocol:
 
         # Test getting notification for coin that is about to be created
         await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
-        [tx_record] = await standard_wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
+        [tx_record] = await standard_wallet.generate_signed_transaction([Payment(puzzle_hash, uint64(10), [])], uint64(0))
 
         tx_record.spend_bundle.additions()
 

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -256,7 +256,9 @@ class TestWalletSimulator:
 
         await time_out_assert(5, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
-        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction([Payment(32 * b"0", 10, [])], 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+            [Payment(32 * b"0", 10, [])], 0
+        )
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert_not_none(5, full_node_0.mempool_manager.get_spendbundle, tx.spend_bundle.name())

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -806,9 +806,8 @@ class TestWalletSimulator:
         AMOUNT_TO_SEND = 4000000000000
         coins = list(await wallet.select_coins(AMOUNT_TO_SEND))
 
-        tx = await wallet.generate_signed_transaction(
-            AMOUNT_TO_SEND,
-            await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
+        [tx] = await wallet.generate_signed_transaction(
+            [Payment((await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash()), AMOUNT_TO_SEND, [])],
             0,
             coins=coins,
             origin_id=coins[2].name(),

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -142,7 +142,7 @@ class TestWalletSimulator:
         await time_out_assert(5, wallet.get_confirmed_balance, funds)
         await time_out_assert(5, wallet.get_unconfirmed_balance, funds)
 
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             10,
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             0,
@@ -256,7 +256,7 @@ class TestWalletSimulator:
 
         await time_out_assert(5, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, 32 * b"0", 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, 32 * b"0", 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert_not_none(5, full_node_0.mempool_manager.get_spendbundle, tx.spend_bundle.name())
@@ -311,7 +311,7 @@ class TestWalletSimulator:
         assert await wallet_0.get_confirmed_balance() == funds
         assert await wallet_0.get_unconfirmed_balance() == funds
 
-        tx = await wallet_0.generate_signed_transaction(
+        [tx] = await wallet_0.generate_signed_transaction(
             10,
             await wallet_node_1.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             0,
@@ -340,7 +340,7 @@ class TestWalletSimulator:
         await time_out_assert(5, wallet_0.get_unconfirmed_balance, new_funds - 10)
         await time_out_assert(5, wallet_1.get_confirmed_balance, 10)
 
-        tx = await wallet_1.generate_signed_transaction(5, await wallet_0.get_new_puzzlehash(), 0)
+        [tx] = await wallet_1.generate_signed_transaction(5, await wallet_0.get_new_puzzlehash(), 0)
         await wallet_1.push_transaction(tx)
         await time_out_assert(5, full_node_0.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)
 
@@ -430,7 +430,7 @@ class TestWalletSimulator:
         assert await wallet.get_unconfirmed_balance() == funds
         tx_amount = 3200000000000
         tx_fee = 10
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             tx_amount,
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             tx_fee,
@@ -496,7 +496,7 @@ class TestWalletSimulator:
         for i in range(0, 60):
             primaries.append({"puzzlehash": ph, "amount": 1000000000 + i})
 
-        tx_split_coins = await wallet.generate_signed_transaction(1, ph, 0, primaries=primaries)
+        [tx_split_coins] = await wallet.generate_signed_transaction(1, ph, 0, primaries=primaries)
 
         await wallet.push_transaction(tx_split_coins)
         await time_out_assert(
@@ -518,7 +518,7 @@ class TestWalletSimulator:
         # 1) Generate transaction that is under the limit
         under_limit_tx = None
         try:
-            under_limit_tx = await wallet.generate_signed_transaction(
+            [under_limit_tx] = await wallet.generate_signed_transaction(
                 max_sent_amount - 1,
                 ph,
                 0,
@@ -531,7 +531,7 @@ class TestWalletSimulator:
         # 2) Generate transaction that is equal to limit
         at_limit_tx = None
         try:
-            at_limit_tx = await wallet.generate_signed_transaction(
+            [at_limit_tx] = await wallet.generate_signed_transaction(
                 max_sent_amount,
                 ph,
                 0,
@@ -544,7 +544,7 @@ class TestWalletSimulator:
         # 3) Generate transaction that is greater than limit
         above_limit_tx = None
         try:
-            above_limit_tx = await wallet.generate_signed_transaction(
+            [above_limit_tx] = await wallet.generate_signed_transaction(
                 max_sent_amount + 1,
                 ph,
                 0,
@@ -593,7 +593,7 @@ class TestWalletSimulator:
         assert await wallet.get_unconfirmed_balance() == funds
         tx_amount = 3200000000000
         tx_fee = 300000000000
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             tx_amount,
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             tx_fee,
@@ -679,7 +679,7 @@ class TestWalletSimulator:
         coin = list(all_blocks[-3].get_included_reward_coins())[0]
         await asyncio.sleep(5)
 
-        tx = await wallet.generate_signed_transaction(1000, ph2, coins={coin})
+        [tx] = await wallet.generate_signed_transaction(1000, ph2, coins={coin})
         await wallet.push_transaction(tx)
         await full_node_api.full_node.respond_transaction(tx.spend_bundle, tx.name)
         await time_out_assert(5, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)


### PR DESCRIPTION
The first few commits in this PR are to refactor mostly the standard wallet's `generate_signed_transaction` method to change two things:
* Every `generate_signed_transaction` method should return a list of transactions (most other wallets need this for fee txs)
* The methods now take `Payment` objects as inputs.  These objects roughly correspond to the `primaries` argument before and allow ease of passing in multiple amounts, puzzle hashes, and memos (especially if you don't want a memo on every transaction).  It also makes much of the logic inside the function simpler.

I also carried over the changes from #8965 since it was relevant to the same function.

There are also a few commits aimed at removing some of the areas where we do an `if/else` branch based on whether the wallet is a CAT wallet or not, simply because the functions previously had different APIs.  This made adding CAT support to `send_transaction` and `create_signed_transaction` much simpler and more sensible.  The APIs should also work for any other wallets that properly implement a `generate_signed_transaction` method.