### PR TITLE
wallet: Reduce log level for `Pulled from queue` message

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -355,7 +355,7 @@ class WalletNode:
             try:
                 peer, item = None, None
                 item = await self.new_peak_queue.get()
-                self.log.info(f"Pulled from queue: {item}")
+                self.log.debug(f"Pulled from queue: {item}")
                 assert item is not None
                 if item.item_type == NewPeakQueueTypes.COIN_ID_SUBSCRIPTION:
                     # Subscriptions are the highest priority, because we don't want to process any more peaks or


### PR DESCRIPTION
It prints messages per connection for a new peak, `DEBUG` is probably good enough?