### PR TITLE
Remove deprecated initial_num_public_keys_new_wallet from initial-config.yaml

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -464,7 +464,6 @@ wallet:
   start_height_buffer: 100  # Wallet will stop fly sync at starting_height - buffer
   num_sync_batches: 50
   initial_num_public_keys: 100
-  initial_num_public_keys_new_wallet: 5
 
   dns_servers:
     - "dns-introducer.chia.net"


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/blob/231ef6faf20fba7463831a5015edee649a1d5d49/CHANGELOG.md
> Fixed issues where the wallet code would not generate enough addresses when looking for coins, which can result in missed coins due to the address not being checked. Deprecated the config setting initial_num_public_keys_new_wallet. The config setting initial_num_public_keys is now used in all cases.