### PR TITLE
enable stricter mempool rule

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Optional
-from chia_rs import MEMPOOL_MODE, COND_CANON_INTS, NO_NEG_DIV, STRICT_ARGS_COUNT
+from chia_rs import MEMPOOL_MODE, COND_CANON_INTS, NO_NEG_DIV
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.cost_calculator import NPCResult
@@ -42,8 +42,7 @@ def get_name_puzzle_conditions(
     assert (MEMPOOL_MODE & NO_NEG_DIV) != 0
 
     if mempool_mode:
-        # Don't apply the strict args count rule yet
-        flags = MEMPOOL_MODE & (~STRICT_ARGS_COUNT)
+        flags = MEMPOOL_MODE
     elif unwrap(height) >= DEFAULT_CONSTANTS.SOFT_FORK_HEIGHT:
         # conditions must use integers in canonical encoding (i.e. no redundant
         # leading zeros)

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -642,14 +642,15 @@ class TestMempoolManager:
     async def test_block_index_garbage(self, bt, one_node_one_block, wallet_a):
 
         full_node_1, server_1 = one_node_one_block
-        # garbage at the end of the argument list is ignored
+        # garbage at the end of the argument list is ignored in consensus mode,
+        # but not in mempool-mode
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(1), b"garbage"])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_negative_block_index(self, bt, one_node_one_block, wallet_a):
@@ -708,7 +709,8 @@ class TestMempoolManager:
     async def test_block_age_garbage(self, bt, one_node_one_block, wallet_a):
 
         full_node_1, server_1 = one_node_one_block
-        # garbage at the end of the argument list is ignored
+        # garbage at the end of the argument list is ignored in consensus mode,
+        # but not in mempool mode
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(1), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
@@ -716,9 +718,9 @@ class TestMempoolManager:
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_negative_block_age(self, bt, one_node_one_block, wallet_a):
@@ -762,7 +764,8 @@ class TestMempoolManager:
         _ = await next_block(full_node_1, wallet_a, bt)
         _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
-        # garbage at the end of the argument list is ignored
+        # garbage at the end of the argument list is ignored in consensus mode,
+        # but not in mempool mode
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin.name(), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
@@ -770,9 +773,9 @@ class TestMempoolManager:
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_invalid_my_id(self, bt, one_node_one_block, wallet_a):
@@ -885,14 +888,15 @@ class TestMempoolManager:
         full_node_1, server_1 = one_node_one_block
         time_now = full_node_1.full_node.blockchain.get_peak().timestamp + 5
 
-        # garbage at the end of the argument list is ignored
+        # garbage at the end of the argument list is ignored in consensus mode,
+        # but not in mempool mode
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_assert_time_relative_exceeds(self, bt, one_node_one_block, wallet_a):
@@ -927,15 +931,16 @@ class TestMempoolManager:
         full_node_1, server_1 = one_node_one_block
         time_relative = 0
 
-        # garbage at the end of the arguments is ignored
+        # garbage at the end of the arguments is ignored in consensus mode, but
+        # not in mempool mode
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [int_to_bytes(time_relative), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_assert_time_relative_missing_arg(self, bt, one_node_one_block, wallet_a):
@@ -990,17 +995,34 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     # ensure one spend can assert a coin announcement from another spend, even
-    # though the conditions have garbage (ignored) at the end
+    # though the conditions have garbage at the end
     @pytest.mark.asyncio
-    async def test_coin_announcement_garbage(self, bt, one_node_one_block, wallet_a):
+    @pytest.mark.parametrize(
+        "assert_garbage,announce_garbage,expected,expected_included",
+        [
+            (True, False, Err.INVALID_CONDITION, MempoolInclusionStatus.FAILED),
+            (False, True, Err.INVALID_CONDITION, MempoolInclusionStatus.FAILED),
+            (False, False, None, MempoolInclusionStatus.SUCCESS),
+        ],
+    )
+    async def test_coin_announcement_garbage(
+        self, assert_garbage, announce_garbage, expected, expected_included, bt, one_node_one_block, wallet_a
+    ):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
-            # garbage at the end is ignored
-            cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name(), b"garbage"])
+            # garbage at the end is ignored in consensus mode, but not in
+            # mempool mode
+            cvp = ConditionWithArgs(
+                ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT,
+                [bytes(announce.name())] + ([b"garbage"] if announce_garbage else []),
+            )
             dic = {cvp.opcode: [cvp]}
 
-            # garbage at the end is ignored
-            cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test", b"garbage"])
+            # garbage at the end is ignored in consensus mode, but not in
+            # mempool mode
+            cvp2 = ConditionWithArgs(
+                ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, [b"test"] + ([b"garbage"] if assert_garbage else [])
+            )
             dic2 = {cvp.opcode: [cvp2]}
             spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
             spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
