### PR TITLE
Fix wallet DB migration from the light wallet when initiated by the GUI

### DIFF
--- a/chia/util/default_root.py
+++ b/chia/util/default_root.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 
 DEFAULT_ROOT_PATH = Path(os.path.expanduser(os.getenv("CHIA_ROOT", "~/.chia/mainnet"))).resolve()
-STANDALONE_ROOT_PATH = Path(os.path.expanduser(os.getenv("CHIA_ROOT", "~/.chia/standalone_wallet"))).resolve()
+STANDALONE_ROOT_PATH = Path(
+    os.path.expanduser(os.getenv("CHIA_STANDALONE_WALLET_ROOT", "~/.chia/standalone_wallet"))
+).resolve()
 
 DEFAULT_KEYS_ROOT_PATH = Path(os.path.expanduser(os.getenv("CHIA_KEYS_ROOT", "~/.chia_keys"))).resolve()

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -213,6 +213,7 @@ class WalletNode:
         standalone_path = path_from_root(STANDALONE_ROOT_PATH, f"{db_path_replaced.replace('v2', 'v1')}_new")
         if not path.exists():
             if standalone_path.exists():
+                self.log.info(f"Copying wallet db from {standalone_path} to {path}")
                 path.write_bytes(standalone_path.read_bytes())
 
         mkdir(path.parent)


### PR DESCRIPTION
When CHIA_ROOT was set (by the GUI), STANDALONE_ROOT_PATH == DEFAULT_ROOT_PATH

STANDALONE_ROOT_PATH now expands to a different env variable to avoid conflicting with DEFAULT_ROOT_PATH when 
CHIA_ROOT is set. When the GUI launches chia services, CHIA_ROOT is set, which was preventing the wallet backend from copying existing DBs from the standalone_wallet.