### PR TITLE
remove constraint on v1 database 'peak'-index

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -97,7 +97,7 @@ class BlockStore:
 
             await self.db.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
 
-            await self.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak) where is_peak = 1")
+            await self.db.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
 
         await self.db.commit()
         self.block_cache = LRUCache(1000)


### PR DESCRIPTION
Constraints like this require at least sqlite 3.9 (2015)