### PR TITLE
Check that offer coins exist as well as not spent

### DIFF
--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -353,7 +353,6 @@ class TradeManager:
         coin_states = await self.wallet_state_manager.wallet_node.get_coin_state(
             [c.name() for c in non_ephemeral_removals]
         )
-        assert coin_states is not None
         return len(coin_states) == len(non_ephemeral_removals) and all([cs.spent_height is None for cs in coin_states])
 
     async def calculate_tx_records_for_offer(self, offer: Offer, validate: bool) -> List[TransactionRecord]:

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -353,8 +353,8 @@ class TradeManager:
         coin_states = await self.wallet_state_manager.wallet_node.get_coin_state(
             [c.name() for c in non_ephemeral_removals]
         )
-        assert coin_states is not None and len(coin_states) == len(non_ephemeral_removals)
-        return not any([cs.spent_height is not None for cs in coin_states])
+        assert coin_states is not None
+        return len(coin_states) == len(non_ephemeral_removals) and all([cs.spent_height is None for cs in coin_states])
 
     async def calculate_tx_records_for_offer(self, offer: Offer, validate: bool) -> List[TransactionRecord]:
         if validate:

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -353,7 +353,7 @@ class TradeManager:
         coin_states = await self.wallet_state_manager.wallet_node.get_coin_state(
             [c.name() for c in non_ephemeral_removals]
         )
-        assert coin_states is not None
+        assert coin_states is not None and len(coin_states) == len(non_ephemeral_removals)
         return not any([cs.spent_height is not None for cs in coin_states])
 
     async def calculate_tx_records_for_offer(self, offer: Offer, validate: bool) -> List[TransactionRecord]:


### PR DESCRIPTION
I had an incorrect assumption about how `get_coin_states` worked and the `check_offer_validity` would return true even if some of the coins in the offer did not exist.