### PR TITLE
Db convert offline mode

### DIFF
--- a/chia/cmds/db.py
+++ b/chia/cmds/db.py
@@ -26,8 +26,19 @@ def db_cmd() -> None:
     "the database file, you must not have a full node running against it. This may "
     "provide some performance improvements",
 )
+@click.option(
+    "--vacuum",
+    default=False,
+    is_flag=True,
+    help="vacuum the input database in an attempt to improve performance when "
+    "converting. This is only valid when also specifying --offline.",
+)
 @click.pass_context
-def db_upgrade_cmd(ctx: click.Context, no_update_config: bool, offline: bool, **kwargs) -> None:
+def db_upgrade_cmd(ctx: click.Context, no_update_config: bool, offline: bool, vacuum: bool, **kwargs) -> None:
+
+    if vacuum and not offline:
+        print("--vacuum is only valid when also specifying --offline")
+        raise RuntimeError("invalid command line option")
 
     in_db_path = kwargs.get("input")
     out_db_path = kwargs.get("output")
@@ -37,6 +48,7 @@ def db_upgrade_cmd(ctx: click.Context, no_update_config: bool, offline: bool, **
         None if out_db_path is None else Path(out_db_path),
         no_update_config=no_update_config,
         offline=offline,
+        vacuum=vacuum,
     )
 
 

--- a/chia/cmds/db.py
+++ b/chia/cmds/db.py
@@ -18,8 +18,16 @@ def db_cmd() -> None:
     help="don't update config file to point to new database. When specifying a "
     "custom output file, the config will not be updated regardless",
 )
+@click.option(
+    "--offline",
+    default=False,
+    is_flag=True,
+    help="open the input database in offline-mode. no other process may use "
+    "the database file, you must not have a full node running against it. This may "
+    "provide some performance improvements",
+)
 @click.pass_context
-def db_upgrade_cmd(ctx: click.Context, no_update_config: bool, **kwargs) -> None:
+def db_upgrade_cmd(ctx: click.Context, no_update_config: bool, offline: bool, **kwargs) -> None:
 
     in_db_path = kwargs.get("input")
     out_db_path = kwargs.get("output")
@@ -27,7 +35,8 @@ def db_upgrade_cmd(ctx: click.Context, no_update_config: bool, **kwargs) -> None
         Path(ctx.obj["root_path"]),
         None if in_db_path is None else Path(in_db_path),
         None if out_db_path is None else Path(out_db_path),
-        no_update_config,
+        no_update_config=no_update_config,
+        offline=offline,
     )
 
 

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -79,8 +79,8 @@ async def convert_v1_to_v2(in_path: Path, out_path: Path, *, offline: bool, vacu
     print(f"opening file for reading: {in_path}{' in offline mode' if offline else ''}")
     async with aiosqlite.connect(in_path) as in_db:
         if offline:
-            await in_db.execute("pragma journal_mode=OFF")
-            await in_db.execute("pragma locking_mode=exclusive")
+            await (await in_db.execute("pragma journal_mode=OFF")).close()
+            await (await in_db.execute("pragma locking_mode=exclusive")).close()
 
         try:
             async with in_db.execute("SELECT * from database_version") as cursor:

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -106,10 +106,6 @@ class TestDbUpgrade:
             await convert_v1_to_v2(in_file, out_file, offline=offline, vacuum=vacuum)
 
             async with aiosqlite.connect(in_file) as conn, aiosqlite.connect(out_file) as conn2:
-                db_wrapper2 = DBWrapper(conn2, 2)
-                block_store2 = await BlockStore.create(db_wrapper2)
-                coin_store2 = await CoinStore.create(db_wrapper2, uint32(0))
-                hint_store2 = await HintStore.create(db_wrapper2)
 
                 db_wrapper1 = DBWrapper(conn, 1)
                 block_store1 = await BlockStore.create(db_wrapper1)
@@ -150,6 +146,7 @@ class TestDbUpgrade:
 
                 # check coins
                 for block in blocks:
+
                     coins = await coin_store1.get_coins_added_at_height(block.height)
                     assert await coin_store2.get_coins_added_at_height(block.height) == coins
                     assert await coin_store1.get_coins_removed_at_height(

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -9,11 +9,7 @@ from typing import List, Tuple
 from tests.setup_nodes import test_constants
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-<<<<<<< HEAD
 from chia.util.ints import uint32, uint64
-=======
-from chia.util.ints import uint32
->>>>>>> 5fe115b6b (add option to open input database in offline mode when upgrading from v1 to v2)
 from chia.cmds.db_upgrade_func import convert_v1_to_v2
 from chia.util.db_wrapper import DBWrapper
 from chia.full_node.block_store import BlockStore
@@ -52,8 +48,8 @@ def event_loop():
 class TestDbUpgrade:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("with_hints", [True, False])
-    @pytest.mark.parametrize("offline", [True, False])
-    async def test_blocks(self, default_1000_blocks, with_hints: bool, offline: bool):
+    @pytest.mark.parametrize("offline, vacuum", [(True, True), (True, False), (False, False)])
+    async def test_blocks(self, default_1000_blocks, with_hints: bool, offline: bool, vacuum: bool):
 
         blocks = default_1000_blocks
 
@@ -107,7 +103,7 @@ class TestDbUpgrade:
                     assert err is None
 
             # now, convert v1 in_file to v2 out_file
-            await convert_v1_to_v2(in_file, out_file)
+            await convert_v1_to_v2(in_file, out_file, offline=offline, vacuum=vacuum)
 
             async with aiosqlite.connect(in_file) as conn, aiosqlite.connect(out_file) as conn2:
                 db_wrapper2 = DBWrapper(conn2, 2)

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -9,7 +9,11 @@ from typing import List, Tuple
 from tests.setup_nodes import test_constants
 
 from chia.types.blockchain_format.sized_bytes import bytes32
+<<<<<<< HEAD
 from chia.util.ints import uint32, uint64
+=======
+from chia.util.ints import uint32
+>>>>>>> 5fe115b6b (add option to open input database in offline mode when upgrading from v1 to v2)
 from chia.cmds.db_upgrade_func import convert_v1_to_v2
 from chia.util.db_wrapper import DBWrapper
 from chia.full_node.block_store import BlockStore
@@ -48,7 +52,8 @@ def event_loop():
 class TestDbUpgrade:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("with_hints", [True, False])
-    async def test_blocks(self, default_1000_blocks, with_hints: bool):
+    @pytest.mark.parametrize("offline", [True, False])
+    async def test_blocks(self, default_1000_blocks, with_hints: bool, offline: bool):
 
         blocks = default_1000_blocks
 
@@ -105,6 +110,10 @@ class TestDbUpgrade:
             await convert_v1_to_v2(in_file, out_file)
 
             async with aiosqlite.connect(in_file) as conn, aiosqlite.connect(out_file) as conn2:
+                db_wrapper2 = DBWrapper(conn2, 2)
+                block_store2 = await BlockStore.create(db_wrapper2)
+                coin_store2 = await CoinStore.create(db_wrapper2, uint32(0))
+                hint_store2 = await HintStore.create(db_wrapper2)
 
                 db_wrapper1 = DBWrapper(conn, 1)
                 block_store1 = await BlockStore.create(db_wrapper1)

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -44,7 +44,7 @@ def persistent_blocks(
     normalized_to_identity_icc_eos: bool = False,
     normalized_to_identity_cc_sp: bool = False,
     normalized_to_identity_cc_ip: bool = False,
-):
+) -> List[FullBlock]:
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
     block_path_dir = Path("~/.chia/blocks").expanduser()
@@ -87,7 +87,7 @@ def new_test_db(
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
-):
+) -> List[FullBlock]:
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
         num_of_blocks,


