### PR TITLE
Show observer-derived wallet address in chia keys show

### DIFF
--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -28,10 +28,21 @@ def generate_cmd(ctx: click.Context):
 @click.option(
     "--show-mnemonic-seed", help="Show the mnemonic seed of the keys", default=False, show_default=True, is_flag=True
 )
-def show_cmd(show_mnemonic_seed):
+@click.option(
+    "--non-observer-derivation",
+    "-d",
+    help=(
+        "Show the first wallet address using non-observer derivation. Older Chia versions use "
+        "non-observer derivation when generating wallet addresses."
+    ),
+    default=False,
+    show_default=True,
+    is_flag=True,
+)
+def show_cmd(show_mnemonic_seed, non_observer_derivation):
     from .keys_funcs import show_all_keys
 
-    show_all_keys(show_mnemonic_seed)
+    show_all_keys(show_mnemonic_seed, non_observer_derivation)
 
 
 @keys_cmd.command("add", short_help="Add a private key by mnemonic")
@@ -201,7 +212,7 @@ def derive_cmd(ctx: click.Context, fingerprint: Optional[int], filename: Optiona
     "--derive-from-hd-path",
     "-p",
     help="Search for items derived from a specific HD path. Indices ending in an 'n' indicate that "
-    "non-observer derivation should used at that index. Example HD path: m/12381n/8444n/2/",
+    "non-observer derivation should be used at that index. Example HD path: m/12381n/8444n/2/",
     type=str,
 )
 @click.pass_context
@@ -289,7 +300,7 @@ def wallet_address_cmd(
     "--derive-from-hd-path",
     "-p",
     help="Derive child keys rooted from a specific HD path. Indices ending in an 'n' indicate that "
-    "non-observer derivation should used at that index. Example HD path: m/12381n/8444n/2/",
+    "non-observer derivation should be used at that index. Example HD path: m/12381n/8444n/2/",
     type=str,
 )
 @click.option(

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -67,7 +67,7 @@ def add_private_key_seed(mnemonic: str):
 
 
 @unlocks_keyring(use_passphrase_cache=True)
-def show_all_keys(show_mnemonic: bool):
+def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
     """
     Prints all keys and mnemonics (if available).
     """
@@ -92,10 +92,13 @@ def show_all_keys(show_mnemonic: bool):
             master_sk_to_farmer_sk(sk).get_g1(),
         )
         print("Pool public key (m/12381/8444/1/0):", master_sk_to_pool_sk(sk).get_g1())
-        print(
-            "First wallet address:",
-            encode_puzzle_hash(create_puzzlehash_for_pk(master_sk_to_wallet_sk(sk, uint32(0)).get_g1()), prefix),
+        first_wallet_sk: PrivateKey = (
+            master_sk_to_wallet_sk(sk, uint32(0))
+            if non_observer_derivation
+            else master_sk_to_wallet_sk_unhardened(sk, uint32(0))
         )
+        wallet_address: str = encode_puzzle_hash(create_puzzlehash_for_pk(first_wallet_sk.get_g1()), prefix)
+        print(f"First wallet address{' (non-observer)' if non_observer_derivation else ''}: {wallet_address}")
         assert seed is not None
         if show_mnemonic:
             print("Master private key (m):", bytes(sk).hex())


### PR DESCRIPTION
`chia keys show` will default to displaying the first observer-derived wallet address. With the addition of the `-d` option, the non-observer derived wallet address can be displayed.

Issue #10591 