### PR TITLE
Add healthcheck endpoint to rpc services

### DIFF
--- a/chia/rpc/rpc_client.py
+++ b/chia/rpc/rpc_client.py
@@ -66,6 +66,9 @@ class RpcClient:
 
     async def stop_node(self) -> Dict:
         return await self.fetch("stop_node", {})
+    
+    async def healthz(self) -> Dict:
+        return await self.fetch("healthz", {})
 
     def close(self):
         self.closing_task = asyncio.create_task(self.session.close())

--- a/chia/rpc/rpc_client.py
+++ b/chia/rpc/rpc_client.py
@@ -66,7 +66,7 @@ class RpcClient:
 
     async def stop_node(self) -> Dict:
         return await self.fetch("stop_node", {})
-    
+
     async def healthz(self) -> Dict:
         return await self.fetch("healthz", {})
 

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -87,6 +87,7 @@ class RpcServer:
             "/close_connection": self.close_connection,
             "/stop_node": self.stop_node,
             "/get_routes": self._get_routes,
+            "/healthz": self.healthz,
         }
 
     async def _get_routes(self, request: Dict) -> Dict:
@@ -182,6 +183,11 @@ class RpcServer:
         if self.stop_cb is not None:
             self.stop_cb()
         return {}
+
+    async def healthz(self, request: Dict) -> Dict:
+        return {
+            "success": "true",
+        }
 
     async def ws_api(self, message):
         """


### PR DESCRIPTION
Some deployment environments (for example, within the chia-docker container) attempt to self-correct when services end abruptly. Generally, for that to happen, some kind of "health check" is required. This adds a minimal endpoint that just returns a short success message and an http 200 if the RPC service is running. The idea is that this endpoint will be queried at intervals and should ideally do a minimal amount of work to succeed.

The "/healthz" route was made popular by convention set by google, and is now used widely for many other applications that provide dedicated healthcheck endpoints. The idea behind the "z" suffix is to avoid naming collisions.