### PR TITLE
Check prefix on send_transaction before sending

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -756,7 +756,12 @@ class WalletRpcApi:
         if not isinstance(request["amount"], int) or not isinstance(request["fee"], int):
             raise ValueError("An integer amount or fee is required (too many decimals)")
         amount: uint64 = uint64(request["amount"])
-        puzzle_hash: bytes32 = decode_puzzle_hash(request["address"])
+        address = request["address"]
+        selected_network = self.service.config["selected_network"]
+        expected_prefix = self.service.config["network_overrides"]["config"][selected_network]["address_prefix"]
+        if address[0 : len(expected_prefix)] != expected_prefix:
+            raise ValueError("Unexpected Address Prefix")
+        puzzle_hash: bytes32 = decode_puzzle_hash(address)
 
         memos: List[bytes] = []
         if "memos" in request:

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -142,7 +142,7 @@ class TestWalletRpc:
         client_node = await FullNodeRpcClient.create(self_hostname, test_rpc_port_node, bt.root_path, config)
         try:
             await time_out_assert(5, client.get_synced)
-            addr = encode_puzzle_hash(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), "xch")
+            addr = encode_puzzle_hash(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), "txch")
             tx_amount = 15600000
             try:
                 await client.send_transaction("1", 100000000000000001, addr)
@@ -263,7 +263,7 @@ class TestWalletRpc:
             ] == initial_funds_eventually - tx_amount
 
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
 
             await time_out_assert(5, eventual_balance, initial_funds_eventually - tx_amount - signed_tx_amount)
@@ -290,7 +290,7 @@ class TestWalletRpc:
             push_res = await client_node.push_tx(tx_res.spend_bundle)
             assert push_res["success"]
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
 
             found: bool = False
@@ -330,7 +330,7 @@ class TestWalletRpc:
 
             await asyncio.sleep(3)
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
 
             new_balance = new_balance - 555 - 666 - 200
@@ -356,7 +356,7 @@ class TestWalletRpc:
             assert all_transactions == sorted(all_transactions, key=attrgetter("confirmed_at_height"), reverse=True)
 
             # Test RELEVANCE
-            await client.send_transaction("1", 1, encode_puzzle_hash(ph_2, "xch"))  # Create a pending tx
+            await client.send_transaction("1", 1, encode_puzzle_hash(ph_2, "txch"))  # Create a pending tx
 
             all_transactions = await client.get_transactions("1", sort_key=SortKey.RELEVANCE)
             sorted_transactions = sorted(all_transactions, key=attrgetter("created_at_time"), reverse=True)
@@ -386,11 +386,11 @@ class TestWalletRpc:
 
             # Test get_transactions to address
             ph_by_addr = await wallet.get_new_puzzlehash()
-            await client.send_transaction("1", 1, encode_puzzle_hash(ph_by_addr, "xch"))
-            await client.farm_block(encode_puzzle_hash(ph_by_addr, "xch"))
+            await client.send_transaction("1", 1, encode_puzzle_hash(ph_by_addr, "txch"))
+            await client.farm_block(encode_puzzle_hash(ph_by_addr, "txch"))
             await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
             tx_for_address = await wallet_rpc_api.get_transactions(
-                {"wallet_id": "1", "to_address": encode_puzzle_hash(ph_by_addr, "xch")}
+                {"wallet_id": "1", "to_address": encode_puzzle_hash(ph_by_addr, "txch")}
             )
             assert len(tx_for_address["transactions"]) == 1
             assert decode_puzzle_hash(tx_for_address["transactions"][0]["to_address"]) == ph_by_addr
@@ -428,7 +428,7 @@ class TestWalletRpc:
 
             await asyncio.sleep(1)
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
 
             await time_out_assert(10, eventual_balance_det, 20, client, cat_0_id)
@@ -445,7 +445,7 @@ class TestWalletRpc:
 
             await asyncio.sleep(1)
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
             bal_1 = await client_2.get_wallet_balance(cat_1_id)
             assert bal_1["confirmed_wallet_balance"] == 0
@@ -459,7 +459,7 @@ class TestWalletRpc:
 
             await asyncio.sleep(1)
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
 
             await time_out_assert(10, eventual_balance_det, 16, client, cat_0_id)
@@ -507,7 +507,7 @@ class TestWalletRpc:
 
             await asyncio.sleep(1)
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
 
             async def is_trade_confirmed(client, trade) -> bool:


### PR DESCRIPTION
Checks the target address prefix on send_transaction compared to the expected value in the config and raises a ValueError if the prefix doesn't match what is expected.

Checked the initial config, and prefixes have been in there since at least 1.0.0: [1.0.0 Initial Config](https://github.com/Chia-Network/chia-blockchain/blob/91f038e2193755e2a6ca22e2160e2c8f547c23fe/src/util/initial-config.yaml)

**_I had zero balance, so I couldn't actually send anything, but the error varies, and is inline with expectations with this code change_**

## CLI Tests

### Mainnet

```
chia wallet send -f 2241697793 -i 1 -a 1 -m 0 -t xfx1ll4q092ulfqdzq7vnksdtht5t4h99zzn52lcvzs2mvmhprpv3jdqy2twhh
Submitting transaction...
Exception from 'wallet' {'error': 'Unexpected Address Prefix', 'success': False}
```

```
chia wallet send -f 2241697793 -i 1 -a 1 -m 0 -t xch1ll4q092ulfqdzq7vnksdtht5t4h99zzn52lcvzs2mvmhprpv3jdqafv254
Submitting transaction...
Exception from 'wallet' {'error': "Can't send more than 0 in a single transaction", 'success': False}
```

### Testnet

```
chia wallet send -f 2241697793 -i 1 -a 1 -m 0 -t xfx1ll4q092ulfqdzq7vnksdtht5t4h99zzn52lcvzs2mvmhprpv3jdqy2twhh
Submitting transaction...
Exception from 'wallet' {'error': 'Unexpected Address Prefix', 'success': False}
```

```
chia wallet send -f 2241697793 -i 1 -a 1 -m 0 -t txch1ll4q092ulfqdzq7vnksdtht5t4h99zzn52lcvzs2mvmhprpv3jdqswtu4x
Submitting transaction...
Exception from 'wallet' {'error': "Can't send more than 0 in a single transaction", 'success': False}
```

## UI Test

<img width="1067" alt="Screen Shot 2022-03-05 at 3 57 17 PM" src="https://user-images.githubusercontent.com/1915905/156901144-68d6d948-5f6e-470f-9c00-8b1fec82eb4a.png">

