### PR TITLE
improve the picking of free ports for tests

### DIFF
--- a/tests/util/socket.py
+++ b/tests/util/socket.py
@@ -1,11 +1,25 @@
+import random
 import socket
+from typing import Set
+
+recent_ports: Set[int] = set()
 
 
 def find_available_listen_port(name: str = "free") -> int:
-    s = socket.socket()
-    s.bind(("127.0.0.1", 0))
-    addr = s.getsockname()
-    assert addr[1] > 0
-    s.close()
-    print(f"{name} port: {addr[1]}")
-    return int(addr[1])
+    global recent_ports
+
+    while True:
+        port = random.randint(2000, 65535)
+        if port in recent_ports:
+            continue
+
+        s = socket.socket()
+        try:
+            s.bind(("127.0.0.1", port))
+        except BaseException:
+            s.close()
+            continue
+        s.close()
+        recent_ports.add(port)
+        print(f"{name} port: {port}")
+        return port


### PR DESCRIPTION
the current (simple) logic ended up picking the same port twice in a test. This patch explicitly picks a random port every time, and ensures we haven't picked it already, nor that it's in use.

https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true

```
daemon port port: 58475
[26](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:26)
Can't find private CA, creating a new one in /tmp/tmpr8by8eg4 to generate TLS certificates
[27](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:27)
daemon port port: 43357
[28](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:28)
introducer port: 36479
[29](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:29)
farmer port: 35553
[30](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:30)
farmer rpc port: 43381
[31](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:31)
node1 port: 60123
[32](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:32)
node1 rpc port: 37897
[33](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:33)
node2 port: 46459
[34](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:34)
node2 rpc port: 37383
[35](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:35)
timelord1 port: 35091
[36](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:36)
timelord1 rpc port: 52147
[37](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:37)
timelord2 port: 40019
[38](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:38)
timelord2 rpc port: 37383
[39](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:39)
vdf1 port: 43469
[40](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:40)
vdf2 port: 57661
[41](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:41)
harvester port: 56773
[42](https://github.com/Chia-Network/chia-blockchain/runs/5368813982?check_suite_focus=true#step:12:42)
harvester rpc port: 45969
```

37383 was picked twice.