### PR TITLE
Wallet improvements

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -776,10 +776,10 @@ class WalletNode:
                                 return
                             assert weight_proof is not None
                             old_proof = self.wallet_state_manager.blockchain.synced_weight_proof
-                            peak = await self.wallet_state_manager.blockchain.get_peak_block()
+                            curr_peak = await self.wallet_state_manager.blockchain.get_peak_block()
                             fork_point = 0
-                            if peak is not None:
-                                fork_point = max(0, peak.height - 32)
+                            if curr_peak is not None:
+                                fork_point = max(0, curr_peak.height - 32)
 
                             if old_proof is not None:
                                 wp_fork_point = self.wallet_state_manager.weight_proof_handler.get_fork_point(

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -614,6 +614,7 @@ class WalletNode:
             return None
 
     async def last_local_tx_block(self, header_hash: bytes32) -> Optional[BlockRecord]:
+        assert self.wallet_state_manager is not None
         current_hash = header_hash
         while True:
             if self.wallet_state_manager.blockchain.contains_block(current_hash):
@@ -753,6 +754,7 @@ class WalletNode:
                             tx_timestamp = last_tx_block.foliage_transaction_block.timestamp
                     else:
                         last_tx_block = response.header_block
+                        assert last_tx_block.foliage_transaction_block is not None
                         tx_timestamp = last_tx_block.foliage_transaction_block.timestamp
 
                     if tx_timestamp is None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -623,6 +623,8 @@ class WalletNode:
                     return None
                 if block.is_transaction_block:
                     return block
+                if block.prev_transaction_block_hash is None:
+                    return None
                 current_hash = block.prev_transaction_block_hash
             else:
                 break
@@ -1186,7 +1188,7 @@ class WalletNode:
                 if stored_record.header_hash == block.header_hash:
                     return True
 
-        weight_proof: WeightProof = self.wallet_state_manager.blockchain.synced_weight_proof
+        weight_proof: Optional[WeightProof] = self.wallet_state_manager.blockchain.synced_weight_proof
         if weight_proof is None:
             return False
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -749,9 +749,9 @@ class WalletNode:
                             tx_timestamp = last_block_record.timestamp
                         else:
                             last_tx_block = await self.fetch_last_tx_from_peer(response.header_block.height, peer)
-                            assert last_tx_block is not None
-                            assert last_tx_block.foliage_transaction_block is not None
-                            tx_timestamp = last_tx_block.foliage_transaction_block.timestamp
+                            if last_tx_block is not None:
+                                assert last_tx_block.foliage_transaction_block is not None
+                                tx_timestamp = last_tx_block.foliage_transaction_block.timestamp
                     else:
                         last_tx_block = response.header_block
                         assert last_tx_block.foliage_transaction_block is not None

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -887,8 +887,6 @@ class WalletNode:
             fork_height = top.height - 1
 
         blocks.reverse()
-        # Roll back coins and transactions
-        self.log.info(f"Rolling back to {fork_height}")
         await self.wallet_state_manager.reorg_rollback(fork_height)
         peak = await self.wallet_state_manager.blockchain.get_peak_block()
         self.rollback_request_caches(fork_height)

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -571,7 +571,7 @@ class WalletStateManager:
         ):
             return None, None
 
-        response: List[CoinState] = await self.wallet_node.get_coin_state([coin_state.coin.parent_coin_info])
+        response: List[CoinState] = await self.wallet_node.get_coin_state([coin_state.coin.parent_coin_info], peer)
         if len(response) == 0:
             self.log.warning(f"Could not find a parent coin with ID: {coin_state.coin.parent_coin_info}")
             return None, None
@@ -866,10 +866,30 @@ class WalletStateManager:
                     pool_state = None
                     try:
                         pool_state = solution_to_pool_state(launcher_spend)
+                        if pool_state is None:
+                            self.log.debug("solution_to_pool_state returned None, ignore and continue")
+                            continue
+                        if child.spent_height is None:
+                            self.log.debug("child.spent_height is None, ignore and continue")
+                            continue
+                        pool_wallet = await PoolWallet.create(
+                            self,
+                            self.main_wallet,
+                            child.coin.name(),
+                            [launcher_spend],
+                            child.spent_height,
+                            False,
+                            "pool_wallet",
+                        )
+                        await pool_wallet.apply_state_transitions(launcher_spend, coin_state.spent_height)
+                        coin_added = launcher_spend.additions()[0]
+                        await self.coin_added(
+                            coin_added, coin_state.spent_height, [], pool_wallet.id(), WalletType(pool_wallet.type())
+                        )
+                        await self.add_interested_coin_id(coin_added.name())
                     except Exception as e:
                         self.log.debug(f"Not a pool wallet launcher {e}")
                         continue
-
                     # solution_to_pool_state may return None but this may not be an error
                     if pool_state is None:
                         self.log.debug("solution_to_pool_state returned None, ignore and continue")

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -866,27 +866,6 @@ class WalletStateManager:
                     pool_state = None
                     try:
                         pool_state = solution_to_pool_state(launcher_spend)
-                        if pool_state is None:
-                            self.log.debug("solution_to_pool_state returned None, ignore and continue")
-                            continue
-                        if child.spent_height is None:
-                            self.log.debug("child.spent_height is None, ignore and continue")
-                            continue
-                        pool_wallet = await PoolWallet.create(
-                            self,
-                            self.main_wallet,
-                            child.coin.name(),
-                            [launcher_spend],
-                            child.spent_height,
-                            False,
-                            "pool_wallet",
-                        )
-                        await pool_wallet.apply_state_transitions(launcher_spend, coin_state.spent_height)
-                        coin_added = launcher_spend.additions()[0]
-                        await self.coin_added(
-                            coin_added, coin_state.spent_height, [], pool_wallet.id(), WalletType(pool_wallet.type())
-                        )
-                        await self.add_interested_coin_id(coin_added.name())
                     except Exception as e:
                         self.log.debug(f"Not a pool wallet launcher {e}")
                         continue


### PR DESCRIPTION
Disconnect from non-trusted nodes, if connection to trusted & synced node is established. 
Fix key index bug that was causing kiwi's wallet not to sync. 
Reduce number of header block requests to full nodes.