### PR TITLE
Preserve existing pool payout_instructions when creating a PoolWallet

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -237,7 +237,7 @@ class PoolWallet:
         payout_instructions: str = existing_config.payout_instructions if existing_config is not None else ""
 
         if len(payout_instructions) == 0:
-            self.log.info(f"Missing payout_instructions for {current_state.launcher_id}. Generating new puzzle hash...")
+            self.log.info("New config entry, generating new puzzle hash...")
             payout_instructions = (await self.standard_wallet.get_new_puzzlehash(in_transaction=True)).hex()
             self.log.info(f"Generated payout_instructions puzzle hash: {payout_instructions}")
 

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -229,16 +229,17 @@ class PoolWallet:
     async def get_tip(self) -> Tuple[uint32, CoinSpend]:
         return self.wallet_state_manager.pool_store.get_spends_for_wallet(self.wallet_id)[-1]
 
-    async def update_pool_config(self, make_new_authentication_key: bool):
+    async def update_pool_config(self):
         current_state: PoolWalletInfo = await self.get_current_state()
         pool_config_list: List[PoolWalletConfig] = load_pool_config(self.wallet_state_manager.root_path)
         pool_config_dict: Dict[bytes32, PoolWalletConfig] = {c.launcher_id: c for c in pool_config_list}
         existing_config: Optional[PoolWalletConfig] = pool_config_dict.get(current_state.launcher_id, None)
+        payout_instructions: str = existing_config.payout_instructions if existing_config is not None else ""
 
