### PR TITLE
farmer: Wait until `xch_target_address` is in the config in `setup_keys`

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -153,6 +153,10 @@ class Farmer:
             log.warning(no_keys_error_str)
             return False
 
+        if "xch_target_address" not in self.config or "xch_target_address" not in self.pool_config:
+            log.debug("xch_target_address missing in the config")
+            return False
+
         # This is the farmer configuration
         self.farmer_target_encoded = self.config["xch_target_address"]
         self.farmer_target = decode_puzzle_hash(self.farmer_target_encoded)

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -153,6 +153,11 @@ class Farmer:
             log.warning(no_keys_error_str)
             return False
 
+        config = load_config(self._root_path, "config.yaml")
+        if "xch_target_address" not in self.config:
+            self.config = config["farmer"]
+        if "xch_target_address" not in self.pool_config:
+            self.pool_config = config["pool"]
         if "xch_target_address" not in self.config or "xch_target_address" not in self.pool_config:
             log.debug("xch_target_address missing in the config")
             return False


### PR DESCRIPTION
Fixes startup errors like 

```
2022-02-10T22:28:31.940 farmer chia.farmer.farmer         : WARNING  No keys exist. Please run 'chia keys generate' or open the UI.
2022-02-10T22:28:33.084 farmer asyncio                    : ERROR    Task exception was never retrieved
future: <Task finished name='Task-2' coro=<Farmer._start.<locals>.start_task() done, defined at /Users/me/GIT/chia-blockchain/chia/farmer/farmer.py:189> exception=KeyError('xch_target_address')>
Traceback (most recent call last):
  File "/Users/me/GIT/chia-blockchain/chia/farmer/farmer.py", line 193, in start_task
    if await self.setup_keys():
  File "/Users/me/GIT/chia-blockchain/chia/farmer/farmer.py", line 168, in setup_keys
    self.farmer_target_encoded = self.config["xch_target_address"]
KeyError: 'xch_target_address'
```