### PR TITLE
improve listen port selection for tests

### DIFF
--- a/tests/util/socket.py
+++ b/tests/util/socket.py
@@ -1,15 +1,18 @@
 import random
+import secrets
 import socket
 from typing import Set
 
 recent_ports: Set[int] = set()
+prng = random.Random()
+prng.seed(secrets.randbits(32))
 
 
 def find_available_listen_port(name: str = "free") -> int:
     global recent_ports
 
     while True:
-        port = random.randint(2000, 65535)
+        port = prng.randint(2000, 65535)
         if port in recent_ports:
             continue
 
@@ -17,6 +20,7 @@ def find_available_listen_port(name: str = "free") -> int:
             try:
                 s.bind(("127.0.0.1", port))
             except OSError:
+                recent_ports.add(port)
                 continue
 
         recent_ports.add(port)


### PR DESCRIPTION
a problem with using random.randint() to pick a port is that all processes (running in parallel) are seeded the same, and so pick the same ports at the same time, causing conflicts. This uses proper entropy instead.