### PR TITLE
Improve SQL performance by using arraysize

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -326,9 +326,12 @@ class CoinStore:
             puzzle_hashes_db + (start_height, end_height),
         ) as cursor:
 
-            for row in await cursor.fetchall():
-                coins.add(self.row_to_coin_state(row))
-
+            while True:
+                rows = await cursor.fetchmany(10)
+                if not rows:
+                    break
+                for row in rows:
+                    coins.add(self.row_to_coin_state(row))
             return list(coins)
 
     async def get_coin_records_by_parent_ids(


### PR DESCRIPTION
This PR replaces fetchall by fetchmany using an arraysize of 10.

The function `get_coin_states_by_puzzle_hashes` was just chosen as example, this replacement should imo be done for every use of fetchall.

The arraysize of 10 is also just an arbitrary number and to get the most out of it, the actual number can/should depend on things like count of rows commonly fetched by a function and available memory. Arraysize basically means the number of rows you want to fetch at once.

In general, using fetchall is equal to fetchmany(1), so you are fetching row after row, having a rather big processing overhead. In classic client/server architecture also a massive network roundtrip overhead would be added, but this is of course no problem here.

I tried to show the benefit using your benchmark tools, but I think they aren't really using functions which select multiple rows, because they showed no improvement at all. 

So I wrote a very simple python script, which just selects rows from coin_record table.
(replace the arraysize of 10 with 1, 2 and so on, so you can see the improvement)

 ```
import aiosqlite
import asyncio
from time import time

async def test():
    try:
        async with aiosqlite.connect('/home/chia/.chia/mainnet/db/blockchain_v1_mainnet.sqlite') as db:
            async with db.execute('select coin_name, confirmed_index, amount from coin_record where confirmed_index between 750000 and 770000') as cursor:
                start_time = time()
                count = 0
                while True:
                    rows = await cursor.fetchmany(10)
#                    rows = await cursor.fetchall()
                    if not rows:
                        break
                    for row in rows:
                        count += 1
                        if (count % 100000) == 0:
                            print(f"\r{count} rows processed")
                end_time = time()
                print(f"Time for overall: {end_time - start_time:.2f} seconds")
    except:
        print(f"error")
    return True

asyncio.run(test())
```

Runtimes for this example on my plotter HW:
arraysize 1:  `Time for overall: 102.18 seconds`
arraysize 2:  `Time for overall: 53.06 seconds`
arraysize 10: `Time for overall: 18.71 seconds`
