### PR TITLE
Fix exception when `chia keys migrate` is run without needing migration

### DIFF
--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -242,10 +242,15 @@ class Keychain:
     def __init__(self, user: Optional[str] = None, service: Optional[str] = None, force_legacy: bool = False):
         self.user = user if user is not None else default_keychain_user()
         self.service = service if service is not None else default_keychain_service()
-        if force_legacy:
-            self.keyring_wrapper = KeyringWrapper.get_legacy_instance()
-        else:
-            self.keyring_wrapper = KeyringWrapper.get_shared_instance()
+
+        keyring_wrapper: Optional[KeyringWrapper] = (
+            KeyringWrapper.get_legacy_instance() if force_legacy else KeyringWrapper.get_shared_instance()
+        )
+
+        if keyring_wrapper is None:
+            raise KeyringNotSet(f"KeyringWrapper not set: force_legacy={force_legacy}")
+
+        self.keyring_wrapper = keyring_wrapper
 
     @unlocks_keyring(use_passphrase_cache=True)
     def _get_pk_and_entropy(self, user: str) -> Optional[Tuple[G1Element, bytes]]:

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -43,6 +43,10 @@ class KeyringMaxUnlockAttempts(Exception):
     pass
 
 
+class KeyringNotSet(Exception):
+    pass
+
+
 def supports_keyring_passphrase() -> bool:
     # Support can be disabled by setting CHIA_PASSPHRASE_SUPPORT to 0/false
     return os.environ.get("CHIA_PASSPHRASE_SUPPORT", "true").lower() in ["1", "true"]
@@ -239,11 +243,7 @@ class Keychain:
         self.user = user if user is not None else default_keychain_user()
         self.service = service if service is not None else default_keychain_service()
         if force_legacy:
-            legacy_keyring_wrapper = KeyringWrapper.get_legacy_instance()
-            if legacy_keyring_wrapper is not None:
-                self.keyring_wrapper = legacy_keyring_wrapper
-            else:
-                return None
+            self.keyring_wrapper = KeyringWrapper.get_legacy_instance()
         else:
             self.keyring_wrapper = KeyringWrapper.get_shared_instance()
 
@@ -561,8 +561,10 @@ class Keychain:
 
     @staticmethod
     def get_keys_needing_migration() -> Tuple[List[Tuple[PrivateKey, bytes]], Optional["Keychain"]]:
-        legacy_keyring: Optional[Keychain] = Keychain(force_legacy=True)
-        if legacy_keyring is None:
+        try:
+            legacy_keyring: Keychain = Keychain(force_legacy=True)
+        except KeyringNotSet:
+            # No legacy keyring available, so no keys need to be migrated
             return [], None
         keychain = Keychain()
         all_legacy_sks = legacy_keyring.get_all_private_keys()

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -110,15 +110,20 @@ class KeyringWrapper:
         used CryptFileKeyring. We now use our own FileKeyring backend and migrate
         the data from the legacy CryptFileKeyring (on write).
         """
+        from chia.util.keychain import KeyringNotSet
+
         self.keys_root_path = keys_root_path
         if force_legacy:
             legacy_keyring = get_legacy_keyring_instance()
             if check_legacy_keyring_keys_present(legacy_keyring):
                 self.keyring = legacy_keyring
-            else:
-                return None
         else:
             self.refresh_keyrings()
+
+        if self.keyring is None:
+            raise KeyringNotSet(
+                f"Unable to initialize keyring backend: keys_root_path={keys_root_path}, force_legacy={force_legacy}"
+            )
 
     def refresh_keyrings(self):
         self.keyring = None


### PR DESCRIPTION
An exception was being raised when `chia keys migrate` was invoked without any keys needing migration. The code assumed that returning None from `__init__()` would result in the caller being able to test if object creation succeeded, but this didn't work as expected. Instead of returning `None`, forcing `KeyringWrapper` creation with a legacy keyring will raise `KeyringNotSet` so that the caller can handle the case where legacy keys are not present.

Issue #10628 