### PR TITLE
Added CAT wallet name parameter

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -446,7 +446,7 @@ class WalletRpcApi:
             elif request["mode"] == "existing":
                 async with self.service.wallet_state_manager.lock:
                     cat_wallet = await CATWallet.create_wallet_for_cat(
-                        wallet_state_manager, main_wallet, request["asset_id"]
+                        wallet_state_manager, main_wallet, request["asset_id"], name
                     )
                 self.service.wallet_state_manager.state_changed("wallet_created")
                 return {"type": cat_wallet.type(), "asset_id": request["asset_id"], "wallet_id": cat_wallet.id()}


### PR DESCRIPTION
The `create_wallet_for_cat` method call accepts a `name` parameter for the new CAT being created, but we weren't passing that `name` variable here so all new wallets created via this method end up being named "CAT WALLET" (the default for name parameter in `create_wallet_for_cat`) even if you specified a wallet name here.