### PR TITLE
add another wallet is synced assert to test_subscribe_for_ph

### DIFF
--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -226,6 +226,8 @@ class TestSimpleSyncProtocol:
         for i in range(0, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(SINGLETON_LAUNCHER_HASH))
 
+        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+
         # Send a transaction to make sure the wallet is still running
         tx_record = await wallet.generate_signed_transaction(uint64(10), junk_ph, uint64(0))
         await wallet.push_transaction(tx_record)


### PR DESCRIPTION
To fix test flakes such as https://github.com/Chia-Network/chia-blockchain/runs/5253945366?check_suite_focus=true.

```
        for i in range(0, num_blocks):
            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(SINGLETON_LAUNCHER_HASH))
    
        # Send a transaction to make sure the wallet is still running
        tx_record = await wallet.generate_signed_transaction(uint64(10), junk_ph, uint64(0))
        await wallet.push_transaction(tx_record)
    
>       await time_out_assert(
            15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx_record.spend_bundle.name()
        )
E       AssertionError: Timed assertion timed out after 15 seconds: expected True, got False
```