### PR TITLE
when creating a new blockchain database implicitly, make it v2

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -23,6 +24,7 @@ from chia.util.config import (
     unflatten_properties,
     get_config_lock,
 )
+from chia.util.db_version import set_db_version
 from chia.util.keychain import Keychain
 from chia.util.path import mkdir, path_from_root
 from chia.util.ssl_check import (
@@ -463,24 +465,29 @@ def chia_init(
 
     config: Dict
 
-    if v1_db:
-        with get_config_lock(root_path, "config.yaml"):
+    with get_config_lock(root_path, "config.yaml"):
+        db_path_replaced: str
+        if v1_db:
             config = load_config(root_path, "config.yaml", acquire_lock=False)
             db_pattern = config["full_node"]["database_path"]
             new_db_path = db_pattern.replace("_v2_", "_v1_")
             config["full_node"]["database_path"] = new_db_path
-            save_config(root_path, "config.yaml", config)
-    else:
-        config = load_config(root_path, "config.yaml")["full_node"]
-        db_path_replaced: str = config["database_path"].replace("CHALLENGE", config["selected_network"])
-        db_path = path_from_root(root_path, db_path_replaced)
-        mkdir(db_path.parent)
-        import sqlite3
+            db_path_replaced = new_db_path.replace("CHALLENGE", config["selected_network"])
+            db_path = path_from_root(root_path, db_path_replaced)
 
-        with sqlite3.connect(db_path) as connection:
-            connection.execute("CREATE TABLE database_version(version int)")
-            connection.execute("INSERT INTO database_version VALUES (2)")
-            connection.commit()
+            with sqlite3.connect(db_path) as connection:
+                set_db_version(connection, 1)
+
+            save_config(root_path, "config.yaml", config)
+
+        else:
+            config = load_config(root_path, "config.yaml")["full_node"]
+            db_path_replaced = config["database_path"].replace("CHALLENGE", config["selected_network"])
+            db_path = path_from_root(root_path, db_path_replaced)
+            mkdir(db_path.parent)
+
+            with sqlite3.connect(db_path) as connection:
+                set_db_version(connection, 2)
 
     print("")
     print("To see your keys, run 'chia keys show --show-mnemonic-seed'")

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -481,7 +481,7 @@ def chia_init(
             save_config(root_path, "config.yaml", config)
 
         else:
-            config = load_config(root_path, "config.yaml")["full_node"]
+            config = load_config(root_path, "config.yaml", acquire_lock=False)["full_node"]
             db_path_replaced = config["database_path"].replace("CHALLENGE", config["selected_network"])
             db_path = path_from_root(root_path, db_path_replaced)
             mkdir(db_path.parent)

--- a/chia/util/db_version.py
+++ b/chia/util/db_version.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 import aiosqlite
 
 
@@ -12,3 +14,15 @@ async def lookup_db_version(db: aiosqlite.Connection) -> int:
     except aiosqlite.OperationalError:
         # expects OperationalError('no such table: database_version')
         return 1
+
+
+async def set_db_version_async(db: aiosqlite.Connection, version: int) -> None:
+    await db.execute("CREATE TABLE database_version(version int)")
+    await db.execute("INSERT INTO database_version VALUES (?)", (version,))
+    db.commit()
+
+
+def set_db_version(db: sqlite3.Connection, version: int) -> None:
+    db.execute("CREATE TABLE database_version(version int)")
+    db.execute("INSERT INTO database_version VALUES (?)", (version,))
+    db.commit()


### PR DESCRIPTION
This patch makes three changes:

1. `chia init` always creates a database file that contains a version number, even with `--v1`
2. When the full node starts up and opens the database file, if it's an empty database (i.e. no `full_blocks` table) it will attempt to set it to be version 2. So, in case the user runs `chia init` and then deletes the database file, the new database file will still be v2.
3. On the off-chance that the user is running `chia init` a second time (after deleting `config.yaml`) with an existing database file, the database file won't be touched.