### PR TITLE
Stop assuming `True == 1`

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -486,7 +486,7 @@ class MempoolManager:
         for record in removals.values():
             removal = record.coin
             # 1. Checks if it's been spent already
-            if record.spent == 1:
+            if record.spent:
                 return Err.DOUBLE_SPEND, []
             # 2. Checks if there's a mempool conflict
             if removal.name() in self.mempool.removals:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -335,7 +335,6 @@ class MempoolManager:
             return uint64(cost), MempoolInclusionStatus.SUCCESS, None
 
         removal_record_dict: Dict[bytes32, CoinRecord] = {}
-        removal_coin_dict: Dict[bytes32, Coin] = {}
         removal_amount: int = 0
         for name in removal_names:
             removal_record = await self.coin_store.get_coin_record(name)
@@ -361,9 +360,8 @@ class MempoolManager:
             assert removal_record is not None
             removal_amount = removal_amount + removal_record.coin.amount
             removal_record_dict[name] = removal_record
-            removal_coin_dict[name] = removal_record.coin
 
-        removals: List[Coin] = [coin for coin in removal_coin_dict.values()]
+        removals: List[Coin] = [record.coin for record in removal_record_dict.values()]
 
         if addition_amount > removal_amount:
             return None, MempoolInclusionStatus.FAILED, Err.MINTING_COIN
@@ -400,7 +398,6 @@ class MempoolManager:
         # Use this information later when constructing a block
         fail_reason, conflicts = await self.check_removals(removal_record_dict)
         # If there is a mempool conflict check if this spendbundle has a higher fee per cost than all others
-        tmp_error: Optional[Err] = None
         conflicting_pool_items: Dict[bytes32, MempoolItem] = {}
         if fail_reason is Err.MEMPOOL_CONFLICT:
             for conflicting in conflicts:
@@ -419,9 +416,6 @@ class MempoolManager:
 
         elif fail_reason:
             return None, MempoolInclusionStatus.FAILED, fail_reason
-
-        if tmp_error:
-            return None, MempoolInclusionStatus.FAILED, tmp_error
 
         # Verify conditions, create hash_key list for aggsig check
         error: Optional[Err] = None


### PR DESCRIPTION
This might be really dangerous when future version of Python stop recognizing `True` as `1`.

# Changelog
- Changed `record.spent == 1`  to `record.spent` because the type of `record.spent` is `Boolean`, not `int`
- Removed `removal_coin_dict` because it was used just for constructing `removals: List[Coin]` later but `removal_record_dict` alone can do the work.
- Removed `tmp_error` because it was always `None`. Suspecting a debug code left forgotten.