### PR TITLE
Added `-n`/`--new-address` option to `chia wallet get_address`

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -167,7 +167,9 @@ def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_type: Opti
 )
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-@click.option("-n", "--new-address", help="Create a new wallet receive address", is_flag=True, default=False, show_default=True)
+@click.option(
+    "-n", "--new-address", help="Create a new wallet receive address", is_flag=True, default=False, show_default=True
+)
 def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int, new_address: bool) -> None:
     extra_params = {"id": id, "new_address": new_address}
     import asyncio

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -168,7 +168,14 @@ def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_type: Opti
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(
-    "-n", "--new-address", help="Create a new wallet receive address", is_flag=True, default=False, show_default=True
+    "-n/-l",
+    "--new-address/--latest-address",
+    help=(
+        "Create a new wallet receive address, or show the most recently created wallet receive address"
+        "  [default: show most recent address]"
+    ),
+    is_flag=True,
+    default=False,
 )
 def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int, new_address: bool) -> None:
     extra_params = {"id": id, "new_address": new_address}

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -167,8 +167,9 @@ def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_type: Opti
 )
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int) -> None:
-    extra_params = {"id": id}
+@click.option("-n", "--new-address", help="Create a new wallet receive address", is_flag=True, default=False, show_default=True)
+def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int, new_address: bool) -> None:
+    extra_params = {"id": id, "new_address": new_address}
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_address
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -216,7 +216,8 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
 
 async def get_address(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["id"]
-    res = await wallet_client.get_next_address(wallet_id, False)
+    new_address: bool = args.get("new_address", False)
+    res = await wallet_client.get_next_address(wallet_id, new_address)
     print(res)
 
 


### PR DESCRIPTION
`chia wallet address` defaults to returning the wallet address computed from the most recently derived wallet key. This change introduces a `-n` or `--new-address` option to return a new wallet address using a newly derived wallet key.

Issue #4869
