### PR TITLE
run benchmarks separately

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [ 3.9 ]
 
     steps:
     - name: Checkout Code

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,4 @@
-#
-# THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
-#
-name: Ubuntu clvm Test
+name: Benchmarks
 
 on:
   push:
@@ -20,15 +17,14 @@ concurrency:
 
 jobs:
   build:
-    name: Ubuntu clvm Test
-    runs-on: ${{ matrix.os }}
+    name: Benchmarks
+    runs-on: benchmark
     timeout-minutes: 30
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        os: [ubuntu-latest]
 
     steps:
     - name: Checkout Code
@@ -40,14 +36,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Cache npm
-      uses: actions/cache@v2.1.6
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
 
     - name: Get pip cache dir
       id: pip-cache
@@ -62,8 +50,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-# Omitted checking out blocks and plots repo Chia-Network/test-cache
-
     - name: Install ubuntu dependencies
       run: |
         sudo apt-get install software-properties-common
@@ -77,14 +63,7 @@ jobs:
       run: |
         sh install.sh -d
 
-# Omitted installing Timelord
-
-    - name: Test clvm code with pytest
+    - name: pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n auto -m "not benchmark"
-
-
-#
-# THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
-#
+        ./venv/bin/py.test -n 0 -m benchmark tests

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test blockchain code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-clvm.yml
+++ b/.github/workflows/build-test-macos-clvm.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Test clvm code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n auto
+        ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n auto -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-cmds.yml
+++ b/.github/workflows/build-test-macos-core-cmds.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-cmds code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-consensus.yml
+++ b/.github/workflows/build-test-macos-core-consensus.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-consensus code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-custom_types.yml
+++ b/.github/workflows/build-test-macos-core-custom_types.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-custom_types code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-daemon code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-full_node-full_sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-full_node-stores.yml
+++ b/.github/workflows/build-test-macos-core-full_node-stores.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-full_node-stores code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/full_node/stores/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/full_node/stores/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-full_node code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/full_node/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/full_node/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-server code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-ssl code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core-util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test core code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test farmer_harvester code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-generator.yml
+++ b/.github/workflows/build-test-macos-generator.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test generator code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Test plotting code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test pools code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test simulation code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-tools.yml
+++ b/.github/workflows/build-test-macos-tools.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test tools code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-util.yml
+++ b/.github/workflows/build-test-macos-util.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test wallet-cat_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-did_wallet.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test wallet-did_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-rl_wallet.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test wallet-rl_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test wallet-rpc code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test wallet-simple_sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test wallet-sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Test weight_proof code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0 -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test blockchain code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-cmds.yml
+++ b/.github/workflows/build-test-ubuntu-core-cmds.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-cmds code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-consensus code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-custom_types code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-daemon code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-full_node-full_sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-full_node-stores code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/full_node/stores/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/full_node/stores/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
     - name: Check resource usage

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-full_node code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/full_node/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/full_node/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
     - name: Check resource usage

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-server code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-ssl code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core-util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test core code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test farmer_harvester code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test generator code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Test plotting code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test pools code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test simulation code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-tools.yml
+++ b/.github/workflows/build-test-ubuntu-tools.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test tools code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test wallet-cat_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test wallet-did_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test wallet-rl_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test wallet-rpc code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test wallet-simple_sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test wallet-sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Test weight_proof code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0
+        ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0 -m "not benchmark"
 
 
 #

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -2183,6 +2183,7 @@ class TestMaliciousGenerators:
             ConditionOpcode.ASSERT_SECONDS_RELATIVE,
         ],
     )
+    @pytest.mark.benchmark
     def test_duplicate_large_integer_ladder(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_LADDER_COND.format(opcode=opcode.value[0], num=28, filler="0x00")
         start_time = time()
@@ -2199,8 +2200,8 @@ class TestMaliciousGenerators:
                     [ConditionWithArgs(opcode, [int_to_bytes(28)])],
                 )
             ]
-        assert run_time < 1.5
         print(f"run time:{run_time}")
+        assert run_time < 0.7
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2211,6 +2212,7 @@ class TestMaliciousGenerators:
             ConditionOpcode.ASSERT_SECONDS_RELATIVE,
         ],
     )
+    @pytest.mark.benchmark
     def test_duplicate_large_integer(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
         start_time = time()
@@ -2227,8 +2229,8 @@ class TestMaliciousGenerators:
                     [ConditionWithArgs(opcode, [bytes([100])])],
                 )
             ]
