### PR TITLE
Disable the pytest-monitor plugin in CI if not checking results

### DIFF
--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test blockchain code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-clvm.yml
+++ b/.github/workflows/build-test-ubuntu-clvm.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Test clvm code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n auto -m "not benchmark"
+        ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n auto -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-clvm.yml
+++ b/.github/workflows/build-test-ubuntu-clvm.yml
@@ -77,6 +77,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n auto -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-cmds.yml
+++ b/.github/workflows/build-test-ubuntu-core-cmds.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core-cmds code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-cmds.yml
+++ b/.github/workflows/build-test-ubuntu-core-cmds.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core-consensus code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core-custom_types code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -102,6 +102,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Test core-daemon code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core-full_node-full_sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -90,7 +90,6 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/full_node/stores/test_*.py -s -v --durations 0 -m "not benchmark"
 
-
     - name: Check resource usage
       run: |
         sqlite3 -readonly -separator " " .pymon "select item,cpu_usage,total_time,mem_usage from TEST_METRICS order by mem_usage desc;" >metrics.out

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -90,7 +90,6 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/full_node/test_*.py -s -v --durations 0 -m "not benchmark"
 
-
     - name: Check resource usage
       run: |
         sqlite3 -readonly -separator " " .pymon "select item,cpu_usage,total_time,mem_usage from TEST_METRICS order by mem_usage desc;" >metrics.out

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core-server code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core-ssl code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core-util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test core code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test farmer_harvester code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test generator code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test plotting code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test pools code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -102,6 +102,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Test simulation code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-tools.yml
+++ b/.github/workflows/build-test-ubuntu-tools.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-tools.yml
+++ b/.github/workflows/build-test-ubuntu-tools.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test tools code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test util code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test wallet-cat_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test wallet-did_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test wallet-rl_wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test wallet-rpc code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test wallet-simple_sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test wallet-sync code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test wallet code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Test weight_proof code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0 -m "not benchmark"
+        ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
 
 #

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -90,6 +90,7 @@ jobs:
         . ./activate
         ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0 -m "not benchmark" -p no:monitor
 
+# Omitted resource usage check
 
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme

--- a/tests/build-workflows.py
+++ b/tests/build-workflows.py
@@ -87,6 +87,10 @@ def generate_replacements(conf, dir):
     replacements["TEST_NAME"] = test_name(dir)
     if "test_name" in conf:
         replacements["TEST_NAME"] = conf["test_name"]
+    if "CHECK_RESOURCE_USAGE" in conf:
+        replacements["DISABLE_PYTEST_MONITOR"] = ""
+    else:
+        replacements["DISABLE_PYTEST_MONITOR"] = "-p no:monitor"
     for var in conf["custom_vars"]:
         replacements[var] = conf[var] if var in conf else ""
     return replacements
@@ -135,6 +139,8 @@ for os in testconfig.oses:
         conf = update_config(module_dict(testconfig), dir_config(dir))
         replacements = generate_replacements(conf, dir)
         txt = transform_template(template_text, replacements)
+        # remove trailing whitespace from lines and assure a single EOF at EOL
+        txt = "\n".join(line.rstrip() for line in txt.rstrip().splitlines()) + "\n"
         logging.info(f"Writing {os}-{test_name(dir)}")
         workflow_yaml_path: Path = workflow_yaml_file(args.output_dir, os, test_name(dir))
         if workflow_yaml_path not in current_workflows or current_workflows[workflow_yaml_path] != txt:

--- a/tests/build-workflows.py
+++ b/tests/build-workflows.py
@@ -68,6 +68,10 @@ def generate_replacements(conf, dir):
         "CHECKOUT_TEST_BLOCKS_AND_PLOTS": read_file(
             Path(root_path / "runner_templates/checkout-test-plots.include.yml")
         ).rstrip(),
+        "CHECK_RESOURCE_USAGE": read_file(
+            Path(root_path / "runner_templates/check-resource-usage.include.yml")
+        ).rstrip(),
+        "DISABLE_PYTEST_MONITOR": "",
         "TEST_DIR": "",
         "TEST_NAME": "",
         "PYTEST_PARALLEL_ARGS": "",
