### PR TITLE
automatic db locking

### DIFF
--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -330,9 +330,7 @@ class DataStore:
 
         return Root.from_row(row=row)
 
-    async def get_roots_between(
-        self, tree_id: bytes32, generation_begin: int, generation_end: int
-    ) -> List[Root]:
+    async def get_roots_between(self, tree_id: bytes32, generation_begin: int, generation_end: int) -> List[Root]:
         async with self.db_wrapper.locked_transaction():
             cursor = await self.db.execute(
                 "SELECT * FROM root WHERE tree_id == :tree_id "
@@ -379,9 +377,7 @@ class DataStore:
 
         return ancestors
 
-    async def get_keys_values(
-        self, tree_id: bytes32, root_hash: Optional[bytes32] = None
-    ) -> List[TerminalNode]:
+    async def get_keys_values(self, tree_id: bytes32, root_hash: Optional[bytes32] = None) -> List[TerminalNode]:
         async with self.db_wrapper.locked_transaction():
             if root_hash is None:
                 root = await self.get_tree_root(tree_id=tree_id)
@@ -511,9 +507,7 @@ class DataStore:
                 if root.node_hash is None:
                     raise Exception("Internal error.")
 
-                ancestors: List[InternalNode] = await self.get_ancestors(
-                    node_hash=reference_node_hash, tree_id=tree_id
-                )
+                ancestors: List[InternalNode] = await self.get_ancestors(node_hash=reference_node_hash, tree_id=tree_id)
 
                 if side == Side.LEFT:
                     left = new_terminal_node_hash

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -10,7 +10,10 @@ import aiosqlite
 
 
 already_entered: contextvars.ContextVar[bool] = contextvars.ContextVar("already_entered", default=False)
-surrounding_task: contextvars.ContextVar[Optional[asyncio.Task]] = contextvars.ContextVar("surrounding_task", default=None)
+surrounding_task: contextvars.ContextVar[Optional[asyncio.Task]] = contextvars.ContextVar(
+    "surrounding_task",
+    default=None,
+)
 
 
 T = TypeVar("T")
@@ -25,7 +28,7 @@ def set_contextvar(contextvar: contextvars.ContextVar[T], value: T) -> Iterator[
         contextvar.reset(token)
 
 
-connection_locks = weakref.WeakKeyDictionary()
+connection_locks: weakref.WeakKeyDictionary[aiosqlite.Connection, asyncio.Lock] = weakref.WeakKeyDictionary()
 
 
 class DBWrapper:

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -74,10 +74,13 @@ class DBWrapper:
         in_new_task = current_task != surrounding_task.get()
 
         if in_new_task:
-            # initialize in new tasks to force new tasks to acquire resources
+            # Initialize in new tasks to force new tasks to acquire resources.  If
+            # context variables could be configured to reset to defaults in a new
+            # context, as is created for each new task, this would be unneeded.
             already_entered.set(False)
             surrounding_task.set(current_task)
-        elif already_entered.get():
+
+        if already_entered.get():
             yield self.db
             return
 

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -46,7 +46,7 @@ class DBWrapper:
 
     # TODO: Deprecate this, I do not like properties as an API.
     @property
-    def lock(self) -> aiosqlite.Connection:
+    def lock(self) -> asyncio.Lock:
         return connection_locks[self.db]
 
     async def begin_transaction(self):

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -1,7 +1,31 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
+import contextvars
+import weakref
+from typing import AsyncIterator, Iterator, Optional, TypeVar
 
 import aiosqlite
+
+
+already_entered: contextvars.ContextVar[bool] = contextvars.ContextVar("already_entered", default=False)
+surrounding_task: contextvars.ContextVar[Optional[asyncio.Task]] = contextvars.ContextVar("surrounding_task", default=None)
+
+
+T = TypeVar("T")
+
+
+@contextlib.contextmanager
+def set_contextvar(contextvar: contextvars.ContextVar[T], value: T) -> Iterator[None]:
+    token = contextvar.set(value)
+    try:
+        yield
+    finally:
+        contextvar.reset(token)
+
+
+connection_locks = weakref.WeakKeyDictionary()
 
 
 class DBWrapper:
@@ -10,13 +34,17 @@ class DBWrapper:
     """
 
     db: aiosqlite.Connection
-    lock: asyncio.Lock
     db_version: int
 
     def __init__(self, connection: aiosqlite.Connection, db_version: int = 1):
+        connection_locks.setdefault(key=connection, default=asyncio.Lock())
         self.db = connection
-        self.lock = asyncio.Lock()
         self.db_version = db_version
+
+    # TODO: Deprecate this, I do not like properties as an API.
+    @property
+    def lock(self) -> aiosqlite.Connection:
+        return connection_locks[self.db]
 
     async def begin_transaction(self):
         cursor = await self.db.execute("BEGIN TRANSACTION")
@@ -32,21 +60,33 @@ class DBWrapper:
         await self.db.commit()
 
     @contextlib.asynccontextmanager
-    async def locked_transaction(self, *, lock=True):
-        # TODO: look into contextvars perhaps instead of this manual lock tracking
-        if not lock:
-            yield
+    async def locked_transaction(self) -> AsyncIterator[aiosqlite.Connection]:
+        """Lock against concurrent usage of the same db connection and enter, rollback,
+        and commit transactions as needed.  The lock is tied to the specific db
+        connection object.  Nested usage within a single asyncio task does nothing for
+        the inner uses.  Uses of the same connection across different tasks will
+        block each other via the lock.
+        """
+        current_task = asyncio.current_task()
+        in_new_task = current_task != surrounding_task.get()
+
+        if in_new_task:
+            # initialize in new tasks to force new tasks to acquire resources
+            already_entered.set(False)
+            surrounding_task.set(current_task)
+        elif already_entered.get():
+            yield self.db
             return
 
         # TODO: add a lock acquisition timeout
         #       maybe https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for
-
         async with self.lock:
-            await self.begin_transaction()
-            try:
-                yield
-            except BaseException:
-                await self.rollback_transaction()
-                raise
-            else:
-                await self.commit_transaction()
+            with set_contextvar(contextvar=already_entered, value=True):
+                await self.begin_transaction()
+                try:
+                    yield self.db
+                except BaseException:
+                    await self.rollback_transaction()
+                    raise
+                else:
+                    await self.commit_transaction()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+from typing import AsyncIterable
+
+import aiosqlite
 import pytest
 import tempfile
 from pathlib import Path
@@ -93,3 +96,18 @@ async def default_10000_blocks_compact():
 async def tmp_dir():
     with tempfile.TemporaryDirectory() as folder:
         yield Path(folder)
+
+
+sqlite3_memory_db_url = "file:memory_db_connection_db?mode=memory&cache=shared"
+
+
+@pytest.fixture(name="memory_db_connection", scope="function")
+async def memory_db_connection_fixture() -> AsyncIterable[aiosqlite.Connection]:
+    async with aiosqlite.connect(sqlite3_memory_db_url) as connection:
+        yield connection
+
+
+@pytest.fixture(name="second_memory_db_connection", scope="function")
+async def second_memory_db_connection_fixture(memory_db_connection) -> AsyncIterable[aiosqlite.Connection]:
+    async with aiosqlite.connect(sqlite3_memory_db_url) as connection:
+        yield connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,11 +106,11 @@ sqlite3_memory_db_url = "file:memory_db_connection_db?mode=memory&cache=shared"
 
 @pytest.fixture(name="memory_db_connection", scope="function")
 async def memory_db_connection_fixture() -> AsyncIterable[aiosqlite.Connection]:
-    async with aiosqlite.connect(sqlite3_memory_db_url) as connection:
+    async with aiosqlite.connect(sqlite3_memory_db_url, uri=True) as connection:
         yield connection
 
 
 @pytest.fixture(name="second_memory_db_connection", scope="function")
 async def second_memory_db_connection_fixture(memory_db_connection) -> AsyncIterable[aiosqlite.Connection]:
-    async with aiosqlite.connect(sqlite3_memory_db_url) as connection:
+    async with aiosqlite.connect(sqlite3_memory_db_url, uri=True) as connection:
         yield connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ from pathlib import Path
 #       fixtures avoids the issue.
 
 
+pytest_plugins = "pytester"
+
+
 @pytest.fixture(scope="function", params=[1, 2])
 async def empty_blockchain(request):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ async def tmp_dir():
         yield Path(folder)
 
 
-sqlite3_memory_db_url = "file::memory_db_connection_db?mode=memory&cache=shared"
+sqlite3_memory_db_url = "file:memory_db_connection_db?mode=memory&cache=shared"
 
 
 @pytest.fixture(name="memory_db_connection", scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ async def tmp_dir():
         yield Path(folder)
 
 
-sqlite3_memory_db_url = "file:memory_db_connection_db?mode=memory&cache=shared"
+sqlite3_memory_db_url = "file::memory_db_connection_db?mode=memory&cache=shared"
 
 
 @pytest.fixture(name="memory_db_connection", scope="function")

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -82,11 +82,9 @@ def create_example_fixture(request: SubRequest) -> Callable[[DataStore, bytes32]
 
 
 @pytest.fixture(name="db_connection", scope="function")
-async def db_connection_fixture() -> AsyncIterable[aiosqlite.Connection]:
-    async with aiosqlite.connect(":memory:") as connection:
-        # make sure this is on for tests even if we disable it at run time
-        await connection.execute("PRAGMA foreign_keys = ON")
-        yield connection
+async def db_connection_fixture(memory_db_connection) -> AsyncIterable[aiosqlite.Connection]:
+    await memory_db_connection.execute("PRAGMA foreign_keys = ON")
+    yield memory_db_connection
 
 
 @pytest.fixture(name="db_wrapper", scope="function")

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -82,7 +82,7 @@ def create_example_fixture(request: SubRequest) -> Callable[[DataStore, bytes32]
 
 
 @pytest.fixture(name="db_connection", scope="function")
-async def db_connection_fixture(memory_db_connection) -> AsyncIterable[aiosqlite.Connection]:
+async def db_connection_fixture(memory_db_connection: aiosqlite.Connection) -> AsyncIterable[aiosqlite.Connection]:
     await memory_db_connection.execute("PRAGMA foreign_keys = ON")
     yield memory_db_connection
 

--- a/tests/core/test_conftest.py
+++ b/tests/core/test_conftest.py
@@ -5,20 +5,26 @@ import pytest
 from tests import conftest
 
 
+# TODO: figure out how to filter this at the collection stage to avoid skips
+# @pytest.mark.parametrize(
+#     argnames="maybe_first",
+#     argvalues=[pytest.param([], id="-"), pytest.param(["memory_db_connection"], id="first")],
+# )
+# @pytest.mark.parametrize(
+#     argnames="maybe_second",
+#     argvalues=[pytest.param([], id="-"), pytest.param(["second_memory_db_connection"], id="second")],
+# )
 @pytest.mark.parametrize(
-    argnames="maybe_first",
-    argvalues=[pytest.param([], id="-"), pytest.param(["memory_db_connection"], id="first")],
+    argnames="fixtures",
+    argvalues=[
+        pytest.param([*first.values[0], *second.values[0]], id=f"{first.id},{second.id}")
+        for second in [pytest.param([], id="-"), pytest.param(["second_memory_db_connection"], id="second")]
+        for first in [pytest.param([], id="-"), pytest.param(["memory_db_connection"], id="first")]
+        if len([*first.values[0], *second.values[0]]) > 0
+    ],
 )
-@pytest.mark.parametrize(
-    argnames="maybe_second",
-    argvalues=[pytest.param([], id="-"), pytest.param(["second_memory_db_connection"], id="second")],
-)
-def test_memory_db_connection_cleared_after_function_scope(pytester, maybe_first, maybe_second) -> None:
-    fixtures = [*maybe_first, *maybe_second]
-
-    if len(fixtures) == 0:
-        pytest.skip(msg="will not work with no fixtures")
-
+def test_memory_db_connection_cleared_after_function_scope(pytester, fixtures) -> None:
+    print(fixtures)
     fixtures_as_parameters = ", ".join(fixtures)
     fixture_to_use = fixtures[0]
     test_file = f"""

--- a/tests/core/test_conftest.py
+++ b/tests/core/test_conftest.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+from tests import conftest
+
+
+@pytest.mark.parametrize(
+    argnames="maybe_first",
+    argvalues=[pytest.param([], id="-"), pytest.param(["memory_db_connection"], id="first")],
+)
+@pytest.mark.parametrize(
+    argnames="maybe_second",
+    argvalues=[pytest.param([], id="-"), pytest.param(["second_memory_db_connection"], id="second")],
+)
+def test_memory_db_connection_cleared_after_function_scope(pytester, maybe_first, maybe_second) -> None:
+    fixtures = [*maybe_first, *maybe_second]
+
+    if len(fixtures) == 0:
+        pytest.skip(msg="will not work with no fixtures")
+
+    fixtures_as_parameters = ", ".join(fixtures)
+    fixture_to_use = fixtures[0]
+    test_file = f"""
+    import pytest
+
+    @pytest.mark.asyncio
+    async def test_add({fixtures_as_parameters}):
+        await {fixture_to_use}.execute("CREATE TABLE a_table(some_column INTEGER NOT NULL)")
+
+        async with {fixture_to_use}.execute(
+            "SELECT name FROM sqlite_master WHERE type ='table' AND name NOT LIKE 'sqlite_%'"
+        ) as cursor:
+            row = await cursor.fetchone()
+
+        assert row == ("a_table",)
+
+    @pytest.mark.asyncio
+    async def test_check({fixtures_as_parameters}):
+        async with {fixture_to_use}.execute(
+            "SELECT name FROM sqlite_master WHERE type ='table' AND name NOT LIKE 'sqlite_%'"
+        ) as cursor:
+            row = await cursor.fetchone()
+
+        assert row is None
+    """
+
+    pytester.makepyfile(test_file)
+    pytester.makeconftest(Path(conftest.__file__).read_text(encoding="utf-8"))
+    result = pytester.run("pytest", timeout=30)
+    result.assert_outcomes(passed=2)

--- a/tests/core/test_conftest.py
+++ b/tests/core/test_conftest.py
@@ -17,10 +17,10 @@ from tests import conftest
 @pytest.mark.parametrize(
     argnames="fixtures",
     argvalues=[
-        pytest.param([*first.values[0], *second.values[0]], id=f"{first.id},{second.id}")
-        for second in [pytest.param([], id="-"), pytest.param(["second_memory_db_connection"], id="second")]
-        for first in [pytest.param([], id="-"), pytest.param(["memory_db_connection"], id="first")]
-        if len([*first.values[0], *second.values[0]]) > 0
+        pytest.param([*first.values, *second.values], id=f"{first.id},{second.id}")
+        for second in [pytest.param(id="-"), pytest.param("second_memory_db_connection", id="second")]
+        for first in [pytest.param(id="-"), pytest.param("memory_db_connection", id="first")]
+        if len([*first.values, *second.values]) > 0
     ],
 )
 def test_memory_db_connection_cleared_after_function_scope(pytester, fixtures) -> None:

--- a/tests/core/util/test_db_wrapper.py
+++ b/tests/core/util/test_db_wrapper.py
@@ -144,3 +144,11 @@ async def test_locked_transaction_allows_another_wrapper_with_another_connection
 ) -> None:
     async with counter_db_wrapper.locked_transaction():
         await asyncio.wait_for(enter_one(one=second_connection_db_wrapper), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_locked_transaction_sequential_blocks_subtask(counter_db_wrapper: DBWrapper) -> None:
+    for _ in range(5):
+        async with counter_db_wrapper.locked_transaction():
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.create_task(enter_one(one=counter_db_wrapper)), timeout=1)

--- a/tests/core/util/test_db_wrapper.py
+++ b/tests/core/util/test_db_wrapper.py
@@ -34,7 +34,10 @@ async def counter_db_wrapper_fixture(db_wrapper: DBWrapper) -> AsyncIterator[DBW
 async def lock_read_wait_write(db_wrapper: DBWrapper) -> None:
     async with db_wrapper.locked_transaction() as connection:
         async with connection.execute("SELECT value FROM counter") as cursor:
-            [old_value] = await cursor.fetchone()
+            row = await cursor.fetchone()
+
+        assert row is not None
+        [old_value] = row
 
         await asyncio.sleep(0.010)
 
@@ -64,7 +67,10 @@ async def test_locked_transaction_blocks_concurrency(counter_db_wrapper: DBWrapp
 
     async with counter_db_wrapper.locked_transaction() as connection:
         async with connection.execute("SELECT value FROM counter") as cursor:
-            [value] = await cursor.fetchone()
+            row = await cursor.fetchone()
+
+        assert row is not None
+        [value] = row
 
     assert value == concurrent_task_count
 
@@ -73,7 +79,10 @@ async def test_locked_transaction_blocks_concurrency(counter_db_wrapper: DBWrapp
 async def test_locked_transaction_nests(counter_db_wrapper: DBWrapper) -> None:
     async with counter_db_wrapper.locked_transaction() as outer_connection:
         async with outer_connection.execute("SELECT value FROM counter") as cursor:
-            [old_value] = await cursor.fetchone()
+            row = await cursor.fetchone()
+
+        assert row is not None
+        [old_value] = row
 
         new_value = old_value + 1
         async with counter_db_wrapper.locked_transaction() as inner_connection:
@@ -81,7 +90,10 @@ async def test_locked_transaction_nests(counter_db_wrapper: DBWrapper) -> None:
 
     async with counter_db_wrapper.locked_transaction() as connection:
         async with connection.execute("SELECT value FROM counter") as cursor:
-            [value] = await cursor.fetchone()
+            row = await cursor.fetchone()
+
+        assert row is not None
+        [value] = row
 
     assert value == 1
 

--- a/tests/core/util/test_db_wrapper.py
+++ b/tests/core/util/test_db_wrapper.py
@@ -59,8 +59,7 @@ async def test_locked_transaction_blocks_concurrency(counter_db_wrapper: DBWrapp
 
         tasks = []
         for index in range(concurrent_task_count):
-            name = f"lock_read_wait_write()[{index:4}]"
-            task = asyncio.create_task(lock_read_wait_write(db_wrapper=counter_db_wrapper), name=name)
+            task = asyncio.create_task(lock_read_wait_write(db_wrapper=counter_db_wrapper))
             tasks.append(task)
 
     await asyncio.wait_for(asyncio.gather(*tasks), timeout=10)

--- a/tests/core/util/test_db_wrapper.py
+++ b/tests/core/util/test_db_wrapper.py
@@ -1,0 +1,135 @@
+import asyncio
+import contextlib
+from typing import AsyncIterator
+
+import aiosqlite
+import pytest
+
+from chia.util.db_wrapper import DBWrapper, already_entered
+
+
+@pytest.fixture(name="db_wrapper")
+async def db_wrapper_fixture(memory_db_connection: aiosqlite.Connection) -> AsyncIterator[DBWrapper]:
+    db_wrapper = DBWrapper(connection=memory_db_connection)
+    yield db_wrapper
+
+
+@pytest.fixture(name="second_connection_db_wrapper")
+async def second_connection_db_wrapper_fixture(
+    second_memory_db_connection: aiosqlite.Connection,
+) -> AsyncIterator[DBWrapper]:
+    db_wrapper = DBWrapper(connection=second_memory_db_connection)
+    yield db_wrapper
+
+
+@pytest.fixture(name="counter_db_wrapper")
+async def counter_db_wrapper_fixture(db_wrapper: DBWrapper) -> AsyncIterator[DBWrapper]:
+    async with db_wrapper.locked_transaction() as connection:
+        await connection.execute("CREATE TABLE counter(value INTEGER NOT NULL)")
+        await connection.execute("INSERT INTO counter(value) VALUES(0)")
+
+    yield db_wrapper
+
+
+async def lock_read_wait_write(db_wrapper: DBWrapper) -> None:
+    async with db_wrapper.locked_transaction() as connection:
+        async with connection.execute("SELECT value FROM counter") as cursor:
+            [old_value] = await cursor.fetchone()
+
+        await asyncio.sleep(0.010)
+
+        new_value = old_value + 1
+        await connection.execute("UPDATE counter SET value = :value", {"value": new_value})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    argnames="acquire_outside",
+    argvalues=[pytest.param(False, id="not acquired outside"), pytest.param(True, id="acquired outside")],
+)
+async def test_locked_transaction_blocks_concurrency(counter_db_wrapper: DBWrapper, acquire_outside: bool) -> None:
+    concurrent_task_count = 3
+
+    async with contextlib.AsyncExitStack() as exit_stack:
+        if acquire_outside:
+            await exit_stack.enter_async_context(counter_db_wrapper.locked_transaction())
+
+        tasks = []
+        for index in range(concurrent_task_count):
+            name = f"lock_read_wait_write()[{index:4}]"
+            task = asyncio.create_task(lock_read_wait_write(db_wrapper=counter_db_wrapper), name=name)
+            tasks.append(task)
+
+    await asyncio.wait_for(asyncio.gather(*tasks), timeout=10)
+
+    async with counter_db_wrapper.locked_transaction() as connection:
+        async with connection.execute("SELECT value FROM counter") as cursor:
+            [value] = await cursor.fetchone()
+
+    assert value == concurrent_task_count
+
+
+@pytest.mark.asyncio
+async def test_locked_transaction_nests(counter_db_wrapper: DBWrapper) -> None:
+    async with counter_db_wrapper.locked_transaction() as outer_connection:
+        async with outer_connection.execute("SELECT value FROM counter") as cursor:
+            [old_value] = await cursor.fetchone()
+
+        new_value = old_value + 1
+        async with counter_db_wrapper.locked_transaction() as inner_connection:
+            await inner_connection.execute("UPDATE counter SET value = :value", {"value": new_value})
+
+    async with counter_db_wrapper.locked_transaction() as connection:
+        async with connection.execute("SELECT value FROM counter") as cursor:
+            [value] = await cursor.fetchone()
+
+    assert value == 1
+
+
+async def get_already_entered_value() -> bool:
+    return already_entered.get()
+
+
+@pytest.mark.asyncio
+async def test_locked_transaction_new_task_not_already_entered(counter_db_wrapper: DBWrapper) -> None:
+    task = asyncio.create_task(get_already_entered_value())
+
+    entered = await task
+    assert entered is not None and not entered
+
+
+# async def enter_both(one: DBWrapper, another: DBWrapper) -> None:
+#     # just adding this layer for an easy timeout
+#     async with one.locked_transaction():
+#         async with another.locked_transaction():
+#             pass
+
+
+async def enter_one(one: DBWrapper) -> None:
+    # just adding this layer for an easy timeout
+    async with one.locked_transaction():
+        pass
+
+
+@pytest.mark.asyncio
+async def test_locked_transaction_blocks_subtask(counter_db_wrapper: DBWrapper) -> None:
+    async with counter_db_wrapper.locked_transaction():
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.create_task(enter_one(one=counter_db_wrapper)), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_locked_transaction_blocks_another_wrapper_with_same_connection(counter_db_wrapper: DBWrapper) -> None:
+    another_db_wrapper = DBWrapper(connection=counter_db_wrapper.db)
+    async with counter_db_wrapper.locked_transaction():
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.create_task(enter_one(one=another_db_wrapper)), timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_locked_transaction_allows_another_wrapper_with_another_connection_to_same_db(
+    counter_db_wrapper: DBWrapper,
+    second_connection_db_wrapper: DBWrapper,
+) -> None:
+    async with counter_db_wrapper.locked_transaction():
+        await asyncio.wait_for(enter_one(one=second_connection_db_wrapper), timeout=5)


### PR DESCRIPTION
The existing `DBWrapper.locked_transaction()` context manager is used in the data layer store to provide a centralized definition of how locking and transactions should be handled.  The hassle is that you have to explicitly tell it whether to lock or not.  The use case being that sometimes a given function that needs a transaction and locking for integrity might be called directly and sometimes it is called from an outer function that already has to fulfill those requirements itself.  One feature enabled with this change is that there is no need to explicitly tell it to lock or not.  It tracks via [context variables](https://docs.python.org/3.10/library/contextvars.html) whether it needs to acquire the lock and enter a transaction, or if that has already been handled at an outer layer.  It also tracks the task it is used in as new tasks need to acquire the lock regardless of any 'nesting'.  A new task indicates concurrency at which point we are not in control of the interleaving of commands so the two tasks must operate sequentially, one after the other.

This could be expanded to provide separate connections per task as well and move away from the explicit async locking and towards SQLite-level locking via transactions.

Below is a contrived example show how `C.either()` can be called either directly or via `C.directly()`.  The outermost call in any given task will acquire the lock and handle the transaction opening, rollback, and commit.

```python
@dataclass
class C:
    db_wrapper: DBWrapper

    def either(self, addend):
        async with self.db_wrapper.locked_transaction() as connection:
            async with connection.execute("SELECT a_column FROM some_table WHERE other == 3") as cursor:
                row = await cursor.fetchone()
            assert row is not None
            [value] = row
            connection.execute("UPDATE some_table SET a_value = :a_value", {"a_value": value + addend})

    def directly(self):
        async with self.db_wrapper.locked_transaction() as connection:
            async with connection.execute("SELECT a_column FROM some_table WHERE other == 7") as cursor:
                row = await cursor.fetchone()
            assert row is not None
            [value] = row
            await self.either(addend=value)
```

Draft for:
- [ ] self consideration
- [ ] probably come up with more test cases