### PR TITLE
Adding check for python3.9 alongside python3.10 on Arch

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -128,7 +128,7 @@ jobs:
         # The behavior we follow in install.sh is unique with Arch in that
         # we leave it to the user to install the appropriate version of python,
         # so we need to install python here in order for the test to succeed.
-        pacman -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
+        pacman --noconfirm -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
 
     - name: Prepare CentOS
       if: ${{ matrix.distribution.type == 'centos' }}

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -125,6 +125,10 @@ jobs:
       if: ${{ matrix.distribution.type == 'arch' }}
       run: |
         pacman --noconfirm --refresh base --sync git sudo
+        # The behavior we follow in install.sh is unique with Arch in that
+        # we leave it to the user to install the appropriate version of python,
+        # so we need to install python here in order for the test to succeed.
+        pacman -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
 
     - name: Prepare CentOS
       if: ${{ matrix.distribution.type == 'centos' }}

--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ if [ "$(uname)" = "Linux" ]; then
     if ! command -v python3.9 >/dev/null 2>&1; then
       echo "Installing on Arch Linux."
       echo "Python <= 3.9.9 is required. You can install 'python39' from the AUR and try again, or proceed with installing 'python-3.9.9-1' from the Arch Linux Archive."
-      read -r -p "Proceed with installing 'python-3.9.9-1'? " ARCH_CONFIRM
+      read -r -p "Proceed with installing 'python-3.9.9-1'? [y/N] " ARCH_CONFIRM
       case "$ARCH_CONFIRM" in
         [yY][eE][sS]|[yY])
           case $(uname -m) in

--- a/install.sh
+++ b/install.sh
@@ -135,18 +135,18 @@ if [ "$(uname)" = "Linux" ]; then
     # Arch Linux
     # Arch provides latest python version. User will need to manually install python 3.9 if it is not present
     echo "Installing on Arch Linux."
-      case $(uname -m) in
-        x86_64|aarch64)
-				  if ! command -v python3.9 >/dev/null 2>&1; then
-            echo "Python <= 3.9.10 is required. Please see https://wiki.archlinux.org/title/python#Old_versions for support."
-            exit 0
-          fi
-          ;;
-        *)
-          echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
-          exit 0
-          ;;
-      esac
+    case $(uname -m) in
+      x86_64|aarch64)
+        if ! command -v python3.9 >/dev/null 2>&1; then
+          echo "Python <= 3.9.10 is required. Please see https://wiki.archlinux.org/title/python#Old_versions for support."
+          exit 1
+        fi
+        ;;
+      *)
+        echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
+        exit 1
+        ;;
+    esac
     sudo pacman ${PACMAN_AUTOMATED} -S --needed git
   elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
     # AMZN 2

--- a/install.sh
+++ b/install.sh
@@ -137,17 +137,13 @@ if [ "$(uname)" = "Linux" ]; then
     echo "Installing on Arch Linux."
     case $(uname -m) in
       x86_64|aarch64)
-        if ! command -v python3.9 >/dev/null 2>&1; then
-          echo "Python <= 3.9.10 is required. Please see https://wiki.archlinux.org/title/python#Old_versions for support."
-          exit 1
-        fi
+        sudo pacman ${PACMAN_AUTOMATED} -S --needed git
         ;;
       *)
         echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
         exit 1
         ;;
     esac
-    sudo pacman ${PACMAN_AUTOMATED} -S --needed git
   elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
     # AMZN 2
     echo "Installing on Amazon Linux 2."
@@ -191,8 +187,12 @@ find_python() {
         if [ "$BEST_VERSION" = "3" ]; then
           PY3_VERSION=$(python$BEST_VERSION --version | cut -d ' ' -f2)
           if [[ "$PY3_VERSION" =~ 3.10.* ]]; then
-            echo "Chia requires Python version <= 3.9.9"
+            echo "Chia requires Python version <= 3.9.10"
             echo "Current Python version = $PY3_VERSION"
+            # If Arch, direct to Arch Wiki
+            if type pacman >/dev/null 2>&1 && [ -f "/etc/arch-release" ]; then
+              echo "Please see https://wiki.archlinux.org/title/python#Old_versions for support."
+            fi
             exit 1
           fi
         fi

--- a/install.sh
+++ b/install.sh
@@ -133,20 +133,31 @@ if [ "$(uname)" = "Linux" ]; then
     sudo apt-get install -y python3-venv
   elif type pacman >/dev/null 2>&1 && [ -f "/etc/arch-release" ]; then
     # Arch Linux
-    echo "Installing on Arch Linux."
-    echo "Python <= 3.9.9 is required. Installing python-3.9.9-1"
-    case $(uname -m) in
-      x86_64)
-        sudo pacman ${PACMAN_AUTOMATED} -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
-        ;;
-      aarch64)
-        sudo pacman ${PACMAN_AUTOMATED} -U --needed http://tardis.tiny-vps.com/aarm/packages/p/python/python-3.9.9-1-aarch64.pkg.tar.xz
-        ;;
-      *)
-        echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
-        exit 1
-        ;;
+    # python39 is available in the AUR, so a check is needed to accommodate this being installed alongside python 3.10
+    if ! command -v python3.9 >/dev/null 2>&1; then
+      echo "Installing on Arch Linux."
+      echo "Python <= 3.9.9 is required. You can install 'python39' from the AUR and try again, or proceed with installing 'python-3.9.9-1' from the Arch Linux Archive."
+      read -r -p "Proceed with installing 'python-3.9.9-1'? " ARCH_CONFIRM
+      case "$ARCH_CONFIRM" in
+        [yY][eE][sS]|[yY])
+          case $(uname -m) in
+            x86_64)
+              sudo pacman ${PACMAN_AUTOMATED} -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
+              ;;
+            aarch64)
+              sudo pacman ${PACMAN_AUTOMATED} -U --needed http://tardis.tiny-vps.com/aarm/packages/p/python/python-3.9.9-1-aarch64.pkg.tar.xz
+              ;;
+            *)
+              echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
+              exit 1
+              ;;
+          esac
+          ;;
+        *)
+          exit 0
+          ;;
       esac
