### PR TITLE
new DBWrapper supporting concurrent readers

### DIFF
--- a/benchmarks/block_ref.py
+++ b/benchmarks/block_ref.py
@@ -17,7 +17,7 @@ from chia.full_node.hint_store import HintStore
 from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.db_version import lookup_db_version
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32
 
 # the first transaction block. Each byte in transaction_height_delta is the
@@ -57,7 +57,9 @@ async def main(db_path: Path):
         await connection.execute("pragma query_only=ON")
         db_version: int = await lookup_db_version(connection)
 
-        db_wrapper = DBWrapper(connection, db_version=db_version)
+        db_wrapper = DBWrapper2(connection, db_version=db_version)
+        await db_wrapper.add_connection(await aiosqlite.connect(db_path))
+
         block_store = await BlockStore.create(db_wrapper)
         hint_store = await HintStore.create(db_wrapper)
         coin_store = await CoinStore.create(db_wrapper)

--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 from benchmarks.utils import clvm_generator
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint128, uint64, uint32, uint8
 from utils import (
     rewards,
@@ -40,7 +40,7 @@ random.seed(123456789)
 async def run_add_block_benchmark(version: int):
 
     verbose: bool = "--verbose" in sys.argv
-    db_wrapper: DBWrapper = await setup_db("block-store-benchmark.db", version)
+    db_wrapper: DBWrapper2 = await setup_db("block-store-benchmark.db", version)
 
     # keep track of benchmark total time
     all_test_time = 0.0
@@ -218,7 +218,6 @@ async def run_add_block_benchmark(version: int):
             await block_store.set_in_chain([(header_hash,)])
             header_hashes.append(header_hash)
             await block_store.set_peak(header_hash)
-            await db_wrapper.db.commit()
 
             stop = monotonic()
             total_time += stop - start
@@ -411,7 +410,7 @@ async def run_add_block_benchmark(version: int):
         print(f"database size: {db_size/1000000:.3f} MB")
 
     finally:
-        await db_wrapper.db.close()
+        await db_wrapper.close()
 
 
 if __name__ == "__main__":

--- a/benchmarks/coin_store.py
+++ b/benchmarks/coin_store.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 import os
 import sys
 
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.coin import Coin
 from chia.util.ints import uint64, uint32
@@ -37,7 +37,7 @@ def make_coins(num: int) -> Tuple[List[Coin], List[bytes32]]:
 async def run_new_block_benchmark(version: int):
 
     verbose: bool = "--verbose" in sys.argv
-    db_wrapper: DBWrapper = await setup_db("coin-store-benchmark.db", version)
+    db_wrapper: DBWrapper2 = await setup_db("coin-store-benchmark.db", version)
 
     # keep track of benchmark total time
     all_test_time = 0.0
@@ -75,7 +75,6 @@ async def run_new_block_benchmark(version: int):
                 additions,
                 removals,
             )
-            await db_wrapper.db.commit()
 
             # 19 seconds per block
             timestamp += 19
@@ -117,7 +116,6 @@ async def run_new_block_benchmark(version: int):
                 additions,
                 removals,
             )
-            await db_wrapper.db.commit()
             stop = monotonic()
 
             # 19 seconds per block
@@ -168,7 +166,6 @@ async def run_new_block_benchmark(version: int):
                 additions,
                 removals,
             )
-            await db_wrapper.db.commit()
 
             stop = monotonic()
 
@@ -218,7 +215,6 @@ async def run_new_block_benchmark(version: int):
                 additions,
                 removals,
             )
-            await db_wrapper.db.commit()
             stop = monotonic()
 
             # 19 seconds per block
@@ -305,7 +301,7 @@ async def run_new_block_benchmark(version: int):
         print(f"all tests completed in {all_test_time:0.4f}s")
 
     finally:
-        await db_wrapper.db.close()
+        await db_wrapper.close()
 
     db_size = os.path.getsize(Path("coin-store-benchmark.db"))
     print(f"database size: {db_size/1000000:.3f} MB")

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -12,7 +12,7 @@ from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock
 from chia.types.full_block import FullBlock
 from chia.util.ints import uint128
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from typing import Tuple
 from pathlib import Path
 from datetime import datetime
@@ -176,7 +176,7 @@ def rand_full_block() -> FullBlock:
     return full_block
 
 
-async def setup_db(name: str, db_version: int) -> DBWrapper:
+async def setup_db(name: str, db_version: int) -> DBWrapper2:
     db_filename = Path(name)
     try:
         os.unlink(db_filename)
@@ -197,7 +197,9 @@ async def setup_db(name: str, db_version: int) -> DBWrapper:
     await connection.execute("pragma journal_mode=wal")
     await connection.execute("pragma synchronous=full")
 
-    return DBWrapper(connection, db_version)
+    ret = DBWrapper2(connection, db_version)
+    await ret.add_connection(await aiosqlite.connect(db_filename))
+    return ret
 
 
 def get_commit_hash() -> str:

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -101,22 +101,22 @@ class SpendSim:
 
         # Load the next data if there is any
         async with self.db_wrapper.write_db() as conn:
-             await conn.execute("CREATE TABLE IF NOT EXISTS block_data(data blob PRIMARY_KEY)")
-             cursor = await conn.execute("SELECT * from block_data")
-             row = await cursor.fetchone()
-             await cursor.close()
-             if row is not None:
-                 store_data = SimStore.from_bytes(row[0])
-                 self.timestamp = store_data.timestamp
-                 self.block_height = store_data.block_height
-                 self.block_records = store_data.block_records
-                 self.blocks = store_data.blocks
-             else:
-                 self.timestamp = 1
-                 self.block_height = 0
-                 self.block_records = []
-                 self.blocks = []
-             return self
+            await conn.execute("CREATE TABLE IF NOT EXISTS block_data(data blob PRIMARY_KEY)")
+            cursor = await conn.execute("SELECT * from block_data")
+            row = await cursor.fetchone()
+            await cursor.close()
+            if row is not None:
+                store_data = SimStore.from_bytes(row[0])
+                self.timestamp = store_data.timestamp
+                self.block_height = store_data.block_height
+                self.block_records = store_data.block_records
+                self.blocks = store_data.blocks
+            else:
+                self.timestamp = 1
+                self.block_height = 0
+                self.block_records = []
+                self.blocks = []
+            return self
 
     async def close(self):
         async with self.db_wrapper.write_db() as conn:

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -1,4 +1,5 @@
 import aiosqlite
+import random
 
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Tuple, Any
@@ -9,7 +10,7 @@ from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.util.ints import uint64, uint32
 from chia.util.hash import std_hash
 from chia.util.errors import Err, ValidationError
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.streamable import Streamable, streamable
 from chia.types.coin_record import CoinRecord
 from chia.types.spend_bundle import SpendBundle
@@ -79,7 +80,7 @@ class SimStore(Streamable):
 
 class SpendSim:
 
-    connection: aiosqlite.Connection
+    db_wrapper: DBWrapper2
     mempool_manager: MempoolManager
     block_records: List[SimBlockRecord]
     blocks: List[SimFullBlock]
@@ -90,39 +91,43 @@ class SpendSim:
     @classmethod
     async def create(cls, db_path=":memory:", defaults=DEFAULT_CONSTANTS):
         self = cls()
-        self.connection = DBWrapper(await aiosqlite.connect(db_path))
-        coin_store = await CoinStore.create(self.connection)
+        uri = f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
+        connection = await aiosqlite.connect(uri, uri=True)
+        self.db_wrapper = DBWrapper2(connection)
+        await self.db_wrapper.add_connection(await aiosqlite.connect(uri, uri=True))
+        coin_store = await CoinStore.create(self.db_wrapper)
         self.mempool_manager = MempoolManager(coin_store, defaults)
         self.defaults = defaults
 
         # Load the next data if there is any
-        await self.connection.db.execute("CREATE TABLE IF NOT EXISTS block_data(data blob PRIMARY_KEY)")
-        cursor = await self.connection.db.execute("SELECT * from block_data")
-        row = await cursor.fetchone()
-        await cursor.close()
-        if row is not None:
-            store_data = SimStore.from_bytes(row[0])
-            self.timestamp = store_data.timestamp
-            self.block_height = store_data.block_height
-            self.block_records = store_data.block_records
-            self.blocks = store_data.blocks
-        else:
-            self.timestamp = 1
-            self.block_height = 0
-            self.block_records = []
-            self.blocks = []
-        return self
+        async with self.db_wrapper.write_db() as conn:
+             await conn.execute("CREATE TABLE IF NOT EXISTS block_data(data blob PRIMARY_KEY)")
+             cursor = await conn.execute("SELECT * from block_data")
+             row = await cursor.fetchone()
+             await cursor.close()
+             if row is not None:
+                 store_data = SimStore.from_bytes(row[0])
+                 self.timestamp = store_data.timestamp
+                 self.block_height = store_data.block_height
+                 self.block_records = store_data.block_records
+                 self.blocks = store_data.blocks
+             else:
+                 self.timestamp = 1
+                 self.block_height = 0
+                 self.block_records = []
+                 self.blocks = []
+             return self
 
     async def close(self):
-        c = await self.connection.db.execute("DELETE FROM block_data")
-        await c.close()
-        c = await self.connection.db.execute(
-            "INSERT INTO block_data VALUES(?)",
-            (bytes(SimStore(self.timestamp, self.block_height, self.block_records, self.blocks)),),
-        )
-        await c.close()
-        await self.connection.db.commit()
-        await self.connection.db.close()
+        async with self.db_wrapper.write_db() as conn:
+            c = await conn.execute("DELETE FROM block_data")
+            await c.close()
+            c = await conn.execute(
+                "INSERT INTO block_data VALUES(?)",
+                (bytes(SimStore(self.timestamp, self.block_height, self.block_records, self.blocks)),),
+            )
+            await c.close()
+        await self.db_wrapper.close()
 
     async def new_peak(self):
         await self.mempool_manager.new_peak(self.block_records[-1], [])
@@ -138,12 +143,13 @@ class SpendSim:
 
     async def all_non_reward_coins(self) -> List[Coin]:
         coins = set()
-        cursor = await self.mempool_manager.coin_store.coin_record_db.execute(
-            "SELECT * from coin_record WHERE coinbase=0 AND spent=0 ",
-        )
-        rows = await cursor.fetchall()
+        async with self.mempool_manager.coin_store.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT * from coin_record WHERE coinbase=0 AND spent=0 ",
+            )
+            rows = await cursor.fetchall()
 
-        await cursor.close()
+            await cursor.close()
         for row in rows:
             coin = Coin(bytes32(bytes.fromhex(row[6])), bytes32(bytes.fromhex(row[5])), uint64.from_bytes(row[7]))
             coins.add(coin)

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Dict, List, Optional, Tuple, Any
 
-import aiosqlite
 import zstd
 
 from chia.consensus.block_record import BlockRecord
@@ -10,7 +9,7 @@ from chia.types.full_block import FullBlock
 from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.weight_proof import SubEpochChallengeSegment, SubEpochSegments
 from chia.util.errors import Err
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32
 from chia.util.lru_cache import LRUCache
 from chia.util.full_block_utils import generator_from_block
@@ -19,94 +18,92 @@ log = logging.getLogger(__name__)
 
 
 class BlockStore:
-    db: aiosqlite.Connection
     block_cache: LRUCache
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
     ses_challenge_cache: LRUCache
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper):
+    async def create(cls, db_wrapper: DBWrapper2):
         self = cls()
-
         # All full blocks which have been added to the blockchain. Header_hash -> block
         self.db_wrapper = db_wrapper
-        self.db = db_wrapper.db
 
-        if self.db_wrapper.db_version == 2:
+        async with self.db_wrapper.write_db() as conn:
 
-            # TODO: most data in block is duplicated in block_record. The only
-            # reason for this is that our parsing of a FullBlock is so slow,
-            # it's faster to store duplicate data to parse less when we just
-            # need the BlockRecord. Once we fix the parsing (and data structure)
-            # of FullBlock, this can use less space
-            await self.db.execute(
-                "CREATE TABLE IF NOT EXISTS full_blocks("
-                "header_hash blob PRIMARY KEY,"
-                "prev_hash blob,"
-                "height bigint,"
-                "sub_epoch_summary blob,"
-                "is_fully_compactified tinyint,"
-                "in_main_chain tinyint,"
-                "block blob,"
-                "block_record blob)"
-            )
+            if self.db_wrapper.db_version == 2:
 
