### PR TITLE
run pytest in strict asyncio mode

### DIFF
--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 import pytest
+import pytest_asyncio
 from clvm.casts import int_to_bytes
 
 from chia.protocols import full_node_protocol, wallet_protocol
@@ -31,7 +32,7 @@ def event_loop():
 
 
 class TestBlockchainTransactions:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_nodes(self, db_version):
         async for _ in setup_two_nodes(test_constants, db_version=db_version):
             yield _

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 import tempfile
 from pathlib import Path
 
@@ -14,7 +15,7 @@ from pathlib import Path
 #       fixtures avoids the issue.
 
 
-@pytest.fixture(scope="function", params=[1, 2])
+@pytest_asyncio.fixture(scope="function", params=[1, 2])
 async def empty_blockchain(request):
     """
     Provides a list of 10 valid blocks, as well as a blockchain with 9 blocks added to it.
@@ -43,21 +44,21 @@ def softfork_height(request):
 block_format_version = "rc4"
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def default_400_blocks():
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", seed=b"alternate2")
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def default_1000_blocks():
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db")
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def pre_genesis_empty_slots_1000_blocks():
     from tests.util.blockchain import persistent_blocks
 
@@ -66,21 +67,21 @@ async def pre_genesis_empty_slots_1000_blocks():
     )
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def default_10000_blocks():
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db")
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def default_20000_blocks():
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db")
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def default_10000_blocks_compact():
     from tests.util.blockchain import persistent_blocks
 
@@ -94,7 +95,7 @@ async def default_10000_blocks_compact():
     )
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def tmp_dir():
     with tempfile.TemporaryDirectory() as folder:
         yield Path(folder)

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -15,10 +15,11 @@ import json
 
 import aiohttp
 import pytest
+import pytest_asyncio
 
 
 class TestDaemon:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def get_daemon(self, get_b_tools):
         async for _ in setup_daemon(btools=get_b_tools):
             yield _
@@ -27,23 +28,23 @@ class TestDaemon:
     # fixture, to test all versions of the database schema. This doesn't work
     # because of a hack in shutting down the full node, which means you cannot run
     # more than one simulations per process.
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def simulation(self, get_b_tools, get_b_tools_1):
         async for _ in setup_full_system(
             test_constants_modified, b_tools=get_b_tools, b_tools_1=get_b_tools_1, connect_to_daemon=True, db_version=1
         ):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def get_temp_keyring(self):
         with TempKeyring() as keychain:
             yield keychain
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def get_b_tools_1(self, get_temp_keyring):
         return await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def get_b_tools(self, get_temp_keyring):
         local_b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
         new_config = local_b_tools._config
@@ -51,7 +52,7 @@ class TestDaemon:
         local_b_tools.change_config(new_config)
         return local_b_tools
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def get_daemon_with_temp_keyring(self, get_b_tools):
         async for _ in setup_daemon(btools=get_b_tools):
             yield get_b_tools

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -5,6 +5,7 @@ import time
 from typing import List
 
 import pytest
+import pytest_asyncio
 
 from chia.full_node.weight_proof import _validate_sub_epoch_summaries
 from chia.protocols import full_node_protocol
@@ -28,22 +29,22 @@ log = logging.getLogger(__name__)
 
 
 class TestFullSync:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_nodes(self, db_version):
         async for _ in setup_two_nodes(test_constants, db_version=db_version):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_nodes(self, db_version):
         async for _ in setup_n_nodes(test_constants, 3, db_version=db_version):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def four_nodes(self, db_version):
         async for _ in setup_n_nodes(test_constants, 4, db_version=db_version):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def five_nodes(self, db_version):
         async for _ in setup_n_nodes(test_constants, 5, db_version=db_version):
             yield _

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -10,6 +10,7 @@ from blspy import G2Element
 
 from clvm.casts import int_to_bytes
 import pytest
+import pytest_asyncio
 
 from chia.consensus.blockchain import ReceiveBlockResult
 from chia.consensus.pot_iterations import is_overflow_block
@@ -106,7 +107,7 @@ def event_loop():
     yield loop
 
 
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def wallet_nodes():
     async_gen = setup_simulators_and_wallets(2, 1, {"MEMPOOL_BLOCK_BUFFER": 2, "MAX_BLOCK_COST_CLVM": 400000000})
     nodes, wallets = await async_gen.__anext__()
@@ -122,25 +123,25 @@ async def wallet_nodes():
         yield _
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def setup_four_nodes(db_version):
     async for _ in setup_simulators_and_wallets(5, 0, {}, starting_port=51000, db_version=db_version):
         yield _
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes(db_version):
     async for _ in setup_simulators_and_wallets(2, 0, {}, starting_port=51100, db_version=db_version):
         yield _
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes_and_wallet():
     async for _ in setup_simulators_and_wallets(2, 1, {}, starting_port=51200, db_version=2):
         yield _
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def wallet_nodes_mainnet(db_version):
     async_gen = setup_simulators_and_wallets(2, 1, {"NETWORK_TYPE": 0}, starting_port=40000, db_version=db_version)
     nodes, wallets = await async_gen.__anext__()

--- a/tests/core/full_node/test_full_node_store.py
+++ b/tests/core/full_node/test_full_node_store.py
@@ -6,6 +6,7 @@ from secrets import token_bytes
 from typing import List, Optional
 
 import pytest
+import pytest_asyncio
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain import ReceiveBlockResult
@@ -52,7 +53,7 @@ def event_loop():
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="function", params=[1, 2])
+@pytest_asyncio.fixture(scope="function", params=[1, 2])
 async def empty_blockchain(request):
     bc1, connection, db_path = await create_blockchain(test_constants, request.param)
     yield bc1
@@ -61,7 +62,7 @@ async def empty_blockchain(request):
     db_path.unlink()
 
 
-@pytest.fixture(scope="function", params=[1, 2])
+@pytest_asyncio.fixture(scope="function", params=[1, 2])
 async def empty_blockchain_original(request):
     bc1, connection, db_path = await create_blockchain(test_constants_original, request.param)
     yield bc1

--- a/tests/core/full_node/test_hint_store.py
+++ b/tests/core/full_node/test_hint_store.py
@@ -51,6 +51,7 @@ class TestHintStore:
             coins_for_non_hint = await hint_store.get_coin_ids(not_existing_hint)
             assert coins_for_non_hint == []
 
+    @pytest.mark.asyncio
     async def test_duplicate_coins(self, db_version):
         async with DBConnection(db_version) as db_wrapper:
             hint_store = await HintStore.create(db_wrapper)

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Tuple, Callable
 
 from clvm.casts import int_to_bytes
 import pytest
+import pytest_asyncio
 
 import chia.server.ws_connection as ws
 
@@ -86,7 +87,7 @@ def event_loop():
 # The reason for this is that our simulators can't be destroyed correctly, which
 # means you can't instantiate more than one per process, so this is a hack until
 # that is fixed. For now, our tests are not independent
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def two_nodes():
     async_gen = setup_simulators_and_wallets(2, 1, {})
     nodes, _ = await async_gen.__anext__()

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 
 import pytest
+import pytest_asyncio
 import logging
 
 from chia.protocols import full_node_protocol
@@ -41,7 +42,7 @@ def event_loop():
 
 
 class TestMempoolPerformance:
-    @pytest.fixture(scope="module")
+    @pytest_asyncio.fixture(scope="module")
     async def wallet_nodes(self):
         key_seed = bt.farmer_master_sk_entropy
         async for _ in setup_simulators_and_wallets(2, 1, {}, key_seed=key_seed):

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 
 import pytest
+import pytest_asyncio
 
 from chia.protocols import full_node_protocol
 from chia.types.peer_info import PeerInfo
@@ -18,7 +19,7 @@ def event_loop():
 
 
 class TestNodeLoad:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_nodes(self, db_version):
         async for _ in setup_two_nodes(test_constants, db_version=db_version):
             yield _

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -8,6 +8,7 @@ from typing import Dict
 
 from clvm.casts import int_to_bytes
 import pytest
+import pytest_asyncio
 import cProfile
 
 from chia.consensus.block_record import BlockRecord
@@ -44,7 +45,7 @@ def event_loop():
     yield loop
 
 
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(scope="module")
 async def wallet_nodes():
     async_gen = setup_simulators_and_wallets(1, 1, {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 11000000000})
     nodes, wallets = await async_gen.__anext__()

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -3,6 +3,7 @@ from secrets import token_bytes
 from typing import Optional
 
 import pytest
+import pytest_asyncio
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
@@ -22,17 +23,17 @@ def event_loop():
 
 
 class TestTransactions:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_nodes_two_wallets(self):
         async for _ in setup_simulators_and_wallets(3, 2, {}):
             yield _

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 import pytest
+import pytest_asyncio
 from aiohttp import ClientSession, ClientTimeout, ServerDisconnectedError, WSCloseCode, WSMessage, WSMsgType
 
 from chia.full_node.full_node_api import FullNodeAPI
@@ -38,7 +39,7 @@ def event_loop():
     yield loop
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes(db_version):
     async for _ in setup_simulators_and_wallets(2, 0, {}, starting_port=60000, db_version=db_version):
         yield _

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -2,6 +2,7 @@ import asyncio
 
 import aiohttp
 import pytest
+import pytest_asyncio
 
 from chia.protocols.shared_protocol import protocol_version
 from chia.server.outbound_message import NodeType
@@ -51,22 +52,22 @@ async def establish_connection(server: ChiaServer, dummy_port: int, ssl_context)
 
 
 class TestSSL:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def harvester_farmer(self):
         async for _ in setup_farmer_harvester(test_constants):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def introducer(self):
         async for _ in setup_introducer(21233):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def timelord(self):
         async for _ in setup_timelord(21236, 21237, False, test_constants, bt):
             yield _

--- a/tests/core/test_daemon_rpc.py
+++ b/tests/core/test_daemon_rpc.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from tests.setup_nodes import setup_daemon
 from chia.daemon.client import connect_to_daemon
@@ -7,7 +8,7 @@ from chia import __version__
 
 
 class TestDaemonRpc:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def get_daemon(self):
         async for _ in setup_daemon(btools=bt):
             yield _

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 import aiosqlite
 import tempfile
 import random
@@ -39,7 +40,7 @@ def rand_bytes(num) -> bytes:
     return bytes(ret)
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 def event_loop():
     loop = asyncio.get_event_loop()
     yield loop

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import pytest
+import pytest_asyncio
 
 from chia.consensus.coinbase import create_puzzlehash_for_pk
 from chia.protocols import farmer_protocol
@@ -24,13 +25,13 @@ from tests.util.rpc import validate_get_routes
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def simulation():
     async for _ in setup_farmer_harvester(test_constants):
         yield _
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def environment(simulation):
     harvester_service, farmer_service = simulation
 

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import List
 
 import pytest
+import pytest_asyncio
 from chiabip158 import PyBIP158
 
 from tests.setup_nodes import setup_simulators_and_wallets, bt
@@ -14,7 +15,7 @@ def event_loop():
 
 
 class TestFilter:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_and_node(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -3,6 +3,7 @@ import logging
 from typing import List
 
 import pytest
+import pytest_asyncio
 from blspy import AugSchemeMPL
 
 from chia.consensus.pot_iterations import is_overflow_block
@@ -27,7 +28,7 @@ from tests.util.rpc import validate_get_routes
 
 
 class TestRpc:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_nodes(self):
         async for _ in setup_simulators_and_wallets(2, 0, {}):
             yield _

--- a/tests/farmer_harvester/test_farmer_harvester.py
+++ b/tests/farmer_harvester/test_farmer_harvester.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+import pytest_asyncio
 
 from chia.farmer.farmer import Farmer
 from chia.util.keychain import generate_mnemonic
@@ -12,7 +13,7 @@ def farmer_is_started(farmer):
     return farmer.started
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def environment():
     async for _ in setup_farmer_harvester(test_constants, False):
         yield _

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -6,6 +6,7 @@ from shutil import rmtree
 from typing import Optional, List, Dict
 
 import pytest
+import pytest_asyncio
 from blspy import G1Element
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
@@ -81,12 +82,12 @@ PREFARMED_BLOCKS = 4
 
 
 class TestPoolWalletRpc:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def one_wallet_node_and_rpc(self):
         rmtree(get_pool_plot_dir(), ignore_errors=True)
         async for nodes in setup_simulators_and_wallets(1, 1, {}):
@@ -122,7 +123,7 @@ class TestPoolWalletRpc:
             await client.await_closed()
             await rpc_cleanup()
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def setup(self, two_wallet_nodes):
         rmtree(get_pool_plot_dir(), ignore_errors=True)
         full_nodes, wallets = two_wallet_nodes

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -3,3 +3,4 @@
 log_cli = 1
 log_level = WARNING
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
+asyncio_mode = strict

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from chia.types.peer_info import PeerInfo
 from tests.block_tools import create_block_tools_async
@@ -30,7 +31,7 @@ class TestSimulation:
     # fixture, to test all versions of the database schema. This doesn't work
     # because of a hack in shutting down the full node, which means you cannot run
     # more than one simulations per process.
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def extra_node(self):
         with TempKeyring() as keychain:
             b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=keychain)
@@ -43,7 +44,7 @@ class TestSimulation:
             ):
                 yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def simulation(self):
         async for _ in setup_full_system(test_constants_modified, db_version=1):
             yield _

--- a/tests/wallet/cat_wallet/test_cat_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_cat_lifecycle.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from typing import List, Tuple, Optional, Dict
 from blspy import PrivateKey, AugSchemeMPL, G2Element
@@ -38,7 +39,7 @@ NO_LINEAGE_PROOF = LineageProof()
 class TestCATLifecycle:
     cost: Dict[str, int] = {}
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def setup_sim(self):
         sim = await SpendSim.create()
         sim_client = SimClient(sim)

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import List
 
 import pytest
+import pytest_asyncio
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.full_node.mempool_manager import MempoolManager
@@ -34,17 +35,17 @@ async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32):
 
 
 class TestCATWallet:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 3, {}):
             yield _

--- a/tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 from typing import Dict, Optional, List
 from blspy import G2Element
@@ -43,7 +44,7 @@ def str_to_cat_hash(tail_str: str) -> bytes32:
 class TestOfferLifecycle:
     cost: Dict[str, int] = {}
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def setup_sim(self):
         sim = await SpendSim.create()
         sim_client = SimClient(sim)

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -3,6 +3,7 @@ from secrets import token_bytes
 from typing import List
 
 import pytest
+import pytest_asyncio
 
 from chia.full_node.mempool_manager import MempoolManager
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
@@ -30,7 +31,7 @@ def event_loop():
     yield loop
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def two_wallet_nodes():
     async for _ in setup_simulators_and_wallets(1, 2, {}):
         yield _
@@ -39,7 +40,7 @@ async def two_wallet_nodes():
 buffer_blocks = 4
 
 
-@pytest.fixture(scope="function")
+@pytest_asyncio.fixture(scope="function")
 async def wallets_prefarm(two_wallet_nodes, trusted):
     """
     Sets up the node with 10 blocks, and returns a payer and payee wallet.

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import pytest_asyncio
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
@@ -21,27 +22,27 @@ def event_loop():
 
 
 class TestDIDWallet:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 3, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes_five_freeze(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_sim_two_wallets(self):
         async for _ in setup_simulators_and_wallets(3, 2, {}):
             yield _

--- a/tests/wallet/did_wallet/test_did_rpc.py
+++ b/tests/wallet/did_wallet/test_did_rpc.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import pytest
+import pytest_asyncio
 
 from chia.rpc.rpc_server import start_rpc_server
 from chia.rpc.wallet_rpc_api import WalletRpcApi
@@ -26,7 +27,7 @@ def event_loop():
 
 
 class TestDIDWallet:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 3, {}):
             yield _

