### PR TITLE
reduce output from running tests

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,7 +1,9 @@
 [pytest]
 ; logging options
-log_cli = 1
-log_level = WARNING
+log_cli = False
+addopts = --verbose --tb=short
+log_level = INFO
+console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 asyncio_mode = strict
 filterwarnings =

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,7 +2,7 @@
 ; logging options
 log_cli = False
 addopts = --verbose --tb=short
-log_level = INFO
+log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 asyncio_mode = strict


### PR DESCRIPTION
setting `log_cli` to false (which technically is the default already) means we won't get live logging. i.e. no logs from tests that pass. This is by far the main source of noise in the logs.

This allows us to set the `log_level` to `INFO` (since we only see those logs for tests that actually fail).

However, disabling `log_cli` also means that default output just prints a `.` for each test that's run, rather than the full name of the test. In order to restore that output, I added `-v` (verbose) to the commandline (via `addopts`). This will print the full names of the tests as they are run.

The `console_output_style` prints the number of tests run, rather than the fraction of tests that have run.

The `--nf` option runs new test files first (i.e. with a more recent timestamp). This isn't important for CI, but for running tests locally, it helps shorten the development cycle.

Finally, `--tb=short` shortens the trace backs printed, rather than printing whole python function source code, just file, line number and one line of source code per frame.

Example output:

```
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/arvid/dev/2/chia-blockchain/venv/bin/python
cachedir: .pytest_cache
rootdir: /home/arvid/dev/2/chia-blockchain/tests, configfile: pytest.ini
plugins: asyncio-0.18.1, forked-1.3.0, xdist-2.4.0, monitor-1.6.2
asyncio: mode=strict
collected 1069 items                                                                                                                                                                                                 

tests/util/test_struct_stream.py::TestStructStream::test_uint32_from_decimal PASSED                                                                                                                       [   1/1069]
tests/util/test_struct_stream.py::TestStructStream::test_uint32_from_float PASSED                                                                                                                         [   2/1069]
tests/util/test_struct_stream.py::TestStructStream::test_uint32_from_str PASSED                                                                                                                           [   3/1069]
tests/util/test_struct_stream.py::TestStructStream::test_uint32_from_bytes PASSED                                                                                                                         [   4/1069]
tests/clvm/test_puzzles.py::TestPuzzles::test_p2_conditions PASSED                                                                                                                                        [   5/1069]
tests/clvm/test_puzzles.py::TestPuzzles::test_p2_delegated_conditions PASSED                                                                                                                              [   6/1069]
tests/clvm/test_puzzles.py::TestPuzzles::test_p2_delegated_puzzle_graftroot PASSED                                                                                                                        [   7/1069]
tests/clvm/test_puzzles.py::TestPuzzles::test_p2_delegated_puzzle_or_hidden_puzzle_with_delegated_puzzle PASSED                                                                                           [   8/1069]
tests/clvm/test_puzzles.py::TestPuzzles::test_p2_delegated_puzzle_or_hidden_puzzle_with_hidden_puzzle PASSED                                                                                              [   9/1069]
tests/clvm/test_puzzles.py::TestPuzzles::test_p2_delegated_puzzle_simple PASSED                                                                                                                           [  10/1069]
tests/clvm/test_puzzles.py::TestPuzzles::test_p2_m_of_n_delegated_puzzle PASSED                                                                                                                           [  11/1069]
...
```