### PR TITLE
produce a correct error message when referencing a block that doesn't exist

### DIFF
--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -254,7 +254,7 @@ class TestBlockStore:
                 generators = await store.get_generators_at([4, 8, 3, 9])
                 assert generators == expected_generators
 
-                with pytest.raises(KeyError):
+                with pytest.raises(ValueError):
                     await store.get_generators_at([100])
 
             assert await store.get_generator(blocks[2].header_hash) == new_blocks[2].transactions_generator


### PR DESCRIPTION
When a block reference points to a height that doesn't exist in the blockchain, rather than failing with `KeyError`, fail with `ValueError` and a proper consensus error code.