### PR TITLE
::1

### DIFF
--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -9,6 +9,7 @@ import websockets
 
 from chia.util.config import load_config
 from chia.util.json_util import dict_to_json_str
+from chia.util.network import Url
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
 
 
@@ -129,7 +130,8 @@ async def connect_to_daemon(self_hostname: str, daemon_port: int, ssl_context: O
     Connect to the local daemon.
     """
 
-    client = DaemonProxy(f"wss://[{self_hostname}]:{daemon_port}", ssl_context)
+    url = Url.create(scheme="wss", host=self_hostname, port=daemon_port)
+    client = DaemonProxy(url.for_connections(), ssl_context)
     await client.start()
     return client
 

--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -129,7 +129,7 @@ async def connect_to_daemon(self_hostname: str, daemon_port: int, ssl_context: O
     Connect to the local daemon.
     """
 
-    client = DaemonProxy(f"wss://{self_hostname}:{daemon_port}", ssl_context)
+    client = DaemonProxy(f"wss://[{self_hostname}]:{daemon_port}", ssl_context)
     await client.start()
     return client
 

--- a/chia/daemon/keychain_proxy.py
+++ b/chia/daemon/keychain_proxy.py
@@ -19,6 +19,7 @@ from chia.util.keychain import (
     mnemonic_to_seed,
     supports_keyring_passphrase,
 )
+from chia.util.network import Url
 from chia.util.ws_message import WsRpcMessage
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -310,8 +311,9 @@ async def connect_to_keychain(
     Connect to the local daemon.
     """
 
+    url = Url.create(scheme="wss", host=self_hostname, port=daemon_port)
     client = KeychainProxy(
-        uri=f"wss://[{self_hostname}]:{daemon_port}", ssl_context=ssl_context, log=log, user=user, service=service
+        uri=url.for_connections(), ssl_context=ssl_context, log=log, user=user, service=service
     )
     # Connect to the service if the proxy isn't using a local keychain
     if not client.use_local_keychain():

--- a/chia/daemon/keychain_proxy.py
+++ b/chia/daemon/keychain_proxy.py
@@ -311,7 +311,7 @@ async def connect_to_keychain(
     """
 
     client = KeychainProxy(
-        uri=f"wss://{self_hostname}:{daemon_port}", ssl_context=ssl_context, log=log, user=user, service=service
+        uri=f"wss://[{self_hostname}]:{daemon_port}", ssl_context=ssl_context, log=log, user=user, service=service
     )
     # Connect to the service if the proxy isn't using a local keychain
     if not client.use_local_keychain():

--- a/chia/daemon/keychain_proxy.py
+++ b/chia/daemon/keychain_proxy.py
@@ -312,9 +312,7 @@ async def connect_to_keychain(
     """
 
     url = Url.create(scheme="wss", host=self_hostname, port=daemon_port)
-    client = KeychainProxy(
-        uri=url.for_connections(), ssl_context=ssl_context, log=log, user=user, service=service
-    )
+    client = KeychainProxy(uri=url.for_connections(), ssl_context=ssl_context, log=log, user=user, service=service)
     # Connect to the service if the proxy isn't using a local keychain
     if not client.use_local_keychain():
         await client.start()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -66,6 +66,7 @@ from chia.util.config import PEER_DB_PATH_KEY_DEPRECATED
 from chia.util.db_wrapper import DBWrapper
 from chia.util.errors import ConsensusError, Err, ValidationError
 from chia.util.ints import uint8, uint32, uint64, uint128
+from chia.util.network import get_host_addr
 from chia.util.path import mkdir, path_from_root
 from chia.util.safe_cancel_task import cancel_task_safe
 from chia.util.profiler import profile_task
@@ -304,6 +305,13 @@ class FullNode:
             # If `dns_servers` misses from the `config`, hardcode it if we're running mainnet.
             dns_servers.append("dns-introducer.chia.net")
         try:
+            introducer_peer = {
+                "host": get_host_addr(
+                    host=self.config["introducer_peer"]["host"],
+                    prefer_ipv6=self.config["prefer_ipv6"],
+                ),
+                "port": self.config["introducer_peer"]["port"],
+            }
             self.full_node_peers = FullNodePeers(
                 self.server,
                 self.config["target_peer_count"] - self.config["target_outbound_peer_count"],
@@ -316,7 +324,7 @@ class FullNode:
                     legacy_peer_db_path_key=PEER_DB_PATH_KEY_DEPRECATED,
                     default_peers_file_path="db/peers.dat",
                 ),
-                self.config["introducer_peer"],
+                introducer_peer,
                 dns_servers,
                 self.config["peer_connect_interval"],
                 self.config["selected_network"],

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -305,13 +305,16 @@ class FullNode:
             # If `dns_servers` misses from the `config`, hardcode it if we're running mainnet.
             dns_servers.append("dns-introducer.chia.net")
         try:
-            introducer_peer = {
-                "host": get_host_addr(
-                    host=self.config["introducer_peer"]["host"],
-                    prefer_ipv6=self.config["prefer_ipv6"],
-                ),
-                "port": self.config["introducer_peer"]["port"],
-            }
+            if self.config["introducer_peer"] is None:
+                introducer_peer = None
+            else:
+                introducer_peer = {
+                    "host": get_host_addr(
+                        host=self.config["introducer_peer"]["host"],
+                        prefer_ipv6=self.config["prefer_ipv6"],
+                    ),
+                    "port": self.config["introducer_peer"]["port"],
+                }
             self.full_node_peers = FullNodePeers(
                 self.server,
                 self.config["target_peer_count"] - self.config["target_outbound_peer_count"],

--- a/chia/rpc/rpc_client.py
+++ b/chia/rpc/rpc_client.py
@@ -9,6 +9,7 @@ from chia.server.ssl_context import private_ssl_ca_paths
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint16
+from chia.util.network import Url
 
 
 class RpcClient:
@@ -32,7 +33,9 @@ class RpcClient:
         self = cls()
         self.hostname = self_hostname
         self.port = port
-        self.url = f"https://[{self_hostname}]:{str(port)}/"
+        url = Url.create(scheme="https", host=self_hostname, port=port)
+        # TODO: Maybe just save the Url object and check all uses?
+        self.url = url.for_connections()
         self.session = aiohttp.ClientSession()
         ca_crt_path, ca_key_path = private_ssl_ca_paths(root_path, net_config)
         crt_path = root_path / net_config["daemon_ssl"]["private_crt"]

--- a/chia/rpc/rpc_client.py
+++ b/chia/rpc/rpc_client.py
@@ -9,7 +9,7 @@ from chia.server.ssl_context import private_ssl_ca_paths
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint16
-from chia.util.network import Url
+from chia.util.network import get_host_addr, Url
 
 
 class RpcClient:
@@ -33,7 +33,8 @@ class RpcClient:
         self = cls()
         self.hostname = self_hostname
         self.port = port
-        url = Url.create(scheme="https", host=self_hostname, port=port)
+        host = get_host_addr(host=self_hostname, prefer_ipv6=net_config["prefer_ipv6"])
+        url = Url.create(scheme="https", host=host, port=port)
         # TODO: Maybe just save the Url object and check all uses?
         self.url = url.for_connections()
         self.session = aiohttp.ClientSession()

--- a/chia/rpc/rpc_client.py
+++ b/chia/rpc/rpc_client.py
@@ -32,7 +32,7 @@ class RpcClient:
         self = cls()
         self.hostname = self_hostname
         self.port = port
-        self.url = f"https://{self_hostname}:{str(port)}/"
+        self.url = f"https://[{self_hostname}]:{str(port)}/"
         self.session = aiohttp.ClientSession()
         ca_crt_path, ca_key_path = private_ssl_ca_paths(root_path, net_config)
         crt_path = root_path / net_config["daemon_ssl"]["private_crt"]

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -14,6 +14,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint16
 from chia.util.json_util import dict_to_json_str
+from chia.util.network import Url
 from chia.util.ws_message import create_payload, create_payload_dict, format_response, pong
 
 log = logging.getLogger(__name__)
@@ -267,11 +268,9 @@ class RpcServer:
                 if self.shut_down:
                     break
                 async with aiohttp.ClientSession() as session:
-                    if ":" in self_hostname and "." not in self_hostname:
-                        self_hostname = self_hostname.strip("[]")
-                    url = f"wss://[{self_hostname}]:{daemon_port}"
+                    url = Url.create(scheme="wss", host=self_hostname, port=daemon_port)
                     async with session.ws_connect(
-                        url,
+                        url.for_connections(),
                         autoclose=True,
                         autoping=True,
                         heartbeat=60,

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -310,7 +310,7 @@ async def start_rpc_server(
         daemon_connection = asyncio.create_task(rpc_server.connect_to_daemon(self_hostname, daemon_port))
     runner = aiohttp.web.AppRunner(app, access_log=None)
     await runner.setup()
-    site = aiohttp.web.TCPSite(runner, "::1", int(rpc_port), ssl_context=rpc_server.ssl_context)
+    site = aiohttp.web.TCPSite(runner, self_hostname, int(rpc_port), ssl_context=rpc_server.ssl_context)
     await site.start()
 
     async def cleanup():

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -310,7 +310,7 @@ async def start_rpc_server(
         daemon_connection = asyncio.create_task(rpc_server.connect_to_daemon(self_hostname, daemon_port))
     runner = aiohttp.web.AppRunner(app, access_log=None)
     await runner.setup()
-    site = aiohttp.web.TCPSite(runner, self_hostname, int(rpc_port), ssl_context=rpc_server.ssl_context)
+    site = aiohttp.web.TCPSite(runner, "::1", int(rpc_port), ssl_context=rpc_server.ssl_context)
     await site.start()
 
     async def cleanup():

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -270,7 +270,7 @@ class RpcServer:
                     if ":" in self_hostname and "." not in self_hostname:
                         self_hostname = f"[{self_hostname.strip('[]')}]"
                     async with session.ws_connect(
-                        f"wss://{self_hostname}:{daemon_port}",
+                        f"wss://[{self_hostname}]:{daemon_port}",
                         autoclose=True,
                         autoping=True,
                         heartbeat=60,

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -267,6 +267,8 @@ class RpcServer:
                 if self.shut_down:
                     break
                 async with aiohttp.ClientSession() as session:
+                    if ":" in self_hostname and "." not in self_hostname:
+                        self_hostname = f"[{self_hostname.strip('[]')}]"
                     async with session.ws_connect(
                         f"wss://{self_hostname}:{daemon_port}",
                         autoclose=True,

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -268,9 +268,10 @@ class RpcServer:
                     break
                 async with aiohttp.ClientSession() as session:
                     if ":" in self_hostname and "." not in self_hostname:
-                        self_hostname = f"[{self_hostname.strip('[]')}]"
+                        self_hostname = self_hostname.strip('[]')
+                    url = f"wss://[{self_hostname}]:{daemon_port}"
                     async with session.ws_connect(
-                        f"wss://[{self_hostname}]:{daemon_port}",
+                        url,
                         autoclose=True,
                         autoping=True,
                         heartbeat=60,
@@ -281,7 +282,7 @@ class RpcServer:
                         await self.connection(ws)
                     self.websocket = None
             except aiohttp.ClientConnectorError:
-                self.log.warning(f"Cannot connect to daemon at ws://{self_hostname}:{daemon_port}")
+                self.log.warning(f"Cannot connect to daemon at {url}")
             except Exception as e:
                 tb = traceback.format_exc()
                 self.log.warning(f"Exception: {tb} {type(e)}")

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -268,7 +268,7 @@ class RpcServer:
                     break
                 async with aiohttp.ClientSession() as session:
                     if ":" in self_hostname and "." not in self_hostname:
-                        self_hostname = self_hostname.strip('[]')
+                        self_hostname = self_hostname.strip("[]")
                     url = f"wss://[{self_hostname}]:{daemon_port}"
                     async with session.ws_connect(
                         url,

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -282,7 +282,7 @@ class RpcServer:
                         await self.connection(ws)
                     self.websocket = None
             except aiohttp.ClientConnectorError:
-                self.log.warning(f"Cannot connect to daemon at {url.for_user()} {self.service_name=}")
+                self.log.warning(f"Cannot connect to daemon at {url.for_user()}")
             except Exception as e:
                 tb = traceback.format_exc()
                 self.log.warning(f"Exception: {tb} {type(e)}")

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -30,7 +30,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import Err, ProtocolError
 from chia.util.ints import uint16
-from chia.util.network import is_in_network, is_localhost
+from chia.util.network import is_in_network, is_localhost, Url
 from chia.util.ssl_check import verify_ssl_certs_and_keys
 
 
@@ -421,17 +421,17 @@ class ChiaServer:
             except ValueError:
                 pass
 
-            url = f"wss://[{target_node.host}]:{target_node.port}/ws"
-            self.log.debug(f"Connecting: {url}, Peer info: {target_node}")
+            url = Url.create(scheme="wss", host=target_node.host, port=target_node.port, path="ws")
+            self.log.debug(f"Connecting: {url.for_user()}, Peer info: {target_node}")
             try:
                 ws = await session.ws_connect(
-                    url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=50 * 1024 * 1024
+                    url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=50 * 1024 * 1024
                 )
             except ServerDisconnectedError:
-                self.log.debug(f"Server disconnected error connecting to {url}. Perhaps we are banned by the peer.")
+                self.log.debug(f"Server disconnected error connecting to {url.for_user()}. Perhaps we are banned by the peer.")
                 return False
             except asyncio.TimeoutError:
-                self.log.debug(f"Timeout error connecting to {url}")
+                self.log.debug(f"Timeout error connecting to {url.for_user()}")
                 return False
             if ws is None:
                 return False

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -261,6 +261,7 @@ class ChiaServer:
 
         self.site = web.TCPSite(
             self.runner,
+            host="::1",
             port=self._port,
             shutdown_timeout=3,
             ssl_context=ssl_context,

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -100,6 +100,7 @@ def ssl_context_for_client(
 class ChiaServer:
     def __init__(
         self,
+        host: str,
         port: int,
         node: Any,
         api: Any,
@@ -129,6 +130,7 @@ class ChiaServer:
             NodeType.INTRODUCER: {},
         }
 
+        self._host = host
         self._port = port  # TCP port to identify our node
         self._local_type: NodeType = local_type
 
@@ -261,7 +263,7 @@ class ChiaServer:
 
         self.site = web.TCPSite(
             self.runner,
-            host="::1",
+            host=self._host,
             port=self._port,
             shutdown_timeout=3,
             ssl_context=ssl_context,

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -417,11 +417,11 @@ class ChiaServer:
 
             try:
                 if type(ip_address(target_node.host)) is IPv6Address:
-                    target_node = PeerInfo(f"[{target_node.host}]", target_node.port)
+                    target_node = PeerInfo(f"{target_node.host}", target_node.port)
             except ValueError:
                 pass
 
-            url = f"wss://{target_node.host}:{target_node.port}/ws"
+            url = f"wss://[{target_node.host}]:{target_node.port}/ws"
             self.log.debug(f"Connecting: {url}, Peer info: {target_node}")
             try:
                 ws = await session.ws_connect(

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -30,7 +30,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import Err, ProtocolError
 from chia.util.ints import uint16
-from chia.util.network import is_in_network, is_localhost, Url
+from chia.util.network import get_host_addr, is_in_network, is_localhost, Url
 from chia.util.ssl_check import verify_ssl_certs_and_keys
 
 
@@ -264,6 +264,7 @@ class ChiaServer:
         self.site = web.TCPSite(
             self.runner,
             host=self._host,
+            # host="::1",
             port=self._port,
             shutdown_timeout=3,
             ssl_context=ssl_context,
@@ -421,14 +422,22 @@ class ChiaServer:
             except ValueError:
                 pass
 
-            url = Url.create(scheme="wss", host=target_node.host, port=target_node.port, path="ws")
+            host = get_host_addr(host=target_node.host, prefer_ipv6=bool(self.config["prefer_ipv6"]))
+            url = Url.create(scheme="wss", host=host, port=target_node.port, path="ws")
             self.log.debug(f"Connecting: {url.for_user()}, Peer info: {target_node}")
             try:
                 ws = await session.ws_connect(
-                    url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=50 * 1024 * 1024
+                    url.for_connections(),
+                    autoclose=True,
+                    autoping=True,
+                    heartbeat=60,
+                    ssl=ssl_context,
+                    max_msg_size=50 * 1024 * 1024,
                 )
             except ServerDisconnectedError:
-                self.log.debug(f"Server disconnected error connecting to {url.for_user()}. Perhaps we are banned by the peer.")
+                self.log.debug(
+                    f"Server disconnected error connecting to {url.for_user()}. Perhaps we are banned by the peer.",
+                )
                 return False
             except asyncio.TimeoutError:
                 self.log.debug(f"Timeout error connecting to {url.for_user()}")

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -12,6 +12,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.config import load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.keychain import Keychain
+from chia.util.network import get_host_addr
 
 # See: https://bugs.python.org/issue29288
 "".encode("idna")
@@ -30,7 +31,8 @@ def service_kwargs_for_farmer(
     connect_peers = []
     fnp = config.get("full_node_peer")
     if fnp is not None:
-        connect_peers.append(PeerInfo(fnp["host"], fnp["port"]))
+        host = get_host_addr(host=fnp["host"], prefer_ipv6=config["prefer_ipv6"])
+        connect_peers.append(PeerInfo(host, fnp["port"]))
 
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)

--- a/chia/server/start_harvester.py
+++ b/chia/server/start_harvester.py
@@ -11,6 +11,7 @@ from chia.server.start_service import run_service
 from chia.types.peer_info import PeerInfo
 from chia.util.config import load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.network import get_host_addr
 
 # See: https://bugs.python.org/issue29288
 "".encode("idna")
@@ -23,7 +24,8 @@ def service_kwargs_for_harvester(
     config: Dict,
     consensus_constants: ConsensusConstants,
 ) -> Dict:
-    connect_peers = [PeerInfo(config["farmer_peer"]["host"], config["farmer_peer"]["port"])]
+    farmer_peer_host = get_host_addr(host=config["farmer_peer"]["host"], prefer_ipv6=config["prefer_ipv6"])
+    connect_peers = [PeerInfo(farmer_peer_host, config["farmer_peer"]["port"])]
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
 

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -54,7 +54,7 @@ class Service:
         self.root_path = root_path
         self.config = load_config(root_path, "config.yaml")
         ping_interval = self.config.get("ping_interval")
-        self.self_hostname = self.config.get("self_hostname")
+        self.self_hostname = self.config.get("self_hostname", "localhost")
         self.daemon_port = self.config.get("daemon_port")
         assert ping_interval is not None
         self._connect_to_daemon = connect_to_daemon

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -54,7 +54,7 @@ class Service:
         self.root_path = root_path
         self.config = load_config(root_path, "config.yaml")
         ping_interval = self.config.get("ping_interval")
-        self.self_hostname = self.config.get("self_hostname", "::1")
+        self.self_hostname = self.config["self_hostname"]
         self.daemon_port = self.config.get("daemon_port")
         assert ping_interval is not None
         self._connect_to_daemon = connect_to_daemon

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -85,6 +85,7 @@ class Service:
 
         assert inbound_rlp and outbound_rlp
         self._server = ChiaServer(
+            self.self_hostname,
             advertised_port,
             node,
             peer_api,

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -54,7 +54,7 @@ class Service:
         self.root_path = root_path
         self.config = load_config(root_path, "config.yaml")
         ping_interval = self.config.get("ping_interval")
-        self.self_hostname = self.config.get("self_hostname", "localhost")
+        self.self_hostname = self.config.get("self_hostname", "::1")
         self.daemon_port = self.config.get("daemon_port")
         assert ping_interval is not None
         self._connect_to_daemon = connect_to_daemon

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -11,6 +11,8 @@ from chia.timelord.timelord_api import TimelordAPI
 from chia.types.peer_info import PeerInfo
 from chia.util.config import load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.network import get_host_addr
+
 
 # See: https://bugs.python.org/issue29288
 "".encode("idna")
@@ -26,8 +28,8 @@ def service_kwargs_for_timelord(
     config: Dict,
     constants: ConsensusConstants,
 ) -> Dict:
-
-    connect_peers = [PeerInfo(config["full_node_peer"]["host"], config["full_node_peer"]["port"])]
+    full_node_peer_host = get_host_addr(host=config["full_node_peer"]["host"], prefer_ipv6=config["prefer_ipv6"])
+    connect_peers = [PeerInfo(full_node_peer_host, config["full_node_peer"]["port"])]
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
     updated_constants = constants.replace_str_to_bytes(**overrides)
 

--- a/chia/simulator/start_simulator.py
+++ b/chia/simulator/start_simulator.py
@@ -60,6 +60,7 @@ def main() -> None:
         config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
         config["database_path"] = config["simulator_database_path"]
         config["peers_file_path"] = config["simulator_peers_file_path"]
+        # TODO: probably ought to change this to be ipv6 preference aware
         config["introducer_peer"]["host"] = "127.0.0.1"
         config["introducer_peer"]["port"] = 58555
         config["selected_network"] = "testnet0"

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -33,6 +33,7 @@ from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
+from chia.util.network import get_host_addr
 from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)
@@ -119,9 +120,10 @@ class Timelord:
 
     async def _start(self):
         self.lock: asyncio.Lock = asyncio.Lock()
+        host = get_host_addr(host=self.config["vdf_server"]["host"], prefer_ipv6=self.config["prefer_ipv6"])
         self.vdf_server = await asyncio.start_server(
             self._handle_client,
-            self.config["vdf_server"]["host"],
+            host,
             self.config["vdf_server"]["port"],
         )
         self.last_state: LastState = LastState(self.constants)

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -77,6 +77,7 @@ def load_config(
             "harvester",
             "introducer",
             "timelord",
+            "timelord_launcher",
             "wallet",
         }:
             final_config.setdefault("prefer_ipv6", all_config.get("prefer_ipv6", True))

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -64,10 +64,24 @@ def load_config(
         print("** please run `chia init` to migrate or create new config files **")
         # TODO: fix this hack
         sys.exit(-1)
-    r = yaml.safe_load(open(path, "r"))
-    if sub_config is not None:
-        r = r.get(sub_config)
-    return r
+    all_config = yaml.safe_load(open(path, "r"))
+    if sub_config is None:
+        final_config = all_config
+    else:
+        final_config = all_config.get(sub_config)
+        # TODO: don't do this...  probably just overlay the loaded config over the
+        #       the default config instead to handle this in general.
+        if isinstance(final_config, dict) and sub_config in {
+            "farmer",
+            "full_node",
+            "harvester",
+            "introducer",
+            "timelord",
+            "wallet",
+        }:
+            final_config.setdefault("prefer_ipv6", all_config.get("prefer_ipv6", True))
+
+    return final_config
 
 
 def load_config_cli(root_path: Path, filename: str, sub_config: Optional[str] = None) -> Dict:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -2,7 +2,7 @@ min_mainnet_k_size: 32
 
 # Send a ping to all peers after ping_interval seconds
 ping_interval: 120
-self_hostname: &self_hostname "localhost"
+self_hostname: &self_hostname "::1"
 prefer_ipv6: True
 daemon_port: 55400
 daemon_max_message_size: 50000000 # maximum size of RPC message in bytes

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -2,8 +2,8 @@ min_mainnet_k_size: 32
 
 # Send a ping to all peers after ping_interval seconds
 ping_interval: 120
-self_hostname: &self_hostname "::1"
-prefer_ipv6: True
+self_hostname: &self_hostname "localhost"
+prefer_ipv6: &prefer_ipv6 true
 daemon_port: 55400
 daemon_max_message_size: 50000000 # maximum size of RPC message in bytes
 inbound_rate_limit_percent: 100
@@ -162,6 +162,7 @@ seeder:
 harvester:
   # The harvester server (if run) will run on this port
   port: 8448
+  prefer_ipv6: *prefer_ipv6
   farmer_peer:
     host: *self_hostname
     port: 8447
@@ -210,6 +211,7 @@ pool:
 farmer:
   # The farmer server (if run) will run on this port
   port: 8447
+  prefer_ipv6: *prefer_ipv6
   # The farmer will attempt to connect to this full node and harvester
   full_node_peer:
     host: *self_hostname
@@ -252,6 +254,7 @@ timelord_launcher:
 timelord:
   # The timelord server (if run) will run on this port
   port: 8446
+  prefer_ipv6: *prefer_ipv6
   # Provides a list of VDF clients expected to connect to this timelord.
   # For each client, an IP is provided, together with the estimated iterations per second.
   vdf_clients:
@@ -305,6 +308,7 @@ timelord:
 full_node:
   # The full node server (if run) will run on this port
   port: 8444
+  prefer_ipv6: *prefer_ipv6
 
   # controls the sync-to-disk behavior of the database connection. Can be one of:
   # "on"    enables syncing to disk, minimizes risk of corrupting the DB in
@@ -435,6 +439,7 @@ ui:
 introducer:
   host: *self_hostname
   port: 8445
+  prefer_ipv6: *prefer_ipv6
   max_peers_to_send: 20
   # The introducer will only return peers it has seen in the last
   # recent_peer_threshold seconds
@@ -450,6 +455,7 @@ introducer:
 wallet:
   port: 8449
   rpc_port: 9256
+  prefer_ipv6: *prefer_ipv6
 
   enable_profiler: False
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -2,7 +2,7 @@ min_mainnet_k_size: 32
 
 # Send a ping to all peers after ping_interval seconds
 ping_interval: 120
-self_hostname: &self_hostname "::1"
+self_hostname: &self_hostname "localhost"
 prefer_ipv6: True
 daemon_port: 55400
 daemon_max_message_size: 50000000 # maximum size of RPC message in bytes

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -246,6 +246,7 @@ timelord_launcher:
   # The server where the VDF clients will connect to.
   host: *self_hostname
   port: 8000
+  prefer_ipv6: *prefer_ipv6
   # Number of VDF client processes to keep alive in the local machine.
   process_count: 3
   logging: *logging

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -2,8 +2,8 @@ min_mainnet_k_size: 32
 
 # Send a ping to all peers after ping_interval seconds
 ping_interval: 120
-self_hostname: &self_hostname "localhost"
-prefer_ipv6: False
+self_hostname: &self_hostname "::1"
+prefer_ipv6: True
 daemon_port: 55400
 daemon_max_message_size: 50000000 # maximum size of RPC message in bytes
 inbound_rate_limit_percent: 100

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -15,7 +15,7 @@ def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Netw
 
 
 def is_localhost(peer_host: str) -> bool:
-    return peer_host == "127.0.0.1" or peer_host == "localhost" or peer_host == "::1" or peer_host == "0:0:0:0:0:0:0:1"
+    return peer_host == "127.0.0.1" or peer_host == "localhost" or peer_host == "::1" or peer_host == "[::1]" or peer_host == "0:0:0:0:0:0:0:1"
 
 
 def class_for_type(type: NodeType) -> Any:

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import dataclasses
 import socket
 from ipaddress import ip_address, IPv4Address, IPv6Address, IPv4Network, IPv6Network
-from typing import Iterable, List, Literal, Tuple, Type, TypeVar, Union, Any, Optional
+from typing import Iterable, List, Tuple, Type, TypeVar, Union, Any, Optional
 from chia.server.outbound_message import NodeType
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
+
+from typing_extensions import Literal
 
 
 def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Network]]) -> bool:
@@ -84,7 +86,7 @@ def get_host_addr(host: Union[PeerInfo, str], prefer_ipv6: Optional[bool]) -> st
 
 
 _T_Url = TypeVar("_T_Url", bound="Url")
-SchemeType = Literal["wss"]
+SchemeType = Literal["https", "wss"]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -20,13 +20,7 @@ def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Netw
 
 
 def is_localhost(peer_host: str) -> bool:
-    return (
-        peer_host == "127.0.0.1"
-        or peer_host == "localhost"
-        or peer_host == "::1"
-        or peer_host == "[::1]"
-        or peer_host == "0:0:0:0:0:0:0:1"
-    )
+    return peer_host == "127.0.0.1" or peer_host == "localhost" or peer_host == "::1" or peer_host == "0:0:0:0:0:0:0:1"
 
 
 def class_for_type(type: NodeType) -> Any:
@@ -72,6 +66,15 @@ def get_host_addr(host: Union[PeerInfo, str], prefer_ipv6: Optional[bool]) -> st
         hoststr = host
         if PeerInfo(hoststr, uint16(0)).is_valid(True):
             return hoststr
+
+    if isinstance(hoststr, dict):
+        print(f" ==== {host=} {hoststr=}")
+    if hoststr.strip() == "localhost":
+        if prefer_ipv6:
+            return "::1"
+
+        return "127.0.0.1"
+
     addrset: List[
         Tuple["socket.AddressFamily", "socket.SocketKind", int, str, Union[Tuple[str, int], Tuple[str, int, int, int]]]
     ] = socket.getaddrinfo(hoststr, None)

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -67,8 +67,6 @@ def get_host_addr(host: Union[PeerInfo, str], prefer_ipv6: Optional[bool]) -> st
         if PeerInfo(hoststr, uint16(0)).is_valid(True):
             return hoststr
 
-    if isinstance(hoststr, dict):
-        print(f" ==== {host=} {hoststr=}")
     if hoststr.strip() == "localhost":
         if prefer_ipv6:
             return "::1"

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -15,7 +15,13 @@ def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Netw
 
 
 def is_localhost(peer_host: str) -> bool:
-    return peer_host == "127.0.0.1" or peer_host == "localhost" or peer_host == "::1" or peer_host == "[::1]" or peer_host == "0:0:0:0:0:0:0:1"
+    return (
+        peer_host == "127.0.0.1"
+        or peer_host == "localhost"
+        or peer_host == "::1"
+        or peer_host == "[::1]"
+        or peer_host == "0:0:0:0:0:0:0:1"
+    )
 
 
 def class_for_type(type: NodeType) -> Any:

--- a/tests/connection_utils.py
+++ b/tests/connection_utils.py
@@ -15,6 +15,7 @@ from chia.ssl.create_ssl import generate_ca_signed_cert
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
+from chia.util.network import Url
 from tests.setup_nodes import self_hostname
 from tests.time_out_assert import time_out_assert
 
@@ -45,8 +46,8 @@ async def add_dummy_connection(
     pem_cert = x509.load_pem_x509_certificate(dummy_crt_path.read_bytes(), default_backend())
     der_cert = x509.load_der_x509_certificate(pem_cert.public_bytes(serialization.Encoding.DER), default_backend())
     peer_id = bytes32(der_cert.fingerprint(hashes.SHA256()))
-    url = f"wss://[{self_hostname}]:{server._port}/ws"
-    ws = await session.ws_connect(url, autoclose=True, autoping=True, ssl=ssl_context)
+    url = Url.create(scheme="wss", host=self_hostname, port=server._port, path="/ws")
+    ws = await session.ws_connect(url=url.for_connections(), autoclose=True, autoping=True, ssl=ssl_context)
     wsc = WSChiaConnection(
         type,
         ws,

--- a/tests/connection_utils.py
+++ b/tests/connection_utils.py
@@ -45,7 +45,7 @@ async def add_dummy_connection(
     pem_cert = x509.load_pem_x509_certificate(dummy_crt_path.read_bytes(), default_backend())
     der_cert = x509.load_der_x509_certificate(pem_cert.public_bytes(serialization.Encoding.DER), default_backend())
     peer_id = bytes32(der_cert.fingerprint(hashes.SHA256()))
-    url = f"wss://{self_hostname}:{server._port}/ws"
+    url = f"wss://[{self_hostname}]:{server._port}/ws"
     ws = await session.ws_connect(url, autoclose=True, autoping=True, ssl=ssl_context)
     wsc = WSChiaConnection(
         type,

--- a/tests/connection_utils.py
+++ b/tests/connection_utils.py
@@ -15,7 +15,7 @@ from chia.ssl.create_ssl import generate_ca_signed_cert
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
-from chia.util.network import Url
+from chia.util.network import get_host_addr, Url
 from tests.setup_nodes import self_hostname
 from tests.time_out_assert import time_out_assert
 
@@ -46,7 +46,8 @@ async def add_dummy_connection(
     pem_cert = x509.load_pem_x509_certificate(dummy_crt_path.read_bytes(), default_backend())
     der_cert = x509.load_der_x509_certificate(pem_cert.public_bytes(serialization.Encoding.DER), default_backend())
     peer_id = bytes32(der_cert.fingerprint(hashes.SHA256()))
-    url = Url.create(scheme="wss", host=self_hostname, port=server._port, path="/ws")
+    host = get_host_addr(host=self_hostname, prefer_ipv6=server.config["prefer_ipv6"])
+    url = Url.create(scheme="wss", host=host, port=server._port, path="/ws")
     ws = await session.ws_connect(url=url.for_connections(), autoclose=True, autoping=True, ssl=ssl_context)
     wsc = WSChiaConnection(
         type,

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -58,7 +58,7 @@ class TestDaemon:
             yield get_b_tools
 
     @pytest.mark.asyncio
-    async def test_daemon_simulation(self, simulation, get_daemon, get_b_tools: BlockTools):
+    async def test_daemon_simulation(self, simulation, get_daemon, get_b_tools):
         node1, node2, _, _, _, _, _, _, _, _, server1 = simulation
         await server1.start_client(PeerInfo(self_hostname, uint16(21238)))
 

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -75,8 +75,6 @@ class TestDaemon:
         raw_host = get_b_tools._config["self_hostname"]
         prefer_ipv6 = get_b_tools._config["prefer_ipv6"]
         host = get_host_addr(host=raw_host, prefer_ipv6=prefer_ipv6)
-        if ":" in host and "." not in host:
-            host = f"[{host.strip('[]')}]"
         ws = await session.ws_connect(
             f"wss://[{host}]:55401",
             autoclose=True,

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -10,6 +10,7 @@ from tests.setup_nodes import setup_daemon, self_hostname, setup_full_system
 from tests.simulation.test_simulation import test_constants_modified
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.keyring import TempKeyring
+from chia.util.network import Url
 
 import asyncio
 import json
@@ -75,8 +76,9 @@ class TestDaemon:
         raw_host = get_b_tools._config["self_hostname"]
         prefer_ipv6 = get_b_tools._config["prefer_ipv6"]
         host = get_host_addr(host=raw_host, prefer_ipv6=prefer_ipv6)
+        url = Url.create(scheme="wss", host=host, port=55401)
         ws = await session.ws_connect(
-            f"wss://[{host}]:55401",
+            url=url.for_connections(),
             autoclose=True,
             autoping=True,
             heartbeat=60,
@@ -178,8 +180,9 @@ class TestDaemon:
             assert message["data"]["success"] is False
 
         async with aiohttp.ClientSession() as session:
+            url = Url.create(scheme="wss", host="::1", port=55401)
             async with session.ws_connect(
-                "wss://[::1]:55401",
+                url=url.for_connections(),
                 autoclose=True,
                 autoping=True,
                 heartbeat=60,

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -78,7 +78,7 @@ class TestDaemon:
         if ":" in host and "." not in host:
             host = f"[{host.strip('[]')}]"
         ws = await session.ws_connect(
-            f"wss://{host}:55401",
+            f"wss://[{host}]:55401",
             autoclose=True,
             autoping=True,
             heartbeat=60,

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -75,6 +75,8 @@ class TestDaemon:
         raw_host = get_b_tools._config["self_hostname"]
         prefer_ipv6 = get_b_tools._config["prefer_ipv6"]
         host = get_host_addr(host=raw_host, prefer_ipv6=prefer_ipv6)
+        if ":" in host and "." not in host:
+            host = f"[{host.strip('[]')}]"
         ws = await session.ws_connect(
             f"wss://{host}:55401",
             autoclose=True,
@@ -179,7 +181,7 @@ class TestDaemon:
 
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
-                "wss://127.0.0.1:55401",
+                "wss://[::1]:55401",
                 autoclose=True,
                 autoping=True,
                 heartbeat=60,

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -61,7 +61,8 @@ class TestDaemon:
     @pytest.mark.asyncio
     async def test_daemon_simulation(self, simulation, get_daemon, get_b_tools):
         node1, node2, _, _, _, _, _, _, _, _, server1 = simulation
-        await server1.start_client(PeerInfo(self_hostname, uint16(21238)))
+        host = get_host_addr(host=self_hostname, prefer_ipv6=get_b_tools.config["prefer_ipv6"])
+        await server1.start_client(PeerInfo(host, uint16(21238)))
 
         async def num_connections():
             count = len(node2.server.connection_by_type[NodeType.FULL_NODE].items())

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -473,7 +473,7 @@ class TestFullNodeProtocol:
                 [TimestampedPeerInfo("127.0.0.1", uint16(1000), uint64(int(time.time())) - 1000)],
                 None,
             )
-            msg_bytes = await full_node_2.full_node.full_node_peers.request_peers(PeerInfo("[::1]", server_2._port))
+            msg_bytes = await full_node_2.full_node.full_node_peers.request_peers(PeerInfo("::1", server_2._port))
             msg = fnp.RespondPeers.from_bytes(msg_bytes.data)
             if msg is not None and not (len(msg.peer_list) == 1):
                 return False

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -59,7 +59,7 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1, and send a huge message
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        url = f"wss://{self_hostname}:{server_1._port}/ws"
+        url = f"wss://[{self_hostname}]:{server_1._port}/ws"
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
@@ -108,7 +108,7 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1, and send a huge message
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        url = f"wss://{self_hostname}:{server_1._port}/ws"
+        url = f"wss://[{self_hostname}]:{server_1._port}/ws"
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
@@ -154,7 +154,7 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        url = f"wss://{self_hostname}:{server_1._port}/ws"
+        url = f"wss://[{self_hostname}]:{server_1._port}/ws"
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -16,6 +16,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
 from chia.util.errors import Err
+from chia.util.network import Url
 from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
@@ -59,20 +60,20 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1, and send a huge message
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        url = f"wss://[{self_hostname}]:{server_1._port}/ws"
+        url = Url.create(scheme="wss", host=self_hostname, port=server_1._port, path="/ws")
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
         )
         ws = await session.ws_connect(
-            url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
         )
         assert not ws.closed
         await ws.close()
         assert ws.closed
 
         ws = await session.ws_connect(
-            url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
         )
         assert not ws.closed
 
@@ -90,7 +91,7 @@ class TestDos:
         assert ws.closed
         try:
             ws = await session.ws_connect(
-                url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+                url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
             )
             response: WSMessage = await ws.receive()
             assert response.type == WSMsgType.CLOSE
@@ -154,13 +155,13 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        url = f"wss://[{self_hostname}]:{server_1._port}/ws"
+        url = Url.create(scheme="wss", host=self_hostname, port=server_1.port, path="/ws")
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
         )
         ws = await session.ws_connect(
-            url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
         )
 
         # Construct an otherwise valid handshake message

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -14,9 +14,10 @@ from chia.server.rate_limits import RateLimiter
 from chia.server.server import ssl_context_for_client
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import PeerInfo
+from chia.util.config import load_config
 from chia.util.ints import uint16, uint64
 from chia.util.errors import Err
-from chia.util.network import Url
+from chia.util.network import get_host_addr, Url
 from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
@@ -60,7 +61,11 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1, and send a huge message
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        url = Url.create(scheme="wss", host=self_hostname, port=server_1._port, path="/ws")
+
+        prefer_ipv6 = server_1.config["prefer_ipv6"]
+        host = get_host_addr(host=self_hostname, prefer_ipv6=prefer_ipv6)
+
+        url = Url.create(scheme="wss", host=host, port=server_1._port, path="/ws")
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
@@ -125,8 +130,10 @@ class TestDos:
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
 
-        # host = get_addr_info(host=self_hostname, prefer_ipv6=)
-        url = Url(scheme="wss", host=self_hostname, port=server_1._port, path="/ws")
+        prefer_ipv6 = server_1.config["prefer_ipv6"]
+        host = get_host_addr(host=self_hostname, prefer_ipv6=prefer_ipv6)
+
+        url = Url.create(scheme="wss", host=host, port=server_1._port, path="/ws")
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
@@ -187,8 +194,11 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        # host = get_addr_info(host=self_hostname, prefer_ipv6=)
-        url = Url.create(scheme="wss", host=self_hostname, port=server_1.port, path="/ws")
+
+        prefer_ipv6 = server_1.config["prefer_ipv6"]
+        host = get_host_addr(host=self_hostname, prefer_ipv6=prefer_ipv6)
+
+        url = Url.create(scheme="wss", host=host, port=server_1._port, path="/ws")
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -66,14 +66,24 @@ class TestDos:
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
         )
         ws = await session.ws_connect(
-            url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url=url.for_connections(),
+            autoclose=True,
+            autoping=True,
+            heartbeat=60,
+            ssl=ssl_context,
+            max_msg_size=100 * 1024 * 1024,
         )
         assert not ws.closed
         await ws.close()
         assert ws.closed
 
         ws = await session.ws_connect(
-            url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url=url.for_connections(),
+            autoclose=True,
+            autoping=True,
+            heartbeat=60,
+            ssl=ssl_context,
+            max_msg_size=100 * 1024 * 1024,
         )
         assert not ws.closed
 
@@ -91,7 +101,12 @@ class TestDos:
         assert ws.closed
         try:
             ws = await session.ws_connect(
-                url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+                url=url.for_connections(),
+                autoclose=True,
+                autoping=True,
+                heartbeat=60,
+                ssl=ssl_context,
+                max_msg_size=100 * 1024 * 1024,
             )
             response: WSMessage = await ws.receive()
             assert response.type == WSMsgType.CLOSE
@@ -109,13 +124,20 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1, and send a huge message
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
-        url = f"wss://[{self_hostname}]:{server_1._port}/ws"
+
+        # host = get_addr_info(host=self_hostname, prefer_ipv6=)
+        url = Url(scheme="wss", host=self_hostname, port=server_1._port, path="/ws")
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
         )
         ws = await session.ws_connect(
-            url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url.for_connections(),
+            autoclose=True,
+            autoping=True,
+            heartbeat=60,
+            ssl=ssl_context,
+            max_msg_size=100 * 1024 * 1024,
         )
         await ws.send_bytes(bytes([1] * 1024))
 
@@ -130,7 +152,12 @@ class TestDos:
         assert ws.closed
         try:
             ws = await session.ws_connect(
-                url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+                url.for_connections(),
+                autoclose=True,
+                autoping=True,
+                heartbeat=60,
+                ssl=ssl_context,
+                max_msg_size=100 * 1024 * 1024,
             )
             response: WSMessage = await ws.receive()
             assert response.type == WSMsgType.CLOSE
@@ -140,7 +167,12 @@ class TestDos:
 
         # Ban expired
         await session.ws_connect(
-            url, autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url.for_connections(),
+            autoclose=True,
+            autoping=True,
+            heartbeat=60,
+            ssl=ssl_context,
+            max_msg_size=100 * 1024 * 1024,
         )
 
         await session.close()
@@ -155,13 +187,19 @@ class TestDos:
         # Use the server_2 ssl information to connect to server_1
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
+        # host = get_addr_info(host=self_hostname, prefer_ipv6=)
         url = Url.create(scheme="wss", host=self_hostname, port=server_1.port, path="/ws")
 
         ssl_context = ssl_context_for_client(
             server_2.chia_ca_crt_path, server_2.chia_ca_key_path, server_2.p2p_crt_path, server_2.p2p_key_path
         )
         ws = await session.ws_connect(
-            url=url.for_connections(), autoclose=True, autoping=True, heartbeat=60, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+            url=url.for_connections(),
+            autoclose=True,
+            autoping=True,
+            heartbeat=60,
+            ssl=ssl_context,
+            max_msg_size=100 * 1024 * 1024,
         )
 
         # Construct an otherwise valid handshake message

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -11,6 +11,7 @@ from chia.ssl.create_ssl import generate_ca_signed_cert
 from chia.types.peer_info import PeerInfo
 from tests.block_tools import test_constants
 from chia.util.ints import uint16
+from chia.util.network import Url
 from tests.setup_nodes import (
     bt,
     self_hostname,
@@ -26,8 +27,8 @@ async def establish_connection(server: ChiaServer, dummy_port: int, ssl_context)
     session = aiohttp.ClientSession(timeout=timeout)
     try:
         incoming_queue: asyncio.Queue = asyncio.Queue()
-        url = f"wss://[{self_hostname}]:{server._port}/ws"
-        ws = await session.ws_connect(url, autoclose=False, autoping=True, ssl=ssl_context)
+        url = Url.create(scheme="wss", host=self_hostname, port=server._port, path="/ws")
+        ws = await session.ws_connect(url=url.for_connections(), autoclose=False, autoping=True, ssl=ssl_context)
         wsc = WSChiaConnection(
             NodeType.FULL_NODE,
             ws,

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -26,7 +26,7 @@ async def establish_connection(server: ChiaServer, dummy_port: int, ssl_context)
     session = aiohttp.ClientSession(timeout=timeout)
     try:
         incoming_queue: asyncio.Queue = asyncio.Queue()
-        url = f"wss://{self_hostname}:{server._port}/ws"
+        url = f"wss://[{self_hostname}]:{server._port}/ws"
         ws = await session.ws_connect(url, autoclose=False, autoping=True, ssl=ssl_context)
         wsc = WSChiaConnection(
             NodeType.FULL_NODE,

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -11,7 +11,7 @@ from chia.ssl.create_ssl import generate_ca_signed_cert
 from chia.types.peer_info import PeerInfo
 from tests.block_tools import test_constants
 from chia.util.ints import uint16
-from chia.util.network import Url
+from chia.util.network import get_host_addr, Url
 from tests.setup_nodes import (
     bt,
     self_hostname,
@@ -27,7 +27,9 @@ async def establish_connection(server: ChiaServer, dummy_port: int, ssl_context)
     session = aiohttp.ClientSession(timeout=timeout)
     try:
         incoming_queue: asyncio.Queue = asyncio.Queue()
-        url = Url.create(scheme="wss", host=self_hostname, port=server._port, path="/ws")
+        prefer_ipv6 = server.config["prefer_ipv6"]
+        host = get_host_addr(host=self_hostname, prefer_ipv6=prefer_ipv6)
+        url = Url.create(scheme="wss", host=host, port=server._port, path="/ws")
         ws = await session.ws_connect(url=url.for_connections(), autoclose=False, autoping=True, ssl=ssl_context)
         wsc = WSChiaConnection(
             NodeType.FULL_NODE,

--- a/tests/core/test_daemon_rpc.py
+++ b/tests/core/test_daemon_rpc.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.setup_nodes import setup_daemon
 from chia.daemon.client import connect_to_daemon
+from chia.util.network import get_host_addr
 from tests.setup_nodes import bt
 from chia import __version__
 
@@ -15,7 +16,10 @@ class TestDaemonRpc:
     @pytest.mark.asyncio
     async def test_get_version_rpc(self, get_daemon):
         config = bt.config
-        client = await connect_to_daemon(config["self_hostname"], config["daemon_port"], bt.get_daemon_ssl_context())
+        prefer_ipv6 = config["prefer_ipv6"]
+        host = get_host_addr(host=config["self_hostname"], prefer_ipv6=prefer_ipv6)
+
+        client = await connect_to_daemon(host, config["daemon_port"], bt.get_daemon_ssl_context())
         response = await client.get_version()
 
         assert response["data"]["success"]

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -149,7 +149,7 @@ class TestConfig:
         assert config is not None
         # Expect: config values should match the defaults (from a small sampling)
         assert config["daemon_port"] == default_config_dict["daemon_port"] == 55400
-        assert config["self_hostname"] == default_config_dict["self_hostname"] == "::1"
+        assert config["self_hostname"] == default_config_dict["self_hostname"] == "localhost"
         assert (
             config["farmer"]["network_overrides"]["constants"]["mainnet"]["GENESIS_CHALLENGE"]
             == default_config_dict["farmer"]["network_overrides"]["constants"]["mainnet"]["GENESIS_CHALLENGE"]

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -149,7 +149,7 @@ class TestConfig:
         assert config is not None
         # Expect: config values should match the defaults (from a small sampling)
         assert config["daemon_port"] == default_config_dict["daemon_port"] == 55400
-        assert config["self_hostname"] == default_config_dict["self_hostname"] == "localhost"
+        assert config["self_hostname"] == default_config_dict["self_hostname"] == "::1"
         assert (
             config["farmer"]["network_overrides"]["constants"]["mainnet"]["GENESIS_CHALLENGE"]
             == default_config_dict["farmer"]["network_overrides"]["constants"]["mainnet"]["GENESIS_CHALLENGE"]

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -40,6 +40,10 @@ def get_pool_plot_dir():
     return get_plot_dir() / Path("pool_tests")
 
 
+if ":" in self_hostname and "." not in self_hostname:
+    self_hostname = f"[{self_hostname.strip('[]')}]"
+
+
 @dataclass
 class TemporaryPoolPlot:
     p2_singleton_puzzle_hash: bytes32

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -40,10 +40,6 @@ def get_pool_plot_dir():
     return get_plot_dir() / Path("pool_tests")
 
 
-if ":" in self_hostname and "." not in self_hostname:
-    self_hostname = f"[{self_hostname.strip('[]')}]"
-
-
 @dataclass
 class TemporaryPoolPlot:
     p2_singleton_puzzle_hash: bytes32

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -285,7 +285,10 @@ async def setup_introducer(port):
 
 
 async def setup_vdf_client(port):
-    vdf_task_1 = asyncio.create_task(spawn_process(self_hostname, port, 1, bt.config.get("prefer_ipv6")))
+    # TODO: if we're passing through prefer_ipv6 it seems this shouldn't be needed
+    #       but...  if the subprocess doesn't localhost->::1 then...  maybe.
+    host = get_host_addr(host=self_hostname, prefer_ipv6=bt.config["prefer_ipv6"])
+    vdf_task_1 = asyncio.create_task(spawn_process(host, port, 1, bt.config.get("prefer_ipv6")))
 
     def stop():
         asyncio.create_task(kill_processes())

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -25,6 +25,7 @@ from tests.util.keyring import TempKeyring
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint32
 from chia.util.keychain import bytes_to_mnemonic
+from chia.util.network import get_host_addr
 from tests.time_out_assert import time_out_assert_custom_interval
 
 
@@ -202,10 +203,11 @@ async def setup_harvester(
     port, farmer_port, consensus_constants: ConsensusConstants, b_tools, start_service: bool = True
 ):
     kwargs = service_kwargs_for_harvester(b_tools.root_path, b_tools.config["harvester"], consensus_constants)
+    host = get_host_addr(host=self_hostname, prefer_ipv6=b_tools.config["harvester"]["prefer_ipv6"])
     kwargs.update(
         server_listen_ports=[port],
         advertised_port=port,
-        connect_peers=[PeerInfo(self_hostname, farmer_port)],
+        connect_peers=[PeerInfo(host, farmer_port)],
         parse_cli_args=False,
         connect_to_daemon=False,
     )

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -3,6 +3,7 @@ import pytest
 from chia.types.peer_info import PeerInfo
 from tests.block_tools import create_block_tools_async
 from chia.util.ints import uint16
+from chia.util.network import get_host_addr
 from tests.core.node_height import node_height_at_least
 from tests.setup_nodes import self_hostname, setup_full_node, setup_full_system, test_constants
 from tests.time_out_assert import time_out_assert
@@ -51,10 +52,11 @@ class TestSimulation:
     @pytest.mark.asyncio
     async def test_simulation_1(self, simulation, extra_node):
         node1, node2, _, _, _, _, _, _, _, sanitizer_server, server1 = simulation
-        await server1.start_client(PeerInfo(self_hostname, uint16(21238)))
+        host = get_host_addr(host=self_hostname, prefer_ipv6=server1.config["prefer_ipv6"])
+        await server1.start_client(PeerInfo(host, uint16(21238)))
         # Use node2 to test node communication, since only node1 extends the chain.
         await time_out_assert(1500, node_height_at_least, True, node2, 7)
-        await sanitizer_server.start_client(PeerInfo(self_hostname, uint16(21238)))
+        await sanitizer_server.start_client(PeerInfo(host, uint16(21238)))
 
         async def has_compact(node1, node2):
             peak_height_1 = node1.full_node.blockchain.get_peak_height()
@@ -98,6 +100,6 @@ class TestSimulation:
         node3 = extra_node
         server3 = node3.full_node.server
         peak_height = max(node1.full_node.blockchain.get_peak_height(), node2.full_node.blockchain.get_peak_height())
-        await server3.start_client(PeerInfo(self_hostname, uint16(21237)))
-        await server3.start_client(PeerInfo(self_hostname, uint16(21238)))
+        await server3.start_client(PeerInfo(host, uint16(21237)))
+        await server3.start_client(PeerInfo(host, uint16(21238)))
         await time_out_assert(600, node_height_at_least, True, node3, peak_height)

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -64,8 +64,8 @@ class TestWalletRpc:
         ph = await wallet.get_new_puzzlehash()
         ph_2 = await wallet_2.get_new_puzzlehash()
 
-        await server_2.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
-        await server_3.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+        await server_2.start_client(PeerInfo(full_node_server._host, uint16(full_node_server._port)), None)
+        await server_3.start_client(PeerInfo(full_node_server._host, uint16(full_node_server._port)), None)
 
         if trusted:
             wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}


### PR DESCRIPTION
GitHub Actions does support IPv6.  From my glance at https://github.com/actions/virtual-environments/issues/668 it is about _external_ IPv6 connections, not localhost.  Trio and Twisted both test IPv6 as best as both I and they know.  Twisted goes so far as to _disable_ IPv6 entirely for a dedicated IPv4-only test job.  If you want to look at a trivial example of IPv6 seemingly working, see https://github.com/altendky/altendpy/pull/15.

Draft for:
- [ ] deal with localhost
  - Wikipedia says ["The name localhost normally resolves to the IPv4 loopback address 127.0.0.1, and to the IPv6 loopback address ::1."](https://en.wikipedia.org/wiki/Localhost#Loopback) but they cite [RFC 4291](https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.3) which doesn't even mention `localhost` per my search.
  - On my laptop running Ubuntu 20.04, `localhost` does not resolve to an IPv6 unless I manually add it to `/etc/hosts`.  At least according to `nmap -6 -p 0-65535 localhost` which says `Warning: Hostname localhost resolves, but not to any IPv6 address. Try scanning without -6`.
- [ ] making this not a hack
- [ ] considering ux on the parallel `self_hostname` and `prefer_ipv6` configuration options
- [ ] learn what all `prefer_ipv6` affects
- [x] make a common ipv6 aware url builder (or `hyperlink`?)
- [ ] if listening on IPv6 should we allow v4 as well on the same socket?
- [ ] how do we want to setup tests for coverage with `prefer_ipv6` both true and false
- [ ] review all uses of `127.0.0.1` and `::1`