--- a/tests/wallet/rl_wallet/test_rl_rpc.py
+++ b/tests/wallet/rl_wallet/test_rl_rpc.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+import pytest_asyncio
 
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
@@ -52,7 +53,7 @@ async def check_balance(api, wallet_id):
 
 
 class TestRLWallet:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 3, {}):
             yield _

--- a/tests/wallet/rl_wallet/test_rl_wallet.py
+++ b/tests/wallet/rl_wallet/test_rl_wallet.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+import pytest_asyncio
 
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
@@ -17,7 +18,7 @@ def event_loop():
 
 
 class TestCATWallet:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}):
             yield _

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -11,6 +11,7 @@ from operator import attrgetter
 import logging
 
 import pytest
+import pytest_asyncio
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.rpc.full_node_rpc_api import FullNodeRpcApi
@@ -40,7 +41,7 @@ log = logging.getLogger(__name__)
 
 
 class TestWalletRpc:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}):
             yield _

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -3,6 +3,7 @@ import asyncio
 from typing import List, Optional
 
 import pytest
+import pytest_asyncio
 from clvm.casts import int_to_bytes
 from colorlog import getLogger
 
@@ -46,12 +47,12 @@ def event_loop():
 
 
 class TestSimpleSyncProtocol:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node_simulator(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_two_node_simulator(self):
         async for _ in setup_simulators_and_wallets(2, 1, {}):
             yield _

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -2,6 +2,7 @@
 import asyncio
 
 import pytest
+import pytest_asyncio
 from colorlog import getLogger
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
@@ -33,17 +34,17 @@ def event_loop():
 
 
 class TestWalletSync:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node(self):
         async for _ in setup_node_and_wallet(test_constants):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node_simulator(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node_starting_height(self):
         async for _ in setup_node_and_wallet(test_constants, starting_height=100):
             yield _

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import pytest_asyncio
 import time
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.protocols.full_node_protocol import RespondBlock
@@ -27,27 +28,27 @@ def event_loop():
 
 
 class TestWalletSimulator:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}, True):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node_100_pk(self):
         async for _ in setup_simulators_and_wallets(1, 1, {}, initial_num_public_keys=100):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}, True):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes_five_freeze(self):
         async for _ in setup_simulators_and_wallets(1, 2, {}, True):
             yield _
 
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def three_sim_two_wallets(self):
         async for _ in setup_simulators_and_wallets(3, 2, {}, True):
             yield _

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import aiosqlite
 import pytest
+import pytest_asyncio
 
 from chia.consensus.blockchain import ReceiveBlockResult
 from chia.protocols import full_node_protocol
@@ -23,7 +24,7 @@ def event_loop():
 
 
 class TestWalletBlockchain:
-    @pytest.fixture(scope="function")
+    @pytest_asyncio.fixture(scope="function")
     async def wallet_node(self):
         async for _ in setup_node_and_wallet(test_constants):
             yield _


### PR DESCRIPTION
the latest version of `pytest_asyncio` prints this deprecation warning:

```
venv/lib/python3.9/site-packages/pytest_asyncio/plugin.py:191
  /home/arvid/dev/2/chia-blockchain/venv/lib/python3.9/site-packages/pytest_asyncio/plugin.py:191:
DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please
explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)
```

This patch sets:
```
asyncio_mode = strict
```

This is the core of this patch:

https://github.com/Chia-Network/chia-blockchain/pull/10230/files#diff-338af70c6877cd271f4d5d1c05bbfc692ad15c5dbff0f7ea3c0e578f3f59c850R6

All other changes are to honor the strict marking of asyncio fixtures.