### PR TITLE
Fix to allow debugging services when launched alongside the GUI

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1093,7 +1093,7 @@ class WebSocketServer:
             self.log.info(f"Service {service_command} already registered")
             already_running = True
 
-        if already_running is False and error is None:
+        if not already_running and error is None:
             try:
                 exe_command = service_command
                 if testing is True:

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1071,6 +1071,7 @@ class WebSocketServer:
         error = None
         success = False
         testing = False
+        already_running = False
         if "testing" in request:
             testing = request["testing"]
 
@@ -1084,9 +1085,15 @@ class WebSocketServer:
                 self.services.pop(service_command)
                 error = None
             else:
-                error = f"Service {service_command} already running"
+                self.log.info(f"Service {service_command} already running")
+                already_running = True
+        elif service_command in self.connections:
+            # If the service was started manually (not launched by the daemon), we should
+            # have a connection to it.
+            self.log.info(f"Service {service_command} already registered")
+            already_running = True
 
-        if error is None:
+        if already_running is False and error is None:
             try:
                 exe_command = service_command
                 if testing is True:
@@ -1097,6 +1104,8 @@ class WebSocketServer:
             except (subprocess.SubprocessError, IOError):
                 log.exception(f"problem starting {service_command}")
                 error = "start failed"
+        elif already_running:
+            success = True
 
         response = {"success": success, "service": service_command, "error": error}
         return response
@@ -1121,6 +1130,12 @@ class WebSocketServer:
         else:
             process = self.services.get(service_name)
             is_running = process is not None and process.poll() is None
+            if not is_running:
+                # Check if we have a connection to the requested service. This might be the
+                # case if the service was started manually (i.e. not started by the daemon).
+                service_connections = self.connections.get(service_name)
+                if service_connections is not None:
+                    is_running = len(service_connections) > 0
             response = {
                 "success": True,
                 "service_name": service_name,

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1093,7 +1093,9 @@ class WebSocketServer:
             self.log.info(f"Service {service_command} already registered")
             already_running = True
 
-        if not already_running and error is None:
+        if already_running:
+            success = True
+        elif error is None:
             try:
                 exe_command = service_command
                 if testing is True:
@@ -1104,8 +1106,6 @@ class WebSocketServer:
             except (subprocess.SubprocessError, IOError):
                 log.exception(f"problem starting {service_command}")
                 error = "start failed"
-        elif already_running:
-            success = True
 
         response = {"success": success, "service": service_command, "error": error}
         return response


### PR DESCRIPTION
Daemon RPCs `start_service` and `is_running` will now additionally check self.connections to determine if a service is running.

When launching services manually (e.g. when debugging), the GUI would attempt (and fail) to relaunch services that were already running, due to the daemon only reporting the statuses of services started by the daemon.

Tested that `chia start <service` worked properly, as well as launching a full set of services from the GUI for farming. Additionally tested that manually running `chia run_daemon` and `python chia/server/start_wallet.py` worked as expected alongside the GUI.