### PR TITLE
do not enable signals on services in tests

### DIFF
--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -51,6 +51,7 @@ class Service:
         rpc_info: Optional[Tuple[type, int]] = None,
         parse_cli_args=True,
         connect_to_daemon=True,
+        handle_signals=True,
     ) -> None:
         self.root_path = root_path
         self.config = load_config(root_path, "config.yaml")
@@ -64,6 +65,7 @@ class Service:
         self._rpc_task: Optional[asyncio.Task] = None
         self._rpc_close_task: Optional[asyncio.Task] = None
         self._network_id: str = network_id
+        self._handle_signals = handle_signals
 
         proctitle_name = f"chia_{service_name}"
         setproctitle(proctitle_name)
@@ -135,7 +137,8 @@ class Service:
 
         self._did_start = True
 
-        self._enable_signals()
+        if self._handle_signals:
+            self._enable_signals()
 
         await self._node._start(**kwargs)
         self._node._shut_down = False

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -119,7 +119,7 @@ async def setup_full_node(
         connect_to_daemon=connect_to_daemon,
     )
 
-    service = Service(**kwargs)
+    service = Service(**kwargs, handle_signals=False)
 
     await service.start()
 
@@ -185,7 +185,7 @@ async def setup_wallet_node(
             connect_to_daemon=False,
         )
 
-        service = Service(**kwargs)
+        service = Service(**kwargs, handle_signals=False)
 
         await service.start()
 
@@ -210,7 +210,7 @@ async def setup_harvester(
         connect_to_daemon=False,
     )
 
-    service = Service(**kwargs)
+    service = Service(**kwargs, handle_signals=False)
 
     if start_service:
         await service.start()
@@ -250,7 +250,7 @@ async def setup_farmer(
         connect_to_daemon=False,
     )
 
-    service = Service(**kwargs)
+    service = Service(**kwargs, handle_signals=False)
 
     if start_service:
         await service.start()
@@ -272,7 +272,7 @@ async def setup_introducer(port):
         connect_to_daemon=False,
     )
 
-    service = Service(**kwargs)
+    service = Service(**kwargs, handle_signals=False)
 
     await service.start()
 
@@ -326,7 +326,7 @@ async def setup_timelord(port, full_node_port, sanitizer, consensus_constants: C
         connect_to_daemon=False,
     )
 
-    service = Service(**kwargs)
+    service = Service(**kwargs, handle_signals=False)
 
     await service.start()
 


### PR DESCRIPTION
This does not make tests exit cleanly, but it should make at least some tests at least somewhat more responsive to ctrl+c.  The basic change is that in the tests using the modified setup functions no signal handler will be registered.  Normally this is used to catch ctrl+c or similar to trigger the services close method.  Instead, we leave signal handling to pytest/pytest-asyncio.  They terminate the test and in the fixture teardown the setup function does it's own teardown including calling the service close method.