### PR TITLE
farmer: Move some member instantiations into `Farmer.__init__`

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -128,6 +128,17 @@ class Farmer:
         self.started = False
         self.harvester_handshake_task: Optional[asyncio.Task] = None
 
+        # From p2_singleton_puzzle_hash to pool state dict
+        self.pool_state: Dict[bytes32, Dict] = {}
+
+        # From p2_singleton to auth PrivateKey
+        self.authentication_keys: Dict[bytes32, PrivateKey] = {}
+
+        # Last time we updated pool_state based on the config file
+        self.last_config_access_time: uint64 = uint64(0)
+
+        self.harvester_cache: Dict[str, Dict[str, HarvesterCacheEntry]] = {}
+
     async def ensure_keychain_proxy(self) -> KeychainProxy:
         if not self.keychain_proxy:
             if self.local_keychain:
@@ -171,19 +182,6 @@ class Farmer:
         if len(self.pool_sks_map) == 0:
             log.warning(no_keys_error_str)
             return False
-
-        # The variables below are for use with an actual pool
-
-        # From p2_singleton_puzzle_hash to pool state dict
-        self.pool_state: Dict[bytes32, Dict] = {}
-
-        # From p2_singleton to auth PrivateKey
-        self.authentication_keys: Dict[bytes32, PrivateKey] = {}
-
-        # Last time we updated pool_state based on the config file
-        self.last_config_access_time: uint64 = uint64(0)
-
-        self.harvester_cache: Dict[str, Dict[str, HarvesterCacheEntry]] = {}
 
         return True
 


### PR DESCRIPTION
This fixes logs like below appearing if the GUI accesses the farmer RPC while no keys are loaded:

```
2022-02-10T07:50:47.445 farmer chia.rpc.rpc_server        : WARNING  Error while handling message: Traceback (most recent call last):
  File "chia/rpc/rpc_server.py", line 215, in safe_handle
  File "chia/rpc/rpc_server.py", line 206, in ws_api
  File "chia/rpc/farmer_rpc_api.py", line 126, in get_harvesters
  File "chia/farmer/farmer.py", line 705, in get_harvesters
  File "chia/farmer/farmer.py", line 691, in get_cached_harvesters
AttributeError: 'Farmer' object has no attribute 'harvester_cache'
```