### PR TITLE
wallet: Optional wallet type parameter for `get_wallets` and `wallet show`

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import click
 
@@ -138,11 +138,15 @@ def send_cmd(
     default=None,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int) -> None:
+@click.option("-w", "--wallet_type", help="Choose a specific wallet type to return", type=int, default=None)
+def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_type: Optional[int]) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet, print_balances
 
-    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, {}, print_balances))
+    args: Dict[str, Any] = {}
+    if wallet_type is not None:
+        args["type"] = wallet_type
+    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, args, print_balances))
 
 
 @wallet_cmd.command("get_address", short_help="Get a wallet receive address")

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Optional, Tuple
 
 import click
 
+from chia.wallet.util.wallet_types import WalletType
+
 
 @click.group("wallet", short_help="Manage your wallet")
 def wallet_cmd() -> None:
@@ -138,14 +140,20 @@ def send_cmd(
     default=None,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-@click.option("-w", "--wallet_type", help="Choose a specific wallet type to return", type=int, default=None)
-def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_type: Optional[int]) -> None:
+@click.option(
+    "-w",
+    "--wallet_type",
+    help="Choose a specific wallet type to return",
+    type=click.Choice([x.name.lower() for x in WalletType]),
+    default=None,
+)
+def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_type: Optional[str]) -> None:
     import asyncio
     from .wallet_funcs import execute_with_wallet, print_balances
 
     args: Dict[str, Any] = {}
     if wallet_type is not None:
-        args["type"] = wallet_type
+        args["type"] = WalletType[wallet_type.upper()]
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, args, print_balances))
 
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -415,7 +415,11 @@ class WalletRpcApi:
     async def get_wallets(self, request: Dict):
         assert self.service.wallet_state_manager is not None
 
