### PR TITLE
benchmarks: Implement benchmarks for streamable

### DIFF
--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -6,6 +6,7 @@ from chia.full_node.block_store import BlockStore
 import os
 import sys
 
+from benchmarks.utils import clvm_generator
 from chia.util.db_wrapper import DBWrapper
 from chia.util.ints import uint128, uint64, uint32, uint8
 from utils import (
@@ -34,10 +35,6 @@ NUM_ITERS = 20000
 
 # we need seeded random, to have reproducible benchmark runs
 random.seed(123456789)
-
-
-with open("clvm_generator.bin", "rb") as f:
-    clvm_generator = f.read()
 
 
 async def run_add_block_benchmark(version: int):

--- a/benchmarks/streamable.py
+++ b/benchmarks/streamable.py
@@ -201,6 +201,7 @@ def run_benchmarks(data: Data, mode: Mode, runs: int, milliseconds: int) -> None
                 if mode == Mode.all or current_mode == mode:
                     ns_iteration_results: List[int]
                     all_results: List[List[int]] = results[current_data][current_mode]
+                    obj = parameter.object_creation_cb()
 
                     def print_results(print_run: int, final: bool) -> None:
                         total_iterations: int = sum(len(x) for x in all_results)
@@ -218,7 +219,7 @@ def run_benchmarks(data: Data, mode: Mode, runs: int, milliseconds: int) -> None
                     current_run: int = 0
                     while current_run < runs:
                         current_run += 1
-                        obj = parameter.object_creation_cb()
+
                         if current_mode == Mode.creation:
                             cls = type(obj)
                             ns_iteration_results = run_for_ms(lambda: cls(**obj.__dict__), milliseconds)
@@ -226,10 +227,10 @@ def run_benchmarks(data: Data, mode: Mode, runs: int, milliseconds: int) -> None
                             assert current_mode_parameter is not None
                             conversion_cb = current_mode_parameter.conversion_cb
                             assert conversion_cb is not None
-                            obj = parameter.object_creation_cb()
+                            prepared_obj = parameter.object_creation_cb()
                             if current_mode_parameter.preparation_cb is not None:
-                                obj = current_mode_parameter.preparation_cb(obj)
-                            ns_iteration_results = run_for_ms(lambda: conversion_cb(obj), milliseconds)
+                                prepared_obj = current_mode_parameter.preparation_cb(obj)
+                            ns_iteration_results = run_for_ms(lambda: conversion_cb(prepared_obj), milliseconds)
                         all_results.append(ns_iteration_results)
                         print_results(current_run, False)
                     assert current_run == runs

--- a/benchmarks/streamable.py
+++ b/benchmarks/streamable.py
@@ -163,7 +163,8 @@ def calc_stdev_percent(iterations: List[int], avg: float) -> float:
 @click.option("-m", "--mode", default=Mode.all, type=EnumType(Mode))
 @click.option("-r", "--runs", default=100, help="Number of benchmark runs to average results")
 @click.option("-t", "--ms", default=50, help="Milliseconds per run")
-def run(data: Data, mode: Mode, runs: int, ms: int) -> None:
+@click.option("--live/--no-live", default=False, help="Print live results (slower)")
+def run(data: Data, mode: Mode, runs: int, ms: int, live: bool) -> None:
     results: Dict[Data, Dict[Mode, List[List[int]]]] = {}
     for current_data, parameter in benchmark_parameter.items():
         results[current_data] = {}
@@ -217,7 +218,8 @@ def run(data: Data, mode: Mode, runs: int, ms: int) -> None:
                                 prepared_obj = current_mode_parameter.preparation_cb(obj)
                             us_iteration_results = run_for_ms(lambda: conversion_cb(prepared_obj), ms)
                         all_results.append(us_iteration_results)
-                        print_results(current_run, False)
+                        if live:
+                            print_results(current_run, False)
                     assert current_run == runs
                     print_results(runs, True)
 

--- a/benchmarks/streamable.py
+++ b/benchmarks/streamable.py
@@ -1,0 +1,213 @@
+from dataclasses import dataclass
+from enum import Enum
+from time import monotonic
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+import click
+from utils import rand_bytes, rand_full_block, rand_hash
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.full_block import FullBlock
+from chia.util.ints import uint8, uint64
+from chia.util.streamable import Streamable, streamable
+
+
+@dataclass(frozen=True)
+@streamable
+class BenchmarkInner(Streamable):
+    a: str
+
+
+@dataclass(frozen=True)
+@streamable
+class BenchmarkMiddle(Streamable):
+    a: uint64
+    b: List[bytes32]
+    c: Tuple[str, bool, uint8, List[bytes]]
+    d: Tuple[BenchmarkInner, BenchmarkInner]
+    e: BenchmarkInner
+
+
+@dataclass(frozen=True)
+@streamable
+class BenchmarkClass(Streamable):
+    a: Optional[BenchmarkMiddle]
+    b: Optional[BenchmarkMiddle]
+    c: BenchmarkMiddle
+    d: List[BenchmarkMiddle]
+    e: Tuple[BenchmarkMiddle, BenchmarkMiddle, BenchmarkMiddle]
+
+
+def get_random_inner() -> BenchmarkInner:
+    return BenchmarkInner(rand_bytes(20).hex())
+
+
+def get_random_middle() -> BenchmarkMiddle:
+    a: uint64 = uint64(10)
+    b: List[bytes32] = [rand_hash() for _ in range(a)]
+    c: Tuple[str, bool, uint8, List[bytes]] = ("benchmark", False, uint8(1), [rand_bytes(a) for _ in range(a)])
+    d: Tuple[BenchmarkInner, BenchmarkInner] = (get_random_inner(), get_random_inner())
+    e: BenchmarkInner = get_random_inner()
+    return BenchmarkMiddle(a, b, c, d, e)
+
+
+def get_random_benchmark_object() -> BenchmarkClass:
+    a: Optional[BenchmarkMiddle] = None
+    b: Optional[BenchmarkMiddle] = get_random_middle()
+    c: BenchmarkMiddle = get_random_middle()
+    d: List[BenchmarkMiddle] = [get_random_middle() for _ in range(5)]
+    e: Tuple[BenchmarkMiddle, BenchmarkMiddle, BenchmarkMiddle] = (
+        get_random_middle(),
+        get_random_middle(),
+        get_random_middle(),
+    )
+    return BenchmarkClass(a, b, c, d, e)
+
+
+def print_row(
+    runs: Union[str, int], iterations: Union[str, int], mode: str, duration: Union[str, int], end: str = "\n"
+) -> None:
+    runs = "{0:<10}".format(f"{runs}")
+    iterations = "{0:<14}".format(f"{iterations}")
+    mode = "{0:<10}".format(f"{mode}")
+    duration = "{0:>13}".format(f"{duration}")
+    print(f"{runs} | {iterations} | {mode} | {duration}", end=end)
+
+
+def benchmark_object_creation(iterations: int, class_generator: Callable[[], Any]) -> float:
+    start = monotonic()
+    obj = class_generator()
+    cls = type(obj)
+    for i in range(iterations):
+        cls(**obj.__dict__)
+    return monotonic() - start
+
+
+def benchmark_conversion(
+    iterations: int,
+    class_generator: Callable[[], Any],
+    conversion_cb: Callable[[Any], Any],
+    preparation_cb: Optional[Callable[[Any], Any]] = None,
+) -> float:
+    obj = class_generator()
+    start = monotonic()
+    prepared_data = obj
+    if preparation_cb is not None:
+        prepared_data = preparation_cb(obj)
+    for i in range(iterations):
+        conversion_cb(prepared_data)
+    return monotonic() - start
+
+
+class Data(Enum):
+    all = 0
+    benchmark = 1
+    full_block = 2
+
+
+class Mode(Enum):
+    all = 0
+    creation = 1
+    to_bytes = 2
+    from_bytes = 3
+    to_json = 4
+    from_json = 5
+
+
+def to_bytes(obj: Any) -> bytes:
+    return bytes(obj)
+
+
+@dataclass
+class ModeParameter:
+    iterations: int
+    conversion_cb: Optional[Callable[[Any], Any]] = None
+    preparation_cb: Optional[Callable[[Any], Any]] = None
+
+
+@dataclass
+class BenchmarkParameter:
+    data_class: Type[Any]
+    object_creation_cb: Callable[[], Any]
+    mode_parameter: Dict[Mode, ModeParameter]
+
+
+benchmark_parameter: Dict[Data, BenchmarkParameter] = {
+    Data.benchmark: BenchmarkParameter(
+        BenchmarkClass,
+        get_random_benchmark_object,
+        {
+            Mode.creation: ModeParameter(58000),
+            Mode.to_bytes: ModeParameter(2200, to_bytes),
+            Mode.from_bytes: ModeParameter(3600, BenchmarkClass.from_bytes, to_bytes),
+            Mode.to_json: ModeParameter(1100, BenchmarkClass.to_json_dict),
+            Mode.from_json: ModeParameter(930, BenchmarkClass.from_json_dict, BenchmarkClass.to_json_dict),
+        },
+    ),
+    Data.full_block: BenchmarkParameter(
+        FullBlock,
+        rand_full_block,
+        {
+            Mode.creation: ModeParameter(43000),
+            Mode.to_bytes: ModeParameter(9650, to_bytes),
+            Mode.from_bytes: ModeParameter(365, FullBlock.from_bytes, to_bytes),
+            Mode.to_json: ModeParameter(2400, FullBlock.to_json_dict),
+            Mode.from_json: ModeParameter(335, FullBlock.from_json_dict, FullBlock.to_json_dict),
+        },
+    ),
+}
+
+
+def run_benchmarks(data: Data, mode: Mode, runs: int, multiplier: int) -> None:
+    results: Dict[Data, Dict[Mode, List[int]]] = {}
+    for current_data, parameter in benchmark_parameter.items():
+        results[current_data] = {}
+        if data == Data.all or current_data == data:
+            print(f"\nRun {mode.name} benchmarks with the class: {parameter.data_class.__name__}")
+            print_row("runs", "iterations/run", "mode", "result [ms]")
+            for current_mode, mode_parameter in parameter.mode_parameter.items():
+                results[current_data][current_mode] = []
+                if mode == Mode.all or current_mode == mode:
+                    duration: float
+                    iterations: int = mode_parameter.iterations * multiplier
+                    for _ in range(max(1, runs)):
+                        if current_mode == Mode.creation:
+                            duration = benchmark_object_creation(iterations, parameter.object_creation_cb)
+                        else:
+                            assert mode_parameter.conversion_cb is not None
+                            duration = benchmark_conversion(
+                                iterations,
+                                parameter.object_creation_cb,
+                                mode_parameter.conversion_cb,
+                                mode_parameter.preparation_cb,
+                            )
+                        current_duration: int = int(duration * 1000)
+                        results[current_data][current_mode].append(current_duration)
+                        print_row("last", iterations, current_mode.name, current_duration, "\r")
+                    average_duration: int = int(sum(results[current_data][current_mode]) / runs)
+                    print_row(runs, iterations, current_mode.name, average_duration)
+
+
+data_option_help: str = "|".join([d.name for d in Data])
+mode_option_help: str = "|".join([m.name for m in Mode])
+
+
+@click.command()
+@click.option("-d", "--data", default=Data.all.name, help=data_option_help)
+@click.option("-m", "--mode", default=Mode.all.name, help=mode_option_help)
+@click.option("-r", "--runs", default=5, help="Number of benchmark runs to average results")
+@click.option("-n", "--multiplier", default=1, help="Multiplier for iterations/run")
+def run(data: str, mode: str, runs: int, multiplier: int) -> None:
+    try:
+        Data[data]
+    except Exception:
+        raise click.BadOptionUsage("data", f"{data} is not a valid data option. Select one from: " + data_option_help)
+    try:
+        Mode[mode]
+    except Exception:
+        raise click.BadOptionUsage("mode", f"{mode} is not a valid mode option. Select one from: " + mode_option_help)
+    run_benchmarks(Data[data], Mode[mode], runs, multiplier)
+
+
+if __name__ == "__main__":
+    run()  # pylint: disable = no-value-for-parameter

--- a/benchmarks/streamable.py
+++ b/benchmarks/streamable.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from statistics import stdev
-from time import monotonic
+from time import process_time as clock
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import click
@@ -142,11 +142,11 @@ benchmark_parameter: Dict[Data, BenchmarkParameter] = {
 
 def run_for_ms(cb: Callable[[], Any], ms_to_run: int = 100) -> List[int]:
     us_iteration_results: List[int] = []
-    start = monotonic()
-    while int((monotonic() - start) * 1000) < ms_to_run:
-        start_iteration = monotonic()
+    start = clock()
+    while int((clock() - start) * 1000) < ms_to_run:
+        start_iteration = clock()
         cb()
-        stop_iteration = monotonic()
+        stop_iteration = clock()
         us_iteration_results.append(int((stop_iteration - start_iteration) * 1000 * 1000))
     return us_iteration_results
 

--- a/benchmarks/streamable.py
+++ b/benchmarks/streamable.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from statistics import mean, stdev
+from statistics import stdev
 from time import monotonic
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
@@ -78,31 +78,6 @@ def print_row(
     avg_iterations = "{0:>14}".format(f"{avg_iterations}")
     stdev_iterations = "{0:>18}".format(f"{stdev_iterations}")
     print(f"{mode} | {us_per_iteration} | {avg_iterations} | {stdev_iterations}", end=end)
-
-
-def benchmark_object_creation(iterations: int, class_generator: Callable[[], Any]) -> float:
-    start = monotonic()
-    obj = class_generator()
-    cls = type(obj)
-    for i in range(iterations):
-        cls(**obj.__dict__)
-    return monotonic() - start
-
-
-def benchmark_conversion(
-    iterations: int,
-    class_generator: Callable[[], Any],
-    conversion_cb: Callable[[Any], Any],
-    preparation_cb: Optional[Callable[[Any], Any]] = None,
-) -> float:
-    obj = class_generator()
-    start = monotonic()
-    prepared_data = obj
-    if preparation_cb is not None:
-        prepared_data = preparation_cb(obj)
-    for i in range(iterations):
-        conversion_cb(prepared_data)
-    return monotonic() - start
 
 
 # The strings in this Enum are by purpose. See benchmark.utils.EnumType.

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -17,6 +17,7 @@ from typing import Tuple
 from pathlib import Path
 from datetime import datetime
 import aiosqlite
+import click
 import os
 import sys
 import random
@@ -27,6 +28,17 @@ ph = bytes32(b"a" * 32)
 
 with open(Path(os.path.realpath(__file__)).parent / "clvm_generator.bin", "rb") as f:
     clvm_generator = f.read()
+
+
+# Workaround to allow `Enum` with click.Choice: https://github.com/pallets/click/issues/605#issuecomment-901099036
+class EnumType(click.Choice):
+    def __init__(self, enum, case_sensitive=False):
+        self.__enum = enum
+        super().__init__(choices=[item.value for item in enum], case_sensitive=case_sensitive)
+
+    def convert(self, value, param, ctx):
+        converted_str = super().convert(value, param, ctx)
+        return self.__enum(converted_str)
 
 
 def rewards(height: uint32) -> Tuple[Coin, Coin]:


### PR DESCRIPTION
Implements some benchmarks for streamable object creation, byte conversions and json conversions for the classes `FullBlock` and `BenchmarkClass`. The `BenchmarkClass` can probably still be improved so im open for suggestions :) The benchmark collects iterations over a specific time window and this can be done multiple runs to get an average result. See the parameter below:

# Usage

```
python benchmarks/streamable.py --help
Usage: streamable.py [OPTIONS]

Options:
  -d, --data [all|benchmark|full_block]
  -m, --mode [all|creation|to_bytes|from_bytes|to_json|from_json]
  -r, --runs INTEGER              Number of benchmark runs to average results
  -t, --ms INTEGER                Milliseconds per run
  --live / --no-live              Print live results (slower)
  --help                          Show this message and exit.
```

# Example run

```
Run all benchmarks with the class: BenchmarkClass
Run all benchmarks with the class: BenchmarkClass
runs       | ms/run     | ns/iteration | mode       | avg iterations | stdev iterations
100        | 47         | 18           | creation   |           2536 |         22.81
100        | 50         | 462          | to_bytes   |            108 |          0.69
100        | 49         | 275          | from_bytes |            181 |          3.92
100        | 50         | 927          | to_json    |             54 |          1.38
100        | 50         | 1089         | from_json  |             46 |          0.89

Run all benchmarks with the class: FullBlock
runs       | ms/run     | ns/iteration | mode       | avg iterations | stdev iterations
100        | 48         | 23           | creation   |           2077 |         63.08
100        | 49         | 114          | to_bytes   |            434 |         10.39
100        | 51         | 2923         | from_bytes |             17 |          0.42
100        | 50         | 422          | to_json    |            118 |          2.01
100        | 51         | 2974         | from_json  |             17 |          0.45
```

# Benchmark classes

```python
@dataclass(frozen=True)
@streamable
class BenchmarkInner(Streamable):
    a: str


@dataclass(frozen=True)
@streamable
class BenchmarkMiddle(Streamable):
    a: uint64
    b: List[bytes32]
    c: Tuple[str, bool, uint8, List[bytes]]
    d: Tuple[BenchmarkInner, BenchmarkInner]
    e: BenchmarkInner


@dataclass(frozen=True)
@streamable
class BenchmarkClass(Streamable):
    a: Optional[BenchmarkMiddle]
    b: Optional[BenchmarkMiddle]
    c: BenchmarkMiddle
    d: List[BenchmarkMiddle]
    e: Tuple[BenchmarkMiddle, BenchmarkMiddle, BenchmarkMiddle]
```  
