### PR TITLE
New RPC get_coin_records_by_hint - Get coins for a given hint

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -594,7 +594,7 @@ class FullNodeRpcApi:
         if "hint" not in request:
             raise ValueError("Hint not in request")
 
-        names: List[bytes32] = await self.full_node.hint_store.get_coin_ids(request["hint"])
+        names: List[bytes32] = await self.service.blockchain.hint_store.get_coin_ids(request["hint"])
 
         kwargs: Dict[str, Any] = {
             "include_spent_coins": False,

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -593,9 +593,9 @@ class FullNodeRpcApi:
         """
         if "hint" not in request:
             raise ValueError("Hint not in request")
-        
+
         names: List[bytes32] = await self.full_node.hint_store.get_coin_ids(request["hint"])
-        
+
         kwargs: Dict[str, Any] = {
             "include_spent_coins": False,
             "names": names,
@@ -608,7 +608,7 @@ class FullNodeRpcApi:
 
         if "include_spent_coins" in request:
             kwargs["include_spent_coins"] = request["include_spent_coins"]
-        
+
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_names(**kwargs)
 
         return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -54,6 +54,7 @@ class FullNodeRpcApi:
             "/get_coin_record_by_name": self.get_coin_record_by_name,
             "/get_coin_records_by_names": self.get_coin_records_by_names,
             "/get_coin_records_by_parent_ids": self.get_coin_records_by_parent_ids,
+            "/get_coin_records_by_hint": self.get_coin_records_by_hint,
             "/push_tx": self.push_tx,
             "/get_puzzle_and_solution": self.get_puzzle_and_solution,
             # Mempool
@@ -583,6 +584,32 @@ class FullNodeRpcApi:
             kwargs["include_spent_coins"] = request["include_spent_coins"]
 
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_parent_ids(**kwargs)
+
+        return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}
+
+    async def get_coin_records_by_hint(self, request: Dict) -> Optional[Dict]:
+        """
+        Retrieves coins by hint, by default returns unspent coins.
+        """
+        if "hint" not in request:
+            raise ValueError("Hint not in request")
+        
+        names: List[bytes32] = await self.full_node.hint_store.get_coin_ids(request["hint"])
+        
+        kwargs: Dict[str, Any] = {
+            "include_spent_coins": False,
+            "names": names,
+        }
+
+        if "start_height" in request:
+            kwargs["start_height"] = uint32(request["start_height"])
+        if "end_height" in request:
+            kwargs["end_height"] = uint32(request["end_height"])
+
+        if "include_spent_coins" in request:
+            kwargs["include_spent_coins"] = request["include_spent_coins"]
+        
+        coin_records = await self.service.blockchain.coin_store.get_coin_records_by_names(**kwargs)
 
         return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}
 

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -593,9 +593,12 @@ class FullNodeRpcApi:
         """
         if "hint" not in request:
             raise ValueError("Hint not in request")
-        
-        names: List[bytes32] = await self.full_node.hint_store.get_coin_ids(request["hint"])
-        
+
+        if self.service.hint_store is None:
+
+            return {"coin_records": []}
+        names: List[bytes32] = await self.service.hint_store.get_coin_ids(bytes32.from_hexstr(request["hint"]))
+
         kwargs: Dict[str, Any] = {
             "include_spent_coins": False,
             "names": names,
@@ -608,7 +611,7 @@ class FullNodeRpcApi:
 
         if "include_spent_coins" in request:
             kwargs["include_spent_coins"] = request["include_spent_coins"]
-        
+
         coin_records = await self.service.blockchain.coin_store.get_coin_records_by_names(**kwargs)
 
         return {"coin_records": [coin_record_dict_backwards_compat(cr.to_json_dict()) for cr in coin_records]}

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -161,6 +161,22 @@ class FullNodeRpcClient(RpcClient):
         response = await self.fetch("get_coin_records_by_parent_ids", d)
         return [CoinRecord.from_json_dict(coin_record_dict_backwards_compat(coin)) for coin in response["coin_records"]]
 
+    async def get_coin_records_by_hint(
+        self,
+        hint: bytes32,
+        include_spent_coins: bool = True,
+        start_height: Optional[int] = None,
+        end_height: Optional[int] = None,
+    ) -> List:
+        d = {"hint": hint.hex(), "include_spent_coins": include_spent_coins}
+        if start_height is not None:
+            d["start_height"] = start_height
+        if end_height is not None:
+            d["end_height"] = end_height
+
+        response = await self.fetch("get_coin_records_by_hint", d)
+        return [CoinRecord.from_json_dict(coin_record_dict_backwards_compat(coin)) for coin in response["coin_records"]]
+
     async def get_additions_and_removals(self, header_hash: bytes32) -> Tuple[List[CoinRecord], List[CoinRecord]]:
         try:
             response = await self.fetch("get_additions_and_removals", {"header_hash": header_hash.hex()})

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -201,13 +201,17 @@ class TestRpc:
             memo = "c0ffee".encode("utf-8")
 
             # First coin created with memo
-            spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend, memo=memo)
+            spend_bundle = wallet.generate_signed_transaction(
+                coin_to_spend.amount, ph_receiver, coin_to_spend, memo=memo
+            )
             await client.push_tx(spend_bundle)
             await full_node_api_1.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
 
             # Second coin created with memo
             coin_to_spend = list(blocks[-1].get_included_reward_coins())[2]
-            spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend, memo=memo)
+            spend_bundle = wallet.generate_signed_transaction(
+                coin_to_spend.amount, ph_receiver, coin_to_spend, memo=memo
+            )
             await client.push_tx(spend_bundle)
             await full_node_api_1.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
 