@@ -87,9 +91,8 @@ def generate_replacements(conf, dir):
     replacements["TEST_NAME"] = test_name(dir)
     if "test_name" in conf:
         replacements["TEST_NAME"] = conf["test_name"]
-    if "CHECK_RESOURCE_USAGE" in conf:
-        replacements["DISABLE_PYTEST_MONITOR"] = ""
-    else:
+    if not conf["check_resource_usage"]:
+        replacements["CHECK_RESOURCE_USAGE"] = "# Omitted resource usage check"
         replacements["DISABLE_PYTEST_MONITOR"] = "-p no:monitor"
     for var in conf["custom_vars"]:
         replacements[var] = conf[var] if var in conf else ""

--- a/tests/core/full_node/config.py
+++ b/tests/core/full_node/config.py
@@ -1,8 +1,3 @@
 # flake8: noqa: E501
 job_timeout = 50
-CHECK_RESOURCE_USAGE = """
-    - name: Check resource usage
-      run: |
-        sqlite3 -readonly -separator " " .pymon "select item,cpu_usage,total_time,mem_usage from TEST_METRICS order by mem_usage desc;" >metrics.out
-        ./tests/check_pytest_monitor_output.py <metrics.out
-"""
+check_resource_usage = True

--- a/tests/core/full_node/stores/config.py
+++ b/tests/core/full_node/stores/config.py
@@ -1,8 +1,3 @@
 # flake8: noqa: E501
 job_timeout = 40
-CHECK_RESOURCE_USAGE = """
-    - name: Check resource usage
-      run: |
-        sqlite3 -readonly -separator " " .pymon "select item,cpu_usage,total_time,mem_usage from TEST_METRICS order by mem_usage desc;" >metrics.out
-        ./tests/check_pytest_monitor_output.py <metrics.out
-"""
+check_resource_usage = True

--- a/tests/runner_templates/build-test-ubuntu
+++ b/tests/runner_templates/build-test-ubuntu
@@ -78,6 +78,7 @@ INSTALL_TIMELORD
         ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS -m "not benchmark" DISABLE_PYTEST_MONITOR
 
 CHECK_RESOURCE_USAGE
+
 #
 # THIS FILE IS GENERATED. SEE https://github.com/Chia-Network/chia-blockchain/tree/main/tests#readme
 #

--- a/tests/runner_templates/build-test-ubuntu
+++ b/tests/runner_templates/build-test-ubuntu
@@ -75,7 +75,7 @@ INSTALL_TIMELORD
     - name: Test TEST_NAME code with pytest
       run: |
         . ./activate
-        ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS -m "not benchmark"
+        ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS -m "not benchmark" DISABLE_PYTEST_MONITOR
 
 CHECK_RESOURCE_USAGE
 #

--- a/tests/runner_templates/check-resource-usage.include.yml
+++ b/tests/runner_templates/check-resource-usage.include.yml
@@ -1,0 +1,4 @@
+    - name: Check resource usage
+      run: |
+        sqlite3 -readonly -separator " " .pymon "select item,cpu_usage,total_time,mem_usage from TEST_METRICS order by mem_usage desc;" >metrics.out
+        ./tests/check_pytest_monitor_output.py <metrics.out

--- a/tests/testconfig.py
+++ b/tests/testconfig.py
@@ -1,3 +1,5 @@
+from typing import List
+
 # Github actions template config.
 oses = ["ubuntu", "macos"]
 
@@ -7,4 +9,4 @@ checkout_blocks_and_plots = True
 install_timelord = False
 check_resource_usage = False
 job_timeout = 30
-custom_vars = []
+custom_vars: List[str] = []

--- a/tests/testconfig.py
+++ b/tests/testconfig.py
@@ -5,5 +5,6 @@ oses = ["ubuntu", "macos"]
 parallel = False
 checkout_blocks_and_plots = True
 install_timelord = False
+check_resource_usage = False
 job_timeout = 30
-custom_vars = ["CHECK_RESOURCE_USAGE"]
+custom_vars = []


### PR DESCRIPTION
pytest-monitor uses multiprocessing and has caused multiple confusing
issues.  Perhaps it can be adjusted to not use multiprocessing, but
for now lets just isolate the oddities to where we actually use it.