### PR TITLE
pools: Fix `plotnft claim` command's output

### DIFF
--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -279,7 +279,8 @@ async def submit_tx_with_confirmation(
 
     if user_input.lower() == "y" or user_input.lower() == "yes":
         try:
-            tx_record: TransactionRecord = await func()
+            result: Dict = await func()
+            tx_record: TransactionRecord = result["transaction"]
             start = time.time()
             while time.time() - start < 10:
                 await asyncio.sleep(0.1)

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -3,7 +3,7 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import rmtree
-from typing import Optional, List, Dict
+from typing import Any, Optional, List, Dict
 
 import pytest
 import pytest_asyncio
@@ -802,20 +802,24 @@ class TestPoolWalletRpc:
             assert status.target is None
             assert status_2.target is None
 
-            join_pool_tx: TransactionRecord = await client.pw_join_pool(
-                wallet_id,
-                pool_ph,
-                "https://pool.example.com",
-                10,
-                fee,
-            )
-            join_pool_tx_2: TransactionRecord = await client.pw_join_pool(
-                wallet_id_2,
-                pool_ph,
-                "https://pool.example.com",
-                10,
-                fee,
-            )
+            join_pool_tx: TransactionRecord = (
+                await client.pw_join_pool(
+                    wallet_id,
+                    pool_ph,
+                    "https://pool.example.com",
+                    10,
+                    fee,
+                )
+            )["transaction"]
+            join_pool_tx_2: TransactionRecord = (
+                await client.pw_join_pool(
+                    wallet_id_2,
+                    pool_ph,
+                    "https://pool.example.com",
+                    10,
+                    fee,
+                )
+            )["transaction"]
             assert join_pool_tx is not None
             assert join_pool_tx_2 is not None
 
@@ -919,13 +923,15 @@ class TestPoolWalletRpc:
             assert status.current.state == PoolSingletonState.SELF_POOLING.value
             assert status.target is None
 
-            join_pool_tx: TransactionRecord = await client.pw_join_pool(
-                wallet_id,
-                pool_ph,
-                "https://pool.example.com",
-                5,
-                fee,
-            )
+            join_pool_tx: TransactionRecord = (
+                await client.pw_join_pool(
+                    wallet_id,
+                    pool_ph,
+                    "https://pool.example.com",
+                    5,
+                    fee,
+                )
+            )["transaction"]
             assert join_pool_tx is not None
 
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
@@ -953,9 +959,9 @@ class TestPoolWalletRpc:
 
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
-            leave_pool_tx: TransactionRecord = await client.pw_self_pool(wallet_id, fee)
-            assert leave_pool_tx.wallet_id == wallet_id
-            assert leave_pool_tx.amount == 1
+            leave_pool_tx: Dict[str, Any] = await client.pw_self_pool(wallet_id, fee)
+            assert leave_pool_tx["transaction"].wallet_id == wallet_id
+            assert leave_pool_tx["transaction"].amount == 1
 
             async def status_is_leaving():
                 await self.farm_blocks(full_node_api, our_ph, 1)
@@ -1054,13 +1060,15 @@ class TestPoolWalletRpc:
             assert pw_info.current.relative_lock_height == 5
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
-            join_pool_tx: TransactionRecord = await client.pw_join_pool(
-                wallet_id,
-                pool_b_ph,
-                "https://pool-b.org",
-                10,
-                fee,
-            )
+            join_pool_tx: TransactionRecord = (
+                await client.pw_join_pool(
+                    wallet_id,
+                    pool_b_ph,
+                    "https://pool-b.org",
+                    10,
+                    fee,
+                )
+            )["transaction"]
             assert join_pool_tx is not None
 
             async def status_is_leaving():
@@ -1156,13 +1164,15 @@ class TestPoolWalletRpc:
             assert pw_info.current.pool_url == "https://pool-a.org"
             assert pw_info.current.relative_lock_height == 5
 
-            join_pool_tx: TransactionRecord = await client.pw_join_pool(
-                wallet_id,
-                pool_b_ph,
-                "https://pool-b.org",
-                10,
-                fee,
-            )
+            join_pool_tx: TransactionRecord = (
+                await client.pw_join_pool(
+                    wallet_id,
+                    pool_b_ph,
+                    "https://pool-b.org",
+                    10,
+                    fee,
+                )
+            )["transaction"]
             assert join_pool_tx is not None
             await time_out_assert(
                 10,


### PR DESCRIPTION
If you currently claim rewards `claim_cmd` fails to print the txhash with the lookup hint in `submit_tx_with_confirmation`

```
Error performing operation on Plot NFT -f 172057028 wallet id: 12: 'dict' object has no attribute 'name'
```

Because `submit_tx_with_confirmation` expects a `TransactionRecord` as result from its callable parameter `func` but `pw_absorb_rewards` returns a dict which includes the `TransactionRecord` as value for the key `transaction` (amongst others). This PR makes sure all other methods used as `func` callable have the same return behaviour as `pw_absorb_rewards`. We could have adjusted it the other way around (only return `TransactionRecord` in `pw_absorb_rewards`) but then we would drop information in the RPC client.  


With this PR you get:

```
Do chia wallet get_transaction -f 172057028 -tx 
0x34f74a1ffd9da9a493b78463e635996fd03d4f805ade583acb9764df73355f9c to 
get status
```

Fixes #10606