### PR TITLE
Fix setuptools_scm local_scheme configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-# setuptools !=60.9.1, !=60.9.2 for bug missing no-local-version
-requires = ["setuptools>=42,!=60.9.1,!=60.9.2", "wheel", "setuptools_scm[toml]>=4.1.2"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = ["setuptools>=42,!=60.9.1,!=60.9.2", "wheel", "setuptools_scm[toml]>=
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+fallback_version = "unknown-no-.git-directory"
 local_scheme = "no-local-version"
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ kwargs = dict(
     python_requires=">=3.7, <4",
     keywords="chia blockchain node",
     install_requires=dependencies,
-    setup_requires=["setuptools_scm"],
     extras_require=dict(
         uvloop=["uvloop"],
         dev=dev_dependencies,
@@ -133,7 +132,6 @@ kwargs = dict(
         "chia.ssl": ["chia_ca.crt", "chia_ca.key", "dst_root_ca.pem"],
         "mozilla-ca": ["cacert.pem"],
     },
-    use_scm_version={"fallback_version": "unknown-no-.git-directory"},
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     zip_safe=False,


### PR DESCRIPTION
With the release of setuptools 60.9.1 our build started creating wheels with the local git hash segment.  This resulted in uploads to test PyPI failing since local segments are not allowed to be published.

setuptools_scm has two entry point hooks it registers with setuptools (at least two that we configure via).  One is for the `setuptools.setup(use_setuptools_scm=)` keyword ([entry point](https://github.com/pypa/setuptools_scm/blob/5f0471c78cb172942057dc9f3795b659550de2ff/setup.cfg#L43-L44), [function](https://github.com/pypa/setuptools_scm/blob/5f0471c78cb172942057dc9f3795b659550de2ff/src/setuptools_scm/integration.py#L57-L76)) and the other is for finalizing the distribution options ([entry point](https://github.com/pypa/setuptools_scm/blob/5f0471c78cb172942057dc9f3795b659550de2ff/setup.cfg#L47-L48), [function](https://github.com/pypa/setuptools_scm/blob/5f0471c78cb172942057dc9f3795b659550de2ff/src/setuptools_scm/integration.py#L92-L105)).  The keyword hook uses the passed dict as the configuration.  The finalization hook uses the `pyproject.toml` as the configuration.

We had specified `local_scheme` in `pyproject.toml` but `fallback_version` in `setup.py` so each hook got a different value for each of those configurations.  Something has happened where with at least setuptools 60.9.1, 60.9.2, and 60.9.3 the hooks end up running in a different order than with 60.9.0 when calling `python -m build` in GitHub Actions.  I was not able to recreate the issue locally and have not explored why the order changed or why it only changed in CI.

This new setup seems better anyways so I consider it an improvement regardless of whether any tooling makes changes to revert this new behavior.