### PR TITLE
extend pools test workflow timeout to 60 minutes

### DIFF
--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: MacOS pools Tests
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     name: Ubuntu pools Test
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/tests/pools/config.py
+++ b/tests/pools/config.py
@@ -1,1 +1,1 @@
-job_timeout = 45
+job_timeout = 60


### PR DESCRIPTION
Recent runs on `main` have been taking over 40 minutes.