### PR TITLE
Remove block tools and keychain globals

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,10 +14,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
     - name: Display mypy version
       id: display-mypy-version
       run: |
         mypy --version
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,8 +16,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - name: Display mypy version
-      id: display-mypy-version
-      run: |
-        mypy --version
     - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+    - name: Display mypy version
+      id: display-mypy-version
+      run: |
+        mypy --version
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -11,8 +11,7 @@ from keyring.backends.Windows import WinVaultKeyring as WinKeyring
 from keyring.errors import KeyringError, PasswordDeleteError
 from pathlib import Path
 from sys import exit, platform
-from typing import Any, List, Optional, Tuple, Type, Union
-
+from typing import Any, List, Optional, Tuple, Type, Union, TypeVar
 
 # We want to protect the keyring, even if a user-specified master passphrase isn't provided
 #
@@ -82,6 +81,9 @@ def warn_if_macos_errSecInteractionNotAllowed(error: KeyringError) -> bool:
     return False
 
 
+_T_KeyringWrapper = TypeVar("_T_KeyringWrapper", bound="KeyringWrapper")
+
+
 class KeyringWrapper:
     """
     KeyringWrapper provides an abstraction that the Keychain class can use
@@ -104,24 +106,37 @@ class KeyringWrapper:
     cached_passphrase_is_validated: bool = False
     legacy_keyring = None
 
-    def __init__(self, keys_root_path: Path = DEFAULT_KEYS_ROOT_PATH, force_legacy: bool = False):
+    @classmethod
+    def create(
+        cls: Type[_T_KeyringWrapper], keys_root_path: Path = DEFAULT_KEYS_ROOT_PATH, force_legacy: bool = False
+    ) -> Optional[_T_KeyringWrapper]:
         """
-        Initializes the keyring backend based on the OS. For Linux, we previously
-        used CryptFileKeyring. We now use our own FileKeyring backend and migrate
-        the data from the legacy CryptFileKeyring (on write).
+        Create a new KeyringWrapper instance.
         """
-        self.keys_root_path = keys_root_path
+        # instance: KeyringWrapper = KeyringWrapper()
+        instance = cls()
+        instance.keys_root_path = keys_root_path
         if force_legacy:
             legacy_keyring = get_legacy_keyring_instance()
             if check_legacy_keyring_keys_present(legacy_keyring):
-                self.keyring = legacy_keyring
+                instance.keyring = legacy_keyring
             else:
                 return None
         else:
-            self.refresh_keyrings()
+            instance.refresh_keyrings(keys_root_path)
+        return instance
 
-    def refresh_keyrings(self):
-        self.keyring = None
+    def refresh_keyrings(self, keys_root_path: Optional[Path]) -> None:
+        """
+        Initializes or updates the keyring backend based on the OS. For Linux, we
+        previously used CryptFileKeyring. We now use our own FileKeyring backend
+        and migrate the data from the legacy CryptFileKeyring (on write).
+        """
+
+        if keys_root_path is not None:
+            self.keys_root_path = keys_root_path
+
+        self.cleanup_keyring()
         self.keyring = self._configure_backend()
 
         # Configure the legacy keyring if keyring passphrases are supported to support migration (if necessary)
@@ -187,17 +202,29 @@ class KeyringWrapper:
     @staticmethod
     def get_shared_instance(create_if_necessary=True):
         if not KeyringWrapper.__shared_instance and create_if_necessary:
-            KeyringWrapper.__shared_instance = KeyringWrapper(keys_root_path=KeyringWrapper.__keys_root_path)
+            KeyringWrapper.__shared_instance = KeyringWrapper.create(keys_root_path=KeyringWrapper.__keys_root_path)
 
         return KeyringWrapper.__shared_instance
 
     @staticmethod
-    def cleanup_shared_instance():
-        KeyringWrapper.__shared_instance = None
+    def set_shared_instance(instance: "KeyringWrapper"):
+        KeyringWrapper.__shared_instance = instance
 
     @staticmethod
-    def get_legacy_instance() -> Optional["KeyringWrapper"]:
-        return KeyringWrapper(force_legacy=True)
+    def cleanup_shared_instance():
+        if KeyringWrapper.__shared_instance is not None:
+            KeyringWrapper.__shared_instance.cleanup_keyring()
+            KeyringWrapper.__shared_instance = None
+
+    def cleanup_keyring(self):
+        filekeyring: Optional[FileKeyring] = self.keyring if type(self.keyring) == FileKeyring else None
+        if filekeyring is not None:
+            filekeyring.cleanup_keyring_file_watcher()
+        self.keyring = None
+
+    @staticmethod
+    def get_legacy_instance() -> Optional[_T_KeyringWrapper]:
+        return KeyringWrapper.create(force_legacy=True)
 
     def get_keyring(self):
         """
@@ -423,7 +450,8 @@ class KeyringWrapper:
             if user is not None:
                 passphrase = self.get_passphrase(service, user)
 
-            if passphrase is not None:
+            # if passphrase and user:
+            if passphrase:
                 user_passphrase_pairs.append((user, passphrase))
 
             index += 1

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -219,7 +219,7 @@ class KeyringWrapper:
         self.keyring = None
 
     @staticmethod
-    def get_legacy_instance():
+    def get_legacy_instance() -> Optional["KeyringWrapper"]:
         return KeyringWrapper.create(force_legacy=True)
 
     def get_keyring(self):

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -446,8 +446,7 @@ class KeyringWrapper:
             if user is not None:
                 passphrase = self.get_passphrase(service, user)
 
-            # if passphrase and user:
-            if passphrase:
+            if passphrase is not None:
                 user_passphrase_pairs.append((user, passphrase))
 
             index += 1

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -165,7 +165,7 @@ class KeyringWrapper:
 
         return keyring
 
-    def _configure_legacy_backend(self) -> LegacyKeyring:
+    def _configure_legacy_backend(self) -> Optional[LegacyKeyring]:
         # If keyring.yaml isn't found or is empty, check if we're using
         # CryptFileKeyring, Mac Keychain, or Windows Credential Manager
         filekeyring = self.keyring if type(self.keyring) == FileKeyring else None

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -27,6 +27,8 @@ MASTER_PASSPHRASE_USER_NAME = "Chia Passphrase"
 LegacyKeyring = Union[MacKeyring, WinKeyring, CryptFileKeyring]
 OSPassphraseStore = Union[MacKeyring, WinKeyring]
 
+_T_KeyringWrapper = TypeVar("_T_KeyringWrapper", bound="KeyringWrapper")
+
 
 def get_legacy_keyring_instance() -> Optional[LegacyKeyring]:
     if platform == "darwin":
@@ -79,9 +81,6 @@ def warn_if_macos_errSecInteractionNotAllowed(error: KeyringError) -> bool:
         )
         return True
     return False
-
-
-_T_KeyringWrapper = TypeVar("_T_KeyringWrapper", bound="KeyringWrapper")
 
 
 class KeyringWrapper:

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -207,10 +207,6 @@ class KeyringWrapper:
         return KeyringWrapper.__shared_instance
 
     @staticmethod
-    def set_shared_instance(instance: "KeyringWrapper"):
-        KeyringWrapper.__shared_instance = instance
-
-    @staticmethod
     def cleanup_shared_instance():
         if KeyringWrapper.__shared_instance is not None:
             KeyringWrapper.__shared_instance.cleanup_keyring()

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -223,7 +223,7 @@ class KeyringWrapper:
         self.keyring = None
 
     @staticmethod
-    def get_legacy_instance() -> Optional[_T_KeyringWrapper]:
+    def get_legacy_instance():
         return KeyringWrapper.create(force_legacy=True)
 
     def get_keyring(self):

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ dev_dependencies = [
     "build",
     "pre-commit",
     "pytest",
-    # >=0.17.0 for the fixture decorator
-    "pytest-asyncio >=0.17.0",
+    "pytest-asyncio>=0.18.1",  # require attribute 'fixture'
     "pytest-monitor; sys_platform == 'linux'",
     "pytest-xdist",
     "twine",

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -2033,7 +2033,6 @@ async def create_block_tools_async(
     return bt
 
 
-# xxx redirect to the fixture
 def create_block_tools(
     constants: ConsensusConstants = test_constants,
     root_path: Optional[Path] = None,

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -133,6 +133,7 @@ class BlockTools:
         root_path: Optional[Path] = None,
         const_dict=None,
         keychain: Optional[Keychain] = None,
+        daemon_port=None,
     ):
         self._tempdir = None
         if root_path is None:
@@ -153,7 +154,10 @@ class BlockTools:
             self._config[service]["selected_network"] = "testnet0"
 
         # some tests start the daemon, make sure it's on a free port
-        self._config["daemon_port"] = find_available_listen_port("daemon port")
+        if daemon_port is None:
+            self._config["daemon_port"] = find_available_listen_port("BlockTools daemon")
+        else:
+            self._config["daemon_port"] = daemon_port
 
         save_config(self.root_path, "config.yaml", self._config)
         overrides = self._config["network_overrides"]["constants"][self._config["selected_network"]]
@@ -2030,11 +2034,12 @@ async def create_block_tools_async(
     root_path: Optional[Path] = None,
     const_dict=None,
     keychain: Optional[Keychain] = None,
+    daemon_port: Optional[uint16] = None,
 ) -> BlockTools:
     global create_block_tools_async_count
     create_block_tools_async_count += 1
     print(f"  create_block_tools_async called {create_block_tools_async_count} times")
-    bt = BlockTools(constants, root_path, const_dict, keychain)
+    bt = BlockTools(constants, root_path, const_dict, keychain, daemon_port=daemon_port)
     await bt.setup_keys()
     await bt.setup_plots()
 

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -2012,11 +2012,19 @@ def create_test_unfinished_block(
     )
 
 
+# Remove these counters when `create_block_tools` and `create_block_tools_async` are removed
 create_block_tools_async_count = 0
 create_block_tools_count = 0
 
+# Note: tests that still use `create_block_tools` and `create_block_tools_async` should probably be
+# moved to the bt fixture in conftest.py. Take special care to find out if the users of these functions
+# need different BlockTools instances
 
-# xxx do the callers need different instances?
+# All tests need different root directories containing different config.yaml files.
+# The daemon's listen port is configured in the config.yaml, and the only way a test can control which
+# listen port it uses is to write it to the config file.
+
+
 async def create_block_tools_async(
     constants: ConsensusConstants = test_constants,
     root_path: Optional[Path] = None,

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -2012,6 +2012,7 @@ def create_test_unfinished_block(
     )
 
 
+# xxx do the callers need different instances?
 async def create_block_tools_async(
     constants: ConsensusConstants = test_constants,
     root_path: Optional[Path] = None,
@@ -2025,6 +2026,7 @@ async def create_block_tools_async(
     return bt
 
 
+# xxx redirect to the fixture
 def create_block_tools(
     constants: ConsensusConstants = test_constants,
     root_path: Optional[Path] = None,

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -2034,7 +2034,12 @@ async def create_block_tools_async(
     global create_block_tools_async_count
     create_block_tools_async_count += 1
     print(f"  create_block_tools_async called {create_block_tools_async_count} times")
-    bt = BlockTools(constants, root_path, const_dict, keychain,)
+    bt = BlockTools(
+        constants,
+        root_path,
+        const_dict,
+        keychain,
+    )
     await bt.setup_keys()
     await bt.setup_plots()
 

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -133,7 +133,6 @@ class BlockTools:
         root_path: Optional[Path] = None,
         const_dict=None,
         keychain: Optional[Keychain] = None,
-        daemon_port=None,
     ):
         self._tempdir = None
         if root_path is None:
@@ -154,10 +153,7 @@ class BlockTools:
             self._config[service]["selected_network"] = "testnet0"
 
         # some tests start the daemon, make sure it's on a free port
-        if daemon_port is None:
-            self._config["daemon_port"] = find_available_listen_port("BlockTools daemon")
-        else:
-            self._config["daemon_port"] = daemon_port
+        self._config["daemon_port"] = find_available_listen_port("BlockTools daemon")
 
         save_config(self.root_path, "config.yaml", self._config)
         overrides = self._config["network_overrides"]["constants"][self._config["selected_network"]]
@@ -2034,12 +2030,11 @@ async def create_block_tools_async(
     root_path: Optional[Path] = None,
     const_dict=None,
     keychain: Optional[Keychain] = None,
-    daemon_port: Optional[uint16] = None,
 ) -> BlockTools:
     global create_block_tools_async_count
     create_block_tools_async_count += 1
     print(f"  create_block_tools_async called {create_block_tools_async_count} times")
-    bt = BlockTools(constants, root_path, const_dict, keychain, daemon_port=daemon_port)
+    bt = BlockTools(constants, root_path, const_dict, keychain,)
     await bt.setup_keys()
     await bt.setup_plots()
 

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -2012,6 +2012,10 @@ def create_test_unfinished_block(
     )
 
 
+create_block_tools_async_count = 0
+create_block_tools_count = 0
+
+
 # xxx do the callers need different instances?
 async def create_block_tools_async(
     constants: ConsensusConstants = test_constants,
@@ -2019,6 +2023,9 @@ async def create_block_tools_async(
     const_dict=None,
     keychain: Optional[Keychain] = None,
 ) -> BlockTools:
+    global create_block_tools_async_count
+    create_block_tools_async_count += 1
+    print(f"  create_block_tools_async called {create_block_tools_async_count} times")
     bt = BlockTools(constants, root_path, const_dict, keychain)
     await bt.setup_keys()
     await bt.setup_plots()
@@ -2033,6 +2040,9 @@ def create_block_tools(
     const_dict=None,
     keychain: Optional[Keychain] = None,
 ) -> BlockTools:
+    global create_block_tools_count
+    create_block_tools_count += 1
+    print(f"  create_block_tools called {create_block_tools_count} times")
     bt = BlockTools(constants, root_path, const_dict, keychain)
 
     asyncio.get_event_loop().run_until_complete(bt.setup_keys())

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -50,7 +50,7 @@ from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block_no_error,
 )
 from tests.wallet_tools import WalletTool
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
 from tests.util.blockchain import create_blockchain
 from tests.util.keyring import TempKeyring
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
@@ -540,7 +540,7 @@ class TestBlockHeaderValidation:
         )
         await _validate_and_add_block(empty_blockchain, block_0_bad, expected_error=Err.SHOULD_NOT_HAVE_ICC)
 
-    async def do_test_invalid_icc_sub_slot_vdf(self, keychain, db_version, bt):
+    async def do_test_invalid_icc_sub_slot_vdf(self, keychain, db_version):
         bt_high_iters = await create_block_tools_async(
             constants=test_constants.replace(SUB_SLOT_ITERS_STARTING=(2 ** 12), DIFFICULTY_STARTING=(2 ** 14)),
             keychain=keychain,

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -94,29 +94,29 @@ class TestGenesisBlock:
             raise Exception("invalid proof")
 
     @pytest.mark.asyncio
-    async def test_non_overflow_genesis(self, empty_blockchain):
+    async def test_non_overflow_genesis(self, empty_blockchain, bt):
         assert empty_blockchain.get_peak() is None
         genesis = bt.get_consecutive_blocks(1, force_overflow=False)[0]
         await _validate_and_add_block(empty_blockchain, genesis)
         assert empty_blockchain.get_peak().height == 0
 
     @pytest.mark.asyncio
-    async def test_overflow_genesis(self, empty_blockchain):
+    async def test_overflow_genesis(self, empty_blockchain, bt):
         genesis = bt.get_consecutive_blocks(1, force_overflow=True)[0]
         await _validate_and_add_block(empty_blockchain, genesis)
 
     @pytest.mark.asyncio
-    async def test_genesis_empty_slots(self, empty_blockchain):
+    async def test_genesis_empty_slots(self, empty_blockchain, bt):
         genesis = bt.get_consecutive_blocks(1, force_overflow=False, skip_slots=30)[0]
         await _validate_and_add_block(empty_blockchain, genesis)
 
     @pytest.mark.asyncio
-    async def test_overflow_genesis_empty_slots(self, empty_blockchain):
+    async def test_overflow_genesis_empty_slots(self, empty_blockchain, bt):
         genesis = bt.get_consecutive_blocks(1, force_overflow=True, skip_slots=3)[0]
         await _validate_and_add_block(empty_blockchain, genesis)
 
     @pytest.mark.asyncio
-    async def test_genesis_validate_1(self, empty_blockchain):
+    async def test_genesis_validate_1(self, empty_blockchain, bt):
         genesis = bt.get_consecutive_blocks(1, force_overflow=False)[0]
         bad_prev = bytes([1] * 32)
         genesis = recursive_replace(genesis, "foliage.prev_block_hash", bad_prev)
@@ -251,7 +251,7 @@ class TestBlockHeaderValidation:
         assert empty_blockchain.get_peak().height == len(blocks) - 1
 
     @pytest.mark.asyncio
-    async def test_unfinished_blocks(self, empty_blockchain, softfork_height):
+    async def test_unfinished_blocks(self, empty_blockchain, softfork_height, bt):
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(3)
         for block in blocks[:-1]:
@@ -301,13 +301,13 @@ class TestBlockHeaderValidation:
         assert validate_res.error is None
 
     @pytest.mark.asyncio
-    async def test_empty_genesis(self, empty_blockchain):
+    async def test_empty_genesis(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         for block in bt.get_consecutive_blocks(2, skip_slots=3):
             await _validate_and_add_block(empty_blockchain, block)
 
     @pytest.mark.asyncio
-    async def test_empty_slots_non_genesis(self, empty_blockchain):
+    async def test_empty_slots_non_genesis(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(10)
         for block in blocks:
@@ -319,7 +319,7 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == 19
 
     @pytest.mark.asyncio
-    async def test_one_sb_per_slot(self, empty_blockchain):
+    async def test_one_sb_per_slot(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         num_blocks = 20
         blocks = []
@@ -329,7 +329,7 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == num_blocks - 1
 
     @pytest.mark.asyncio
-    async def test_all_overflow(self, empty_blockchain):
+    async def test_all_overflow(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         num_rounds = 5
         blocks = []
@@ -342,7 +342,7 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == num_blocks - 1
 
     @pytest.mark.asyncio
-    async def test_unf_block_overflow(self, empty_blockchain, softfork_height):
+    async def test_unf_block_overflow(self, empty_blockchain, softfork_height, bt):
         blockchain = empty_blockchain
 
         blocks = []
@@ -386,7 +386,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_one_sb_per_two_slots(self, empty_blockchain):
+    async def test_one_sb_per_two_slots(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         num_blocks = 20
         blocks = []
@@ -396,7 +396,7 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == num_blocks - 1
 
     @pytest.mark.asyncio
-    async def test_one_sb_per_five_slots(self, empty_blockchain):
+    async def test_one_sb_per_five_slots(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         num_blocks = 10
         blocks = []
@@ -406,14 +406,14 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == num_blocks - 1
 
     @pytest.mark.asyncio
-    async def test_basic_chain_overflow(self, empty_blockchain):
+    async def test_basic_chain_overflow(self, empty_blockchain, bt):
         blocks = bt.get_consecutive_blocks(5, force_overflow=True)
         for block in blocks:
             await _validate_and_add_block(empty_blockchain, block)
         assert empty_blockchain.get_peak().height == len(blocks) - 1
 
     @pytest.mark.asyncio
-    async def test_one_sb_per_two_slots_force_overflow(self, empty_blockchain):
+    async def test_one_sb_per_two_slots_force_overflow(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         num_blocks = 10
         blocks = []
@@ -423,7 +423,7 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == num_blocks - 1
 
     @pytest.mark.asyncio
-    async def test_invalid_prev(self, empty_blockchain):
+    async def test_invalid_prev(self, empty_blockchain, bt):
         # 1
         blocks = bt.get_consecutive_blocks(2, force_overflow=False)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -432,7 +432,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_1_bad, expected_error=Err.INVALID_PREV_BLOCK_HASH)
 
     @pytest.mark.asyncio
-    async def test_invalid_pospace(self, empty_blockchain):
+    async def test_invalid_pospace(self, empty_blockchain, bt):
         # 2
         blocks = bt.get_consecutive_blocks(2, force_overflow=False)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -441,7 +441,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_1_bad, expected_error=Err.INVALID_POSPACE)
 
     @pytest.mark.asyncio
-    async def test_invalid_sub_slot_challenge_hash_genesis(self, empty_blockchain):
+    async def test_invalid_sub_slot_challenge_hash_genesis(self, empty_blockchain, bt):
         # 2a
         blocks = bt.get_consecutive_blocks(1, force_overflow=False, skip_slots=1)
         new_finished_ss = recursive_replace(
@@ -467,7 +467,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_0_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
-    async def test_invalid_sub_slot_challenge_hash_non_genesis(self, empty_blockchain):
+    async def test_invalid_sub_slot_challenge_hash_non_genesis(self, empty_blockchain, bt):
         # 2b
         blocks = bt.get_consecutive_blocks(1, force_overflow=False, skip_slots=0)
         blocks = bt.get_consecutive_blocks(1, force_overflow=False, skip_slots=1, block_list_input=blocks)
@@ -494,7 +494,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_1_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
-    async def test_invalid_sub_slot_challenge_hash_empty_ss(self, empty_blockchain):
+    async def test_invalid_sub_slot_challenge_hash_empty_ss(self, empty_blockchain, bt):
         # 2c
         blocks = bt.get_consecutive_blocks(1, force_overflow=False, skip_slots=0)
         blocks = bt.get_consecutive_blocks(1, force_overflow=False, skip_slots=2, block_list_input=blocks)
@@ -521,7 +521,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_1_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
-    async def test_genesis_no_icc(self, empty_blockchain):
+    async def test_genesis_no_icc(self, empty_blockchain, bt):
         # 2d
         blocks = bt.get_consecutive_blocks(1, force_overflow=False, skip_slots=1)
         new_finished_ss = recursive_replace(
@@ -540,7 +540,7 @@ class TestBlockHeaderValidation:
         )
         await _validate_and_add_block(empty_blockchain, block_0_bad, expected_error=Err.SHOULD_NOT_HAVE_ICC)
 
-    async def do_test_invalid_icc_sub_slot_vdf(self, keychain, db_version):
+    async def do_test_invalid_icc_sub_slot_vdf(self, keychain, db_version, bt):
         bt_high_iters = await create_block_tools_async(
             constants=test_constants.replace(SUB_SLOT_ITERS_STARTING=(2 ** 12), DIFFICULTY_STARTING=(2 ** 14)),
             keychain=keychain,
@@ -627,7 +627,7 @@ class TestBlockHeaderValidation:
             await self.do_test_invalid_icc_sub_slot_vdf(keychain, db_version)
 
     @pytest.mark.asyncio
-    async def test_invalid_icc_into_cc(self, empty_blockchain):
+    async def test_invalid_icc_into_cc(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(blockchain, blocks[0])
@@ -718,7 +718,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(blockchain, block)
 
     @pytest.mark.asyncio
-    async def test_empty_slot_no_ses(self, empty_blockchain):
+    async def test_empty_slot_no_ses(self, empty_blockchain, bt):
         # 2l
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(1)
@@ -747,7 +747,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(blockchain, block_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
-    async def test_empty_sub_slots_epoch(self, empty_blockchain):
+    async def test_empty_sub_slots_epoch(self, empty_blockchain, bt):
         # 2m
         # Tests adding an empty sub slot after the sub-epoch / epoch.
         # Also tests overflow block in epoch
@@ -764,7 +764,7 @@ class TestBlockHeaderValidation:
         )
 
     @pytest.mark.asyncio
-    async def test_wrong_cc_hash_rc(self, empty_blockchain):
+    async def test_wrong_cc_hash_rc(self, empty_blockchain, bt):
         # 2o
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(1, skip_slots=1)
@@ -783,7 +783,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(blockchain, block_1_bad, expected_error=Err.INVALID_CHALLENGE_SLOT_HASH_RC)
 
     @pytest.mark.asyncio
-    async def test_invalid_cc_sub_slot_vdf(self, empty_blockchain):
+    async def test_invalid_cc_sub_slot_vdf(self, empty_blockchain, bt):
         # 2q
         blocks = bt.get_consecutive_blocks(10)
 
@@ -868,7 +868,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, block)
 
     @pytest.mark.asyncio
-    async def test_invalid_rc_sub_slot_vdf(self, empty_blockchain):
+    async def test_invalid_rc_sub_slot_vdf(self, empty_blockchain, bt):
         # 2p
         blocks = bt.get_consecutive_blocks(10)
         for block in blocks:
@@ -932,7 +932,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, block)
 
     @pytest.mark.asyncio
-    async def test_genesis_bad_deficit(self, empty_blockchain):
+    async def test_genesis_bad_deficit(self, empty_blockchain, bt):
         # 2r
         block = bt.get_consecutive_blocks(1, skip_slots=2)[0]
         new_finished_ss = recursive_replace(
@@ -948,7 +948,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_DEFICIT)
 
     @pytest.mark.asyncio
-    async def test_reset_deficit(self, empty_blockchain):
+    async def test_reset_deficit(self, empty_blockchain, bt):
         # 2s, 2t
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(2)
@@ -982,7 +982,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_genesis_has_ses(self, empty_blockchain):
+    async def test_genesis_has_ses(self, empty_blockchain, bt):
         # 3a
         block = bt.get_consecutive_blocks(1, skip_slots=1)[0]
         new_finished_ss = recursive_replace(
@@ -1010,7 +1010,7 @@ class TestBlockHeaderValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_no_ses_if_no_se(self, empty_blockchain):
+    async def test_no_ses_if_no_se(self, empty_blockchain, bt):
         # 3b
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1056,7 +1056,7 @@ class TestBlockHeaderValidation:
         pass
 
     @pytest.mark.asyncio
-    async def test_bad_pos(self, empty_blockchain):
+    async def test_bad_pos(self, empty_blockchain, bt):
         # 5
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1094,7 +1094,7 @@ class TestBlockHeaderValidation:
         # TODO: test not passing the plot filter
 
     @pytest.mark.asyncio
-    async def test_bad_signage_point_index(self, empty_blockchain):
+    async def test_bad_signage_point_index(self, empty_blockchain, bt):
         # 6
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1111,7 +1111,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_SP_INDEX)
 
     @pytest.mark.asyncio
-    async def test_sp_0_no_sp(self, empty_blockchain):
+    async def test_sp_0_no_sp(self, empty_blockchain, bt):
         # 7
         blocks = []
         case_1, case_2 = False, False
@@ -1136,7 +1136,7 @@ class TestBlockHeaderValidation:
         pass
 
     @pytest.mark.asyncio
-    async def test_bad_total_iters(self, empty_blockchain):
+    async def test_bad_total_iters(self, empty_blockchain, bt):
         # 10
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1147,7 +1147,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_TOTAL_ITERS)
 
     @pytest.mark.asyncio
-    async def test_bad_rc_sp_vdf(self, empty_blockchain):
+    async def test_bad_rc_sp_vdf(self, empty_blockchain, bt):
         # 11
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1181,7 +1181,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_bad_rc_sp_sig(self, empty_blockchain):
+    async def test_bad_rc_sp_sig(self, empty_blockchain, bt):
         # 12
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1189,7 +1189,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_RC_SIGNATURE)
 
     @pytest.mark.asyncio
-    async def test_bad_cc_sp_vdf(self, empty_blockchain):
+    async def test_bad_cc_sp_vdf(self, empty_blockchain, bt):
         # 13. Note: does not validate fully due to proof of space being validated first
 
         blocks = bt.get_consecutive_blocks(1)
@@ -1230,7 +1230,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_bad_cc_sp_sig(self, empty_blockchain):
+    async def test_bad_cc_sp_sig(self, empty_blockchain, bt):
         # 14
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1245,7 +1245,7 @@ class TestBlockHeaderValidation:
         pass
 
     @pytest.mark.asyncio
-    async def test_bad_foliage_sb_sig(self, empty_blockchain):
+    async def test_bad_foliage_sb_sig(self, empty_blockchain, bt):
         # 16
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1253,7 +1253,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_PLOT_SIGNATURE)
 
     @pytest.mark.asyncio
-    async def test_bad_foliage_transaction_block_sig(self, empty_blockchain):
+    async def test_bad_foliage_transaction_block_sig(self, empty_blockchain, bt):
         # 17
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1269,7 +1269,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_unfinished_reward_chain_sb_hash(self, empty_blockchain):
+    async def test_unfinished_reward_chain_sb_hash(self, empty_blockchain, bt):
         # 18
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1282,7 +1282,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_URSB_HASH)
 
     @pytest.mark.asyncio
-    async def test_pool_target_height(self, empty_blockchain):
+    async def test_pool_target_height(self, empty_blockchain, bt):
         # 19
         blocks = bt.get_consecutive_blocks(3)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1294,7 +1294,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.OLD_POOL_TARGET)
 
     @pytest.mark.asyncio
-    async def test_pool_target_pre_farm(self, empty_blockchain):
+    async def test_pool_target_pre_farm(self, empty_blockchain, bt):
         # 20a
         blocks = bt.get_consecutive_blocks(1)
         block_bad: FullBlock = recursive_replace(
@@ -1306,7 +1306,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_PREFARM)
 
     @pytest.mark.asyncio
-    async def test_pool_target_signature(self, empty_blockchain):
+    async def test_pool_target_signature(self, empty_blockchain, bt):
         # 20b
         blocks_initial = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks_initial[0])
@@ -1330,7 +1330,7 @@ class TestBlockHeaderValidation:
             attempts += 1
 
     @pytest.mark.asyncio
-    async def test_pool_target_contract(self, empty_blockchain):
+    async def test_pool_target_contract(self, empty_blockchain, bt):
         # 20c invalid pool target with contract
         blocks_initial = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks_initial[0])
@@ -1354,7 +1354,7 @@ class TestBlockHeaderValidation:
             attempts += 1
 
     @pytest.mark.asyncio
-    async def test_foliage_data_presence(self, empty_blockchain):
+    async def test_foliage_data_presence(self, empty_blockchain, bt):
         # 22
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1381,7 +1381,7 @@ class TestBlockHeaderValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_foliage_transaction_block_hash(self, empty_blockchain):
+    async def test_foliage_transaction_block_hash(self, empty_blockchain, bt):
         # 23
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1403,7 +1403,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_genesis_bad_prev_block(self, empty_blockchain):
+    async def test_genesis_bad_prev_block(self, empty_blockchain, bt):
         # 24a
         blocks = bt.get_consecutive_blocks(1)
         block_bad: FullBlock = recursive_replace(
@@ -1418,7 +1418,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_PREV_BLOCK_HASH)
 
     @pytest.mark.asyncio
-    async def test_bad_prev_block_non_genesis(self, empty_blockchain):
+    async def test_bad_prev_block_non_genesis(self, empty_blockchain, bt):
         # 24b
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1439,7 +1439,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_bad_filter_hash(self, empty_blockchain):
+    async def test_bad_filter_hash(self, empty_blockchain, bt):
         # 25
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1462,7 +1462,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_bad_timestamp(self, empty_blockchain):
+    async def test_bad_timestamp(self, empty_blockchain, bt):
         # 26
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1513,7 +1513,7 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_height(self, empty_blockchain):
+    async def test_height(self, empty_blockchain, bt):
         # 27
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1521,14 +1521,14 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_HEIGHT)
 
     @pytest.mark.asyncio
-    async def test_height_genesis(self, empty_blockchain):
+    async def test_height_genesis(self, empty_blockchain, bt):
         # 27
         blocks = bt.get_consecutive_blocks(1)
         block_bad: FullBlock = recursive_replace(blocks[-1], "reward_chain_block.height", 1)
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_PREV_BLOCK_HASH)
 
     @pytest.mark.asyncio
-    async def test_weight(self, empty_blockchain):
+    async def test_weight(self, empty_blockchain, bt):
         # 28
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1536,14 +1536,14 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_WEIGHT)
 
     @pytest.mark.asyncio
-    async def test_weight_genesis(self, empty_blockchain):
+    async def test_weight_genesis(self, empty_blockchain, bt):
         # 28
         blocks = bt.get_consecutive_blocks(1)
         block_bad: FullBlock = recursive_replace(blocks[-1], "reward_chain_block.weight", 0)
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_WEIGHT)
 
     @pytest.mark.asyncio
-    async def test_bad_cc_ip_vdf(self, empty_blockchain):
+    async def test_bad_cc_ip_vdf(self, empty_blockchain, bt):
         # 29
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1571,7 +1571,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_CC_IP_VDF)
 
     @pytest.mark.asyncio
