### PR TITLE
Ensure wallet/db directory exists before attempting to migrate a wallet db from standalone_wallet/wallet/db

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -210,13 +210,14 @@ class WalletNode:
             .replace("KEY", db_path_key_suffix)
         )
         path = path_from_root(self.root_path, db_path_replaced.replace("v1", "v2"))
+        mkdir(path.parent)
+
         standalone_path = path_from_root(STANDALONE_ROOT_PATH, f"{db_path_replaced.replace('v2', 'v1')}_new")
         if not path.exists():
             if standalone_path.exists():
                 self.log.info(f"Copying wallet db from {standalone_path} to {path}")
                 path.write_bytes(standalone_path.read_bytes())
 
-        mkdir(path.parent)
         self.new_peak_lock = asyncio.Lock()
         assert self.server is not None
         self.wallet_state_manager = await WalletStateManager.create(


### PR DESCRIPTION
When attempting to migrate a wallet DB from standalone_wallet, the copy would fail if mainnet/wallet/db didn't already exist. This would happen for light wallet users that haven't run 1.2.11 (or older) previously.