### PR TITLE
Change name of `harvester_farmer` to order of returned values. 

### DIFF
--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -13,7 +13,7 @@ from chia.types.peer_info import PeerInfo
 from tests.block_tools import test_constants
 from chia.util.ints import uint16
 from tests.setup_nodes import (
-    setup_farmer_harvester,
+    setup_harvester_farmer,
     setup_introducer,
     setup_simulators_and_wallets,
     setup_timelord,
@@ -53,7 +53,7 @@ async def establish_connection(server: ChiaServer, self_hostname: str, ssl_conte
 
 @pytest_asyncio.fixture(scope="function")
 async def harvester_farmer(bt):
-    async for _ in setup_farmer_harvester(bt, test_constants):
+    async for _ in setup_harvester_farmer(bt, test_constants, start_services=True):
         yield _
 
 

--- a/tests/farmer_harvester/test_farmer_harvester.py
+++ b/tests/farmer_harvester/test_farmer_harvester.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 
 from chia.farmer.farmer import Farmer
 from chia.util.keychain import generate_mnemonic
-from tests.setup_nodes import setup_farmer_harvester, test_constants
+from tests.setup_nodes import setup_harvester_farmer, test_constants
 from tests.time_out_assert import time_out_assert
 
 
@@ -14,14 +14,14 @@ def farmer_is_started(farmer):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def environment(bt):
-    async for _ in setup_farmer_harvester(bt, test_constants, False):
+async def harvester_farmer_environment_no_start(bt):
+    async for _ in setup_harvester_farmer(bt, test_constants, start_services=False):
         yield _
 
 
 @pytest.mark.asyncio
-async def test_start_with_empty_keychain(environment, bt):
-    _, farmer_service = environment
+async def test_start_with_empty_keychain(harvester_farmer_environment_no_start, bt):
+    _, farmer_service = harvester_farmer_environment_no_start
     farmer: Farmer = farmer_service._node
     # First remove all keys from the keychain
     bt.local_keychain.delete_all_keys()
@@ -41,8 +41,8 @@ async def test_start_with_empty_keychain(environment, bt):
 
 
 @pytest.mark.asyncio
-async def test_harvester_handshake(environment, bt):
-    harvester_service, farmer_service = environment
+async def test_harvester_handshake(harvester_farmer_environment_no_start, bt):
+    harvester_service, farmer_service = harvester_farmer_environment_no_start
     harvester = harvester_service._node
     farmer = farmer_service._node
 

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -534,7 +534,7 @@ async def setup_simulators_and_wallets(
         await _teardown_nodes(node_iters)
 
 
-async def setup_farmer_harvester(bt: BlockTools, consensus_constants: ConsensusConstants, start_services: bool = True):
+async def setup_harvester_farmer(bt: BlockTools, consensus_constants: ConsensusConstants, *, start_services: bool):
     farmer_port = find_available_listen_port("farmer")
     farmer_rpc_port = find_available_listen_port("farmer rpc")
     harvester_port = find_available_listen_port("harvester")


### PR DESCRIPTION
Enforce mandatory naming and inclusion of start_services parameter