### PR TITLE
fix full sync on DB v2

### DIFF
--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -245,9 +245,7 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
                     commit_in -= 1
                     if commit_in == 0:
                         commit_in = HINT_COMMIT_RATE
-                        await out_db.executemany(
-                            "INSERT OR IGNORE INTO hints VALUES(?, ?)", hint_values
-                        )
+                        await out_db.executemany("INSERT OR IGNORE INTO hints VALUES(?, ?)", hint_values)
                         await out_db.commit()
                         await out_db.execute("begin transaction")
                         hint_values = []

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -246,7 +246,7 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
                     if commit_in == 0:
                         commit_in = HINT_COMMIT_RATE
                         await out_db.executemany(
-                            "INSERT OR IGNORE INTO hints VALUES(?, ?) ON CONFLICT DO NOTHING", hint_values
+                            "INSERT OR IGNORE INTO hints VALUES(?, ?)", hint_values
                         )
                         await out_db.commit()
                         await out_db.execute("begin transaction")

--- a/chia/full_node/hint_store.py
+++ b/chia/full_node/hint_store.py
@@ -38,7 +38,7 @@ class HintStore:
     async def add_hints(self, coin_hint_list: List[Tuple[bytes32, bytes]]) -> None:
         if self.db_wrapper.db_version == 2:
             cursor = await self.db_wrapper.db.executemany(
-                "INSERT INTO hints VALUES(?, ?) ON CONFLICT DO NOTHING",
+                "INSERT OR IGNORE INTO hints VALUES(?, ?)",
                 coin_hint_list,
             )
         else:


### PR DESCRIPTION
Fixes SQL syntax error when full syncing using DB v2
```
full_node chia.consensus.blockchain: ERROR    Error while adding block e8e3065fbee01eeb8c04a4ee918fdffa18126223aa7a1688cd5ee67030ca6d1a height 225698, rolling back: Traceback (most recent call last):
  File "chia/consensus/blockchain.py", line 258, in receive_block
  File "chia/consensus/blockchain.py", line 425, in _reconsider_peak
  File "chia/full_node/hint_store.py", line 40, in add_hints
  File "aiosqlite/core.py", line 210, in executemany
  File "aiosqlite/core.py", line 129, in _execute
  File "aiosqlite/core.py", line 102, in run
sqlite3.OperationalError: near "ON": syntax error
 near "ON": syntax error
```
there is no `ON CONFLICT DO NOTHING` syntax in SQLite.

Documentation from https://www.sqlite.org/lang_conflict.html
_For the INSERT and UPDATE commands, the keywords "ON CONFLICT" are replaced by "OR" so that the syntax reads more naturally._