### PR TITLE
Adds handling for daemon not sending `initial_target_state` (#10058)

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -532,6 +532,9 @@ class WalletRpcApi:
 
         elif request["wallet_type"] == "pool_wallet":
             if request["mode"] == "new":
+                if "initial_target_state" not in request:
+                    raise AttributeError("Daemon didn't send `initial_target_state`. Try updating the daemon.")
+
                 owner_puzzle_hash: bytes32 = await self.service.wallet_state_manager.main_wallet.get_puzzle_hash(True)
 
                 from chia.pools.pool_wallet_info import initial_pool_state_from_dict


### PR DESCRIPTION
Currently, if the daemon doesn't send `initial_target_state` for new pool_wallets, it will cause a `KeyError`.

This PR makes it give a more informative error, so less users are confused by this.