-            # This is a single-row table containing the hash of the current
-            # peak. The "key" field is there to make update statements simple
-            await self.db.execute("CREATE TABLE IF NOT EXISTS current_peak(key int PRIMARY KEY, hash blob)")
+                # TODO: most data in block is duplicated in block_record. The only
+                # reason for this is that our parsing of a FullBlock is so slow,
+                # it's faster to store duplicate data to parse less when we just
+                # need the BlockRecord. Once we fix the parsing (and data structure)
+                # of FullBlock, this can use less space
+                await conn.execute(
+                    "CREATE TABLE IF NOT EXISTS full_blocks("
+                    "header_hash blob PRIMARY KEY,"
+                    "prev_hash blob,"
+                    "height bigint,"
+                    "sub_epoch_summary blob,"
+                    "is_fully_compactified tinyint,"
+                    "in_main_chain tinyint,"
+                    "block blob,"
+                    "block_record blob)"
+                )
 
-            # If any of these indices are altered, they should also be altered
-            # in the chia/cmds/db_upgrade.py file
-            await self.db.execute("CREATE INDEX IF NOT EXISTS height on full_blocks(height)")
+                # This is a single-row table containing the hash of the current
+                # peak. The "key" field is there to make update statements simple
+                await conn.execute("CREATE TABLE IF NOT EXISTS current_peak(key int PRIMARY KEY, hash blob)")
 
-            # Sub epoch segments for weight proofs
-            await self.db.execute(
-                "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3("
-                "ses_block_hash blob PRIMARY KEY,"
-                "challenge_segments blob)"
-            )
+                # If any of these indices are altered, they should also be altered
+                # in the chia/cmds/db_upgrade.py file
+                await conn.execute("CREATE INDEX IF NOT EXISTS height on full_blocks(height)")
 
-            # If any of these indices are altered, they should also be altered
-            # in the chia/cmds/db_upgrade.py file
-            await self.db.execute(
-                "CREATE INDEX IF NOT EXISTS is_fully_compactified ON"
-                " full_blocks(is_fully_compactified, in_main_chain) WHERE in_main_chain=1"
-            )
-            await self.db.execute(
-                "CREATE INDEX IF NOT EXISTS main_chain ON full_blocks(height, in_main_chain) WHERE in_main_chain=1"
-            )
+                # Sub epoch segments for weight proofs
+                await conn.execute(
+                    "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3("
+                    "ses_block_hash blob PRIMARY KEY,"
+                    "challenge_segments blob)"
+                )
 
-        else:
+                # If any of these indices are altered, they should also be altered
+                # in the chia/cmds/db_upgrade.py file
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS is_fully_compactified ON"
+                    " full_blocks(is_fully_compactified, in_main_chain) WHERE in_main_chain=1"
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS main_chain ON full_blocks(height, in_main_chain) WHERE in_main_chain=1"
+                )
 
-            await self.db.execute(
-                "CREATE TABLE IF NOT EXISTS full_blocks(header_hash text PRIMARY KEY, height bigint,"
-                "  is_block tinyint, is_fully_compactified tinyint, block blob)"
-            )
+            else:
 
-            # Block records
-            await self.db.execute(
-                "CREATE TABLE IF NOT EXISTS block_records(header_hash "
-                "text PRIMARY KEY, prev_hash text, height bigint,"
-                "block blob, sub_epoch_summary blob, is_peak tinyint, is_block tinyint)"
-            )
+                await conn.execute(
+                    "CREATE TABLE IF NOT EXISTS full_blocks(header_hash text PRIMARY KEY, height bigint,"
+                    "  is_block tinyint, is_fully_compactified tinyint, block blob)"
+                )
 
-            # Sub epoch segments for weight proofs
-            await self.db.execute(
-                "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3(ses_block_hash text PRIMARY KEY,"
-                "challenge_segments blob)"
-            )
+                # Block records
+                await conn.execute(
+                    "CREATE TABLE IF NOT EXISTS block_records(header_hash "
+                    "text PRIMARY KEY, prev_hash text, height bigint,"
+                    "block blob, sub_epoch_summary blob, is_peak tinyint, is_block tinyint)"
+                )
 
-            # Height index so we can look up in order of height for sync purposes
-            await self.db.execute("CREATE INDEX IF NOT EXISTS full_block_height on full_blocks(height)")
-            await self.db.execute(
-                "CREATE INDEX IF NOT EXISTS is_fully_compactified on full_blocks(is_fully_compactified)"
-            )
+                # Sub epoch segments for weight proofs
+                await conn.execute(
+                    "CREATE TABLE IF NOT EXISTS sub_epoch_segments_v3(ses_block_hash text PRIMARY KEY,"
+                    "challenge_segments blob)"
+                )
 
-            await self.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
+                # Height index so we can look up in order of height for sync purposes
+                await conn.execute("CREATE INDEX IF NOT EXISTS full_block_height on full_blocks(height)")
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS is_fully_compactified on full_blocks(is_fully_compactified)"
+                )
 
-            await self.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
+                await conn.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
 
-        await self.db.commit()
+                await conn.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
+
         self.block_cache = LRUCache(1000)
         self.ses_challenge_cache = LRUCache(50)
         return self
@@ -134,15 +131,17 @@ class BlockStore:
 
     async def rollback(self, height: int) -> None:
         if self.db_wrapper.db_version == 2:
-            await self.db.execute(
-                "UPDATE OR FAIL full_blocks SET in_main_chain=0 WHERE height>? AND in_main_chain=1", (height,)
-            )
+            async with self.db_wrapper.write_db() as conn:
+                await conn.execute(
+                    "UPDATE OR FAIL full_blocks SET in_main_chain=0 WHERE height>? AND in_main_chain=1", (height,)
+                )
 
     async def set_in_chain(self, header_hashes: List[Tuple[bytes32]]) -> None:
         if self.db_wrapper.db_version == 2:
-            await self.db.executemany(
-                "UPDATE OR FAIL full_blocks SET in_main_chain=1 WHERE header_hash=?", header_hashes
-            )
+            async with self.db_wrapper.write_db() as conn:
+                await conn.executemany(
+                    "UPDATE OR FAIL full_blocks SET in_main_chain=1 WHERE header_hash=?", header_hashes
+                )
 
     async def replace_proof(self, header_hash: bytes32, block: FullBlock) -> None:
 
@@ -156,14 +155,15 @@ class BlockStore:
 
         self.block_cache.put(header_hash, block)
 
-        await self.db.execute(
-            "UPDATE full_blocks SET block=?,is_fully_compactified=? WHERE header_hash=?",
-            (
-                block_bytes,
-                int(block.is_fully_compactified()),
-                self.maybe_to_hex(header_hash),
-            ),
-        )
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
+                "UPDATE full_blocks SET block=?,is_fully_compactified=? WHERE header_hash=?",
+                (
+                    block_bytes,
+                    int(block.is_fully_compactified()),
+                    self.maybe_to_hex(header_hash),
+                ),
+            )
 
     async def add_full_block(self, header_hash: bytes32, block: FullBlock, block_record: BlockRecord) -> None:
         self.block_cache.put(header_hash, block)
@@ -176,56 +176,57 @@ class BlockStore:
                 else bytes(block_record.sub_epoch_summary_included)
             )
 
-            await self.db.execute(
-                "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    header_hash,
-                    block.prev_header_hash,
-                    block.height,
-                    ses,
-                    int(block.is_fully_compactified()),
-                    False,  # in_main_chain
-                    self.compress(block),
-                    bytes(block_record),
-                ),
-            )
+            async with self.db_wrapper.write_db() as conn:
+                await conn.execute(
+                    "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        header_hash,
+                        block.prev_header_hash,
+                        block.height,
+                        ses,
+                        int(block.is_fully_compactified()),
+                        False,  # in_main_chain
+                        self.compress(block),
+                        bytes(block_record),
+                    ),
+                )
 
         else:
-            await self.db.execute(
-                "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
-                (
-                    header_hash.hex(),
-                    block.height,
-                    int(block.is_transaction_block()),
-                    int(block.is_fully_compactified()),
-                    bytes(block),
-                ),
-            )
+            async with self.db_wrapper.write_db() as conn:
+                await conn.execute(
+                    "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
+                    (
+                        header_hash.hex(),
+                        block.height,
+                        int(block.is_transaction_block()),
+                        int(block.is_fully_compactified()),
+                        bytes(block),
+                    ),
+                )
 
-            await self.db.execute(
-                "INSERT OR IGNORE INTO block_records VALUES(?, ?, ?, ?,?, ?, ?)",
-                (
-                    header_hash.hex(),
-                    block.prev_header_hash.hex(),
-                    block.height,
-                    bytes(block_record),
-                    None
-                    if block_record.sub_epoch_summary_included is None
-                    else bytes(block_record.sub_epoch_summary_included),
-                    False,
-                    block.is_transaction_block(),
-                ),
-            )
+                await conn.execute(
+                    "INSERT OR IGNORE INTO block_records VALUES(?, ?, ?, ?,?, ?, ?)",
+                    (
+                        header_hash.hex(),
+                        block.prev_header_hash.hex(),
+                        block.height,
+                        bytes(block_record),
+                        None
+                        if block_record.sub_epoch_summary_included is None
+                        else bytes(block_record.sub_epoch_summary_included),
+                        False,
+                        block.is_transaction_block(),
+                    ),
+                )
 
     async def persist_sub_epoch_challenge_segments(
         self, ses_block_hash: bytes32, segments: List[SubEpochChallengeSegment]
     ) -> None:
-        async with self.db_wrapper.lock:
-            await self.db.execute(
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
                 "INSERT OR REPLACE INTO sub_epoch_segments_v3 VALUES(?, ?)",
                 (self.maybe_to_hex(ses_block_hash), bytes(SubEpochSegments(segments))),
             )
-            await self.db.commit()
 
     async def get_sub_epoch_challenge_segments(
         self,
@@ -235,11 +236,12 @@ class BlockStore:
         if cached is not None:
             return cached
 
-        async with self.db.execute(
-            "SELECT challenge_segments from sub_epoch_segments_v3 WHERE ses_block_hash=?",
-            (self.maybe_to_hex(ses_block_hash),),
-        ) as cursor:
-            row = await cursor.fetchone()
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                "SELECT challenge_segments from sub_epoch_segments_v3 WHERE ses_block_hash=?",
+                (self.maybe_to_hex(ses_block_hash),),
+            ) as cursor:
+                row = await cursor.fetchone()
 
         if row is not None:
             challenge_segments = SubEpochSegments.from_bytes(row[0]).challenge_segments
@@ -261,10 +263,11 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return cached
         log.debug(f"cache miss for block {header_hash.hex()}")
-        async with self.db.execute(
-            "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
-        ) as cursor:
-            row = await cursor.fetchone()
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
+            ) as cursor:
+                row = await cursor.fetchone()
         if row is not None:
             block = self.maybe_decompress(row[0])
             self.block_cache.put(header_hash, block)
@@ -277,10 +280,11 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return bytes(cached)
         log.debug(f"cache miss for block {header_hash.hex()}")
-        async with self.db.execute(
-            "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
-        ) as cursor:
-            row = await cursor.fetchone()
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
+            ) as cursor:
+                row = await cursor.fetchone()
         if row is not None:
             if self.db_wrapper.db_version == 2:
                 return zstd.decompress(row[0])
@@ -295,11 +299,12 @@ class BlockStore:
 
         heights_db = tuple(heights)
         formatted_str = f'SELECT block from full_blocks WHERE height in ({"?," * (len(heights_db) - 1)}?)'
-        async with self.db.execute(formatted_str, heights_db) as cursor:
-            ret: List[FullBlock] = []
-            for row in await cursor.fetchall():
-                ret.append(self.maybe_decompress(row[0]))
-            return ret
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(formatted_str, heights_db) as cursor:
+                ret: List[FullBlock] = []
+                for row in await cursor.fetchall():
+                    ret.append(self.maybe_decompress(row[0]))
+                return ret
 
     async def get_generator(self, header_hash: bytes32) -> Optional[SerializedProgram]:
 
@@ -309,24 +314,25 @@ class BlockStore:
             return cached.transactions_generator
 
         formatted_str = "SELECT block, height from full_blocks WHERE header_hash=?"
-        async with self.db.execute(formatted_str, (self.maybe_to_hex(header_hash),)) as cursor:
-            row = await cursor.fetchone()
-            if row is None:
-                return None
-            if self.db_wrapper.db_version == 2:
-                block_bytes = zstd.decompress(row[0])
-            else:
-                block_bytes = row[0]
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(formatted_str, (self.maybe_to_hex(header_hash),)) as cursor:
+                row = await cursor.fetchone()
+                if row is None:
+                    return None
+                if self.db_wrapper.db_version == 2:
+                    block_bytes = zstd.decompress(row[0])
+                else:
+                    block_bytes = row[0]
 