### PR DESCRIPTION
I haven't had a chance to benchmark these new options yet. Converting a recent v1 database takes weeks on a slow HDD.

This is from one USB-attached HDD to another USB-attached HDD. The computer is otherwise relatively powerful.

Running:
```
time chia db upgrade --input /media/arvid/plots/blockchain_v1_modified.sqlite --output=/media/arvid/seagate/test-v2.sqlite --offline --vacuum
```

```
opening file for reading: /media/arvid/plots/blockchain_v1_modified.sqlite in offline mode
vacuuming input database
      52469.13 seconds
opening file for writing: /media/arvid/seagate/test-v2.sqlite
initializing v2 version
initializing v2 block store
peak: 56e4b442dba0f58c6489991ea87274507e8cb839cb49f93804e9176c4537cf63 height: 1517080
[1/5] converting full_blocks
      12809.48 seconds
[2/5] converting sub_epoch_segments_v3
      109.66 seconds
[3/5] converting hint_store
      8.71 seconds
[4/5] converting coin_store
      11470.76 seconds
[5/5] build indices
      block store
      coin store
      hint store
      5377.89 seconds


LEAVING PREVIOUS DB FILE UNTOUCHED /media/arvid/plots/blockchain_v1_modified.sqlite


real    1370m47,751s
user    41m35,470s
sys     25m12,156s

```

the baseline to compare against is running without vacuum and not offline (i.e. the input database is read-only).

Running:
```
time chia db upgrade --input /media/arvid/plots/blockchain_v1_mainnet.sqlite --output=/media/arvid/seagate/test-v2.sqlite
```

```
opening file for reading: /media/arvid/plots/blockchain_v1_mainnet.sqlite
opening file for writing: /media/arvid/seagate/test-v2.sqlite
initializing v2 version
initializing v2 block store
peak: 56e4b442dba0f58c6489991ea87274507e8cb839cb49f93804e9176c4537cf63 height: 1517080
[1/5] converting full_blocks
      23123.05 seconds
[2/5] converting sub_epoch_segments_v3
      109.08 seconds
[3/5] converting hint_store
      44.69 seconds
[4/5] converting coin_store
      15011.19 seconds
[5/5] build indices
      block store
      coin store
      hint store
      5589.73 seconds


LEAVING PREVIOUS DB FILE UNTOUCHED /media/arvid/plots/blockchain_v1_mainnet.sqlite


real    731m19,301s
user    46m21,826s
sys     15m57,859s
```

Running in offline mode without vacuuming:

```
time chia db upgrade --input /media/arvid/plots/blockchain_v1_mainnet.sqlite --output=/media/arvid/seagate/test-v2.sqlite --offline
```

```
opening file for reading: /media/arvid/plots/blockchain_v1_mainnet.sqlite in offline mode
opening file for writing: /media/arvid/seagate/test-v2.sqlite
initializing v2 version
initializing v2 block store
peak: 56e4b442dba0f58c6489991ea87274507e8cb839cb49f93804e9176c4537cf63 height: 1517080
[1/5] converting full_blocks
      22958.98 seconds
[2/5] converting sub_epoch_segments_v3
      109.18 seconds
[3/5] converting hint_store
      45.11 seconds
[4/5] converting coin_store
      14024.27 seconds
[5/5] build indices
      block store
      coin store
      hint store
      7433.54 seconds


LEAVING PREVIOUS DB FILE UNTOUCHED /media/arvid/plots/blockchain_v1_mainnet.sqlite


real    742m52,488s
user    46m10,757s
sys     15m47,161s
```