### PR TITLE
Ms.sync cancel

### DIFF
--- a/chia/protocols/protocol_state_machine.py
+++ b/chia/protocols/protocol_state_machine.py
@@ -30,6 +30,7 @@ VALID_REPLY_MESSAGE_MAP = {
     pmt.request_signage_point_or_end_of_sub_slot: [pmt.respond_signage_point, pmt.respond_end_of_sub_slot],
     pmt.request_compact_vdf: [pmt.respond_compact_vdf],
     pmt.request_peers: [pmt.respond_peers],
+    pmt.request_header_blocks: [pmt.respond_header_blocks, pmt.reject_header_blocks],
 }
 
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -373,7 +373,7 @@ class WalletRpcApi:
 
     async def get_height_info(self, request: Dict):
         assert self.service.wallet_state_manager is not None
-        height = self.service.wallet_state_manager.blockchain.get_peak_height()
+        height = await self.service.wallet_state_manager.blockchain.get_finished_sync_up_to()
         return {"height": height}
 
     async def get_network_info(self, request: Dict):

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -79,9 +79,9 @@ class Service:
         chia_ca_crt, chia_ca_key = chia_ssl_ca_paths(root_path, self.config)
         inbound_rlp = self.config.get("inbound_rate_limit_percent")
         outbound_rlp = self.config.get("outbound_rate_limit_percent")
-        if NodeType == NodeType.WALLET:
+        if node_type == NodeType.WALLET:
             inbound_rlp = service_config.get("inbound_rate_limit_percent", inbound_rlp)
