### PR TITLE
Safe config file reading and writing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     rev: v0.930
     hooks:
     - id: mypy
-      additional_dependencies: [pytest, pytest-asyncio, types-aiofiles, types-click, types-setuptools, types-PyYAML]
+      additional_dependencies: [filelock, pytest, pytest-asyncio, types-aiofiles, types-click, types-setuptools, types-PyYAML]
       # This intentionally counters the settings in mypy.ini to allow a loose local
       # check and a strict CI check. This difference may or may not be retained long
       # term.

--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -16,6 +16,7 @@ from chia.cmds.wallet import wallet_cmd
 from chia.cmds.plotnft import plotnft_cmd
 from chia.cmds.plotters import plotters_cmd
 from chia.cmds.db import db_cmd
+from chia.util.config import config_path_for_filename
 from chia.util.default_root import DEFAULT_KEYS_ROOT_PATH, DEFAULT_ROOT_PATH
 from chia.util.keychain import (
     Keychain,
@@ -91,7 +92,8 @@ def cli(
         except Exception as e:
             print(f"Failed to read passphrase: {e}")
 
-    check_ssl(Path(root_path))
+    if config_path_for_filename(Path(root_path), "config.yaml").exists():
+        check_ssl(Path(root_path))
 
 
 if not supports_keyring_passphrase():

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 import click
 
-from chia.util.config import load_config, save_config, str2bool, create_config_lock
+from chia.util.config import load_config, save_config, str2bool, get_config_lock
 from chia.util.default_root import DEFAULT_ROOT_PATH
 
 
@@ -24,7 +24,7 @@ def configure(
     seeder_domain_name: str,
     seeder_nameserver: str,
 ):
-    with create_config_lock(root_path, "config.yaml"):
+    with get_config_lock(root_path, "config.yaml"):
         config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml", acquire_lock=False)
         change_made = False
         if set_node_introducer:

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 import click
 
-from chia.util.config import load_config, save_config, str2bool
+from chia.util.config import load_config, save_config, str2bool, create_config_lock
 from chia.util.default_root import DEFAULT_ROOT_PATH
 
 
@@ -24,172 +24,173 @@ def configure(
     seeder_domain_name: str,
     seeder_nameserver: str,
 ):
-    config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    change_made = False
-    if set_node_introducer:
-        try:
-            if set_node_introducer.index(":"):
-                host, port = (
-                    ":".join(set_node_introducer.split(":")[:-1]),
-                    set_node_introducer.split(":")[-1],
-                )
-                config["full_node"]["introducer_peer"]["host"] = host
-                config["full_node"]["introducer_peer"]["port"] = int(port)
-                config["introducer"]["port"] = int(port)
-                print("Node introducer updated")
+    with create_config_lock(root_path, "config.yaml"):
+        config: Dict = load_config(DEFAULT_ROOT_PATH, "config.yaml", acquire_lock=False)
+        change_made = False
+        if set_node_introducer:
+            try:
+                if set_node_introducer.index(":"):
+                    host, port = (
+                        ":".join(set_node_introducer.split(":")[:-1]),
+                        set_node_introducer.split(":")[-1],
+                    )
+                    config["full_node"]["introducer_peer"]["host"] = host
+                    config["full_node"]["introducer_peer"]["port"] = int(port)
+                    config["introducer"]["port"] = int(port)
+                    print("Node introducer updated")
+                    change_made = True
+            except ValueError:
+                print("Node introducer address must be in format [IP:Port]")
+        if set_farmer_peer:
+            try:
+                if set_farmer_peer.index(":"):
+                    host, port = (
+                        ":".join(set_farmer_peer.split(":")[:-1]),
+                        set_farmer_peer.split(":")[-1],
+                    )
+                    config["full_node"]["farmer_peer"]["host"] = host
+                    config["full_node"]["farmer_peer"]["port"] = int(port)
+                    config["harvester"]["farmer_peer"]["host"] = host
+                    config["harvester"]["farmer_peer"]["port"] = int(port)
+                    print("Farmer peer updated, make sure your harvester has the proper cert installed")
+                    change_made = True
+            except ValueError:
+                print("Farmer address must be in format [IP:Port]")
+        if set_fullnode_port:
+            config["full_node"]["port"] = int(set_fullnode_port)
+            config["full_node"]["introducer_peer"]["port"] = int(set_fullnode_port)
+            config["farmer"]["full_node_peer"]["port"] = int(set_fullnode_port)
+            config["timelord"]["full_node_peer"]["port"] = int(set_fullnode_port)
+            config["wallet"]["full_node_peer"]["port"] = int(set_fullnode_port)
+            config["wallet"]["introducer_peer"]["port"] = int(set_fullnode_port)
+            config["introducer"]["port"] = int(set_fullnode_port)
+            print("Default full node port updated")
+            change_made = True
+        if set_harvester_port:
+            config["harvester"]["port"] = int(set_harvester_port)
+            config["farmer"]["harvester_peer"]["port"] = int(set_harvester_port)
+            print("Default harvester port updated")
+            change_made = True
+        if set_log_level:
+            levels = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
+            if set_log_level in levels:
+                config["logging"]["log_level"] = set_log_level
+                print(f"Logging level updated. Check {DEFAULT_ROOT_PATH}/log/debug.log")
                 change_made = True
-        except ValueError:
-            print("Node introducer address must be in format [IP:Port]")
-    if set_farmer_peer:
-        try:
-            if set_farmer_peer.index(":"):
-                host, port = (
-                    ":".join(set_farmer_peer.split(":")[:-1]),
-                    set_farmer_peer.split(":")[-1],
-                )
-                config["full_node"]["farmer_peer"]["host"] = host
-                config["full_node"]["farmer_peer"]["port"] = int(port)
-                config["harvester"]["farmer_peer"]["host"] = host
-                config["harvester"]["farmer_peer"]["port"] = int(port)
-                print("Farmer peer updated, make sure your harvester has the proper cert installed")
+            else:
+                print(f"Logging level not updated. Use one of: {levels}")
+        if enable_upnp:
+            config["full_node"]["enable_upnp"] = str2bool(enable_upnp)
+            if str2bool(enable_upnp):
+                print("uPnP enabled")
+            else:
+                print("uPnP disabled")
+            change_made = True
+        if set_outbound_peer_count:
+            config["full_node"]["target_outbound_peer_count"] = int(set_outbound_peer_count)
+            print("Target outbound peer count updated")
+            change_made = True
+        if set_peer_count:
+            config["full_node"]["target_peer_count"] = int(set_peer_count)
+            print("Target peer count updated")
+            change_made = True
+        if testnet:
+            if testnet == "true" or testnet == "t":
+                print("Setting Testnet")
+                testnet_port = "58444"
+                testnet_introducer = "introducer-testnet10.chia.net"
+                testnet_dns_introducer = "dns-introducer-testnet10.chia.net"
+                bootstrap_peers = ["testnet10-node.chia.net"]
+                testnet = "testnet10"
+                config["full_node"]["port"] = int(testnet_port)
+                config["full_node"]["introducer_peer"]["port"] = int(testnet_port)
+                config["farmer"]["full_node_peer"]["port"] = int(testnet_port)
+                config["timelord"]["full_node_peer"]["port"] = int(testnet_port)
+                config["wallet"]["full_node_peer"]["port"] = int(testnet_port)
+                config["wallet"]["introducer_peer"]["port"] = int(testnet_port)
+                config["introducer"]["port"] = int(testnet_port)
+                config["full_node"]["introducer_peer"]["host"] = testnet_introducer
+                config["full_node"]["dns_servers"] = [testnet_dns_introducer]
+                config["wallet"]["dns_servers"] = [testnet_dns_introducer]
+                config["selected_network"] = testnet
+                config["harvester"]["selected_network"] = testnet
+                config["pool"]["selected_network"] = testnet
+                config["farmer"]["selected_network"] = testnet
+                config["timelord"]["selected_network"] = testnet
+                config["full_node"]["selected_network"] = testnet
+                config["ui"]["selected_network"] = testnet
+                config["introducer"]["selected_network"] = testnet
+                config["wallet"]["selected_network"] = testnet
+
+                if "seeder" in config:
+                    config["seeder"]["port"] = int(testnet_port)
+                    config["seeder"]["other_peers_port"] = int(testnet_port)
+                    config["seeder"]["selected_network"] = testnet
+                    config["seeder"]["bootstrap_peers"] = bootstrap_peers
+
+                print("Default full node port, introducer and network setting updated")
                 change_made = True
-        except ValueError:
-            print("Farmer address must be in format [IP:Port]")
-    if set_fullnode_port:
-        config["full_node"]["port"] = int(set_fullnode_port)
-        config["full_node"]["introducer_peer"]["port"] = int(set_fullnode_port)
-        config["farmer"]["full_node_peer"]["port"] = int(set_fullnode_port)
-        config["timelord"]["full_node_peer"]["port"] = int(set_fullnode_port)
-        config["wallet"]["full_node_peer"]["port"] = int(set_fullnode_port)
-        config["wallet"]["introducer_peer"]["port"] = int(set_fullnode_port)
-        config["introducer"]["port"] = int(set_fullnode_port)
-        print("Default full node port updated")
-        change_made = True
-    if set_harvester_port:
-        config["harvester"]["port"] = int(set_harvester_port)
-        config["farmer"]["harvester_peer"]["port"] = int(set_harvester_port)
-        print("Default harvester port updated")
-        change_made = True
-    if set_log_level:
-        levels = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
-        if set_log_level in levels:
-            config["logging"]["log_level"] = set_log_level
-            print(f"Logging level updated. Check {DEFAULT_ROOT_PATH}/log/debug.log")
-            change_made = True
-        else:
-            print(f"Logging level not updated. Use one of: {levels}")
-    if enable_upnp:
-        config["full_node"]["enable_upnp"] = str2bool(enable_upnp)
-        if str2bool(enable_upnp):
-            print("uPnP enabled")
-        else:
-            print("uPnP disabled")
-        change_made = True
-    if set_outbound_peer_count:
-        config["full_node"]["target_outbound_peer_count"] = int(set_outbound_peer_count)
-        print("Target outbound peer count updated")
-        change_made = True
-    if set_peer_count:
-        config["full_node"]["target_peer_count"] = int(set_peer_count)
-        print("Target peer count updated")
-        change_made = True
-    if testnet:
-        if testnet == "true" or testnet == "t":
-            print("Setting Testnet")
-            testnet_port = "58444"
-            testnet_introducer = "introducer-testnet10.chia.net"
-            testnet_dns_introducer = "dns-introducer-testnet10.chia.net"
-            bootstrap_peers = ["testnet10-node.chia.net"]
-            testnet = "testnet10"
-            config["full_node"]["port"] = int(testnet_port)
-            config["full_node"]["introducer_peer"]["port"] = int(testnet_port)
-            config["farmer"]["full_node_peer"]["port"] = int(testnet_port)
-            config["timelord"]["full_node_peer"]["port"] = int(testnet_port)
-            config["wallet"]["full_node_peer"]["port"] = int(testnet_port)
-            config["wallet"]["introducer_peer"]["port"] = int(testnet_port)
-            config["introducer"]["port"] = int(testnet_port)
-            config["full_node"]["introducer_peer"]["host"] = testnet_introducer
-            config["full_node"]["dns_servers"] = [testnet_dns_introducer]
-            config["wallet"]["dns_servers"] = [testnet_dns_introducer]
-            config["selected_network"] = testnet
-            config["harvester"]["selected_network"] = testnet
-            config["pool"]["selected_network"] = testnet
-            config["farmer"]["selected_network"] = testnet
-            config["timelord"]["selected_network"] = testnet
-            config["full_node"]["selected_network"] = testnet
-            config["ui"]["selected_network"] = testnet
-            config["introducer"]["selected_network"] = testnet
-            config["wallet"]["selected_network"] = testnet
 
-            if "seeder" in config:
-                config["seeder"]["port"] = int(testnet_port)
-                config["seeder"]["other_peers_port"] = int(testnet_port)
-                config["seeder"]["selected_network"] = testnet
-                config["seeder"]["bootstrap_peers"] = bootstrap_peers
+            elif testnet == "false" or testnet == "f":
+                print("Setting Mainnet")
+                mainnet_port = "8444"
+                mainnet_introducer = "introducer.chia.net"
+                mainnet_dns_introducer = "dns-introducer.chia.net"
+                bootstrap_peers = ["node.chia.net"]
+                net = "mainnet"
+                config["full_node"]["port"] = int(mainnet_port)
+                config["full_node"]["introducer_peer"]["port"] = int(mainnet_port)
+                config["farmer"]["full_node_peer"]["port"] = int(mainnet_port)
+                config["timelord"]["full_node_peer"]["port"] = int(mainnet_port)
+                config["wallet"]["full_node_peer"]["port"] = int(mainnet_port)
+                config["wallet"]["introducer_peer"]["port"] = int(mainnet_port)
+                config["introducer"]["port"] = int(mainnet_port)
+                config["full_node"]["introducer_peer"]["host"] = mainnet_introducer
+                config["full_node"]["dns_servers"] = [mainnet_dns_introducer]
+                config["selected_network"] = net
+                config["harvester"]["selected_network"] = net
+                config["pool"]["selected_network"] = net
+                config["farmer"]["selected_network"] = net
+                config["timelord"]["selected_network"] = net
+                config["full_node"]["selected_network"] = net
+                config["ui"]["selected_network"] = net
+                config["introducer"]["selected_network"] = net
+                config["wallet"]["selected_network"] = net
 
-            print("Default full node port, introducer and network setting updated")
+                if "seeder" in config:
+                    config["seeder"]["port"] = int(mainnet_port)
+                    config["seeder"]["other_peers_port"] = int(mainnet_port)
+                    config["seeder"]["selected_network"] = net
+                    config["seeder"]["bootstrap_peers"] = bootstrap_peers
+
+                print("Default full node port, introducer and network setting updated")
+                change_made = True
+            else:
+                print("Please choose True or False")
+
+        if peer_connect_timeout:
+            config["full_node"]["peer_connect_timeout"] = int(peer_connect_timeout)
             change_made = True
 
-        elif testnet == "false" or testnet == "f":
-            print("Setting Mainnet")
-            mainnet_port = "8444"
-            mainnet_introducer = "introducer.chia.net"
-            mainnet_dns_introducer = "dns-introducer.chia.net"
-            bootstrap_peers = ["node.chia.net"]
-            net = "mainnet"
-            config["full_node"]["port"] = int(mainnet_port)
-            config["full_node"]["introducer_peer"]["port"] = int(mainnet_port)
-            config["farmer"]["full_node_peer"]["port"] = int(mainnet_port)
-            config["timelord"]["full_node_peer"]["port"] = int(mainnet_port)
-            config["wallet"]["full_node_peer"]["port"] = int(mainnet_port)
-            config["wallet"]["introducer_peer"]["port"] = int(mainnet_port)
-            config["introducer"]["port"] = int(mainnet_port)
-            config["full_node"]["introducer_peer"]["host"] = mainnet_introducer
-            config["full_node"]["dns_servers"] = [mainnet_dns_introducer]
-            config["selected_network"] = net
-            config["harvester"]["selected_network"] = net
-            config["pool"]["selected_network"] = net
-            config["farmer"]["selected_network"] = net
-            config["timelord"]["selected_network"] = net
-            config["full_node"]["selected_network"] = net
-            config["ui"]["selected_network"] = net
-            config["introducer"]["selected_network"] = net
-            config["wallet"]["selected_network"] = net
-
-            if "seeder" in config:
-                config["seeder"]["port"] = int(mainnet_port)
-                config["seeder"]["other_peers_port"] = int(mainnet_port)
-                config["seeder"]["selected_network"] = net
-                config["seeder"]["bootstrap_peers"] = bootstrap_peers
-
-            print("Default full node port, introducer and network setting updated")
+        if crawler_db_path is not None and "seeder" in config:
+            config["seeder"]["crawler_db_path"] = crawler_db_path
             change_made = True
-        else:
-            print("Please choose True or False")
 
-    if peer_connect_timeout:
-        config["full_node"]["peer_connect_timeout"] = int(peer_connect_timeout)
-        change_made = True
+        if crawler_minimum_version_count is not None and "seeder" in config:
+            config["seeder"]["minimum_version_count"] = crawler_minimum_version_count
+            change_made = True
 
-    if crawler_db_path is not None and "seeder" in config:
-        config["seeder"]["crawler_db_path"] = crawler_db_path
-        change_made = True
+        if seeder_domain_name is not None and "seeder" in config:
+            config["seeder"]["domain_name"] = seeder_domain_name
+            change_made = True
 
-    if crawler_minimum_version_count is not None and "seeder" in config:
-        config["seeder"]["minimum_version_count"] = crawler_minimum_version_count
-        change_made = True
+        if seeder_nameserver is not None and "seeder" in config:
+            config["seeder"]["nameserver"] = seeder_nameserver
+            change_made = True
 
-    if seeder_domain_name is not None and "seeder" in config:
-        config["seeder"]["domain_name"] = seeder_domain_name
-        change_made = True
-
-    if seeder_nameserver is not None and "seeder" in config:
-        config["seeder"]["nameserver"] = seeder_nameserver
-        change_made = True
-
-    if change_made:
-        print("Restart any running chia services for changes to take effect")
-        save_config(root_path, "config.yaml", config)
+        if change_made:
+            print("Restart any running chia services for changes to take effect")
+            save_config(root_path, "config.yaml", config)
 
 
 @click.command("configure", short_help="Modify configuration")

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 import click
 
-from chia.util.config import load_config, save_config, str2bool, get_config_lock
+from chia.util.config import get_config_lock, load_config, save_config, str2bool
 from chia.util.default_root import DEFAULT_ROOT_PATH
 
 

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sys
 from time import time
 
-from chia.util.config import load_config, save_config
+from chia.util.config import load_config, save_config, create_config_lock
 from chia.util.path import mkdir, path_from_root
 from chia.util.ints import uint32
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -44,11 +44,12 @@ def db_upgrade_func(
 
     if update_config:
         print("updating config.yaml")
-        config = load_config(root_path, "config.yaml")
-        new_db_path = db_pattern.replace("_v1_", "_v2_")
-        config["full_node"]["database_path"] = new_db_path
-        print(f"database_path: {new_db_path}")
-        save_config(root_path, "config.yaml", config)
+        with create_config_lock(root_path, "config.yaml"):
+            config = load_config(root_path, "config.yaml", acquire_lock=False)
+            new_db_path = db_pattern.replace("_v1_", "_v2_")
+            config["full_node"]["database_path"] = new_db_path
+            print(f"database_path: {new_db_path}")
+            save_config(root_path, "config.yaml", config)
 
     print(f"\n\nLEAVING PREVIOUS DB FILE UNTOUCHED {in_db_path}\n")
 

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sys
 from time import time
 
-from chia.util.config import load_config, save_config, create_config_lock
+from chia.util.config import load_config, save_config, get_config_lock
 from chia.util.path import mkdir, path_from_root
 from chia.util.ints import uint32
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -44,7 +44,7 @@ def db_upgrade_func(
 
     if update_config:
         print("updating config.yaml")
-        with create_config_lock(root_path, "config.yaml"):
+        with get_config_lock(root_path, "config.yaml"):
             config = load_config(root_path, "config.yaml", acquire_lock=False)
             new_db_path = db_pattern.replace("_v1_", "_v2_")
             config["full_node"]["database_path"] = new_db_path

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -21,6 +21,7 @@ from chia.util.config import (
     load_config,
     save_config,
     unflatten_properties,
+    create_config_lock,
 )
 from chia.util.keychain import Keychain
 from chia.util.path import mkdir, path_from_root
@@ -74,88 +75,89 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
         print("No keys are present in the keychain. Generate them with 'chia keys generate'")
         return None
 
-    config: Dict = load_config(new_root, "config.yaml")
-    pool_child_pubkeys = [master_sk_to_pool_sk(sk).get_g1() for sk, _ in all_sks]
-    all_targets = []
-    stop_searching_for_farmer = "xch_target_address" not in config["farmer"]
-    stop_searching_for_pool = "xch_target_address" not in config["pool"]
-    number_of_ph_to_search = 50
-    selected = config["selected_network"]
-    prefix = config["network_overrides"]["config"][selected]["address_prefix"]
+    with create_config_lock(new_root, "config.yaml"):
+        config: Dict = load_config(new_root, "config.yaml", acquire_lock=False)
+        pool_child_pubkeys = [master_sk_to_pool_sk(sk).get_g1() for sk, _ in all_sks]
+        all_targets = []
+        stop_searching_for_farmer = "xch_target_address" not in config["farmer"]
+        stop_searching_for_pool = "xch_target_address" not in config["pool"]
+        number_of_ph_to_search = 50
+        selected = config["selected_network"]
+        prefix = config["network_overrides"]["config"][selected]["address_prefix"]
 
-    intermediates = {}
-    for sk, _ in all_sks:
-        intermediates[bytes(sk)] = {
-            "observer": master_sk_to_wallet_sk_unhardened_intermediate(sk),
-            "non-observer": master_sk_to_wallet_sk_intermediate(sk),
-        }
-
-    for i in range(number_of_ph_to_search):
-        if stop_searching_for_farmer and stop_searching_for_pool and i > 0:
-            break
+        intermediates = {}
         for sk, _ in all_sks:
-            intermediate_n = intermediates[bytes(sk)]["non-observer"]
-            intermediate_o = intermediates[bytes(sk)]["observer"]
+            intermediates[bytes(sk)] = {
+                "observer": master_sk_to_wallet_sk_unhardened_intermediate(sk),
+                "non-observer": master_sk_to_wallet_sk_intermediate(sk),
+            }
 
-            all_targets.append(
-                encode_puzzle_hash(
-                    create_puzzlehash_for_pk(_derive_path_unhardened(intermediate_o, [i]).get_g1()), prefix
+        for i in range(number_of_ph_to_search):
+            if stop_searching_for_farmer and stop_searching_for_pool and i > 0:
+                break
+            for sk, _ in all_sks:
+                intermediate_n = intermediates[bytes(sk)]["non-observer"]
+                intermediate_o = intermediates[bytes(sk)]["observer"]
+
+                all_targets.append(
+                    encode_puzzle_hash(
+                        create_puzzlehash_for_pk(_derive_path_unhardened(intermediate_o, [i]).get_g1()), prefix
+                    )
                 )
+                all_targets.append(
+                    encode_puzzle_hash(create_puzzlehash_for_pk(_derive_path(intermediate_n, [i]).get_g1()), prefix)
+                )
+                if all_targets[-1] == config["farmer"].get("xch_target_address") or all_targets[-2] == config[
+                    "farmer"
+                ].get("xch_target_address"):
+                    stop_searching_for_farmer = True
+                if all_targets[-1] == config["pool"].get("xch_target_address") or all_targets[-2] == config["pool"].get(
+                    "xch_target_address"
+                ):
+                    stop_searching_for_pool = True
+
+        # Set the destinations, if necessary
+        updated_target: bool = False
+        if "xch_target_address" not in config["farmer"]:
+            print(
+                f"Setting the xch destination for the farmer reward (1/8 plus fees, solo and pooling) to {all_targets[0]}"
             )
-            all_targets.append(
-                encode_puzzle_hash(create_puzzlehash_for_pk(_derive_path(intermediate_n, [i]).get_g1()), prefix)
+            config["farmer"]["xch_target_address"] = all_targets[0]
+            updated_target = True
+        elif config["farmer"]["xch_target_address"] not in all_targets:
+            print(
+                f"WARNING: using a farmer address which we might not have the private"
+                f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
+                f"{config['farmer']['xch_target_address']} with {all_targets[0]}"
             )
-            if all_targets[-1] == config["farmer"].get("xch_target_address") or all_targets[-2] == config["farmer"].get(
-                "xch_target_address"
-            ):
-                stop_searching_for_farmer = True
-            if all_targets[-1] == config["pool"].get("xch_target_address") or all_targets[-2] == config["pool"].get(
-                "xch_target_address"
-            ):
-                stop_searching_for_pool = True
 
-    # Set the destinations, if necessary
-    updated_target: bool = False
-    if "xch_target_address" not in config["farmer"]:
-        print(
-            f"Setting the xch destination for the farmer reward (1/8 plus fees, solo and pooling) to {all_targets[0]}"
-        )
-        config["farmer"]["xch_target_address"] = all_targets[0]
-        updated_target = True
-    elif config["farmer"]["xch_target_address"] not in all_targets:
-        print(
-            f"WARNING: using a farmer address which we might not have the private"
-            f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
-            f"{config['farmer']['xch_target_address']} with {all_targets[0]}"
-        )
+        if "pool" not in config:
+            config["pool"] = {}
+        if "xch_target_address" not in config["pool"]:
+            print(f"Setting the xch destination address for pool reward (7/8 for solo only) to {all_targets[0]}")
+            config["pool"]["xch_target_address"] = all_targets[0]
+            updated_target = True
+        elif config["pool"]["xch_target_address"] not in all_targets:
+            print(
+                f"WARNING: using a pool address which we might not have the private"
+                f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
+                f"{config['pool']['xch_target_address']} with {all_targets[0]}"
+            )
+        if updated_target:
+            print(
+                f"To change the XCH destination addresses, edit the `xch_target_address` entries in"
+                f" {(new_root / 'config' / 'config.yaml').absolute()}."
+            )
 
-    if "pool" not in config:
-        config["pool"] = {}
-    if "xch_target_address" not in config["pool"]:
-        print(f"Setting the xch destination address for pool reward (7/8 for solo only) to {all_targets[0]}")
-        config["pool"]["xch_target_address"] = all_targets[0]
-        updated_target = True
-    elif config["pool"]["xch_target_address"] not in all_targets:
-        print(
-            f"WARNING: using a pool address which we might not have the private"
-            f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
-            f"{config['pool']['xch_target_address']} with {all_targets[0]}"
-        )
-    if updated_target:
-        print(
-            f"To change the XCH destination addresses, edit the `xch_target_address` entries in"
-            f" {(new_root / 'config' / 'config.yaml').absolute()}."
-        )
+        # Set the pool pks in the farmer
+        pool_pubkeys_hex = set(bytes(pk).hex() for pk in pool_child_pubkeys)
+        if "pool_public_keys" in config["farmer"]:
+            for pk_hex in config["farmer"]["pool_public_keys"]:
+                # Add original ones in config
+                pool_pubkeys_hex.add(pk_hex)
 
-    # Set the pool pks in the farmer
-    pool_pubkeys_hex = set(bytes(pk).hex() for pk in pool_child_pubkeys)
-    if "pool_public_keys" in config["farmer"]:
-        for pk_hex in config["farmer"]["pool_public_keys"]:
-            # Add original ones in config
-            pool_pubkeys_hex.add(pk_hex)
-
-    config["farmer"]["pool_public_keys"] = pool_pubkeys_hex
-    save_config(new_root, "config.yaml", config)
+        config["farmer"]["pool_public_keys"] = pool_pubkeys_hex
+        save_config(new_root, "config.yaml", config)
 
 
 def copy_files_rec(old_path: Path, new_path: Path):
@@ -193,17 +195,19 @@ def migrate_from(
         copy_files_rec(old_path, new_path)
 
     # update config yaml with new keys
-    config: Dict = load_config(new_root, "config.yaml")
-    config_str: str = initial_config_file("config.yaml")
-    default_config: Dict = yaml.safe_load(config_str)
-    flattened_keys = unflatten_properties({k: "" for k in do_not_migrate_settings})
-    dict_add_new_default(config, default_config, flattened_keys)
 
-    save_config(new_root, "config.yaml", config)
+    with create_config_lock(new_root, "config.yaml"):
+        config: Dict = load_config(new_root, "config.yaml", acquire_lock=False)
+        config_str: str = initial_config_file("config.yaml")
+        default_config: Dict = yaml.safe_load(config_str)
+        flattened_keys = unflatten_properties({k: "" for k in do_not_migrate_settings})
+        dict_add_new_default(config, default_config, flattened_keys)
 
-    create_all_ssl(new_root)
+        save_config(new_root, "config.yaml", config)
 
-    return 1
+        create_all_ssl(new_root)
+
+        return 1
 
 
 def create_all_ssl(root_path: Path):
@@ -457,23 +461,25 @@ def chia_init(
         check_keys(root_path)
 
     config: Dict
-    if v1_db:
-        config = load_config(root_path, "config.yaml")
-        db_pattern = config["full_node"]["database_path"]
-        new_db_path = db_pattern.replace("_v2_", "_v1_")
-        config["full_node"]["database_path"] = new_db_path
-        save_config(root_path, "config.yaml", config)
-    else:
-        config = load_config(root_path, "config.yaml")["full_node"]
-        db_path_replaced: str = config["database_path"].replace("CHALLENGE", config["selected_network"])
-        db_path = path_from_root(root_path, db_path_replaced)
-        mkdir(db_path.parent)
-        import sqlite3
 
-        with sqlite3.connect(db_path) as connection:
-            connection.execute("CREATE TABLE database_version(version int)")
-            connection.execute("INSERT INTO database_version VALUES (2)")
-            connection.commit()
+    with create_config_lock(root_path, "config.yaml"):
+        if v1_db:
+            config = load_config(root_path, "config.yaml", acquire_lock=False)
+            db_pattern = config["full_node"]["database_path"]
+            new_db_path = db_pattern.replace("_v2_", "_v1_")
+            config["full_node"]["database_path"] = new_db_path
+            save_config(root_path, "config.yaml", config)
+        else:
+            config = load_config(root_path, "config.yaml", acquire_lock=False)["full_node"]
+            db_path_replaced: str = config["database_path"].replace("CHALLENGE", config["selected_network"])
+            db_path = path_from_root(root_path, db_path_replaced)
+            mkdir(db_path.parent)
+            import sqlite3
+
+            with sqlite3.connect(db_path) as connection:
+                connection.execute("CREATE TABLE database_version(version int)")
+                connection.execute("INSERT INTO database_version VALUES (2)")
+                connection.commit()
 
     print("")
     print("To see your keys, run 'chia keys show --show-mnemonic-seed'")

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -21,7 +21,7 @@ from chia.util.config import (
     load_config,
     save_config,
     unflatten_properties,
-    create_config_lock,
+    get_config_lock,
 )
 from chia.util.keychain import Keychain
 from chia.util.path import mkdir, path_from_root
@@ -75,7 +75,7 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
         print("No keys are present in the keychain. Generate them with 'chia keys generate'")
         return None
 
-    with create_config_lock(new_root, "config.yaml"):
+    with get_config_lock(new_root, "config.yaml"):
         config: Dict = load_config(new_root, "config.yaml", acquire_lock=False)
         pool_child_pubkeys = [master_sk_to_pool_sk(sk).get_g1() for sk, _ in all_sks]
         all_targets = []
@@ -120,7 +120,8 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
         updated_target: bool = False
         if "xch_target_address" not in config["farmer"]:
             print(
-                f"Setting the xch destination for the farmer reward (1/8 plus fees, solo and pooling) to {all_targets[0]}"
+                f"Setting the xch destination for the farmer reward (1/8 plus fees, solo and pooling)"
+                f" to {all_targets[0]}"
             )
             config["farmer"]["xch_target_address"] = all_targets[0]
             updated_target = True
@@ -196,7 +197,7 @@ def migrate_from(
 
     # update config yaml with new keys
 
-    with create_config_lock(new_root, "config.yaml"):
+    with get_config_lock(new_root, "config.yaml"):
         config: Dict = load_config(new_root, "config.yaml", acquire_lock=False)
         config_str: str = initial_config_file("config.yaml")
         default_config: Dict = yaml.safe_load(config_str)
@@ -462,7 +463,7 @@ def chia_init(
 
     config: Dict
 
-    with create_config_lock(root_path, "config.yaml"):
+    with get_config_lock(root_path, "config.yaml"):
         if v1_db:
             config = load_config(root_path, "config.yaml", acquire_lock=False)
             db_pattern = config["full_node"]["database_path"]

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -40,7 +40,7 @@ from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import decode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import load_config, save_config, config_path_for_filename
+from chia.util.config import load_config, save_config, config_path_for_filename, create_config_lock
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.util.keychain import Keychain
@@ -581,34 +581,36 @@ class Farmer:
         }
 
     def set_reward_targets(self, farmer_target_encoded: Optional[str], pool_target_encoded: Optional[str]):
-        config = load_config(self._root_path, "config.yaml")
-        if farmer_target_encoded is not None:
-            self.farmer_target_encoded = farmer_target_encoded
-            self.farmer_target = decode_puzzle_hash(farmer_target_encoded)
-            config["farmer"]["xch_target_address"] = farmer_target_encoded
-        if pool_target_encoded is not None:
-            self.pool_target_encoded = pool_target_encoded
-            self.pool_target = decode_puzzle_hash(pool_target_encoded)
-            config["pool"]["xch_target_address"] = pool_target_encoded
-        save_config(self._root_path, "config.yaml", config)
+        with create_config_lock(self._root_path, "config.yaml"):
+            config = load_config(self._root_path, "config.yaml", acquire_lock=False)
+            if farmer_target_encoded is not None:
+                self.farmer_target_encoded = farmer_target_encoded
+                self.farmer_target = decode_puzzle_hash(farmer_target_encoded)
+                config["farmer"]["xch_target_address"] = farmer_target_encoded
+            if pool_target_encoded is not None:
+                self.pool_target_encoded = pool_target_encoded
+                self.pool_target = decode_puzzle_hash(pool_target_encoded)
+                config["pool"]["xch_target_address"] = pool_target_encoded
+            save_config(self._root_path, "config.yaml", config)
 
     async def set_payout_instructions(self, launcher_id: bytes32, payout_instructions: str):
         for p2_singleton_puzzle_hash, pool_state_dict in self.pool_state.items():
             if launcher_id == pool_state_dict["pool_config"].launcher_id:
-                config = load_config(self._root_path, "config.yaml")
-                new_list = []
-                pool_list = config["pool"].get("pool_list", [])
-                if pool_list is not None:
-                    for list_element in pool_list:
-                        if hexstr_to_bytes(list_element["launcher_id"]) == bytes(launcher_id):
-                            list_element["payout_instructions"] = payout_instructions
-                        new_list.append(list_element)
+                with create_config_lock(self._root_path, "config.yaml"):
+                    config = load_config(self._root_path, "config.yaml", acquire_lock=False)
+                    new_list = []
+                    pool_list = config["pool"].get("pool_list", [])
+                    if pool_list is not None:
+                        for list_element in pool_list:
+                            if hexstr_to_bytes(list_element["launcher_id"]) == bytes(launcher_id):
+                                list_element["payout_instructions"] = payout_instructions
+                            new_list.append(list_element)
 
-                config["pool"]["pool_list"] = new_list
-                save_config(self._root_path, "config.yaml", config)
-                # Force a GET /farmer which triggers the PUT /farmer if it detects the changed instructions
-                pool_state_dict["next_farmer_update"] = 0
-                return
+                    config["pool"]["pool_list"] = new_list
+                    save_config(self._root_path, "config.yaml", config)
+                    # Force a GET /farmer which triggers the PUT /farmer if it detects the changed instructions
+                    pool_state_dict["next_farmer_update"] = 0
+                    return
 
         self.log.warning(f"Launcher id: {launcher_id} not found")
 

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -40,7 +40,7 @@ from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import decode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import load_config, save_config, config_path_for_filename, create_config_lock
+from chia.util.config import load_config, save_config, config_path_for_filename, get_config_lock
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.util.keychain import Keychain
@@ -581,7 +581,7 @@ class Farmer:
         }
 
     def set_reward_targets(self, farmer_target_encoded: Optional[str], pool_target_encoded: Optional[str]):
-        with create_config_lock(self._root_path, "config.yaml"):
+        with get_config_lock(self._root_path, "config.yaml"):
             config = load_config(self._root_path, "config.yaml", acquire_lock=False)
             if farmer_target_encoded is not None:
                 self.farmer_target_encoded = farmer_target_encoded
@@ -596,7 +596,7 @@ class Farmer:
     async def set_payout_instructions(self, launcher_id: bytes32, payout_instructions: str):
         for p2_singleton_puzzle_hash, pool_state_dict in self.pool_state.items():
             if launcher_id == pool_state_dict["pool_config"].launcher_id:
-                with create_config_lock(self._root_path, "config.yaml"):
+                with get_config_lock(self._root_path, "config.yaml"):
                     config = load_config(self._root_path, "config.yaml", acquire_lock=False)
                     new_list = []
                     pool_list = config["pool"].get("pool_list", [])

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -9,7 +9,7 @@ from blspy import G1Element, PrivateKey
 from chiapos import DiskProver
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.config import load_config, save_config, create_config_lock
+from chia.util.config import load_config, save_config, get_config_lock
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def get_plot_filenames(root_path: Path) -> Dict[Path, List[Path]]:
 
 def add_plot_directory(root_path: Path, str_path: str) -> Dict:
     log.debug(f"add_plot_directory {str_path}")
-    with create_config_lock(root_path, "config.yaml"):
+    with get_config_lock(root_path, "config.yaml"):
         config = load_config(root_path, "config.yaml", acquire_lock=False)
         if str(Path(str_path).resolve()) not in get_plot_directories(root_path, config):
             config["harvester"]["plot_directories"].append(str(Path(str_path).resolve()))
@@ -89,7 +89,7 @@ def add_plot_directory(root_path: Path, str_path: str) -> Dict:
 
 def remove_plot_directory(root_path: Path, str_path: str) -> None:
     log.debug(f"remove_plot_directory {str_path}")
-    with create_config_lock(root_path, "config.yaml"):
+    with get_config_lock(root_path, "config.yaml"):
         config = load_config(root_path, "config.yaml", acquire_lock=False)
         str_paths: List[str] = get_plot_directories(root_path, config)
         # If path str matches exactly, remove

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -9,7 +9,7 @@ from blspy import G1Element, PrivateKey
 from chiapos import DiskProver
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.config import load_config, save_config
+from chia.util.config import load_config, save_config, create_config_lock
 
 log = logging.getLogger(__name__)
 
@@ -79,28 +79,30 @@ def get_plot_filenames(root_path: Path) -> Dict[Path, List[Path]]:
 
 def add_plot_directory(root_path: Path, str_path: str) -> Dict:
     log.debug(f"add_plot_directory {str_path}")
-    config = load_config(root_path, "config.yaml")
-    if str(Path(str_path).resolve()) not in get_plot_directories(root_path, config):
-        config["harvester"]["plot_directories"].append(str(Path(str_path).resolve()))
-    save_config(root_path, "config.yaml", config)
-    return config
+    with create_config_lock(root_path, "config.yaml"):
+        config = load_config(root_path, "config.yaml", acquire_lock=False)
+        if str(Path(str_path).resolve()) not in get_plot_directories(root_path, config):
+            config["harvester"]["plot_directories"].append(str(Path(str_path).resolve()))
+        save_config(root_path, "config.yaml", config)
+        return config
 
 
 def remove_plot_directory(root_path: Path, str_path: str) -> None:
     log.debug(f"remove_plot_directory {str_path}")
-    config = load_config(root_path, "config.yaml")
-    str_paths: List[str] = get_plot_directories(root_path, config)
-    # If path str matches exactly, remove
-    if str_path in str_paths:
-        str_paths.remove(str_path)
+    with create_config_lock(root_path, "config.yaml"):
+        config = load_config(root_path, "config.yaml", acquire_lock=False)
+        str_paths: List[str] = get_plot_directories(root_path, config)
+        # If path str matches exactly, remove
+        if str_path in str_paths:
+            str_paths.remove(str_path)
 
-    # If path matches full path, remove
-    new_paths = [Path(sp).resolve() for sp in str_paths]
-    if Path(str_path).resolve() in new_paths:
-        new_paths.remove(Path(str_path).resolve())
+        # If path matches full path, remove
+        new_paths = [Path(sp).resolve() for sp in str_paths]
+        if Path(str_path).resolve() in new_paths:
+            new_paths.remove(Path(str_path).resolve())
 
-    config["harvester"]["plot_directories"] = [str(np) for np in new_paths]
-    save_config(root_path, "config.yaml", config)
+        config["harvester"]["plot_directories"] = [str(np) for np in new_paths]
+        save_config(root_path, "config.yaml", config)
 
 
 def remove_plot(path: Path):

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -7,7 +7,7 @@ from blspy import G1Element
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import load_config, save_config, get_config_lock
+from chia.util.config import get_config_lock, load_config, save_config
 from chia.util.streamable import Streamable, streamable
 
 """

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -7,7 +7,7 @@ from blspy import G1Element
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import load_config, save_config, create_config_lock
+from chia.util.config import load_config, save_config, get_config_lock
 from chia.util.streamable import Streamable, streamable
 
 """
@@ -61,7 +61,7 @@ def load_pool_config(root_path: Path) -> List[PoolWalletConfig]:
 # TODO: remove this a few versions after 1.3, since authentication_public_key is deprecated. This is here to support
 # downgrading to versions older than 1.3.
 def add_auth_key(root_path: Path, config_entry: PoolWalletConfig, auth_key: G1Element):
-    with create_config_lock(root_path, "config.yaml"):
+    with get_config_lock(root_path, "config.yaml"):
         config = load_config(root_path, "config.yaml", acquire_lock=False)
         pool_list = config["pool"].get("pool_list", [])
         updated = False
@@ -82,7 +82,7 @@ def add_auth_key(root_path: Path, config_entry: PoolWalletConfig, auth_key: G1El
 
 
 async def update_pool_config(root_path: Path, pool_config_list: List[PoolWalletConfig]):
-    with create_config_lock(root_path, "config.yaml"):
+    with get_config_lock(root_path, "config.yaml"):
         full_config = load_config(root_path, "config.yaml", acquire_lock=False)
         full_config["pool"]["pool_list"] = [c.to_json_dict() for c in pool_config_list]
         save_config(root_path, "config.yaml", full_config)

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -67,10 +67,7 @@ def add_auth_key(root_path: Path, config_entry: PoolWalletConfig, auth_key: G1El
     if pool_list is not None:
         for pool_config_dict in pool_list:
             try:
-                if (
-                    G1Element.from_bytes(hexstr_to_bytes(pool_config_dict["owner_public_key"]))
-                    == config_entry.owner_public_key
-                ):
+                if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(config_entry.owner_public_key):
                     auth_key_hex = bytes(auth_key).hex()
                     if pool_config_dict.get("authentication_public_key", "") != auth_key_hex:
                         pool_config_dict["authentication_public_key"] = auth_key_hex
@@ -78,6 +75,7 @@ def add_auth_key(root_path: Path, config_entry: PoolWalletConfig, auth_key: G1El
             except Exception as e:
                 log.error(f"Exception updating config: {pool_config_dict} {e}")
     if updated:
+        log.info(f"Updating pool config for auth key: {auth_key}")
         config["pool"]["pool_list"] = pool_list
         save_config(root_path, "config.yaml", config)
 

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -7,7 +7,7 @@ from blspy import G1Element
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import load_config, save_config
+from chia.util.config import load_config, save_config, create_config_lock
 from chia.util.streamable import Streamable, streamable
 
 """
@@ -61,26 +61,28 @@ def load_pool_config(root_path: Path) -> List[PoolWalletConfig]:
 # TODO: remove this a few versions after 1.3, since authentication_public_key is deprecated. This is here to support
 # downgrading to versions older than 1.3.
 def add_auth_key(root_path: Path, config_entry: PoolWalletConfig, auth_key: G1Element):
-    config = load_config(root_path, "config.yaml")
-    pool_list = config["pool"].get("pool_list", [])
-    updated = False
-    if pool_list is not None:
-        for pool_config_dict in pool_list:
-            try:
-                if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(config_entry.owner_public_key):
-                    auth_key_hex = bytes(auth_key).hex()
-                    if pool_config_dict.get("authentication_public_key", "") != auth_key_hex:
-                        pool_config_dict["authentication_public_key"] = auth_key_hex
-                        updated = True
-            except Exception as e:
-                log.error(f"Exception updating config: {pool_config_dict} {e}")
-    if updated:
-        log.info(f"Updating pool config for auth key: {auth_key}")
-        config["pool"]["pool_list"] = pool_list
-        save_config(root_path, "config.yaml", config)
+    with create_config_lock(root_path, "config.yaml"):
+        config = load_config(root_path, "config.yaml", acquire_lock=False)
+        pool_list = config["pool"].get("pool_list", [])
+        updated = False
+        if pool_list is not None:
+            for pool_config_dict in pool_list:
+                try:
+                    if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(config_entry.owner_public_key):
+                        auth_key_hex = bytes(auth_key).hex()
+                        if pool_config_dict.get("authentication_public_key", "") != auth_key_hex:
+                            pool_config_dict["authentication_public_key"] = auth_key_hex
+                            updated = True
+                except Exception as e:
+                    log.error(f"Exception updating config: {pool_config_dict} {e}")
+        if updated:
+            log.info(f"Updating pool config for auth key: {auth_key}")
+            config["pool"]["pool_list"] = pool_list
+            save_config(root_path, "config.yaml", config)
 
 
 async def update_pool_config(root_path: Path, pool_config_list: List[PoolWalletConfig]):
-    full_config = load_config(root_path, "config.yaml")
-    full_config["pool"]["pool_list"] = [c.to_json_dict() for c in pool_config_list]
-    save_config(root_path, "config.yaml", full_config)
+    with create_config_lock(root_path, "config.yaml"):
+        full_config = load_config(root_path, "config.yaml", acquire_lock=False)
+        full_config["pool"]["pool_list"] = [c.to_json_dict() for c in pool_config_list]
+        save_config(root_path, "config.yaml", full_config)

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -51,7 +51,7 @@ def get_config_lock(root_path: Path, filename: Union[str, Path]) -> BaseFileLock
     lock_path: Path = config_path_for_filename(root_path, filename).with_suffix(".lock")
     if not lock_path.exists():
         lock_path.touch(exist_ok=True)
-    return FileLock(str(lock_path.absolute()))
+    return FileLock(lock_path)  # type: ignore[arg-type]
 
 
 def save_config(root_path: Path, filename: Union[str, Path], config_data: Any):

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -49,7 +49,7 @@ def config_path_for_filename(root_path: Path, filename: Union[str, Path]) -> Pat
 def save_config(root_path: Path, filename: Union[str, Path], config_data: Any):
     path: Path = config_path_for_filename(root_path, filename)
     with tempfile.TemporaryDirectory(dir=path.parent) as tmp_dir:
-        tmp_path: Path = Path(tmp_dir) / (filename + str(os.getpid()))
+        tmp_path: Path = Path(tmp_dir) / (Path(filename).with_suffix("." + str(os.getpid())))
         with open(tmp_path, "w") as f:
             yaml.safe_dump(config_data, f)
         try:

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -51,7 +51,7 @@ def get_config_lock(root_path: Path, filename: Union[str, Path]) -> BaseFileLock
     lock_path: Path = config_path_for_filename(root_path, filename).with_suffix(".lock")
     if not lock_path.exists():
         lock_path.touch(exist_ok=True)
-    return FileLock(lock_path)  # type: ignore[arg-type]
+    return FileLock(lock_path)
 
 
 def save_config(root_path: Path, filename: Union[str, Path], config_data: Any):

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -75,7 +75,6 @@ def load_config(
     acquire_lock: bool = True,
 ) -> Dict:
     # This must be called under an acquired config lock, or acquire_lock should be True
-    # This is a re-entrant lock, so it does not work with multiple threads
 
     path = config_path_for_filename(root_path, filename)
 

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -14,7 +14,7 @@ import yaml
 from typing_extensions import Literal
 
 from chia.util.path import mkdir
-from filelock import Timeout, FileLock
+from filelock import FileLock
 
 PEER_DB_PATH_KEY_DEPRECATED = "peer_db_path"  # replaced by "peers_file_path"
 WALLET_PEERS_PATH_KEY_DEPRECATED = "wallet_peers_path"  # replaced by "wallet_peers_file_path"

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -14,7 +14,7 @@ import yaml
 from typing_extensions import Literal
 
 from chia.util.path import mkdir
-from filelock import FileLock
+from fasteners import InterProcessLock
 
 PEER_DB_PATH_KEY_DEPRECATED = "peer_db_path"  # replaced by "peers_file_path"
 WALLET_PEERS_PATH_KEY_DEPRECATED = "wallet_peers_path"  # replaced by "wallet_peers_file_path"
@@ -49,7 +49,7 @@ def config_path_for_filename(root_path: Path, filename: Union[str, Path]) -> Pat
 
 def save_config(root_path: Path, filename: Union[str, Path], config_data: Any):
     path: Path = config_path_for_filename(root_path, filename)
-    with FileLock(path.with_suffix(".lock")):
+    with InterProcessLock(path.with_suffix(".lock")):
         with tempfile.TemporaryDirectory(dir=path.parent) as tmp_dir:
             tmp_path: Path = Path(tmp_dir) / Path(filename)
             with open(tmp_path, "w") as f:
@@ -67,7 +67,7 @@ def load_config(
     exit_on_error=True,
 ) -> Dict:
     path = config_path_for_filename(root_path, filename)
-    with FileLock(path.with_suffix(".lock")):
+    with InterProcessLock(path.with_suffix(".lock")):
         if not path.is_file():
             if not exit_on_error:
                 raise ValueError("Config not found")

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import pkg_resources
 import yaml
-from filelock import FileLock, BaseFileLock
+from filelock import BaseFileLock, FileLock
 from typing_extensions import Literal
 
 from chia.util.path import mkdir

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -51,7 +51,7 @@ def get_config_lock(root_path: Path, filename: Union[str, Path]) -> BaseFileLock
     lock_path: Path = config_path_for_filename(root_path, filename).with_suffix(".lock")
     if not lock_path.exists():
         lock_path.touch(exist_ok=True)
-    return FileLock(lock_path)
+    return FileLock(str(lock_path.absolute()))
 
 
 def save_config(root_path: Path, filename: Union[str, Path], config_data: Any):

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -41,7 +41,7 @@ async def fetch_last_tx_from_peer(height: uint32, peer: WSChiaConnection) -> Opt
         if response is not None and isinstance(response, RespondBlockHeader):
             if response.header_block.is_transaction_block:
                 return response.header_block
-        elif request_height < height:
+        else:
             break
         request_height = request_height - 1
     return None

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -41,7 +41,7 @@ async def fetch_last_tx_from_peer(height: uint32, peer: WSChiaConnection) -> Opt
         if response is not None and isinstance(response, RespondBlockHeader):
             if response.header_block.is_transaction_block:
                 return response.header_block
-        else:
+        elif request_height < height:
             break
         request_height = request_height - 1
     return None

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ dependencies = [
     "colorlog==5.0.1",  # Adds color to logs
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
     "cryptography==3.4.7",  # Python cryptography library for TLS - keyring conflict
-    "fasteners==0.16.3",  # For interprocess file locking
     "filelock==3.4.2",  # For reading and writing config multiprocess and multithread safely  (non-reentrant locks)
     "keyring==23.0.1",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ dependencies = [
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
     "cryptography==3.4.7",  # Python cryptography library for TLS - keyring conflict
     "fasteners==0.16.3",  # For interprocess file locking
-    "filelock==3.4.2",  # For reading and writing config multiprocess safely
     "keyring==23.0.1",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)
     #  "keyrings.cryptfile==1.3.8",  # Secure storage for keys on Linux (Will be replaced)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ dependencies = [
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
     "cryptography==3.4.7",  # Python cryptography library for TLS - keyring conflict
     "fasteners==0.16.3",  # For interprocess file locking
+    "filelock==3.4.2",  # For reading and writing config multiprocess safely
     "keyring==23.0.1",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)
     #  "keyrings.cryptfile==1.3.8",  # Secure storage for keys on Linux (Will be replaced)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ dev_dependencies = [
     "types-aiofiles",
     "types-click",
     "types-cryptography",
-    "types-filelock",
     "types-pkg_resources",
     "types-pyyaml",
     "types-setuptools",

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ dev_dependencies = [
     "types-aiofiles",
     "types-click",
     "types-cryptography",
+    "types-filelock",
     "types-pkg_resources",
     "types-pyyaml",
     "types-setuptools",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ dependencies = [
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
     "cryptography==3.4.7",  # Python cryptography library for TLS - keyring conflict
     "fasteners==0.16.3",  # For interprocess file locking
+    "filelock==3.4.2",  # For reading and writing config multiprocess and multithread safely  (non-reentrant locks)
     "keyring==23.0.1",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)
     #  "keyrings.cryptfile==1.3.8",  # Secure storage for keys on Linux (Will be replaced)

--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -117,7 +117,7 @@ class TestKeysCommands:
 
         # Generate the new config
         runner = CliRunner()
-        init_result: Result = runner.invoke(cli, ["--root-path", os.fspath(tmp_path), "init"])
+        init_result: Result = runner.invoke(cli, ["--root-path", os.fspath(tmp_path), "init"], catch_exceptions=False)
 
         assert init_result.exit_code == 0
 

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -7,7 +7,6 @@ from concurrent.futures import ProcessPoolExecutor
 import pytest
 import random
 import yaml
-from fasteners import InterProcessLock
 
 from chia.util.config import (
     create_default_chia_config,
@@ -15,7 +14,7 @@ from chia.util.config import (
     load_config,
     save_config,
     config_path_for_filename,
-    create_config_lock,
+    get_config_lock,
 )
 from chia.util.path import mkdir
 from multiprocessing import Pool, TimeoutError
@@ -52,7 +51,7 @@ def write_config(root_path: Path, config: Dict, atomic_write: bool, do_sleep: bo
             save_config(root_path=root_path, filename="config.yaml", config_data=config)
         else:
             path: Path = config_path_for_filename(root_path, filename="config.yaml")
-            with create_config_lock(root_path, "config.yaml"):
+            with get_config_lock(root_path, "config.yaml"):
                 with tempfile.TemporaryDirectory(dir=path.parent) as tmp_dir:
                     tmp_path: Path = Path(tmp_dir) / Path("config.yaml")
                     with open(tmp_path, "w") as f:
@@ -76,7 +75,7 @@ def read_and_compare_config(root_path: Path, default_config: Dict, do_sleep: boo
             sleep(random.random())
         # log.warning(f"[pid:{os.getpid()}:{threading.get_ident()}] read_and_compare_config")
 
-        with create_config_lock(root_path, "config.yaml"):
+        with get_config_lock(root_path, "config.yaml"):
             config: Dict = load_config(root_path=root_path, filename="config.yaml")
             assert len(config) > 0
             # if config != default_config:

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -7,7 +7,7 @@ from concurrent.futures import ProcessPoolExecutor
 import pytest
 import random
 import yaml
-from filelock import FileLock
+from fasteners import InterProcessLock
 
 from chia.util.config import (
     create_default_chia_config,
@@ -51,7 +51,7 @@ def write_config(root_path: Path, config: Dict, atomic_write: bool, do_sleep: bo
             save_config(root_path=root_path, filename="config.yaml", config_data=config)
         else:
             path: Path = config_path_for_filename(root_path, filename="config.yaml")
-            with FileLock(path.with_suffix(".lock")):
+            with InterProcessLock(path.with_suffix(".lock")):
                 with tempfile.TemporaryDirectory(dir=path.parent) as tmp_dir:
                     tmp_path: Path = Path(tmp_dir) / Path("config.yaml")
                     with open(tmp_path, "w") as f:

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -21,7 +21,7 @@ from multiprocessing import Pool, TimeoutError
 from pathlib import Path
 from threading import Thread
 from time import sleep
-from typing import Dict, List
+from typing import Dict
 
 
 # Commented-out lines are preserved to aide in debugging the multiprocessing tests

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -56,9 +56,7 @@ def write_config(root_path: Path, config: Dict, atomic_write: bool, do_sleep: bo
                     tmp_path: Path = Path(tmp_dir) / Path("config.yaml")
                     with open(tmp_path, "w") as f:
                         yaml.safe_dump(config, f)
-                    print("started copy")
                     shutil.copy2(str(tmp_path), str(path))
-                    print("ended copy")
 
 
 def read_and_compare_config(root_path: Path, default_config: Dict, do_sleep: bool, iterations: int):

--- a/tests/core/util/test_file_keyring_synchronization.py
+++ b/tests/core/util/test_file_keyring_synchronization.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import pytest
-from filelock import FileLock, Timeout
+from filelock import BaseFileLock, FileLock, Timeout
 
 from chia.util.file_keyring import acquire_writer_lock, FileKeyring, FileKeyringLockTimeout
 from chia.util.keyring_wrapper import KeyringWrapper
@@ -147,7 +147,7 @@ def poll_directory(dir: Path, expected_entries: int, max_attempts: int, interval
     return found_all
 
 
-def create_dir_and_lock(lock_path: Path) -> FileLock:
+def create_dir_and_lock(lock_path: Path) -> BaseFileLock:
     lock = FileLock(str(lock_path))
     if not lock_path.exists():
         lock_path.parent.mkdir(exist_ok=True)

--- a/tests/core/util/test_file_keyring_synchronization.py
+++ b/tests/core/util/test_file_keyring_synchronization.py
@@ -1,7 +1,7 @@
-import fasteners
 import logging
 import os
 import pytest
+from filelock import FileLock
 
 from chia.util.file_keyring import acquire_writer_lock, FileKeyring, FileKeyringLockTimeout
 from chia.util.keyring_wrapper import KeyringWrapper
@@ -215,44 +215,42 @@ class TestFileKeyringSynchronization:
         the same lock, failing after n attempts
         """
         lock_path = FileKeyring.lockfile_path_for_file_path(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        lock = fasteners.InterProcessReaderWriterLock(str(lock_path))
+        if not lock_path.exists():
+            lock_path.touch(exist_ok=True)
 
         # When: a writer lock is already acquired
-        lock.acquire_write_lock()
+        with FileLock(str(lock_path)):
+            child_proc_fn = dummy_fn_requiring_writer_lock
+            timeout = 0.25
+            attempts = 4
+            num_workers = 1
 
-        child_proc_fn = dummy_fn_requiring_writer_lock
-        timeout = 0.25
-        attempts = 4
-        num_workers = 1
+            with Pool(processes=num_workers) as pool:
+                # When: a child process attempts to acquire the same writer lock, failing after 1 second
+                res = pool.starmap_async(
+                    child_writer_dispatch_with_readiness_check,
+                    [(child_proc_fn, lock_path, timeout, attempts, ready_dir, finished_dir)],
+                )
 
-        with Pool(processes=num_workers) as pool:
-            # When: a child process attempts to acquire the same writer lock, failing after 1 second
-            res = pool.starmap_async(
-                child_writer_dispatch_with_readiness_check,
-                [(child_proc_fn, lock_path, timeout, attempts, ready_dir, finished_dir)],
-            )
+                # Wait up to 30 seconds for all processes to indicate readiness
+                assert poll_directory(ready_dir, num_workers, 30) is True
 
-            # Wait up to 30 seconds for all processes to indicate readiness
-            assert poll_directory(ready_dir, num_workers, 30) is True
+                log.warning(f"Test setup complete: {num_workers} workers ready")
 
-            log.warning(f"Test setup complete: {num_workers} workers ready")
+                # Signal that testing should begin
+                start_file_path: Path = ready_dir / "start"
+                with open(start_file_path, "w") as f:
+                    f.write(f"{os.getpid()}\n")
 
-            # Signal that testing should begin
-            start_file_path: Path = ready_dir / "start"
-            with open(start_file_path, "w") as f:
-                f.write(f"{os.getpid()}\n")
+                # Wait up to 30 seconds for all processes to indicate completion
+                assert poll_directory(finished_dir, num_workers, 30) is True
 
-            # Wait up to 30 seconds for all processes to indicate completion
-            assert poll_directory(finished_dir, num_workers, 30) is True
+                log.warning(f"Finished: {num_workers} workers finished")
 
-            log.warning(f"Finished: {num_workers} workers finished")
-
-            # Expect: the child to fail acquiring the writer lock (raises as FileKeyringLockTimeout)
-            with pytest.raises(FileKeyringLockTimeout):
-                # 10 second timeout to prevent a bad test from spoiling the fun (raises as TimeoutException)
-                res.get(timeout=10)
-
-        lock.release_write_lock()
+                # Expect: the child to fail acquiring the writer lock (raises as FileKeyringLockTimeout)
+                with pytest.raises(FileKeyringLockTimeout):
+                    # 10 second timeout to prevent a bad test from spoiling the fun (raises as TimeoutException)
+                    res.get(timeout=10)
 
     # When: using a new empty keyring
     @using_temp_file_keyring()
@@ -262,10 +260,10 @@ class TestFileKeyringSynchronization:
         same lock once the lock is released by the current holder
         """
         lock_path = FileKeyring.lockfile_path_for_file_path(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        lock = fasteners.InterProcessReaderWriterLock(str(lock_path))
+        lock = FileLock(str(lock_path))
 
         # When: a writer lock is already acquired
-        lock.acquire_write_lock()
+        lock.acquire()
 
         child_proc_fn = dummy_fn_requiring_writer_lock
         timeout = 0.25
@@ -293,7 +291,7 @@ class TestFileKeyringSynchronization:
             sleep(0.50)
 
             # When: the writer lock is released
-            lock.release_write_lock()
+            lock.release()
 
             # Expect: the child to acquire the writer lock
             result = res.get(timeout=10)  # 10 second timeout to prevent a bad test from spoiling the fun
@@ -312,10 +310,10 @@ class TestFileKeyringSynchronization:
         holder should not be able to quickly reacquire the lock
         """
         lock_path = FileKeyring.lockfile_path_for_file_path(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        lock = fasteners.InterProcessReaderWriterLock(str(lock_path))
+        lock = FileLock(str(lock_path))
 
         # When: a writer lock is already acquired
-        lock.acquire_write_lock()
+        lock.acquire()
 
         child_proc_function = dummy_sleep_fn  # Sleeps for DUMMY_SLEEP_VALUE seconds
         timeout = 0.25
@@ -340,13 +338,13 @@ class TestFileKeyringSynchronization:
                 f.write(f"{os.getpid()}\n")
 
             # When: the writer lock is released
-            lock.release_write_lock()
+            lock.release()
 
             # Brief delay to allow the child to acquire the lock
             sleep(1)
 
             # Expect: Reacquiring the lock should fail due to the child holding the lock and sleeping
-            assert lock.acquire_write_lock(timeout=0.25) is False
+            assert lock.acquire(timeout=0.25) is False
 
             # Wait up to 30 seconds for all processes to indicate completion
             assert poll_directory(finished_dir, num_workers, 30) is True
@@ -361,10 +359,10 @@ class TestFileKeyringSynchronization:
         acquire the lock
         """
         lock_path = FileKeyring.lockfile_path_for_file_path(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        lock = fasteners.InterProcessReaderWriterLock(str(lock_path))
+        lock = FileLock(str(lock_path))
 
         # When: a writer lock is already acquired
-        lock.acquire_write_lock()
+        lock.acquire()
 
         child_proc_function = dummy_sleep_fn  # Sleeps for DUMMY_SLEEP_VALUE seconds
         timeout = 0.25
@@ -389,7 +387,7 @@ class TestFileKeyringSynchronization:
                 f.write(f"{os.getpid()}\n")
 
             # When: the writer lock is released
-            lock.release_write_lock()
+            lock.release()
 
             # Wait up to 30 seconds for all processes to indicate completion
             assert poll_directory(finished_dir, num_workers, 30) is True
@@ -397,7 +395,7 @@ class TestFileKeyringSynchronization:
             log.warning(f"Finished: {num_workers} workers finished")
 
             # Expect: Reacquiring the lock should succeed after the child finishes and releases the lock
-            assert lock.acquire_write_lock(timeout=(DUMMY_SLEEP_VALUE + 0.25)) is True
+            assert lock.acquire(timeout=(DUMMY_SLEEP_VALUE + 0.25)) is True
 
     # When: using a new empty keyring
     @pytest.mark.skipif(platform == "darwin", reason="triggers the CrashReporter prompt")
@@ -408,10 +406,10 @@ class TestFileKeyringSynchronization:
         able to acquire the lock
         """
         lock_path = FileKeyring.lockfile_path_for_file_path(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        lock = fasteners.InterProcessReaderWriterLock(str(lock_path))
+        lock = FileLock(str(lock_path))
 
         # When: a writer lock is already acquired
-        lock.acquire_write_lock()
+        lock.acquire()
 
         child_proc_function = dummy_abort_fn
         timeout = 0.25
@@ -422,14 +420,14 @@ class TestFileKeyringSynchronization:
             res = pool.starmap_async(child_writer_dispatch, [(child_proc_function, lock_path, timeout, attempts)])
 
             # When: the writer lock is released
-            lock.release_write_lock()
+            lock.release()
 
             # When: timing out waiting for the child process (because it aborted)
             with pytest.raises(TimeoutError):
                 res.get(timeout=2)
 
             # Expect: Reacquiring the lock should succeed after the child exits, automatically releasing the lock
-            assert lock.acquire_write_lock(timeout=(2)) is True
+            assert lock.acquire(timeout=(2)) is True
 
     # When: using a new empty keyring
     @using_temp_file_keyring()
@@ -439,10 +437,10 @@ class TestFileKeyringSynchronization:
         to acquire the lock for writing
         """
         lock_path = FileKeyring.lockfile_path_for_file_path(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        lock = fasteners.InterProcessReaderWriterLock(str(lock_path))
+        lock = FileLock(str(lock_path))
 
         # When: a reader lock is already held
-        lock.acquire_read_lock()
+        lock.acquire()
 
         child_proc_function = dummy_fn_requiring_writer_lock
         timeout = 0.25
@@ -475,7 +473,7 @@ class TestFileKeyringSynchronization:
             with pytest.raises(FileKeyringLockTimeout):
                 res.get(timeout=30)
 
-        lock.release_read_lock()
+        lock.release()
 
     # When: using a new empty keyring
     @using_temp_file_keyring()
@@ -485,10 +483,10 @@ class TestFileKeyringSynchronization:
         to acquire the lock for writing until the reader releases its lock
         """
         lock_path = FileKeyring.lockfile_path_for_file_path(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        lock = fasteners.InterProcessReaderWriterLock(str(lock_path))
+        lock = FileLock(str(lock_path))
 
         # When: a reader lock is already acquired
-        assert lock.acquire_read_lock() is True
+        assert lock.acquire() is True
 
         child_proc_function = dummy_fn_requiring_writer_lock
         timeout = 1
@@ -517,7 +515,7 @@ class TestFileKeyringSynchronization:
                 res.get(timeout=5)
 
             # When: the reader releases its lock
-            lock.release_read_lock()
+            lock.release()
 
             # Wait up to 30 seconds for all processes to indicate completion
             assert poll_directory(finished_dir, num_workers, 30) is True


### PR DESCRIPTION
 Config writes need to be atomic.
On windows, `os.replace`, which is atomic, sometimes throws a `PermissionError`. Then we fall back to `shutil.move` which copies the file on error. However copy is not atomix, and thus there can be conflicts if another file is reading the config. 

I believe that we might have encountered this issue on Windows on 1.3, since farmer and wallet both write to the config file. 
This PR does a retry if read fails. It also uses a new tmp directory for every write, just in case. 

This fix does seem to help the users that had plotNFT syncing issues.


* load_config by default uses the Lock, to keep the PR simple, since we use load_config a lot. However, if you want to also save after, you should use the lock around `load_config` and `save_config`, and pass in `acquire_lock=False` to `load_config`.
* test_config.py was not throwing on exceptions, the exceptions were being eaten by the threads.
* NOTE: a lot of the diff changes are just tab under the lock context, so view with Hide whitespace changes toggled.


Next steps:
- Make a config locking PR - https://github.com/Chia-Network/chia-blockchain/pull/10680
- Make a keyring PR