### PR TITLE
Fix setuptools_scm local_scheme configuration (#10296)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
-requires = ["setuptools>=42,!=60.9.1", "wheel", "setuptools_scm[toml]>=4.1.2"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+fallback_version = "unknown-no-.git-directory"
 local_scheme = "no-local-version"
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ kwargs = dict(
     python_requires=">=3.7, <4",
     keywords="chia blockchain node",
     install_requires=dependencies,
-    setup_requires=["setuptools_scm"],
     extras_require=dict(
         uvloop=["uvloop"],
         dev=dev_dependencies,
@@ -138,7 +137,6 @@ kwargs = dict(
         "chia.ssl": ["chia_ca.crt", "chia_ca.key", "dst_root_ca.pem"],
         "mozilla-ca": ["cacert.pem"],
     },
-    use_scm_version={"fallback_version": "unknown-no-.git-directory"},
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     zip_safe=False,


### PR DESCRIPTION
* only configure setuptools_scm in pyproject.toml
* unban setuptools 60.9.1 and 60.9.2

Explained in https://github.com/Chia-Network/chia-blockchain/pull/10296.