@@ -1009,11 +1031,9 @@ class TestMempoolManager:
 
         full_node_1, server_1 = one_node_one_block
         blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
-        mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
-        assert err is None
-        assert mempool_bundle is bundle
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is expected
+        assert status == expected_included
 
     @pytest.mark.asyncio
     async def test_coin_announcement_missing_arg(self, bt, one_node_one_block, wallet_a):
@@ -1175,17 +1195,34 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_puzzle_announcement_garbage(self, bt, one_node_one_block, wallet_a):
+    @pytest.mark.parametrize(
+        "assert_garbage,announce_garbage,expected,expected_included",
+        [
+            (True, False, Err.INVALID_CONDITION, MempoolInclusionStatus.FAILED),
+            (False, True, Err.INVALID_CONDITION, MempoolInclusionStatus.FAILED),
+            (False, False, None, MempoolInclusionStatus.SUCCESS),
+        ],
+    )
+    async def test_puzzle_announcement_garbage(
+        self, assert_garbage, announce_garbage, expected, expected_included, bt, one_node_one_block, wallet_a
+    ):
         full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.puzzle_hash, bytes(0x80))
 
-            # garbage at the end is ignored
-            cvp = ConditionWithArgs(ConditionOpcode.ASSERT_PUZZLE_ANNOUNCEMENT, [announce.name(), b"garbage"])
+            # garbage at the end is ignored in consensus mode, but not in
+            # mempool mode
+            cvp = ConditionWithArgs(
+                ConditionOpcode.ASSERT_PUZZLE_ANNOUNCEMENT,
+                [bytes(announce.name())] + ([b"garbage"] if assert_garbage else []),
+            )
             dic = {cvp.opcode: [cvp]}
-            # garbage at the end is ignored
-            cvp2 = ConditionWithArgs(ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT, [bytes(0x80), b"garbage"])
+            # garbage at the end is ignored in consensus mode, but not in
+            # mempool mode
+            cvp2 = ConditionWithArgs(
+                ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT, [bytes(0x80)] + ([b"garbage"] if announce_garbage else [])
+            )
             dic2 = {cvp.opcode: [cvp2]}
             spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic)
             spend_bundle2 = generate_test_spend_bundle(wallet_a, coin_2, dic2)
@@ -1193,11 +1230,9 @@ class TestMempoolManager:
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
         blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
-        mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
-        assert err is None
-        assert mempool_bundle is bundle
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is expected
+        assert status == expected_included
 
     @pytest.mark.asyncio
     async def test_puzzle_announcement_missing_arg(self, bt, one_node_one_block, wallet_a):
@@ -1330,7 +1365,8 @@ class TestMempoolManager:
     async def test_assert_fee_condition_garbage(self, bt, one_node_one_block, wallet_a):
 
         full_node_1, server_1 = one_node_one_block
-        # garbage at the end of the arguments is ignored
+        # garbage at the end of the arguments is ignored in consensus mode, but
+        # not in mempool mode
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(10), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
@@ -1338,9 +1374,9 @@ class TestMempoolManager:
         )
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
-        assert err is None
-        assert mempool_bundle is not None
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert mempool_bundle is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_assert_fee_condition_missing_arg(self, bt, one_node_one_block, wallet_a):
@@ -1583,7 +1619,8 @@ class TestMempoolManager:
         _ = await next_block(full_node_1, wallet_a, bt)
         _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
-        # garbage at the end of the arguments list is allowed but stripped
+        # garbage at the end of the arguments list is allowed in consensus mode,
+        # but not in mempool mode
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin.parent_coin_info, b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
@@ -1592,9 +1629,9 @@ class TestMempoolManager:
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_my_parent_missing_arg(self, bt, one_node_one_block, wallet_a):
@@ -1669,9 +1706,9 @@ class TestMempoolManager:
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_my_puzhash_missing_arg(self, bt, one_node_one_block, wallet_a):
@@ -1736,7 +1773,8 @@ class TestMempoolManager:
         _ = await next_block(full_node_1, wallet_a, bt)
         _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
-        # garbage at the end of the arguments list is allowed but stripped
+        # garbage at the end of the arguments list is allowed in consensus mode,
+        # but not in mempool mode
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(coin.amount), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
@@ -1745,9 +1783,9 @@ class TestMempoolManager:
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
-        assert err is None
-        assert sb1 is spend_bundle1
-        assert status == MempoolInclusionStatus.SUCCESS
+        assert err is Err.INVALID_CONDITION
+        assert sb1 is None
+        assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
     async def test_my_amount_missing_arg(self, bt, one_node_one_block, wallet_a):


### PR DESCRIPTION
enable the `STRICT_ARGS_COUNT` mempool rule and fix the mempool tests accordingly.

This rule forbids conditions from having too many arguments. Under normal consensus rules, additional arguments are ignored, so this only affects the mempool.