### PR TITLE
cmds: Implement `chia rpc` command

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -9,6 +9,7 @@ from chia.cmds.keys import keys_cmd
 from chia.cmds.netspace import netspace_cmd
 from chia.cmds.passphrase import passphrase_cmd
 from chia.cmds.plots import plots_cmd
+from chia.cmds.rpc import rpc_cmd
 from chia.cmds.show import show_cmd
 from chia.cmds.start import start_cmd
 from chia.cmds.stop import stop_cmd
@@ -131,6 +132,7 @@ cli.add_command(wallet_cmd)
 cli.add_command(plotnft_cmd)
 cli.add_command(configure_cmd)
 cli.add_command(init_cmd)
+cli.add_command(rpc_cmd)
 cli.add_command(show_cmd)
 cli.add_command(start_cmd)
 cli.add_command(stop_cmd)

--- a/chia/cmds/rpc.py
+++ b/chia/cmds/rpc.py
@@ -1,0 +1,140 @@
+import asyncio
+import json
+import sys
+from typing import Any, Dict, List, Optional, TextIO
+
+import click
+from aiohttp import ClientResponseError
+
+from chia.util.config import load_config
+from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.ints import uint16
+
+services: List[str] = ["farmer", "full_node", "harvester", "wallet"]
+
+
+async def call_endpoint(
+    service: str, host: str, port: uint16, endpoint: str, request: Dict[str, Any], config: Dict[str, Any]
+) -> Dict[str, Any]:
+    from chia.rpc.rpc_client import RpcClient
+
+    try:
+        client = await RpcClient.create(host, port, DEFAULT_ROOT_PATH, config)
+    except Exception as e:
+        raise Exception(f"Failed to create RPC client {service}: {e}")
+    result: Dict[str, Any]
+    try:
+        result = await client.fetch(endpoint, request)
+    except ClientResponseError as e:
+        if e.code == 404:
+            raise Exception(f"Invalid endpoint for {service}: {endpoint}")
+        raise e
+    except Exception as e:
+        raise Exception(f"Request failed: {e}")
+    finally:
+        client.close()
+        await client.await_closed()
+    return result
+
+
+def print_result(json_dict: Dict[str, Any]) -> None:
+    print(json.dumps(json_dict, indent=4, sort_keys=True))
+
+
+def get_routes(service: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    return asyncio.run(
+        call_endpoint(service, config["self_hostname"], uint16(config[service]["rpc_port"]), "get_routes", {}, config)
+    )
+
+
+@click.group("rpc", short_help="RPC Client")
+def rpc_cmd() -> None:
+    pass
+
+
+@rpc_cmd.command("endpoints", help="Print all endpoints of a service")
+@click.argument("service", type=click.Choice(services))
+def endpoints_cmd(service: str) -> None:
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    try:
+        routes = get_routes(service, config)
+        for route in routes["routes"]:
+            print(route[1:])
+    except Exception as e:
+        print(e)
+
+
+@rpc_cmd.command("status", help="Print the status of all available RPC services")
+def status_cmd() -> None:
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+
+    def print_row(c0: str, c1: str) -> None:
+        c0 = "{0:<12}".format(f"{c0}")
+        c1 = "{0:<9}".format(f"{c1}")
+        print(f"{c0} | {c1}")
+
+    print_row("SERVICE", "STATUS")
+    print_row("------------", "---------")
+    for service in services:
+        status = "ACTIVE"
+        try:
+            if not get_routes(service, config)["success"]:
+                raise Exception()
+        except Exception:
+            status = "INACTIVE"
+        print_row(service, status)
+
+
+def create_commands() -> None:
+    for service in services:
+
+        @rpc_cmd.command(
+            service,
+            short_help=f"RPC client for the {service} RPC API",
+            help=(
+                f"Call ENDPOINT (RPC endpoint as as string) of the {service} "
+                "RPC API with REQUEST (must be a JSON string) as request data."
+            ),
+        )
+        @click.argument("endpoint", type=str)
+        @click.argument("request", type=str, required=False)
+        @click.option(
+            "-j",
+            "--json-file",
+            help="Optionally instead of REQUEST you can provide a json file containing the request data",
+            type=click.File("r"),
+            default=None,
+        )
+        def rpc_client_cmd(
+            endpoint: str, request: Optional[str], json_file: Optional[TextIO], service: str = service
+        ) -> None:
+            config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+            if request is not None and json_file is not None:
+                sys.exit(
+                    "Can only use one request source: REQUEST argument OR -j/--json-file option. See the help with -h"
+                )
+
+            request_json: Dict[str, Any] = {}
+            if json_file is not None:
+                try:
+                    request_json = json.load(json_file)
+                except Exception as e:
+                    sys.exit(f"Invalid JSON file: {e}")
+            if request is not None:
+                try:
+                    request_json = json.loads(request)
+                except Exception as e:
+                    sys.exit(f"Invalid REQUEST JSON: {e}")
+
+            port: uint16 = uint16(config[service]["rpc_port"])
+            try:
+                if endpoint[0] == "/":
+                    endpoint = endpoint[1:]
+                print_result(
+                    asyncio.run(call_endpoint(service, config["self_hostname"], port, endpoint, request_json, config))
+                )
+            except Exception as e:
+                sys.exit(e)
+
+
+create_commands()


### PR DESCRIPTION
Adds the new command `chia rpc` to have an easy way to access all RPC endpoints via CLI. It enables direct access to all endpoints of the selected service with the JSON request provided as string argument like in 

```
chia rpc wallet get_wallet_balance '{"wallet_id": 12}'
``` 

or with the JSON request provided via a JSON file like in 

```
chia rpc wallet get_wallet_balance -j ~/request.json 
```

### Help
```
chia rpc
Usage: chia rpc [OPTIONS] COMMAND [ARGS]...

Options:
  -h, --help  Show this message and exit.

Commands:
  farmer     RPC client for the farmer RPC API
  full_node  RPC client for the full_node RPC API
  harvester  RPC client for the harvester RPC API
  routes     Print all routes of a service
  status     Print the status of all available RPC services
  wallet     RPC client for the wallet RPC API
```

## Examples

```
chia rpc wallet get_wallets
{
    "success": true,
    "wallets": [
        {
            "data": "",
            "id": 1,
            "name": "Chia Wallet",
            "type": 0
        },
        {
            "data": "",
            "id": 12,
            "name": "Pool wallet",
            "type": 9
        }
    ]
}
```

and 

```
chia rpc wallet get_wallet_balance '{"wallet_id": 12}'
{
    "success": true,
    "wallet_balance": {
        "confirmed_wallet_balance": 0,
        "fingerprint": 172057028,
        "max_send_amount": 0,
        "pending_change": 0,
        "pending_coin_removal_count": 0,
        "spendable_balance": 0,
        "unconfirmed_wallet_balance": 0,
        "unspent_coin_count": 0,
        "wallet_id": 12
    }
}
```