-    async def test_bad_rc_ip_vdf(self, empty_blockchain):
+    async def test_bad_rc_ip_vdf(self, empty_blockchain, bt):
         # 30
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1599,7 +1599,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_RC_IP_VDF)
 
     @pytest.mark.asyncio
-    async def test_bad_icc_ip_vdf(self, empty_blockchain):
+    async def test_bad_icc_ip_vdf(self, empty_blockchain, bt):
         # 31
         blocks = bt.get_consecutive_blocks(1)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1631,7 +1631,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_ICC_VDF)
 
     @pytest.mark.asyncio
-    async def test_reward_block_hash(self, empty_blockchain):
+    async def test_reward_block_hash(self, empty_blockchain, bt):
         # 32
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
@@ -1639,7 +1639,7 @@ class TestBlockHeaderValidation:
         await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_REWARD_BLOCK_HASH)
 
     @pytest.mark.asyncio
-    async def test_reward_block_hash_2(self, empty_blockchain):
+    async def test_reward_block_hash_2(self, empty_blockchain, bt):
         # 33
         blocks = bt.get_consecutive_blocks(1)
         block_bad: FullBlock = recursive_replace(blocks[0], "reward_chain_block.is_transaction_block", False)
@@ -1666,7 +1666,7 @@ class TestBlockHeaderValidation:
 
 class TestPreValidation:
     @pytest.mark.asyncio
-    async def test_pre_validation_fails_bad_blocks(self, empty_blockchain):
+    async def test_pre_validation_fails_bad_blocks(self, empty_blockchain, bt):
         blocks = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks[0])
 
@@ -1680,7 +1680,7 @@ class TestPreValidation:
         assert res[1].error is not None
 
     @pytest.mark.asyncio
-    async def test_pre_validation(self, empty_blockchain, default_1000_blocks):
+    async def test_pre_validation(self, empty_blockchain, default_1000_blocks, bt):
         blocks = default_1000_blocks[:100]
         start = time.time()
         n_at_a_time = min(multiprocessing.cpu_count(), 32)
@@ -1726,7 +1726,7 @@ class TestBodyValidation:
             (False, (ReceiveBlockResult.NEW_PEAK, None, 2)),
         ],
     )
-    async def test_aggsig_garbage(self, empty_blockchain, opcode, with_garbage, expected):
+    async def test_aggsig_garbage(self, empty_blockchain, opcode, with_garbage, expected, bt):
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
             3,
@@ -1797,7 +1797,7 @@ class TestBodyValidation:
             (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10032, ReceiveBlockResult.INVALID_BLOCK),
         ],
     )
-    async def test_ephemeral_timelock(self, empty_blockchain, opcode, lock_value, expected):
+    async def test_ephemeral_timelock(self, empty_blockchain, opcode, lock_value, expected, bt):
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
             3,
@@ -1847,7 +1847,7 @@ class TestBodyValidation:
             assert c is not None and not c.spent
 
     @pytest.mark.asyncio
-    async def test_not_tx_block_but_has_data(self, empty_blockchain):
+    async def test_not_tx_block_but_has_data(self, empty_blockchain, bt):
         # 1
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(1)
@@ -1877,7 +1877,7 @@ class TestBodyValidation:
         )
 
     @pytest.mark.asyncio
-    async def test_tx_block_missing_data(self, empty_blockchain):
+    async def test_tx_block_missing_data(self, empty_blockchain, bt):
         # 2
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
@@ -1904,7 +1904,7 @@ class TestBodyValidation:
             return None
 
     @pytest.mark.asyncio
-    async def test_invalid_transactions_info_hash(self, empty_blockchain):
+    async def test_invalid_transactions_info_hash(self, empty_blockchain, bt):
         # 3
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
@@ -1925,7 +1925,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block, expected_error=Err.INVALID_TRANSACTIONS_INFO_HASH)
 
     @pytest.mark.asyncio
-    async def test_invalid_transactions_block_hash(self, empty_blockchain):
+    async def test_invalid_transactions_block_hash(self, empty_blockchain, bt):
         # 4
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
@@ -1939,7 +1939,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block, expected_error=Err.INVALID_FOLIAGE_BLOCK_HASH)
 
     @pytest.mark.asyncio
-    async def test_invalid_reward_claims(self, empty_blockchain):
+    async def test_invalid_reward_claims(self, empty_blockchain, bt):
         # 5
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
@@ -2007,7 +2007,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block_2, expected_error=Err.INVALID_REWARD_COINS, skip_prevalidation=True)
 
     @pytest.mark.asyncio
-    async def test_invalid_transactions_generator_hash(self, empty_blockchain):
+    async def test_invalid_transactions_generator_hash(self, empty_blockchain, bt):
         # 7
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
@@ -2064,7 +2064,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block_2, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
 
     @pytest.mark.asyncio
-    async def test_invalid_transactions_ref_list(self, empty_blockchain):
+    async def test_invalid_transactions_ref_list(self, empty_blockchain, bt):
         # No generator should have [1]s for the root
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2165,7 +2165,7 @@ class TestBodyValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_cost_exceeds_max(self, empty_blockchain, softfork_height):
+    async def test_cost_exceeds_max(self, empty_blockchain, softfork_height, bt):
         # 7
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2211,12 +2211,12 @@ class TestBodyValidation:
         assert Err(results[0].error) == Err.BLOCK_COST_EXCEEDS_MAX
 
     @pytest.mark.asyncio
-    async def test_clvm_must_not_fail(self, empty_blockchain):
+    async def test_clvm_must_not_fail(self, empty_blockchain, bt):
         # 8
         pass
 
     @pytest.mark.asyncio
-    async def test_invalid_cost_in_block(self, empty_blockchain, softfork_height):
+    async def test_invalid_cost_in_block(self, empty_blockchain, softfork_height, bt):
         # 9
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2320,7 +2320,7 @@ class TestBodyValidation:
         # a general runtime error. The previous test tests this.
 
     @pytest.mark.asyncio
-    async def test_max_coin_amount(self, db_version):
+    async def test_max_coin_amount(self, db_version, bt):
         # 10
         # TODO: fix, this is not reaching validation. Because we can't create a block with such amounts due to uint64
         # limit in Coin
@@ -2369,7 +2369,7 @@ class TestBodyValidation:
         #     db_path.unlink()
 
     @pytest.mark.asyncio
-    async def test_invalid_merkle_roots(self, empty_blockchain):
+    async def test_invalid_merkle_roots(self, empty_blockchain, bt):
         # 11
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2418,7 +2418,7 @@ class TestBodyValidation:
         await _validate_and_add_block(empty_blockchain, block_2, expected_error=Err.BAD_REMOVAL_ROOT)
 
     @pytest.mark.asyncio
-    async def test_invalid_filter(self, empty_blockchain):
+    async def test_invalid_filter(self, empty_blockchain, bt):
         # 12
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2452,7 +2452,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block_2, expected_error=Err.INVALID_TRANSACTIONS_FILTER_HASH)
 
     @pytest.mark.asyncio
-    async def test_duplicate_outputs(self, empty_blockchain):
+    async def test_duplicate_outputs(self, empty_blockchain, bt):
         # 13
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2482,7 +2482,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, blocks[-1], expected_error=Err.DUPLICATE_OUTPUT)
 
     @pytest.mark.asyncio
-    async def test_duplicate_removals(self, empty_blockchain):
+    async def test_duplicate_removals(self, empty_blockchain, bt):
         # 14
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2511,7 +2511,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, blocks[-1], expected_error=Err.DOUBLE_SPEND)
 
     @pytest.mark.asyncio
-    async def test_double_spent_in_coin_store(self, empty_blockchain):
+    async def test_double_spent_in_coin_store(self, empty_blockchain, bt):
         # 15
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2545,7 +2545,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, blocks[-1], expected_error=Err.DOUBLE_SPEND)
 
     @pytest.mark.asyncio
-    async def test_double_spent_in_reorg(self, empty_blockchain):
+    async def test_double_spent_in_reorg(self, empty_blockchain, bt):
         # 15
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2637,7 +2637,7 @@ class TestBodyValidation:
         assert first_coin is not None and farmer_coin.spent
 
     @pytest.mark.asyncio
-    async def test_minting_coin(self, empty_blockchain):
+    async def test_minting_coin(self, empty_blockchain, bt):
         # 16 Minting coin check
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2675,7 +2675,7 @@ class TestBodyValidation:
         pass
 
     @pytest.mark.asyncio
-    async def test_invalid_fees_in_block(self, empty_blockchain):
+    async def test_invalid_fees_in_block(self, empty_blockchain, bt):
         # 19
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2716,7 +2716,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block_2, expected_error=Err.INVALID_BLOCK_FEE_AMOUNT)
 
     @pytest.mark.asyncio
-    async def test_invalid_agg_sig(self, empty_blockchain):
+    async def test_invalid_agg_sig(self, empty_blockchain, bt):
         # 22
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2762,7 +2762,7 @@ class TestBodyValidation:
 
 class TestReorgs:
     @pytest.mark.asyncio
-    async def test_basic_reorg(self, empty_blockchain):
+    async def test_basic_reorg(self, empty_blockchain, bt):
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(15)
 
@@ -2781,7 +2781,7 @@ class TestReorgs:
         assert b.get_peak().height == 16
 
     @pytest.mark.asyncio
-    async def test_long_reorg(self, empty_blockchain, default_10000_blocks):
+    async def test_long_reorg(self, empty_blockchain, default_10000_blocks, bt):
         # Reorg longer than a difficulty adjustment
         # Also tests higher weight chain but lower height
         b = empty_blockchain
@@ -2833,7 +2833,7 @@ class TestReorgs:
         assert b.get_peak().height == len(default_10000_blocks_compact) - 1
 
     @pytest.mark.asyncio
-    async def test_reorg_from_genesis(self, empty_blockchain):
+    async def test_reorg_from_genesis(self, empty_blockchain, bt):
         b = empty_blockchain
         WALLET_A = WalletTool(b.constants)
         WALLET_A_PUZZLE_HASHES = [WALLET_A.get_new_puzzlehash() for _ in range(5)]
@@ -2866,7 +2866,7 @@ class TestReorgs:
         assert b.get_peak().height == 17
 
     @pytest.mark.asyncio
-    async def test_reorg_transaction(self, empty_blockchain):
+    async def test_reorg_transaction(self, empty_blockchain, bt):
         b = empty_blockchain
         wallet_a = WalletTool(b.constants)
         WALLET_A_PUZZLE_HASHES = [wallet_a.get_new_puzzlehash() for _ in range(5)]
@@ -2911,7 +2911,7 @@ class TestReorgs:
             await _validate_and_add_block_no_error(b, block)
 
     @pytest.mark.asyncio
-    async def test_get_header_blocks_in_range_tx_filter(self, empty_blockchain):
+    async def test_get_header_blocks_in_range_tx_filter(self, empty_blockchain, bt):
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
             3,

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -14,7 +14,7 @@ from chia.util.errors import ConsensusError, Err
 from chia.util.ints import uint64
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.wallet_tools import WalletTool
-from tests.setup_nodes import bt, setup_two_nodes, test_constants
+from tests.setup_nodes import setup_two_nodes, test_constants
 from tests.util.generator_tools_testing import run_and_get_removals_and_additions
 
 BURN_PUZZLE_HASH = b"0" * 32
@@ -33,8 +33,8 @@ def event_loop():
 
 class TestBlockchainTransactions:
     @pytest_asyncio.fixture(scope="function")
-    async def two_nodes(self, db_version):
-        async for _ in setup_two_nodes(test_constants, db_version=db_version):
+    async def two_nodes(self, db_version, self_hostname):
+        async for _ in setup_two_nodes(test_constants, db_version=db_version, self_hostname=self_hostname):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -38,7 +38,7 @@ class TestBlockchainTransactions:
             yield _
 
     @pytest.mark.asyncio
-    async def test_basic_blockchain_tx(self, two_nodes):
+    async def test_basic_blockchain_tx(self, two_nodes, bt):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -99,7 +99,7 @@ class TestBlockchainTransactions:
             assert not unspent.coinbase
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_with_double_spend(self, two_nodes):
+    async def test_validate_blockchain_with_double_spend(self, two_nodes, bt):
         num_blocks = 5
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -137,7 +137,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, next_block, expected_error=Err.DOUBLE_SPEND)
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_duplicate_output(self, two_nodes):
+    async def test_validate_blockchain_duplicate_output(self, two_nodes, bt):
         num_blocks = 3
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -175,7 +175,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, next_block, expected_error=Err.DUPLICATE_OUTPUT)
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_with_reorg_double_spend(self, two_nodes):
+    async def test_validate_blockchain_with_reorg_double_spend(self, two_nodes, bt):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -282,7 +282,7 @@ class TestBlockchainTransactions:
                 await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_spend_reorg_coin(self, two_nodes, softfork_height):
+    async def test_validate_blockchain_spend_reorg_coin(self, two_nodes, softfork_height, bt):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -369,7 +369,7 @@ class TestBlockchainTransactions:
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_spend_reorg_cb_coin(self, two_nodes):
+    async def test_validate_blockchain_spend_reorg_cb_coin(self, two_nodes, bt):
         num_blocks = 15
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -412,7 +412,7 @@ class TestBlockchainTransactions:
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_spend_reorg_since_genesis(self, two_nodes):
+    async def test_validate_blockchain_spend_reorg_since_genesis(self, two_nodes, bt):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -461,7 +461,7 @@ class TestBlockchainTransactions:
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
 
     @pytest.mark.asyncio
-    async def test_assert_my_coin_id(self, two_nodes):
+    async def test_assert_my_coin_id(self, two_nodes, bt):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -528,7 +528,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, new_blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_assert_coin_announcement_consumed(self, two_nodes):
+    async def test_assert_coin_announcement_consumed(self, two_nodes, bt):
 
         num_blocks = 10
         wallet_a = WALLET_A
@@ -610,7 +610,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, new_blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_assert_puzzle_announcement_consumed(self, two_nodes):
+    async def test_assert_puzzle_announcement_consumed(self, two_nodes, bt):
 
         num_blocks = 10
         wallet_a = WALLET_A
@@ -692,7 +692,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, new_blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_assert_height_absolute(self, two_nodes):
+    async def test_assert_height_absolute(self, two_nodes, bt):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -756,7 +756,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, new_blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_assert_height_relative(self, two_nodes):
+    async def test_assert_height_relative(self, two_nodes, bt):
         num_blocks = 11
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -822,7 +822,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, new_blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_assert_seconds_relative(self, two_nodes):
+    async def test_assert_seconds_relative(self, two_nodes, bt):
 
         num_blocks = 10
         wallet_a = WALLET_A
@@ -880,7 +880,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, valid_new_blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_assert_seconds_absolute(self, two_nodes):
+    async def test_assert_seconds_absolute(self, two_nodes, bt):
 
         num_blocks = 10
         wallet_a = WALLET_A
