### PR TITLE
fix typo in 'chia init --db-v1'

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -427,7 +427,7 @@ def chia_init(
     config: Dict
     if v1_db:
         config = load_config(root_path, "config.yaml")
-        db_pattern = config["database_path"]
+        db_pattern = config["full_node"]["database_path"]
         new_db_path = db_pattern.replace("_v2_", "_v1_")
         config["full_node"]["database_path"] = new_db_path
         save_config(root_path, "config.yaml", config)


### PR DESCRIPTION
otherwise:
```
chia init --v1-db
```

fails with:

```
Traceback (most recent call last):
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/bin/chia", line 33, in <module>
    sys.exit(load_entry_point('chia-blockchain', 'console_scripts', 'chia')())
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/cmds/chia.py", line 148, in main
    cli()  # pylint: disable=no-value-for-parameter
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/arvid/Documents/dev/chia-blockchain/venv/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/cmds/init.py", line 47, in init_cmd
    init(
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/cmds/init_funcs.py", line 320, in init
    return chia_init(root_path, fix_ssl_permissions=fix_ssl_permissions, testnet=testnet, v1_db=v1_db)
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/cmds/init_funcs.py", line 430, in chia_init
    db_pattern = config["database_path"]
KeyError: 'database_path'
```