### PR TITLE
Log slow block height

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -7,7 +7,7 @@ from chia.types.coin_record import CoinRecord
 from chia.util.db_wrapper import DBWrapper
 from chia.util.ints import uint32, uint64
 from chia.util.lru_cache import LRUCache
-from time import time
+import time
 import logging
 
 log = logging.getLogger(__name__)
@@ -114,7 +114,7 @@ class CoinStore:
         Returns a list of the CoinRecords that were added by this block
         """
 
-        start = time()
+        start = time.monotonic()
 
         additions = []
 
@@ -146,7 +146,7 @@ class CoinStore:
         await self._add_coin_records(additions)
         await self._set_spent(tx_removals, height)
 
-        end = time()
+        end = time.monotonic()
         log.log(
             logging.WARNING if end - start > 10 else logging.DEBUG,
             f"Height {height}: It took {end - start:0.2f}s to apply {len(tx_additions)} additions and "

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -149,7 +149,7 @@ class CoinStore:
         end = time()
         log.log(
             logging.WARNING if end - start > 10 else logging.DEBUG,
-            f"It took {end - start:0.2f}s to apply {len(tx_additions)} additions and "
+            f"Height {height}: It took {end - start:0.2f}s to apply {len(tx_additions)} additions and "
             + f"{len(tx_removals)} removals to the coin store. Make sure "
             + "blockchain database is on a fast drive",
         )

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1053,9 +1053,15 @@ class FullNode:
         )
         pre_validate_end = time.time()
         if pre_validate_end - pre_validate_start > 10:
-            self.log.warning(f"Block pre-validation time: {pre_validate_end - pre_validate_start:0.2f} seconds")
+            self.log.warning(
+                f"Block pre-validation time: {pre_validate_end - pre_validate_start:0.2f} seconds "
+                f"({len(blocks_to_validate)} blocks, height: {blocks_to_validate[0].height})"
+            )
         else:
-            self.log.debug(f"Block pre-validation time: {pre_validate_end - pre_validate_start:0.2f} seconds")
+            self.log.debug(
+                f"Block pre-validation time: {pre_validate_end - pre_validate_start:0.2f} seconds "
+                f"({len(blocks_to_validate)} blocks)"
+            )
         for i, block in enumerate(blocks_to_validate):
             if pre_validation_results[i].error is not None:
                 self.log.error(
@@ -1553,7 +1559,7 @@ class FullNode:
             f"Block validation time: {validation_time:0.2f} seconds, "
             f"pre_validation time: {pre_validation_time:0.2f} seconds, "
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
-            f"{percent_full_str}",
+            f"{percent_full_str} header_hash: {header_hash} height: {block.height}",
         )
 
         # This code path is reached if added == ADDED_AS_ORPHAN or NEW_TIP

--- a/tests/tools/test_full_sync.py
+++ b/tests/tools/test_full_sync.py
@@ -9,4 +9,4 @@ from pathlib import Path
 def test_full_sync_test():
     file_path = os.path.realpath(__file__)
     db_file = Path(file_path).parent / "test-blockchain-db.sqlite"
-    asyncio.run(run_sync_test(db_file, db_version=2))
+    asyncio.run(run_sync_test(db_file, db_version=2, profile=False))

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -4,6 +4,7 @@ import asyncio
 import aiosqlite
 import zstd
 import click
+import logging
 from pathlib import Path
 from time import time
 import tempfile
@@ -17,6 +18,17 @@ from chia.cmds.init_funcs import chia_init
 
 
 async def run_sync_test(file: Path, db_version=2) -> None:
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.WARNING)
+    handler = logging.FileHandler("test-full-sync.log")
+    handler.setFormatter(
+        logging.Formatter(
+            "\n%(levelname)-8s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    )
+    logger.addHandler(handler)
 
     with tempfile.TemporaryDirectory() as root_dir:
 

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -23,7 +23,7 @@ from chia.cmds.init_funcs import chia_init
 
 class ExitOnError(logging.Handler):
     def __init__(self):
-        logging.Handler.__init__(self)
+        super().__init__()
         self.exit_with_failure = False
 
     def emit(self, record):

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -5,9 +5,13 @@ import aiosqlite
 import zstd
 import click
 import logging
+import cProfile
+from typing import Iterator
+
 from pathlib import Path
-from time import time
+import time
 import tempfile
+from contextlib import contextmanager
 
 from chia.types.full_block import FullBlock
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -17,18 +21,46 @@ from chia.full_node.full_node import FullNode
 from chia.cmds.init_funcs import chia_init
 
 
-async def run_sync_test(file: Path, db_version=2) -> None:
+class ExitOnError(logging.Handler):
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.exit_with_failure = False
+
+    def emit(self, record):
+        if record.levelno != logging.ERROR:
+            return
+        self.exit_with_failure = True
+
+
+@contextmanager
+def enable_profiler(profile: bool, counter: int) -> Iterator[None]:
+    if not profile:
+        yield
+        return
+
+    with cProfile.Profile() as pr:
+        receive_start_time = time.monotonic()
+        yield
+
+    if time.monotonic() - receive_start_time > 10:
+        pr.create_stats()
+        pr.dump_stats(f"slow-batch-{counter:05d}.profile")
+
+
+async def run_sync_test(file: Path, db_version, profile: bool) -> None:
 
     logger = logging.getLogger()
     logger.setLevel(logging.WARNING)
     handler = logging.FileHandler("test-full-sync.log")
     handler.setFormatter(
         logging.Formatter(
-            "\n%(levelname)-8s %(message)s",
+            "%(levelname)-8s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
         )
     )
     logger.addHandler(handler)
+    check_log = ExitOnError()
+    logger.addHandler(check_log)
 
     with tempfile.TemporaryDirectory() as root_dir:
 
@@ -55,7 +87,7 @@ async def run_sync_test(file: Path, db_version=2) -> None:
 
                 block_batch = []
 
-                start_time = time()
+                start_time = time.monotonic()
                 async for r in rows:
                     block = FullBlock.from_bytes(zstd.decompress(r[2]))
 
@@ -63,26 +95,51 @@ async def run_sync_test(file: Path, db_version=2) -> None:
                     if len(block_batch) < 32:
                         continue
 
-                    success, advanced_peak, fork_height, coin_changes = await full_node.receive_block_batch(
-                        block_batch, None, None  # type: ignore[arg-type]
-                    )
+                    with enable_profiler(profile, counter):
+                        success, advanced_peak, fork_height, coin_changes = await full_node.receive_block_batch(
+                            block_batch, None, None  # type: ignore[arg-type]
+                        )
+
                     assert success
                     assert advanced_peak
                     counter += len(block_batch)
-                    print(f"\rheight {counter} {counter/(time() - start_time):0.2f} blocks/s   ", end="")
+                    print(f"\rheight {counter} {counter/(time.monotonic() - start_time):0.2f} blocks/s   ", end="")
                     block_batch = []
+                    if check_log.exit_with_failure:
+                        raise RuntimeError("error printed to log. exiting")
         finally:
             print("closing full node")
             full_node._close()
             await full_node._await_closed()
 
 
-@click.command()
-@click.argument("file", type=click.Path(), required=True)
-@click.argument("db-version", type=int, required=False, default=2)
-def main(file: Path, db_version) -> None:
-    asyncio.run(run_sync_test(Path(file), db_version))
+@click.group()
+def main() -> None:
+    pass
 
+
+@main.command("run", short_help="run simulated full sync from an existing blockchain db")
+@click.argument("file", type=click.Path(), required=True)
+@click.option("--db-version", type=int, required=False, default=2, help="the version of the specified db file")
+@click.option("--profile", is_flag=True, required=False, default=False, help="dump CPU profiles for slow batches")
+def run(file: Path, db_version: int, profile: bool) -> None:
+    asyncio.run(run_sync_test(Path(file), db_version, profile))
+
+
+@main.command("analyze", short_help="generate call stacks for all profiles dumped to current directory")
+def analyze() -> None:
+    from shlex import quote
+    from glob import glob
+    from subprocess import check_call
+
+    for input_file in glob("slow-batch-*.profile"):
+        output = input_file.replace(".profile", ".png")
+        print(f"{input_file}")
+        check_call(f"gprof2dot -f pstats {quote(input_file)} | dot -T png >{quote(output)}", shell=True)
+
+
+main.add_command(run)
+main.add_command(analyze)
 
 if __name__ == "__main__":
     # pylint: disable = no-value-for-parameter


### PR DESCRIPTION
This helps identifying CPU spikes and slow-downs during a full sync. We currently have warning logs if adding blocks or coins to the chain takes a surprisingly long time. While running the full-sync simulation, that happened to me on a fast computer.

This patch amends those logs to include the block height of these stalls (to help trouble-shoot/analyze them).
It also adds a profiler option to the full-sync simulator. This catches a few bottlenecks, enabling fixing them.

A few example outputs from the CPU spikes are:

![slot-594016](https://user-images.githubusercontent.com/661450/153249916-be471485-d250-443a-931a-777a215ad848.png)

![slot-571776](https://user-images.githubusercontent.com/661450/153250112-33a1532d-c870-464c-a8fd-3a80804c8636.png)