### PR TITLE
harvester: Reuse legacy refresh interval if new params aren't available

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent
+import dataclasses
 import logging
 from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
@@ -42,6 +43,9 @@ class Harvester:
             self.log.info(
                 "`harvester.plot_loading_frequency_seconds` is deprecated. Consider replacing it with the new section "
                 "`harvester.plots_refresh_parameter`. See `initial-config.yaml`."
+            )
+            refresh_parameter = dataclasses.replace(
+                refresh_parameter, interval_seconds=config["plot_loading_frequency_seconds"]
             )
         if "plots_refresh_parameter" in config:
             refresh_parameter = dataclass_from_dict(PlotsRefreshParameter, config["plots_refresh_parameter"])


### PR DESCRIPTION
Currently the default parameters are used if `plots_refresh_parameter` is missing in the config even if `plot_loading_frequency_seconds` is still provided.