### PR TITLE
use free listen ports when running tests

### DIFF
--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -84,6 +84,7 @@ from chia.util.path import mkdir
 from chia.util.vdf_prover import get_vdf_info_and_proof
 from tests.time_out_assert import time_out_assert
 from tests.wallet_tools import WalletTool
+from tests.util.socket import find_available_listen_port
 from chia.wallet.derive_keys import (
     master_sk_to_farmer_sk,
     master_sk_to_local_sk,
@@ -150,6 +151,10 @@ class BlockTools:
         self._config["selected_network"] = "testnet0"
         for service in ["harvester", "farmer", "full_node", "wallet", "introducer", "timelord", "pool"]:
             self._config[service]["selected_network"] = "testnet0"
+
+        # some tests start the daemon, make sure it's on a free port
+        self._config["daemon_port"] = find_available_listen_port("daemon port")
+
         save_config(self.root_path, "config.yaml", self._config)
         overrides = self._config["network_overrides"]["constants"][self._config["selected_network"]]
         updated_constants = constants.replace_str_to_bytes(**overrides)

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -125,25 +125,25 @@ async def wallet_nodes():
 
 @pytest_asyncio.fixture(scope="function")
 async def setup_four_nodes(db_version):
-    async for _ in setup_simulators_and_wallets(5, 0, {}, starting_port=51000, db_version=db_version):
+    async for _ in setup_simulators_and_wallets(5, 0, {}, db_version=db_version):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes(db_version):
-    async for _ in setup_simulators_and_wallets(2, 0, {}, starting_port=51100, db_version=db_version):
+    async for _ in setup_simulators_and_wallets(2, 0, {}, db_version=db_version):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes_and_wallet():
-    async for _ in setup_simulators_and_wallets(2, 1, {}, starting_port=51200, db_version=2):
+    async for _ in setup_simulators_and_wallets(2, 1, {}, db_version=2):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def wallet_nodes_mainnet(db_version):
-    async_gen = setup_simulators_and_wallets(2, 1, {"NETWORK_TYPE": 0}, starting_port=40000, db_version=db_version)
+    async_gen = setup_simulators_and_wallets(2, 1, {"NETWORK_TYPE": 0}, db_version=db_version)
     nodes, wallets = await async_gen.__anext__()
     full_node_1 = nodes[0]
     full_node_2 = nodes[1]

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -41,7 +41,7 @@ def event_loop():
 
 @pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes(db_version):
-    async for _ in setup_simulators_and_wallets(2, 0, {}, starting_port=60000, db_version=db_version):
+    async for _ in setup_simulators_and_wallets(2, 0, {}, db_version=db_version):
         yield _
 
 

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -20,11 +20,13 @@ from tests.setup_nodes import (
     setup_simulators_and_wallets,
     setup_timelord,
 )
+from tests.util.socket import find_available_listen_port
 
 
-async def establish_connection(server: ChiaServer, dummy_port: int, ssl_context) -> bool:
+async def establish_connection(server: ChiaServer, ssl_context) -> bool:
     timeout = aiohttp.ClientTimeout(total=10)
     session = aiohttp.ClientSession(timeout=timeout)
+    dummy_port = 5  # this does not matter
     try:
         incoming_queue: asyncio.Queue = asyncio.Queue()
         url = f"wss://{self_hostname}:{server._port}/ws"
@@ -64,12 +66,17 @@ class TestSSL:
 
     @pytest_asyncio.fixture(scope="function")
     async def introducer(self):
-        async for _ in setup_introducer(21233):
+        introducer_port = find_available_listen_port("introducer")
+        async for _ in setup_introducer(introducer_port):
             yield _
 
     @pytest_asyncio.fixture(scope="function")
     async def timelord(self):
-        async for _ in setup_timelord(21236, 21237, 0, False, test_constants, bt):
+        timelord_port = find_available_listen_port("timelord")
+        node_port = find_available_listen_port("node")
+        rpc_port = find_available_listen_port("rpc")
+        vdf_port = find_available_listen_port("vdf")
+        async for _ in setup_timelord(timelord_port, node_port, rpc_port, vdf_port, False, test_constants, bt):
             yield _
 
     @pytest.mark.asyncio
@@ -100,7 +107,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             farmer_server.ca_private_crt_path, farmer_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(farmer_server, 12312, ssl_context)
+        connected = await establish_connection(farmer_server, ssl_context)
         assert connected is True
 
         # Create not authenticated cert
@@ -112,12 +119,12 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             farmer_server.chia_ca_crt_path, farmer_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(farmer_server, 12312, ssl_context)
+        connected = await establish_connection(farmer_server, ssl_context)
         assert connected is False
         ssl_context = ssl_context_for_client(
             farmer_server.ca_private_crt_path, farmer_server.ca_private_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(farmer_server, 12312, ssl_context)
+        connected = await establish_connection(farmer_server, ssl_context)
         assert connected is False
 
     @pytest.mark.asyncio
@@ -138,7 +145,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             full_node_server.chia_ca_crt_path, full_node_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(full_node_server, 12312, ssl_context)
+        connected = await establish_connection(full_node_server, ssl_context)
         assert connected is True
 
     @pytest.mark.asyncio
@@ -155,7 +162,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             wallet_server.chia_ca_crt_path, wallet_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(wallet_server, 12312, ssl_context)
+        connected = await establish_connection(wallet_server, ssl_context)
         assert connected is False
 
         # Not even signed by private cert
@@ -170,7 +177,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             wallet_server.ca_private_crt_path, wallet_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(wallet_server, 12312, ssl_context)
+        connected = await establish_connection(wallet_server, ssl_context)
         assert connected is False
 
     @pytest.mark.asyncio
@@ -190,7 +197,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             harvester_server.chia_ca_crt_path, harvester_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(harvester_server, 12312, ssl_context)
+        connected = await establish_connection(harvester_server, ssl_context)
         assert connected is False
 
         # Not even signed by private cert
@@ -205,7 +212,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             harvester_server.ca_private_crt_path, harvester_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(harvester_server, 12312, ssl_context)
+        connected = await establish_connection(harvester_server, ssl_context)
         assert connected is False
 
     @pytest.mark.asyncio
@@ -224,7 +231,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             introducer_server.chia_ca_crt_path, introducer_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(introducer_server, 12312, ssl_context)
+        connected = await establish_connection(introducer_server, ssl_context)
         assert connected is True
 
     @pytest.mark.asyncio
@@ -243,7 +250,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             timelord_server.chia_ca_crt_path, timelord_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(timelord_server, 12312, ssl_context)
+        connected = await establish_connection(timelord_server, ssl_context)
         assert connected is False
 
         # Not even signed by private cert
@@ -258,5 +265,5 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             timelord_server.ca_private_crt_path, timelord_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(timelord_server, 12312, ssl_context)
+        connected = await establish_connection(timelord_server, ssl_context)
         assert connected is False

--- a/tests/core/test_daemon_rpc.py
+++ b/tests/core/test_daemon_rpc.py
@@ -5,11 +5,17 @@ from tests.setup_nodes import setup_daemon
 from chia.daemon.client import connect_to_daemon
 from tests.setup_nodes import bt
 from chia import __version__
+from tests.util.socket import find_available_listen_port
+from chia.util.config import save_config
 
 
 class TestDaemonRpc:
     @pytest_asyncio.fixture(scope="function")
     async def get_daemon(self):
+        bt._config["daemon_port"] = find_available_listen_port()
+        # unfortunately, the daemon's WebSocketServer loads the configs from
+        # disk, so the only way to configure its port is to write it to disk
+        save_config(bt.root_path, "config.yaml", bt._config)
         async for _ in setup_daemon(btools=bt):
             yield _
 

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -21,6 +21,7 @@ from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from tests.setup_nodes import bt, self_hostname, setup_farmer_harvester, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.rpc import validate_get_routes
+from tests.util.socket import find_available_listen_port
 
 log = logging.getLogger(__name__)
 
@@ -45,8 +46,8 @@ async def environment(simulation):
     farmer_rpc_api = FarmerRpcApi(farmer_service._api.farmer)
     harvester_rpc_api = HarvesterRpcApi(harvester_service._node)
 
-    rpc_port_farmer = uint16(21522)
-    rpc_port_harvester = uint16(21523)
+    rpc_port_farmer = uint16(find_available_listen_port("farmer rpc"))
+    rpc_port_harvester = uint16(find_available_listen_port("harvester rpc"))
 
     rpc_cleanup = await start_rpc_server(
         farmer_rpc_api,

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -25,6 +25,7 @@ from tests.connection_utils import connect_and_get_peer
 from tests.setup_nodes import bt, self_hostname, setup_simulators_and_wallets, test_constants
 from tests.time_out_assert import time_out_assert
 from tests.util.rpc import validate_get_routes
+from tests.util.socket import find_available_listen_port
 
 
 class TestRpc:
@@ -36,7 +37,7 @@ class TestRpc:
     @pytest.mark.asyncio
     async def test1(self, two_nodes):
         num_blocks = 5
-        test_rpc_port = uint16(21522)
+        test_rpc_port = find_available_listen_port()
         nodes, _ = two_nodes
         full_node_api_1, full_node_api_2 = nodes
         server_1 = full_node_api_1.full_node.server
@@ -231,7 +232,7 @@ class TestRpc:
 
     @pytest.mark.asyncio
     async def test_signage_points(self, two_nodes, empty_blockchain):
-        test_rpc_port = uint16(21522)
+        test_rpc_port = find_available_listen_port()
         nodes, _ = two_nodes
         full_node_api_1, full_node_api_2 = nodes
         server_1 = full_node_api_1.full_node.server

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -32,6 +32,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.wallet_types import WalletType
 from tests.setup_nodes import self_hostname, setup_simulators_and_wallets, bt
 from tests.time_out_assert import time_out_assert
+from tests.util.socket import find_available_listen_port
 
 # TODO: Compare deducted fees in all tests against reported total_fee
 log = logging.getLogger(__name__)
@@ -103,7 +104,7 @@ class TestPoolWalletRpc:
             config = bt.config
             hostname = config["self_hostname"]
             daemon_port = config["daemon_port"]
-            test_rpc_port = uint16(21529)
+            test_rpc_port = find_available_listen_port()
 
             rpc_cleanup = await start_rpc_server(
                 api_user,

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -22,6 +22,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
 from tests.block_tools import create_block_tools, create_block_tools_async, test_constants
 from tests.util.keyring import TempKeyring
+from tests.util.socket import find_available_listen_port
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint32
 from chia.util.keychain import bytes_to_mnemonic
@@ -75,6 +76,7 @@ async def setup_full_node(
     consensus_constants: ConsensusConstants,
     db_name,
     port,
+    rpc_port,
     local_bt,
     introducer_port=None,
     simulator=False,
@@ -106,7 +108,7 @@ async def setup_full_node(
         config["introducer_peer"] = None
     config["dns_servers"] = []
     config["port"] = port
-    config["rpc_port"] = port + 1000
+    config["rpc_port"] = rpc_port
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
     if simulator:
@@ -134,6 +136,7 @@ async def setup_full_node(
 
 async def setup_wallet_node(
     port,
+    rpc_port,
     consensus_constants: ConsensusConstants,
     local_bt,
     full_node_port=None,
@@ -145,7 +148,7 @@ async def setup_wallet_node(
     with TempKeyring() as keychain:
         config = bt.config["wallet"]
         config["port"] = port
-        config["rpc_port"] = port + 1000
+        config["rpc_port"] = rpc_port
         if starting_height is not None:
             config["starting_height"] = starting_height
         config["initial_num_public_keys"] = initial_num_public_keys
@@ -201,9 +204,13 @@ async def setup_wallet_node(
 
 
 async def setup_harvester(
-    port, farmer_port, consensus_constants: ConsensusConstants, b_tools, start_service: bool = True
+    port, rpc_port, farmer_port, consensus_constants: ConsensusConstants, b_tools, start_service: bool = True
 ):
-    kwargs = service_kwargs_for_harvester(b_tools.root_path, b_tools.config["harvester"], consensus_constants)
+
+    config = bt.config["harvester"]
+    config["port"] = port
+    config["rpc_port"] = rpc_port
+    kwargs = service_kwargs_for_harvester(b_tools.root_path, config, consensus_constants)
     kwargs.update(
         server_listen_ports=[port],
         advertised_port=port,
@@ -226,6 +233,7 @@ async def setup_harvester(
 
 async def setup_farmer(
     port,
+    rpc_port,
     consensus_constants: ConsensusConstants,
     b_tools,
     full_node_port: Optional[uint16] = None,
@@ -237,6 +245,7 @@ async def setup_farmer(
     config["xch_target_address"] = encode_puzzle_hash(b_tools.farmer_ph, "xch")
     config["pool_public_keys"] = [bytes(pk).hex() for pk in b_tools.pool_pubkeys]
     config["port"] = port
+    config["rpc_port"] = rpc_port
     config_pool["xch_target_address"] = encode_puzzle_hash(b_tools.pool_ph, "xch")
 
     if full_node_port:
@@ -316,14 +325,15 @@ async def setup_vdf_clients(port):
     await kill_processes()
 
 
-async def setup_timelord(port, full_node_port, rpc_port, sanitizer, consensus_constants: ConsensusConstants, b_tools):
+async def setup_timelord(
+    port, full_node_port, rpc_port, vdf_port, sanitizer, consensus_constants: ConsensusConstants, b_tools
+):
     config = b_tools.config["timelord"]
     config["port"] = port
     config["full_node_peer"]["port"] = full_node_port
     config["bluebox_mode"] = sanitizer
     config["fast_algorithm"] = False
-    if sanitizer:
-        config["vdf_server"]["port"] = 7999
+    config["vdf_server"]["port"] = vdf_port
     config["start_rpc_server"] = True
     config["rpc_port"] = rpc_port
 
@@ -354,7 +364,8 @@ async def setup_two_nodes(consensus_constants: ConsensusConstants, db_version: i
             setup_full_node(
                 consensus_constants,
                 "blockchain_test.db",
-                21234,
+                find_available_listen_port("node1"),
+                find_available_listen_port("node1 rpc"),
                 await create_block_tools_async(constants=test_constants, keychain=keychain1),
                 simulator=False,
                 db_version=db_version,
@@ -362,7 +373,8 @@ async def setup_two_nodes(consensus_constants: ConsensusConstants, db_version: i
             setup_full_node(
                 consensus_constants,
                 "blockchain_test_2.db",
-                21235,
+                find_available_listen_port("node2"),
+                find_available_listen_port("node2 rpc"),
                 await create_block_tools_async(constants=test_constants, keychain=keychain2),
                 simulator=False,
                 db_version=db_version,
@@ -381,7 +393,6 @@ async def setup_n_nodes(consensus_constants: ConsensusConstants, n: int, db_vers
     """
     Setup and teardown of n full nodes, with blockchains and separate DBs.
     """
-    port_start = 21244
     node_iters = []
     keyrings_to_cleanup = []
     for i in range(n):
@@ -391,7 +402,8 @@ async def setup_n_nodes(consensus_constants: ConsensusConstants, n: int, db_vers
             setup_full_node(
                 consensus_constants,
                 f"blockchain_test_{i}.db",
-                port_start + i,
+                find_available_listen_port(f"node{i}"),
+                find_available_listen_port(f"node{i} rpc"),
                 await create_block_tools_async(constants=test_constants, keychain=keyring.get_keychain()),
                 simulator=False,
                 db_version=db_version,
@@ -416,10 +428,22 @@ async def setup_node_and_wallet(
         btools = await create_block_tools_async(constants=test_constants, keychain=keychain)
         node_iters = [
             setup_full_node(
-                consensus_constants, "blockchain_test.db", 21234, btools, simulator=False, db_version=db_version
+                consensus_constants,
+                "blockchain_test.db",
+                find_available_listen_port("node1"),
+                find_available_listen_port("node1 rpc"),
+                btools,
+                simulator=False,
+                db_version=db_version,
             ),
             setup_wallet_node(
-                21235, consensus_constants, btools, None, starting_height=starting_height, key_seed=key_seed
+                find_available_listen_port("node2"),
+                find_available_listen_port("node2 rpc"),
+                consensus_constants,
+                btools,
+                None,
+                starting_height=starting_height,
+                key_seed=key_seed,
             ),
         ]
 
@@ -437,7 +461,6 @@ async def setup_simulators_and_wallets(
     dic: Dict,
     starting_height=None,
     key_seed=None,
-    starting_port=50000,
     initial_num_public_keys=5,
     db_version=1,
 ):
@@ -448,7 +471,8 @@ async def setup_simulators_and_wallets(
 
         consensus_constants = constants_for_dic(dic)
         for index in range(0, simulator_count):
-            port = starting_port + index
+            port = find_available_listen_port(f"node{index}")
+            rpc_port = find_available_listen_port(f"node{index} rpc")
             db_name = f"blockchain_test_{port}.db"
             bt_tools = await create_block_tools_async(
                 consensus_constants, const_dict=dic, keychain=keychain1
@@ -457,6 +481,7 @@ async def setup_simulators_and_wallets(
                 bt_tools.constants,
                 db_name,
                 port,
+                rpc_port,
                 bt_tools,
                 simulator=True,
                 db_version=db_version,
@@ -469,12 +494,14 @@ async def setup_simulators_and_wallets(
                 seed = std_hash(uint32(index))
             else:
                 seed = key_seed
-            port = starting_port + 5000 + index
+            port = find_available_listen_port(f"wallet{index}")
+            rpc_port = find_available_listen_port(f"wallet{index} rpc")
             bt_tools = await create_block_tools_async(
                 consensus_constants, const_dict=dic, keychain=keychain2
             )  # block tools modifies constants
             wlt = setup_wallet_node(
                 port,
+                rpc_port,
                 bt_tools.constants,
                 bt_tools,
                 None,
@@ -491,9 +518,13 @@ async def setup_simulators_and_wallets(
 
 
 async def setup_farmer_harvester(consensus_constants: ConsensusConstants, start_services: bool = True):
+    farmer_port = find_available_listen_port("farmer")
+    farmer_rpc_port = find_available_listen_port("farmer rpc")
+    harvester_port = find_available_listen_port("harvester")
+    harvester_rpc_port = find_available_listen_port("harvester rpc")
     node_iters = [
-        setup_harvester(21234, 21235, consensus_constants, bt, start_services),
-        setup_farmer(21235, consensus_constants, bt, start_service=start_services),
+        setup_harvester(harvester_port, harvester_rpc_port, farmer_port, consensus_constants, bt, start_services),
+        setup_farmer(farmer_port, farmer_rpc_port, consensus_constants, bt, start_service=start_services),
     ]
 
     harvester_service = await node_iters[0].__anext__()
@@ -512,18 +543,37 @@ async def setup_full_system(
             b_tools = await create_block_tools_async(constants=test_constants, keychain=keychain1)
         if b_tools_1 is None:
             b_tools_1 = await create_block_tools_async(constants=test_constants, keychain=keychain2)
+        introducer_port = find_available_listen_port("introducer")
+        farmer_port = find_available_listen_port("farmer")
+        farmer_rpc_port = find_available_listen_port("farmer rpc")
+        node1_port = find_available_listen_port("node1")
+        rpc1_port = find_available_listen_port("node1 rpc")
+        node2_port = find_available_listen_port("node2")
+        rpc2_port = find_available_listen_port("node2 rpc")
+        timelord1_port = find_available_listen_port("timelord1")
+        timelord1_rpc_port = find_available_listen_port("timelord1 rpc")
+        timelord2_port = find_available_listen_port("timelord2")
+        timelord2_rpc_port = find_available_listen_port("timelord2 rpc")
+        vdf1_port = find_available_listen_port("vdf1")
+        vdf2_port = find_available_listen_port("vdf2")
+        harvester_port = find_available_listen_port("harvester")
+        harvester_rpc_port = find_available_listen_port("harvester rpc")
+
         node_iters = [
-            setup_introducer(21233),
-            setup_harvester(21234, 21235, consensus_constants, b_tools),
-            setup_farmer(21235, consensus_constants, b_tools, uint16(21237)),
-            setup_vdf_clients(8000),
-            setup_timelord(21236, 21237, 21241, False, consensus_constants, b_tools),
+            setup_introducer(introducer_port),
+            setup_harvester(harvester_port, harvester_rpc_port, farmer_port, consensus_constants, b_tools),
+            setup_farmer(farmer_port, farmer_rpc_port, consensus_constants, b_tools, uint16(node1_port)),
+            setup_vdf_clients(vdf1_port),
+            setup_timelord(
+                timelord2_port, node1_port, timelord2_rpc_port, vdf1_port, False, consensus_constants, b_tools
+            ),
             setup_full_node(
                 consensus_constants,
                 "blockchain_test.db",
-                21237,
+                node1_port,
+                rpc1_port,
                 b_tools,
-                21233,
+                introducer_port,
                 False,
                 10,
                 True,
@@ -533,18 +583,22 @@ async def setup_full_system(
             setup_full_node(
                 consensus_constants,
                 "blockchain_test_2.db",
-                21238,
+                node2_port,
+                rpc2_port,
                 b_tools_1,
-                21233,
+                introducer_port,
                 False,
                 10,
                 True,
-                connect_to_daemon,
+                False,  # connect_to_daemon,
                 db_version=db_version,
             ),
-            setup_vdf_client(7999),
-            setup_timelord(21239, 1000, 21242, True, consensus_constants, b_tools_1),
+            setup_vdf_client(vdf2_port),
+            setup_timelord(timelord1_port, 1000, timelord1_rpc_port, vdf2_port, True, consensus_constants, b_tools_1),
         ]
+
+        if connect_to_daemon:
+            node_iters.append(setup_daemon(btools=b_tools))
 
         introducer, introducer_server = await node_iters[0].__anext__()
         harvester_service = await node_iters[1].__anext__()
@@ -565,7 +619,7 @@ async def setup_full_system(
         vdf_sanitizer = await node_iters[7].__anext__()
         sanitizer, sanitizer_server = await node_iters[8].__anext__()
 
-        yield (
+        ret = (
             node_api_1,
             node_api_2,
             harvester,
@@ -578,5 +632,11 @@ async def setup_full_system(
             sanitizer_server,
             node_api_1.full_node.server,
         )
+
+        if connect_to_daemon:
+            daemon1 = await node_iters[9].__anext__()
+            yield ret + (daemon1,)
+        else:
+            yield ret
 
         await _teardown_nodes(node_iters)

--- a/tests/util/socket.py
+++ b/tests/util/socket.py
@@ -1,0 +1,11 @@
+import socket
+
+
+def find_available_listen_port(name: str = "free") -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    addr = s.getsockname()
+    assert addr[1] > 0
+    s.close()
+    print(f"{name} port: {addr[1]}")
+    return int(addr[1])

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -36,6 +36,7 @@ from chia.wallet.util.compute_memos import compute_memos
 from tests.pools.test_pool_rpc import wallet_is_synced
 from tests.setup_nodes import bt, setup_simulators_and_wallets, self_hostname
 from tests.time_out_assert import time_out_assert
+from tests.util.socket import find_available_listen_port
 
 log = logging.getLogger(__name__)
 
@@ -52,9 +53,9 @@ class TestWalletRpc:
     )
     @pytest.mark.asyncio
     async def test_wallet_rpc(self, two_wallet_nodes, trusted):
-        test_rpc_port = uint16(21529)
-        test_rpc_port_2 = uint16(21536)
-        test_rpc_port_node = uint16(21530)
+        test_rpc_port = find_available_listen_port()
+        test_rpc_port_2 = find_available_listen_port()
+        test_rpc_port_node = find_available_listen_port()
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]


### PR DESCRIPTION
The purpose of this patch is to make tests more reliable. Currently, they rely on hard coded listen ports to be available on the machine running the tests. This is problematic for two main reasons:

1. You may be unlucky and have some other process already use one of the ports (or there may be a left-over process from a previous test run).
2. It prevents certain tests from being run in parallel, significantly extending the time it takes to run all the tests

## implementation

The main mechanism is implemented in `find_available_listen_port()` ([here](https://github.com/Chia-Network/chia-blockchain/pull/10307/files#diff-4d6d97099999cfdcd1b709572c5de9dc23edf7d77e05edaf6e2bae16930fdd2eR4)) which finds a port that's free. This function is then used in tests to configure them to use those (dynamic) ports rather than hard coded (static) ports.

The implementation of `find_available_listen_port()` is not sophisticated, but it's good enough. If we end up having issues with "address in use" errors, we can make it more sophisticated.

The main challenge has been to understand all the implicit dependencies between default service ports and tests (implicitly) relying on them. Particularly the daemon port (more on that in the code annotation).