### PR TITLE
tests: Add `_PYTEST_RAISE` to fix exception breakpoints with pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import os
 import pytest
 import pytest_asyncio
 import tempfile
@@ -103,3 +104,15 @@ async def default_10000_blocks_compact():
 async def tmp_dir():
     with tempfile.TemporaryDirectory() as folder:
         yield Path(folder)
+
+
+# For the below see https://stackoverflow.com/a/62563106/15133773
+if os.getenv("_PYTEST_RAISE", "0") != "0":
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_exception_interact(call):
+        raise call.excinfo.value
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_internalerror(excinfo):
+        raise excinfo.value


### PR DESCRIPTION
It's currently not possible to have the debuger stop on an uncaught exception when debugging tests. With this patch, adding `_PYTEST_RAISE=1` to the environment variables in the pytest configuration template fixes this.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/35775977/156089853-ea353262-9ec8-4b13-aac2-3925c053ea45.png">


To enable the breakpoints: 

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/35775977/156090128-7ff49227-f3cb-4307-b97f-483c18cc5554.png">