@@ -245,7 +249,6 @@ class TestRpc:
             assert blocks[1].header_hash == new_blocks[1].header_hash
             assert blocks[2].header_hash == new_blocks[2].header_hash
             assert blocks[3].header_hash != new_blocks[3].header_hash
-
 
         finally:
             # Checks that the RPC manages to stop the node

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -196,6 +196,27 @@ class TestRpc:
             assert len(await client.get_coin_records_by_puzzle_hash(ph, True, 0, blocks[-1].height + 1)) == 2
             assert len(await client.get_coin_records_by_puzzle_hash(ph, True, 0, 1)) == 0
 
+            coin_to_spend = list(blocks[-1].get_included_reward_coins())[1]
+
+            memo = "c0ffee".encode("utf-8")
+
+            # First coin created with memo
+            spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend, memo=memo)
+            await client.push_tx(spend_bundle)
+            await full_node_api_1.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
+
+            # Second coin created with memo
+            coin_to_spend = list(blocks[-1].get_included_reward_coins())[2]
+            spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend, memo=memo)
+            await client.push_tx(spend_bundle)
+            await full_node_api_1.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
+
+            # Get coin records by hint
+            coin_records = await client.get_coin_records_by_hint(memo)
+            assert len(coin_records) == 2
+
+            # todo: tests that cover include_spent_coins / start_height / end_height
+
             assert len(await client.get_connections()) == 0
 
             await client.open_connection(self_hostname, server_2._port)
@@ -224,6 +245,7 @@ class TestRpc:
             assert blocks[1].header_hash == new_blocks[1].header_hash
             assert blocks[2].header_hash == new_blocks[2].header_hash
             assert blocks[3].header_hash != new_blocks[3].header_hash
+
 
         finally:
             # Checks that the RPC manages to stop the node

--- a/tests/wallet_tools.py
+++ b/tests/wallet_tools.py
@@ -1,4 +1,3 @@
-from optparse import Option
 from typing import Dict, List, Optional, Tuple, Any
 
 from blspy import AugSchemeMPL, G2Element, PrivateKey

--- a/tests/wallet_tools.py
+++ b/tests/wallet_tools.py
@@ -1,3 +1,4 @@
+from optparse import Option
 from typing import Dict, List, Optional, Tuple, Any
 
 from blspy import AugSchemeMPL, G2Element, PrivateKey
@@ -106,6 +107,7 @@ class WalletTool:
         fee: int = 0,
         secret_key: Optional[PrivateKey] = None,
         additional_outputs: Optional[List[Tuple[bytes32, int]]] = None,
+        memo: Optional[bytes32] = None,
     ) -> List[CoinSpend]:
         spends = []
 
@@ -116,7 +118,10 @@ class WalletTool:
         if ConditionOpcode.CREATE_COIN_ANNOUNCEMENT not in condition_dic:
             condition_dic[ConditionOpcode.CREATE_COIN_ANNOUNCEMENT] = []
 
-        output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [new_puzzle_hash, int_to_bytes(amount)])
+        coin_create = [new_puzzle_hash, int_to_bytes(amount)]
+        if memo is not None:
+            coin_create.append(memo)
+        output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, coin_create)
         condition_dic[output.opcode].append(output)
         if additional_outputs is not None:
             for o in additional_outputs:
@@ -199,11 +204,12 @@ class WalletTool:
         condition_dic: Dict[ConditionOpcode, List[ConditionWithArgs]] = None,
         fee: int = 0,
         additional_outputs: Optional[List[Tuple[bytes32, int]]] = None,
+        memo: Optional[bytes32] = None,
     ) -> SpendBundle:
         if condition_dic is None:
             condition_dic = {}
         transaction = self.generate_unsigned_transaction(
-            amount, new_puzzle_hash, [coin], condition_dic, fee, additional_outputs=additional_outputs
+            amount, new_puzzle_hash, [coin], condition_dic, fee, additional_outputs=additional_outputs, memo=memo
         )
         assert transaction is not None
         return self.sign_transaction(transaction)


### PR DESCRIPTION
This allows you to find all CATs for a given inner puzzle hash.

Currently trying to work out how to get the tests to work.