### PR TITLE
improve checking arguments when converting the blockchain db

### DIFF
--- a/chia/cmds/db.py
+++ b/chia/cmds/db.py
@@ -21,14 +21,17 @@ def db_cmd() -> None:
 @click.pass_context
 def db_upgrade_cmd(ctx: click.Context, no_update_config: bool, **kwargs) -> None:
 
-    in_db_path = kwargs.get("input")
-    out_db_path = kwargs.get("output")
-    db_upgrade_func(
-        Path(ctx.obj["root_path"]),
-        None if in_db_path is None else Path(in_db_path),
-        None if out_db_path is None else Path(out_db_path),
-        no_update_config,
-    )
+    try:
+        in_db_path = kwargs.get("input")
+        out_db_path = kwargs.get("output")
+        db_upgrade_func(
+            Path(ctx.obj["root_path"]),
+            None if in_db_path is None else Path(in_db_path),
+            None if out_db_path is None else Path(out_db_path),
+            no_update_config,
+        )
+    except RuntimeError as e:
+        print(f"FAILED: {e}")
 
 
 if __name__ == "__main__":

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -65,6 +65,14 @@ def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
 
     from contextlib import closing
 
+    if not in_path.exists():
+        print(f"input file doesn't exist. {in_path}")
+        raise RuntimeError(f"can't find {in_path}")
+
+    if in_path == out_path:
+        print(f"output file is the same as the input {in_path}")
+        raise RuntimeError("invalid conversion files")
+
     if out_path.exists():
         print(f"output file already exists. {out_path}")
         raise RuntimeError("already exists")


### PR DESCRIPTION
This improves error messages in case users have odd states in their .chia folder. It's a response to https://github.com/Chia-Network/chia-blockchain/issues/10262.

The scenario where the source file doesn't exist is especially important to catch, since when we open the sqlite database, it will happily create one if it isn't there already, even though we only intend to open an existing file.

The case where the source and destination files are the same is currently caught by `CREATE TABLE` (by omitting `IF EXISTS` sqlite will throw if we're trying to write into the same file as we're converting. This is not a very helpful error message of what the underlying problem is, nor is it very safe to get so far to open the file twice. There's a risk it becomes corrupt.