@@ -939,7 +939,7 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(full_node_1.blockchain, valid_new_blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition(self, two_nodes):
+    async def test_assert_fee_condition(self, two_nodes, bt):
 
         num_blocks = 10
         wallet_a = WALLET_A

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,10 +27,9 @@ def bt(get_keychain) -> BlockTools:
     return _shared_block_tools
 
 
-@pytest.fixture(scope="session")
-def self_hostname(bt):
-    return bt.config["self_hostname"]
-
+# if you have a system that has an unusual hostname for localhost and you want
+# to run the tests, change this constant
+self_hostname = "localhost"
 
 # NOTE:
 #       Instantiating the bt fixture results in an attempt to create the chia root directory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,16 @@
+# flake8: noqa E402 # See imports after multiprocessing.set_start_method
 import multiprocessing
 import pytest
 import pytest_asyncio
 import tempfile
+
+# Set spawn after stdlib imports, but before other imports
+multiprocessing.set_start_method("spawn")
+
 from pathlib import Path
 from chia.util.keyring_wrapper import KeyringWrapper
 from tests.block_tools import BlockTools, test_constants, create_block_tools
 from tests.util.keyring import TempKeyring
-
-
-def cleanup_keyring(keyring: TempKeyring):
-    keyring.cleanup()
-
-
-# temp_keyring = TempKeyring(populate=True)
-# keychain = temp_keyring.get_keychain()
-# atexit.register(cleanup_keyring, temp_keyring)  # Attempt to clean up the temp keychain
 
 
 @pytest.fixture(scope="session")
@@ -35,9 +31,6 @@ def bt(get_keychain) -> BlockTools:
 @pytest.fixture(scope="session")
 def self_hostname(bt):
     return bt.config["self_hostname"]
-
-
-multiprocessing.set_start_method("spawn")
 
 
 # NOTE:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,13 @@
 import multiprocessing
 import atexit
-
 import pytest
 import pytest_asyncio
 import tempfile
 from pathlib import Path
-
 from chia.consensus.constants import ConsensusConstants
 from tests.block_tools import BlockTools, test_constants, create_block_tools
-
-# from tests.setup_nodes import setup_shared_block_tools_and_keyring
 from tests.util.keyring import TempKeyring
-
-# from tests.wallet_tools import WalletTool # see test_mempool.py
 from typing import Tuple
-
-# the_block_tools = BlockTools()
-# the_wallet_tool = WalletTool()
-
-
-# @pytest.fixture(scope="module")
-# def shared_block_tools_helper():
-#    yield the_block_tools
-# cleanup the_block_tools
-
-
-# @pytest.fixture(scope="module")
-# def shared_wallet_tool_helper():
-#    return the_wallet_tool
-# cleanup
 
 
 def cleanup_keyring(keyring: TempKeyring):
@@ -59,6 +38,7 @@ def setup_shared_block_tools_and_keyring(
     temp_keyring = TempKeyring(populate=True)
     bt = create_block_tools(constants=consensus_constants, keychain=temp_keyring.get_keychain())
     return bt, temp_keyring
+
 
 
 # @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import multiprocessing
+import atexit
+
 import pytest
 import pytest_asyncio
 import tempfile
@@ -8,9 +10,9 @@ from chia.consensus.constants import ConsensusConstants
 from tests.block_tools import BlockTools, test_constants, create_block_tools
 
 # from tests.setup_nodes import setup_shared_block_tools_and_keyring
-from tests.setup_nodes import bt
 from tests.util.keyring import TempKeyring
-from tests.wallet_tools import WalletTool
+
+# from tests.wallet_tools import WalletTool # see test_mempool.py
 from typing import Tuple
 
 # the_block_tools = BlockTools()
@@ -27,6 +29,28 @@ from typing import Tuple
 # def shared_wallet_tool_helper():
 #    return the_wallet_tool
 # cleanup
+
+
+def cleanup_keyring(keyring: TempKeyring):
+    keyring.cleanup()
+
+
+temp_keyring = TempKeyring(populate=True)
+keychain = temp_keyring.get_keychain()
+atexit.register(cleanup_keyring, temp_keyring)  # Attempt to clean up the temp keychain
+
+
+@pytest.fixture(scope="session", name="bt")
+def bt() -> BlockTools:
+    _shared_block_tools = create_block_tools(constants=test_constants, keychain=keychain)
+    return _shared_block_tools
+    # yield _shared_block_tools
+    # _shared_block_tools.cleanup()
+
+
+@pytest.fixture(scope="session")
+def self_hostname(bt):
+    return bt.config["self_hostname"]
 
 
 def setup_shared_block_tools_and_keyring(
@@ -48,7 +72,7 @@ def setup_shared_block_tools_and_keyring(
 #    yield shared_block_tools_helper.block_tools
 #    shared_block_tools_helper.cleanup()
 
-
+'''
 @pytest.fixture(scope="module")
 def wallet_a(shared_block_tools, cleanup_shared_wallet_tool) -> WalletTool:
     """
@@ -56,7 +80,7 @@ def wallet_a(shared_block_tools, cleanup_shared_wallet_tool) -> WalletTool:
     for all tests in the module.
     """
     return shared_block_tools.wallet_tool
-
+'''
 
 multiprocessing.set_start_method("spawn")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,16 +15,15 @@ from tests.util.keyring import TempKeyring
 
 @pytest.fixture(scope="session")
 def get_keychain():
-    with TempKeyring(user="user-chia-1.8", service="chia-user-chia-1.8") as keychain:
+    with TempKeyring() as keychain:
         yield keychain
         KeyringWrapper.cleanup_shared_instance()
 
 
 @pytest.fixture(scope="session", name="bt")
 def bt(get_keychain) -> BlockTools:
-    k = get_keychain
-    # Note that this changes a lot of state - disk, DB, ports, process creation ...
-    _shared_block_tools = create_block_tools(constants=test_constants, keychain=k)
+    # Note that this causes a lot of CPU and disk traffic - disk, DB, ports, process creation ...
+    _shared_block_tools = create_block_tools(constants=test_constants, keychain=get_keychain)
     return _shared_block_tools
 
 
@@ -34,12 +33,11 @@ def self_hostname(bt):
 
 
 # NOTE:
-#       Note that the bt fixture results in an attempt to create
-#       the chia root directory which the build scripts symlink to a sometimes-not-there
-#       directory.  When not there Python complains since, well, the symlink is a file
-#       not a directory and also not pointing to a directory.
+#       Instantiating the bt fixture results in an attempt to create the chia root directory
+#       which the build scripts symlink to a sometimes-not-there directory.
+#       When not there, Python complains since, well, the symlink is not a directory nor points to a directory.
 #
-#       Now that we have removed the global at tests.setup_nodes.bt, we should can move the imports out of
+#       Now that we have removed the global at tests.setup_nodes.bt, we can move the imports out of
 #       the fixtures below. Just be aware of the filesystem modification during bt fixture creation
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,21 +27,11 @@ def bt(get_keychain) -> BlockTools:
     return _shared_block_tools
 
 
-# If you attempt to use a global hostname variable, or a constant fixture like the one below,
-# some system tests behave more timing dependent and flaky, possible because the bt (BlockTools)
-# fixture is not fully initialized before it is used. See:
-#     tests/wallet/cat_wallet/test_trades.py
-#     tests/wallet/rpc/test_wallet_rpc.py
-# @pytest_asyncio.fixture(scope="function")
-# def self_hostname():
-#    return "localhost"
-
-
 # if you have a system that has an unusual hostname for localhost and you want
 # to run the tests, change the `self_hostname` fixture
-@pytest_asyncio.fixture(scope="function")
-def self_hostname(bt):
-    return bt.config["self_hostname"]
+@pytest_asyncio.fixture(scope="session")
+def self_hostname():
+    return "localhost"
 
 
 # NOTE:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,59 @@ import pytest_asyncio
 import tempfile
 from pathlib import Path
 
+from chia.consensus.constants import ConsensusConstants
+from tests.block_tools import BlockTools, test_constants, create_block_tools
+
+# from tests.setup_nodes import setup_shared_block_tools_and_keyring
+from tests.setup_nodes import bt
+from tests.util.keyring import TempKeyring
+from tests.wallet_tools import WalletTool
+from typing import Tuple
+
+# the_block_tools = BlockTools()
+# the_wallet_tool = WalletTool()
+
+
+# @pytest.fixture(scope="module")
+# def shared_block_tools_helper():
+#    yield the_block_tools
+# cleanup the_block_tools
+
+
+# @pytest.fixture(scope="module")
+# def shared_wallet_tool_helper():
+#    return the_wallet_tool
+# cleanup
+
+
+def setup_shared_block_tools_and_keyring(
+    consensus_constants: ConsensusConstants = test_constants,
+) -> Tuple[BlockTools, TempKeyring]:
+    temp_keyring = TempKeyring(populate=True)
+    bt = create_block_tools(constants=consensus_constants, keychain=temp_keyring.get_keychain())
+    return bt, temp_keyring
+
+
+# @pytest.fixture(scope="module")
+# def shared_block_tools(cleanup_shared_block_tools) -> BlockTools:
+#    """
+#    This fixture is run once per module and is used to create the shared block tools
+#    for all tests in the module.
+#    """
+#    b_tools, keyring = setup_shared_block_tools_and_keyring()
+#    shared_block_tools_helper = BlockToolsFixtureHelper(b_tools, keyring)
+#    yield shared_block_tools_helper.block_tools
+#    shared_block_tools_helper.cleanup()
+
+
+@pytest.fixture(scope="module")
+def wallet_a(shared_block_tools, cleanup_shared_wallet_tool) -> WalletTool:
+    """
+    This fixture is run once per module and is used to create the shared wallet tool
+    for all tests in the module.
+    """
+    return shared_block_tools.wallet_tool
+
 
 multiprocessing.set_start_method("spawn")
 
@@ -52,14 +105,14 @@ block_format_version = "rc4"
 def default_400_blocks():
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", seed=b"alternate2")
+    return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", bt, seed=b"alternate2")
 
 
 @pytest.fixture(scope="session")
 def default_1000_blocks():
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db")
+    return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db", bt)
 
 
 @pytest.fixture(scope="session")
@@ -67,7 +120,7 @@ def pre_genesis_empty_slots_1000_blocks():
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        1000, f"pre_genesis_empty_slots_1000_blocks{block_format_version}.db", seed=b"alternate2", empty_sub_slots=1
+        1000, f"pre_genesis_empty_slots_1000_blocks{block_format_version}.db", bt, seed=b"alternate2", empty_sub_slots=1
     )
 
 
@@ -75,14 +128,14 @@ def pre_genesis_empty_slots_1000_blocks():
 def default_10000_blocks():
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db")
+    return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db", bt)
 
 
 @pytest.fixture(scope="session")
 def default_20000_blocks():
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db")
+    return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db", bt)
 
 
 @pytest.fixture(scope="session")
@@ -92,6 +145,7 @@ def default_10000_blocks_compact():
     return persistent_blocks(
         10000,
         f"test_blocks_10000_compact_{block_format_version}.db",
+        bt,
         normalized_to_identity_cc_eos=True,
         normalized_to_identity_icc_eos=True,
         normalized_to_identity_cc_ip=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,22 @@ def bt(get_keychain) -> BlockTools:
     return _shared_block_tools
 
 
+# If you attempt to use a global hostname variable, or a constant fixture like the one below,
+# some system tests behave more timing dependent and flaky, possible because the bt (BlockTools)
+# fixture is not fully initialized before it is used. See:
+#     tests/wallet/cat_wallet/test_trades.py
+#     tests/wallet/rpc/test_wallet_rpc.py
+# @pytest_asyncio.fixture(scope="function")
+# def self_hostname():
+#    return "localhost"
+
+
 # if you have a system that has an unusual hostname for localhost and you want
-# to run the tests, change this constant
-self_hostname = "localhost"
+# to run the tests, change the `self_hostname` fixture
+@pytest_asyncio.fixture(scope="function")
+def self_hostname(bt):
+    return bt.config["self_hostname"]
+
 
 # NOTE:
 #       Instantiating the bt fixture results in an attempt to create the chia root directory

--- a/tests/connection_utils.py
+++ b/tests/connection_utils.py
@@ -15,13 +15,12 @@ from chia.ssl.create_ssl import generate_ca_signed_cert
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
-from tests.setup_nodes import self_hostname
 from tests.time_out_assert import time_out_assert
 
 log = logging.getLogger(__name__)
 
 
-async def disconnect_all_and_reconnect(server: ChiaServer, reconnect_to: ChiaServer) -> bool:
+async def disconnect_all_and_reconnect(server: ChiaServer, reconnect_to: ChiaServer, self_hostname: str) -> bool:
     cons = list(server.all_connections.values())[:]
     for con in cons:
         await con.close()
@@ -29,7 +28,7 @@ async def disconnect_all_and_reconnect(server: ChiaServer, reconnect_to: ChiaSer
 
 
 async def add_dummy_connection(
-    server: ChiaServer, dummy_port: int, type: NodeType = NodeType.FULL_NODE
+    server: ChiaServer, self_hostname: str, dummy_port: int, type: NodeType = NodeType.FULL_NODE
 ) -> Tuple[asyncio.Queue, bytes32]:
     timeout = aiohttp.ClientTimeout(total=10)
     session = aiohttp.ClientSession(timeout=timeout)
@@ -66,7 +65,7 @@ async def add_dummy_connection(
     return incoming_queue, peer_id
 
 
-async def connect_and_get_peer(server_1: ChiaServer, server_2: ChiaServer) -> WSChiaConnection:
+async def connect_and_get_peer(server_1: ChiaServer, server_2: ChiaServer, self_hostname: str) -> WSChiaConnection:
     """
     Connect server_2 to server_1, and get return the connection in server_1.
     """

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -47,7 +47,7 @@ class TestDaemon:
         return await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
 
     @pytest_asyncio.fixture(scope="function")
-    async def get_b_tools(self, get_temp_keyring):  # xxx
+    async def get_b_tools(self, get_temp_keyring):
         local_b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
         new_config = local_b_tools._config
         local_b_tools.change_config(new_config)

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -32,9 +32,8 @@ class TestDaemon:
 
     @pytest_asyncio.fixture(scope="function")
     async def get_b_tools(self, get_temp_keyring):
-        daemon_port = find_available_listen_port("daemon")
         local_b_tools = await create_block_tools_async(
-            constants=test_constants_modified, keychain=get_temp_keyring, daemon_port=daemon_port
+            constants=test_constants_modified, keychain=get_temp_keyring
         )
         new_config = local_b_tools._config
         local_b_tools.change_config(new_config)

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -1,3 +1,10 @@
+import aiohttp
+import asyncio
+import json
+import logging
+import pytest
+import pytest_asyncio
+
 from chia.daemon.server import WebSocketServer
 from chia.server.outbound_message import NodeType
 from chia.types.peer_info import PeerInfo
@@ -6,20 +13,37 @@ from chia.util.ints import uint16
 from chia.util.keyring_wrapper import DEFAULT_PASSPHRASE_IF_NO_MASTER_PASSPHRASE
 from chia.util.ws_message import create_payload
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import setup_daemon, setup_full_system
+from tests.setup_nodes import setup_daemon, self_hostname, setup_full_system
 from tests.simulation.test_simulation import test_constants_modified
-from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
+from tests.time_out_assert import time_out_assert_custom_interval, time_out_assert
 from tests.util.keyring import TempKeyring
-
-import asyncio
-import json
-
-import aiohttp
-import pytest
-import pytest_asyncio
+from tests.util.socket import find_available_listen_port
 
 
 class TestDaemon:
+    @pytest_asyncio.fixture(scope="function")
+    async def get_temp_keyring(self):
+        with TempKeyring() as keychain:
+            yield keychain
+
+    @pytest_asyncio.fixture(scope="function")
+    async def get_b_tools_1(self, get_temp_keyring):
+        return await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
+
+    @pytest_asyncio.fixture(scope="function")
+    async def get_b_tools(self, get_temp_keyring):
+        daemon_port = find_available_listen_port("daemon")
+        local_b_tools = await create_block_tools_async(
+            constants=test_constants_modified, keychain=get_temp_keyring, daemon_port=daemon_port
+        )
+        new_config = local_b_tools._config
+        local_b_tools.change_config(new_config)
+        return local_b_tools
+
+    @pytest_asyncio.fixture(scope="function")
+    async def get_daemon_with_temp_keyring(self, get_b_tools):
+        async for daemon in setup_daemon(btools=get_b_tools):
+            yield get_b_tools, daemon
 
     # TODO: Ideally, the db_version should be the (parameterized) db_version
     # fixture, to test all versions of the database schema. This doesn't work
@@ -32,34 +56,13 @@ class TestDaemon:
             bt,
             b_tools=get_b_tools,
             b_tools_1=get_b_tools_1,
-            connect_to_daemon=True,
+            connect_to_daemon_port=get_b_tools._config["daemon_port"],
             db_version=1,
         ):
             yield _
 
-    @pytest_asyncio.fixture(scope="function")
-    async def get_temp_keyring(self):
-        with TempKeyring() as keychain:
-            yield keychain
-
-    @pytest_asyncio.fixture(scope="function")
-    async def get_b_tools_1(self, get_temp_keyring):
-        return await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
-
-    @pytest_asyncio.fixture(scope="function")
-    async def get_b_tools(self, get_temp_keyring):
-        local_b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
-        new_config = local_b_tools._config
-        local_b_tools.change_config(new_config)
-        return local_b_tools
-
-    @pytest_asyncio.fixture(scope="function")
-    async def get_daemon_with_temp_keyring(self, get_b_tools):
-        async for daemon in setup_daemon(btools=get_b_tools):
-            yield get_b_tools, daemon
-
     @pytest.mark.asyncio
-    async def test_daemon_simulation(self, simulation, get_daemon, get_b_tools, self_hostname):
+    async def test_daemon_simulation(self, simulation, bt, get_b_tools, get_b_tools_1):
         node1, node2, _, _, _, _, _, _, _, _, server1, daemon1 = simulation
         node2_port = node2.full_node.config["port"]
         await server1.start_client(PeerInfo(self_hostname, uint16(node2_port)))
@@ -70,16 +73,18 @@ class TestDaemon:
 
         await time_out_assert_custom_interval(60, 1, num_connections, 1)
 
-        await time_out_assert(1500, node_height_at_least, True, node2, 1)
-        session = aiohttp.ClientSession()
-        ssl_context = get_b_tools.get_daemon_ssl_context()
+        await time_out_assert(30, node_height_at_least, True, node2, 1)
 
+        session = aiohttp.ClientSession()
+
+        log = logging.getLogger()
+        log.warning(f"Connecting to daemon on port {daemon1.daemon_port}")
         ws = await session.ws_connect(
             f"wss://127.0.0.1:{daemon1.daemon_port}",
             autoclose=True,
             autoping=True,
             heartbeat=60,
-            ssl_context=ssl_context,
+            ssl_context=get_b_tools.get_daemon_ssl_context(),
             max_msg_size=100 * 1024 * 1024,
         )
         service_name = "test_service_name"

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -13,7 +13,7 @@ from chia.util.ints import uint16
 from chia.util.keyring_wrapper import DEFAULT_PASSPHRASE_IF_NO_MASTER_PASSPHRASE
 from chia.util.ws_message import create_payload
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import setup_daemon, self_hostname, setup_full_system
+from tests.setup_nodes import setup_daemon, setup_full_system
 from tests.simulation.test_simulation import test_constants_modified
 from tests.time_out_assert import time_out_assert_custom_interval, time_out_assert
 from tests.util.keyring import TempKeyring
@@ -58,7 +58,7 @@ class TestDaemon:
             yield _
 
     @pytest.mark.asyncio
-    async def test_daemon_simulation(self, simulation, bt, get_b_tools, get_b_tools_1):
+    async def test_daemon_simulation(self, self_hostname, simulation, bt, get_b_tools, get_b_tools_1):
         node1, node2, _, _, _, _, _, _, _, _, server1, daemon1 = simulation
         node2_port = node2.full_node.config["port"]
         await server1.start_client(PeerInfo(self_hostname, uint16(node2_port)))

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -6,7 +6,7 @@ from chia.util.ints import uint16
 from chia.util.keyring_wrapper import DEFAULT_PASSPHRASE_IF_NO_MASTER_PASSPHRASE
 from chia.util.ws_message import create_payload
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import setup_daemon, self_hostname, setup_full_system
+from tests.setup_nodes import setup_daemon, setup_full_system
 from tests.simulation.test_simulation import test_constants_modified
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.keyring import TempKeyring
@@ -26,9 +26,14 @@ class TestDaemon:
     # because of a hack in shutting down the full node, which means you cannot run
     # more than one simulations per process.
     @pytest_asyncio.fixture(scope="function")
-    async def simulation(self, get_b_tools, get_b_tools_1):
+    async def simulation(self, bt, get_b_tools, get_b_tools_1):
         async for _ in setup_full_system(
-            test_constants_modified, b_tools=get_b_tools, b_tools_1=get_b_tools_1, connect_to_daemon=True, db_version=1
+            test_constants_modified,
+            bt,
+            b_tools=get_b_tools,
+            b_tools_1=get_b_tools_1,
+            connect_to_daemon=True,
+            db_version=1,
         ):
             yield _
 
@@ -42,7 +47,7 @@ class TestDaemon:
         return await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
 
     @pytest_asyncio.fixture(scope="function")
-    async def get_b_tools(self, get_temp_keyring):
+    async def get_b_tools(self, get_temp_keyring):  # xxx
         local_b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
         new_config = local_b_tools._config
         local_b_tools.change_config(new_config)
@@ -54,7 +59,7 @@ class TestDaemon:
             yield get_b_tools, daemon
 
     @pytest.mark.asyncio
-    async def test_daemon_simulation(self, simulation, get_b_tools):
+    async def test_daemon_simulation(self, simulation, get_daemon, get_b_tools, self_hostname):
         node1, node2, _, _, _, _, _, _, _, _, server1, daemon1 = simulation
         node2_port = node2.full_node.config["port"]
         await server1.start_client(PeerInfo(self_hostname, uint16(node2_port)))

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -17,7 +17,6 @@ from tests.setup_nodes import setup_daemon, self_hostname, setup_full_system
 from tests.simulation.test_simulation import test_constants_modified
 from tests.time_out_assert import time_out_assert_custom_interval, time_out_assert
 from tests.util.keyring import TempKeyring
-from tests.util.socket import find_available_listen_port
 
 
 class TestDaemon:
@@ -32,9 +31,7 @@ class TestDaemon:
 
     @pytest_asyncio.fixture(scope="function")
     async def get_b_tools(self, get_temp_keyring):
-        local_b_tools = await create_block_tools_async(
-            constants=test_constants_modified, keychain=get_temp_keyring
-        )
+        local_b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
         new_config = local_b_tools._config
         local_b_tools.change_config(new_config)
         return local_b_tools
@@ -55,7 +52,7 @@ class TestDaemon:
             bt,
             b_tools=get_b_tools,
             b_tools_1=get_b_tools_1,
-            connect_to_daemon_port=get_b_tools._config["daemon_port"],
+            connect_to_daemon=True,
             db_version=1,
         ):
             yield _

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -73,7 +73,7 @@ class TestDaemon:
 
         await time_out_assert_custom_interval(60, 1, num_connections, 1)
 
-        await time_out_assert(30, node_height_at_least, True, node2, 1)
+        await time_out_assert(1500, node_height_at_least, True, node2, 1)
 
         session = aiohttp.ClientSession()
 

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -15,7 +15,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.hash import std_hash
 from chia.util.ints import uint16
 from tests.core.node_height import node_height_exactly, node_height_between
-from tests.setup_nodes import bt, self_hostname, setup_n_nodes, setup_two_nodes, test_constants
+from tests.setup_nodes import setup_n_nodes, setup_two_nodes, test_constants
 from tests.time_out_assert import time_out_assert
 
 
@@ -30,27 +30,27 @@ log = logging.getLogger(__name__)
 
 class TestFullSync:
     @pytest_asyncio.fixture(scope="function")
-    async def two_nodes(self, db_version):
-        async for _ in setup_two_nodes(test_constants, db_version=db_version):
+    async def two_nodes(self, db_version, self_hostname):
+        async for _ in setup_two_nodes(test_constants, db_version=db_version, self_hostname=self_hostname):
             yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def three_nodes(self, db_version):
-        async for _ in setup_n_nodes(test_constants, 3, db_version=db_version):
+    async def three_nodes(self, db_version, self_hostname):
+        async for _ in setup_n_nodes(test_constants, 3, db_version=db_version, self_hostname=self_hostname):
             yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def four_nodes(self, db_version):
-        async for _ in setup_n_nodes(test_constants, 4, db_version=db_version):
+    async def four_nodes(self, db_version, self_hostname):
+        async for _ in setup_n_nodes(test_constants, 4, db_version=db_version, self_hostname=self_hostname):
             yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def five_nodes(self, db_version):
-        async for _ in setup_n_nodes(test_constants, 5, db_version=db_version):
+    async def five_nodes(self, db_version, self_hostname):
+        async for _ in setup_n_nodes(test_constants, 5, db_version=db_version, self_hostname=self_hostname):
             yield _
 
     @pytest.mark.asyncio
-    async def test_long_sync_from_zero(self, five_nodes, default_400_blocks, bt):
+    async def test_long_sync_from_zero(self, five_nodes, default_400_blocks, bt, self_hostname):
         # Must be larger than "sync_block_behind_threshold" in the config
         num_blocks = len(default_400_blocks)
         blocks: List[FullBlock] = default_400_blocks
@@ -138,7 +138,9 @@ class TestFullSync:
         await time_out_assert(timeout_seconds, node_height_exactly, True, full_node_1, 409)
 
     @pytest.mark.asyncio
-    async def test_sync_from_fork_point_and_weight_proof(self, three_nodes, default_1000_blocks, default_400_blocks):
+    async def test_sync_from_fork_point_and_weight_proof(
+        self, three_nodes, default_1000_blocks, default_400_blocks, self_hostname
+    ):
         start = time.time()
         # Must be larger than "sync_block_behind_threshold" in the config
         num_blocks_initial = len(default_1000_blocks) - 50
@@ -209,7 +211,7 @@ class TestFullSync:
         await time_out_assert(180, node_height_exactly, True, full_node_2, 999)
 
     @pytest.mark.asyncio
-    async def test_batch_sync(self, two_nodes, bt):
+    async def test_batch_sync(self, two_nodes, bt, self_hostname):
         # Must be below "sync_block_behind_threshold" in the config
         num_blocks = 20
         num_blocks_2 = 9
@@ -232,7 +234,7 @@ class TestFullSync:
         await time_out_assert(60, node_height_exactly, True, full_node_2, num_blocks - 1)
 
     @pytest.mark.asyncio
-    async def test_backtrack_sync_1(self, two_nodes, bt):
+    async def test_backtrack_sync_1(self, two_nodes, bt, self_hostname):
         blocks = bt.get_consecutive_blocks(1, skip_slots=1)
         blocks = bt.get_consecutive_blocks(1, blocks, skip_slots=0)
         blocks = bt.get_consecutive_blocks(1, blocks, skip_slots=0)
@@ -249,7 +251,7 @@ class TestFullSync:
         await time_out_assert(60, node_height_exactly, True, full_node_2, 2)
 
     @pytest.mark.asyncio
-    async def test_backtrack_sync_2(self, two_nodes, bt):
+    async def test_backtrack_sync_2(self, two_nodes, bt, self_hostname):
         blocks = bt.get_consecutive_blocks(1, skip_slots=3)
         blocks = bt.get_consecutive_blocks(8, blocks, skip_slots=0)
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -265,7 +267,7 @@ class TestFullSync:
         await time_out_assert(60, node_height_exactly, True, full_node_2, 8)
 
     @pytest.mark.asyncio
-    async def test_close_height_but_big_reorg(self, three_nodes, bt):
+    async def test_close_height_but_big_reorg(self, three_nodes, bt, self_hostname):
         blocks_a = bt.get_consecutive_blocks(50)
         blocks_b = bt.get_consecutive_blocks(51, seed=b"B")
         blocks_c = bt.get_consecutive_blocks(90, seed=b"C")
@@ -303,7 +305,9 @@ class TestFullSync:
         await time_out_assert(60, node_height_exactly, True, full_node_3, 89)
 
     @pytest.mark.asyncio
-    async def test_sync_bad_peak_while_synced(self, three_nodes, default_1000_blocks, default_10000_blocks):
+    async def test_sync_bad_peak_while_synced(
+        self, three_nodes, default_1000_blocks, default_10000_blocks, self_hostname
+    ):
         # Must be larger than "sync_block_behind_threshold" in the config
         num_blocks_initial = len(default_1000_blocks) - 250
         blocks_750 = default_1000_blocks[:num_blocks_initial]
@@ -347,7 +351,7 @@ class TestFullSync:
         assert node_height_exactly(full_node_2, 999)
 
     @pytest.mark.asyncio
-    async def test_block_ses_mismatch(self, two_nodes, default_1000_blocks):
+    async def test_block_ses_mismatch(self, two_nodes, default_1000_blocks, self_hostname):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = default_1000_blocks
 

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -50,7 +50,7 @@ class TestFullSync:
             yield _
 
     @pytest.mark.asyncio
-    async def test_long_sync_from_zero(self, five_nodes, default_400_blocks):
+    async def test_long_sync_from_zero(self, five_nodes, default_400_blocks, bt):
         # Must be larger than "sync_block_behind_threshold" in the config
         num_blocks = len(default_400_blocks)
         blocks: List[FullBlock] = default_400_blocks
@@ -209,7 +209,7 @@ class TestFullSync:
         await time_out_assert(180, node_height_exactly, True, full_node_2, 999)
 
     @pytest.mark.asyncio
-    async def test_batch_sync(self, two_nodes):
+    async def test_batch_sync(self, two_nodes, bt):
         # Must be below "sync_block_behind_threshold" in the config
         num_blocks = 20
         num_blocks_2 = 9
@@ -232,7 +232,7 @@ class TestFullSync:
         await time_out_assert(60, node_height_exactly, True, full_node_2, num_blocks - 1)
 
     @pytest.mark.asyncio
-    async def test_backtrack_sync_1(self, two_nodes):
+    async def test_backtrack_sync_1(self, two_nodes, bt):
         blocks = bt.get_consecutive_blocks(1, skip_slots=1)
         blocks = bt.get_consecutive_blocks(1, blocks, skip_slots=0)
         blocks = bt.get_consecutive_blocks(1, blocks, skip_slots=0)
@@ -249,7 +249,7 @@ class TestFullSync:
         await time_out_assert(60, node_height_exactly, True, full_node_2, 2)
 
     @pytest.mark.asyncio
-    async def test_backtrack_sync_2(self, two_nodes):
+    async def test_backtrack_sync_2(self, two_nodes, bt):
         blocks = bt.get_consecutive_blocks(1, skip_slots=3)
         blocks = bt.get_consecutive_blocks(8, blocks, skip_slots=0)
         full_node_1, full_node_2, server_1, server_2 = two_nodes
@@ -265,7 +265,7 @@ class TestFullSync:
         await time_out_assert(60, node_height_exactly, True, full_node_2, 8)
 
     @pytest.mark.asyncio
-    async def test_close_height_but_big_reorg(self, three_nodes):
+    async def test_close_height_but_big_reorg(self, three_nodes, bt):
         blocks_a = bt.get_consecutive_blocks(50)
         blocks_b = bt.get_consecutive_blocks(51, seed=b"B")
         blocks_c = bt.get_consecutive_blocks(90, seed=b"C")

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -31,7 +31,7 @@ def event_loop():
 
 class TestBlockStore:
     @pytest.mark.asyncio
-    async def test_block_store(self, tmp_dir, db_version):
+    async def test_block_store(self, tmp_dir, db_version, bt):
         assert sqlite3.threadsafety == 1
         blocks = bt.get_consecutive_blocks(10)
 
@@ -69,7 +69,7 @@ class TestBlockStore:
             assert len(block_record_records) == len(blocks)
 
     @pytest.mark.asyncio
-    async def test_deadlock(self, tmp_dir, db_version):
+    async def test_deadlock(self, tmp_dir, db_version, bt):
         """
         This test was added because the store was deadlocking in certain situations, when fetching and
         adding blocks repeatedly. The issue was patched.

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -18,7 +18,8 @@ from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.blockchain_format.program import SerializedProgram
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.util.db_connection import DBConnection
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
+
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ class TestBlockStore:
             await asyncio.gather(*tasks)
 
     @pytest.mark.asyncio
-    async def test_rollback(self, tmp_dir):
+    async def test_rollback(self, bt, tmp_dir):
         blocks = bt.get_consecutive_blocks(10)
 
         async with DBConnection(2) as db_wrapper:
@@ -145,7 +146,7 @@ class TestBlockStore:
                 count += 1
 
     @pytest.mark.asyncio
-    async def test_count_compactified_blocks(self, tmp_dir, db_version):
+    async def test_count_compactified_blocks(self, bt, tmp_dir, db_version):
         blocks = bt.get_consecutive_blocks(10)
 
         async with DBConnection(db_version) as db_wrapper:
@@ -164,7 +165,7 @@ class TestBlockStore:
             assert count == 0
 
     @pytest.mark.asyncio
-    async def test_count_uncompactified_blocks(self, tmp_dir, db_version):
+    async def test_count_uncompactified_blocks(self, bt, tmp_dir, db_version):
         blocks = bt.get_consecutive_blocks(10)
 
         async with DBConnection(db_version) as db_wrapper:
@@ -183,7 +184,7 @@ class TestBlockStore:
             assert count == 10
 
     @pytest.mark.asyncio
-    async def test_replace_proof(self, tmp_dir, db_version):
+    async def test_replace_proof(self, bt, tmp_dir, db_version):
         blocks = bt.get_consecutive_blocks(10)
 
         def rand_bytes(num) -> bytes:
@@ -227,7 +228,7 @@ class TestBlockStore:
                 assert b.challenge_chain_ip_proof == proof
 
     @pytest.mark.asyncio
-    async def test_get_generator(self, db_version):
+    async def test_get_generator(self, bt, db_version):
         blocks = bt.get_consecutive_blocks(10)
 
         def generator(i: int) -> SerializedProgram:

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -20,7 +20,7 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint64, uint32
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.wallet_tools import WalletTool
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
 from chia.types.blockchain_format.sized_bytes import bytes32
 from tests.util.db_connection import DBConnection
 
@@ -190,7 +190,7 @@ class TestCoinStoreWithBlocks:
                         assert record.spent_block_index == block.height
 
     @pytest.mark.asyncio
-    async def test_num_unspent(self, db_version):
+    async def test_num_unspent(self, bt, db_version):
         blocks = bt.get_consecutive_blocks(37, [])
 
         expect_unspent = 0
@@ -339,17 +339,12 @@ class TestCoinStoreWithBlocks:
     async def test_get_puzzle_hash(self, cache_size: uint32, tmp_dir, db_version, bt):
         async with DBConnection(db_version) as db_wrapper:
             num_blocks = 20
-            farmer_ph = 32 * b"0"
-            pool_ph = 32 * b"1"
-            # TODO: address hint error and remove ignore
-            #       error: Argument "farmer_reward_puzzle_hash" to "get_consecutive_blocks" of "BlockTools" has
-            #       incompatible type "bytes"; expected "Optional[bytes32]"  [arg-type]
-            #       error: Argument "pool_reward_puzzle_hash" to "get_consecutive_blocks" of "BlockTools" has
-            #       incompatible type "bytes"; expected "Optional[bytes32]"  [arg-type]
+            farmer_ph = bytes32(32 * b"0")
+            pool_ph = bytes32(32 * b"1")
             blocks = bt.get_consecutive_blocks(
                 num_blocks,
-                farmer_reward_puzzle_hash=farmer_ph,  # type: ignore[arg-type]
-                pool_reward_puzzle_hash=pool_ph,  # type: ignore[arg-type]
+                farmer_reward_puzzle_hash=farmer_ph,
+                pool_reward_puzzle_hash=pool_ph,
                 guarantee_transaction_block=True,
             )
             coin_store = await CoinStore.create(db_wrapper, cache_size=uint32(cache_size))

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -59,7 +59,7 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 class TestCoinStoreWithBlocks:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0])
-    async def test_basic_coin_store(self, cache_size: uint32, db_version, softfork_height):
+    async def test_basic_coin_store(self, cache_size: uint32, db_version, softfork_height, bt):
         wallet_a = WALLET_A
         reward_ph = wallet_a.get_new_puzzlehash()
 
@@ -157,7 +157,7 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_set_spent(self, cache_size: uint32, db_version):
+    async def test_set_spent(self, cache_size: uint32, db_version, bt):
         blocks = bt.get_consecutive_blocks(9, [])
 
         async with DBConnection(db_version) as db_wrapper:
@@ -223,7 +223,7 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_rollback(self, cache_size: uint32, db_version):
+    async def test_rollback(self, cache_size: uint32, db_version, bt):
         blocks = bt.get_consecutive_blocks(20)
 
         async with DBConnection(db_version) as db_wrapper:
@@ -275,7 +275,7 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_basic_reorg(self, cache_size: uint32, tmp_dir, db_version):
+    async def test_basic_reorg(self, cache_size: uint32, tmp_dir, db_version, bt):
 
         async with DBConnection(db_version) as db_wrapper:
             initial_block_count = 30
@@ -336,7 +336,7 @@ class TestCoinStoreWithBlocks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cache_size", [0, 10, 100000])
-    async def test_get_puzzle_hash(self, cache_size: uint32, tmp_dir, db_version):
+    async def test_get_puzzle_hash(self, cache_size: uint32, tmp_dir, db_version, bt):
         async with DBConnection(db_version) as db_wrapper:
             num_blocks = 20
             farmer_ph = 32 * b"0"

--- a/tests/core/full_node/stores/test_hint_store.py
+++ b/tests/core/full_node/stores/test_hint_store.py
@@ -12,7 +12,6 @@ from chia.types.spend_bundle import SpendBundle
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block, _validate_and_add_block_no_error
 from tests.util.db_connection import DBConnection
 from tests.wallet_tools import WalletTool
-from tests.setup_nodes import bt
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/full_node/stores/test_hint_store.py
+++ b/tests/core/full_node/stores/test_hint_store.py
@@ -115,7 +115,7 @@ class TestHintStore:
                 assert rows[0][0] == 4
 
     @pytest.mark.asyncio
-    async def test_hints_in_blockchain(self, empty_blockchain):  # noqa: F811
+    async def test_hints_in_blockchain(self, empty_blockchain, bt):  # noqa: F811
         blockchain: Blockchain = empty_blockchain
 
         blocks = bt.get_consecutive_blocks(

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -584,11 +584,10 @@ class TestFullNodeProtocol:
 
         # First get two blocks in the same sub slot
         blocks = await full_node_1.get_all_full_blocks()
-        saved_seed = b""
+
         for i in range(0, 9999999):
             blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, skip_slots=1, seed=i.to_bytes(4, "big"))
             if len(blocks[-1].finished_sub_slots) == 0:
-                saved_seed = i.to_bytes(4, "big")
                 break
 
         # Then create a fork after the first block.
@@ -622,7 +621,6 @@ class TestFullNodeProtocol:
 
         # First get two blocks in the same sub slot
         blocks = await full_node_1.get_all_full_blocks()
-        saved_seed = b""
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
 
         await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), peer)
@@ -869,8 +867,6 @@ class TestFullNodeProtocol:
         fake_peer = server_1.all_connections[node_id]
         # Mempool has capacity of 100, make 110 unspent coins that we can use
         puzzle_hashes = []
-
-        block_buffer_count = full_node_1.full_node.constants.MEMPOOL_BLOCK_BUFFER
 
         # Makes a bunch of coins
         for i in range(5):

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811, F401
 import asyncio
 import dataclasses
 import logging
@@ -12,7 +11,6 @@ from clvm.casts import int_to_bytes
 import pytest
 import pytest_asyncio
 
-from chia.consensus.blockchain import ReceiveBlockResult
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.bundle_tools import detect_potential_template_generator
 from chia.full_node.full_node_api import FullNodeAPI
@@ -47,7 +45,6 @@ from tests.blockchain.blockchain_test_utils import (
 )
 from tests.pools.test_pool_rpc import wallet_is_synced
 from tests.wallet_tools import WalletTool
-from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.transaction_record import TransactionRecord
 
 from tests.connection_utils import add_dummy_connection, connect_and_get_peer
@@ -55,7 +52,7 @@ from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.full_node.test_mempool_performance import wallet_height_at_least
 from tests.core.make_block_generator import make_spend_bundle
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import bt, self_hostname, setup_simulators_and_wallets, test_constants
+from tests.setup_nodes import self_hostname, setup_simulators_and_wallets, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 
 log = logging.getLogger(__name__)
@@ -108,7 +105,7 @@ def event_loop():
 
 
 @pytest_asyncio.fixture(scope="module")
-async def wallet_nodes():
+async def wallet_nodes(bt):
     async_gen = setup_simulators_and_wallets(2, 1, {"MEMPOOL_BLOCK_BUFFER": 2, "MAX_BLOCK_COST_CLVM": 400000000})
     nodes, wallets = await async_gen.__anext__()
     full_node_1 = nodes[0]
@@ -142,7 +139,7 @@ async def setup_two_nodes_and_wallet():
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_nodes_mainnet(db_version):
+async def wallet_nodes_mainnet(bt, db_version):
     async_gen = setup_simulators_and_wallets(2, 1, {"NETWORK_TYPE": 0}, db_version=db_version)
     nodes, wallets = await async_gen.__anext__()
     full_node_1 = nodes[0]
@@ -160,7 +157,7 @@ async def wallet_nodes_mainnet(db_version):
 class TestFullNodeBlockCompression:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("tx_size", [10000, 3000000000000])
-    async def test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain, tx_size):
+    async def test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, bt):
         nodes, wallets = setup_two_nodes_and_wallet
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -493,7 +490,7 @@ class TestFullNodeProtocol:
         full_node_1.full_node.full_node_peers.address_manager = AddressManager()
 
     @pytest.mark.asyncio
-    async def test_basic_chain(self, wallet_nodes):
+    async def test_basic_chain(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
         incoming_queue, _ = await add_dummy_connection(server_1, 12312)
@@ -516,7 +513,7 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.blockchain.get_peak().height == 29
 
     @pytest.mark.asyncio
-    async def test_respond_end_of_sub_slot(self, wallet_nodes):
+    async def test_respond_end_of_sub_slot(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
         incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
@@ -574,7 +571,7 @@ class TestFullNodeProtocol:
         )
 
     @pytest.mark.asyncio
-    async def test_respond_end_of_sub_slot_no_reorg(self, wallet_nodes):
+    async def test_respond_end_of_sub_slot_no_reorg(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
         incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
@@ -612,7 +609,7 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.full_node_store.finished_sub_slots == original_ss
 
     @pytest.mark.asyncio
-    async def test_respond_end_of_sub_slot_race(self, wallet_nodes):
+    async def test_respond_end_of_sub_slot_race(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
         incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
@@ -643,7 +640,7 @@ class TestFullNodeProtocol:
             await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
 
     @pytest.mark.asyncio
-    async def test_respond_unfinished(self, wallet_nodes):
+    async def test_respond_unfinished(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
         incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
@@ -791,7 +788,7 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.blockchain.contains_block(block.header_hash)
 
     @pytest.mark.asyncio
-    async def test_new_peak(self, wallet_nodes):
+    async def test_new_peak(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
         incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
@@ -847,7 +844,7 @@ class TestFullNodeProtocol:
         await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 1))
 
     @pytest.mark.asyncio
-    async def test_new_transaction_and_mempool(self, wallet_nodes):
+    async def test_new_transaction_and_mempool(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1021,7 +1018,7 @@ class TestFullNodeProtocol:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_request_respond_transaction(self, wallet_nodes):
+    async def test_request_respond_transaction(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         wallet_ph = wallet_a.get_new_puzzlehash()
         blocks = await full_node_1.get_all_full_blocks()
@@ -1069,7 +1066,7 @@ class TestFullNodeProtocol:
         assert msg.data == bytes(fnp.RespondTransaction(spend_bundle))
 
     @pytest.mark.asyncio
-    async def test_respond_transaction_fail(self, wallet_nodes):
+    async def test_respond_transaction_fail(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cb_ph = wallet_a.get_new_puzzlehash()
@@ -1116,7 +1113,7 @@ class TestFullNodeProtocol:
         assert incoming_queue.qsize() == 0
 
     @pytest.mark.asyncio
-    async def test_request_block(self, wallet_nodes):
+    async def test_request_block(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1158,7 +1155,7 @@ class TestFullNodeProtocol:
         assert res.type != ProtocolMessageTypes.reject_block.value
 
     @pytest.mark.asyncio
-    async def test_request_blocks(self, wallet_nodes):
+    async def test_request_blocks(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1219,7 +1216,7 @@ class TestFullNodeProtocol:
         assert std_hash(fetched_blocks[-1]) == std_hash(blocks_t[-1])
 
     @pytest.mark.asyncio
-    async def test_new_unfinished_block(self, wallet_nodes):
+    async def test_new_unfinished_block(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1250,7 +1247,7 @@ class TestFullNodeProtocol:
         assert res is None
 
     @pytest.mark.asyncio
-    async def test_double_blocks_same_pospace(self, wallet_nodes):
+    async def test_double_blocks_same_pospace(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
         incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12315)
@@ -1299,7 +1296,7 @@ class TestFullNodeProtocol:
         await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 1))
 
     @pytest.mark.asyncio
-    async def test_request_unfinished_block(self, wallet_nodes):
+    async def test_request_unfinished_block(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
         peer = await connect_and_get_peer(server_1, server_2)
@@ -1329,7 +1326,7 @@ class TestFullNodeProtocol:
         assert res is not None
 
     @pytest.mark.asyncio
-    async def test_new_signage_point_or_end_of_sub_slot(self, wallet_nodes):
+    async def test_new_signage_point_or_end_of_sub_slot(self, wallet_nodes, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1384,7 +1381,7 @@ class TestFullNodeProtocol:
         await time_out_assert(20, caught_up_slots)
 
     @pytest.mark.asyncio
-    async def test_new_signage_point_caching(self, wallet_nodes, empty_blockchain):
+    async def test_new_signage_point_caching(self, wallet_nodes, empty_blockchain, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1435,7 +1432,7 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.full_node_store.get_signage_point(sp.cc_vdf.output.get_hash()) is not None
 
     @pytest.mark.asyncio
-    async def test_slot_catch_up_genesis(self, setup_two_nodes):
+    async def test_slot_catch_up_genesis(self, setup_two_nodes, bt):
         nodes, _ = setup_two_nodes
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -1467,7 +1464,7 @@ class TestFullNodeProtocol:
 
     @pytest.mark.skip("a timebomb causes mainnet to stop after transactions start, so this test doesn't work yet")
     @pytest.mark.asyncio
-    async def test_mainnet_softfork(self, wallet_nodes_mainnet):
+    async def test_mainnet_softfork(self, wallet_nodes_mainnet, bt):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes_mainnet
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1525,7 +1522,7 @@ class TestFullNodeProtocol:
         await _validate_and_add_block(full_node_1.full_node.blockchain, valid_block)
 
     @pytest.mark.asyncio
-    async def test_compact_protocol(self, setup_two_nodes):
+    async def test_compact_protocol(self, setup_two_nodes, bt):
         nodes, _ = setup_two_nodes
         full_node_1 = nodes[0]
         full_node_2 = nodes[1]
@@ -1643,7 +1640,7 @@ class TestFullNodeProtocol:
             assert full_node_2.full_node.blockchain.get_peak().height == height
 
     @pytest.mark.asyncio
-    async def test_compact_protocol_invalid_messages(self, setup_two_nodes):
+    async def test_compact_protocol_invalid_messages(self, setup_two_nodes, bt):
         nodes, _ = setup_two_nodes
         full_node_1 = nodes[0]
         full_node_2 = nodes[1]

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -52,7 +52,7 @@ from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.full_node.test_mempool_performance import wallet_height_at_least
 from tests.core.make_block_generator import make_spend_bundle
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets, test_constants
+from tests.setup_nodes import setup_simulators_and_wallets, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 
 log = logging.getLogger(__name__)
@@ -157,7 +157,7 @@ async def wallet_nodes_mainnet(bt, db_version):
 class TestFullNodeBlockCompression:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("tx_size", [10000, 3000000000000])
-    async def test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, bt):
+    async def test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, bt, self_hostname):
         nodes, wallets = setup_two_nodes_and_wallet
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -174,8 +174,8 @@ class TestFullNodeBlockCompression:
             and full_node_1.full_node.block_store.db_wrapper.db_version >= 2
             and full_node_2.full_node.block_store.db_wrapper.db_version >= 2
         )
-        _ = await connect_and_get_peer(server_1, server_2)
-        _ = await connect_and_get_peer(server_1, server_3)
+        _ = await connect_and_get_peer(server_1, server_2, self_hostname)
+        _ = await connect_and_get_peer(server_1, server_3, self_hostname)
 
         ph = await wallet.get_new_puzzlehash()
 
@@ -457,7 +457,7 @@ class TestFullNodeProtocol:
         assert bytes(sb) == bytes(protocol_message)
 
     @pytest.mark.asyncio
-    async def test_inbound_connection_limit(self, setup_four_nodes):
+    async def test_inbound_connection_limit(self, setup_four_nodes, self_hostname):
         nodes, _ = setup_four_nodes
         server_1 = nodes[0].full_node.server
         server_1.config["target_peer_count"] = 2
@@ -469,7 +469,7 @@ class TestFullNodeProtocol:
         assert len(server_1.get_full_node_connections()) == 2
 
     @pytest.mark.asyncio
-    async def test_request_peers(self, wallet_nodes):
+    async def test_request_peers(self, wallet_nodes, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         full_node_2.full_node.full_node_peers.address_manager.make_private_subnets_valid()
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)))
@@ -490,15 +490,15 @@ class TestFullNodeProtocol:
         full_node_1.full_node.full_node_peers.address_manager = AddressManager()
 
     @pytest.mark.asyncio
-    async def test_basic_chain(self, wallet_nodes, bt):
+    async def test_basic_chain(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
-        incoming_queue, _ = await add_dummy_connection(server_1, 12312)
+        incoming_queue, _ = await add_dummy_connection(server_1, self_hostname, 12312)
         expected_requests = 0
         if await full_node_1.full_node.synced():
             expected_requests = 1
         await time_out_assert(10, time_out_messages(incoming_queue, "request_mempool_transactions", expected_requests))
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         blocks = bt.get_consecutive_blocks(1)
         for block in blocks[:1]:
             await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
@@ -513,16 +513,16 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.blockchain.get_peak().height == 29
 
     @pytest.mark.asyncio
-    async def test_respond_end_of_sub_slot(self, wallet_nodes, bt):
+    async def test_respond_end_of_sub_slot(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         expected_requests = 0
         if await full_node_1.full_node.synced():
             expected_requests = 1
         await time_out_assert(10, time_out_messages(incoming_queue, "request_mempool_transactions", expected_requests))
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         # Create empty slots
         blocks = await full_node_1.get_all_full_blocks()
@@ -571,16 +571,16 @@ class TestFullNodeProtocol:
         )
 
     @pytest.mark.asyncio
-    async def test_respond_end_of_sub_slot_no_reorg(self, wallet_nodes, bt):
+    async def test_respond_end_of_sub_slot_no_reorg(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         expected_requests = 0
         if await full_node_1.full_node.synced():
             expected_requests = 1
         await time_out_assert(10, time_out_messages(incoming_queue, "request_mempool_transactions", expected_requests))
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         # First get two blocks in the same sub slot
         blocks = await full_node_1.get_all_full_blocks()
@@ -609,16 +609,16 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.full_node_store.finished_sub_slots == original_ss
 
     @pytest.mark.asyncio
-    async def test_respond_end_of_sub_slot_race(self, wallet_nodes, bt):
+    async def test_respond_end_of_sub_slot_race(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         expected_requests = 0
         if await full_node_1.full_node.synced():
             expected_requests = 1
         await time_out_assert(10, time_out_messages(incoming_queue, "request_mempool_transactions", expected_requests))
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         # First get two blocks in the same sub slot
         blocks = await full_node_1.get_all_full_blocks()
@@ -640,16 +640,16 @@ class TestFullNodeProtocol:
             await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
 
     @pytest.mark.asyncio
-    async def test_respond_unfinished(self, wallet_nodes, bt):
+    async def test_respond_unfinished(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         expected_requests = 0
         if await full_node_1.full_node.synced():
             expected_requests = 1
         await time_out_assert(10, time_out_messages(incoming_queue, "request_mempool_transactions", expected_requests))
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         blocks = await full_node_1.get_all_full_blocks()
 
         # Create empty slots
@@ -788,16 +788,16 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.blockchain.contains_block(block.header_hash)
 
     @pytest.mark.asyncio
-    async def test_new_peak(self, wallet_nodes, bt):
+    async def test_new_peak(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         dummy_peer = server_1.all_connections[dummy_node_id]
         expected_requests = 0
         if await full_node_1.full_node.synced():
             expected_requests = 1
         await time_out_assert(10, time_out_messages(incoming_queue, "request_mempool_transactions", expected_requests))
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         blocks = await full_node_1.get_all_full_blocks()
         blocks = bt.get_consecutive_blocks(3, block_list_input=blocks)  # Alternate chain
@@ -844,7 +844,7 @@ class TestFullNodeProtocol:
         await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 1))
 
     @pytest.mark.asyncio
-    async def test_new_transaction_and_mempool(self, wallet_nodes, bt):
+    async def test_new_transaction_and_mempool(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -864,10 +864,10 @@ class TestFullNodeProtocol:
             if full_node_1.full_node.blockchain.get_peak() is not None
             else -1
         )
-        peer = await connect_and_get_peer(server_1, server_2)
-        incoming_queue, node_id = await add_dummy_connection(server_1, 12312)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
+        incoming_queue, node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         fake_peer = server_1.all_connections[node_id]
-        # Mempool has capacity of 100, make 110 unspents that we can use
+        # Mempool has capacity of 100, make 110 unspent coins that we can use
         puzzle_hashes = []
 
         block_buffer_count = full_node_1.full_node.constants.MEMPOOL_BLOCK_BUFFER
@@ -1018,7 +1018,7 @@ class TestFullNodeProtocol:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_request_respond_transaction(self, wallet_nodes, bt):
+    async def test_request_respond_transaction(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         wallet_ph = wallet_a.get_new_puzzlehash()
         blocks = await full_node_1.get_all_full_blocks()
@@ -1031,9 +1031,9 @@ class TestFullNodeProtocol:
             pool_reward_puzzle_hash=wallet_ph,
         )
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         for block in blocks[-3:]:
             await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
@@ -1066,13 +1066,13 @@ class TestFullNodeProtocol:
         assert msg.data == bytes(fnp.RespondTransaction(spend_bundle))
 
     @pytest.mark.asyncio
-    async def test_respond_transaction_fail(self, wallet_nodes, bt):
+    async def test_respond_transaction_fail(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cb_ph = wallet_a.get_new_puzzlehash()
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12312)
-        peer = await connect_and_get_peer(server_1, server_2)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         tx_id = token_bytes(32)
         request_transaction = fnp.RequestTransaction(tx_id)
@@ -1216,11 +1216,11 @@ class TestFullNodeProtocol:
         assert std_hash(fetched_blocks[-1]) == std_hash(blocks_t[-1])
 
     @pytest.mark.asyncio
-    async def test_new_unfinished_block(self, wallet_nodes, bt):
+    async def test_new_unfinished_block(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
         block: FullBlock = blocks[-1]
@@ -1247,12 +1247,12 @@ class TestFullNodeProtocol:
         assert res is None
 
     @pytest.mark.asyncio
-    async def test_double_blocks_same_pospace(self, wallet_nodes, bt):
+    async def test_double_blocks_same_pospace(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12315)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12315)
         dummy_peer = server_1.all_connections[dummy_node_id]
-        _ = await connect_and_get_peer(server_1, server_2)
+        _ = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         ph = wallet_a.get_new_puzzlehash()
 
@@ -1296,10 +1296,10 @@ class TestFullNodeProtocol:
         await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 1))
 
     @pytest.mark.asyncio
-    async def test_request_unfinished_block(self, wallet_nodes, bt):
+    async def test_request_unfinished_block(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         blocks = bt.get_consecutive_blocks(10, block_list_input=blocks, seed=b"12345")
         for block in blocks[:-1]:
             await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
@@ -1326,7 +1326,7 @@ class TestFullNodeProtocol:
         assert res is not None
 
     @pytest.mark.asyncio
-    async def test_new_signage_point_or_end_of_sub_slot(self, wallet_nodes, bt):
+    async def test_new_signage_point_or_end_of_sub_slot(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
@@ -1348,7 +1348,7 @@ class TestFullNodeProtocol:
             peak.sub_slot_iters,
         )
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         res = await full_node_1.new_signage_point_or_end_of_sub_slot(
             fnp.NewSignagePointOrEndOfSubSlot(None, sp.cc_vdf.challenge, uint8(11), sp.rc_vdf.challenge), peer
         )
@@ -1369,7 +1369,7 @@ class TestFullNodeProtocol:
             await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
         assert len(full_node_1.full_node.full_node_store.finished_sub_slots) >= num_slots - 1
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12315)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12315)
         dummy_peer = server_1.all_connections[dummy_node_id]
         await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slots[-1]), dummy_peer)
 
@@ -1381,11 +1381,11 @@ class TestFullNodeProtocol:
         await time_out_assert(20, caught_up_slots)
 
     @pytest.mark.asyncio
-    async def test_new_signage_point_caching(self, wallet_nodes, empty_blockchain, bt):
+    async def test_new_signage_point_caching(self, wallet_nodes, empty_blockchain, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         blocks = bt.get_consecutive_blocks(3, block_list_input=blocks, skip_slots=2)
         await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-3]))
         await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-2]))
@@ -1432,14 +1432,14 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.full_node_store.get_signage_point(sp.cc_vdf.output.get_hash()) is not None
 
     @pytest.mark.asyncio
-    async def test_slot_catch_up_genesis(self, setup_two_nodes, bt):
+    async def test_slot_catch_up_genesis(self, setup_two_nodes, bt, self_hostname):
         nodes, _ = setup_two_nodes
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
         full_node_1 = nodes[0]
         full_node_2 = nodes[1]
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         num_slots = 20
         blocks = bt.get_consecutive_blocks(1, skip_slots=num_slots)
         slots = blocks[-1].finished_sub_slots
@@ -1451,7 +1451,7 @@ class TestFullNodeProtocol:
             await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
         assert len(full_node_1.full_node.full_node_store.finished_sub_slots) >= num_slots - 1
 
-        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, 12315)
+        incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12315)
         dummy_peer = server_1.all_connections[dummy_node_id]
         await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slots[-1]), dummy_peer)
 
@@ -1640,7 +1640,7 @@ class TestFullNodeProtocol:
             assert full_node_2.full_node.blockchain.get_peak().height == height
 
     @pytest.mark.asyncio
-    async def test_compact_protocol_invalid_messages(self, setup_two_nodes, bt):
+    async def test_compact_protocol_invalid_messages(self, setup_two_nodes, bt, self_hostname):
         nodes, _ = setup_two_nodes
         full_node_1 = nodes[0]
         full_node_2 = nodes[1]
@@ -1851,7 +1851,7 @@ class TestFullNodeProtocol:
             )
         server_1 = full_node_1.full_node.server
         server_2 = full_node_2.full_node.server
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         for invalid_compact_proof in timelord_protocol_invalid_messages:
             await full_node_1.full_node.respond_compact_proof_of_time(invalid_compact_proof)
         for invalid_compact_proof in full_node_protocol_invalid_messaages:

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -768,7 +768,7 @@ class TestMempoolManager:
     async def test_correct_my_id(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin.name()])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
@@ -782,7 +782,7 @@ class TestMempoolManager:
     async def test_my_id_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin.name(), b"garbage"])
         dic = {cvp.opcode: [cvp]}
@@ -797,8 +797,8 @@ class TestMempoolManager:
     async def test_invalid_my_id(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
-        coin_2 = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
+        coin_2 = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin_2.name()])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
@@ -1483,10 +1483,10 @@ class TestMempoolManager:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
-        #coin = list(blocks[-1].get_included_reward_coins())[0]
-        #spend_bundle1 = generate_test_spend_bundle(wallet_a, coin)
-        coin = await next_block(full_node_1, WALLET_A, bt)
-        spend_bundle1 = generate_test_spend_bundle(coin)
+        # coin = list(blocks[-1].get_included_reward_coins())[0]
+        # spend_bundle1 = generate_test_spend_bundle(wallet_a, coin)
+        coin = await next_block(full_node_1, wallet_a, bt)
+        spend_bundle1 = generate_test_spend_bundle(wallet_a, coin)
 
         assert spend_bundle1 is not None
 
@@ -1502,7 +1502,7 @@ class TestMempoolManager:
 
         tx: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle_combined)
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
         status, err = await respond_transaction(full_node_1, tx, peer)
 
         sb = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle_combined.name())
@@ -1530,7 +1530,7 @@ class TestMempoolManager:
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         coin = await next_block(full_node_1, wallet_a, bt)
-        #coin = list(blocks[-1].get_included_reward_coins())[0]
+        # coin = list(blocks[-1].get_included_reward_coins())[0]
         spend_bundle_0 = generate_test_spend_bundle(wallet_a, coin)
         unsigned: List[CoinSpend] = spend_bundle_0.coin_spends
 
@@ -1562,7 +1562,7 @@ class TestMempoolManager:
     async def test_correct_my_parent(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin.parent_coin_info])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
@@ -1577,7 +1577,7 @@ class TestMempoolManager:
     async def test_my_parent_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin.parent_coin_info, b"garbage"])
         dic = {cvp.opcode: [cvp]}
@@ -1608,8 +1608,8 @@ class TestMempoolManager:
     async def test_invalid_my_parent(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
-        coin_2 = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
+        coin_2 = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin_2.parent_coin_info])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
@@ -1624,7 +1624,7 @@ class TestMempoolManager:
     async def test_correct_my_puzhash(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [coin.puzzle_hash])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
@@ -1639,7 +1639,7 @@ class TestMempoolManager:
     async def test_my_puzhash_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [coin.puzzle_hash, b"garbage"])
         dic = {cvp.opcode: [cvp]}
@@ -1670,7 +1670,7 @@ class TestMempoolManager:
     async def test_invalid_my_puzhash(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [Program.to([]).get_tree_hash()])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
@@ -1685,7 +1685,7 @@ class TestMempoolManager:
     async def test_correct_my_amount(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(coin.amount)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
@@ -1700,7 +1700,7 @@ class TestMempoolManager:
     async def test_my_amount_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(coin.amount), b"garbage"])
         dic = {cvp.opcode: [cvp]}

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -40,7 +40,7 @@ from chia.util.recursive_replace import recursive_replace
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.connection_utils import connect_and_get_peer
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import bt, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.consensus.cost_calculator import NPCResult
@@ -51,15 +51,22 @@ from chia.types.generator_types import BlockGenerator
 from clvm.casts import int_from_bytes
 from blspy import G1Element
 
-BURN_PUZZLE_HASH = b"0" * 32
-BURN_PUZZLE_HASH_2 = b"1" * 32
+from tests.wallet_tools import WalletTool
 
-WALLET_A = bt.get_pool_wallet_tool()
+BURN_PUZZLE_HASH = bytes32(b"0" * 32)
+BURN_PUZZLE_HASH_2 = bytes32(b"1" * 32)
+
+
+@pytest.fixture(scope="module")
+def wallet_a(bt):
+    return bt.get_pool_wallet_tool()
+
 
 log = logging.getLogger(__name__)
 
 
 def generate_test_spend_bundle(
+    wallet_a: WalletTool,
     coin: Coin,
     condition_dic: Dict[ConditionOpcode, List[ConditionWithArgs]] = None,
     fee: uint64 = uint64(0),
@@ -68,7 +75,7 @@ def generate_test_spend_bundle(
 ) -> SpendBundle:
     if condition_dic is None:
         condition_dic = {}
-    transaction = WALLET_A.generate_signed_transaction(amount, new_puzzle_hash, coin, condition_dic, fee)
+    transaction = wallet_a.generate_signed_transaction(amount, new_puzzle_hash, coin, condition_dic, fee)
     assert transaction is not None
     return transaction
 
@@ -88,7 +95,7 @@ def event_loop():
 # means you can't instantiate more than one per process, so this is a hack until
 # that is fixed. For now, our tests are not independent
 @pytest_asyncio.fixture(scope="module")
-async def two_nodes():
+async def two_nodes(bt, wallet_a):
     async_gen = setup_simulators_and_wallets(2, 1, {})
     nodes, _ = await async_gen.__anext__()
     full_node_1 = nodes[0]
@@ -96,7 +103,7 @@ async def two_nodes():
     server_1 = full_node_1.full_node.server
     server_2 = full_node_2.full_node.server
 
-    reward_ph = WALLET_A.get_new_puzzlehash()
+    reward_ph = wallet_a.get_new_puzzlehash()
     blocks = bt.get_consecutive_blocks(
         3,
         guarantee_transaction_block=True,
@@ -192,7 +199,7 @@ class TestPendingTxCache:
 
 class TestMempool:
     @pytest.mark.asyncio
-    async def test_basic_mempool(self, two_nodes):
+    async def test_basic_mempool(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
@@ -203,8 +210,8 @@ class TestMempool:
         with pytest.raises(ValueError):
             mempool.get_min_fee_rate(max_mempool_cost + 1)
 
-        coin = await next_block(full_node_1, WALLET_A, bt)
-        spend_bundle = generate_test_spend_bundle(coin)
+        coin = await next_block(full_node_1, wallet_a, bt)
+        spend_bundle = generate_test_spend_bundle(wallet_a, coin)
         assert spend_bundle is not None
 
 
@@ -254,13 +261,13 @@ async def next_block(full_node_1, wallet_a, bt) -> Coin:
 
 class TestMempoolManager:
     @pytest.mark.asyncio
-    async def test_basic_mempool_manager(self, two_nodes):
+    async def test_basic_mempool_manager(self, bt, two_nodes, wallet_a, self_hostname):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
-        coin = await next_block(full_node_1, WALLET_A, bt)
-        spend_bundle = generate_test_spend_bundle(coin)
+        coin = await next_block(full_node_1, wallet_a, bt)
+        spend_bundle = generate_test_spend_bundle(wallet_a, coin)
         assert spend_bundle is not None
         tx: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle)
         await full_node_1.respond_transaction(tx, peer)
@@ -298,24 +305,24 @@ class TestMempoolManager:
             # (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10032, MempoolInclusionStatus.FAILED),
         ],
     )
-    async def test_ephemeral_timelock(self, two_nodes, opcode, lock_value, expected):
+    async def test_ephemeral_timelock(self, bt, two_nodes, wallet_a, opcode, lock_value, expected):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
 
             conditions = {opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)])]}
-            tx1 = WALLET_A.generate_signed_transaction(
-                uint64(1000000), WALLET_A.get_new_puzzlehash(), coin_2, conditions.copy(), uint64(0)
+            tx1 = wallet_a.generate_signed_transaction(
+                uint64(1000000), wallet_a.get_new_puzzlehash(), coin_2, conditions.copy(), uint64(0)
             )
 
             ephemeral_coin: Coin = tx1.additions()[0]
-            tx2 = WALLET_A.generate_signed_transaction(
-                uint64(1000000), WALLET_A.get_new_puzzlehash(), ephemeral_coin, conditions.copy(), uint64(0)
+            tx2 = wallet_a.generate_signed_transaction(
+                uint64(1000000), wallet_a.get_new_puzzlehash(), ephemeral_coin, conditions.copy(), uint64(0)
             )
 
             bundle = SpendBundle.aggregate([tx1, tx2])
             return bundle
 
         full_node_1, _, server_1, _ = two_nodes
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         print(f"status: {status}")
@@ -332,7 +339,7 @@ class TestMempoolManager:
     # this test makes sure that one spend successfully asserts the announce from
     # another spend, even though the assert condition is duplicated 100 times
     @pytest.mark.asyncio
-    async def test_coin_announcement_duplicate_consumed(self, two_nodes):
+    async def test_coin_announcement_duplicate_consumed(self, bt, two_nodes, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
@@ -340,13 +347,13 @@ class TestMempoolManager:
 
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -356,7 +363,7 @@ class TestMempoolManager:
     # this test makes sure that one spend successfully asserts the announce from
     # another spend, even though the create announcement is duplicated 100 times
     @pytest.mark.asyncio
-    async def test_coin_duplicate_announcement_consumed(self, two_nodes):
+    async def test_coin_duplicate_announcement_consumed(self, bt, two_nodes, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
@@ -364,13 +371,13 @@ class TestMempoolManager:
 
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
             dic2 = {cvp.opcode: [cvp2] * 100}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -378,8 +385,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_double_spend(self, two_nodes):
-        reward_ph = WALLET_A.get_new_puzzlehash()
+    async def test_double_spend(self, bt, two_nodes, wallet_a, self_hostname):
+        reward_ph = wallet_a.get_new_puzzlehash()
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
@@ -390,13 +397,13 @@ class TestMempoolManager:
             farmer_reward_puzzle_hash=reward_ph,
             pool_reward_puzzle_hash=reward_ph,
         )
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
-        spend_bundle1 = generate_test_spend_bundle(list(blocks[-1].get_included_reward_coins())[0])
+        spend_bundle1 = generate_test_spend_bundle(wallet_a, list(blocks[-1].get_included_reward_coins())[0])
 
         assert spend_bundle1 is not None
         tx1: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle1)
@@ -405,6 +412,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
         spend_bundle2 = generate_test_spend_bundle(
+            wallet_a,
             list(blocks[-1].get_included_reward_coins())[0],
             new_puzzle_hash=BURN_PUZZLE_HASH_2,
         )
@@ -438,8 +446,8 @@ class TestMempoolManager:
         assert node.full_node.mempool_manager.get_spendbundle(sb.name()) is None
 
     @pytest.mark.asyncio
-    async def test_double_spend_with_higher_fee(self, two_nodes):
-        reward_ph = WALLET_A.get_new_puzzlehash()
+    async def test_double_spend_with_higher_fee(self, bt, two_nodes, wallet_a, self_hostname):
+        reward_ph = wallet_a.get_new_puzzlehash()
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
@@ -451,7 +459,7 @@ class TestMempoolManager:
             farmer_reward_puzzle_hash=reward_ph,
             pool_reward_puzzle_hash=reward_ph,
         )
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
@@ -462,8 +470,8 @@ class TestMempoolManager:
         coins = iter(blocks[-2].get_included_reward_coins())
         coin3, coin4 = next(coins), next(coins)
 
-        sb1_1 = await self.gen_and_send_sb(full_node_1, peer, coin1)
-        sb1_2 = await self.gen_and_send_sb(full_node_1, peer, coin1, fee=uint64(1))
+        sb1_1 = await self.gen_and_send_sb(full_node_1, peer, wallet_a, coin1)
+        sb1_2 = await self.gen_and_send_sb(full_node_1, peer, wallet_a, coin1, fee=uint64(1))
 
         # Fee increase is insufficient, the old spendbundle must stay
         self.assert_sb_in_pool(full_node_1, sb1_1)
@@ -471,13 +479,13 @@ class TestMempoolManager:
 
         min_fee_increase = full_node_1.full_node.mempool_manager.get_min_fee_increase()
 
-        sb1_3 = await self.gen_and_send_sb(full_node_1, peer, coin1, fee=uint64(min_fee_increase))
+        sb1_3 = await self.gen_and_send_sb(full_node_1, peer, wallet_a, coin1, fee=uint64(min_fee_increase))
 
         # Fee increase is sufficiently high, sb1_1 gets replaced with sb1_3
         self.assert_sb_not_in_pool(full_node_1, sb1_1)
         self.assert_sb_in_pool(full_node_1, sb1_3)
 
-        sb2 = generate_test_spend_bundle(coin2, fee=uint64(min_fee_increase))
+        sb2 = generate_test_spend_bundle(wallet_a, coin2, fee=uint64(min_fee_increase))
         sb12 = SpendBundle.aggregate((sb2, sb1_3))
         await self.send_sb(full_node_1, sb12)
 
@@ -486,7 +494,7 @@ class TestMempoolManager:
         self.assert_sb_in_pool(full_node_1, sb12)
         self.assert_sb_not_in_pool(full_node_1, sb1_3)
 
-        sb3 = generate_test_spend_bundle(coin3, fee=uint64(min_fee_increase * 2))
+        sb3 = generate_test_spend_bundle(wallet_a, coin3, fee=uint64(min_fee_increase * 2))
         sb23 = SpendBundle.aggregate((sb2, sb3))
         await self.send_sb(full_node_1, sb23)
 
@@ -499,13 +507,13 @@ class TestMempoolManager:
         # Adding non-conflicting sb3 should succeed
         self.assert_sb_in_pool(full_node_1, sb3)
 
-        sb4_1 = generate_test_spend_bundle(coin4, fee=uint64(min_fee_increase))
+        sb4_1 = generate_test_spend_bundle(wallet_a, coin4, fee=uint64(min_fee_increase))
         sb1234_1 = SpendBundle.aggregate((sb12, sb3, sb4_1))
         await self.send_sb(full_node_1, sb1234_1)
         # sb1234_1 should not be in pool as it decreases total fees per cost
         self.assert_sb_not_in_pool(full_node_1, sb1234_1)
 
-        sb4_2 = generate_test_spend_bundle(coin4, fee=uint64(min_fee_increase * 2))
+        sb4_2 = generate_test_spend_bundle(wallet_a, coin4, fee=uint64(min_fee_increase * 2))
         sb1234_2 = SpendBundle.aggregate((sb12, sb3, sb4_2))
         await self.send_sb(full_node_1, sb1234_2)
         # sb1234_2 has a higher fee per cost than its conflicts and should get
@@ -515,8 +523,8 @@ class TestMempoolManager:
         self.assert_sb_not_in_pool(full_node_1, sb3)
 
     @pytest.mark.asyncio
-    async def test_invalid_signature(self, two_nodes):
-        reward_ph = WALLET_A.get_new_puzzlehash()
+    async def test_invalid_signature(self, bt, two_nodes, wallet_a):
+        reward_ph = wallet_a.get_new_puzzlehash()
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
@@ -537,7 +545,7 @@ class TestMempoolManager:
         coin1 = next(coins)
         coins = iter(blocks[-2].get_included_reward_coins())
 
-        sb: SpendBundle = generate_test_spend_bundle(coin1)
+        sb: SpendBundle = generate_test_spend_bundle(wallet_a, coin1)
         assert sb.aggregated_signature != G2Element.generator()
         sb = dataclasses.replace(sb, aggregated_signature=G2Element.generator())
         res: Optional[Message] = await self.send_sb(full_node_1, sb)
@@ -548,13 +556,15 @@ class TestMempoolManager:
 
     async def condition_tester(
         self,
+        bt,
         two_nodes,
+        wallet_a,
         dic: Dict[ConditionOpcode, List[ConditionWithArgs]],
         fee: int = 0,
         num_blocks: int = 3,
         coin: Optional[Coin] = None,
     ):
-        reward_ph = WALLET_A.get_new_puzzlehash()
+        reward_ph = wallet_a.get_new_puzzlehash()
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
@@ -565,7 +575,7 @@ class TestMempoolManager:
             farmer_reward_puzzle_hash=reward_ph,
             pool_reward_puzzle_hash=reward_ph,
         )
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
@@ -573,7 +583,7 @@ class TestMempoolManager:
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + num_blocks)
 
         spend_bundle1 = generate_test_spend_bundle(
-            coin or list(blocks[-num_blocks + 2].get_included_reward_coins())[0], dic, uint64(fee)
+            wallet_a, coin or list(blocks[-num_blocks + 2].get_included_reward_coins())[0], dic, uint64(fee)
         )
 
         assert spend_bundle1 is not None
@@ -584,8 +594,8 @@ class TestMempoolManager:
         return blocks, spend_bundle1, peer, status, err
 
     @pytest.mark.asyncio
-    async def condition_tester2(self, two_nodes, test_fun: Callable[[Coin, Coin], SpendBundle]):
-        reward_ph = WALLET_A.get_new_puzzlehash()
+    async def condition_tester2(self, bt, two_nodes, wallet_a, test_fun: Callable[[Coin, Coin], SpendBundle]):
+        reward_ph = wallet_a.get_new_puzzlehash()
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height if len(blocks) > 0 else -1
@@ -596,7 +606,7 @@ class TestMempoolManager:
             farmer_reward_puzzle_hash=reward_ph,
             pool_reward_puzzle_hash=reward_ph,
         )
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
@@ -614,7 +624,7 @@ class TestMempoolManager:
         return blocks, bundle, status, err
 
     @pytest.mark.asyncio
-    async def test_invalid_block_index(self, two_nodes):
+    async def test_invalid_block_index(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
@@ -624,7 +634,7 @@ class TestMempoolManager:
             [int_to_bytes(start_height + 5)],
         )
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert sb1 is None
         # the transaction may become valid later
@@ -632,13 +642,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.PENDING
 
     @pytest.mark.asyncio
-    async def test_block_index_missing_arg(self, two_nodes):
+    async def test_block_index_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert sb1 is None
         # the transaction may become valid later
@@ -646,49 +656,49 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_block_index(self, two_nodes):
+    async def test_correct_block_index(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(1)])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_block_index_garbage(self, two_nodes):
+    async def test_block_index_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(1), b"garbage"])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_negative_block_index(self, two_nodes):
+    async def test_negative_block_index(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(-1)])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_invalid_block_age(self, two_nodes):
+    async def test_invalid_block_age(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(5)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_HEIGHT_RELATIVE_FAILED
         assert sb1 is None
@@ -696,12 +706,12 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.PENDING
 
     @pytest.mark.asyncio
-    async def test_block_age_missing_arg(self, two_nodes):
+    async def test_block_age_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
         assert sb1 is None
@@ -709,12 +719,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_block_age(self, two_nodes):
+    async def test_correct_block_age(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(1)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, num_blocks=4)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(
+            bt, two_nodes, wallet_a, dic, num_blocks=4
+        )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -722,13 +734,15 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_block_age_garbage(self, two_nodes):
+    async def test_block_age_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(1), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, num_blocks=4)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(
+            bt, two_nodes, wallet_a, dic, num_blocks=4
+        )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -736,12 +750,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_negative_block_age(self, two_nodes):
+    async def test_negative_block_age(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(-1)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, num_blocks=4)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(
+            bt, two_nodes, wallet_a, dic, num_blocks=4
+        )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -749,13 +765,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_correct_my_id(self, two_nodes):
+    async def test_correct_my_id(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin.name()])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -763,14 +779,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_id_garbage(self, two_nodes):
+    async def test_my_id_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin.name(), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -778,14 +794,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_invalid_my_id(self, two_nodes):
+    async def test_invalid_my_id(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         coin_2 = await next_block(full_node_1, WALLET_A, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin_2.name()])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_MY_COIN_ID_FAILED
@@ -793,13 +809,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_my_id_missing_arg(self, two_nodes):
+    async def test_my_id_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
@@ -807,7 +823,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_time_exceeds(self, two_nodes):
+    async def test_assert_time_exceeds(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         # 5 seconds should be before the next block
@@ -815,28 +831,28 @@ class TestMempoolManager:
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_fail(self, two_nodes):
+    async def test_assert_time_fail(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         time_now = full_node_1.full_node.blockchain.get_peak().timestamp + 1000
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_SECONDS_ABSOLUTE_FAILED
         assert sb1 is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_height_pending(self, two_nodes):
+    async def test_assert_height_pending(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         print(full_node_1.full_node.blockchain.get_peak())
@@ -844,41 +860,41 @@ class TestMempoolManager:
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(current_height + 4)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_HEIGHT_ABSOLUTE_FAILED
         assert sb1 is None
         assert status == MempoolInclusionStatus.PENDING
 
     @pytest.mark.asyncio
-    async def test_assert_time_negative(self, two_nodes):
+    async def test_assert_time_negative(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         time_now = -1
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_missing_arg(self, two_nodes):
+    async def test_assert_time_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
         assert sb1 is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_time_garbage(self, two_nodes):
+    async def test_assert_time_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         time_now = full_node_1.full_node.blockchain.get_peak().timestamp + 5
@@ -886,21 +902,21 @@ class TestMempoolManager:
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_exceeds(self, two_nodes):
+    async def test_assert_time_relative_exceeds(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         time_relative = 3
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [int_to_bytes(time_relative)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_SECONDS_RELATIVE_FAILED
@@ -908,7 +924,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
         for i in range(0, 4):
-            await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
+            await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(32 * b"0")))
 
         tx2: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle1)
 
@@ -920,7 +936,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_garbage(self, two_nodes):
+    async def test_assert_time_relative_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         time_relative = 0
@@ -928,7 +944,7 @@ class TestMempoolManager:
         # garbage at the end of the arguments is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [int_to_bytes(time_relative), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -936,13 +952,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_missing_arg(self, two_nodes):
+    async def test_assert_time_relative_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
@@ -950,14 +966,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_negative(self, two_nodes):
+    async def test_assert_time_relative_negative(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         time_relative = -3
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [int_to_bytes(time_relative)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -966,7 +982,7 @@ class TestMempoolManager:
 
     # ensure one spend can assert a coin announcement from another spend
     @pytest.mark.asyncio
-    async def test_correct_coin_announcement_consumed(self, two_nodes):
+    async def test_correct_coin_announcement_consumed(self, bt, two_nodes, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
@@ -974,13 +990,13 @@ class TestMempoolManager:
 
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -990,7 +1006,7 @@ class TestMempoolManager:
     # ensure one spend can assert a coin announcement from another spend, even
     # though the conditions have garbage (ignored) at the end
     @pytest.mark.asyncio
-    async def test_coin_announcement_garbage(self, two_nodes):
+    async def test_coin_announcement_garbage(self, bt, two_nodes, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             # garbage at the end is ignored
@@ -1000,13 +1016,13 @@ class TestMempoolManager:
             # garbage at the end is ignored
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test", b"garbage"])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -1014,7 +1030,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_coin_announcement_missing_arg(self, two_nodes):
+    async def test_coin_announcement_missing_arg(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1023,19 +1039,19 @@ class TestMempoolManager:
             dic = {cvp.opcode: [cvp]}
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         assert err == Err.INVALID_CONDITION
         assert full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name()) is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_coin_announcement_missing_arg2(self, two_nodes):
+    async def test_coin_announcement_missing_arg2(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1045,19 +1061,19 @@ class TestMempoolManager:
             # missing arg here
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         assert err == Err.INVALID_CONDITION
         assert full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name()) is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_coin_announcement_too_big(self, two_nodes):
+    async def test_coin_announcement_too_big(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1069,12 +1085,12 @@ class TestMempoolManager:
 
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         assert err == Err.ASSERT_ANNOUNCE_CONSUMED_FAILED
         assert full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name()) is None
@@ -1092,7 +1108,7 @@ class TestMempoolManager:
     # ensure an assert coin announcement is rejected if it doesn't match the
     # create announcement
     @pytest.mark.asyncio
-    async def test_invalid_coin_announcement_rejected(self, two_nodes):
+    async def test_invalid_coin_announcement_rejected(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1107,12 +1123,12 @@ class TestMempoolManager:
                 [b"wrong test"],
             )
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1121,7 +1137,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_coin_announcement_rejected_two(self, two_nodes):
+    async def test_invalid_coin_announcement_rejected_two(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1133,13 +1149,13 @@ class TestMempoolManager:
 
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
             # coin 2 is making the announcement, right message wrong coin
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err == Err.ASSERT_ANNOUNCE_CONSUMED_FAILED
@@ -1147,7 +1163,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_puzzle_announcement(self, two_nodes):
+    async def test_correct_puzzle_announcement(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1159,12 +1175,12 @@ class TestMempoolManager:
 
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT, [bytes(0x80)])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1173,7 +1189,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_puzzle_announcement_garbage(self, two_nodes):
+    async def test_puzzle_announcement_garbage(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1185,12 +1201,12 @@ class TestMempoolManager:
             # garbage at the end is ignored
             cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT, [bytes(0x80), b"garbage"])
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -1198,7 +1214,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_puzzle_announcement_missing_arg(self, two_nodes):
+    async def test_puzzle_announcement_missing_arg(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1210,12 +1226,12 @@ class TestMempoolManager:
                 [b"test"],
             )
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1224,7 +1240,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_puzzle_announcement_missing_arg2(self, two_nodes):
+    async def test_puzzle_announcement_missing_arg2(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1238,12 +1254,12 @@ class TestMempoolManager:
                 [],
             )
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1252,7 +1268,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_puzzle_announcement_rejected(self, two_nodes):
+    async def test_invalid_puzzle_announcement_rejected(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1267,12 +1283,12 @@ class TestMempoolManager:
                 [b"wrong test"],
             )
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1281,7 +1297,7 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_puzzle_announcement_rejected_two(self, two_nodes):
+    async def test_invalid_puzzle_announcement_rejected_two(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         def test_fun(coin_1: Coin, coin_2: Coin):
@@ -1296,12 +1312,12 @@ class TestMempoolManager:
                 [b"test"],
             )
             dic2 = {cvp.opcode: [cvp2]}
-            spend_bundle1 = generate_test_spend_bundle(coin_1, dic)
-            spend_bundle2 = generate_test_spend_bundle(coin_2, dic2)
+            spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
+            spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(two_nodes, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1310,12 +1326,12 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition(self, two_nodes):
+    async def test_assert_fee_condition(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(10)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, fee=10)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, fee=10)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
         assert err is None
@@ -1323,13 +1339,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_garbage(self, two_nodes):
+    async def test_assert_fee_condition_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         # garbage at the end of the arguments is ignored
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(10), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, fee=10)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, fee=10)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
         assert err is None
@@ -1337,20 +1353,20 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_missing_arg(self, two_nodes):
+    async def test_assert_fee_condition_missing_arg(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, fee=10)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, fee=10)
         assert err == Err.INVALID_CONDITION
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_negative_fee(self, two_nodes):
+    async def test_assert_fee_condition_negative_fee(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(-1)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, fee=10)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, fee=10)
         assert err == Err.RESERVE_FEE_CONDITION_FAILED
         assert status == MempoolInclusionStatus.FAILED
         blocks = bt.get_consecutive_blocks(
@@ -1362,11 +1378,11 @@ class TestMempoolManager:
         )
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_fee_too_large(self, two_nodes):
+    async def test_assert_fee_condition_fee_too_large(self, bt, two_nodes, wallet_a):
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(2 ** 64)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, fee=10)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, fee=10)
         assert err == Err.RESERVE_FEE_CONDITION_FAILED
         assert status == MempoolInclusionStatus.FAILED
         blocks = bt.get_consecutive_blocks(
@@ -1378,13 +1394,13 @@ class TestMempoolManager:
         )
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_wrong_fee(self, two_nodes):
+    async def test_assert_fee_condition_wrong_fee(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
 
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(10)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, fee=9)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, fee=9)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
         assert err == Err.RESERVE_FEE_CONDITION_FAILED
@@ -1392,8 +1408,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_stealing_fee(self, two_nodes):
-        reward_ph = WALLET_A.get_new_puzzlehash()
+    async def test_stealing_fee(self, bt, two_nodes, wallet_a):
+        reward_ph = wallet_a.get_new_puzzlehash()
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
@@ -1406,7 +1422,7 @@ class TestMempoolManager:
         )
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
@@ -1425,10 +1441,10 @@ class TestMempoolManager:
         for coin in list(blocks[-1].get_included_reward_coins()):
             if coin.amount == coin_1.amount:
                 coin_2 = coin
-        spend_bundle1 = generate_test_spend_bundle(coin_1, dic, uint64(fee))
+        spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic, uint64(fee))
 
-        steal_fee_spendbundle = WALLET_A.generate_signed_transaction(
-            coin_1.amount + fee - 4, receiver_puzzlehash, coin_2
+        steal_fee_spendbundle = wallet_a.generate_signed_transaction(
+            uint64(coin_1.amount + fee - 4), receiver_puzzlehash, coin_2
         )
 
         assert spend_bundle1 is not None
@@ -1449,15 +1465,33 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_double_spend_same_bundle(self, two_nodes):
+    async def test_double_spend_same_bundle(self, bt, two_nodes, wallet_a):
+        reward_ph = wallet_a.get_new_puzzlehash()
         full_node_1, full_node_2, server_1, server_2 = two_nodes
+        blocks = await full_node_1.get_all_full_blocks()
+        start_height = blocks[-1].height
+        blocks = bt.get_consecutive_blocks(
+            3,
+            block_list_input=blocks,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=reward_ph,
+            pool_reward_puzzle_hash=reward_ph,
+        )
+        peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
 
+        for block in blocks:
+            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+
+        await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
+        #coin = list(blocks[-1].get_included_reward_coins())[0]
+        #spend_bundle1 = generate_test_spend_bundle(wallet_a, coin)
         coin = await next_block(full_node_1, WALLET_A, bt)
         spend_bundle1 = generate_test_spend_bundle(coin)
 
         assert spend_bundle1 is not None
 
         spend_bundle2 = generate_test_spend_bundle(
+            wallet_a,
             coin,
             new_puzzle_hash=BURN_PUZZLE_HASH_2,
         )
@@ -1477,12 +1511,27 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_agg_sig_condition(self, two_nodes):
+    async def test_agg_sig_condition(self, bt, two_nodes, wallet_a):
+        reward_ph = wallet_a.get_new_puzzlehash()
         full_node_1, full_node_2, server_1, server_2 = two_nodes
+        blocks = await full_node_1.get_all_full_blocks()
+        start_height = blocks[-1].height
+        blocks = bt.get_consecutive_blocks(
+            3,
+            block_list_input=blocks,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=reward_ph,
+            pool_reward_puzzle_hash=reward_ph,
+        )
 
-        coin = await next_block(full_node_1, WALLET_A, bt)
+        for block in blocks:
+            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        spend_bundle_0 = generate_test_spend_bundle(coin)
+        await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
+
+        coin = await next_block(full_node_1, wallet_a, bt)
+        #coin = list(blocks[-1].get_included_reward_coins())[0]
+        spend_bundle_0 = generate_test_spend_bundle(wallet_a, coin)
         unsigned: List[CoinSpend] = spend_bundle_0.coin_spends
 
         assert len(unsigned) == 1
@@ -1500,7 +1549,7 @@ class TestMempoolManager:
         #
         # assert pkm_pairs[0][1] == solution.rest().first().get_tree_hash() + coin_spend.coin.name()
         #
-        # spend_bundle = WALLET_A.sign_transaction(unsigned)
+        # spend_bundle = wallet_a.sign_transaction(unsigned)
         # assert spend_bundle is not None
         #
         # tx: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle)
@@ -1510,13 +1559,13 @@ class TestMempoolManager:
         # assert sb is spend_bundle
 
     @pytest.mark.asyncio
-    async def test_correct_my_parent(self, two_nodes):
+    async def test_correct_my_parent(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin.parent_coin_info])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1525,14 +1574,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_parent_garbage(self, two_nodes):
+    async def test_my_parent_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin.parent_coin_info, b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1541,13 +1590,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_parent_missing_arg(self, two_nodes):
+    async def test_my_parent_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1556,14 +1605,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_my_parent(self, two_nodes):
+    async def test_invalid_my_parent(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         coin_2 = await next_block(full_node_1, WALLET_A, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin_2.parent_coin_info])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1572,13 +1621,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_my_puzhash(self, two_nodes):
+    async def test_correct_my_puzhash(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [coin.puzzle_hash])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1587,14 +1636,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_puzhash_garbage(self, two_nodes):
+    async def test_my_puzhash_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [coin.puzzle_hash, b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1603,13 +1652,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_puzhash_missing_arg(self, two_nodes):
+    async def test_my_puzhash_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1618,13 +1667,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_my_puzhash(self, two_nodes):
+    async def test_invalid_my_puzhash(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [Program.to([]).get_tree_hash()])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1633,13 +1682,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_my_amount(self, two_nodes):
+    async def test_correct_my_amount(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(coin.amount)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1648,14 +1697,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_amount_garbage(self, two_nodes):
+    async def test_my_amount_garbage(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         coin = await next_block(full_node_1, WALLET_A, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(coin.amount), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic, coin=coin)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic, coin=coin)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1664,13 +1713,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_amount_missing_arg(self, two_nodes):
+    async def test_my_amount_missing_arg(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1679,13 +1728,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_my_amount(self, two_nodes):
+    async def test_invalid_my_amount(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(1000)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1694,13 +1743,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_negative_my_amount(self, two_nodes):
+    async def test_negative_my_amount(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(-1)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1709,13 +1758,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_my_amount_too_large(self, two_nodes):
+    async def test_my_amount_too_large(self, bt, two_nodes, wallet_a):
 
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(2 ** 64)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(two_nodes, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1776,7 +1825,7 @@ class TestGeneratorConditions:
             (False, 2300000, 1, None),
         ],
     )
-    def test_div(self, mempool, height, operand, expected):
+    def test_div(self, mempool, height: uint32, operand, expected):
 
         # op_div is disallowed on negative numbers in the mempool, and after the
         # softfork
@@ -2011,7 +2060,7 @@ class TestGeneratorConditions:
             (False, 2300000),
         ],
     )
-    def test_unknown_condition(self, mempool, height):
+    def test_unknown_condition(self, mempool: bool, height: uint32):
         for c in ['(1 100 "foo" "bar")', "(100)", "(1 1) (2 2) (3 3)", '("foobar")']:
             npc_result = generator_condition_tester(c, mempool_mode=mempool, height=height)
             print(npc_result)
@@ -2352,8 +2401,8 @@ class TestMaliciousGenerators:
         print(f"run time:{run_time}")
 
     @pytest.mark.asyncio
-    async def test_invalid_coin_spend_coin(self, two_nodes):
-        reward_ph = WALLET_A.get_new_puzzlehash()
+    async def test_invalid_coin_spend_coin(self, bt, two_nodes, wallet_a):
+        reward_ph = wallet_a.get_new_puzzlehash()
         blocks = bt.get_consecutive_blocks(
             5,
             guarantee_transaction_block=True,
@@ -2367,7 +2416,7 @@ class TestMaliciousGenerators:
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
 
-        spend_bundle = generate_test_spend_bundle(list(blocks[-1].get_included_reward_coins())[0])
+        spend_bundle = generate_test_spend_bundle(wallet_a, list(blocks[-1].get_included_reward_coins())[0])
         coin_spend_0 = recursive_replace(spend_bundle.coin_spends[0], "coin.puzzle_hash", bytes32([1] * 32))
         new_bundle = recursive_replace(spend_bundle, "coin_spends", [coin_spend_0] + spend_bundle.coin_spends[1:])
         assert spend_bundle is not None
@@ -2377,10 +2426,10 @@ class TestMaliciousGenerators:
 
 class TestPkmPairs:
 
-    h1 = b"a" * 32
-    h2 = b"b" * 32
-    h3 = b"c" * 32
-    h4 = b"d" * 32
+    h1 = bytes32(b"a" * 32)
+    h2 = bytes32(b"b" * 32)
+    h3 = bytes32(b"c" * 32)
+    h4 = bytes32(b"d" * 32)
 
     pk1 = G1Element.generator()
     pk2 = G1Element.generator()

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -13,7 +13,7 @@ from chia.util.ints import uint16
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_node import WalletNode
 from tests.connection_utils import connect_and_get_peer
-from tests.setup_nodes import bt, self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
 
@@ -43,13 +43,13 @@ def event_loop():
 
 class TestMempoolPerformance:
     @pytest_asyncio.fixture(scope="module")
-    async def wallet_nodes(self):
+    async def wallet_nodes(self, bt):
         key_seed = bt.farmer_master_sk_entropy
         async for _ in setup_simulators_and_wallets(2, 1, {}, key_seed=key_seed):
             yield _
 
     @pytest.mark.asyncio
-    async def test_mempool_update_performance(self, wallet_nodes, default_400_blocks):
+    async def test_mempool_update_performance(self, bt, wallet_nodes, default_400_blocks, self_hostname):
         blocks = default_400_blocks
         full_nodes, wallets = wallet_nodes
         wallet_node = wallets[0][0]
@@ -72,7 +72,7 @@ class TestMempoolPerformance:
 
         big_transaction: TransactionRecord = await wallet.generate_signed_transaction(send_amount, ph, fee_amount)
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         await full_node_api_1.respond_transaction(
             full_node_protocol.RespondTransaction(big_transaction.spend_bundle), peer, test=True
         )

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -8,7 +8,7 @@ from chia.protocols import full_node_protocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 from tests.connection_utils import connect_and_get_peer
-from tests.setup_nodes import bt, self_hostname, setup_two_nodes, test_constants
+from tests.setup_nodes import setup_two_nodes, test_constants
 from tests.time_out_assert import time_out_assert
 
 
@@ -20,16 +20,16 @@ def event_loop():
 
 class TestNodeLoad:
     @pytest_asyncio.fixture(scope="function")
-    async def two_nodes(self, db_version):
-        async for _ in setup_two_nodes(test_constants, db_version=db_version):
+    async def two_nodes(self, db_version, self_hostname):
+        async for _ in setup_two_nodes(test_constants, db_version=db_version, self_hostname=self_hostname):
             yield _
 
     @pytest.mark.asyncio
-    async def test_blocks_load(self, two_nodes):
+    async def test_blocks_load(self, bt, two_nodes, self_hostname):
         num_blocks = 50
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = bt.get_consecutive_blocks(num_blocks)
-        peer = await connect_and_get_peer(server_1, server_2)
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[0]), peer)
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -20,11 +20,11 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.ints import uint64
 from tests.wallet_tools import WalletTool
 
-from tests.connection_utils import add_dummy_connection, connect_and_get_peer
+from tests.connection_utils import add_dummy_connection
 from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import bt, setup_simulators_and_wallets, test_constants
-from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
+from tests.setup_nodes import setup_simulators_and_wallets
+from tests.time_out_assert import time_out_assert
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ def event_loop():
 
 
 @pytest_asyncio.fixture(scope="module")
-async def wallet_nodes():
+async def wallet_nodes(bt):
     async_gen = setup_simulators_and_wallets(1, 1, {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 11000000000})
     nodes, wallets = await async_gen.__anext__()
     full_node_1 = nodes[0]
@@ -61,7 +61,7 @@ async def wallet_nodes():
 
 class TestPerformance:
     @pytest.mark.asyncio
-    async def test_full_block_performance(self, wallet_nodes):
+    async def test_full_block_performance(self, bt, wallet_nodes, self_hostname):
         full_node_1, server_1, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
         full_node_1.full_node.mempool_manager.limit_factor = 1
@@ -82,7 +82,7 @@ class TestPerformance:
             if full_node_1.full_node.blockchain.get_peak() is not None
             else -1
         )
-        incoming_queue, node_id = await add_dummy_connection(server_1, 12312)
+        incoming_queue, node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         fake_peer = server_1.all_connections[node_id]
         # Mempool has capacity of 100, make 110 unspents that we can use
         puzzle_hashes = []

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -12,7 +12,7 @@ from chia.protocols import full_node_protocol
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
 
@@ -39,7 +39,7 @@ class TestTransactions:
             yield _
 
     @pytest.mark.asyncio
-    async def test_wallet_coinbase(self, wallet_node):
+    async def test_wallet_coinbase(self, wallet_node, self_hostname):
         num_blocks = 5
         full_nodes, wallets = wallet_node
         full_node_api = full_nodes[0]
@@ -61,7 +61,7 @@ class TestTransactions:
         await time_out_assert(10, wallet.get_confirmed_balance, funds)
 
     @pytest.mark.asyncio
-    async def test_tx_propagation(self, three_nodes_two_wallets):
+    async def test_tx_propagation(self, three_nodes_two_wallets, self_hostname):
         num_blocks = 5
         full_nodes, wallets = three_nodes_two_wallets
 
@@ -143,7 +143,7 @@ class TestTransactions:
         await time_out_assert(15, wallet_1.wallet_state_manager.main_wallet.get_confirmed_balance, 10)
 
     @pytest.mark.asyncio
-    async def test_mempool_tx_sync(self, three_nodes_two_wallets):
+    async def test_mempool_tx_sync(self, three_nodes_two_wallets, self_hostname):
         num_blocks = 5
         full_nodes, wallets = three_nodes_two_wallets
 

--- a/tests/core/server/test_dos.py
+++ b/tests/core/server/test_dos.py
@@ -17,7 +17,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
 from chia.util.errors import Err
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
 log = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class FakeRateLimiter:
 
 class TestDos:
     @pytest.mark.asyncio
-    async def test_large_message_disconnect_and_ban(self, setup_two_nodes):
+    async def test_large_message_disconnect_and_ban(self, setup_two_nodes, self_hostname):
         nodes, _ = setup_two_nodes
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -100,7 +100,7 @@ class TestDos:
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_bad_handshake_and_ban(self, setup_two_nodes):
+    async def test_bad_handshake_and_ban(self, setup_two_nodes, self_hostname):
         nodes, _ = setup_two_nodes
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -146,7 +146,7 @@ class TestDos:
         await session.close()
 
     @pytest.mark.asyncio
-    async def test_invalid_protocol_handshake(self, setup_two_nodes):
+    async def test_invalid_protocol_handshake(self, setup_two_nodes, self_hostname):
         nodes, _ = setup_two_nodes
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -179,7 +179,7 @@ class TestDos:
         await asyncio.sleep(1)  # give some time for cleanup to work
 
     @pytest.mark.asyncio
-    async def test_spam_tx(self, setup_two_nodes):
+    async def test_spam_tx(self, setup_two_nodes, self_hostname):
         nodes, _ = setup_two_nodes
         full_node_1, full_node_2 = nodes
         server_1 = nodes[0].full_node.server
@@ -232,7 +232,7 @@ class TestDos:
         await time_out_assert(15, is_banned)
 
     @pytest.mark.asyncio
-    async def test_spam_message_non_tx(self, setup_two_nodes):
+    async def test_spam_message_non_tx(self, setup_two_nodes, self_hostname):
         nodes, _ = setup_two_nodes
         full_node_1, full_node_2 = nodes
         server_1 = nodes[0].full_node.server
@@ -281,7 +281,7 @@ class TestDos:
         await time_out_assert(15, is_banned)
 
     @pytest.mark.asyncio
-    async def test_spam_message_too_large(self, setup_two_nodes):
+    async def test_spam_message_too_large(self, setup_two_nodes, self_hostname):
         nodes, _ = setup_two_nodes
         full_node_1, full_node_2 = nodes
         server_1 = nodes[0].full_node.server

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -13,8 +13,6 @@ from chia.types.peer_info import PeerInfo
 from tests.block_tools import test_constants
 from chia.util.ints import uint16
 from tests.setup_nodes import (
-    bt,
-    self_hostname,
     setup_farmer_harvester,
     setup_introducer,
     setup_simulators_and_wallets,
@@ -55,8 +53,8 @@ async def establish_connection(server: ChiaServer, ssl_context) -> bool:
 
 class TestSSL:
     @pytest_asyncio.fixture(scope="function")
-    async def harvester_farmer(self):
-        async for _ in setup_farmer_harvester(test_constants):
+    async def harvester_farmer(self, bt):
+        async for _ in setup_farmer_harvester(bt, test_constants):
             yield _
 
     @pytest_asyncio.fixture(scope="function")
@@ -67,11 +65,11 @@ class TestSSL:
     @pytest_asyncio.fixture(scope="function")
     async def introducer(self):
         introducer_port = find_available_listen_port("introducer")
-        async for _ in setup_introducer(introducer_port):
+        async for _ in setup_introducer(bt, introducer_port):
             yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def timelord(self):
+    async def timelord(self, bt):
         timelord_port = find_available_listen_port("timelord")
         node_port = find_available_listen_port("node")
         rpc_port = find_available_listen_port("rpc")
@@ -80,7 +78,7 @@ class TestSSL:
             yield _
 
     @pytest.mark.asyncio
-    async def test_public_connections(self, wallet_node):
+    async def test_public_connections(self, wallet_node, self_hostname):
         full_nodes, wallets = wallet_node
         full_node_api = full_nodes[0]
         server_1: ChiaServer = full_node_api.full_node.server
@@ -90,7 +88,7 @@ class TestSSL:
         assert success is True
 
     @pytest.mark.asyncio
-    async def test_farmer(self, harvester_farmer):
+    async def test_farmer(self, harvester_farmer, self_hostname):
         harvester_service, farmer_service = harvester_farmer
         farmer_api = farmer_service._api
 
@@ -107,7 +105,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             farmer_server.ca_private_crt_path, farmer_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(farmer_server, ssl_context)
+        connected = await establish_connection(farmer_server, self_hostname, ssl_context)
         assert connected is True
 
         # Create not authenticated cert
@@ -119,16 +117,16 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             farmer_server.chia_ca_crt_path, farmer_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(farmer_server, ssl_context)
+        connected = await establish_connection(farmer_server, self_hostname, ssl_context)
         assert connected is False
         ssl_context = ssl_context_for_client(
             farmer_server.ca_private_crt_path, farmer_server.ca_private_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(farmer_server, ssl_context)
+        connected = await establish_connection(farmer_server, self_hostname, ssl_context)
         assert connected is False
 
     @pytest.mark.asyncio
-    async def test_full_node(self, wallet_node):
+    async def test_full_node(self, wallet_node, self_hostname):
         full_nodes, wallets = wallet_node
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -145,11 +143,11 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             full_node_server.chia_ca_crt_path, full_node_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(full_node_server, ssl_context)
+        connected = await establish_connection(full_node_server, self_hostname, ssl_context)
         assert connected is True
 
     @pytest.mark.asyncio
-    async def test_wallet(self, wallet_node):
+    async def test_wallet(self, wallet_node, self_hostname):
         full_nodes, wallets = wallet_node
         wallet_node, wallet_server = wallets[0]
 
@@ -162,7 +160,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             wallet_server.chia_ca_crt_path, wallet_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(wallet_server, ssl_context)
+        connected = await establish_connection(wallet_server, self_hostname, ssl_context)
         assert connected is False
 
         # Not even signed by private cert
@@ -177,11 +175,11 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             wallet_server.ca_private_crt_path, wallet_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(wallet_server, ssl_context)
+        connected = await establish_connection(wallet_server, self_hostname, ssl_context)
         assert connected is False
 
     @pytest.mark.asyncio
-    async def test_harvester(self, harvester_farmer):
+    async def test_harvester(self, harvester_farmer, self_hostname):
         harvester, farmer_api = harvester_farmer
         harvester_server = harvester._server
 
@@ -197,7 +195,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             harvester_server.chia_ca_crt_path, harvester_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(harvester_server, ssl_context)
+        connected = await establish_connection(harvester_server, self_hostname, ssl_context)
         assert connected is False
 
         # Not even signed by private cert
@@ -212,11 +210,11 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             harvester_server.ca_private_crt_path, harvester_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(harvester_server, ssl_context)
+        connected = await establish_connection(harvester_server, self_hostname, ssl_context)
         assert connected is False
 
     @pytest.mark.asyncio
-    async def test_introducer(self, introducer):
+    async def test_introducer(self, introducer, self_hostname):
         introducer_api, introducer_server = introducer
 
         # Create not authenticated cert
@@ -231,11 +229,11 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             introducer_server.chia_ca_crt_path, introducer_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(introducer_server, ssl_context)
+        connected = await establish_connection(introducer_server, self_hostname, ssl_context)
         assert connected is True
 
     @pytest.mark.asyncio
-    async def test_timelord(self, timelord):
+    async def test_timelord(self, timelord, self_hostname):
         timelord_api, timelord_server = timelord
 
         # timelord should not accept incoming connections
@@ -250,7 +248,7 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             timelord_server.chia_ca_crt_path, timelord_server.chia_ca_key_path, pub_crt, pub_key
         )
-        connected = await establish_connection(timelord_server, ssl_context)
+        connected = await establish_connection(timelord_server, self_hostname, ssl_context)
         assert connected is False
 
         # Not even signed by private cert
@@ -265,5 +263,5 @@ class TestSSL:
         ssl_context = ssl_context_for_client(
             timelord_server.ca_private_crt_path, timelord_server.ca_private_key_path, priv_crt, priv_key
         )
-        connected = await establish_connection(timelord_server, ssl_context)
+        connected = await establish_connection(timelord_server, self_hostname, ssl_context)
         assert connected is False

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -21,7 +21,7 @@ from tests.setup_nodes import (
 from tests.util.socket import find_available_listen_port
 
 
-async def establish_connection(server: ChiaServer, ssl_context) -> bool:
+async def establish_connection(server: ChiaServer, self_hostname: str, ssl_context) -> bool:
     timeout = aiohttp.ClientTimeout(total=10)
     session = aiohttp.ClientSession(timeout=timeout)
     dummy_port = 5  # this does not matter
@@ -63,7 +63,7 @@ class TestSSL:
             yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def introducer(self):
+    async def introducer(self, bt):
         introducer_port = find_available_listen_port("introducer")
         async for _ in setup_introducer(bt, introducer_port):
             yield _

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import asyncio
 import logging
 import pathlib
@@ -13,7 +14,7 @@ from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, 
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.generator_types import BlockGenerator
 from chia.wallet.puzzles import p2_delegated_puzzle_or_hidden_puzzle
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
 
 from .make_block_generator import make_block_generator
 

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -55,7 +55,7 @@ def large_block_generator(size):
 
 class TestCostCalculation:
     @pytest.mark.asyncio
-    async def test_basics(self, softfork_height):
+    async def test_basics(self, softfork_height, bt):
         wallet_tool = bt.get_pool_wallet_tool()
         ph = wallet_tool.get_new_puzzlehash()
         num_blocks = 3
@@ -111,7 +111,7 @@ class TestCostCalculation:
         )
 
     @pytest.mark.asyncio
-    async def test_mempool_mode(self, softfork_height):
+    async def test_mempool_mode(self, softfork_height, bt):
         wallet_tool = bt.get_pool_wallet_tool()
         ph = wallet_tool.get_new_puzzlehash()
 

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 import logging
 import pathlib

--- a/tests/core/test_daemon_rpc.py
+++ b/tests/core/test_daemon_rpc.py
@@ -1,5 +1,3 @@
-# flake8: noqa: F821
-# pylint: disable=E0602
 import pytest
 import pytest_asyncio
 

--- a/tests/core/test_daemon_rpc.py
+++ b/tests/core/test_daemon_rpc.py
@@ -4,25 +4,21 @@ import pytest_asyncio
 from tests.setup_nodes import setup_daemon
 from chia.daemon.client import connect_to_daemon
 from chia import __version__
-from tests.util.socket import find_available_listen_port
-from chia.util.config import save_config
 
 
 class TestDaemonRpc:
     @pytest_asyncio.fixture(scope="function")
     async def get_daemon(self, bt):
-        bt._config["daemon_port"] = find_available_listen_port()
-        # unfortunately, the daemon's WebSocketServer loads the configs from
-        # disk, so the only way to configure its port is to write it to disk
-        save_config(bt.root_path, "config.yaml", bt._config)
         async for _ in setup_daemon(btools=bt):
             yield _
 
     @pytest.mark.asyncio
     async def test_get_version_rpc(self, get_daemon, bt):
+        ws_server = get_daemon
         config = bt.config
         client = await connect_to_daemon(config["self_hostname"], config["daemon_port"], bt.get_daemon_ssl_context())
         response = await client.get_version()
 
         assert response["data"]["success"]
         assert response["data"]["version"] == __version__
+        ws_server.stop()

--- a/tests/core/test_daemon_rpc.py
+++ b/tests/core/test_daemon_rpc.py
@@ -1,9 +1,10 @@
+# flake8: noqa: F821
+# pylint: disable=E0602
 import pytest
 import pytest_asyncio
 
 from tests.setup_nodes import setup_daemon
 from chia.daemon.client import connect_to_daemon
-from tests.setup_nodes import bt
 from chia import __version__
 from tests.util.socket import find_available_listen_port
 from chia.util.config import save_config
@@ -11,7 +12,7 @@ from chia.util.config import save_config
 
 class TestDaemonRpc:
     @pytest_asyncio.fixture(scope="function")
-    async def get_daemon(self):
+    async def get_daemon(self, bt):
         bt._config["daemon_port"] = find_available_listen_port()
         # unfortunately, the daemon's WebSocketServer loads the configs from
         # disk, so the only way to configure its port is to write it to disk
@@ -20,7 +21,7 @@ class TestDaemonRpc:
             yield _
 
     @pytest.mark.asyncio
-    async def test_get_version_rpc(self, get_daemon):
+    async def test_get_version_rpc(self, get_daemon, bt):
         config = bt.config
         client = await connect_to_daemon(config["self_hostname"], config["daemon_port"], bt.get_daemon_ssl_context())
         response = await client.get_version()

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -220,7 +220,7 @@ async def test_farmer_reward_target_endpoints(bt, environment):
 
 
 @pytest.mark.asyncio
-async def test_farmer_get_pool_state(environment):
+async def test_farmer_get_pool_state(environment, self_hostname):
     (
         farmer_service,
         farmer_rpc_api,

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -18,7 +18,7 @@ from chia.util.config import load_config, save_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.wallet.derive_keys import master_sk_to_wallet_sk
-from tests.setup_nodes import bt, self_hostname, setup_farmer_harvester, test_constants
+from tests.setup_nodes import setup_farmer_harvester, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.rpc import validate_get_routes
 from tests.util.socket import find_available_listen_port
@@ -27,13 +27,13 @@ log = logging.getLogger(__name__)
 
 
 @pytest_asyncio.fixture(scope="function")
-async def simulation():
-    async for _ in setup_farmer_harvester(test_constants):
+async def simulation(bt):
+    async for _ in setup_farmer_harvester(bt, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def environment(simulation):
+async def environment(bt, simulation, self_hostname):
     harvester_service, farmer_service = simulation
 
     def stop_node_cb():
@@ -171,7 +171,7 @@ async def test_farmer_signage_point_endpoints(environment):
 
 
 @pytest.mark.asyncio
-async def test_farmer_reward_target_endpoints(environment):
+async def test_farmer_reward_target_endpoints(bt, environment):
     (
         farmer_service,
         farmer_rpc_api,

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 from typing import List
 

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -21,7 +21,7 @@ class TestFilter:
             yield _
 
     @pytest.mark.asyncio
-    async def test_basic_filter_test(self, wallet_and_node):
+    async def test_basic_filter_test(self, wallet_and_node, bt):
         full_nodes, wallets = wallet_and_node
         wallet_node, server_2 = wallets[0]
         wallet = wallet_node.wallet_state_manager.main_wallet

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import asyncio
 from typing import List
 
@@ -5,7 +6,7 @@ import pytest
 import pytest_asyncio
 from chiabip158 import PyBIP158
 
-from tests.setup_nodes import setup_simulators_and_wallets, bt
+from tests.setup_nodes import setup_simulators_and_wallets
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -22,7 +22,7 @@ from chia.util.ints import uint16, uint8
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.wallet_tools import WalletTool
 from tests.connection_utils import connect_and_get_peer
-from tests.setup_nodes import bt, self_hostname, setup_simulators_and_wallets, test_constants
+from tests.setup_nodes import setup_simulators_and_wallets, test_constants
 from tests.time_out_assert import time_out_assert
 from tests.util.rpc import validate_get_routes
 from tests.util.socket import find_available_listen_port
@@ -35,7 +35,7 @@ class TestRpc:
             yield _
 
     @pytest.mark.asyncio
-    async def test1(self, two_nodes):
+    async def test1(self, two_nodes, bt, self_hostname):
         num_blocks = 5
         test_rpc_port = find_available_listen_port()
         nodes, _ = two_nodes
@@ -231,14 +231,18 @@ class TestRpc:
             await rpc_cleanup()
 
     @pytest.mark.asyncio
-    async def test_signage_points(self, two_nodes, empty_blockchain):
+    async def test_signage_points(self, two_nodes, empty_blockchain, bt):
         test_rpc_port = find_available_listen_port()
         nodes, _ = two_nodes
         full_node_api_1, full_node_api_2 = nodes
         server_1 = full_node_api_1.full_node.server
         server_2 = full_node_api_2.full_node.server
 
-        peer = await connect_and_get_peer(server_1, server_2)
+        config = bt.config
+        self_hostname = config["self_hostname"]
+        daemon_port = config["daemon_port"]
+
+        peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         def stop_node_cb():
             full_node_api_1._close()
@@ -246,13 +250,9 @@ class TestRpc:
 
         full_node_rpc_api = FullNodeRpcApi(full_node_api_1.full_node)
 
-        config = bt.config
-        hostname = config["self_hostname"]
-        daemon_port = config["daemon_port"]
-
         rpc_cleanup = await start_rpc_server(
             full_node_rpc_api,
-            hostname,
+            self_hostname,
             daemon_port,
             test_rpc_port,
             stop_node_cb,

--- a/tests/core/test_merkle_set.py
+++ b/tests/core/test_merkle_set.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 import itertools
 

--- a/tests/core/test_merkle_set.py
+++ b/tests/core/test_merkle_set.py
@@ -14,7 +14,7 @@ def event_loop():
 
 class TestMerkleSet:
     @pytest.mark.asyncio
-    async def test_basics(self):
+    async def test_basics(self, bt):
         num_blocks = 20
         blocks = bt.get_consecutive_blocks(num_blocks)
 

--- a/tests/core/test_merkle_set.py
+++ b/tests/core/test_merkle_set.py
@@ -1,10 +1,10 @@
+# flake8: noqa: F811
 import asyncio
 import itertools
 
 import pytest
 
 from chia.util.merkle_set import MerkleSet, confirm_included_already_hashed
-from tests.setup_nodes import bt
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -11,7 +11,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.weight_proof import SubEpochChallengeSegment
-from chia.util.ints import uint8, uint32
+from chia.util.ints import uint8, uint32, uint64
 from chia.util.streamable import (
     Streamable,
     streamable,

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -66,7 +66,7 @@ def test_variable_size():
 
 
 def test_json(bt):
-    block = bt.create_genesis_block(test_constants, bytes([0] * 32), b"0")
+    block = bt.create_genesis_block(test_constants, bytes32([0] * 32), uint64(0))
     dict_block = block.to_json_dict()
     assert FullBlock.from_json_dict(dict_block) == block
 

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -25,7 +25,7 @@ from chia.util.streamable import (
     parse_size_hints,
     parse_str,
 )
-from tests.setup_nodes import bt, test_constants
+from tests.setup_nodes import test_constants
 
 
 def test_basic():
@@ -65,9 +65,8 @@ def test_variable_size():
             a: int
 
 
-def test_json():
+def test_json(bt):
     block = bt.create_genesis_block(test_constants, bytes([0] * 32), b"0")
-
     dict_block = block.to_json_dict()
     assert FullBlock.from_json_dict(dict_block) == block
 

--- a/tests/farmer_harvester/test_farmer_harvester.py
+++ b/tests/farmer_harvester/test_farmer_harvester.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 
 from chia.farmer.farmer import Farmer
 from chia.util.keychain import generate_mnemonic
-from tests.setup_nodes import bt, setup_farmer_harvester, test_constants
+from tests.setup_nodes import setup_farmer_harvester, test_constants
 from tests.time_out_assert import time_out_assert
 
 
@@ -14,13 +14,13 @@ def farmer_is_started(farmer):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def environment():
-    async for _ in setup_farmer_harvester(test_constants, False):
+async def environment(bt):
+    async for _ in setup_farmer_harvester(bt, test_constants, False):
         yield _
 
 
 @pytest.mark.asyncio
-async def test_start_with_empty_keychain(environment):
+async def test_start_with_empty_keychain(environment, bt):
     _, farmer_service = environment
     farmer: Farmer = farmer_service._node
     # First remove all keys from the keychain
@@ -41,7 +41,7 @@ async def test_start_with_empty_keychain(environment):
 
 
 @pytest.mark.asyncio
-async def test_harvester_handshake(environment):
+async def test_harvester_handshake(environment, bt):
     harvester_service, farmer_service = environment
     harvester = harvester_service._node
     farmer = farmer_service._node

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import logging
 import time
 from os import unlink

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import logging
 import time
 from os import unlink
@@ -22,7 +23,6 @@ from chia.util.path import mkdir
 from chia.plotting.manager import PlotManager
 from tests.block_tools import get_plot_dir
 from tests.plotting.util import get_test_plots
-from tests.setup_nodes import bt
 from tests.time_out_assert import time_out_assert
 
 log = logging.getLogger(__name__)
@@ -139,7 +139,7 @@ class TestEnvironment:
 
 
 @pytest.fixture(scope="function")
-def test_environment(tmp_path) -> Iterator[TestEnvironment]:
+def test_environment(tmp_path, bt) -> Iterator[TestEnvironment]:
     dir_1_count: int = 7
     dir_2_count: int = 3
     plots: List[Path] = get_test_plots()

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -447,7 +447,7 @@ async def test_keys_missing(test_environment: TestEnvironment) -> None:
 
 
 @pytest.mark.asyncio
-async def test_plot_info_caching(test_environment):
+async def test_plot_info_caching(test_environment, bt):
     env: TestEnvironment = test_environment
     expected_result = PlotRefreshResult()
     add_plot_directory(env.root_path, str(env.dir_1.path))

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 import logging
 from dataclasses import dataclass

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -90,7 +90,7 @@ class TestPoolWalletRpc:
             yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def one_wallet_node_and_rpc(self, bt):
+    async def one_wallet_node_and_rpc(self, bt, self_hostname):
         rmtree(get_pool_plot_dir(), ignore_errors=True)
         async for nodes in setup_simulators_and_wallets(1, 1, {}):
             full_nodes, wallets = nodes
@@ -125,7 +125,7 @@ class TestPoolWalletRpc:
             await rpc_cleanup()
 
     @pytest_asyncio.fixture(scope="function")
-    async def setup(self, two_wallet_nodes, bt):
+    async def setup(self, two_wallet_nodes, bt, self_hostname):
         rmtree(get_pool_plot_dir(), ignore_errors=True)
         full_nodes, wallets = two_wallet_nodes
         wallet_node_0, wallet_server_0 = wallets[0]
@@ -174,7 +174,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.parametrize("fee", [0, FEE_AMOUNT])
-    async def test_create_new_pool_wallet_self_farm(self, one_wallet_node_and_rpc, fee, trusted):
+    async def test_create_new_pool_wallet_self_farm(self, one_wallet_node_and_rpc, fee, trusted, self_hostname):
         client, wallet_node_0, full_node_api = one_wallet_node_and_rpc
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         if trusted:
@@ -250,7 +250,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.parametrize("fee", [0, FEE_AMOUNT])
-    async def test_create_new_pool_wallet_farm_to_pool(self, one_wallet_node_and_rpc, fee, trusted):
+    async def test_create_new_pool_wallet_farm_to_pool(self, one_wallet_node_and_rpc, fee, trusted, self_hostname):
         client, wallet_node_0, full_node_api = one_wallet_node_and_rpc
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         if trusted:
@@ -329,7 +329,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.parametrize("fee", [0, FEE_AMOUNT])
-    async def test_create_multiple_pool_wallets(self, one_wallet_node_and_rpc, fee, trusted):
+    async def test_create_multiple_pool_wallets(self, one_wallet_node_and_rpc, fee, trusted, self_hostname):
         client, wallet_node_0, full_node_api = one_wallet_node_and_rpc
         if trusted:
             wallet_node_0.config["trusted_peers"] = {
@@ -459,7 +459,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.parametrize("fee", [0, FEE_AMOUNT])
-    async def test_absorb_self(self, one_wallet_node_and_rpc, fee, trusted, bt):
+    async def test_absorb_self(self, one_wallet_node_and_rpc, fee, trusted, bt, self_hostname):
         client, wallet_node_0, full_node_api = one_wallet_node_and_rpc
         if trusted:
             wallet_node_0.config["trusted_peers"] = {
@@ -575,7 +575,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.parametrize("fee", [0, FEE_AMOUNT])
-    async def test_absorb_pooling(self, one_wallet_node_and_rpc, fee, trusted, bt):
+    async def test_absorb_pooling(self, one_wallet_node_and_rpc, fee, trusted, bt, self_hostname):
         client, wallet_node_0, full_node_api = one_wallet_node_and_rpc
         if trusted:
             wallet_node_0.config["trusted_peers"] = {
@@ -723,7 +723,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True])
     @pytest.mark.parametrize("fee", [0])
-    async def test_self_pooling_to_pooling(self, setup, fee, trusted):
+    async def test_self_pooling_to_pooling(self, setup, fee, trusted, self_hostname):
         """This tests self-pooling -> pooling"""
         num_blocks = 4  # Num blocks to farm at a time
         total_blocks = 0  # Total blocks farmed so far
@@ -860,7 +860,7 @@ class TestPoolWalletRpc:
         "fee",
         [0, FEE_AMOUNT],
     )
-    async def test_leave_pool(self, setup, fee, trusted):
+    async def test_leave_pool(self, setup, fee, trusted, self_hostname):
         """This tests self-pooling -> pooling -> escaping -> self pooling"""
         full_nodes, wallet_nodes, receive_address, client, rpc_cleanup = setup
         our_ph = receive_address[0]
@@ -982,7 +982,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.parametrize("fee", [0, FEE_AMOUNT])
-    async def test_change_pools(self, setup, fee, trusted):
+    async def test_change_pools(self, setup, fee, trusted, self_hostname):
         """This tests Pool A -> escaping -> Pool B"""
         full_nodes, wallet_nodes, receive_address, client, rpc_cleanup = setup
         our_ph = receive_address[0]
@@ -1086,7 +1086,7 @@ class TestPoolWalletRpc:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.parametrize("fee", [0, FEE_AMOUNT])
-    async def test_change_pools_reorg(self, setup, fee, trusted, bt):
+    async def test_change_pools_reorg(self, setup, fee, trusted, bt, self_hostname):
         """This tests Pool A -> escaping -> reorg -> escaping -> Pool B"""
         full_nodes, wallet_nodes, receive_address, client, rpc_cleanup = setup
         our_ph = receive_address[0]

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -48,11 +48,6 @@ def bt() -> BlockTools:
     return _shared_block_tools
 
 
-# if you have a system that has an unusual hostname for localhost and you want
-# to run the tests, change this constant
-self_hostname = "localhost"
-
-
 def constants_for_dic(dic):
     return test_constants.replace(**dic)
 
@@ -452,7 +447,7 @@ async def setup_n_nodes(consensus_constants: ConsensusConstants, n: int, db_vers
 
 
 async def setup_node_and_wallet(
-    consensus_constants: ConsensusConstants, starting_height=None, key_seed=None, db_version=1
+    consensus_constants: ConsensusConstants, self_hostname: str, starting_height=None, key_seed=None, db_version=1
 ):
     with TempKeyring(populate=True) as keychain:
         btools = await create_block_tools_async(constants=test_constants, keychain=keychain)

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -112,7 +112,7 @@ async def setup_full_node(
     config = local_bt.config["full_node"]
 
     connect_to_daemon = False
-    if connect_to_daemon_port:
+    if connect_to_daemon_port is not None:
         config["daemon_port"] = connect_to_daemon_port
         connect_to_daemon = True
 
@@ -513,7 +513,6 @@ async def setup_simulators_and_wallets(
             port = find_available_listen_port(f"node{index}")
             rpc_port = find_available_listen_port(f"node{index} rpc")
             db_name = f"blockchain_test_{port}.db"
-            # TODO convert this bt_tools variable to a passed-in variable
             bt_tools = await create_block_tools_async(
                 consensus_constants, const_dict=dic, keychain=keychain1
             )  # block tools modifies constants

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -1,3 +1,4 @@
+import atexit
 import pytest
 import asyncio
 import signal
@@ -20,7 +21,7 @@ from chia.simulator.start_simulator import service_kwargs_for_full_node_simulato
 from chia.timelord.timelord_launcher import kill_processes, spawn_process
 from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
-from tests.block_tools import create_block_tools_async, test_constants, BlockTools
+from tests.block_tools import create_block_tools_async, test_constants, BlockTools, create_block_tools
 from tests.util.keyring import TempKeyring
 from tests.util.socket import find_available_listen_port
 from chia.util.hash import std_hash
@@ -47,7 +48,6 @@ def bt() -> BlockTools:
 # if you have a system that has an unusual hostname for localhost and you want
 # to run the tests, change this constant
 self_hostname = "localhost"
-
 
 
 def constants_for_dic(dic):
@@ -449,7 +449,7 @@ async def setup_node_and_wallet(
     consensus_constants: ConsensusConstants, starting_height=None, key_seed=None, db_version=1
 ):
     with TempKeyring(populate=True) as keychain:
-        btools = await create_block_tools_async(constants=test_constants, keychain=keychain)  # xxx
+        btools = await create_block_tools_async(constants=test_constants, keychain=keychain)
         node_iters = [
             setup_full_node(
                 consensus_constants,
@@ -481,7 +481,7 @@ async def setup_node_and_wallet(
         await _teardown_nodes(node_iters)
 
 
-async def setup_simulators_and_wallets(  # XXX
+async def setup_simulators_and_wallets(
     simulator_count: int,
     wallet_count: int,
     dic: Dict,
@@ -500,7 +500,7 @@ async def setup_simulators_and_wallets(  # XXX
             port = find_available_listen_port(f"node{index}")
             rpc_port = find_available_listen_port(f"node{index} rpc")
             db_name = f"blockchain_test_{port}.db"
-            # xxx convert bt_tools to bt fixture
+            # TODO convert this bt_tools variable to a passed-in variable
             bt_tools = await create_block_tools_async(
                 consensus_constants, const_dict=dic, keychain=keychain1
             )  # block tools modifies constants
@@ -564,7 +564,7 @@ async def setup_farmer_harvester(bt: BlockTools, consensus_constants: ConsensusC
     await _teardown_nodes(node_iters)
 
 
-async def setup_full_system(  # xxx which of these 3 block_tools are needed in which places?
+async def setup_full_system(
     consensus_constants: ConsensusConstants,
     shared_b_tools: BlockTools,
     b_tools: BlockTools = None,

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -676,7 +676,8 @@ async def setup_full_system(
         ]
 
         if connect_to_daemon_port:
-            daemon_ws = await setup_daemon(btools=b_tools).__anext__()
+            node_iters.append(setup_daemon(btools=b_tools))
+            daemon_ws = await node_iters[9].__anext__()
 
         introducer, introducer_server = await node_iters[0].__anext__()
         harvester_service = await node_iters[1].__anext__()
@@ -712,10 +713,12 @@ async def setup_full_system(
         )
 
         if connect_to_daemon_port:
-            node_iters.append(daemon_ws)
             yield ret + (daemon_ws,)
         else:
             yield ret
 
-        await _teardown_nodes(node_iters[:-1])
-        await _teardown_nodes([node_iters[-1]])
+        if connect_to_daemon_port:
+            await _teardown_nodes(node_iters[:-1])
+            await _teardown_nodes([node_iters[-1]])
+        else:
+            await _teardown_nodes(node_iters)

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -217,7 +217,6 @@ async def setup_wallet_node(
 
 
 async def setup_harvester(
-    # xxx port, rpc_port, farmer_port, consensus_constants: ConsensusConstants, b_tools, start_service: bool = True
     b_tools: BlockTools,
     self_hostname: str,
     port,
@@ -227,7 +226,7 @@ async def setup_harvester(
     start_service: bool = True,
 ):
 
-    config = bt.config["harvester"]
+    config = b_tools.config["harvester"]
     config["port"] = port
     config["rpc_port"] = rpc_port
     kwargs = service_kwargs_for_harvester(b_tools.root_path, config, consensus_constants)
@@ -552,8 +551,23 @@ async def setup_farmer_harvester(bt: BlockTools, consensus_constants: ConsensusC
     harvester_port = find_available_listen_port("harvester")
     harvester_rpc_port = find_available_listen_port("harvester rpc")
     node_iters = [
-        setup_harvester(bt, bt.config["self_hostname"],harvester_port, harvester_rpc_port, farmer_port, consensus_constants, start_services),
-        setup_farmer(bt, bt.config["self_hostname"],farmer_port, farmer_rpc_port, consensus_constants, start_service=start_services),
+        setup_harvester(
+            bt,
+            bt.config["self_hostname"],
+            harvester_port,
+            harvester_rpc_port,
+            farmer_port,
+            consensus_constants,
+            start_services,
+        ),
+        setup_farmer(
+            bt,
+            bt.config["self_hostname"],
+            farmer_port,
+            farmer_rpc_port,
+            consensus_constants,
+            start_service=start_services,
+        ),
     ]
 
     harvester_service = await node_iters[0].__anext__()
@@ -595,12 +609,26 @@ async def setup_full_system(
 
         node_iters = [
             setup_introducer(shared_b_tools, introducer_port),
-            setup_harvester(shared_b_tools, shared_b_tools.config["self_hostname"], harvester_port, harvester_rpc_port, farmer_port, consensus_constants),
+            setup_harvester(
+                shared_b_tools,
+                shared_b_tools.config["self_hostname"],
+                harvester_port,
+                harvester_rpc_port,
+                farmer_port,
+                consensus_constants,
+            ),
             setup_farmer(
-                shared_b_tools, shared_b_tools.config["self_hostname"], farmer_port, farmer_rpc_port, consensus_constants, uint16(node1_port)
+                shared_b_tools,
+                shared_b_tools.config["self_hostname"],
+                farmer_port,
+                farmer_rpc_port,
+                consensus_constants,
+                uint16(node1_port),
             ),
             setup_vdf_clients(shared_b_tools, shared_b_tools.config["self_hostname"], vdf1_port),
-            setup_timelord(timelord2_port, node1_port, timelord2_rpc_port, vdf1_port, False, consensus_constants, b_tools),
+            setup_timelord(
+                timelord2_port, node1_port, timelord2_rpc_port, vdf1_port, False, consensus_constants, b_tools
+            ),
             setup_full_node(
                 consensus_constants,
                 "blockchain_test.db",

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -1,6 +1,4 @@
-import atexit
 import logging
-import pytest
 import asyncio
 import signal
 import sqlite3
@@ -22,7 +20,7 @@ from chia.simulator.start_simulator import service_kwargs_for_full_node_simulato
 from chia.timelord.timelord_launcher import kill_processes, spawn_process
 from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
-from tests.block_tools import create_block_tools_async, test_constants, BlockTools, create_block_tools
+from tests.block_tools import create_block_tools_async, test_constants, BlockTools
 from tests.util.keyring import TempKeyring
 from tests.util.socket import find_available_listen_port
 from chia.util.hash import std_hash
@@ -35,17 +33,7 @@ def cleanup_keyring(keyring: TempKeyring):
     keyring.cleanup()
 
 
-temp_keyring = TempKeyring(populate=True)
-keychain = temp_keyring.get_keychain()
-atexit.register(cleanup_keyring, temp_keyring)  # Attempt to cleanup the temp keychain
-
 log = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="session")
-def bt() -> BlockTools:
-    _shared_block_tools = create_block_tools(constants=test_constants, keychain=keychain)
-    return _shared_block_tools
 
 
 def constants_for_dic(dic):

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -34,12 +34,13 @@ class TestSimulation:
     # because of a hack in shutting down the full node, which means you cannot run
     # more than one simulations per process.
     @pytest_asyncio.fixture(scope="function")
-    async def extra_node(self):
+    async def extra_node(self, self_hostname):
         with TempKeyring() as keychain:
             b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=keychain)
             async for _ in setup_full_node(
                 test_constants_modified,
                 "blockchain_test_3.db",
+                self_hostname,
                 find_available_listen_port(),
                 find_available_listen_port(),
                 b_tools,
@@ -53,7 +54,7 @@ class TestSimulation:
             yield _
 
     @pytest.mark.asyncio
-    async def test_simulation_1(self, simulation, extra_node):
+    async def test_simulation_1(self, simulation, extra_node, self_hostname):
         node1, node2, _, _, _, _, _, _, _, sanitizer_server, server1 = simulation
 
         node1_port = node1.full_node.config["port"]

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import pytest
 import pytest_asyncio
 

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -49,8 +49,8 @@ class TestSimulation:
                 yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def simulation(self, shared_b_tools):
-        async for _ in setup_full_system(test_constants_modified, shared_b_tools, db_version=1):
+    async def simulation(self, bt):
+        async for _ in setup_full_system(test_constants_modified, bt, db_version=1):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import pytest
 import pytest_asyncio
 
@@ -5,7 +6,7 @@ from chia.types.peer_info import PeerInfo
 from tests.block_tools import create_block_tools_async
 from chia.util.ints import uint16
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import self_hostname, setup_full_node, setup_full_system, test_constants
+from tests.setup_nodes import setup_full_node, setup_full_system, test_constants
 from tests.time_out_assert import time_out_assert
 from tests.util.keyring import TempKeyring
 from tests.util.socket import find_available_listen_port

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -47,8 +47,8 @@ class TestSimulation:
                 yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def simulation(self):
-        async for _ in setup_full_system(test_constants_modified, db_version=1):
+    async def simulation(self, shared_b_tools):
+        async for _ in setup_full_system(test_constants_modified, shared_b_tools, db_version=1):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -14,8 +14,8 @@ from chia.full_node.hint_store import HintStore
 from chia.types.full_block import FullBlock
 from chia.util.db_wrapper import DBWrapper
 from chia.util.path import mkdir
+from tests.block_tools import BlockTools
 
-from tests.setup_nodes import bt
 
 
 async def create_blockchain(constants: ConsensusConstants, db_version: int):
@@ -33,9 +33,11 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int):
     return bc1, connection, db_path
 
 
+# @pytest.fixture(scope="module")
 def persistent_blocks(
     num_of_blocks: int,
     db_name: str,
+    bt: BlockTools,
     seed: bytes = b"",
     empty_sub_slots=0,
     normalized_to_identity_cc_eos: bool = False,
@@ -69,6 +71,7 @@ def persistent_blocks(
         num_of_blocks,
         seed,
         empty_sub_slots,
+        bt,
         normalized_to_identity_cc_eos,
         normalized_to_identity_icc_eos,
         normalized_to_identity_cc_sp,
@@ -76,11 +79,13 @@ def persistent_blocks(
     )
 
 
+# @pytest.fixture(scope="module")
 def new_test_db(
     path: Path,
     num_of_blocks: int,
     seed: bytes,
     empty_sub_slots: int,
+    bt: BlockTools,
     normalized_to_identity_cc_eos: bool = False,  # CC_EOS,
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -17,7 +17,6 @@ from chia.util.path import mkdir
 from tests.block_tools import BlockTools
 
 
-
 async def create_blockchain(constants: ConsensusConstants, db_version: int):
     db_path = Path(tempfile.NamedTemporaryFile().name)
 

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -32,7 +32,6 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int):
     return bc1, connection, db_path
 
 
-# @pytest.fixture(scope="module")
 def persistent_blocks(
     num_of_blocks: int,
     db_name: str,
@@ -78,7 +77,6 @@ def persistent_blocks(
     )
 
 
-# @pytest.fixture(scope="module")
 def new_test_db(
     path: Path,
     num_of_blocks: int,

--- a/tests/util/keyring.py
+++ b/tests/util/keyring.py
@@ -165,7 +165,8 @@ class TempKeyring:
             add_dummy_key_to_cryptfilekeyring(crypt_file_keyring)
 
         keychain = Keychain(user=user, service=service)
-        keychain.keyring_wrapper = KeyringWrapper(keys_root_path=Path(temp_dir))
+        keychain.keyring_wrapper = KeyringWrapper.create(keys_root_path=Path(temp_dir))
+        # keychain.keyring_wrapper = KeyringWrapper(keys_root_path=Path(temp_dir))
 
         # Stash the temp_dir in the keychain instance
         keychain._temp_dir = temp_dir  # type: ignore

--- a/tests/util/keyring.py
+++ b/tests/util/keyring.py
@@ -165,7 +165,7 @@ class TempKeyring:
             add_dummy_key_to_cryptfilekeyring(crypt_file_keyring)
 
         keychain = Keychain(user=user, service=service)
-        keychain.keyring_wrapper = KeyringWrapper.create(keys_root_path=Path(temp_dir))
+        keychain.keyring_wrapper = KeyringWrapper(keys_root_path=Path(temp_dir))
 
         # Stash the temp_dir in the keychain instance
         keychain._temp_dir = temp_dir  # type: ignore

--- a/tests/util/keyring.py
+++ b/tests/util/keyring.py
@@ -166,7 +166,6 @@ class TempKeyring:
 
         keychain = Keychain(user=user, service=service)
         keychain.keyring_wrapper = KeyringWrapper.create(keys_root_path=Path(temp_dir))
-        # keychain.keyring_wrapper = KeyringWrapper(keys_root_path=Path(temp_dir))
 
         # Stash the temp_dir in the keychain instance
         keychain._temp_dir = temp_dir  # type: ignore

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -19,7 +19,7 @@ from chia.wallet.puzzles.cat_loader import CAT_MOD
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_info import WalletInfo
 from tests.pools.test_pool_rpc import wallet_is_synced
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
 
@@ -51,7 +51,7 @@ class TestCATWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_cat_creation(self, two_wallet_nodes, trusted):
+    async def test_cat_creation(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 3
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -120,7 +120,7 @@ class TestCATWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_cat_spend(self, two_wallet_nodes, trusted):
+    async def test_cat_spend(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 3
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -221,7 +221,7 @@ class TestCATWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_get_wallet_for_asset_id(self, two_wallet_nodes, trusted):
+    async def test_get_wallet_for_asset_id(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 3
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -274,7 +274,7 @@ class TestCATWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_cat_doesnt_see_eve(self, two_wallet_nodes, trusted):
+    async def test_cat_doesnt_see_eve(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 3
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -377,7 +377,7 @@ class TestCATWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_cat_spend_multiple(self, three_wallet_nodes, trusted):
+    async def test_cat_spend_multiple(self, self_hostname, three_wallet_nodes, trusted):
         num_blocks = 3
         full_nodes, wallets = three_wallet_nodes
         full_node_api = full_nodes[0]
@@ -518,7 +518,7 @@ class TestCATWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_cat_max_amount_send(self, two_wallet_nodes, trusted):
+    async def test_cat_max_amount_send(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 3
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -650,7 +650,7 @@ class TestCATWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_cat_hint(self, two_wallet_nodes, trusted, autodiscovery):
+    async def test_cat_hint(self, self_hostname, two_wallet_nodes, trusted, autodiscovery):
         num_blocks = 3
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]

--- a/tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -86,7 +86,7 @@ class TestOfferLifecycle:
                 else:
                     payments.append(Payment(acs_ph, amount, []))
 
-        # This bundle create all of the initial coins
+        # This bundle creates all of the initial coins
         parent_bundle = SpendBundle(
             [
                 CoinSpend(

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -15,7 +15,7 @@ from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 from tests.pools.test_pool_rpc import wallet_is_synced
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
 
@@ -42,7 +42,7 @@ buffer_blocks = 4
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallets_prefarm(two_wallet_nodes, trusted):
+async def wallets_prefarm(two_wallet_nodes, self_hostname, trusted):
     """
     Sets up the node with 10 blocks, and returns a payer and payee wallet.
     """

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -42,6 +42,12 @@ buffer_blocks = 4
 
 
 @pytest_asyncio.fixture(scope="function")
+def self_hostname():
+    from tests.conftest import self_hostname
+    return self_hostname
+
+
+@pytest_asyncio.fixture(scope="function")
 async def wallets_prefarm(two_wallet_nodes, self_hostname, trusted):
     """
     Sets up the node with 10 blocks, and returns a payer and payee wallet.

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -42,12 +42,6 @@ buffer_blocks = 4
 
 
 @pytest_asyncio.fixture(scope="function")
-def self_hostname():
-    from tests.conftest import self_hostname
-    return self_hostname
-
-
-@pytest_asyncio.fixture(scope="function")
 async def wallets_prefarm(two_wallet_nodes, self_hostname, trusted):
     """
     Sets up the node with 10 blocks, and returns a payer and payee wallet.

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -4,7 +4,7 @@ import pytest_asyncio
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.types.blockchain_format.program import Program
 from blspy import AugSchemeMPL
@@ -48,7 +48,7 @@ class TestDIDWallet:
             yield _
 
     @pytest.mark.asyncio
-    async def test_creation_from_backup_file(self, three_wallet_nodes):
+    async def test_creation_from_backup_file(self, self_hostname, three_wallet_nodes):
         num_blocks = 5
         full_nodes, wallets = three_wallet_nodes
         full_node_api = full_nodes[0]
@@ -173,7 +173,7 @@ class TestDIDWallet:
         await time_out_assert(45, did_wallet_2.get_unconfirmed_balance, 0)
 
     @pytest.mark.asyncio
-    async def test_did_recovery_with_multiple_backup_dids(self, two_wallet_nodes):
+    async def test_did_recovery_with_multiple_backup_dids(self, self_hostname, two_wallet_nodes):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_1 = full_nodes[0]
@@ -281,7 +281,7 @@ class TestDIDWallet:
         await time_out_assert(15, did_wallet_3.get_unconfirmed_balance, 0)
 
     @pytest.mark.asyncio
-    async def test_did_recovery_with_empty_set(self, two_wallet_nodes):
+    async def test_did_recovery_with_empty_set(self, self_hostname, two_wallet_nodes):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_1 = full_nodes[0]
@@ -328,7 +328,7 @@ class TestDIDWallet:
         assert additions == []
 
     @pytest.mark.asyncio
-    async def test_did_attest_after_recovery(self, two_wallet_nodes):
+    async def test_did_attest_after_recovery(self, self_hostname, two_wallet_nodes):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_1 = full_nodes[0]

--- a/tests/wallet/did_wallet/test_did_rpc.py
+++ b/tests/wallet/did_wallet/test_did_rpc.py
@@ -34,7 +34,7 @@ class TestDIDWallet:
             yield _
 
     @pytest.mark.asyncio
-    async def test_create_did(self, bt, three_wallet_nodes):
+    async def test_create_did(self, bt, three_wallet_nodes, self_hostname):
         num_blocks = 4
         full_nodes, wallets = three_wallet_nodes
         full_node_api = full_nodes[0]

--- a/tests/wallet/did_wallet/test_did_rpc.py
+++ b/tests/wallet/did_wallet/test_did_rpc.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import asyncio
 import logging
 import pytest
@@ -10,7 +11,7 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
 from chia.wallet.util.wallet_types import WalletType
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets, bt
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from tests.util.socket import find_available_listen_port
@@ -34,7 +35,7 @@ class TestDIDWallet:
             yield _
 
     @pytest.mark.asyncio
-    async def test_create_did(self, three_wallet_nodes):
+    async def test_create_did(self, bt, three_wallet_nodes):
         num_blocks = 4
         full_nodes, wallets = three_wallet_nodes
         full_node_api = full_nodes[0]

--- a/tests/wallet/did_wallet/test_did_rpc.py
+++ b/tests/wallet/did_wallet/test_did_rpc.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 import logging
 import pytest

--- a/tests/wallet/rl_wallet/test_rl_rpc.py
+++ b/tests/wallet/rl_wallet/test_rl_rpc.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 
 import pytest

--- a/tests/wallet/rl_wallet/test_rl_rpc.py
+++ b/tests/wallet/rl_wallet/test_rl_rpc.py
@@ -60,7 +60,7 @@ class TestRLWallet:
 
     @pytest.mark.asyncio
     @pytest.mark.skip
-    async def test_create_rl_coin(self, three_wallet_nodes):
+    async def test_create_rl_coin(self, three_wallet_nodes, self_hostname):
         num_blocks = 4
         full_nodes, wallets = three_wallet_nodes
         full_node_api = full_nodes[0]

--- a/tests/wallet/rl_wallet/test_rl_rpc.py
+++ b/tests/wallet/rl_wallet/test_rl_rpc.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import asyncio
 
 import pytest
@@ -13,7 +14,7 @@ from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint16
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.wallet_types import WalletType
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from tests.wallet.sync.test_wallet_sync import wallet_height_at_least
 

--- a/tests/wallet/rl_wallet/test_rl_wallet.py
+++ b/tests/wallet/rl_wallet/test_rl_wallet.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 
 import pytest

--- a/tests/wallet/rl_wallet/test_rl_wallet.py
+++ b/tests/wallet/rl_wallet/test_rl_wallet.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import asyncio
 
 import pytest
@@ -7,7 +8,7 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
 from chia.wallet.rl_wallet.rl_wallet import RLWallet
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 
 

--- a/tests/wallet/rl_wallet/test_rl_wallet.py
+++ b/tests/wallet/rl_wallet/test_rl_wallet.py
@@ -25,7 +25,7 @@ class TestCATWallet:
 
     @pytest.mark.asyncio
     @pytest.mark.skip
-    async def test_create_rl_coin(self, two_wallet_nodes):
+    async def test_create_rl_coin(self, two_wallet_nodes, self_hostname):
         num_blocks = 4
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F811
 import asyncio
 from typing import Optional
 
@@ -35,7 +36,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.transaction_sorting import SortKey
 from chia.wallet.util.compute_memos import compute_memos
 from tests.pools.test_pool_rpc import wallet_is_synced
-from tests.setup_nodes import bt, setup_simulators_and_wallets, self_hostname
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from tests.util.socket import find_available_listen_port
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1,4 +1,3 @@
-# flake8: noqa: F811
 import asyncio
 from typing import Optional
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -42,6 +42,12 @@ from tests.util.socket import find_available_listen_port
 log = logging.getLogger(__name__)
 
 
+@pytest_asyncio.fixture(scope="function")
+def self_hostname():
+    from tests.conftest import self_hostname
+    return self_hostname
+
+
 class TestWalletRpc:
     @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -54,7 +54,7 @@ class TestWalletRpc:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_rpc(self, two_wallet_nodes, trusted):
+    async def test_wallet_rpc(self, two_wallet_nodes, trusted, bt):
         test_rpc_port = find_available_listen_port()
         test_rpc_port_2 = find_available_listen_port()
         test_rpc_port_node = find_available_listen_port()
@@ -138,9 +138,9 @@ class TestWalletRpc:
         await time_out_assert(5, wallet.get_confirmed_balance, initial_funds)
         await time_out_assert(5, wallet.get_unconfirmed_balance, initial_funds)
 
-        client = await WalletRpcClient.create(self_hostname, test_rpc_port, bt.root_path, config)
-        client_2 = await WalletRpcClient.create(self_hostname, test_rpc_port_2, bt.root_path, config)
-        client_node = await FullNodeRpcClient.create(self_hostname, test_rpc_port_node, bt.root_path, config)
+        client = await WalletRpcClient.create(hostname, test_rpc_port, bt.root_path, config)
+        client_2 = await WalletRpcClient.create(hostname, test_rpc_port_2, bt.root_path, config)
+        client_node = await FullNodeRpcClient.create(hostname, test_rpc_port_node, bt.root_path, config)
         try:
             await time_out_assert(5, client.get_synced)
             addr = encode_puzzle_hash(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), "xch")

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -53,7 +53,7 @@ class TestWalletRpc:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_rpc(self, two_wallet_nodes, trusted, bt):
+    async def test_wallet_rpc(self, two_wallet_nodes, trusted, bt, self_hostname):
         test_rpc_port = find_available_listen_port()
         test_rpc_port_2 = find_available_listen_port()
         test_rpc_port_node = find_available_listen_port()

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -42,12 +42,6 @@ from tests.util.socket import find_available_listen_port
 log = logging.getLogger(__name__)
 
 
-@pytest_asyncio.fixture(scope="function")
-def self_hostname():
-    from tests.conftest import self_hostname
-    return self_hostname
-
-
 class TestWalletRpc:
     @pytest_asyncio.fixture(scope="function")
     async def two_wallet_nodes(self):

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -25,7 +25,7 @@ from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_state_manager import WalletStateManager
 from tests.connection_utils import add_dummy_connection
 from tests.pools.test_pool_rpc import wallet_is_synced
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets, bt
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from tests.wallet.cat_wallet.test_cat_wallet import tx_in_pool
 from tests.wallet_tools import WalletTool
@@ -67,7 +67,7 @@ class TestSimpleSyncProtocol:
         return all_messages
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_ph(self, wallet_node_simulator):
+    async def test_subscribe_for_ph(self, wallet_node_simulator, self_hostname):
         num_blocks = 4
         full_nodes, wallets = wallet_node_simulator
         full_node_api = full_nodes[0]
@@ -76,7 +76,7 @@ class TestSimpleSyncProtocol:
         wsm: WalletStateManager = wallet_node.wallet_state_manager
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
-        incoming_queue, peer_id = await add_dummy_connection(fn_server, 12312, NodeType.WALLET)
+        incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
 
         zero_ph = 32 * b"\0"
         junk_ph = 32 * b"\a"
@@ -255,7 +255,7 @@ class TestSimpleSyncProtocol:
         assert notified_state.spent_height is not None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_coin_id(self, wallet_node_simulator):
+    async def test_subscribe_for_coin_id(self, wallet_node_simulator, self_hostname):
         num_blocks = 4
         full_nodes, wallets = wallet_node_simulator
         full_node_api = full_nodes[0]
@@ -266,7 +266,7 @@ class TestSimpleSyncProtocol:
         puzzle_hash = await standard_wallet.get_new_puzzlehash()
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
-        incoming_queue, peer_id = await add_dummy_connection(fn_server, 12312, NodeType.WALLET)
+        incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
 
         fake_wallet_peer = fn_server.all_connections[peer_id]
 
@@ -362,7 +362,7 @@ class TestSimpleSyncProtocol:
         assert notified_state.spent_height is None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_ph_reorg(self, wallet_node_simulator):
+    async def test_subscribe_for_ph_reorg(self, wallet_node_simulator, self_hostname):
         num_blocks = 4
         long_blocks = 20
         full_nodes, wallets = wallet_node_simulator
@@ -374,7 +374,7 @@ class TestSimpleSyncProtocol:
         puzzle_hash = await standard_wallet.get_new_puzzlehash()
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
-        incoming_queue, peer_id = await add_dummy_connection(fn_server, 12312, NodeType.WALLET)
+        incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
 
         fake_wallet_peer = fn_server.all_connections[peer_id]
         zero_ph = 32 * b"\0"
@@ -437,7 +437,7 @@ class TestSimpleSyncProtocol:
         assert second_state_coin_2.created_height is None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_coin_id_reorg(self, wallet_node_simulator):
+    async def test_subscribe_for_coin_id_reorg(self, wallet_node_simulator, self_hostname):
         num_blocks = 4
         long_blocks = 20
         full_nodes, wallets = wallet_node_simulator
@@ -449,7 +449,7 @@ class TestSimpleSyncProtocol:
         puzzle_hash = await standard_wallet.get_new_puzzlehash()
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
-        incoming_queue, peer_id = await add_dummy_connection(fn_server, 12312, NodeType.WALLET)
+        incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
 
         fake_wallet_peer = fn_server.all_connections[peer_id]
         zero_ph = 32 * b"\0"
@@ -504,7 +504,7 @@ class TestSimpleSyncProtocol:
         assert second_coin.created_height is None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_hint(self, wallet_node_simulator):
+    async def test_subscribe_for_hint(self, bt, wallet_node_simulator, self_hostname):
         num_blocks = 4
         full_nodes, wallets = wallet_node_simulator
         full_node_api = full_nodes[0]
@@ -513,7 +513,7 @@ class TestSimpleSyncProtocol:
         wsm: WalletStateManager = wallet_node.wallet_state_manager
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
-        incoming_queue, peer_id = await add_dummy_connection(fn_server, 12312, NodeType.WALLET)
+        incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
         ph = wt.get_new_puzzlehash()
@@ -579,7 +579,7 @@ class TestSimpleSyncProtocol:
         assert data_response.coin_states[0] == coin_records[0].coin_state
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_hint_long_sync(self, wallet_two_node_simulator):
+    async def test_subscribe_for_hint_long_sync(self, wallet_two_node_simulator, bt, self_hostname):
         num_blocks = 4
         full_nodes, wallets = wallet_two_node_simulator
         full_node_api = full_nodes[0]
@@ -592,8 +592,8 @@ class TestSimpleSyncProtocol:
         wsm: WalletStateManager = wallet_node.wallet_state_manager
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
-        incoming_queue, peer_id = await add_dummy_connection(fn_server, 12312, NodeType.WALLET)
-        incoming_queue_1, peer_id_1 = await add_dummy_connection(fn_server_1, 12313, NodeType.WALLET)
+        incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
+        incoming_queue_1, peer_id_1 = await add_dummy_connection(fn_server_1, self_hostname, 12313, NodeType.WALLET)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
         ph = wt.get_new_puzzlehash()

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -13,7 +13,7 @@ from chia.util.ints import uint16, uint32
 from chia.wallet.wallet_state_manager import WalletStateManager
 from tests.connection_utils import disconnect_all_and_reconnect
 from tests.pools.test_pool_rpc import wallet_is_synced
-from tests.setup_nodes import bt, self_hostname, setup_node_and_wallet, setup_simulators_and_wallets, test_constants
+from tests.setup_nodes import setup_node_and_wallet, setup_simulators_and_wallets, test_constants
 from tests.time_out_assert import time_out_assert
 
 
@@ -54,7 +54,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_basic_sync_wallet(self, wallet_node, default_400_blocks, trusted):
+    async def test_basic_sync_wallet(self, bt, wallet_node, default_400_blocks, trusted):
 
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
 
@@ -88,7 +88,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_almost_recent(self, wallet_node, default_1000_blocks, trusted):
+    async def test_almost_recent(self, bt, wallet_node, default_1000_blocks, trusted):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
 
@@ -169,7 +169,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_long_sync_wallet(self, wallet_node, default_1000_blocks, default_400_blocks, trusted):
+    async def test_long_sync_wallet(self, bt, wallet_node, default_1000_blocks, default_400_blocks, trusted):
 
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
 
@@ -213,7 +213,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_reorg_sync(self, wallet_node_simulator, default_400_blocks, trusted):
+    async def test_wallet_reorg_sync(self, bt, wallet_node_simulator, default_400_blocks, trusted):
         num_blocks = 5
         full_nodes, wallets = wallet_node_simulator
         full_node_api = full_nodes[0]
@@ -266,7 +266,7 @@ class TestWalletSync:
         [False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_reorg_get_coinbase(self, wallet_node_simulator, default_400_blocks, trusted):
+    async def test_wallet_reorg_get_coinbase(self, bt, wallet_node_simulator, default_400_blocks, trusted):
         full_nodes, wallets = wallet_node_simulator
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -54,7 +54,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_basic_sync_wallet(self, bt, wallet_node, default_400_blocks, trusted):
+    async def test_basic_sync_wallet(self, bt, wallet_node, default_400_blocks, trusted, self_hostname):
 
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
 
@@ -77,7 +77,7 @@ class TestWalletSync:
         for i in range(1, len(blocks_reorg)):
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(blocks_reorg[i]))
 
-        await disconnect_all_and_reconnect(wallet_server, full_node_server)
+        await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
         await time_out_assert(
             100, wallet_height_at_least, True, wallet_node, len(default_400_blocks) + num_blocks - 5 - 1
@@ -88,7 +88,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_almost_recent(self, bt, wallet_node, default_1000_blocks, trusted):
+    async def test_almost_recent(self, bt, wallet_node, default_1000_blocks, trusted, self_hostname):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
 
@@ -119,14 +119,14 @@ class TestWalletSync:
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
-        await time_out_assert(30, wallet.get_confirmed_balance, 20 * calculate_pool_reward(1000))
+        await time_out_assert(30, wallet.get_confirmed_balance, 20 * calculate_pool_reward(uint32(1000)))
 
     @pytest.mark.parametrize(
         "trusted",
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_backtrack_sync_wallet(self, wallet_node, default_400_blocks, trusted):
+    async def test_backtrack_sync_wallet(self, wallet_node, default_400_blocks, trusted, self_hostname):
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
         for block in default_400_blocks[:20]:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
@@ -147,7 +147,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_short_batch_sync_wallet(self, wallet_node, default_400_blocks, trusted):
+    async def test_short_batch_sync_wallet(self, wallet_node, default_400_blocks, trusted, self_hostname):
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
 
         for block in default_400_blocks[:200]:
@@ -169,7 +169,9 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_long_sync_wallet(self, bt, wallet_node, default_1000_blocks, default_400_blocks, trusted):
+    async def test_long_sync_wallet(
+        self, bt, wallet_node, default_1000_blocks, default_400_blocks, trusted, self_hostname
+    ):
 
         full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
 
@@ -190,12 +192,12 @@ class TestWalletSync:
         for block in default_1000_blocks:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        await disconnect_all_and_reconnect(wallet_server, full_node_server)
+        await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
         log.info(f"wallet node height is {wallet_node.wallet_state_manager.blockchain.get_peak_height()}")
         await time_out_assert(600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) - 1)
 
-        await disconnect_all_and_reconnect(wallet_server, full_node_server)
+        await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
         # Tests a short reorg
         num_blocks = 30
@@ -213,7 +215,7 @@ class TestWalletSync:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_reorg_sync(self, bt, wallet_node_simulator, default_400_blocks, trusted):
+    async def test_wallet_reorg_sync(self, bt, wallet_node_simulator, default_400_blocks, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = wallet_node_simulator
         full_node_api = full_nodes[0]
@@ -266,7 +268,9 @@ class TestWalletSync:
         [False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_reorg_get_coinbase(self, bt, wallet_node_simulator, default_400_blocks, trusted):
+    async def test_wallet_reorg_get_coinbase(
+        self, bt, wallet_node_simulator, default_400_blocks, trusted, self_hostname
+    ):
         full_nodes, wallets = wallet_node_simulator
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
@@ -310,7 +314,7 @@ class TestWalletSync:
             await asyncio.sleep(0.4)
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        await disconnect_all_and_reconnect(server_2, fn_server)
+        await disconnect_all_and_reconnect(server_2, fn_server, self_hostname)
 
         # Confirm we have the funds
         funds = calculate_pool_reward(uint32(len(blocks_reorg_1))) + calculate_base_farmer_reward(

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -35,8 +35,8 @@ def event_loop():
 
 class TestWalletSync:
     @pytest_asyncio.fixture(scope="function")
-    async def wallet_node(self):
-        async for _ in setup_node_and_wallet(test_constants):
+    async def wallet_node(self, self_hostname):
+        async for _ in setup_node_and_wallet(test_constants, self_hostname):
             yield _
 
     @pytest_asyncio.fixture(scope="function")
@@ -45,8 +45,8 @@ class TestWalletSync:
             yield _
 
     @pytest_asyncio.fixture(scope="function")
-    async def wallet_node_starting_height(self):
-        async for _ in setup_node_and_wallet(test_constants, starting_height=100):
+    async def wallet_node_starting_height(self, self_hostname):
+        async for _ in setup_node_and_wallet(test_constants, self_hostname, starting_height=100):
             yield _
 
     @pytest.mark.parametrize(

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -16,7 +16,7 @@ from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_state_manager import WalletStateManager
-from tests.setup_nodes import self_hostname, setup_simulators_and_wallets
+from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert, time_out_assert_not_none
 from tests.wallet.cat_wallet.test_cat_wallet import tx_in_pool
 
@@ -52,7 +52,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_coinbase(self, wallet_node, trusted):
+    async def test_wallet_coinbase(self, wallet_node, trusted, self_hostname):
         num_blocks = 10
         full_nodes, wallets = wallet_node
         full_node_api = full_nodes[0]
@@ -108,7 +108,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_make_transaction(self, two_wallet_nodes, trusted):
+    async def test_wallet_make_transaction(self, two_wallet_nodes, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -165,7 +165,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_coinbase_reorg(self, wallet_node, trusted):
+    async def test_wallet_coinbase_reorg(self, wallet_node, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = wallet_node
         full_node_api = full_nodes[0]
@@ -204,7 +204,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_send_to_three_peers(self, three_sim_two_wallets, trusted):
+    async def test_wallet_send_to_three_peers(self, three_sim_two_wallets, trusted, self_hostname):
         num_blocks = 10
         full_nodes, wallets = three_sim_two_wallets
 
@@ -270,7 +270,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_make_transaction_hop(self, two_wallet_nodes_five_freeze, trusted):
+    async def test_wallet_make_transaction_hop(self, two_wallet_nodes_five_freeze, trusted, self_hostname):
         num_blocks = 10
         full_nodes, wallets = two_wallet_nodes_five_freeze
         full_node_api_0 = full_nodes[0]
@@ -390,7 +390,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_make_transaction_with_fee(self, two_wallet_nodes, trusted):
+    async def test_wallet_make_transaction_with_fee(self, two_wallet_nodes, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_1 = full_nodes[0]
@@ -457,7 +457,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_create_hit_max_send_amount(self, two_wallet_nodes, trusted):
+    async def test_wallet_create_hit_max_send_amount(self, two_wallet_nodes, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_1 = full_nodes[0]
@@ -553,7 +553,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_prevent_fee_theft(self, two_wallet_nodes, trusted):
+    async def test_wallet_prevent_fee_theft(self, two_wallet_nodes, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_1 = full_nodes[0]
@@ -638,7 +638,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_tx_reorg(self, two_wallet_nodes, trusted):
+    async def test_wallet_tx_reorg(self, two_wallet_nodes, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -732,7 +732,7 @@ class TestWalletSimulator:
         [False],
     )
     @pytest.mark.asyncio
-    async def test_address_sliding_window(self, wallet_node_100_pk, trusted):
+    async def test_address_sliding_window(self, wallet_node_100_pk, trusted, self_hostname):
         full_nodes, wallets = wallet_node_100_pk
         full_node_api = full_nodes[0]
         server_1: ChiaServer = full_node_api.full_node.server
@@ -775,7 +775,7 @@ class TestWalletSimulator:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_wallet_transaction_options(self, two_wallet_nodes, trusted):
+    async def test_wallet_transaction_options(self, two_wallet_nodes, trusted, self_hostname):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -25,8 +25,8 @@ def event_loop():
 
 class TestWalletBlockchain:
     @pytest_asyncio.fixture(scope="function")
-    async def wallet_node(self):
-        async for _ in setup_node_and_wallet(test_constants):
+    async def wallet_node(self, self_hostname):
+        async for _ in setup_node_and_wallet(test_constants, self_hostname):
             yield _
 
     @pytest.mark.asyncio

--- a/tests/wallet/test_wallet_key_val_store.py
+++ b/tests/wallet/test_wallet_key_val_store.py
@@ -7,7 +7,6 @@ from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
 from chia.util.db_wrapper import DBWrapper
 from chia.wallet.key_val_store import KeyValStore
-from tests.setup_nodes import bt
 
 
 @pytest.fixture(scope="module")
@@ -18,7 +17,7 @@ def event_loop():
 
 class TestWalletKeyValStore:
     @pytest.mark.asyncio
-    async def test_store(self):
+    async def test_store(self, bt):
         db_filename = Path("wallet_store_test.db")
 
         if db_filename.exists():

--- a/tests/weight_proof/test_weight_proof.py
+++ b/tests/weight_proof/test_weight_proof.py
@@ -22,7 +22,7 @@ from tests.block_tools import test_constants
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.generator_tools import get_block_header
-from tests.setup_nodes import bt
+
 
 try:
     from reprlib import repr
@@ -201,7 +201,7 @@ class TestWeightProof:
         assert wp is not None
 
     @pytest.mark.asyncio
-    async def test_weight_proof_edge_cases(self, default_400_blocks):
+    async def test_weight_proof_edge_cases(self, bt, default_400_blocks):
         blocks: List[FullBlock] = default_400_blocks
 
         blocks: List[FullBlock] = bt.get_consecutive_blocks(
@@ -377,7 +377,7 @@ class TestWeightProof:
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof1000_partial_blocks_compact(self, default_10000_blocks_compact):
+    async def test_weight_proof1000_partial_blocks_compact(self, bt, default_10000_blocks_compact):
         blocks: List[FullBlock] = bt.get_consecutive_blocks(
             100,
             block_list_input=default_10000_blocks_compact,


### PR DESCRIPTION
This patch removes a number of global variables from the tests. This builds on an earlier patch from @paninaro 