-            outbound_rlp = service_config.get("outbound_rate_limit_percent", 60)
+            outbound_rlp = 60
 
         assert inbound_rlp and outbound_rlp
         self._server = ChiaServer(

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -270,3 +270,11 @@ def get_block_challenge(
                 curr = all_blocks.get(curr.prev_header_hash, None)
             challenge = reversed_challenge_hashes[challenges_to_look_for - 1]
     return challenge
+
+
+def cs_sort(cs: CoinState) -> int:
+    if cs.spent_height is not None:
+        return cs.spent_height
+    if cs.created_height is not None:
+        return cs.created_height
+    return 0

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -272,9 +272,9 @@ def get_block_challenge(
     return challenge
 
 
-def cs_sort(cs: CoinState) -> int:
+def last_change_height_cs(cs: CoinState) -> uint32:
     if cs.spent_height is not None:
         return cs.spent_height
     if cs.created_height is not None:
         return cs.created_height
-    return 0
+    return uint32(0)

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import random
 from typing import List, Optional, Tuple, Union, Dict
 
 from chia.consensus.constants import ConsensusConstants
@@ -14,6 +16,8 @@ from chia.protocols.wallet_protocol import (
     CoinState,
     RespondToPhUpdates,
     RespondToCoinUpdates,
+    RespondHeaderBlocks,
+    RequestHeaderBlocks,
 )
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import hash_coin_list, Coin
@@ -22,7 +26,7 @@ from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
 from chia.util.ints import uint32
 from chia.util.merkle_set import confirm_not_included_already_hashed, confirm_included_already_hashed, MerkleSet
-
+from chia.wallet.util.peer_request_cache import PeerRequestCache
 
 log = logging.getLogger(__name__)
 
@@ -278,3 +282,64 @@ def last_change_height_cs(cs: CoinState) -> uint32:
     if cs.created_height is not None:
         return cs.created_height
     return uint32(0)
+
+
+async def _fetch_header_blocks_inner(
+    all_peers: List[WSChiaConnection], selected_peer_node_id: bytes32, request: RequestHeaderBlocks
+) -> Optional[RespondHeaderBlocks]:
+    if len(all_peers) == 0:
+        return None
+    random_peer: WSChiaConnection = random.choice(all_peers)
+    res = await random_peer.request_header_blocks(request)
+    if isinstance(res, RespondHeaderBlocks):
+        return res
+    else:
+        bad_peer_id = random_peer.peer_node_id
+        if len(all_peers) == 1:
+            # No more peers to fetch from
+            return None
+        else:
+            if selected_peer_node_id == bad_peer_id:
+                # Select another peer fallback
+                while random_peer != bad_peer_id and len(all_peers) > 1:
+                    random_peer = random.choice(all_peers)
+            else:
+                # Use the selected peer instead
+                random_peer = [p for p in all_peers if p.peer_node_id == selected_peer_node_id][0]
+            # Retry
+            res = await random_peer.request_header_blocks(request)
+            if isinstance(res, RespondHeaderBlocks):
+                return res
+            else:
+                return None
+
+
+async def fetch_header_blocks_in_range(
+    start: uint32,
+    end: uint32,
+    peer_request_cache: PeerRequestCache,
+    all_peers: List[WSChiaConnection],
+    selected_peer_id: bytes32,
+) -> Optional[List[HeaderBlock]]:
+    blocks: List[HeaderBlock] = []
+    for i in range(start - (start % 32), end + 1, 32):
+        request_start = min(uint32(i), end)
+        request_end = min(uint32(i + 31), end)
+        if (request_start, request_end) in peer_request_cache.block_requests:
+            res_h_blocks_task: asyncio.Task = peer_request_cache.block_requests[(request_start, request_end)]
+            if res_h_blocks_task.done():
+                res_h_blocks: Optional[RespondHeaderBlocks] = res_h_blocks_task.result()
+            else:
+                res_h_blocks = await res_h_blocks_task
+        else:
+            request_header_blocks = RequestHeaderBlocks(request_start, request_end)
+            res_h_blocks_task = asyncio.create_task(
+                _fetch_header_blocks_inner(all_peers, selected_peer_id, request_header_blocks)
+            )
+            peer_request_cache.block_requests[(request_start, request_end)] = res_h_blocks_task
+            res_h_blocks = await res_h_blocks_task
+        if res_h_blocks is None:
+            return None
+        assert res_h_blocks is not None
+        blocks.extend([bl for bl in res_h_blocks.header_blocks if bl.height >= start])
+    return blocks

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -181,7 +181,8 @@ class WalletBlockchain(BlockchainInterface):
         return await self._basic_store.get_object("PEAK_BLOCK", HeaderBlock)
 
     async def set_finished_sync_up_to(self, height: uint32):
-        await self._basic_store.set_object("FINISHED_SYNC_UP_TO", height)
+        if height > await self.get_finished_sync_up_to():
+            await self._basic_store.set_object("FINISHED_SYNC_UP_TO", height)
 
     async def get_finished_sync_up_to(self):
         h: Optional[uint32] = await self._basic_store.get_object("FINISHED_SYNC_UP_TO", uint32)

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -610,7 +610,6 @@ class WalletNode:
             try:
                 assert self.validation_semaphore is not None
                 async with self.validation_semaphore:
-                    nonlocal num_concurrent_tasks
                     assert self.wallet_state_manager is not None
                     if header_hash is not None:
                         assert height is not None
@@ -633,6 +632,7 @@ class WalletNode:
                 tb = traceback.format_exc()
                 self.log.error(f"Exception while adding state: {e} {tb}")
             finally:
+                nonlocal num_concurrent_tasks
                 num_concurrent_tasks -= 1
 
         for idx, potential_state in enumerate(items):

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -633,7 +633,7 @@ class WalletNode:
                 self.log.error(f"Exception while adding state: {e} {tb}")
             finally:
                 nonlocal num_concurrent_tasks
-                num_concurrent_tasks -= 1
+                num_concurrent_tasks -= 1  # pylint: disable=E0602
 
         for idx, potential_state in enumerate(items):
             if self.server is None:
@@ -1044,7 +1044,6 @@ class WalletNode:
         # Only use the cache if we are talking about states before the fork point. If we are evaluating something
         # in a reorg, we cannot use the cache, since we don't know if it's actually in the new chain after the reorg.
         if await can_use_peer_request_cache(coin_state, peer_request_cache, fork_height):
-            self.log.info("Cache hit!")
             return True
 
         spent_height = coin_state.spent_height

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1044,7 +1044,7 @@ class WalletNode:
         # Only use the cache if we are talking about states before the fork point. If we are evaluating something
         # in a reorg, we cannot use the cache, since we don't know if it's actually in the new chain after the reorg.
         if await can_use_peer_request_cache(coin_state, peer_request_cache, fork_height):
-            self.log.info("Cache hit!}")
+            self.log.info("Cache hit!")
             return True
 
         spent_height = coin_state.spent_height

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -586,7 +586,6 @@ class WalletNode:
     ) -> bool:
         # Adds the state to the wallet state manager. If the peer is trusted, we do not validate. If the peer is
         # untrusted we do, but we might not add the state, since we need to receive the new_peak message as well.
-        self.log.info(f"Processing: {[(cs.created_height, cs.spent_height) for cs in items[:150]]}")
         assert self.wallet_state_manager is not None
         trusted = self.is_trusted(peer)
         # Validate states in parallel, apply serial
@@ -648,7 +647,6 @@ class WalletNode:
                 await asyncio.sleep(1)
             all_tasks.append(asyncio.create_task(receive_and_validate(potential_state, idx)))
             num_concurrent_tasks += 1
-            self.log.info(f"Number of tasks: {num_concurrent_tasks}")
 
         await asyncio.gather(*all_tasks)
         await self.update_ui()
@@ -1061,16 +1059,12 @@ class WalletNode:
             current_spent_height = current.spent_block_height
 
         # Same as current state, nothing to do
-        self.log.info(
-            f"coin: {coin_state.coin} current: {current} {coin_state.created_height} {coin_state.spent_height}"
-        )
         if (
             current is not None
             and current_spent_height == spent_height
             and current.confirmed_block_height == confirmed_height
         ):
             peer_request_cache.states_validated[coin_state.get_hash()] = coin_state
-            self.log.info("DB Cache hit!")
             return True
 
         reorg_mode = False


### PR DESCRIPTION
- Allows sync interruption
- Sets the height properly after processing some coin states
- Start from zero always when checking coin id subscriptions
- Fix issue with rate limits from wallet config
- hardcode to 0.6 rate limit for wallet
- Return the correct height in RPC
- Sort the applied coin states by last changed height
- Select a random peer when fetching header blocks, fallback to sync target peer
- Fix many tasks created unnecessarily
- Always sync from zero for a secondary untrusted sync
- Don't re-request the same blocks from two tasks that execute concurrently
