### PR TITLE
benchmarks: Implement streamable data comparison

### DIFF
--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -19,6 +19,7 @@ from datetime import datetime
 import aiosqlite
 import click
 import os
+import subprocess
 import sys
 import random
 from blspy import G2Element, G1Element, AugSchemeMPL
@@ -197,3 +198,21 @@ async def setup_db(name: str, db_version: int) -> DBWrapper:
     await connection.execute("pragma synchronous=full")
 
     return DBWrapper(connection, db_version)
+
+
+def get_commit_hash() -> str:
+    try:
+        os.chdir(Path(os.path.realpath(__file__)).parent)
+        commit_hash = (
+            subprocess.run(["git", "rev-parse", "--short", "HEAD"], check=True, stdout=subprocess.PIPE)
+            .stdout.decode("utf-8")
+            .strip()
+        )
+    except Exception:
+        sys.exit("Failed to get the commit hash")
+    try:
+        if len(subprocess.run(["git", "status", "-s"], check=True, stdout=subprocess.PIPE).stdout) > 0:
+            raise Exception()
+    except Exception:
+        commit_hash += "-dirty"
+    return commit_hash


### PR DESCRIPTION
Implements the new program options:

```
-o, --output FILENAME           Write the results to a file
-c, --compare FILENAME          Compare to the results from a file
```

So you can run with `-o whatever` to generate the benchmark output for one commit and then run on another commit `-c whatever` to compare against the recorded one. Example output:

```
python streamable.py -c test.json

benchmarks: all, data: BenchmarkClass runs: 100, ms/run: 50, commit_hash: 41245944d-dirty
mode       | µs/iteration | stdev µs/iteration % | avg iterations/run | stdev iterations/run %
creation   | 18.46        |                 6.39 |               2442 |                   0.98
to_bytes   | 464.94       |                  2.5 |                107 |                   1.43
from_bytes | 284.47       |                 2.72 |                175 |                   1.03
to_json    | 947.45       |                 5.31 |                 53 |                   1.52
from_json  | 1095.34      |                 0.91 |                 45 |                   0.21

benchmarks: all, data: FullBlock runs: 100, ms/run: 50, commit_hash: 41245944d-dirty
mode       | µs/iteration | stdev µs/iteration % | avg iterations/run | stdev iterations/run %
creation   | 23.18        |                 4.31 |               1985 |                   0.61
to_bytes   | 112.32       |                 3.11 |                438 |                   0.78
from_bytes | 2808.2       |                 1.61 |                 18 |                   1.87
to_json    | 430.19       |                 4.97 |                116 |                   1.35
from_json  | 3108.57      |                 1.56 |                 16 |                   2.82

compare: benchmark, old: e386798ca-dirty, new: 41245944d-dirty
mode         | µs/iteration old | µs/iteration new | diff %      
creation     | 18.63            | 18.46            | -0.91       
to_bytes     | 454.96           | 464.94           | 2.19        
from_bytes   | 282.14           | 284.47           | 0.82        
to_json      | 934.97           | 947.45           | 1.33        
from_json    | 1095.76          | 1095.34          | -0.03       

compare: full_block, old: e386798ca-dirty, new: 41245944d-dirty
mode         | µs/iteration old | µs/iteration new | diff %      
creation     | 22.89            | 23.18            | 1.26        
to_bytes     | 110.84           | 112.32           | 1.33        
from_bytes   | 2815.96          | 2808.2           | -0.27       
to_json      | 426.04           | 430.19           | 0.97        
from_json    | 2966.46          | 3108.57          | 4.79        
```