### PR TITLE
WIP: add cat_spend_multi RPC method

### DIFF
--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -5,6 +5,7 @@ from chia.rpc.rpc_client import RpcClient
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.rpc_request import TxAddition
 from chia.util.ints import uint32, uint64
 from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
@@ -392,6 +393,23 @@ class WalletRpcClient(RpcClient):
             "memos": memos if memos else [],
         }
         res = await self.fetch("cat_spend", send_dict)
+        return TransactionRecord.from_json_dict_convenience(res["transaction"])
+
+    async def cat_spend_multi(
+        self,
+        wallet_id: int,
+        additions: List[TxAddition],
+        coins: Optional[List[Coin]] = None,
+        fee: Optional[uint64] = uint64(0),
+    ) -> TransactionRecord:
+
+        request_data = {
+            "wallet_id": wallet_id,
+            "additions": [a.to_json() for a in additions],
+            "coins": coins,
+            "fee": fee
+        }
+        res = await self.fetch("cat_spend_multi", request_data)
         return TransactionRecord.from_json_dict_convenience(res["transaction"])
 
     # Offers

--- a/chia/types/rpc_request.py
+++ b/chia/types/rpc_request.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, TypedDict
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.byte_types import hexstr_to_bytes
+from chia.util.ints import uint64
+
+
+class TxAdditionRequest(TypedDict):
+    puzzle_hash: str
+    amount: int
+    memos: Optional[List[str]]
+
+
+@dataclass(frozen=True)
+class TxAddition:
+    puzzle_hash: bytes32
+    amount: uint64
+    memos: Optional[List[bytes]] = None
+
+    @classmethod
+    def from_json(cls, data: TxAdditionRequest):
+        return cls(
+            puzzle_hash=bytes32(hexstr_to_bytes(data["puzzle_hash"])),
+            amount=uint64(data["amount"]),
+            memos=[m.encode("utf8") for m in data["memos"]] if data["memos"] else None,
+        )
+
+    def to_json(self) -> TxAdditionRequest:
+        return {
+            "puzzle_hash": self.puzzle_hash.hex(),
+            "amount": self.amount,
+            "memos": [m.decode("utf8") for m in self.memos] if self.memos else None,
+        }
+
+
+class CatSpendMultiRequest(TypedDict):
+    wallet_id: int
+    additions: List[TxAdditionRequest]
+    coins: Optional[List[Dict]]
+    fee: Optional[uint64]


### PR DESCRIPTION
This would allow for one-click CAT airdrops by aggregating all spends in a single transaction.

Any initial feedback? Thanks!