### PR TITLE
wallet: Fix `STANDARD_WALLET` creation for `wallet_info.id != 1`

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -182,7 +182,7 @@ class WalletStateManager:
             if wallet_info.type == WalletType.STANDARD_WALLET:
                 if wallet_info.id == 1:
                     continue
-                wallet = await Wallet.create(config, wallet_info)
+                wallet = await Wallet.create(self, wallet_info)
             elif wallet_info.type == WalletType.CAT:
                 wallet = await CATWallet.create(
                     self,


### PR DESCRIPTION
Not sure about the workflow to create a standard wallet with an id != 1 but i somehow ended up with one with ID 29 and when i wanted to query it it failed due to `wallet_state_manager` being the `config` dict. 