### PR TITLE
require test-cache repo is found when run in CI

### DIFF
--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -1374,6 +1374,11 @@ def get_challenges(
 
 def get_plot_dir() -> Path:
     cache_path = Path(os.path.expanduser(os.getenv("CHIA_ROOT", "~/.chia/"))) / "test-plots"
+
+    ci = os.environ.get("CI")
+    if ci is not None and not cache_path.exists():
+        raise Exception(f"Running in CI and expected path not found: {cache_path!r}")
+
     mkdir(cache_path)
     return cache_path
 

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 from os import path
 from pathlib import Path
@@ -47,6 +48,11 @@ def persistent_blocks(
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
     block_path_dir = Path("~/.chia/blocks").expanduser()
     file_path = Path(f"~/.chia/blocks/{db_name}").expanduser()
+
+    ci = os.environ.get("CI")
+    if ci is not None and not file_path.exists():
+        raise Exception(f"Running in CI and expected path not found: {file_path!r}")
+
     if not path.exists(block_path_dir):
         mkdir(block_path_dir.parent)
         mkdir(block_path_dir)


### PR DESCRIPTION
I think we would like to know sooner than later, and more explicitly, if the test-cache is not found.  This also makes it easier to confirm which tests use the cache and detect errors when adjusting how the cache is acquired, including working towards Windows tests.

The failing case has been verified in https://github.com/Chia-Network/chia-blockchain/pull/10713.  Passing locally without the cache has also been verified.