### PR TITLE
stop helping mkdir() do what it already does

### DIFF
--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -1,6 +1,5 @@
 import os
 import pickle
-from os import path
 from pathlib import Path
 from typing import List
 

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -53,9 +53,7 @@ def persistent_blocks(
     if ci is not None and not file_path.exists():
         raise Exception(f"Running in CI and expected path not found: {file_path!r}")
 
-    if not path.exists(block_path_dir):
-        mkdir(block_path_dir.parent)
-        mkdir(block_path_dir)
+    mkdir(block_path_dir)
 
     if file_path.exists():
         try:


### PR DESCRIPTION
I don't really like that we've done this necessarily, but that `mkdir()` isn't python's `mkdir()`.  It is `from chia.util.path import mkdir` https://github.com/Chia-Network/chia-blockchain/blob/657f3c9018c85e65267429b254590b0dd3fafc1c/chia/util/path.py#L18-L23 which uses `pathlib.Path.mkdir(parents=True, exist_ok=True)`.