-            try:
-                return generator_from_block(block_bytes)
-            except Exception as e:
-                log.error(f"cheap parser failed for block at height {row[1]}: {e}")
-                # this is defensive, on the off-chance that
-                # generator_from_block() fails, fall back to the reliable
-                # definition of parsing a block
-                b = FullBlock.from_bytes(block_bytes)
-                return b.transactions_generator
+                try:
+                    return generator_from_block(block_bytes)
+                except Exception as e:
+                    log.error(f"cheap parser failed for block at height {row[1]}: {e}")
+                    # this is defensive, on the off-chance that
+                    # generator_from_block() fails, fall back to the reliable
+                    # definition of parsing a block
+                    b = FullBlock.from_bytes(block_bytes)
+                    return b.transactions_generator
 
     async def get_generators_at(self, heights: List[uint32]) -> List[SerializedProgram]:
         assert self.db_wrapper.db_version == 2
@@ -340,22 +346,23 @@ class BlockStore:
             f"SELECT block, height from full_blocks "
             f'WHERE in_main_chain=1 AND height in ({"?," * (len(heights_db) - 1)}?)'
         )
-        async with self.db.execute(formatted_str, heights_db) as cursor:
-            async for row in cursor:
-                block_bytes = zstd.decompress(row[0])
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(formatted_str, heights_db) as cursor:
+                async for row in cursor:
+                    block_bytes = zstd.decompress(row[0])
 
-                try:
-                    gen = generator_from_block(block_bytes)
-                except Exception as e:
-                    log.error(f"cheap parser failed for block at height {row[1]}: {e}")
-                    # this is defensive, on the off-chance that
-                    # generator_from_block() fails, fall back to the reliable
-                    # definition of parsing a block
-                    b = FullBlock.from_bytes(block_bytes)
-                    gen = b.transactions_generator
-                if gen is None:
-                    raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
-                generators[uint32(row[1])] = gen
+                    try:
+                        gen = generator_from_block(block_bytes)
+                    except Exception as e:
+                        log.error(f"cheap parser failed for block at height {row[1]}: {e}")
+                        # this is defensive, on the off-chance that
+                        # generator_from_block() fails, fall back to the reliable
+                        # definition of parsing a block
+                        b = FullBlock.from_bytes(block_bytes)
+                        gen = b.transactions_generator
+                    if gen is None:
+                        raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
+                    generators[uint32(row[1])] = gen
 
         return [generators[h] for h in heights]
 
@@ -369,20 +376,22 @@ class BlockStore:
 
         all_blocks: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
-            async with self.db.execute(
-                "SELECT header_hash,block_record FROM full_blocks "
-                f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
-                tuple(header_hashes),
-            ) as cursor:
-                for row in await cursor.fetchall():
-                    header_hash = bytes32(row[0])
-                    all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "SELECT header_hash,block_record FROM full_blocks "
+                    f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
+                    tuple(header_hashes),
+                ) as cursor:
+                    for row in await cursor.fetchall():
+                        header_hash = bytes32(row[0])
+                        all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
         else:
             formatted_str = f'SELECT block from block_records WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)'
-            async with self.db.execute(formatted_str, tuple([hh.hex() for hh in header_hashes])) as cursor:
-                for row in await cursor.fetchall():
-                    block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
-                    all_blocks[block_rec.header_hash] = block_rec
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(formatted_str, tuple([hh.hex() for hh in header_hashes])) as cursor:
+                    for row in await cursor.fetchall():
+                        block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
+                        all_blocks[block_rec.header_hash] = block_rec
 
         ret: List[BlockRecord] = []
         for hh in header_hashes:
@@ -409,15 +418,16 @@ class BlockStore:
             f'SELECT header_hash, block from full_blocks WHERE header_hash in ({"?," * (len(header_hashes_db) - 1)}?)'
         )
         all_blocks: Dict[bytes32, FullBlock] = {}
-        async with self.db.execute(formatted_str, header_hashes_db) as cursor:
-            for row in await cursor.fetchall():
-                header_hash = self.maybe_from_hex(row[0])
-                full_block: FullBlock = self.maybe_decompress(row[1])
-                # TODO: address hint error and remove ignore
-                #       error: Invalid index type "bytes" for "Dict[bytes32, FullBlock]";
-                # expected type "bytes32"  [index]
-                all_blocks[header_hash] = full_block  # type: ignore[index]
-                self.block_cache.put(header_hash, full_block)
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(formatted_str, header_hashes_db) as cursor:
+                for row in await cursor.fetchall():
+                    header_hash = self.maybe_from_hex(row[0])
+                    full_block: FullBlock = self.maybe_decompress(row[1])
+                    # TODO: address hint error and remove ignore
+                    #       error: Invalid index type "bytes" for "Dict[bytes32, FullBlock]";
+                    # expected type "bytes32"  [index]
+                    all_blocks[header_hash] = full_block  # type: ignore[index]
+                    self.block_cache.put(header_hash, full_block)
         ret: List[FullBlock] = []
         for hh in header_hashes:
             if hh not in all_blocks:
@@ -429,20 +439,22 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
 
-            async with self.db.execute(
-                "SELECT block_record FROM full_blocks WHERE header_hash=?",
-                (header_hash,),
-            ) as cursor:
-                row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "SELECT block_record FROM full_blocks WHERE header_hash=?",
+                    (header_hash,),
+                ) as cursor:
+                    row = await cursor.fetchone()
             if row is not None:
                 return BlockRecord.from_bytes(row[0])
 
         else:
-            async with self.db.execute(
-                "SELECT block from block_records WHERE header_hash=?",
-                (header_hash.hex(),),
-            ) as cursor:
-                row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "SELECT block from block_records WHERE header_hash=?",
+                    (header_hash.hex(),),
+                ) as cursor:
+                    row = await cursor.fetchone()
             if row is not None:
                 return BlockRecord.from_bytes(row[0])
         return None
@@ -460,40 +472,45 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
 
-            async with self.db.execute(
-                "SELECT header_hash, block_record FROM full_blocks WHERE height >= ? AND height <= ?",
-                (start, stop),
-            ) as cursor:
-                for row in await cursor.fetchall():
-                    header_hash = bytes32(row[0])
-                    ret[header_hash] = BlockRecord.from_bytes(row[1])
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "SELECT header_hash, block_record FROM full_blocks WHERE height >= ? AND height <= ?",
+                    (start, stop),
+                ) as cursor:
+                    for row in await cursor.fetchall():
+                        header_hash = bytes32(row[0])
+                        ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         else:
 
             formatted_str = f"SELECT header_hash, block from block_records WHERE height >= {start} and height <= {stop}"
 
-            async with await self.db.execute(formatted_str) as cursor:
-                for row in await cursor.fetchall():
-                    header_hash = bytes32(self.maybe_from_hex(row[0]))
-                    ret[header_hash] = BlockRecord.from_bytes(row[1])
+            async with self.db_wrapper.read_db() as conn:
+                async with await conn.execute(formatted_str) as cursor:
+                    for row in await cursor.fetchall():
+                        header_hash = bytes32(self.maybe_from_hex(row[0]))
+                        ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret
 
     async def get_peak(self) -> Optional[Tuple[bytes32, uint32]]:
 
         if self.db_wrapper.db_version == 2:
-            async with self.db.execute("SELECT hash FROM current_peak WHERE key = 0") as cursor:
-                peak_row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute("SELECT hash FROM current_peak WHERE key = 0") as cursor:
+                    peak_row = await cursor.fetchone()
             if peak_row is None:
                 return None
-            async with self.db.execute("SELECT height FROM full_blocks WHERE header_hash=?", (peak_row[0],)) as cursor:
-                peak_height = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute("SELECT height FROM full_blocks WHERE header_hash=?", (peak_row[0],)) as cursor:
+                    peak_height = await cursor.fetchone()
             if peak_height is None:
                 return None
             return bytes32(peak_row[0]), uint32(peak_height[0])
         else:
-            async with self.db.execute("SELECT header_hash, height from block_records WHERE is_peak = 1") as cursor:
-                peak_row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute("SELECT header_hash, height from block_records WHERE is_peak = 1") as cursor:
+                    peak_row = await cursor.fetchone()
             if peak_row is None:
                 return None
             return bytes32(bytes.fromhex(peak_row[0])), uint32(peak_row[1])
@@ -513,20 +530,22 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
 
-            async with self.db.execute(
-                "SELECT header_hash, block_record FROM full_blocks WHERE height >= ?",
-                (peak[1] - blocks_n,),
-            ) as cursor:
-                for row in await cursor.fetchall():
-                    header_hash = bytes32(row[0])
-                    ret[header_hash] = BlockRecord.from_bytes(row[1])
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "SELECT header_hash, block_record FROM full_blocks WHERE height >= ?",
+                    (peak[1] - blocks_n,),
+                ) as cursor:
+                    for row in await cursor.fetchall():
+                        header_hash = bytes32(row[0])
+                        ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         else:
             formatted_str = f"SELECT header_hash, block  from block_records WHERE height >= {peak[1] - blocks_n}"
-            async with self.db.execute(formatted_str) as cursor:
-                for row in await cursor.fetchall():
-                    header_hash = bytes32(self.maybe_from_hex(row[0]))
-                    ret[header_hash] = BlockRecord.from_bytes(row[1])
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(formatted_str) as cursor:
+                    for row in await cursor.fetchall():
+                        header_hash = bytes32(self.maybe_from_hex(row[0]))
+                        ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret, peak[0]
 
@@ -536,19 +555,22 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
             # Note: we use the key field as 0 just to ensure all inserts replace the existing row
-            await self.db.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, header_hash))
+            async with self.db_wrapper.write_db() as conn:
+                await conn.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, header_hash))
         else:
-            await self.db.execute("UPDATE block_records SET is_peak=0 WHERE is_peak=1")
-            await self.db.execute(
-                "UPDATE block_records SET is_peak=1 WHERE header_hash=?",
-                (self.maybe_to_hex(header_hash),),
-            )
+            async with self.db_wrapper.write_db() as conn:
+                await conn.execute("UPDATE block_records SET is_peak=0 WHERE is_peak=1")
+                await conn.execute(
+                    "UPDATE block_records SET is_peak=1 WHERE header_hash=?",
+                    (self.maybe_to_hex(header_hash),),
+                )
 
     async def is_fully_compactified(self, header_hash: bytes32) -> Optional[bool]:
-        async with self.db.execute(
-            "SELECT is_fully_compactified from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
-        ) as cursor:
-            row = await cursor.fetchone()
+        async with self.db_wrapper.write_db() as conn:
+            async with conn.execute(
+                "SELECT is_fully_compactified from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
+            ) as cursor:
+                row = await cursor.fetchone()
         if row is None:
             return None
         return bool(row[0])
@@ -556,20 +578,22 @@ class BlockStore:
     async def get_random_not_compactified(self, number: int) -> List[int]:
 
         if self.db_wrapper.db_version == 2:
-            async with self.db.execute(
-                f"SELECT height FROM full_blocks WHERE in_main_chain=1 AND is_fully_compactified=0 "
-                f"ORDER BY RANDOM() LIMIT {number}"
-            ) as cursor:
-                rows = await cursor.fetchall()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    f"SELECT height FROM full_blocks WHERE in_main_chain=1 AND is_fully_compactified=0 "
+                    f"ORDER BY RANDOM() LIMIT {number}"
+                ) as cursor:
+                    rows = await cursor.fetchall()
         else:
             # Since orphan blocks do not get compactified, we need to check whether all blocks with a
             # certain height are not compact. And if we do have compact orphan blocks, then all that
             # happens is that the occasional chain block stays uncompact - not ideal, but harmless.
-            async with self.db.execute(
-                f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 "
-                f"ORDER BY RANDOM() LIMIT {number}"
-            ) as cursor:
-                rows = await cursor.fetchall()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 "
+                    f"ORDER BY RANDOM() LIMIT {number}"
+                ) as cursor:
+                    rows = await cursor.fetchall()
 
         heights = [int(row[0]) for row in rows]
 
@@ -578,13 +602,15 @@ class BlockStore:
     async def count_compactified_blocks(self) -> int:
         if self.db_wrapper.db_version == 2:
             # DB V2 has an index on is_fully_compactified only for blocks in the main chain
-            async with self.db.execute(
-                "select count(*) from full_blocks where is_fully_compactified=1 and in_main_chain=1"
-            ) as cursor:
-                row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "select count(*) from full_blocks where is_fully_compactified=1 and in_main_chain=1"
+                ) as cursor:
+                    row = await cursor.fetchone()
         else:
