### PR TITLE
Add automatic rebasing and conflict handling to DL Wallet

### DIFF
--- a/chia/data_layer/dl_wallet_store.py
+++ b/chia/data_layer/dl_wallet_store.py
@@ -170,6 +170,22 @@ class DataLayerStore:
             return self._row_to_singleton_record(row)
         return None
 
+    async def get_unconfirmed_singletons(self, launcher_id: bytes32) -> List[SingletonRecord]:
+        """
+        Returns all singletons with a specific launcher id that have not yet been marked confirmed
+        """
+        cursor = await self.db_connection.execute(
+            "SELECT * from singleton_records WHERE launcher_id=? AND confirmed=0", (launcher_id,)
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+        records = []
+
+        for row in rows:
+            records.append(self._row_to_singleton_record(row))
+
+        return records
+
     async def get_singletons_by_root(self, launcher_id: bytes32, root: bytes32) -> List[SingletonRecord]:
         cursor = await self.db_connection.execute(
             "SELECT * from singleton_records WHERE launcher_id=? AND root=? ORDER BY generation DESC",

--- a/chia/data_layer/dl_wallet_store.py
+++ b/chia/data_layer/dl_wallet_store.py
@@ -179,10 +179,7 @@ class DataLayerStore:
         )
         rows = await cursor.fetchall()
         await cursor.close()
-        records = []
-
-        for row in rows:
-            records.append(self._row_to_singleton_record(row))
+        records = [self._row_to_singleton_record(row) for row in rows]
 
         return records
 


### PR DESCRIPTION
This patch adds the ability for the DL Wallet to detect that a conflicting update happened while it was waiting for its own update.  One half of this is that it can now properly delete its pending state if something like a report spend comes through.  The other half is that it will attempt to automatically try its spend again with the new coin IFF the root never changed in any of the new conflicting history.