### PR TITLE
correct spelling of genrated

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -240,7 +240,7 @@ def add_token_cmd(wallet_rpc_port: Optional[int], asset_id: str, token_name: str
     required=True,
     multiple=True,
 )
-@click.option("-p", "--filepath", help="The path to write the genrated offer file to", required=True)
+@click.option("-p", "--filepath", help="The path to write the generated offer file to", required=True)
 @click.option("-m", "--fee", help="A fee to add to the offer when it gets taken", default="0")
 def make_offer_cmd(
     wallet_rpc_port: Optional[int], fingerprint: int, offer: Tuple[str], request: Tuple[str], filepath: str, fee: str


### PR DESCRIPTION
The help text for the `make_offer` cli command has a typo. 