-            async with self.db.execute("select count(*) from full_blocks where is_fully_compactified=1") as cursor:
-                row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute("select count(*) from full_blocks where is_fully_compactified=1") as cursor:
+                    row = await cursor.fetchone()
 
         assert row is not None
 
@@ -594,13 +620,15 @@ class BlockStore:
     async def count_uncompactified_blocks(self) -> int:
         if self.db_wrapper.db_version == 2:
             # DB V2 has an index on is_fully_compactified only for blocks in the main chain
-            async with self.db.execute(
-                "select count(*) from full_blocks where is_fully_compactified=0 and in_main_chain=1"
-            ) as cursor:
-                row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "select count(*) from full_blocks where is_fully_compactified=0 and in_main_chain=1"
+                ) as cursor:
+                    row = await cursor.fetchone()
         else:
-            async with self.db.execute("select count(*) from full_blocks where is_fully_compactified=0") as cursor:
-                row = await cursor.fetchone()
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute("select count(*) from full_blocks where is_fully_compactified=0") as cursor:
+                    row = await cursor.fetchone()
 
         assert row is not None
 

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -476,7 +476,7 @@ class CoinStore:
                         record.timestamp,
                     )
                 )
-            if values2 != []:
+            if len(values2) > 0:
                 async with self.db_wrapper.write_db() as conn:
                     await conn.executemany(
                         "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
@@ -499,7 +499,7 @@ class CoinStore:
                         record.timestamp,
                     )
                 )
