### PR TITLE
fix typo and index issues in wallet database

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,11 @@ repos:
         entry: ./tests/build-workflows.py --fail-on-update
         language: python
         pass_filenames: false
+    -   id: check-sql
+        name: Validate SQL statements
+        entry: ./tests/check_sql_statements.py
+        language: python
+        pass_filenames: false
 -   repo: local
     hooks:
     -   id: init_py_files

--- a/chia/wallet/key_val_store.py
+++ b/chia/wallet/key_val_store.py
@@ -22,7 +22,7 @@ class KeyValStore:
             "CREATE TABLE IF NOT EXISTS key_val_store(" " key text PRIMARY KEY," " value blob)"
         )
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS name on key_val_store(key)")
+        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS key_val_name on key_val_store(key)")
 
         await self.db_connection.commit()
         return self

--- a/chia/wallet/wallet_action_store.py
+++ b/chia/wallet/wallet_action_store.py
@@ -39,9 +39,11 @@ class WalletActionStore:
 
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS action_queue_name on action_queue(name)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on action_queue(wallet_id)")
+        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS action_queue_wallet_id on action_queue(wallet_id)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS action_queue_wallet_type on action_queue(wallet_type)")
+        await self.db_connection.execute(
+            "CREATE INDEX IF NOT EXISTS action_queue_wallet_type on action_queue(wallet_type)"
+        )
 
         await self.db_connection.commit()
         return self

--- a/chia/wallet/wallet_action_store.py
+++ b/chia/wallet/wallet_action_store.py
@@ -41,7 +41,7 @@ class WalletActionStore:
 
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on action_queue(wallet_id)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on action_queue(wallet_type)")
+        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS action_queue_wallet_type on action_queue(wallet_type)")
 
         await self.db_connection.commit()
         return self

--- a/chia/wallet/wallet_action_store.py
+++ b/chia/wallet/wallet_action_store.py
@@ -37,7 +37,7 @@ class WalletActionStore:
             )
         )
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS name on action_queue(name)")
+        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS action_queue_name on action_queue(name)")
 
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on action_queue(wallet_id)")
 

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -54,7 +54,9 @@ class WalletCoinStore:
 
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS coin_puzzlehash on coin_record(puzzle_hash)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on coin_record(wallet_type)")
+        await self.db_connection.execute(
+            "CREATE INDEX IF NOT EXISTS coin_record_wallet_type on coin_record(wallet_type)"
+        )
 
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
 

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -57,7 +57,9 @@ class WalletPuzzleStore:
 
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on derivation_paths(wallet_type)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on derivation_paths(wallet_id)")
+        await self.db_connection.execute(
+            "CREATE INDEX IF NOT EXISTS derivation_paths_wallet_id on derivation_paths(wallet_id)"
+        )
 
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS used on derivation_paths(wallet_type)")
 

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -40,7 +40,7 @@ class WalletPuzzleStore:
                 "CREATE TABLE IF NOT EXISTS derivation_paths("
                 "derivation_index int,"
                 " pubkey text,"
-                " puzzle_hash text PRIMARY_KEY,"
+                " puzzle_hash text PRIMARY KEY,"
                 " wallet_type int,"
                 " wallet_id int,"
                 " used tinyint,"

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -71,7 +71,9 @@ class WalletTransactionStore:
             "CREATE INDEX IF NOT EXISTS tx_to_puzzle_hash on transaction_record(to_puzzle_hash)"
         )
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on transaction_record(wallet_id)")
+        await self.db_connection.execute(
+            "CREATE INDEX IF NOT EXISTS transaction_record_wallet_id on transaction_record(wallet_id)"
+        )
 
         await self.db_connection.commit()
         self.tx_record_cache = {}