-        wallets: List[WalletInfo] = await self.service.wallet_state_manager.get_all_wallet_info_entries()
+        wallet_type: Optional[WalletType] = None
+        if "type" in request:
+            wallet_type = WalletType(request["type"])
+
+        wallets: List[WalletInfo] = await self.service.wallet_state_manager.get_all_wallet_info_entries(wallet_type)
 
         return {"wallets": wallets}
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -10,6 +10,7 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.transaction_sorting import SortKey
+from chia.wallet.util.wallet_types import WalletType
 
 
 def parse_result_transactions(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -80,8 +81,11 @@ class WalletRpcClient(RpcClient):
         return await self.fetch("farm_block", {"address": address})
 
     # Wallet Management APIs
-    async def get_wallets(self) -> Dict:
-        return (await self.fetch("get_wallets", {}))["wallets"]
+    async def get_wallets(self, wallet_type: Optional[WalletType] = None) -> Dict:
+        request: Dict[str, Any] = {}
+        if wallet_type is not None:
+            request["type"] = wallet_type
+        return (await self.fetch("get_wallets", request))["wallets"]
 
     # Wallet APIs
     async def get_wallet_balance(self, wallet_id: str) -> Dict:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1147,8 +1147,8 @@ class WalletStateManager:
     def unlink_db(self):
         Path(self.db_path).unlink()
 
-    async def get_all_wallet_info_entries(self) -> List[WalletInfo]:
-        return await self.user_store.get_all_wallet_info_entries()
+    async def get_all_wallet_info_entries(self, wallet_type: Optional[WalletType] = None) -> List[WalletInfo]:
+        return await self.user_store.get_all_wallet_info_entries(wallet_type)
 
     async def get_start_height(self):
         """

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -112,12 +112,17 @@ class WalletUserStore:
 
         return await self.get_wallet_by_id(row[0])
 
-    async def get_all_wallet_info_entries(self) -> List[WalletInfo]:
+    async def get_all_wallet_info_entries(self, wallet_type: Optional[WalletType] = None) -> List[WalletInfo]:
         """
-        Return a set containing all wallets
+        Return a set containing all wallets, optionally with a specific WalletType
         """
+        if wallet_type is None:
+            cursor = await self.db_connection.execute("SELECT * from users_wallets")
+        else:
+            cursor = await self.db_connection.execute(
+                "SELECT * from users_wallets WHERE wallet_type=?", (wallet_type.value,)
+            )
 
-        cursor = await self.db_connection.execute("SELECT * from users_wallets")
         rows = await cursor.fetchall()
         await cursor.close()
         result = []

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -191,10 +191,7 @@ class TestPoolWalletRpc:
         await time_out_assert(10, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
 
         our_ph = await wallet_0.get_new_puzzlehash()
-        summaries_response = await client.get_wallets()
-        for summary in summaries_response:
-            if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                assert False
+        assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
         await time_out_assert(10, wallet_is_synced, True, wallet_node_0, full_node_api)
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(
             our_ph, "", 0, f"{self_hostname}:5000", "new", "SELF_POOLING", fee
@@ -210,12 +207,9 @@ class TestPoolWalletRpc:
         assert full_node_api.full_node.mempool_manager.get_spendbundle(creation_tx.name) is None
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node_0, full_node_api)
-        summaries_response = await client.get_wallets()
-        wallet_id: Optional[int] = None
-        for summary in summaries_response:
-            if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                wallet_id = summary["id"]
-        assert wallet_id is not None
+        summaries_response = await client.get_wallets(WalletType.POOLING_WALLET)
+        assert len(summaries_response) == 1
+        wallet_id: int = summaries_response[0]["id"]
         status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
         assert status.current.state == PoolSingletonState.SELF_POOLING.value
@@ -270,10 +264,7 @@ class TestPoolWalletRpc:
         await time_out_assert(10, wallet_is_synced, True, wallet_node_0, full_node_api)
 
         our_ph = await wallet_0.get_new_puzzlehash()
-        summaries_response = await client.get_wallets()
-        for summary in summaries_response:
-            if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                assert False
+        assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(
             our_ph, "http://pool.example.com", 10, f"{self_hostname}:5000", "new", "FARMING_TO_POOL", fee
@@ -289,12 +280,9 @@ class TestPoolWalletRpc:
         assert full_node_api.full_node.mempool_manager.get_spendbundle(creation_tx.name) is None
 
         await time_out_assert(5, wallet_is_synced, True, wallet_node_0, full_node_api)
-        summaries_response = await client.get_wallets()
-        wallet_id: Optional[int] = None
-        for summary in summaries_response:
-            if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                wallet_id = summary["id"]
-        assert wallet_id is not None
+        summaries_response = await client.get_wallets(WalletType.POOLING_WALLET)
+        assert len(summaries_response) == 1
+        wallet_id: int = summaries_response[0]["id"]
         status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
         assert status.current.state == PoolSingletonState.FARMING_TO_POOL.value
@@ -348,10 +336,7 @@ class TestPoolWalletRpc:
 
         our_ph_1 = await wallet_0.get_new_puzzlehash()
         our_ph_2 = await wallet_0.get_new_puzzlehash()
-        summaries_response = await client.get_wallets()
-        for summary in summaries_response:
-            if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                assert False
+        assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(
             our_ph_1, "", 0, f"{self_hostname}:5000", "new", "SELF_POOLING", fee
@@ -476,10 +461,7 @@ class TestPoolWalletRpc:
         await time_out_assert(10, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
 
         our_ph = await wallet_0.get_new_puzzlehash()
-        summaries_response = await client.get_wallets()
-        for summary in summaries_response:
-            if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                assert False
+        assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node_0, full_node_api)
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(
@@ -593,10 +575,7 @@ class TestPoolWalletRpc:
 
         await time_out_assert(10, wallet_is_synced, True, wallet_node_0, full_node_api)
         our_ph = await wallet_0.get_new_puzzlehash()
-        summaries_response = await client.get_wallets()
-        for summary in summaries_response:
-            if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                assert False
+        assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
         # Balance stars at 6 XCH
         assert (await wallet_0.get_confirmed_balance()) == 6000000000000
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(
@@ -753,10 +732,7 @@ class TestPoolWalletRpc:
             await time_out_assert(10, wallet_is_synced, True, wallet_node_0, full_node_api)
             assert total_block_rewards > 0
 
-            summaries_response = await client.get_wallets()
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    assert False
+            assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
             creation_tx: TransactionRecord = await client.create_new_pool_wallet(
                 our_ph, "", 0, f"{self_hostname}:5000", "new", "SELF_POOLING", fee
@@ -782,18 +758,11 @@ class TestPoolWalletRpc:
             assert full_node_api.full_node.mempool_manager.get_spendbundle(creation_tx.name) is None
             await time_out_assert(10, wallet_is_synced, True, wallet_node_0, full_node_api)
 
-            summaries_response = await client.get_wallets()
-            wallet_id: Optional[int] = None
-            wallet_id_2: Optional[int] = None
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    if wallet_id is not None:
-                        wallet_id_2 = summary["id"]
-                    else:
-                        wallet_id = summary["id"]
+            summaries_response = await client.get_wallets(WalletType.POOLING_WALLET)
+            assert len(summaries_response) == 2
+            wallet_id: int = summaries_response[0]["id"]
+            wallet_id_2: int = summaries_response[1]["id"]
             await asyncio.sleep(1)
-            assert wallet_id is not None
-            assert wallet_id_2 is not None
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
             status_2: PoolWalletInfo = (await client.pw_status(wallet_id_2))[0]
 
@@ -884,10 +853,7 @@ class TestPoolWalletRpc:
         WAIT_SECS = 200
 
         try:
-            summaries_response = await client.get_wallets()
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    assert False
+            assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
             async def have_chia():
                 await farm_blocks(full_node_api, our_ph, 1)
@@ -912,12 +878,9 @@ class TestPoolWalletRpc:
 
             await time_out_assert(10, wallet_is_synced, True, wallet_nodes[0], full_node_api)
 
-            summaries_response = await client.get_wallets()
-            wallet_id: Optional[int] = None
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    wallet_id = summary["id"]
-            assert wallet_id is not None
+            summaries_response = await client.get_wallets(WalletType.POOLING_WALLET)
+            assert len(summaries_response) == 1
+            wallet_id: int = summaries_response[0]["id"]
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
             assert status.current.state == PoolSingletonState.SELF_POOLING.value
@@ -1009,10 +972,7 @@ class TestPoolWalletRpc:
 
         WAIT_SECS = 200
         try:
-            summaries_response = await client.get_wallets()
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    assert False
+            assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
             async def have_chia():
                 await farm_blocks(full_node_api, our_ph, 1)
@@ -1037,12 +997,9 @@ class TestPoolWalletRpc:
 
             await time_out_assert(10, wallet_is_synced, True, wallet_nodes[0], full_node_api)
 
-            summaries_response = await client.get_wallets()
-            wallet_id: Optional[int] = None
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    wallet_id = summary["id"]
-            assert wallet_id is not None
+            summaries_response = await client.get_wallets(WalletType.POOLING_WALLET)
+            assert len(summaries_response) == 1
+            wallet_id: int = summaries_response[0]["id"]
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
             assert status.current.state == PoolSingletonState.FARMING_TO_POOL.value
@@ -1114,10 +1071,7 @@ class TestPoolWalletRpc:
         )
 
         try:
-            summaries_response = await client.get_wallets()
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    assert False
+            assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
             async def have_chia():
                 await farm_blocks(full_node_api, our_ph, 1)
@@ -1142,12 +1096,9 @@ class TestPoolWalletRpc:
 
             await time_out_assert(5, wallet_is_synced, True, wallet_nodes[0], full_node_api)
 
-            summaries_response = await client.get_wallets()
-            wallet_id: Optional[int] = None
-            for summary in summaries_response:
-                if WalletType(int(summary["type"])) == WalletType.POOLING_WALLET:
-                    wallet_id = summary["id"]
-            assert wallet_id is not None
+            summaries_response = await client.get_wallets(WalletType.POOLING_WALLET)
+            assert len(summaries_response) == 1
+            wallet_id: int = summaries_response[0]["id"]
             status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
 
             assert status.current.state == PoolSingletonState.FARMING_TO_POOL.value


### PR DESCRIPTION
This PR:
- Adds an optional parameter `type` to the wallet RPC command `get_wallets` to allow querying specific wallet types only
- Adds the optional parameter `-w, --wallet_type` to the `chia wallet show` command
- Makes use of the optional parameter in pool tests. 