-            if values != []:
+            if len(values) > 0:
                 async with self.db_wrapper.write_db() as conn:
                     await conn.executemany(
                         "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -1,10 +1,9 @@
 from typing import List, Optional, Set, Dict, Any, Tuple
-import aiosqlite
 from chia.protocols.wallet_protocol import CoinState
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
 from chia.util.lru_cache import LRUCache
 from chia.util.chunks import chunks
@@ -22,74 +21,72 @@ class CoinStore:
     A cache is maintained for quicker access to recent coins.
     """
 
-    coin_record_db: aiosqlite.Connection
     coin_record_cache: LRUCache
     cache_size: uint32
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper, cache_size: uint32 = uint32(60000)):
+    async def create(cls, db_wrapper: DBWrapper2, cache_size: uint32 = uint32(60000)):
         self = cls()
 
         self.cache_size = cache_size
         self.db_wrapper = db_wrapper
-        self.coin_record_db = db_wrapper.db
 
-        if self.db_wrapper.db_version == 2:
+        async with self.db_wrapper.write_db() as conn:
 
-            # the coin_name is unique in this table because the CoinStore always
-            # only represent a single peak
-            await self.coin_record_db.execute(
-                "CREATE TABLE IF NOT EXISTS coin_record("
-                "coin_name blob PRIMARY KEY,"
-                " confirmed_index bigint,"
-                " spent_index bigint,"  # if this is zero, it means the coin has not been spent
-                " coinbase int,"
-                " puzzle_hash blob,"
-                " coin_parent blob,"
-                " amount blob,"  # we use a blob of 8 bytes to store uint64
-                " timestamp bigint)"
-            )
+            if self.db_wrapper.db_version == 2:
 
-        else:
-
-            # the coin_name is unique in this table because the CoinStore always
-            # only represent a single peak
-            await self.coin_record_db.execute(
-                (
+                # the coin_name is unique in this table because the CoinStore always
+                # only represent a single peak
+                await conn.execute(
                     "CREATE TABLE IF NOT EXISTS coin_record("
-                    "coin_name text PRIMARY KEY,"
+                    "coin_name blob PRIMARY KEY,"
                     " confirmed_index bigint,"
-                    " spent_index bigint,"
-                    " spent int,"
+                    " spent_index bigint,"  # if this is zero, it means the coin has not been spent
                     " coinbase int,"
-                    " puzzle_hash text,"
-                    " coin_parent text,"
-                    " amount blob,"
+                    " puzzle_hash blob,"
+                    " coin_parent blob,"
+                    " amount blob,"  # we use a blob of 8 bytes to store uint64
                     " timestamp bigint)"
                 )
-            )
 
-        # Useful for reorg lookups
-        await self.coin_record_db.execute(
-            "CREATE INDEX IF NOT EXISTS coin_confirmed_index on coin_record(confirmed_index)"
-        )
+            else:
 
-        await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_spent_index on coin_record(spent_index)")
+                # the coin_name is unique in this table because the CoinStore always
+                # only represent a single peak
+                await conn.execute(
+                    (
+                        "CREATE TABLE IF NOT EXISTS coin_record("
+                        "coin_name text PRIMARY KEY,"
+                        " confirmed_index bigint,"
+                        " spent_index bigint,"
+                        " spent int,"
+                        " coinbase int,"
+                        " puzzle_hash text,"
+                        " coin_parent text,"
+                        " amount blob,"
+                        " timestamp bigint)"
+                    )
+                )
 
-        await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_puzzle_hash on coin_record(puzzle_hash)")
+            # Useful for reorg lookups
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_confirmed_index on coin_record(confirmed_index)")
 
-        await self.coin_record_db.execute("CREATE INDEX IF NOT EXISTS coin_parent_index on coin_record(coin_parent)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_spent_index on coin_record(spent_index)")
 
-        await self.coin_record_db.commit()
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_puzzle_hash on coin_record(puzzle_hash)")
+
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_parent_index on coin_record(coin_parent)")
+
         self.coin_record_cache = LRUCache(cache_size)
         return self
 
     async def num_unspent(self) -> int:
-        async with self.coin_record_db.execute("SELECT COUNT(*) FROM coin_record WHERE spent_index=0") as cursor:
-            row = await cursor.fetchone()
-            if row is not None:
-                return row[0]
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute("SELECT COUNT(*) FROM coin_record WHERE spent_index=0") as cursor:
+                row = await cursor.fetchone()
+        if row is not None:
+            return row[0]
         return 0
 
     def maybe_from_hex(self, field: Any) -> bytes:
@@ -165,48 +162,51 @@ class CoinStore:
         if cached is not None:
             return cached
 
-        async with self.coin_record_db.execute(
-            "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            "coin_parent, amount, timestamp FROM coin_record WHERE coin_name=?",
-            (self.maybe_to_hex(coin_name),),
-        ) as cursor:
-            row = await cursor.fetchone()
-            if row is not None:
-                coin = self.row_to_coin(row)
-                record = CoinRecord(coin, row[0], row[1], row[2], row[6])
-                self.coin_record_cache.put(record.coin.name(), record)
-                return record
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                "coin_parent, amount, timestamp FROM coin_record WHERE coin_name=?",
+                (self.maybe_to_hex(coin_name),),
+            ) as cursor:
+                row = await cursor.fetchone()
+                if row is not None:
+                    coin = self.row_to_coin(row)
+                    record = CoinRecord(coin, row[0], row[1], row[2], row[6])
+                    self.coin_record_cache.put(record.coin.name(), record)
+                    return record
         return None
 
     async def get_coins_added_at_height(self, height: uint32) -> List[CoinRecord]:
-        async with self.coin_record_db.execute(
-            "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index=?",
-            (height,),
-        ) as cursor:
-            rows = await cursor.fetchall()
-            coins = []
-            for row in rows:
-                coin = self.row_to_coin(row)
-                coins.append(CoinRecord(coin, row[0], row[1], row[2], row[6]))
-            return coins
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index=?",
+                (height,),
+            ) as cursor:
+                rows = await cursor.fetchall()
+                coins = []
+                for row in rows:
+                    coin = self.row_to_coin(row)
+                    coins.append(CoinRecord(coin, row[0], row[1], row[2], row[6]))
+                return coins
 
     async def get_coins_removed_at_height(self, height: uint32) -> List[CoinRecord]:
         # Special case to avoid querying all unspent coins (spent_index=0)
         if height == 0:
             return []
-        async with self.coin_record_db.execute(
-            "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            "coin_parent, amount, timestamp FROM coin_record WHERE spent_index=?",
-            (height,),
-        ) as cursor:
-            coins = []
-            for row in await cursor.fetchall():
-                if row[1] != 0:
-                    coin = self.row_to_coin(row)
-                    coin_record = CoinRecord(coin, row[0], row[1], row[2], row[6])
-                    coins.append(coin_record)
-            return coins
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                "coin_parent, amount, timestamp FROM coin_record WHERE spent_index=?",
+                (height,),
+            ) as cursor:
+                coins = []
+                for row in await cursor.fetchall():
+                    if row[1] != 0:
+                        coin = self.row_to_coin(row)
+                        coin_record = CoinRecord(coin, row[0], row[1], row[2], row[6])
+                        coins.append(coin_record)
+                return coins
 
     # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them
     async def get_coin_records_by_puzzle_hash(
@@ -219,18 +219,19 @@ class CoinStore:
 
         coins = set()
 
-        async with self.coin_record_db.execute(
-            f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash=? "
-            f"AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND spent_index=0'}",
-            (self.maybe_to_hex(puzzle_hash), start_height, end_height),
-        ) as cursor:
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash=? "
+                f"AND confirmed_index>=? AND confirmed_index<? "
+                f"{'' if include_spent_coins else 'AND spent_index=0'}",
+                (self.maybe_to_hex(puzzle_hash), start_height, end_height),
+            ) as cursor:
 
-            for row in await cursor.fetchall():
-                coin = self.row_to_coin(row)
-                coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
-            return list(coins)
+                for row in await cursor.fetchall():
+                    coin = self.row_to_coin(row)
+                    coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
+                return list(coins)
 
     async def get_coin_records_by_puzzle_hashes(
         self,
@@ -248,19 +249,21 @@ class CoinStore:
             puzzle_hashes_db = tuple(puzzle_hashes)
         else:
             puzzle_hashes_db = tuple([ph.hex() for ph in puzzle_hashes])
-        async with self.coin_record_db.execute(
-            f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
-            f'WHERE puzzle_hash in ({"?," * (len(puzzle_hashes) - 1)}?) '
-            f"AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND spent_index=0'}",
-            puzzle_hashes_db + (start_height, end_height),
-        ) as cursor:
 
-            for row in await cursor.fetchall():
-                coin = self.row_to_coin(row)
-                coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
-            return list(coins)
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
+                f'WHERE puzzle_hash in ({"?," * (len(puzzle_hashes) - 1)}?) '
+                f"AND confirmed_index>=? AND confirmed_index<? "
+                f"{'' if include_spent_coins else 'AND spent_index=0'}",
+                puzzle_hashes_db + (start_height, end_height),
+            ) as cursor:
+
+                for row in await cursor.fetchall():
+                    coin = self.row_to_coin(row)
+                    coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
+                return list(coins)
 
     async def get_coin_records_by_names(
         self,
@@ -278,17 +281,19 @@ class CoinStore:
             names_db = tuple(names)
         else:
             names_db = tuple([name.hex() for name in names])
-        async with self.coin_record_db.execute(
-            f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            f'coin_parent, amount, timestamp FROM coin_record WHERE coin_name in ({"?," * (len(names) - 1)}?) '
-            f"AND confirmed_index>=? AND confirmed_index<? "
-            f"{'' if include_spent_coins else 'AND spent_index=0'}",
-            names_db + (start_height, end_height),
-        ) as cursor:
 
-            for row in await cursor.fetchall():
-                coin = self.row_to_coin(row)
-                coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute(
+                f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                f'coin_parent, amount, timestamp FROM coin_record WHERE coin_name in ({"?," * (len(names) - 1)}?) '
+                f"AND confirmed_index>=? AND confirmed_index<? "
+                f"{'' if include_spent_coins else 'AND spent_index=0'}",
+                names_db + (start_height, end_height),
+            ) as cursor:
+
+                for row in await cursor.fetchall():
+                    coin = self.row_to_coin(row)
+                    coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
 
         return list(coins)
 
@@ -314,23 +319,24 @@ class CoinStore:
             return []
 
         coins = set()
-        for puzzles in chunks(puzzle_hashes, MAX_SQLITE_PARAMETERS):
-            puzzle_hashes_db: Tuple[Any, ...]
-            if self.db_wrapper.db_version == 2:
-                puzzle_hashes_db = tuple(puzzles)
-            else:
-                puzzle_hashes_db = tuple([ph.hex() for ph in puzzles])
-            async with self.coin_record_db.execute(
-                f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-                f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
-                f'WHERE puzzle_hash in ({"?," * (len(puzzles) - 1)}?) '
-                f"AND (confirmed_index>=? OR spent_index>=?)"
-                f"{'' if include_spent_coins else 'AND spent_index=0'}",
-                puzzle_hashes_db + (min_height, min_height),
-            ) as cursor:
+        async with self.db_wrapper.read_db() as conn:
+            for puzzles in chunks(puzzle_hashes, MAX_SQLITE_PARAMETERS):
+                puzzle_hashes_db: Tuple[Any, ...]
+                if self.db_wrapper.db_version == 2:
+                    puzzle_hashes_db = tuple(puzzles)
+                else:
+                    puzzle_hashes_db = tuple([ph.hex() for ph in puzzles])
+                async with conn.execute(
+                    f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                    f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
+                    f'WHERE puzzle_hash in ({"?," * (len(puzzles) - 1)}?) '
+                    f"AND (confirmed_index>=? OR spent_index>=?)"
+                    f"{'' if include_spent_coins else 'AND spent_index=0'}",
+                    puzzle_hashes_db + (min_height, min_height),
+                ) as cursor:
 
-                async for row in cursor:
-                    coins.add(self.row_to_coin_state(row))
+                    async for row in cursor:
+                        coins.add(self.row_to_coin_state(row))
 
         return list(coins)
 
@@ -345,23 +351,25 @@ class CoinStore:
             return []
 
         coins = set()
-        for ids in chunks(parent_ids, MAX_SQLITE_PARAMETERS):
-            parent_ids_db: Tuple[Any, ...]
-            if self.db_wrapper.db_version == 2:
-                parent_ids_db = tuple(ids)
-            else:
-                parent_ids_db = tuple([pid.hex() for pid in ids])
-            async with self.coin_record_db.execute(
-                f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-                f'coin_parent, amount, timestamp FROM coin_record WHERE coin_parent in ({"?," * (len(ids) - 1)}?) '
-                f"AND confirmed_index>=? AND confirmed_index<? "
-                f"{'' if include_spent_coins else 'AND spent_index=0'}",
-                parent_ids_db + (start_height, end_height),
-            ) as cursor:
+        async with self.db_wrapper.read_db() as conn:
+            for ids in chunks(parent_ids, MAX_SQLITE_PARAMETERS):
+                parent_ids_db: Tuple[Any, ...]
+                if self.db_wrapper.db_version == 2:
+                    parent_ids_db = tuple(ids)
+                else:
+                    parent_ids_db = tuple([pid.hex() for pid in ids])
+                async with conn.execute(
+                    f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                    f'coin_parent, amount, timestamp FROM coin_record WHERE coin_parent in ({"?," * (len(ids) - 1)}?) '
+                    f"AND confirmed_index>=? AND confirmed_index<? "
+                    f"{'' if include_spent_coins else 'AND spent_index=0'}",
+                    parent_ids_db + (start_height, end_height),
+                ) as cursor:
 
-                async for row in cursor:
-                    coin = self.row_to_coin(row)
-                    coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
+                    async for row in cursor:
+                        coin = self.row_to_coin(row)
+                        coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
+
         return list(coins)
 
     async def get_coin_states_by_ids(
@@ -374,21 +382,22 @@ class CoinStore:
             return []
 
         coins = set()
-        for ids in chunks(coin_ids, MAX_SQLITE_PARAMETERS):
-            coin_ids_db: Tuple[Any, ...]
-            if self.db_wrapper.db_version == 2:
-                coin_ids_db = tuple(ids)
-            else:
-                coin_ids_db = tuple([pid.hex() for pid in ids])
-            async with self.coin_record_db.execute(
-                f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-                f'coin_parent, amount, timestamp FROM coin_record WHERE coin_name in ({"?," * (len(ids) - 1)}?) '
-                f"AND (confirmed_index>=? OR spent_index>=?)"
-                f"{'' if include_spent_coins else 'AND spent_index=0'}",
-                coin_ids_db + (min_height, min_height),
-            ) as cursor:
-                async for row in cursor:
-                    coins.add(self.row_to_coin_state(row))
+        async with self.db_wrapper.read_db() as conn:
+            for ids in chunks(coin_ids, MAX_SQLITE_PARAMETERS):
+                coin_ids_db: Tuple[Any, ...]
+                if self.db_wrapper.db_version == 2:
+                    coin_ids_db = tuple(ids)
+                else:
+                    coin_ids_db = tuple([pid.hex() for pid in ids])
+                async with conn.execute(
+                    f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                    f'coin_parent, amount, timestamp FROM coin_record WHERE coin_name in ({"?," * (len(ids) - 1)}?) '
+                    f"AND (confirmed_index>=? OR spent_index>=?)"
+                    f"{'' if include_spent_coins else 'AND spent_index=0'}",
+                    coin_ids_db + (min_height, min_height),
+                ) as cursor:
+                    async for row in cursor:
+                        coins.add(self.row_to_coin_state(row))
         return list(coins)
 
     async def rollback_to_block(self, block_index: int) -> List[CoinRecord]:
@@ -415,38 +424,37 @@ class CoinStore:
             self.coin_record_cache.remove(coin_name)
 
         coin_changes: Dict[bytes32, CoinRecord] = {}
-        async with self.coin_record_db.execute(
-            "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
-            (block_index,),
-        ) as cursor:
-            for row in await cursor.fetchall():
-                coin = self.row_to_coin(row)
-                record = CoinRecord(coin, uint32(0), row[1], row[2], uint64(0))
-                coin_changes[record.name] = record
-
-        # Delete from storage
-        await self.coin_record_db.execute("DELETE FROM coin_record WHERE confirmed_index>?", (block_index,))
-
-        async with self.coin_record_db.execute(
-            "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-            "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
-            (block_index,),
-        ) as cursor:
-            for row in await cursor.fetchall():
-                coin = self.row_to_coin(row)
-                record = CoinRecord(coin, row[0], uint32(0), row[2], row[6])
-                if record.name not in coin_changes:
+        async with self.db_wrapper.write_db() as conn:
+            async with conn.execute(
+                "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
+                (block_index,),
+            ) as cursor:
+                for row in await cursor.fetchall():
+                    coin = self.row_to_coin(row)
+                    record = CoinRecord(coin, uint32(0), row[1], row[2], uint64(0))
                     coin_changes[record.name] = record
 
-        if self.db_wrapper.db_version == 2:
-            await self.coin_record_db.execute(
-                "UPDATE coin_record SET spent_index=0 WHERE spent_index>?", (block_index,)
-            )
-        else:
-            await self.coin_record_db.execute(
-                "UPDATE coin_record SET spent_index = 0, spent = 0 WHERE spent_index>?", (block_index,)
-            )
+            # Delete from storage
+            await conn.execute("DELETE FROM coin_record WHERE confirmed_index>?", (block_index,))
+
+            async with conn.execute(
+                "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
+                "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
+                (block_index,),
+            ) as cursor:
+                for row in await cursor.fetchall():
+                    coin = self.row_to_coin(row)
+                    record = CoinRecord(coin, row[0], uint32(0), row[2], row[6])
+                    if record.name not in coin_changes:
+                        coin_changes[record.name] = record
+
+            if self.db_wrapper.db_version == 2:
+                await conn.execute("UPDATE coin_record SET spent_index=0 WHERE spent_index>?", (block_index,))
+            else:
+                await conn.execute(
+                    "UPDATE coin_record SET spent_index = 0, spent = 0 WHERE spent_index>?", (block_index,)
+                )
         return list(coin_changes.values())
 
     # Store CoinRecord in DB and ram cache
@@ -468,10 +476,12 @@ class CoinStore:
                         record.timestamp,
                     )
                 )
-            await self.coin_record_db.executemany(
-                "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
-                values2,
-            )
+            if values2 != []:
+                async with self.db_wrapper.write_db() as conn:
+                    await conn.executemany(
+                        "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+                        values2,
+                    )
         else:
             values = []
             for record in records:
@@ -489,10 +499,12 @@ class CoinStore:
                         record.timestamp,
                     )
                 )
-            await self.coin_record_db.executemany(
-                "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                values,
-            )
+            if values != []:
+                async with self.db_wrapper.write_db() as conn:
+                    await conn.executemany(
+                        "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        values,
+                    )
 
     # Update coin_record to be spent in DB
     async def _set_spent(self, coin_names: List[bytes32], index: uint32):
@@ -508,11 +520,11 @@ class CoinStore:
                 )
             updates.append((index, self.maybe_to_hex(coin_name)))
 
-        if self.db_wrapper.db_version == 2:
-            await self.coin_record_db.executemany(
-                "UPDATE OR FAIL coin_record SET spent_index=? WHERE coin_name=?", updates
-            )
-        else:
-            await self.coin_record_db.executemany(
-                "UPDATE OR FAIL coin_record SET spent=1,spent_index=? WHERE coin_name=?", updates
-            )
+        if updates != []:
+            async with self.db_wrapper.write_db() as conn:
+                if self.db_wrapper.db_version == 2:
+                    await conn.executemany("UPDATE OR FAIL coin_record SET spent_index=? WHERE coin_name=?", updates)
+                else:
+                    await conn.executemany(
+                        "UPDATE OR FAIL coin_record SET spent=1,spent_index=? WHERE coin_name=?", updates
+                    )

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -85,7 +85,6 @@ class FullNode:
     sync_store: Any
     coin_store: CoinStore
     mempool_manager: MempoolManager
-    connection: aiosqlite.Connection
     _sync_task: Optional[asyncio.Task]
     _init_weight_proof: Optional[asyncio.Task] = None
     blockchain: Blockchain
@@ -164,23 +163,8 @@ class FullNode:
         # These many respond_transaction tasks can be active at any point in time
         self.respond_transaction_semaphore = asyncio.Semaphore(200)
         # create the store (db) and full node instance
-        self.connection = await aiosqlite.connect(self.db_path)
-        await self.connection.execute("pragma journal_mode=wal")
-        db_sync = db_synchronous_on(self.config.get("db_sync", "auto"), self.db_path)
-        self.log.info(f"opening blockchain DB: synchronous={db_sync}")
-        await self.connection.execute("pragma synchronous={}".format(db_sync))
-
-        async with self.connection.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='full_blocks'"
-        ) as conn:
-            if len(await conn.fetchall()) == 0:
-                try:
-                    # this is a new DB file. Make it v2
-                    await set_db_version_async(self.connection, 2)
-                except sqlite3.OperationalError:
-                    # it could be a database created with "chia init", which is
-                    # empty except it has the database_version table
-                    pass
+        db_connection = await aiosqlite.connect(self.db_path)
+        db_version: int = await lookup_db_version(db_connection)
 
         if self.config.get("log_sqlite_cmds", False):
             sql_log_path = path_from_root(self.root_path, "log/sql.log")
@@ -192,11 +176,9 @@ class FullNode:
                 log.write(timestamp + " " + req + "\n")
                 log.close()
 
-            await self.connection.set_trace_callback(sql_trace_callback)
+            await db_connection.set_trace_callback(sql_trace_callback)
 
-        db_version: int = await lookup_db_version(self.connection)
-
-        self.db_wrapper = DBWrapper2(self.connection, db_version=db_version)
+        self.db_wrapper = DBWrapper2(db_connection, db_version=db_version)
 
         # add reader threads for the DB
         for i in range(self.config.get("db_readers", 4)):
@@ -204,6 +186,26 @@ class FullNode:
             if self.config.get("log_sqlite_cmds", False):
                 await c.set_trace_callback(sql_trace_callback)
             await self.db_wrapper.add_connection(c)
+
+        await (await db_connection.execute("pragma journal_mode=wal")).close()
+        db_sync = db_synchronous_on(self.config.get("db_sync", "auto"), self.db_path)
+        self.log.info(f"opening blockchain DB: synchronous={db_sync}")
+        await (await db_connection.execute("pragma synchronous={}".format(db_sync))).close()
+
+        if db_version != 2:
+            async with self.db_wrapper.read_db() as conn:
+                async with conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='full_blocks'"
+                ) as cur:
+                    if len(await cur.fetchall()) == 0:
+                        try:
+                            # this is a new DB file. Make it v2
+                            async with self.db_wrapper.write_db() as w_conn:
+                                await set_db_version_async(w_conn, 2)
+                        except sqlite3.OperationalError:
+                            # it could be a database created with "chia init", which is
+                            # empty except it has the database_version table
+                            pass
 
         self.block_store = await BlockStore.create(self.db_wrapper)
         self.sync_store = await SyncStore.create()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -67,7 +67,7 @@ from chia.util.bech32m import encode_puzzle_hash
 from chia.util.check_fork_next_block import check_fork_next_block
 from chia.util.condition_tools import pkm_pairs
 from chia.util.config import PEER_DB_PATH_KEY_DEPRECATED, process_config_start_method
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.errors import ConsensusError, Err, ValidationError
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.path import mkdir, path_from_root
@@ -196,7 +196,15 @@ class FullNode:
 
         db_version: int = await lookup_db_version(self.connection)
 
-        self.db_wrapper = DBWrapper(self.connection, db_version=db_version)
+        self.db_wrapper = DBWrapper2(self.connection, db_version=db_version)
+
+        # add reader threads for the DB
+        for i in range(self.config.get("db_readers", 4)):
+            c = await aiosqlite.connect(self.db_path)
+            if self.config.get("log_sqlite_cmds", False):
+                await c.set_trace_callback(sql_trace_callback)
+            await self.db_wrapper.add_connection(c)
+
         self.block_store = await BlockStore.create(self.db_wrapper)
         self.sync_store = await SyncStore.create()
         self.hint_store = await HintStore.create(self.db_wrapper)
@@ -770,7 +778,7 @@ class FullNode:
     async def _await_closed(self):
         for task_id, task in list(self.full_node_store.tx_fetch_tasks.items()):
             cancel_task_safe(task, self.log)
-        await self.connection.close()
+        await self.db_wrapper.close()
         if self._init_weight_proof is not None:
             await asyncio.wait([self._init_weight_proof])
         if hasattr(self, "_blockchain_lock_queue"):
@@ -2225,14 +2233,11 @@ class FullNode:
                 new_block = dataclasses.replace(block, challenge_chain_ip_proof=vdf_proof)
         if new_block is None:
             return False
-        async with self.db_wrapper.lock:
+        async with self.db_wrapper.write_db():
             try:
-                await self.block_store.db_wrapper.begin_transaction()
                 await self.block_store.replace_proof(header_hash, new_block)
-                await self.block_store.db_wrapper.commit_transaction()
                 return True
             except BaseException as e:
-                await self.block_store.db_wrapper.rollback_transaction()
                 self.log.error(
                     f"_replace_proof error while adding block {block.header_hash} height {block.height},"
                     f" rolling back: {e} {traceback.format_exc()}"

--- a/chia/full_node/hint_store.py
+++ b/chia/full_node/hint_store.py
@@ -1,56 +1,57 @@
 from typing import List, Tuple
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 import logging
 
 log = logging.getLogger(__name__)
 
 
 class HintStore:
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper):
+    async def create(cls, db_wrapper: DBWrapper2):
         self = cls()
         self.db_wrapper = db_wrapper
 
-        if self.db_wrapper.db_version == 2:
-            await self.db_wrapper.db.execute(
-                "CREATE TABLE IF NOT EXISTS hints(coin_id blob, hint blob, UNIQUE (coin_id, hint))"
-            )
-        else:
-            await self.db_wrapper.db.execute(
-                "CREATE TABLE IF NOT EXISTS hints(id INTEGER PRIMARY KEY AUTOINCREMENT, coin_id blob, hint blob)"
-            )
-        await self.db_wrapper.db.execute("CREATE INDEX IF NOT EXISTS hint_index on hints(hint)")
-        await self.db_wrapper.db.commit()
+        async with self.db_wrapper.write_db() as conn:
+            if self.db_wrapper.db_version == 2:
+                await conn.execute("CREATE TABLE IF NOT EXISTS hints(coin_id blob, hint blob, UNIQUE (coin_id, hint))")
+            else:
+                await conn.execute(
+                    "CREATE TABLE IF NOT EXISTS hints(id INTEGER PRIMARY KEY AUTOINCREMENT, coin_id blob, hint blob)"
+                )
+            await conn.execute("CREATE INDEX IF NOT EXISTS hint_index on hints(hint)")
         return self
 
     async def get_coin_ids(self, hint: bytes) -> List[bytes32]:
-        cursor = await self.db_wrapper.db.execute("SELECT coin_id from hints WHERE hint=?", (hint,))
-        rows = await cursor.fetchall()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT coin_id from hints WHERE hint=?", (hint,))
+            rows = await cursor.fetchall()
+            await cursor.close()
         coin_ids = []
         for row in rows:
             coin_ids.append(row[0])
         return coin_ids
 
     async def add_hints(self, coin_hint_list: List[Tuple[bytes32, bytes]]) -> None:
-        if self.db_wrapper.db_version == 2:
-            cursor = await self.db_wrapper.db.executemany(
-                "INSERT OR IGNORE INTO hints VALUES(?, ?)",
-                coin_hint_list,
-            )
-        else:
-            cursor = await self.db_wrapper.db.executemany(
-                "INSERT INTO hints VALUES(?, ?, ?)",
-                [(None,) + record for record in coin_hint_list],
-            )
-        await cursor.close()
+        async with self.db_wrapper.write_db() as conn:
+            if self.db_wrapper.db_version == 2:
+                cursor = await conn.executemany(
+                    "INSERT OR IGNORE INTO hints VALUES(?, ?)",
+                    coin_hint_list,
+                )
+            else:
+                cursor = await conn.executemany(
+                    "INSERT INTO hints VALUES(?, ?, ?)",
+                    [(None,) + record for record in coin_hint_list],
+                )
+            await cursor.close()
 
     async def count_hints(self) -> int:
-        async with self.db_wrapper.db.execute("select count(*) from hints") as cursor:
-            row = await cursor.fetchone()
+        async with self.db_wrapper.read_db() as conn:
+            async with conn.execute("select count(*) from hints") as cursor:
+                row = await cursor.fetchone()
 
         assert row is not None
 

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -119,7 +119,8 @@ class DBWrapper2:
         # so it can read back updates it has made to its transaction, even
         # though it hasn't been comitted yet
         if self._current_writer == task:
-            # we allow nesting writers within the same task
+            # we allow nesting reading while also having a writer connection
+            # open, within the same task
             yield self._write_connection
             return
 

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import asyncio
+import contextlib
+from typing import AsyncIterator, Dict, Optional
 
 import aiosqlite
 
@@ -10,12 +14,10 @@ class DBWrapper:
 
     db: aiosqlite.Connection
     lock: asyncio.Lock
-    db_version: int
 
     def __init__(self, connection: aiosqlite.Connection, db_version: int = 1):
         self.db = connection
         self.lock = asyncio.Lock()
-        self.db_version = db_version
 
     async def begin_transaction(self):
         cursor = await self.db.execute("BEGIN TRANSACTION")
@@ -29,3 +31,107 @@ class DBWrapper:
 
     async def commit_transaction(self) -> None:
         await self.db.commit()
+
+
+class DBWrapper2:
+    db_version: int
+    _lock: asyncio.Lock
+    _read_connections: asyncio.Queue[aiosqlite.Connection]
+    _write_connection: aiosqlite.Connection
+    _num_read_connections: int
+    _in_use: Dict[asyncio.Task, aiosqlite.Connection]
+    _current_writer: Optional[asyncio.Task]
+    _savepoint_name: int
+
+    async def add_connection(self, c: aiosqlite.Connection) -> None:
+        # this guarantees that reader connections can only be used for reading
+        await c.execute("pragma query_only")
+        self._read_connections.put_nowait(c)
+        self._num_read_connections += 1
+
+    def __init__(self, connection: aiosqlite.Connection, db_version: int = 1) -> None:
+        self._read_connections = asyncio.Queue()
+        self._write_connection = connection
+        self._lock = asyncio.Lock()
+        self.db_version = db_version
+        self._num_read_connections = 0
+        self._in_use = {}
+        self._current_writer = None
+        self._savepoint_name = 0
+
+    async def close(self) -> None:
+        while self._num_read_connections > 0:
+            await (await self._read_connections.get()).close()
+            self._num_read_connections -= 1
+        await self._write_connection.close()
+
+    def _next_savepoint(self) -> str:
+        name = f"s{self._savepoint_name}"
+        self._savepoint_name += 1
+        return name
+
+    @contextlib.asynccontextmanager
+    async def write_db(self) -> AsyncIterator[aiosqlite.Connection]:
+        task = asyncio.current_task()
+        assert task is not None
+        if self._current_writer == task:
+            # we allow nesting writers within the same task
+
+            name = self._next_savepoint()
+            await self._write_connection.execute(f"SAVEPOINT {name}")
+            try:
+                yield self._write_connection
+            except:  # noqa E722
+                await self._write_connection.execute(f"ROLLBACK TO {name}")
+                raise
+            finally:
+                # rollback to a savepoint doesn't cancel the transaction, it
+                # just rolls back the state. We need to cancel it regardless
+                await self._write_connection.execute(f"RELEASE {name}")
+            return
+
+        async with self._lock:
+
+            name = self._next_savepoint()
+            await self._write_connection.execute(f"SAVEPOINT {name}")
+            try:
+                self._current_writer = task
+                yield self._write_connection
+            except:  # noqa E722
+                await self._write_connection.execute(f"ROLLBACK TO {name}")
+                raise
+            finally:
+                self._current_writer = None
+                await self._write_connection.execute(f"RELEASE {name}")
+
+    @contextlib.asynccontextmanager
+    async def read_db(self) -> AsyncIterator[aiosqlite.Connection]:
+        # there should have been read connections added
+        assert self._num_read_connections > 0
+
+        # we can have multiple concurrent readers, just pick a connection from
+        # the pool of readers. If they're all busy, we'll wait for one to free
+        # up.
+        task = asyncio.current_task()
+        assert task is not None
+
+        # if this task currently holds the write lock, use the same connection,
+        # so it can read back updates it has made to its transaction, even
+        # though it hasn't been comitted yet
+        if self._current_writer == task:
+            # we allow nesting writers within the same task
+            yield self._write_connection
+            return
+
+        if task in self._in_use:
+            yield self._in_use[task]
+        else:
+            c = await self._read_connections.get()
+            try:
+                # record our connection in this dict to allow nested calls in
+                # the same task to use the same connection
+                self._in_use[task] = c
+                yield c
+            finally:
+                del self._in_use[task]
+                self._read_connections.put_nowait(c)

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -45,6 +45,7 @@ class DBWrapper2:
 
     async def add_connection(self, c: aiosqlite.Connection) -> None:
         # this guarantees that reader connections can only be used for reading
+        assert c != self._write_connection
         await c.execute("pragma query_only")
         self._read_connections.put_nowait(c)
         self._num_read_connections += 1

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -15,7 +15,7 @@ class DBWrapper:
     db: aiosqlite.Connection
     lock: asyncio.Lock
 
-    def __init__(self, connection: aiosqlite.Connection, db_version: int = 1):
+    def __init__(self, connection: aiosqlite.Connection):
         self.db = connection
         self.lock = asyncio.Lock()
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -332,6 +332,11 @@ full_node:
   #         the particular system we're running on. Defaults to "full".
   db_sync: "auto"
 
+  # the number of threads used to read from the blockchain database
+  # concurrently. There's always only 1 writer, but the number of readers is
+  # configurable
+  db_readers: 4
+
   # Run multiple nodes with different databases by changing the database_path
   database_path: db/blockchain_v2_CHALLENGE.sqlite
   # peer_db_path is deprecated and has been replaced by peers_file_path

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -539,7 +539,7 @@ class TestBlockHeaderValidation:
             constants=test_constants.replace(SUB_SLOT_ITERS_STARTING=(2 ** 12), DIFFICULTY_STARTING=(2 ** 14)),
             keychain=keychain,
         )
-        bc1, connection, db_path = await create_blockchain(bt_high_iters.constants, db_version)
+        bc1, db_wrapper, db_path = await create_blockchain(bt_high_iters.constants, db_version)
         blocks = bt_high_iters.get_consecutive_blocks(10)
         for block in blocks:
             if len(block.finished_sub_slots) > 0 and block.finished_sub_slots[-1].infused_challenge_chain is not None:
@@ -611,7 +611,7 @@ class TestBlockHeaderValidation:
 
             await _validate_and_add_block(bc1, block)
 
-        await connection.close()
+        await db_wrapper.close()
         bc1.shut_down()
         db_path.unlink()
 
@@ -2324,7 +2324,7 @@ class TestBodyValidation:
         #     new_test_constants = test_constants.replace(
         #         **{"GENESIS_PRE_FARM_POOL_PUZZLE_HASH": bt.pool_ph, "GENESIS_PRE_FARM_FARMER_PUZZLE_HASH": bt.pool_ph}
         #     )
-        #     b, connection, db_path = await create_blockchain(new_test_constants, db_version)
+        #     b, db_wrapper, db_path = await create_blockchain(new_test_constants, db_version)
         #     bt_2 = await create_block_tools_async(constants=new_test_constants, keychain=keychain)
         #     bt_2.constants = bt_2.constants.replace(
         #         **{"GENESIS_PRE_FARM_POOL_PUZZLE_HASH": bt.pool_ph, "GENESIS_PRE_FARM_FARMER_PUZZLE_HASH": bt.pool_ph}
@@ -2358,7 +2358,7 @@ class TestBodyValidation:
         #         assert False
         #     except Exception as e:
         #         pass
-        #     await connection.close()
+        #     await db_wrapper.close()
         #     b.shut_down()
         #     db_path.unlink()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,10 +54,10 @@ async def empty_blockchain(request):
     from tests.util.blockchain import create_blockchain
     from tests.setup_nodes import test_constants
 
-    bc1, connection, db_path = await create_blockchain(test_constants, request.param)
+    bc1, db_wrapper, db_path = await create_blockchain(test_constants, request.param)
     yield bc1
 
-    await connection.close()
+    await db_wrapper.close()
     bc1.shut_down()
     db_path.unlink()
 

--- a/tests/core/full_node/ram_db.py
+++ b/tests/core/full_node/ram_db.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 from pathlib import Path
 
+import random
 import aiosqlite
 
 from chia.consensus.blockchain import Blockchain
@@ -8,14 +9,16 @@ from chia.consensus.constants import ConsensusConstants
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 
 
-async def create_ram_blockchain(consensus_constants: ConsensusConstants) -> Tuple[aiosqlite.Connection, Blockchain]:
-    connection = await aiosqlite.connect(":memory:")
-    db_wrapper = DBWrapper(connection)
+async def create_ram_blockchain(consensus_constants: ConsensusConstants) -> Tuple[DBWrapper2, Blockchain]:
+    uri = f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
+    connection = await aiosqlite.connect(uri, uri=True)
+    db_wrapper = DBWrapper2(connection)
+    await db_wrapper.add_connection(await aiosqlite.connect(uri, uri=True))
     block_store = await BlockStore.create(db_wrapper)
     coin_store = await CoinStore.create(db_wrapper)
     hint_store = await HintStore.create(db_wrapper)
     blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, hint_store, Path("."), 2)
-    return connection, blockchain
+    return db_wrapper, blockchain

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -49,18 +49,18 @@ log = logging.getLogger(__name__)
 
 @pytest_asyncio.fixture(scope="function", params=[1, 2])
 async def empty_blockchain(request):
-    bc1, connection, db_path = await create_blockchain(test_constants, request.param)
+    bc1, db_wrapper, db_path = await create_blockchain(test_constants, request.param)
     yield bc1
-    await connection.close()
+    await db_wrapper.close()
     bc1.shut_down()
     db_path.unlink()
 
 
 @pytest_asyncio.fixture(scope="function", params=[1, 2])
 async def empty_blockchain_with_original_constants(request):
-    bc1, connection, db_path = await create_blockchain(test_constants_original, request.param)
+    bc1, db_wrapper, db_path = await create_blockchain(test_constants_original, request.param)
     yield bc1
-    await connection.close()
+    await db_wrapper.close()
     bc1.shut_down()
     db_path.unlink()
 

--- a/tests/core/full_node/stores/test_hint_store.py
+++ b/tests/core/full_node/stores/test_hint_store.py
@@ -31,7 +31,6 @@ class TestHintStore:
 
             hints = [(coin_id_0, hint_0), (coin_id_1, hint_0), (coin_id_2, hint_1)]
             await hint_store.add_hints(hints)
-            await db_wrapper.commit_transaction()
             coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
 
             assert coin_id_0 in coins_for_hint_0
@@ -54,7 +53,6 @@ class TestHintStore:
 
             hints = [(coin_id_0, hint_0), (coin_id_0, hint_1)]
             await hint_store.add_hints(hints)
-            await db_wrapper.commit_transaction()
             coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
             assert coin_id_0 in coins_for_hint_0
 
@@ -73,7 +71,6 @@ class TestHintStore:
 
             hints = [(coin_id_0, hint_0), (coin_id_1, hint_0)]
             await hint_store.add_hints(hints)
-            await db_wrapper.commit_transaction()
             coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
             assert coin_id_0 in coins_for_hint_0
             assert coin_id_1 in coins_for_hint_0
@@ -91,12 +88,12 @@ class TestHintStore:
             for i in range(0, 2):
                 hints = [(coin_id_0, hint_0), (coin_id_0, hint_0)]
                 await hint_store.add_hints(hints)
-                await db_wrapper.commit_transaction()
             coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
             assert coin_id_0 in coins_for_hint_0
 
-            cursor = await db_wrapper.db.execute("SELECT COUNT(*) FROM hints")
-            rows = await cursor.fetchall()
+            async with db_wrapper.read_db() as conn:
+                cursor = await conn.execute("SELECT COUNT(*) FROM hints")
+                rows = await cursor.fetchall()
 
             if db_wrapper.db_version == 2:
                 # even though we inserted the pair multiple times, there's only one
@@ -160,7 +157,6 @@ class TestHintStore:
             coin_id_1 = 32 * b"\5"
             hints = [(coin_id_0, hint_0), (coin_id_1, hint_1)]
             await hint_store.add_hints(hints)
-            await db_wrapper.commit_transaction()
 
             count = await hint_store.count_hints()
             assert count == 2

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -73,7 +73,7 @@ async def check_spend_bundle_validity(
     `SpendBundle`, and then invokes `receive_block` to ensure that it's accepted (if `expected_err=None`)
     or fails with the correct error code.
     """
-    connection, blockchain = await create_ram_blockchain(constants)
+    db_wrapper, blockchain = await create_ram_blockchain(constants)
     try:
         for block in blocks:
             await _validate_and_add_block(blockchain, block)
@@ -98,8 +98,8 @@ async def check_spend_bundle_validity(
         return coins_added, coins_removed
 
     finally:
-        # if we don't close the connection, the test process doesn't exit cleanly
-        await connection.close()
+        # if we don't close the db_wrapper, the test process doesn't exit cleanly
+        await db_wrapper.close()
 
         # we must call `shut_down` or the executor in `Blockchain` doesn't stop
         blockchain.shut_down()

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -10,7 +10,7 @@ from tests.util.temp_file import TempFile
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32, uint64
 from chia.cmds.db_upgrade_func import convert_v1_to_v2
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
@@ -54,13 +54,13 @@ class TestDbUpgrade:
 
         with TempFile() as in_file, TempFile() as out_file:
 
-            async with aiosqlite.connect(in_file) as conn:
+            conn = await aiosqlite.connect(in_file)
+            await conn.execute("pragma journal_mode=OFF")
+            await conn.execute("pragma synchronous=OFF")
 
-                await conn.execute("pragma journal_mode=OFF")
-                await conn.execute("pragma synchronous=OFF")
-                await conn.execute("pragma locking_mode=exclusive")
-
-                db_wrapper1 = DBWrapper(conn, 1)
+            db_wrapper1 = DBWrapper2(conn, 1)
+            await db_wrapper1.add_connection(await aiosqlite.connect(in_file))
+            try:
                 block_store1 = await BlockStore.create(db_wrapper1)
                 coin_store1 = await CoinStore.create(db_wrapper1, uint32(0))
                 if with_hints:
@@ -73,20 +73,27 @@ class TestDbUpgrade:
                 bc = await Blockchain.create(
                     coin_store1, block_store1, test_constants, hint_store1, Path("."), reserved_cores=0
                 )
-                await db_wrapper1.commit_transaction()
 
                 for block in blocks:
                     # await _validate_and_add_block(bc, block)
                     results = PreValidationResult(None, uint64(1), None, False)
                     result, err, _, _ = await bc.receive_block(block, results)
                     assert err is None
+            finally:
+                await db_wrapper1.close()
 
             # now, convert v1 in_file to v2 out_file
             convert_v1_to_v2(in_file, out_file)
 
-            async with aiosqlite.connect(in_file) as conn, aiosqlite.connect(out_file) as conn2:
+            conn = await aiosqlite.connect(in_file)
+            db_wrapper1 = DBWrapper2(conn, 1)
+            await db_wrapper1.add_connection(await aiosqlite.connect(in_file))
 
-                db_wrapper1 = DBWrapper(conn, 1)
+            conn2 = await aiosqlite.connect(out_file)
+            db_wrapper2 = DBWrapper2(conn2, 2)
+            await db_wrapper2.add_connection(await aiosqlite.connect(out_file))
+
+            try:
                 block_store1 = await BlockStore.create(db_wrapper1)
                 coin_store1 = await CoinStore.create(db_wrapper1, uint32(0))
                 if with_hints:
@@ -94,7 +101,6 @@ class TestDbUpgrade:
                 else:
                     hint_store1 = None
 
-                db_wrapper2 = DBWrapper(conn2, 2)
                 block_store2 = await BlockStore.create(db_wrapper2)
                 coin_store2 = await CoinStore.create(db_wrapper2, uint32(0))
                 hint_store2 = await HintStore.create(db_wrapper2)
@@ -133,3 +139,6 @@ class TestDbUpgrade:
                     for c in coins:
                         n = c.coin.name()
                         assert await coin_store1.get_coin_record(n) == await coin_store2.get_coin_record(n)
+            finally:
+                await db_wrapper1.close()
+                await db_wrapper2.close()

--- a/tests/core/test_db_validation.py
+++ b/tests/core/test_db_validation.py
@@ -16,7 +16,7 @@ from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
 from tests.setup_nodes import test_constants
 from tests.util.temp_file import TempFile
@@ -129,29 +129,27 @@ def test_db_validate_in_main_chain(invalid_in_chain: bool) -> None:
 
 
 async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
-    async with aiosqlite.connect(db_file) as conn:
+    db_wrapper = DBWrapper2(await aiosqlite.connect(db_file), 2)
+    try:
+        await db_wrapper.add_connection(await aiosqlite.connect(db_file))
 
-        await conn.execute("pragma journal_mode=OFF")
-        await conn.execute("pragma synchronous=OFF")
-        await conn.execute("pragma locking_mode=exclusive")
+        async with db_wrapper.write_db() as conn:
+            # this is done by chia init normally
+            await conn.execute("CREATE TABLE database_version(version int)")
+            await conn.execute("INSERT INTO database_version VALUES (2)")
 
-        # this is done by chia init normally
-        await conn.execute("CREATE TABLE database_version(version int)")
-        await conn.execute("INSERT INTO database_version VALUES (2)")
-        await conn.commit()
-
-        db_wrapper = DBWrapper(conn, 2)
         block_store = await BlockStore.create(db_wrapper)
         coin_store = await CoinStore.create(db_wrapper, uint32(0))
         hint_store = await HintStore.create(db_wrapper)
 
         bc = await Blockchain.create(coin_store, block_store, test_constants, hint_store, Path("."), reserved_cores=0)
-        await db_wrapper.commit_transaction()
 
         for block in blocks:
             results = PreValidationResult(None, uint64(1), None, False)
             result, err, _, _ = await bc.receive_block(block, results)
             assert err is None
+    finally:
+        await db_wrapper.close()
 
 
 @pytest.mark.asyncio

--- a/tests/core/util/test_db_wrapper.py
+++ b/tests/core/util/test_db_wrapper.py
@@ -102,25 +102,29 @@ async def test_writers_nests() -> None:
 
 @pytest.mark.asyncio
 async def test_partial_failure() -> None:
+    values = []
     async with DBConnection(2) as db_wrapper:
         await setup_table(db_wrapper)
         async with db_wrapper.write_db() as conn1:
             await conn1.execute("UPDATE counter SET value = 42")
             async with conn1.execute("SELECT value FROM counter") as cursor:
-                assert await get_value(cursor) == 42
+                values.append(await get_value(cursor))
             try:
                 async with db_wrapper.write_db() as conn2:
                     await conn2.execute("UPDATE counter SET value = 1337")
                     async with conn1.execute("SELECT value FROM counter") as cursor:
-                        assert await get_value(cursor) == 1337
+                        values.append(await get_value(cursor))
+                    # this simulates a failure, which will cause a rollback of the
+                    # write we just made, back to 42
                     raise RuntimeError("failure within a sub-transaction")
-            except BaseException:
-                pass
+            except RuntimeError:
+                # we expect to get here
+                values.append(1)
             async with conn1.execute("SELECT value FROM counter") as cursor:
-                value = await get_value(cursor)
+                values.append(await get_value(cursor))
 
     # the write of 1337 failed, and was restored to 42
-    assert value == 42
+    assert values == [42, 1337, 1, 42]
 
 
 @pytest.mark.asyncio

--- a/tests/core/util/test_db_wrapper.py
+++ b/tests/core/util/test_db_wrapper.py
@@ -1,0 +1,221 @@
+import asyncio
+import contextlib
+from typing import List
+
+import aiosqlite
+import pytest
+
+from chia.util.db_wrapper import DBWrapper2
+from tests.util.db_connection import DBConnection
+
+
+async def increment_counter(db_wrapper: DBWrapper2) -> None:
+    async with db_wrapper.write_db() as connection:
+        async with connection.execute("SELECT value FROM counter") as cursor:
+            row = await cursor.fetchone()
+
+        assert row is not None
+        [old_value] = row
+
+        await asyncio.sleep(0)
+
+        new_value = old_value + 1
+        await connection.execute("UPDATE counter SET value = :value", {"value": new_value})
+
+
+async def sum_counter(db_wrapper: DBWrapper2, output: List[int]) -> None:
+    async with db_wrapper.read_db() as connection:
+        async with connection.execute("SELECT value FROM counter") as cursor:
+            row = await cursor.fetchone()
+
+        assert row is not None
+        [value] = row
+
+        for i in range(5):
+            await asyncio.sleep(0)
+        output.append(value)
+
+
+async def setup_table(db: DBWrapper2) -> None:
+    async with db.write_db() as conn:
+        await conn.execute("CREATE TABLE counter(value INTEGER NOT NULL)")
+        await conn.execute("INSERT INTO counter(value) VALUES(0)")
+
+
+async def get_value(cursor: aiosqlite.Cursor) -> int:
+    row = await cursor.fetchone()
+    assert row
+    return int(row[0])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    argnames="acquire_outside",
+    argvalues=[pytest.param(False, id="not acquired outside"), pytest.param(True, id="acquired outside")],
+)
+async def test_concurrent_writers(acquire_outside: bool) -> None:
+
+    async with DBConnection(2) as db_wrapper:
+        await setup_table(db_wrapper)
+
+        concurrent_task_count = 200
+
+        async with contextlib.AsyncExitStack() as exit_stack:
+            if acquire_outside:
+                await exit_stack.enter_async_context(db_wrapper.write_db())
+
+            tasks = []
+            for index in range(concurrent_task_count):
+                task = asyncio.create_task(increment_counter(db_wrapper))
+                tasks.append(task)
+
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=None)
+
+        async with db_wrapper.read_db() as connection:
+            async with connection.execute("SELECT value FROM counter") as cursor:
+                row = await cursor.fetchone()
+
+            assert row is not None
+            [value] = row
+
+    assert value == concurrent_task_count
+
+
+@pytest.mark.asyncio
+async def test_writers_nests() -> None:
+    async with DBConnection(2) as db_wrapper:
+        await setup_table(db_wrapper)
+        async with db_wrapper.write_db() as conn1:
+            async with conn1.execute("SELECT value FROM counter") as cursor:
+                value = await get_value(cursor)
+            async with db_wrapper.write_db() as conn2:
+                assert conn1 == conn2
+                value += 1
+                await conn2.execute("UPDATE counter SET value = :value", {"value": value})
+                async with db_wrapper.write_db() as conn3:
+                    assert conn1 == conn3
+                    async with conn3.execute("SELECT value FROM counter") as cursor:
+                        value = await get_value(cursor)
+
+    assert value == 1
+
+
+@pytest.mark.asyncio
+async def test_partial_failure() -> None:
+    async with DBConnection(2) as db_wrapper:
+        await setup_table(db_wrapper)
+        async with db_wrapper.write_db() as conn1:
+            await conn1.execute("UPDATE counter SET value = 42")
+            async with conn1.execute("SELECT value FROM counter") as cursor:
+                assert await get_value(cursor) == 42
+            try:
+                async with db_wrapper.write_db() as conn2:
+                    await conn2.execute("UPDATE counter SET value = 1337")
+                    async with conn1.execute("SELECT value FROM counter") as cursor:
+                        assert await get_value(cursor) == 1337
+                    raise RuntimeError("failure within a sub-transaction")
+            except BaseException:
+                pass
+            async with conn1.execute("SELECT value FROM counter") as cursor:
+                value = await get_value(cursor)
+
+    # the write of 1337 failed, and was restored to 42
+    assert value == 42
+
+
+@pytest.mark.asyncio
+async def test_readers_nests() -> None:
+    async with DBConnection(2) as db_wrapper:
+        await setup_table(db_wrapper)
+
+        async with db_wrapper.read_db() as conn1:
+            async with db_wrapper.read_db() as conn2:
+                assert conn1 == conn2
+                async with db_wrapper.read_db() as conn3:
+                    assert conn1 == conn3
+                    async with conn3.execute("SELECT value FROM counter") as cursor:
+                        value = await get_value(cursor)
+
+    assert value == 0
+
+
+@pytest.mark.asyncio
+async def test_readers_nests_writer() -> None:
+    async with DBConnection(2) as db_wrapper:
+        await setup_table(db_wrapper)
+
+        async with db_wrapper.write_db() as conn1:
+            async with db_wrapper.read_db() as conn2:
+                assert conn1 == conn2
+                async with db_wrapper.write_db() as conn3:
+                    assert conn1 == conn3
+                    async with conn3.execute("SELECT value FROM counter") as cursor:
+                        value = await get_value(cursor)
+
+    assert value == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    argnames="acquire_outside",
+    argvalues=[pytest.param(False, id="not acquired outside"), pytest.param(True, id="acquired outside")],
+)
+async def test_concurrent_readers(acquire_outside: bool) -> None:
+
+    async with DBConnection(2) as db_wrapper:
+        await setup_table(db_wrapper)
+
+        async with db_wrapper.write_db() as connection:
+            await connection.execute("UPDATE counter SET value = 1")
+
+        concurrent_task_count = 200
+
+        async with contextlib.AsyncExitStack() as exit_stack:
+            if acquire_outside:
+                await exit_stack.enter_async_context(db_wrapper.read_db())
+
+            tasks = []
+            values: List[int] = []
+            for index in range(concurrent_task_count):
+                task = asyncio.create_task(sum_counter(db_wrapper, values))
+                tasks.append(task)
+
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=None)
+
+    assert values == [1] * concurrent_task_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    argnames="acquire_outside",
+    argvalues=[pytest.param(False, id="not acquired outside"), pytest.param(True, id="acquired outside")],
+)
+async def test_mixed_readers_writers(acquire_outside: bool) -> None:
+
+    async with DBConnection(2) as db_wrapper:
+        await setup_table(db_wrapper)
+
+        async with db_wrapper.write_db() as connection:
+            await connection.execute("UPDATE counter SET value = 1")
+
+        concurrent_task_count = 200
+
+        async with contextlib.AsyncExitStack() as exit_stack:
+            if acquire_outside:
+                await exit_stack.enter_async_context(db_wrapper.read_db())
+
+            tasks = []
+            values: List[int] = []
+            for index in range(concurrent_task_count):
+                if index == 100:
+                    task = asyncio.create_task(increment_counter(db_wrapper))
+                task = asyncio.create_task(sum_counter(db_wrapper, values))
+                tasks.append(task)
+
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=None)
+
+    # at some unspecified place between the first and the last reads, the value
+    # was updated from 1 to 2
+    assert values[0] == 1
+    assert values[-1] == 2
+    assert len(values) == concurrent_task_count

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -12,7 +12,7 @@ from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
 from chia.types.full_block import FullBlock
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.path import mkdir
 from tests.block_tools import BlockTools
