### PR TITLE
Fix `install-gui.sh`

### DIFF
--- a/install-gui.sh
+++ b/install-gui.sh
@@ -92,8 +92,8 @@ patch_inconsistent_npm_issue(){
   if [ ! -d "$node_module_dir" ]; then
     mkdir "$node_module_dir"
   fi
-  if [ ! -d "{$node_module_dir}/.bin" ]; then
-    mkdir "{$node_module_dir}/.bin"
+  if [ ! -d "${node_module_dir}/.bin" ]; then
+    mkdir "${node_module_dir}/.bin"
   fi
   if [ -e "${node_module_dir}/.bin/npm" ]; then
     rm -f "${node_module_dir}/.bin/npm"

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -155,9 +155,8 @@ if [ ! "$CI" ]; then
 
   if [ "$SUBMODULE_BRANCH" ];
   then
-    git fetch
-    git checkout "$SUBMODULE_BRANCH"
-    git pull
+    git fetch --all
+    git reset --hard "$SUBMODULE_BRANCH"
     echo ""
     echo "Building the GUI with branch $SUBMODULE_BRANCH"
     echo ""

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -32,13 +32,20 @@ nodejs_is_installed(){
 }
 
 do_install_npm_locally(){
+  NODEJS_VERSION="$(node -v | cut -d'.' -f 1 | sed -e 's/^v//')"
   NPM_VERSION="$(npm -v | cut -d'.' -f 1)"
-  if [ "$NPM_VERSION" -lt "7" ]; then
-    echo "Current npm version($(npm -v)) is less than 7. GUI app requires npm>=7."
+
+  if [ "$NODEJS_VERSION" -lt "16" ] || [ "$NPM_VERSION" -lt "7" ]; then
+    if [ "$NODEJS_VERSION" -lt "16" ]; then
+      echo "Current NodeJS version($(node -v)) is less than 16. GUI app requires NodeJS>=16."
+    fi
+    if [ "$NPM_VERSION" -lt "7" ]; then
+      echo "Current npm version($(npm -v)) is less than 7. GUI app requires npm>=7."
+    fi
 
     if [ "$(uname)" = "OpenBSD" ] || [ "$(uname)" = "FreeBSD" ]; then
       # `n` package does not support OpenBSD/FreeBSD
-      echo "Please install npm>=7 manually"
+      echo "Please install NodeJS>=16 and/or npm>=7 manually"
       exit 1
     fi
 
@@ -61,13 +68,19 @@ do_install_npm_locally(){
     # `n 16` here installs nodejs@16 under $N_PREFIX directory
     echo "n 16"
     n 16
+    echo "Current NodeJS version: $(node -v)"
     echo "Current npm version: $(npm -v)"
+    if [ "$(node -v | cut -d'.' -f 1 | sed -e 's/^v//')" -lt "16" ]; then
+      echo "Error: Failed to install NodeJS>=16"
+      exit 1
+    fi
     if [ "$(npm -v | cut -d'.' -f 1)" -lt "7" ]; then
       echo "Error: Failed to install npm>=7"
       exit 1
     fi
     cd "${SCRIPT_DIR}"
   else
+    echo "Found NodeJS $(node -v)"
     echo "Found npm $(npm -v)"
   fi
 }


### PR DESCRIPTION
This PR addersses 3 issues.

## 1. `install-gui.sh` fails on a system with NodeJS < 16 and npm >= 7

The GUI requirements are:
npm>=7 for handling package-lock.json in v2 format
NodeJS>=16 for newer syntax (e.g. nullish coalescing) for some of npm dependencies.

Current `install-gui.sh` only checks `npm>=7` and there is a slight chance that some user have both `npm>=7` and `NodeJS<16` installed on their system.
This PR fixes the failure in such environments.

## 2. `SUBMODULE_BRANCH` not working
When you run `install-gui.sh <ref/tag/branch of chia-blockchain-gui repos>`, it should install the specified commit of `chia-blockchain-gui` but currently it fails because when running `git checkout` on chia-blockchain-gui directory it goes Detached HEAD state thus following `git pull` cannot run.

## 3. Fails running `npm ci` in rare situations
`install-gui.sh` uses `n` as node/npm version switcher because it requires NodeJS>=16 and npm>=7.
However, due to `npm`'s PATH lookup mechanism, there are rare situations where old, incompatible version of `npm` can be used to run `npm install`.
When you run `npm run <script_name>`, npm internally spawns child process with modified `PATH` variable.
Imagine you run `npm run sample` in a situation below:
- Current working directory is `/home/GIT/chia-blockchain/chia-blockchain-gui`
- There is `/home/GIT/chia-blockchain/chia-blockchain-gui/package.json` and its content is:
  ```json
  {
    "name": "sample",
    "scripts": {
      "sample": "npm install"
    }
  }
  ```

When you run `npm run sample`, npm spawns child process to run `npm install`.
To run `npm install` as a separate process, it needs to lookup directories in `PATH` variable to find `npm` executable file.
The problem is, when the original npm spawns child process, it adds lookup directories to "head" of `PATH` like below:
- /home/GIT/chia-blockchain/chia-blockchain-gui/node_modules/.bin
- /home/GIT/chia-blockchain/node_modules/.bin
- /home/GIT/node_modules/.bin
- /home/node_modules/.bin
- /node_modules/.bin

Usually, `npm` executable is stored in `/usr/local/bin` or somewhere globally avaiable. But with the above PATH modification, if there is an old `npm` executable in the newly-added PATH directories, then that old `npm` is used to run `npm install`.
The situation sometimes happens when an user mistakenly ran `npm install npm` in home directory instead of `npm install -g npm` to upgrade `npm` version.

#### Solution for `3.`
By applying this PR, before executing `npm ci` in the `install-gui.sh`:
- it creates `node_modules/.bin` directory under `chia-blockchain` (This is ignored by git. See `.gitignore`)
- it creates a symbolic link of working `npm` to `/.../chia-blockchain/node_modules/.bin`
So even if such `PATH` modification occurs, `/home/GIT/chia-blockchain/node_modules/.bin/npm` is referred and runs without error.