### PR TITLE
cmds: Fix trusted peer hint in `chia wallet show`

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -488,7 +488,7 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
             print(f"   -Spendable: {print_balance(balances['spendable_balance'], scale, address_prefix)}")
 
     print(" ")
-    trusted_peers: Dict = config.get("trusted_peers", {})
+    trusted_peers: Dict = config["wallet"].get("trusted_peers", {})
     await print_connections(wallet_client, time, NodeType, trusted_peers)
 
 


### PR DESCRIPTION
`config` is the root config here.