### PR TITLE
Add maker fee to remaining offer RPCs

### DIFF
--- a/chia/wallet/trade_record.py
+++ b/chia/wallet/trade_record.py
@@ -37,6 +37,7 @@ class TradeRecord(Streamable):
         formatted["summary"] = {
             "offered": offered,
             "requested": requested,
+            "fees": offer.bundle.fees(),
         }
         formatted["pending"] = offer.get_pending_amounts()
         del formatted["offer"]


### PR DESCRIPTION
@Quexington previously added the maker offer fee in the `get_offer_summary` RPC response with #10480 

This change includes the maker fee for the remaining Offers RPCs:

- `create_offer_for_ids`
- `take_offer`
- `get_offer`
- `get_all_offers`

Note: `TradeRecord` doesn't include a summary field (which contains the maker fee), so `WalletRpcClient` doesn't attempt to parse the summary data. For this reason, a test hasn't been added.