### PR TITLE
Increases the probability of connecting to local trusted node

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -41,7 +41,8 @@ async def fetch_last_tx_from_peer(height: uint32, peer: WSChiaConnection) -> Opt
         if response is not None and isinstance(response, RespondBlockHeader):
             if response.header_block.is_transaction_block:
                 return response.header_block
-        else:
+        elif request_height < height:
+            # The peer might be slightly behind others but still synced, so we should allow fetching one more TX block
             break
         request_height = request_height - 1
     return None


### PR DESCRIPTION
Especially when restarting services. There was a significant chance of connecting to an untrusted node and syncing to them first.