### PR TITLE
streamable: Implement `Dict` support

### DIFF
--- a/chia/util/type_checking.py
+++ b/chia/util/type_checking.py
@@ -1,6 +1,6 @@
 import dataclasses
 import sys
-from typing import Any, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 if sys.version_info < (3, 8):
 
@@ -18,6 +18,10 @@ else:
 
 def is_type_List(f_type: Type) -> bool:
     return (get_origin(f_type) is not None and get_origin(f_type) == list) or f_type == list
+
+
+def is_type_dict(f_type: Type) -> bool:
+    return get_origin(f_type) == dict or f_type == dict
 
 
 def is_type_SpecificOptional(f_type) -> bool:
@@ -50,6 +54,18 @@ def strictdataclass(cls: Any):
                 for el in item:
                     collected_list.append(self.parse_item(el, f_name, inner_type))
                 return collected_list
+            if is_type_dict(f_type):
+                parsed_dict: Dict = {}
+                args = get_args(f_type)
+                key_type: Type = args[0]
+                value_type: Type = args[1]
+                if not is_type_dict(type(item)):
+                    raise TypeError(f"Wrong type for {f_name}, need a dict.")
+                for key, value in item.items():
+                    parsed_key = self.parse_item(key, f_name, key_type)
+                    parsed_value = self.parse_item(value, f_name, value_type)
+                    parsed_dict[parsed_key] = parsed_value
+                return parsed_dict
             if is_type_SpecificOptional(f_type):
                 if item is None:
                     return None

--- a/tests/core/util/test_type_checking.py
+++ b/tests/core/util/test_type_checking.py
@@ -2,8 +2,10 @@ import unittest
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
+import pytest
+
 from chia.util.ints import uint8
-from chia.util.type_checking import is_type_List, is_type_SpecificOptional, strictdataclass
+from chia.util.type_checking import is_type_dict, is_type_List, is_type_SpecificOptional, strictdataclass
 
 
 class TestIsTypeList(unittest.TestCase):
@@ -89,6 +91,28 @@ class TestStrictClass(unittest.TestCase):
 
         good = TestClass(12, None, 13, None)
         assert good
+
+
+def test_is_type_dict() -> None:
+    a = {1: 2, 3: 4}
+    assert is_type_dict(type(a))
+    assert is_type_dict(dict)
+    assert is_type_dict(Dict)
+    assert is_type_dict(Dict[int, int])
+    assert not is_type_dict(Tuple)  # type:ignore[arg-type]
+    assert not is_type_dict(tuple)
+    assert not is_type_dict(List)
+    assert not is_type_dict(list)
+
+
+def test_invalid_dict_type() -> None:
+    @dataclass(frozen=True)
+    @strictdataclass
+    class TestClass:
+        a: Dict[int, int]
+
+    with pytest.raises(TypeError):
+        TestClass([])  # type:ignore[arg-type]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enables

```python
@dataclass(frozen=True)
@streamable
class A(Streamable):
    a: Dict[str, uint8]
```
instead of what we currently do in such a case
```python
@dataclass(frozen=True)
@streamable
class A(Streamable):
    a: List[Tuple[str, uint8]]
```

Note: There are some places in the code where we probably can just swap them since the byte representation of those is the same but we need to consider that the JSON representation differs so we need to make sure the places where we swap it only depend on the byte representation.