### PR TITLE
Only show -Trusted when a node is trusted

### DIFF
--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -40,9 +40,12 @@ async def print_connections(client, time, NodeType, trusted_peers: Dict):
                 f"\n                                                 "
             )
             if peak_height is not None:
-                con_str += f"-Height: {peak_height:8.0f}    -Hash: {connection_peak_hash}    -Trusted: {trusted}"
+                con_str += f"-Height: {peak_height:8.0f}    -Hash: {connection_peak_hash}"
             else:
-                con_str += f"-Height: No Info    -Hash: {connection_peak_hash}     -Trusted: {trusted}"
+                con_str += f"-Height: No Info    -Hash: {connection_peak_hash}"
+            # Only show when Trusted is True
+            if trusted:
+                con_str += f"    -Trusted: {trusted}"
         else:
             con_str = (
                 f"{NodeType(con['type']).name:9} {host:38} "


### PR DESCRIPTION
This modifies the CLI back to not showing the status of Trusted unless a node is trusted.

However, this raises a question - I did not think we trusted a node as a node and https://github.com/Chia-Network/chia-blockchain/commit/7fa1861def5797f63edfd2ad54f3efb77b52695b may have pulled wallet code into node showing @mariano54 ?