+    fi
     sudo pacman ${PACMAN_AUTOMATED} -S --needed git
   elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
     # AMZN 2

--- a/install.sh
+++ b/install.sh
@@ -133,31 +133,20 @@ if [ "$(uname)" = "Linux" ]; then
     sudo apt-get install -y python3-venv
   elif type pacman >/dev/null 2>&1 && [ -f "/etc/arch-release" ]; then
     # Arch Linux
-    # python39 is available in the AUR, so a check is needed to accommodate this being installed alongside python 3.10
-    if ! command -v python3.9 >/dev/null 2>&1; then
-      echo "Installing on Arch Linux."
-      echo "Python <= 3.9.9 is required. You can install 'python39' from the AUR and try again, or proceed with installing 'python-3.9.9-1' from the Arch Linux Archive."
-      read -r -p "Proceed with installing 'python-3.9.9-1'? [y/N] " ARCH_CONFIRM
-      case "$ARCH_CONFIRM" in
-        [yY][eE][sS]|[yY])
-          case $(uname -m) in
-            x86_64)
-              sudo pacman ${PACMAN_AUTOMATED} -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
-              ;;
-            aarch64)
-              sudo pacman ${PACMAN_AUTOMATED} -U --needed http://tardis.tiny-vps.com/aarm/packages/p/python/python-3.9.9-1-aarch64.pkg.tar.xz
-              ;;
-            *)
-              echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
-              exit 1
-              ;;
-          esac
+    # Arch provides latest python version. User will need to manually install python 3.9 if it is not present
+    echo "Installing on Arch Linux."
+      case $(uname -m) in
+        x86_64|aarch64)
+				  if ! command -v python3.9 >/dev/null 2>&1; then
+            echo "Python <= 3.9.10 is required. Please see https://wiki.archlinux.org/title/python#Old_versions for support."
+            exit 1
+          fi
           ;;
         *)
-          exit 0
+          echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
+          exit 1
           ;;
       esac
-    fi
     sudo pacman ${PACMAN_AUTOMATED} -S --needed git
   elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
     # AMZN 2

--- a/install.sh
+++ b/install.sh
@@ -139,12 +139,12 @@ if [ "$(uname)" = "Linux" ]; then
         x86_64|aarch64)
 				  if ! command -v python3.9 >/dev/null 2>&1; then
             echo "Python <= 3.9.10 is required. Please see https://wiki.archlinux.org/title/python#Old_versions for support."
-            exit 1
+            exit 0
           fi
           ;;
         *)
           echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
-          exit 1
+          exit 0
           ;;
       esac
     sudo pacman ${PACMAN_AUTOMATED} -S --needed git


### PR DESCRIPTION
This changes the behavior of how python install check is handled within `install.sh`

The reason for this change is due to the fact that Arch is a rolling-release distro, and the latest `python` package will be whatever the latest `python` is. Currently, this is `python 3.10.2-1`.

You cannot specify a particular version of a package to install with `pacman`. You can manually install an older version of the package in the format of a `*.tar.zst` that is obtained from the Arch Repo Package Archive, but it is not in the best interest of the user for us to prescribe an unprompted install of a specific version of python. This can actually break things outside of Chia.

It is also not very reasonable to expect the user to mark python as a held package, and updates to other packages might still expect or depend on python 3.10. We should also not expect that users never attempt to perform an update via `pacman -Syu` for the sake of not breaking Chia.

The guidance from the Arch wiki suggests what is required if a particular application requires an older version of python - https://wiki.archlinux.org/title/python#Old_versions

The answer to this is for the user to install the `python39` package from the AUR, so that a `python3.9` binary can sit alongside a `python3.10` binary. However, we should **not** be attempting to automate an install from the AUR. https://wiki.archlinux.org/title/Arch_User_Repository

Until we are able to support current versions of python > 3.9.10, the best practice is to inform the user of the requirement, and point them to the Arch Wiki for details on how to configure their system to support older versions of python.

Below is the resulting behavior of my changes:
- With no python 3 installed:
```» command -v python
» command -v python3.10
» command -v python3.9
» command -v python2.7
/usr/bin/python2.7

» sh install.sh
Installing on Arch Linux.
Python <= 3.9.9 is required. Please see https://wiki.archlinux.org/title/python#Old_versions for support.
```

We direct them, and exit, because installing python from the Arch repo would install python3.10. We do not attempt to install 3.9 from the archive, because later attempts would update python to the latest, which would break Chia

- With just python 3.9 installed:
```
» pacman -Q | grep 'python39\|python 3.10'
python39 3.9.10-1

» sh install.sh
Installing on Arch Linux.
warning: git-2.35.1-1 is up to date -- skipping
 there is nothing to do
Python version is 3.9
...
```

- With python 3.10 only installed:
```
» pacman -Q | grep 'python39\|python 3.10'
python 3.10.2-1

» sh install.sh
Installing on Arch Linux.
Python <= 3.9.9 is required. Please see https://wiki.archlinux.org/title/python#Old_versions for support.
```

- With both python 3.9, and python 3.10 installed:
```
» pacman -Q | grep 'python39\|python 3.10'
python 3.10.2-1
python39 3.9.10-1

» sh install.sh
Installing on Arch Linux.
warning: git-2.35.1-1 is up to date -- skipping
 there is nothing to do
Python version is 3.9
...
```