### PR TITLE
Atari cleanup

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -174,8 +174,7 @@ class DataLayer:
         to_check: List[SingletonRecord],
         min_generation: int,
     ) -> bool:
-        root: Optional[Root] = await self.data_store.get_tree_root(tree_id=tree_id)
-        assert root is not None
+        root = await self.data_store.get_tree_root(tree_id=tree_id)
         if to_check[0].root == (root.node_hash if root.node_hash is not None else self.none_bytes):
             self.log.info(
                 f"Validated chain hash {to_check[0].root} in downloaded datastore. "
@@ -194,17 +193,17 @@ class DataLayer:
                 self.log.info(f"Skipped checking {record.root}, as it matches the previously checked hash.")
                 continue
             # Pick the latest root in our data store with the desired hash, before our already validated data.
-            root = await self.data_store.get_last_tree_root_by_hash(
+            last_root = await self.data_store.get_last_tree_root_by_hash(
                 tree_id, None if record.root == self.none_bytes else record.root, max_generation
             )
-            if root is None or root.generation < min_generation:
+            if last_root is None or last_root.generation < min_generation:
                 return False
 
             self.log.info(
                 f"Validated chain hash {record.root} in downloaded datastore. "
                 f"Wallet generation: {record.generation}"
             )
-            max_generation = root.generation
+            max_generation = last_root.generation
             last_checked_hash = record.root
 
         return True

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -156,13 +156,6 @@ class DataLayer:
             self.log.error(f"Failed to get root for {store_id.hex()}")
         return latest
 
-    async def get_local_root(self, store_id: bytes32) -> Optional[bytes32]:
-        res = await self.data_store.get_tree_root(tree_id=store_id)
-        if res is None:
-            self.log.error(f"Failed to get root for {store_id.hex()}")
-            return None
-        return res.node_hash
-
     async def get_root_history(self, store_id: bytes32) -> List[SingletonRecord]:
         records = await self.wallet_rpc.dl_history(store_id)
         if records is None:

--- a/chia/rpc/data_layer_rpc_api.py
+++ b/chia/rpc/data_layer_rpc_api.py
@@ -58,7 +58,6 @@ class DataLayerRpcApi:
             "/get_keys_values": self.get_keys_values,
             "/get_ancestors": self.get_ancestors,
             "/get_root": self.get_root,
-            "/get_local_root": self.get_local_root,
             "/get_roots": self.get_roots,
             "/delete_key": self.delete_key,
             "/insert": self.insert,
@@ -165,15 +164,6 @@ class DataLayerRpcApi:
         if rec is None:
             raise Exception(f"Failed to get root for {store_id.hex()}")
         return {"hash": rec.root, "confirmed": rec.confirmed, "timestamp": rec.timestamp}
-
-    async def get_local_root(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        """get hash of latest tree root saved in our local datastore"""
-        store_id = bytes32(hexstr_to_bytes(request["id"]))
-        # todo input checks
-        if self.service is None:
-            raise Exception("Data layer not created")
-        res = await self.service.get_local_root(store_id)
-        return {"hash": res}
 
     async def get_roots(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/chia/rpc/data_layer_rpc_client.py
+++ b/chia/rpc/data_layer_rpc_client.py
@@ -38,11 +38,6 @@ class DataLayerRpcClient(RpcClient):
         # TODO: better hinting for .fetch() (probably a TypedDict)
         return response  # type: ignore[no-any-return]
 
-    async def get_local_root(self, store_id: bytes32) -> Dict[str, Any]:
-        response = await self.fetch("get_local_root", {"id": store_id.hex()})
-        # TODO: better hinting for .fetch() (probably a TypedDict)
-        return response  # type: ignore[no-any-return]
-
     async def get_roots(self, store_ids: List[bytes32]) -> Dict[str, Any]:
         response = await self.fetch("get_roots", {"ids": store_ids})
         # TODO: better hinting for .fetch() (probably a TypedDict)

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -104,9 +104,6 @@ async def test_create_insert_get(one_wallet_node_and_rpc: nodes) -> None:
             await asyncio.sleep(0.2)
         await time_out_assert(15, is_transaction_confirmed, True, "this is unused", wallet_rpc_api, update_tx_rec0)
         res = await data_rpc_api.get_value({"id": store_id.hex(), "key": key.hex()})
-        wallet_root = await data_rpc_api.get_root({"id": store_id.hex()})
-        local_root = await data_rpc_api.get_local_root({"id": store_id.hex()})
-        assert wallet_root["hash"] == local_root["hash"]
         assert hexstr_to_bytes(res["value"]) == value
         changelist = [{"action": "delete", "key": key.hex()}]
         res = await data_rpc_api.batch_update({"id": store_id.hex(), "changelist": changelist})
@@ -118,10 +115,6 @@ async def test_create_insert_get(one_wallet_node_and_rpc: nodes) -> None:
         await time_out_assert(15, is_transaction_confirmed, True, "this is unused", wallet_rpc_api, update_tx_rec1)
         with pytest.raises(Exception):
             val = await data_rpc_api.get_value({"id": store_id.hex(), "key": key.hex()})
-        wallet_root = await data_rpc_api.get_root({"id": store_id.hex()})
-        local_root = await data_rpc_api.get_local_root({"id": store_id.hex()})
-        assert wallet_root["hash"] == bytes32([0] * 32)
-        assert local_root["hash"] == None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Removes the no longer needed `get_local_root` logic and fixes a leftover type checking issue.