### PR TITLE
asyncify wallet weight proof validation

### DIFF
--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -601,7 +601,9 @@ class WeightProofHandler:
         log.info(f"validate weight proof peak height {peak_height}")
 
         # TODO: Consider if this can be spun off to a thread as an alternative to
-        #       sprinkling async sleeps around.
+        #       sprinkling async sleeps around.  Also see the corresponding comment
+        #       in the wallet code.
+        #       all instances tagged as: 098faior2ru08d08ufa
 
         # timing reference: start
         summaries, sub_epoch_weight_list = _validate_sub_epoch_summaries(self.constants, weight_proof)


### PR DESCRIPTION
Follows from the testing and sleep additions for the full node weight proof validation in https://github.com/Chia-Network/chia-blockchain/pull/10163.

Draft for:
- [ ] Testing with `while true; do pkill chia_; ps; chia start wallet; sleep 75; ps; chia stop -d all; date --iso-8601=n; sleep 5; ps; pkill chia_; sleep 5; ps; done` and checking for `sending kill signal to chia_wallet` in the logs.