### PR TITLE
wallet: Fix `CATLineageStore` creation in `create_new_cat_wallet`

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -97,10 +97,8 @@ class CATWallet:
 
         self.wallet_info = new_wallet_info
 
-        self.lineage_store = await CATLineageStore.create(self.wallet_state_manager.db_wrapper, self.get_asset_id())
-
         try:
-            chia_tx, spend_bundle = await ALL_LIMITATIONS_PROGRAMS[
+            chia_tx, spend_bundle, origin_id = await ALL_LIMITATIONS_PROGRAMS[
                 cat_tail_info["identifier"]
             ].generate_issuance_bundle(
                 self,
@@ -116,6 +114,9 @@ class CATWallet:
             raise ValueError("Failed to create spend.")
 
         await self.wallet_state_manager.add_new_wallet(self, self.id())
+
+        self.lineage_store = await CATLineageStore.create(self.wallet_state_manager.db_wrapper, self.get_asset_id())
+        await self.add_lineage(origin_id, LineageProof(), False)
 
         # If the new CAT name wasn't originally provided, we used a temporary name before issuance
         # since we didn't yet know the TAIL. Now we know the TAIL, we can update the name

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -98,7 +98,7 @@ class CATWallet:
         self.wallet_info = new_wallet_info
 
         try:
-            chia_tx, spend_bundle, origin_id = await ALL_LIMITATIONS_PROGRAMS[
+            chia_tx, spend_bundle = await ALL_LIMITATIONS_PROGRAMS[
                 cat_tail_info["identifier"]
             ].generate_issuance_bundle(
                 self,
@@ -114,9 +114,6 @@ class CATWallet:
             raise ValueError("Failed to create spend.")
 
         await self.wallet_state_manager.add_new_wallet(self, self.id())
-
-        self.lineage_store = await CATLineageStore.create(self.wallet_state_manager.db_wrapper, self.get_asset_id())
-        await self.add_lineage(origin_id, LineageProof(), False)
 
         # If the new CAT name wasn't originally provided, we used a temporary name before issuance
         # since we didn't yet know the TAIL. Now we know the TAIL, we can update the name


### PR DESCRIPTION
We currently create the `CATLineageStore` before the new asset id exists which leads to all CATs created by `create_new_cat_wallet` using the same lineage store table: `lineage_proofs_0000000000000000000000000000000000000000`.

The test added in ee02c5cf5baea787d6f75c012de4b44a95a5f34f fails without d295e49ca68aa2260b0eb4115ddac8eb456aed88


Note that i fully fixed it in `puzzles/tails.py` only, not in `puzzles/genesis_checker.py` because of #10790.