@@ -24,13 +24,15 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int):
     if db_path.exists():
         db_path.unlink()
     connection = await aiosqlite.connect(db_path)
-    wrapper = DBWrapper(connection, db_version)
+    wrapper = DBWrapper2(connection, db_version)
+    await wrapper.add_connection(await aiosqlite.connect(db_path))
+
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
     hint_store = await HintStore.create(wrapper)
     bc1 = await Blockchain.create(coin_store, store, constants, hint_store, Path("."), 2)
     assert bc1.get_peak() is None
-    return bc1, connection, db_path
+    return bc1, wrapper, db_path
 
 
 def persistent_blocks(

--- a/tests/util/db_connection.py
+++ b/tests/util/db_connection.py
@@ -1,20 +1,36 @@
 from pathlib import Path
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 import tempfile
 import aiosqlite
+from datetime import datetime
+import sys
+
+
+async def log_conn(c: aiosqlite.Connection, name: str) -> aiosqlite.Connection:
+    def sql_trace_callback(req: str):
+        timestamp = datetime.now().strftime("%H:%M:%S.%f")
+        sys.stdout.write(timestamp + " " + name + " " + req + "\n")
+
+    # uncomment this to debug sqlite interactions
+    # await c.set_trace_callback(sql_trace_callback)
+    return c
 
 
 class DBConnection:
-    def __init__(self, db_version):
+    def __init__(self, db_version: int) -> None:
         self.db_version = db_version
 
-    async def __aenter__(self) -> DBWrapper:
+    async def __aenter__(self) -> DBWrapper2:
         self.db_path = Path(tempfile.NamedTemporaryFile().name)
         if self.db_path.exists():
             self.db_path.unlink()
-        self.connection = await aiosqlite.connect(self.db_path)
-        return DBWrapper(self.connection, self.db_version)
+        connection = await aiosqlite.connect(self.db_path)
+        self._db_wrapper = DBWrapper2(await log_conn(connection, "writer"), self.db_version)
 
-    async def __aexit__(self, exc_t, exc_v, exc_tb):
-        await self.connection.close()
+        for i in range(4):
+            await self._db_wrapper.add_connection(await log_conn(await aiosqlite.connect(self.db_path), f"reader-{i}"))
+        return self._db_wrapper
+
+    async def __aexit__(self, exc_t, exc_v, exc_tb) -> None:
+        await self._db_wrapper.close()
         self.db_path.unlink()


### PR DESCRIPTION
This is derived from work @altendky did, which initially was looking into each task using its own database connection.

This is primarily intended to be a correctness fix. This ensures that only one task at a time is *writing* to the database. Currently, we only acquire the database mutex in some situations, not consistently. This means that one task may have initiated a transaction, while another task is may insert unrelated writes into the transaction (when switched to). Additionally, any other task may insert *reads* into the transactions. This patch also ensures that reads are done independently, and outside of transactions.

In addition to there may be a performance improvements by allowing multiple readers to access the database concurrently. Specifically, lookups like `chia wallet show` or `chia farmer summary` no longer should need to wait for the database mutex to return.

With this patch, all writes are serialized with a mutex, and enforced by protecting the `aiosqlite.Connection` object. It can only be acquired via an API that also:

1. acquires the write mutex
2. initiates a transaction
3. roll backs the transaction on failure
4. commits the transaction when done

It would be possible to support *concurrent* writers, but it would be quite an undertaking. In that case, each write must support failing and retrying. This patch takes a smaller step by implementing:

1. Controlled access to a pool of `Connection` objects.
2. You can only write using the `DBWrapper` context manager, which automatically acquires the write-mutex, starts and commits a transaction (*)
3. You can read using a different context manager, giving you a read-only `Connection` object (attempting to write is an error) and multiple tasks can read concurrently.
4. The nesting behavior is carefully considered. If a task is requesting to read, but already holds the write mutex (and is the current writer) it gets the writer `Connection`, otherwise it wouldn't read uncommitted changes. A task that already has a reader `Connection` assigned to it, will get that same object when requesting to read.

(\*) the fine-print on the transactions is that they technically are sqlite "savepoints", which are like transactions except you're allowed to nest them. Only the outer-most transaction will actually commit, but nested transactions can fail and roll back individually.

# scope

The new class is called `DBWrapper2` to limit the scope of the patch. The wallet also uses `DBWrapper` so I'm hoping to keep this to the full-node only (for now).

# thread pool

Keep in mind that an `aiosqlite.Connection` object is a *thread* that calls the blocking sqlite functions. Therefore, it would be quite expensive to spawn a thread for *every* task (we create tasks for every network request). This patch effectively implements a thread pool of 4 reader threads and 1 writer thread. It would probably make sense to make the number of reader threads configurable. I have not attempted to tune the thread pool size, 4 just seemed like a reasonable number.

# review

The main change is the interface to `DBWrapper` (called `DBWrapper2`), all other changes are consequences of it. It might be easiest to start with understanding the new API. [Here](https://github.com/Chia-Network/chia-blockchain/pull/10166/files?diff=split&w=1#diff-70ec43bc92826e3bab2e1ae6a4c59a21d96a369430ea600f94c903568d47841dR37).

Given that there's now a context manager to access the database, there's a lot of indentation changes. It should be [reviewed ignoring white space](https://github.com/Chia-Network/chia-blockchain/pull/10166/files?diff=split&w=1). 