### PR TITLE
Allow older jobs to run to completion when on main

### DIFF
--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -11,7 +11,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -12,7 +12,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -12,7 +12,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -11,7 +11,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-macos-m1-installer.yml
+++ b/.github/workflows/build-macos-m1-installer.yml
@@ -11,7 +11,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-clvm.yml
+++ b/.github/workflows/build-test-macos-clvm.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-cmds.yml
+++ b/.github/workflows/build-test-macos-core-cmds.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-consensus.yml
+++ b/.github/workflows/build-test-macos-core-consensus.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-custom_types.yml
+++ b/.github/workflows/build-test-macos-core-custom_types.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-generator.yml
+++ b/.github/workflows/build-test-macos-generator.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-tools.yml
+++ b/.github/workflows/build-test-macos-tools.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-util.yml
+++ b/.github/workflows/build-test-macos-util.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-did_wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-rl_wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-clvm.yml
+++ b/.github/workflows/build-test-ubuntu-clvm.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-cmds.yml
+++ b/.github/workflows/build-test-ubuntu-core-cmds.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-tools.yml
+++ b/.github/workflows/build-test-ubuntu-tools.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -11,7 +11,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,8 @@ on:
     - cron: '34 14 * * 3'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,7 +26,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 ###############

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -11,7 +11,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/trigger-docker-main.yml
+++ b/.github/workflows/trigger-docker-main.yml
@@ -6,7 +6,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -11,7 +11,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/tests/runner_templates/build-test-macos
+++ b/tests/runner_templates/build-test-macos
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/tests/runner_templates/build-test-ubuntu
+++ b/tests/runner_templates/build-test-ubuntu
@@ -14,7 +14,8 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
When on main, the concurrency group will now include the SHA, which effectively makes all groups on main unique, so nothing gets cancelled or prevented from running parallel