### PR TITLE
Stop launching more wallet receipt and validation tasks during shut down

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -655,6 +655,9 @@ class WalletNode:
                 return False
             while num_concurrent_tasks >= target_concurrent_tasks:
                 await asyncio.sleep(0.1)
+                if self._shut_down:
+                    self.log.error(f"Terminating receipt and validation due to shut down request")
+                    return False
             all_tasks.append(asyncio.create_task(receive_and_validate(states, idx)))
             num_concurrent_tasks += 1
             idx += len(states)

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -656,7 +656,7 @@ class WalletNode:
             while num_concurrent_tasks >= target_concurrent_tasks:
                 await asyncio.sleep(0.1)
                 if self._shut_down:
-                    self.log.info(f"Terminating receipt and validation due to shut down request")
+                    self.log.info("Terminating receipt and validation due to shut down request")
                     return False
             all_tasks.append(asyncio.create_task(receive_and_validate(states, idx)))
             num_concurrent_tasks += 1

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -656,7 +656,7 @@ class WalletNode:
             while num_concurrent_tasks >= target_concurrent_tasks:
                 await asyncio.sleep(0.1)
                 if self._shut_down:
-                    self.log.error(f"Terminating receipt and validation due to shut down request")
+                    self.log.info(f"Terminating receipt and validation due to shut down request")
                     return False
             all_tasks.append(asyncio.create_task(receive_and_validate(states, idx)))
             num_concurrent_tasks += 1


### PR DESCRIPTION
Extracted from the less-granular https://github.com/Chia-Network/chia-blockchain/pull/10354.