--- a/tests/check_sql_statements.py
+++ b/tests/check_sql_statements.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import sys
+from subprocess import check_output
+from typing import Dict, Set, Tuple
+
+# check for duplicate index names
+
+
+def check_create(sql_type: str, cwd: str, exemptions: Set[Tuple[str, str]] = set()) -> int:
+
+    lines = check_output(["git", "grep", f"CREATE {sql_type}"], cwd=cwd).decode("ascii").split("\n")
+
+    ret = 0
+
+    items: Dict[str, str] = {}
+    for line in lines:
+        if f"CREATE {sql_type}" not in line:
+            continue
+        if line.startswith("tests/"):
+            continue
+        if "db_upgrade_func.py" in line:
+            continue
+
+        name = line.split(f"CREATE {sql_type}")[1]
+        if name.startswith(" IF NOT EXISTS"):
+            name = name[14:]
+        name = name.strip()
+        name = name.split()[0]
+        name = name.split("(")[0]
+
+        if name in items:
+            # these appear as a duplicates, but one is for v1 and the other for v2
+            if (line.split()[0][:-1], name) not in exemptions:
+                print(f'duplicate {sql_type} "{name}"\n    {items[name]}\n    {line}')
+                ret += 1
+
+        items[name] = line
+
+    return ret
+
+
+ret = 0
+
+ret += check_create("INDEX", "chia/wallet")
+ret += check_create(
+    "INDEX",
+    "chia/full_node",
+    set(
+        [
+            ("block_store.py", "is_fully_compactified"),
+            ("block_store.py", "height"),
+        ]
+    ),
+)
+ret += check_create("TABLE", "chia/wallet")
+ret += check_create(
+    "TABLE",
+    "chia/full_node",
+    set(
+        [
+            ("block_store.py", "sub_epoch_segments_v3"),
+            ("block_store.py", "full_blocks"),
+            ("coin_store.py", "coin_record"),
+            ("hint_store.py", "hints"),
+        ]
+    ),
+)
+sys.exit(ret)


### PR DESCRIPTION
This PR addresses the most serious issues raised by @neurosis69 here: https://github.com/Chia-Network/chia-blockchain/issues/10276

it:

* fixed the `PRIMARY_KEY` typo
* introduce a pre-commit check for duplicate index and table names
* deduplicates index names in wallet database ('name', 'wallet_type' and 'wallet_id')

This is the output from the checking script:

```
$ python tests/check_sql_statements.py 
duplicate INDEX "name"
    key_val_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS name on key_val_store(key)")
    wallet_action_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS name on action_queue(name)")
duplicate INDEX "wallet_type"
    wallet_action_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on action_queue(wallet_type)")
    wallet_coin_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on coin_record(wallet_type)")
duplicate INDEX "wallet_id"
    wallet_action_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on action_queue(wallet_id)")
    wallet_coin_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
duplicate INDEX "wallet_type"
    wallet_coin_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on coin_record(wallet_type)")
    wallet_puzzle_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on derivation_paths(wallet_type)")
duplicate INDEX "wallet_id"
    wallet_coin_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
    wallet_puzzle_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on derivation_paths(wallet_id)")
duplicate INDEX "wallet_id"
    wallet_puzzle_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on derivation_paths(wallet_id)")
    wallet_transaction_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on transaction_record(wallet_id)")
duplicate INDEX "name"
    wallet_action_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS name on action_queue(name)")
    wallet_user_store.py:        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS name on users_wallets(name)")
```

Duplicate index names will fail to be created for all but the first one.

The wallet store classes are created in this order:

https://github.com/Chia-Network/chia-blockchain/blob/main/chia/wallet/wallet_state_manager.py#L144
```
        self.coin_store = await WalletCoinStore.create(self.db_wrapper)
        self.tx_store = await WalletTransactionStore.create(self.db_wrapper)
        self.puzzle_store = await WalletPuzzleStore.create(self.db_wrapper)
        self.user_store = await WalletUserStore.create(self.db_wrapper)
        self.action_store = await WalletActionStore.create(self.db_wrapper)
        self.basic_store = await KeyValStore.create(self.db_wrapper)
        self.trade_manager = await TradeManager.create(self, self.db_wrapper)
        self.user_settings = await UserSettings.create(self.basic_store)
        self.pool_store = await WalletPoolStore.create(self.db_wrapper)
        self.interested_store = await WalletInterestedStore.create(self.db_wrapper)
```

"name" is created in key_val_store.py, wallet_action_store.py and wallet_user_store.py. WalletUserStore is created first, and won't be created in key_val_store nor wallet_action_store.

"wallet_type" is created in wallet_action_store.py, wallet_coin_store.py and wallet_puzzle_store.py. WalletCoinStore creates it first and won't be created in wallet_puzzle_store nor wallet_action_store.

"wallet_id" is created in wallet_action_store.py, wallet_coin_store.py, wallet_puzzle_store.py and wallet_transaction_store.py. It's first created in WalletCoinStore. It won't be created in wallet_action_store, wallet_puzzle_store nor wallet_transaction_store.

The indexes are renamed according to this reasoning.