### PR TITLE
check_keys: check 50 instead of 500, farm default observer

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -22,7 +22,6 @@ from chia.util.config import (
     save_config,
     unflatten_properties,
 )
-from chia.util.ints import uint32
 from chia.util.keychain import Keychain
 from chia.util.path import mkdir, path_from_root
 from chia.util.ssl_check import (
@@ -33,7 +32,13 @@ from chia.util.ssl_check import (
     check_and_fix_permissions_for_ssl_file,
     fix_ssl,
 )
-from chia.wallet.derive_keys import master_sk_to_pool_sk, master_sk_to_wallet_sk
+from chia.wallet.derive_keys import (
+    master_sk_to_pool_sk,
+    master_sk_to_wallet_sk_intermediate,
+    master_sk_to_wallet_sk_unhardened_intermediate,
+    _derive_path,
+    _derive_path_unhardened,
+)
 from chia.cmds.configure import configure
 
 private_node_names = {"full_node", "wallet", "farmer", "harvester", "timelord", "daemon"}
@@ -74,15 +79,31 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
     all_targets = []
     stop_searching_for_farmer = "xch_target_address" not in config["farmer"]
     stop_searching_for_pool = "xch_target_address" not in config["pool"]
-    number_of_ph_to_search = 500
+    number_of_ph_to_search = 100
     selected = config["selected_network"]
     prefix = config["network_overrides"]["config"][selected]["address_prefix"]
+
+    intermediates = {}
+    for sk, _ in all_sks:
+        intermediates[bytes(sk)] = {
+            "observer": master_sk_to_wallet_sk_unhardened_intermediate(sk),
+            "non-observer": master_sk_to_wallet_sk_intermediate(sk),
+        }
+
     for i in range(number_of_ph_to_search):
         if stop_searching_for_farmer and stop_searching_for_pool and i > 0:
             break
         for sk, _ in all_sks:
+            intermediate_n = intermediates[bytes(sk)]["non-observer"]
+            intermediate_o = intermediates[bytes(sk)]["observer"]
+
             all_targets.append(
-                encode_puzzle_hash(create_puzzlehash_for_pk(master_sk_to_wallet_sk(sk, uint32(i)).get_g1()), prefix)
+                encode_puzzle_hash(
+                    create_puzzlehash_for_pk(_derive_path_unhardened(intermediate_o, [i]).get_g1()), prefix
+                )
+            )
+            all_targets.append(
+                encode_puzzle_hash(create_puzzlehash_for_pk(_derive_path(intermediate_n, [i]).get_g1()), prefix)
             )
             if all_targets[-1] == config["farmer"].get("xch_target_address"):
                 stop_searching_for_farmer = True
@@ -99,7 +120,7 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
         updated_target = True
     elif config["farmer"]["xch_target_address"] not in all_targets:
         print(
-            f"WARNING: using a farmer address which we don't have the private"
+            f"WARNING: using a farmer address which we might not have the private"
             f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
             f"{config['farmer']['xch_target_address']} with {all_targets[0]}"
         )

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -79,7 +79,7 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
     all_targets = []
     stop_searching_for_farmer = "xch_target_address" not in config["farmer"]
     stop_searching_for_pool = "xch_target_address" not in config["pool"]
-    number_of_ph_to_search = 100
+    number_of_ph_to_search = 50
     selected = config["selected_network"]
     prefix = config["network_overrides"]["config"][selected]["address_prefix"]
 
@@ -105,9 +105,13 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
             all_targets.append(
                 encode_puzzle_hash(create_puzzlehash_for_pk(_derive_path(intermediate_n, [i]).get_g1()), prefix)
             )
-            if all_targets[-1] == config["farmer"].get("xch_target_address"):
+            if all_targets[-1] == config["farmer"].get("xch_target_address") or all_targets[-2] == config["farmer"].get(
+                "xch_target_address"
+            ):
                 stop_searching_for_farmer = True
-            if all_targets[-1] == config["pool"].get("xch_target_address"):
+            if all_targets[-1] == config["pool"].get("xch_target_address") or all_targets[-2] == config["pool"].get(
+                "xch_target_address"
+            ):
                 stop_searching_for_pool = True
 
     # Set the destinations, if necessary
@@ -133,7 +137,7 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
         updated_target = True
     elif config["pool"]["xch_target_address"] not in all_targets:
         print(
-            f"WARNING: using a pool address which we don't have the private"
+            f"WARNING: using a pool address which we might not have the private"
             f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
             f"{config['pool']['xch_target_address']} with {all_targets[0]}"
         )


### PR DESCRIPTION
My daemon was timing out because it was not finding a key, and searching through 500 was way too slow. 

A few changes:
- 500 -> 50 reduces time
- Precompute intermediate paths
- Calculate both observer and non-observer keys
- Change the default to observer