-        assert run_time < 2.5
         print(f"run time:{run_time}")
+        assert run_time < 1.1
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2239,6 +2241,7 @@ class TestMaliciousGenerators:
             ConditionOpcode.ASSERT_SECONDS_RELATIVE,
         ],
     )
+    @pytest.mark.benchmark
     def test_duplicate_large_integer_substr(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_SUBSTR_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
         start_time = time()
@@ -2255,8 +2258,8 @@ class TestMaliciousGenerators:
                     [ConditionWithArgs(opcode, [bytes([100])])],
                 )
             ]
-        assert run_time < 3
         print(f"run time:{run_time}")
+        assert run_time < 1.1
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2267,6 +2270,7 @@ class TestMaliciousGenerators:
             ConditionOpcode.ASSERT_SECONDS_RELATIVE,
         ],
     )
+    @pytest.mark.benchmark
     def test_duplicate_large_integer_substr_tail(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_SUBSTR_TAIL_COND.format(
             opcode=opcode.value[0], num=280, val="0xffffffff", filler="0x00"
@@ -2282,8 +2286,8 @@ class TestMaliciousGenerators:
 
             print(npc_result.npc_list[0].conditions[0][1])
             assert ConditionWithArgs(opcode, [int_to_bytes(0xFFFFFFFF)]) in npc_result.npc_list[0].conditions[0][1]
-        assert run_time < 1
         print(f"run time:{run_time}")
+        assert run_time < 0.3
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2294,6 +2298,7 @@ class TestMaliciousGenerators:
             ConditionOpcode.ASSERT_SECONDS_RELATIVE,
         ],
     )
+    @pytest.mark.benchmark
     def test_duplicate_large_integer_negative(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0xff")
         start_time = time()
@@ -2302,9 +2307,10 @@ class TestMaliciousGenerators:
         assert npc_result.error is None
         assert len(npc_result.npc_list) == 1
         assert npc_result.npc_list[0].conditions == []
-        assert run_time < 2
         print(f"run time:{run_time}")
+        assert run_time < 1
 
+    @pytest.mark.benchmark
     def test_duplicate_reserve_fee(self, softfork_height):
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
@@ -2322,9 +2328,10 @@ class TestMaliciousGenerators:
                     [ConditionWithArgs(opcode, [int_to_bytes(100 * 280000)])],
                 )
             ]
-        assert run_time < 2
         print(f"run time:{run_time}")
+        assert run_time < 1
 
+    @pytest.mark.benchmark
     def test_duplicate_reserve_fee_negative(self, softfork_height):
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=200000, val=100, filler="0xff")
@@ -2335,12 +2342,13 @@ class TestMaliciousGenerators:
         # amount
         assert npc_result.error == Err.RESERVE_FEE_CONDITION_FAILED.value
         assert len(npc_result.npc_list) == 0
-        assert run_time < 1.5
         print(f"run time:{run_time}")
+        assert run_time < 0.8
 
     @pytest.mark.parametrize(
         "opcode", [ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT]
     )
+    @pytest.mark.benchmark
     def test_duplicate_coin_announces(self, opcode, softfork_height):
         condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
         start_time = time()
@@ -2351,9 +2359,10 @@ class TestMaliciousGenerators:
         # coin announcements are not propagated to python, but validated in rust
         assert len(npc_result.npc_list[0].conditions) == 0
         # TODO: optimize clvm to make this run in < 1 second
-        assert run_time < 21
         print(f"run time:{run_time}")
+        assert run_time < 7
 
+    @pytest.mark.benchmark
     def test_create_coin_duplicates(self, softfork_height):
         # CREATE_COIN
         # this program will emit 6000 identical CREATE_COIN conditions. However,
@@ -2365,9 +2374,10 @@ class TestMaliciousGenerators:
         run_time = time() - start_time
         assert npc_result.error == Err.DUPLICATE_OUTPUT.value
         assert len(npc_result.npc_list) == 0
-        assert run_time < 2
         print(f"run time:{run_time}")
+        assert run_time < 0.8
 
+    @pytest.mark.benchmark
     def test_many_create_coin(self, softfork_height):
         # CREATE_COIN
         # this program will emit many CREATE_COIN conditions, all with different
