### PR TITLE
streamable|pools: Fix `Optional` parsing in `dataclass_from_dict`

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -127,7 +127,7 @@ class PoolWallet:
     @classmethod
     def _verify_self_pooled(cls, state) -> Optional[str]:
         err = ""
-        if state.pool_url != "":
+        if state.pool_url not in [None, ""]:
             err += " Unneeded pool_url for self-pooling"
 
         if state.relative_lock_height != 0:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -55,7 +55,7 @@ def dataclass_from_dict(klass, d):
     """
     if is_type_SpecificOptional(klass):
         # Type is optional, data is either None, or Any
-        if not d:
+        if d is None:
             return None
         return dataclass_from_dict(get_args(klass)[0], d)
     elif is_type_Tuple(klass):

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 import io
+import pytest
 
 from clvm_tools import binutils
 from pytest import raises
@@ -70,6 +71,32 @@ def test_json():
 
     dict_block = block.to_json_dict()
     assert FullBlock.from_json_dict(dict_block) == block
+
+
+@dataclass(frozen=True)
+@streamable
+class OptionalTestClass(Streamable):
+    a: Optional[str]
+    b: Optional[bool]
+    c: Optional[List[Optional[str]]]
+
+
+@pytest.mark.parametrize(
+    "a, b, c",
+    [
+        ("", True, ["1"]),
+        ("1", False, ["1"]),
+        ("1", True, []),
+        ("1", True, [""]),
+        ("1", True, ["1"]),
+        (None, None, None),
+    ],
+)
+def test_optional_json(a: Optional[str], b: Optional[bool], c: Optional[List[Optional[str]]]):
+    obj: OptionalTestClass = OptionalTestClass.from_json_dict({"a": a, "b": b, "c": c})
+    assert obj.a == a
+    assert obj.b == b
+    assert obj.c == c
 
 
 def test_recursive_json():

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -225,7 +225,7 @@ class TestPoolWalletRpc:
                 "b286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
             )
         )
-        assert status.current.pool_url is None
+        assert status.current.pool_url == ""
         assert status.current.relative_lock_height == 0
         assert status.current.version == 1
         # Check that config has been written properly
@@ -931,7 +931,7 @@ class TestPoolWalletRpc:
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
             assert status.current.state == PoolSingletonState.SELF_POOLING.value
-            assert status.current.pool_url is None
+            assert status.current.pool_url == ""
             assert status.current.relative_lock_height == 0
             assert status.current.state == 1
             assert status.current.version == 1


### PR DESCRIPTION
35b645b9cf97b6430d3f6bedb28dcf83894e067e Fixes a bug which leads to `dataclass_from_dict` setting values to `None` even though they are actual values like `""` or `False` or `[]` because the current code asks for `if not d` instead of `if d is None`. You can see the tests added by 39bd473bbab61e46af1eda5d81e947e736eda38b failing without 35b645b9cf97b6430d3f6bedb28dcf83894e067e.

Note that i had to adjust the pool wallet / pool tests here 6822e27ff10291d74d3f463a1f05c1cee6a09984. In general i think we should have a URL validator or so instead of just checking for `""`/`None` in all those places but thats a separate issue. 