-        if make_new_authentication_key or existing_config is None:
-            payout_instructions: str = (await self.standard_wallet.get_new_puzzlehash(in_transaction=True)).hex()
-        else:
-            payout_instructions = existing_config.payout_instructions
+        if len(payout_instructions) == 0:
+            self.log.info(f"Missing payout_instructions for {current_state.launcher_id}. Generating new puzzle hash...")
+            payout_instructions = (await self.standard_wallet.get_new_puzzlehash(in_transaction=True)).hex()
+            self.log.info(f"Generated payout_instructions puzzle hash: {payout_instructions}")
 
         new_config: PoolWalletConfig = PoolWalletConfig(
             current_state.launcher_id,
@@ -293,7 +294,7 @@ class PoolWallet:
                     self.next_transaction_fee = uint64(0)
                 break
 
-        await self.update_pool_config(False)
+        await self.update_pool_config()
         return True
 
     async def rewind(self, block_height: int) -> bool:
@@ -312,7 +313,7 @@ class PoolWallet:
                 return True
             else:
                 if await self.get_current_state() != prev_state:
-                    await self.update_pool_config(False)
+                    await self.update_pool_config()
                 return False
         except Exception as e:
             self.log.error(f"Exception rewinding: {e}")
@@ -351,7 +352,7 @@ class PoolWallet:
                 launcher_spend = spend
         assert launcher_spend is not None
         await self.wallet_state_manager.pool_store.add_spend(self.wallet_id, launcher_spend, block_height)
-        await self.update_pool_config(True)
+        await self.update_pool_config()
 
         p2_puzzle_hash: bytes32 = (await self.get_current_state()).p2_singleton_puzzle_hash
         await self.wallet_state_manager.add_new_wallet(self, self.wallet_info.id, create_puzzle_hashes=False)

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -229,7 +229,7 @@ class PoolWallet:
     async def get_tip(self) -> Tuple[uint32, CoinSpend]:
         return self.wallet_state_manager.pool_store.get_spends_for_wallet(self.wallet_id)[-1]
 
-    async def update_pool_config(self):
+    async def update_pool_config(self) -> None:
         current_state: PoolWalletInfo = await self.get_current_state()
         pool_config_list: List[PoolWalletConfig] = load_pool_config(self.wallet_state_manager.root_path)
         pool_config_dict: Dict[bytes32, PoolWalletConfig] = {c.launcher_id: c for c in pool_config_list}

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -237,9 +237,8 @@ class PoolWallet:
         payout_instructions: str = existing_config.payout_instructions if existing_config is not None else ""
 
         if len(payout_instructions) == 0:
-            self.log.info("New config entry, generating new puzzle hash...")
             payout_instructions = (await self.standard_wallet.get_new_puzzlehash(in_transaction=True)).hex()
-            self.log.info(f"Generated payout_instructions puzzle hash: {payout_instructions}")
+            self.log.info(f"New config entry. Generated payout_instructions puzzle hash: {payout_instructions}")
 
         new_config: PoolWalletConfig = PoolWalletConfig(
             current_state.launcher_id,

--- a/tests/pools/test_pool_wallet.py
+++ b/tests/pools/test_pool_wallet.py
@@ -50,7 +50,11 @@ class MockPoolWalletInfo:
 
 @pytest.mark.asyncio
 async def test_update_pool_config_new_config(monkeypatch: Any) -> None:
-    updated_configs: Optional[List[MockPoolWalletConfig]] = None
+    """
+    Test that PoolWallet can create a new pool config
+    """
+
+    updated_configs: List[MockPoolWalletConfig] = []
     payout_instructions_ph = rand_hash()
     launcher_id: bytes32 = rand_hash()
     p2_singleton_puzzle_hash: bytes32 = rand_hash()
@@ -89,14 +93,17 @@ async def test_update_pool_config_new_config(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(PoolWallet, "get_current_state", mock_get_current_state)
 
+    # Create an empty PoolWallet and populate only the required fields
     wallet = PoolWallet()
+    # We need a standard wallet to provide a puzzlehash
     wallet.standard_wallet = cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph))
+    # We need a wallet state manager to hold a root_path member
     wallet.wallet_state_manager = MockWalletStateManager()
+    # We need a log object, but we don't care about how it's used
     wallet.log = MagicMock()
 
     await wallet.update_pool_config()
 
-    assert updated_configs is not None
     assert len(updated_configs) == 1
     assert updated_configs[0].launcher_id == launcher_id
     assert updated_configs[0].pool_url == pool_url
@@ -108,7 +115,11 @@ async def test_update_pool_config_new_config(monkeypatch: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_update_pool_config_existing_payout_instructions(monkeypatch: Any) -> None:
-    updated_configs: Optional[List[MockPoolWalletConfig]] = None
+    """
+    Test that PoolWallet will retain existing payout_instructions when updating the pool config.
+    """
+
+    updated_configs: List[MockPoolWalletConfig] = []
     payout_instructions_ph = rand_hash()
     launcher_id: bytes32 = rand_hash()
     p2_singleton_puzzle_hash: bytes32 = rand_hash()
@@ -165,14 +176,17 @@ async def test_update_pool_config_existing_payout_instructions(monkeypatch: Any)
 
     monkeypatch.setattr(PoolWallet, "get_current_state", mock_get_current_state)
 
+    # Create an empty PoolWallet and populate only the required fields
     wallet = PoolWallet()
+    # We need a standard wallet to provide a puzzlehash
     wallet.standard_wallet = cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph))
+    # We need a wallet state manager to hold a root_path member
     wallet.wallet_state_manager = MockWalletStateManager()
+    # We need a log object, but we don't care about how it's used
     wallet.log = MagicMock()
 
     await wallet.update_pool_config()
 
-    assert updated_configs is not None
     assert len(updated_configs) == 1
     assert updated_configs[0].launcher_id == launcher_id
     assert updated_configs[0].pool_url == pool_url

