### PR TITLE
Only update height if we have processed everything before that height.

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -281,6 +281,8 @@ def last_change_height_cs(cs: CoinState) -> uint32:
         return cs.spent_height
     if cs.created_height is not None:
         return cs.created_height
+
+    # Reorgs should be processed at the beginning
     return uint32(0)
 
 

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -184,9 +184,9 @@ class WalletBlockchain(BlockchainInterface):
             return self._peak
         return await self._basic_store.get_object("PEAK_BLOCK", HeaderBlock)
 
-    async def set_finished_sync_up_to(self, height: uint32):
+    async def set_finished_sync_up_to(self, height: int):
         if height > await self.get_finished_sync_up_to():
-            await self._basic_store.set_object("FINISHED_SYNC_UP_TO", height)
+            await self._basic_store.set_object("FINISHED_SYNC_UP_TO", uint32(height))
             await self.clean_block_records()
 
     async def get_finished_sync_up_to(self):

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -606,8 +606,7 @@ class WalletNode:
         concurrent_tasks_cs_heights: List[uint32] = []
 
         # Ensure the list is sorted
-        items = items_input.copy()
-        items.sort(key=last_change_height_cs)
+        items = sorted(items_input, key=last_change_height_cs)
 
         async def receive_and_validate(inner_states: List[CoinState], inner_idx_start: int):
             nonlocal concurrent_tasks_cs_heights

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -826,7 +826,6 @@ class WalletNode:
             far_behind: bool = (
                 new_peak.height - self.wallet_state_manager.blockchain.get_peak_height() > self.LONG_SYNC_THRESHOLD
             )
-            return
 
             # check if claimed peak is heavier or same as our current peak
             # if we haven't synced fully to this peer sync again

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -640,7 +640,7 @@ class WalletNode:
 
                             if update_finished_height:
                                 if len(concurrent_tasks_cs_heights) == 1:
-                                    # We have processed all past tasks so we can
+                                    # We have processed all past tasks, so we can increase the height safely
                                     synced_up_to = last_change_height_cs(valid_states[-1]) - 1
                                 else:
                                     # We know we have processed everything before this min height

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -41,6 +41,7 @@ from chia.wallet.trade_manager import TradeManager
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_hints import compute_coin_hints
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.util.wallet_sync_utils import last_change_height_cs
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action import WalletAction
@@ -636,14 +637,13 @@ class WalletStateManager:
     ) -> None:
         # TODO: add comment about what this method does
 
-        # Sort by created height, then add the reorg states (created_height is None) to the end
-        created_h_none: List[CoinState] = []
-        for coin_st in coin_states.copy():
-            if coin_st.created_height is None:
-                coin_states.remove(coin_st)
-                created_h_none.append(coin_st)
-        coin_states.sort(key=lambda x: x.created_height, reverse=False)  # type: ignore
-        coin_states.extend(created_h_none)
+        # Input states should already be sorted by cs_height, with reorgs at the beginning
+        curr_h = -1
+        for c_state in coin_states:
+            if last_change_height_cs(c_state) < curr_h:
+                raise ValueError("Input coin_states is not sorted properly")
+            curr_h = last_change_height_cs(c_state)
+
         all_txs_per_wallet: Dict[int, List[TransactionRecord]] = {}
         trade_removals = await self.trade_manager.get_coins_of_interest()
         all_unconfirmed: List[TransactionRecord] = await self.tx_store.get_all_unconfirmed()

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -640,9 +640,10 @@ class WalletStateManager:
         # Input states should already be sorted by cs_height, with reorgs at the beginning
         curr_h = -1
         for c_state in coin_states:
-            if last_change_height_cs(c_state) < curr_h:
+            last_change_height = last_change_height_cs(c_state)
+            if last_change_height < curr_h:
                 raise ValueError("Input coin_states is not sorted properly")
-            curr_h = last_change_height_cs(c_state)
+            curr_h = last_change_height
 
         all_txs_per_wallet: Dict[int, List[TransactionRecord]] = {}
         trade_removals = await self.trade_manager.get_coins_of_interest()


### PR DESCRIPTION
This ensures that if a sync is cancelled (which is normal) we won't set the peak to a height where we have not processed everything before it.