### PR TITLE
Correct comment about max future block timestamp

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -156,7 +156,7 @@ async def validate_block_body(
     removals_puzzle_dic: Dict[bytes32, bytes32] = {}
     cost: uint64 = uint64(0)
 
-    # In header validation we check that timestamp is not more that 10 minutes into the future
+    # In header validation we check that timestamp is not more that 5 minutes into the future
     # 6. No transactions before INITIAL_TRANSACTION_FREEZE timestamp
     # (this test has been removed)
 


### PR DESCRIPTION
The maximum future timestamp of a new block can only be 5 minutes ahead of the previous block.

https://github.com/Chia-Network/chia-blockchain/blob/main/chia/consensus/block_header_validation.py#L814
https://github.com/Chia-Network/chia-blockchain/blob/main/chia/consensus/default_constants.py#L26