--- a/tests/pools/test_pool_wallet.py
+++ b/tests/pools/test_pool_wallet.py
@@ -1,0 +1,184 @@
+import pytest
+
+from benchmarks.utils import rand_g1, rand_hash
+from blspy import G1Element
+from chia.pools.pool_wallet import PoolWallet
+from chia.types.blockchain_format.sized_bytes import bytes32
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast, Any, List, Optional
+from unittest.mock import MagicMock
+
+
+@dataclass
+class MockStandardWallet:
+    canned_puzzlehash: bytes32
+
+    async def get_new_puzzlehash(self, in_transaction: bool = False) -> bytes32:
+        return self.canned_puzzlehash
+
+
+@dataclass
+class MockWalletStateManager:
+    root_path: Optional[Path] = None
+
+
+@dataclass
+class MockPoolWalletConfig:
+    launcher_id: bytes32
+    pool_url: str
+    payout_instructions: str
+    target_puzzle_hash: bytes32
+    p2_singleton_puzzle_hash: bytes32
+    owner_public_key: G1Element
+
+
+@dataclass
+class MockPoolState:
+    pool_url: Optional[str]
+    target_puzzle_hash: bytes32
+    owner_pubkey: G1Element
+
+
+@dataclass
+class MockPoolWalletInfo:
+    launcher_id: bytes32
+    p2_singleton_puzzle_hash: bytes32
+    current: MockPoolState
+
+
+@pytest.mark.asyncio
+async def test_update_pool_config_new_config(monkeypatch: Any) -> None:
+    updated_configs: Optional[List[MockPoolWalletConfig]] = None
+    payout_instructions_ph = rand_hash()
+    launcher_id: bytes32 = rand_hash()
+    p2_singleton_puzzle_hash: bytes32 = rand_hash()
+    pool_url: str = ""
+    target_puzzle_hash: bytes32 = rand_hash()
+    owner_pubkey: G1Element = rand_g1()
+    current: MockPoolState = MockPoolState(
+        pool_url=pool_url,
+        target_puzzle_hash=target_puzzle_hash,
+        owner_pubkey=owner_pubkey,
+    )
+    current_state: MockPoolWalletInfo = MockPoolWalletInfo(
+        launcher_id=launcher_id,
+        p2_singleton_puzzle_hash=p2_singleton_puzzle_hash,
+        current=current,
+    )
+
+    # No config data
+    def mock_load_pool_config(root_path: Path) -> List[MockPoolWalletConfig]:
+        return []
+
+    monkeypatch.setattr("chia.pools.pool_wallet.load_pool_config", mock_load_pool_config)
+
+    # Mock pool_config.update_pool_config to capture the updated configs
+    async def mock_pool_config_update_pool_config(
+        root_path: Path, pool_config_list: List[MockPoolWalletConfig]
+    ) -> None:
+        nonlocal updated_configs
+        updated_configs = pool_config_list
+
+    monkeypatch.setattr("chia.pools.pool_wallet.update_pool_config", mock_pool_config_update_pool_config)
+
+    # Mock PoolWallet.get_current_state to return our canned state
+    async def mock_get_current_state(self: Any) -> Any:
+        return current_state
+
+    monkeypatch.setattr(PoolWallet, "get_current_state", mock_get_current_state)
+
+    wallet = PoolWallet()
+    wallet.standard_wallet = cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph))
+    wallet.wallet_state_manager = MockWalletStateManager()
+    wallet.log = MagicMock()
+
+    await wallet.update_pool_config()
+
+    assert updated_configs is not None
+    assert len(updated_configs) == 1
+    assert updated_configs[0].launcher_id == launcher_id
+    assert updated_configs[0].pool_url == pool_url
+    assert updated_configs[0].payout_instructions == payout_instructions_ph.hex()
+    assert updated_configs[0].target_puzzle_hash == target_puzzle_hash
+    assert updated_configs[0].p2_singleton_puzzle_hash == p2_singleton_puzzle_hash
+    assert updated_configs[0].owner_public_key == owner_pubkey
+
+
+@pytest.mark.asyncio
+async def test_update_pool_config_existing_payout_instructions(monkeypatch: Any) -> None:
+    updated_configs: Optional[List[MockPoolWalletConfig]] = None
+    payout_instructions_ph = rand_hash()
+    launcher_id: bytes32 = rand_hash()
+    p2_singleton_puzzle_hash: bytes32 = rand_hash()
+    pool_url: str = "https://fake.pool.url"
+    target_puzzle_hash: bytes32 = rand_hash()
+    owner_pubkey: G1Element = rand_g1()
+    current: MockPoolState = MockPoolState(
+        pool_url=pool_url,
+        target_puzzle_hash=target_puzzle_hash,
+        owner_pubkey=owner_pubkey,
+    )
+    current_state: MockPoolWalletInfo = MockPoolWalletInfo(
+        launcher_id=launcher_id,
+        p2_singleton_puzzle_hash=p2_singleton_puzzle_hash,
+        current=current,
+    )
+
+    # Existing config data with different values
+    # payout_instructions should _NOT_ be updated after calling update_pool_config
+    existing_launcher_id: bytes32 = launcher_id
+    existing_pool_url: str = ""
+    existing_payout_instructions_ph: bytes32 = rand_hash()
+    existing_target_puzzle_hash: bytes32 = rand_hash()
+    existing_p2_singleton_puzzle_hash: bytes32 = rand_hash()
+    existing_owner_pubkey: G1Element = rand_g1()
+    existing_config: MockPoolWalletConfig = MockPoolWalletConfig(
+        launcher_id=existing_launcher_id,
+        pool_url=existing_pool_url,
+        payout_instructions=existing_payout_instructions_ph.hex(),
+        target_puzzle_hash=existing_target_puzzle_hash,
+        p2_singleton_puzzle_hash=existing_p2_singleton_puzzle_hash,
+        owner_public_key=existing_owner_pubkey,
+    )
+
+    # No config data
+    def mock_load_pool_config(root_path: Path) -> List[MockPoolWalletConfig]:
+        nonlocal existing_config
+        return [existing_config]
+
+    monkeypatch.setattr("chia.pools.pool_wallet.load_pool_config", mock_load_pool_config)
+
+    # Mock pool_config.update_pool_config to capture the updated configs
+    async def mock_pool_config_update_pool_config(
+        root_path: Path, pool_config_list: List[MockPoolWalletConfig]
+    ) -> None:
+        nonlocal updated_configs
+        updated_configs = pool_config_list
+
+    monkeypatch.setattr("chia.pools.pool_wallet.update_pool_config", mock_pool_config_update_pool_config)
+
+    # Mock PoolWallet.get_current_state to return our canned state
+    async def mock_get_current_state(self: Any) -> Any:
+        return current_state
+
+    monkeypatch.setattr(PoolWallet, "get_current_state", mock_get_current_state)
+
+    wallet = PoolWallet()
+    wallet.standard_wallet = cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph))
+    wallet.wallet_state_manager = MockWalletStateManager()
+    wallet.log = MagicMock()
+
+    await wallet.update_pool_config()
+
+    assert updated_configs is not None
+    assert len(updated_configs) == 1
+    assert updated_configs[0].launcher_id == launcher_id
+    assert updated_configs[0].pool_url == pool_url
+
+    # payout_instructions should still point to existing_payout_instructions_ph
+    assert updated_configs[0].payout_instructions == existing_payout_instructions_ph.hex()
+
+    assert updated_configs[0].target_puzzle_hash == target_puzzle_hash
+    assert updated_configs[0].p2_singleton_puzzle_hash == p2_singleton_puzzle_hash
+    assert updated_configs[0].owner_public_key == owner_pubkey

--- a/tests/pools/test_pool_wallet.py
+++ b/tests/pools/test_pool_wallet.py
@@ -1,13 +1,14 @@
-import pytest
-
-from benchmarks.utils import rand_g1, rand_hash
-from blspy import G1Element
-from chia.pools.pool_wallet import PoolWallet
-from chia.types.blockchain_format.sized_bytes import bytes32
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast, Any, List, Optional
+from typing import Any, List, Optional, cast
 from unittest.mock import MagicMock
+
+import pytest
+from blspy import G1Element
+
+from benchmarks.utils import rand_g1, rand_hash
+from chia.pools.pool_wallet import PoolWallet
+from chia.types.blockchain_format.sized_bytes import bytes32
 
 
 @dataclass


### PR DESCRIPTION
When syncing a wallet db from scratch, if a pool nft launcher is found, we were previously overwriting the pool config's `payout_instructions` with a new puzzle hash. This change will preserve the existing `payout_instruction` puzzle hash, if found in the config.

Issue #10478 