@@ -2382,8 +2392,8 @@ class TestMaliciousGenerators:
         assert len(npc_result.npc_list[0].conditions) == 1
         assert npc_result.npc_list[0].conditions[0][0] == ConditionOpcode.CREATE_COIN.value
         assert len(npc_result.npc_list[0].conditions[0][1]) == 6094
-        assert run_time < 1
         print(f"run time:{run_time}")
+        assert run_time < 0.2
 
     @pytest.mark.asyncio
     async def test_invalid_coin_spend_coin(self, bt, two_nodes, wallet_a):

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -44,6 +44,7 @@ async def wallet_nodes(bt):
 
 class TestMempoolPerformance:
     @pytest.mark.asyncio
+    @pytest.mark.benchmark
     async def test_mempool_update_performance(self, bt, wallet_nodes, default_400_blocks, self_hostname):
         blocks = default_400_blocks
         full_nodes, wallets = wallet_nodes
@@ -78,7 +79,12 @@ class TestMempoolPerformance:
         blocks = bt.get_consecutive_blocks(3, blocks)
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[-3]))
 
-        for block in blocks[-2:]:
+        for idx, block in enumerate(blocks):
             start_t_2 = time.time()
             await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
-            assert time.time() - start_t_2 < 1
+            end_t_2 = time.time()
+            duration = end_t_2 - start_t_2
+            if idx >= len(blocks) - 3:
+                assert duration < 0.1
+            else:
+                assert duration < 0.0002

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -55,6 +55,7 @@ async def wallet_nodes(bt):
 
 class TestPerformance:
     @pytest.mark.asyncio
+    @pytest.mark.benchmark
     async def test_full_block_performance(self, bt, wallet_nodes, self_hostname):
         full_node_1, server_1, wallet_a, wallet_receiver = wallet_nodes
         blocks = await full_node_1.get_all_full_blocks()
@@ -146,8 +147,10 @@ class TestPerformance:
 
             if req is None:
                 break
+        end = time.time()
         log.warning(f"Num Tx: {num_tx}")
-        log.warning(f"Time for mempool: {time.time() - start}")
+        log.warning(f"Time for mempool: {end - start:f}")
+        assert end - start < 0.001
         pr.create_stats()
         pr.dump_stats("./mempool-benchmark.pstats")
 
@@ -188,8 +191,10 @@ class TestPerformance:
 
         start = time.time()
         res = await full_node_1.respond_unfinished_block(fnp.RespondUnfinishedBlock(unfinished), fake_peer)
+        end = time.time()
         log.warning(f"Res: {res}")
-        log.warning(f"Time for unfinished: {time.time() - start}")
+        log.warning(f"Time for unfinished: {end - start:f}")
+        assert end - start < 0.1
 
         pr.create_stats()
         pr.dump_stats("./unfinished-benchmark.pstats")
@@ -201,8 +206,10 @@ class TestPerformance:
         # No transactions generator, the full node already cached it from the unfinished block
         block_small = dataclasses.replace(block, transactions_generator=None)
         res = await full_node_1.full_node.respond_block(fnp.RespondBlock(block_small))
+        end = time.time()
         log.warning(f"Res: {res}")
-        log.warning(f"Time for full block: {time.time() - start}")
+        log.warning(f"Time for full block: {end - start:f}")
+        assert end - start < 0.1
 
         pr.create_stats()
         pr.dump_stats("./full-block-benchmark.pstats")

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -6,6 +6,7 @@ log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 asyncio_mode = strict
+markers=benchmark
 filterwarnings =
     error
     ignore:ssl_context is deprecated:DeprecationWarning

--- a/tests/runner_templates/build-test-macos
+++ b/tests/runner_templates/build-test-macos
@@ -77,7 +77,7 @@ INSTALL_TIMELORD
     - name: Test TEST_NAME code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS
+        ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS -m "not benchmark"
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/tests/runner_templates/build-test-ubuntu
+++ b/tests/runner_templates/build-test-ubuntu
@@ -82,7 +82,7 @@ INSTALL_TIMELORD
     - name: Test TEST_NAME code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS
+        ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS -m "not benchmark"
 
 CHECK_RESOURCE_USAGE
 #


### PR DESCRIPTION
This patch separates tests that check the runtime of some operation from other tests. Such tests are marked with `@pytest.mark.benchmark` to indicate this.

All normal github workflows are updated to *not* run benchmark tests, and a new workflow is added that *only* runs benchmark tests (on dedicated hardware). With this added performance reliability, the current time limits can also be tightened.