### PR TITLE
Slightly different query for V2 DBs - block count metrics

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -576,8 +576,15 @@ class BlockStore:
         return heights
 
     async def count_compactified_blocks(self) -> int:
-        async with self.db.execute("select count(*) from full_blocks where is_fully_compactified=1") as cursor:
-            row = await cursor.fetchone()
+        if self.db_wrapper.db_version == 2:
+            # DB V2 has an index on is_fully_compactified only for blocks in the main chain
+            async with self.db.execute(
+                "select count(*) from full_blocks where is_fully_compactified=1 and in_main_chain=1"
+            ) as cursor:
+                row = await cursor.fetchone()
+        else:
+            async with self.db.execute("select count(*) from full_blocks where is_fully_compactified=1") as cursor:
+                row = await cursor.fetchone()
 
         assert row is not None
 
@@ -585,8 +592,15 @@ class BlockStore:
         return int(count)
 
     async def count_uncompactified_blocks(self) -> int:
-        async with self.db.execute("select count(*) from full_blocks where is_fully_compactified=0") as cursor:
-            row = await cursor.fetchone()
+        if self.db_wrapper.db_version == 2:
+            # DB V2 has an index on is_fully_compactified only for blocks in the main chain
+            async with self.db.execute(
+                "select count(*) from full_blocks where is_fully_compactified=0 and in_main_chain=1"
+            ) as cursor:
+                row = await cursor.fetchone()
+        else:
+            async with self.db.execute("select count(*) from full_blocks where is_fully_compactified=0") as cursor:
+                row = await cursor.fetchone()
 
         assert row is not None
 


### PR DESCRIPTION
RPC/Queries for block count metrics was running very slow on a V2 DB. Realized the index that covers `is_fully_compactified` in the table changed slightly in v2, and only covers the query if `in_main_chain=1`

This PR updates the query to be slightly different on V1 vs V2 DBs, so that both perform quickly using the index, instead of v2 having to scan the whole table.

## Testing Results

### V1 DB:

```
EXPLAIN QUERY PLAN select count(*) from full_blocks where is_fully_compactified=0;

QUERY PLAN
--SEARCH full_blocks USING COVERING INDEX is_fully_compactified (is_fully_compactified=?)
```

```
EXPLAIN QUERY PLAN select count(*) from full_blocks where is_fully_compactified=1;

QUERY PLAN
--SEARCH full_blocks USING COVERING INDEX is_fully_compactified (is_fully_compactified=?)
```


### V2 DB:

**With old query, its a full table scan:**
```
EXPLAIN QUERY PLAN select count(*) from full_blocks where is_fully_compactified=0;

QUERY PLAN
--SCAN full_blocks
```

```
EXPLAIN QUERY PLAN select count(*) from full_blocks where is_fully_compactified=1;

QUERY PLAN
--SCAN full_blocks
```

With new query, its utilizing the index available in DB V2
```
EXPLAIN QUERY PLAN select count(*) from full_blocks where is_fully_compactified=0 and in_main_chain=1;

QUERY PLAN
--SEARCH full_blocks USING COVERING INDEX is_fully_compactified (is_fully_compactified=? AND in_main_chain=?)
```

```
EXPLAIN QUERY PLAN select count(*) from full_blocks where is_fully_compactified=1 and in_main_chain=1;

QUERY PLAN
--SEARCH full_blocks USING COVERING INDEX is_fully_compactified (is_fully_compactified=? AND in_main_chain=?)
```