### PR TITLE
Minor output formatting/enhancements for `chia wallet show`

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -482,23 +482,25 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
         else:
             print(f"Balances, fingerprint: {fingerprint}")
         for summary in summaries_response:
+            indent: str = "   "
             asset_id = summary["data"]
             wallet_id = summary["id"]
             balances = await wallet_client.get_wallet_balance(wallet_id)
             typ = WalletType(int(summary["type"]))
             address_prefix, scale = wallet_coin_unit(typ, address_prefix)
             total_balance: str = print_balance(balances["confirmed_wallet_balance"], scale, address_prefix)
-            print(f"{summary['name']}: {total_balance}")
-            print(f"   -Wallet ID: {wallet_id}")
-            print(f"   -Type: {typ.name}")
+            print()
+            print(f"{summary['name']}:")
+            print(f"{indent}{'-Wallet ID:'.ljust(23)} {wallet_id}")
+            print(f"{indent}{'-Type:'.ljust(23)} {typ.name}")
             if len(asset_id) > 0:
-                print(f"   -Asset ID: {asset_id}")
-            print(f"   -Total Balance: {total_balance}")
+                print(f"{indent}{'-Asset ID:'.ljust(23)} {asset_id}")
+            print(f"{indent}{'-Total Balance:'.ljust(23)} {total_balance}")
             print(
-                f"   -Pending Total Balance: "
+                f"{indent}{'-Pending Total Balance:'.ljust(23)} "
                 f"{print_balance(balances['unconfirmed_wallet_balance'], scale, address_prefix)}"
             )
-            print(f"   -Spendable: {print_balance(balances['spendable_balance'], scale, address_prefix)}")
+            print(f"{indent}{'-Spendable:'.ljust(23)} {print_balance(balances['spendable_balance'], scale, address_prefix)}")
 
     print(" ")
     trusted_peers: Dict = config["wallet"].get("trusted_peers", {})
@@ -519,20 +521,23 @@ async def get_wallet(wallet_client: WalletRpcClient, fingerprint: int = None) ->
         log_in_response = await wallet_client.log_in(fingerprint)
     else:
         logged_in_fingerprint: Optional[int] = await wallet_client.get_logged_in_fingerprint()
+        spacing: str = "  " if logged_in_fingerprint is not None else ""
         current_sync_status: str = ""
         if logged_in_fingerprint is not None:
             if await wallet_client.get_synced():
                 current_sync_status = "Synced"
             elif await wallet_client.get_sync_status():
                 current_sync_status = "Syncing"
+            else:
+                current_sync_status = "Not Synced"
         print("Choose wallet key:")
         for i, fp in enumerate(fingerprints):
-            print(f"{i+1}) {fp}", end="")
-            if logged_in_fingerprint == fp:
-                print("*", end="")
-                if len(current_sync_status) > 0:
-                    print(f" ({current_sync_status})", end="")
-            print()
+            row: str = f"{i+1}) "
+            row += "* " if fp == logged_in_fingerprint else spacing
+            row += f"{fp}"
+            if fp == logged_in_fingerprint and len(current_sync_status) > 0:
+                row += f" ({current_sync_status})"
+            print(row)
         val = None
         while val is None:
             val = input("Enter a number to pick or q to quit: ")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -489,18 +489,19 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
             typ = WalletType(int(summary["type"]))
             address_prefix, scale = wallet_coin_unit(typ, address_prefix)
             total_balance: str = print_balance(balances["confirmed_wallet_balance"], scale, address_prefix)
+            unconfirmed_wallet_balance: str = print_balance(
+                balances["unconfirmed_wallet_balance"], scale, address_prefix
+            )
+            spendable_balance: str = print_balance(balances["spendable_balance"], scale, address_prefix)
             print()
             print(f"{summary['name']}:")
-            print(f"{indent}{'-Wallet ID:'.ljust(23)} {wallet_id}")
+            print(f"{indent}{'-Total Balance:'.ljust(23)} {total_balance}")
+            print(f"{indent}{'-Pending Total Balance:'.ljust(23)} " f"{unconfirmed_wallet_balance}")
+            print(f"{indent}{'-Spendable:'.ljust(23)} {spendable_balance}")
             print(f"{indent}{'-Type:'.ljust(23)} {typ.name}")
             if len(asset_id) > 0:
                 print(f"{indent}{'-Asset ID:'.ljust(23)} {asset_id}")
-            print(f"{indent}{'-Total Balance:'.ljust(23)} {total_balance}")
-            print(
-                f"{indent}{'-Pending Total Balance:'.ljust(23)} "
-                f"{print_balance(balances['unconfirmed_wallet_balance'], scale, address_prefix)}"
-            )
-            print(f"{indent}{'-Spendable:'.ljust(23)} {print_balance(balances['spendable_balance'], scale, address_prefix)}")
+            print(f"{indent}{'-Wallet ID:'.ljust(23)} {wallet_id}")
 
     print(" ")
     trusted_peers: Dict = config["wallet"].get("trusted_peers", {})


### PR DESCRIPTION
The wallet selection listing now indicates the logged-in wallet key as well as a brief syncing/synced status:

```
Choose wallet key:
1)   52772570
2)   836768032
3)   3994766492
4) * 3795877592 (Synced)
5)   3808384920
6)   1622336804
7)   3208516197
8)   46513267
Enter a number to pick or q to quit: 4
```

```
Choose wallet key:
1)   52772570
2)   836768032
3)   3994766492
4) * 3795877592 (Syncing)
5)   3808384920
6)   1622336804
7)   3208516197
8)   46513267
```

Wallet listings updated to include the asset ID (for CATs). Formatting has been updated as well:
```
Wallet height: 1740990
Sync status: Synced
Balances, fingerprint: 3795877592

Chia Wallet:
   -Total Balance:         0.000299999996 xch (299999996 mojo)
   -Pending Total Balance: 0.000299999996 xch (299999996 mojo)
   -Spendable:             0.000299999996 xch (299999996 mojo)
   -Type:                  STANDARD_WALLET
   -Wallet ID:             1

Spacebucks:
   -Total Balance:         1.234  (1234 mojo)
   -Pending Total Balance: 1.234  (1234 mojo)
   -Spendable:             1.234  (1234 mojo)
   -Type:                  CAT
   -Asset ID:              78ad32a8c9ea70f27d73e9306fc467bab2a6b15b30289791e37ab6e8612212b100
   -Wallet ID:             2

CAT King Cole:
   -Total Balance:         1.111  (1111 mojo)
   -Pending Total Balance: 1.111  (1111 mojo)
   -Spendable:             1.111  (1111 mojo)
   -Type:                  CAT
   -Asset ID:              1121996b75cce3c746369aced2c8887b02b84e95592c3dc006d82a145adf349a00
   -Wallet ID:             3

<snip>
```