### PR TITLE
Ban setuptools 60.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.2"]
+requires = ["setuptools>=42,!=60.9.1", "wheel", "setuptools_scm[toml]>=4.1.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
[`setuptools` 60.9.1](https://setuptools.pypa.io/en/latest/history.html#v60-9-1) triggers the commit hash (`+g112b9c4a3`) ending up in the PEP 440 local version segment.  Further debugging and reporting to be done aside from this workaround.

https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true
```
Uploading distributions to https://test.pypi.org/legacy/
  dist/chia-blockchain-1.2.[12](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:12).dev290+g112b9c4a3.tar.gz (2.2 MB)
username set by command options
password set by command options
username: __token__
password: <hidden>
Uploading chia-blockchain-1.2.12.dev290+g112b9c4a3.tar.gz

  0%|          | 0.00/2.16M [00:00<?, ?B/s]
  0%|          | 8.00k/2.16M [00:00<01:32, 24.3kB/s]
  7%|▋         | [14](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:14)4k/2.[16](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:16)M [00:00<00:06, 306kB/s]  
 12%|█▏        | 264k/2.16M [00:00<00:04, 489kB/s]
 [20](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:20)%|██        | 448k/2.16M [00:01<00:03, 485kB/s]
 29%|██▊       | 632k/2.16M [00:01<00:02, 550kB/s]
 37%|███▋      | 816k/2.16M [00:01<00:02, 503kB/s]
 48%|████▊     | 1.03M/2.16M [00:02<00:01, 603kB/s]
 59%|█████▊    | 1.[27](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:27)M/2.16M [00:02<00:01, 676kB/s]
100%|██████████| 2.16M/2.16M [00:02<00:00, 853kB/s]
Response from https://test.pypi.org/legacy/:
400 '1.2.12.dev[29](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:29)0+g112b9c4a3' is an invalid value for Version. Error: Can't use PEP 440 local versions. See https://packaging.python.org/specifications/core-metadata for more information.
<html>
 <head>
  <title>400 '1.2.12.dev290+g112b9c4a3' is an invalid value for Version. Error: Can't use PEP 440 local versions. See https://packaging.python.org/specifications/core-metadata for more information.</title>
 </head>
 <body>
  <h1>400 '1.2.12.dev290+g112b9c4a3' is an invalid value for Version. Error: Can't use PEP 440 local versions. See https://packaging.python.org/specifications/core-metadata for more information.</h1>
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
&#x27;1.2.12.dev290+g112b9c4a3&#x27; is an invalid value for Version. Error: Can&#x27;t use PEP 440 local versions. See https://packaging.python.org/specifications/core-metadata for more information.


 </body>
</html>
HTTPError: [40](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:40)0 Bad Request from https://test.pypi.org/legacy/
'1.2.12.dev290+g112b9c4a3' is an invalid value for Version. Error: Can't use PEP [44](https://github.com/Chia-Network/chia-blockchain/runs/5201193312?check_suite_focus=true#step:11:44)0 local versions. See https://packaging.python.org/specifications/core-metadata for more information.
```

https://github.com/Chia-Network/chia-blockchain/runs/5201276860?check_suite_focus=true
```
Uploading distributions to https://test.pypi.org/legacy/
  dist/chia-blockchain-1.2.[12](https://github.com/Chia-Network/chia-blockchain/runs/5201276860?check_suite_focus=true#step:11:12).dev291.tar.gz (2.2 MB)
username set by command options
password set by command options
username: __token__
password: <hidden>
Uploading chia-blockchain-1.2.12.dev291.tar.gz

  0%|          | 0.00/2.[16](https://github.com/Chia-Network/chia-blockchain/runs/5201276860?check_suite_focus=true#step:11:16)M [00:00<?, ?B/s]
100%|██████████| 2.16M/2.16M [00:04<00:00, 5[20](https://github.com/Chia-Network/chia-blockchain/runs/5201276860?check_suite_focus=true#step:11:20)kB/s]
Response from https://test.pypi.org/legacy/:
400 File already exists. See https://test.pypi.org/help/#file-name-reuse for more information.
<html>
 <head>
  <title>400 File already exists. See https://test.pypi.org/help/#file-name-reuse for more information.</title>
 </head>
 <body>
  <h1>400 File already exists. See https://test.pypi.org/help/#file-name-reuse for more information.</h1>
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
File already exists. See https://test.pypi.org/help/#file-name-reuse for more information.


 </body>
</html>
  Skipping chia-blockchain-1.2.12.dev[29](https://github.com/Chia-Network/chia-blockchain/runs/5201276860?check_suite_focus=true#step:11:29)1.tar.gz because it appears to already exist
```