### PR TITLE
Rename migrated standalone_wallet wallet DB to v2

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -474,7 +474,8 @@ wallet:
     port: 8444
 
   testing: False
-  database_path: wallet/db/blockchain_wallet_v1_CHALLENGE_KEY.sqlite
+  # v2 used by the light wallet sync protocol
+  database_path: wallet/db/blockchain_wallet_v2_CHALLENGE_KEY.sqlite
   # wallet_peers_path is deprecated and has been replaced by wallet_peers_file_path
   wallet_peers_path: wallet/db/wallet_peers.sqlite
   wallet_peers_file_path: wallet/db/wallet_peers.dat

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -209,7 +209,7 @@ class WalletNode:
             .replace("CHALLENGE", self.config["selected_network"])
             .replace("KEY", db_path_key_suffix)
         )
-        path = path_from_root(self.root_path, f"{db_path_replaced.replace('.sqlite', '_new.sqlite')}")
+        path = path_from_root(self.root_path, db_path_replaced.replace(".sqlite", "_new.sqlite"))
         standalone_path = path_from_root(STANDALONE_ROOT_PATH, f"{db_path_replaced}_new")
         if not path.exists():
             if standalone_path.exists():

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -209,8 +209,8 @@ class WalletNode:
             .replace("CHALLENGE", self.config["selected_network"])
             .replace("KEY", db_path_key_suffix)
         )
-        path = path_from_root(self.root_path, db_path_replaced.replace(".sqlite", "_new.sqlite"))
-        standalone_path = path_from_root(STANDALONE_ROOT_PATH, f"{db_path_replaced}_new")
+        path = path_from_root(self.root_path, db_path_replaced.replace("v1", "v2"))
+        standalone_path = path_from_root(STANDALONE_ROOT_PATH, f"{db_path_replaced.replace('v2', 'v1')}_new")
         if not path.exists():
             if standalone_path.exists():
                 path.write_bytes(standalone_path.read_bytes())

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -209,7 +209,7 @@ class WalletNode:
             .replace("CHALLENGE", self.config["selected_network"])
             .replace("KEY", db_path_key_suffix)
         )
-        path = path_from_root(self.root_path, f"{db_path_replaced}_new")
+        path = path_from_root(self.root_path, f"{db_path_replaced.replace('.sqlite', '_new.sqlite')}")
         standalone_path = path_from_root(STANDALONE_ROOT_PATH, f"{db_path_replaced}_new")
         if not path.exists():
             if standalone_path.exists():


### PR DESCRIPTION
Updated `initial-config.yaml` so that the wallet DB is named 'v2' instead of 'v1'. standalone_wallet DBs that are migrated to the mainnet directory are renamed to use 'v2' in the name and have the 'sqlite_new' suffix changed to 'sqlite'

e.g.
`~/.chia/standalone_wallet/wallet/db/blockchain_wallet_v1_mainnet_1234567890.sqlite_new`
becomes:
`~/.chia/mainnet/wallet/db/blockchain_wallet_v2_mainnet_1234567890.sqlite`