### PR TITLE
Ms.fix get transactions

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -48,6 +48,15 @@ def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: in
     show_default=True,
     required=True,
 )
+@click.option(
+    "-l",
+    "--limit",
+    help="Max number of transactions to return",
+    type=int,
+    default=1000000000,
+    show_default=True,
+    required=False,
+)
 @click.option("--verbose", "-v", count=True, type=int)
 @click.option(
     "--paginate/--no-paginate",
@@ -59,10 +68,11 @@ def get_transactions_cmd(
     fingerprint: int,
     id: int,
     offset: int,
+    limit: int,
     verbose: bool,
     paginate: Optional[bool],
 ) -> None:
-    extra_params = {"id": id, "verbose": verbose, "offset": offset, "paginate": paginate}
+    extra_params = {"id": id, "verbose": verbose, "offset": offset, "paginate": paginate, "limit": limit}
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transactions
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -53,7 +53,7 @@ def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: in
     "--limit",
     help="Max number of transactions to return",
     type=int,
-    default=1000000000,
+    default=(2 ** 32 - 1),
     show_default=True,
     required=False,
 )

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -111,7 +111,11 @@ async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerpri
     paginate = args["paginate"]
     if paginate is None:
         paginate = sys.stdout.isatty()
-    txs: List[TransactionRecord] = await wallet_client.get_transactions(wallet_id, end=1000000000)
+    offset = args["offset"]
+    limit = args["limit"]
+    txs: List[TransactionRecord] = await wallet_client.get_transactions(
+        wallet_id, start=offset, end=(offset + limit), reverse=True
+    )
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
     address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
     if len(txs) == 0:
@@ -130,9 +134,8 @@ async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerpri
         print(e.args[0])
         return
 
-    offset = args["offset"]
     num_per_screen = 5 if paginate else len(txs)
-    for i in range(offset, len(txs), num_per_screen):
+    for i in range(0, len(txs), num_per_screen):
         for j in range(0, num_per_screen):
             if i + j >= len(txs):
                 break

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -111,7 +111,7 @@ async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerpri
     paginate = args["paginate"]
     if paginate is None:
         paginate = sys.stdout.isatty()
-    txs: List[TransactionRecord] = await wallet_client.get_transactions(wallet_id)
+    txs: List[TransactionRecord] = await wallet_client.get_transactions(wallet_id, end=1000000000)
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
     address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
     if len(txs) == 0:


### PR DESCRIPTION
It was returning max 50, and they were ordered from oldest to newest.
Now allows configuring offset and limit, uses the offset to ask backend, and sorts them in the right order