### PR TITLE
better TLS1.3 check

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -169,7 +169,7 @@ class WebSocketServer:
                 try:
                     # Daemon is internal connections, so override to TLS1.3 only
                     self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_3
-                except Exception:
+                except ValueError:
                     self.log.warning(
                         (
                             "Deprecation Warning: Your version of SSL (%s) does not support TLS1.3. "

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -158,12 +158,13 @@ class WebSocketServer:
 
         # Note: the minimum_version has been already set to TLSv1_2
         # in ssl_context_for_server()
-        # Daemon is internal connections, so override to TLS1.3 only
+        # Daemon is internal connections, so override to TLSv1_3 only
         if ssl.HAS_TLSv1_3:
             try:
                 self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_3
             except ValueError:
-                self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2  # probably not needed but doesn't hurt
+                # in case the attempt above confused the config, set it again (likely not needed but doesn't hurt)
+                self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
 
         if self.ssl_context.minimum_version is not ssl.TLSVersion.TLSv1_3:
             self.log.warning(


### PR DESCRIPTION
A better and more compatible TLS check that works on versions of python using a non-openssl TLS library. Examples include the python3 version in Xcode which is using LibreSSL.

See issue #10285