### PR TITLE
rollback height map

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -380,6 +380,7 @@ class Blockchain(BlockchainInterface):
         # Rollback sub_epoch_summaries
         self.__height_map.rollback(fork_height)
         await self.block_store.rollback(fork_height)
+        self._peak_height = None if fork_height < 0 else uint32(fork_height)
 
         # Collect all blocks from fork point to new peak
         blocks_to_add: List[Tuple[FullBlock, BlockRecord]] = []

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -391,7 +391,16 @@ class Blockchain(BlockchainInterface):
             cm.callback(restore_height_map)
 
             await self.block_store.rollback(fork_height)
+
+            original_peak = self._peak_height
+
+            def restore_peak() -> None:
+                self._peak_height = original_peak
+
             self._peak_height = None if fork_height < 0 else uint32(fork_height)
+
+            # in case of failure during reorg, restore the _peak_height
+            cm.callback(restore_peak)
 
             # Collect all blocks from fork point to new peak
             blocks_to_add: List[Tuple[FullBlock, BlockRecord]] = []

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -4,6 +4,7 @@ import logging
 import multiprocessing
 import traceback
 from concurrent.futures.process import ProcessPoolExecutor
+from contextlib import ExitStack
 from enum import Enum
 from multiprocessing.context import BaseContext
 from pathlib import Path
@@ -329,123 +330,137 @@ class Blockchain(BlockchainInterface):
         It returns the height of the fork between the previous chain and the new chain, or returns
         None if there was no update to the heaviest chain.
         """
-        peak = self.get_peak()
-        latest_coin_state: Dict[bytes32, CoinRecord] = {}
-        hint_coin_state: Dict[bytes, Dict[bytes32, CoinRecord]] = {}
+        with ExitStack() as cm:
+            peak = self.get_peak()
+            latest_coin_state: Dict[bytes32, CoinRecord] = {}
+            hint_coin_state: Dict[bytes, Dict[bytes32, CoinRecord]] = {}
 
-        if genesis:
-            if peak is None:
-                block: Optional[FullBlock] = await self.block_store.get_full_block(block_record.header_hash)
-                assert block is not None
+            if genesis:
+                if peak is None:
+                    block: Optional[FullBlock] = await self.block_store.get_full_block(block_record.header_hash)
+                    assert block is not None
 
-                if npc_result is not None:
-                    tx_removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
-                else:
-                    tx_removals, tx_additions = [], []
-                if block.is_transaction_block():
-                    assert block.foliage_transaction_block is not None
-                    added = await self.coin_store.new_block(
-                        block.height,
-                        block.foliage_transaction_block.timestamp,
-                        block.get_included_reward_coins(),
-                        tx_additions,
-                        tx_removals,
+                    if npc_result is not None:
+                        tx_removals, tx_additions = tx_removals_and_additions(npc_result.npc_list)
+                    else:
+                        tx_removals, tx_additions = [], []
+                    if block.is_transaction_block():
+                        assert block.foliage_transaction_block is not None
+                        added = await self.coin_store.new_block(
+                            block.height,
+                            block.foliage_transaction_block.timestamp,
+                            block.get_included_reward_coins(),
+                            tx_additions,
+                            tx_removals,
+                        )
+                    else:
+                        added, _ = [], []
+                    await self.block_store.set_in_chain([(block_record.header_hash,)])
+                    await self.block_store.set_peak(block_record.header_hash)
+                    return uint32(0), uint32(0), [block_record], (added, {})
+                return None, None, [], ([], {})
+
+            assert peak is not None
+            if block_record.weight <= peak.weight:
+                # This is not a heavier block than the heaviest we have seen, so we don't change the coin set
+                return None, None, [], ([], {})
+
+            # Find the fork. if the block is just being appended, it will return the peak
+            # If no blocks in common, returns -1, and reverts all blocks
+            if block_record.prev_hash == peak.header_hash:
+                fork_height: int = peak.height
+            elif fork_point_with_peak is not None:
+                fork_height = fork_point_with_peak
+            else:
+                fork_height = find_fork_point_in_chain(self, block_record, peak)
+
+            if block_record.prev_hash != peak.header_hash:
+                roll_changes: List[CoinRecord] = await self.coin_store.rollback_to_block(fork_height)
+                for coin_record in roll_changes:
+                    latest_coin_state[coin_record.name] = coin_record
+
+            # Rollback sub_epoch_summaries
+            restore_point = self.__height_map.rollback(fork_height)
+
+            def restore_height_map() -> None:
+                self.__height_map.restore(restore_point)
+
+            # arm the ExitStack to restore __height_map in case we fail from
+            # now on. Once we've completed the reorg successfully, we disarm the
+            # ExitStack to not call the restore function
+            cm.callback(restore_height_map)
+
+            await self.block_store.rollback(fork_height)
+            self._peak_height = None if fork_height < 0 else uint32(fork_height)
+
+            # Collect all blocks from fork point to new peak
+            blocks_to_add: List[Tuple[FullBlock, BlockRecord]] = []
+            curr = block_record.header_hash
+
+            while fork_height < 0 or curr != self.height_to_hash(uint32(fork_height)):
+                fetched_full_block: Optional[FullBlock] = await self.block_store.get_full_block(curr)
+                fetched_block_record: Optional[BlockRecord] = await self.block_store.get_block_record(curr)
+                assert fetched_full_block is not None
+                assert fetched_block_record is not None
+                blocks_to_add.append((fetched_full_block, fetched_block_record))
+                if fetched_full_block.height == 0:
+                    # Doing a full reorg, starting at height 0
+                    break
+                curr = fetched_block_record.prev_hash
+
+            records_to_add = []
+            for fetched_full_block, fetched_block_record in reversed(blocks_to_add):
+                records_to_add.append(fetched_block_record)
+                if not fetched_full_block.is_transaction_block():
+                    continue
+
+                if fetched_block_record.header_hash == block_record.header_hash:
+                    tx_removals, tx_additions, npc_res = await self.get_tx_removals_and_additions(
+                        fetched_full_block, npc_result
                     )
                 else:
-                    added, _ = [], []
-                await self.block_store.set_in_chain([(block_record.header_hash,)])
-                await self.block_store.set_peak(block_record.header_hash)
-                return uint32(0), uint32(0), [block_record], (added, {})
-            return None, None, [], ([], {})
+                    tx_removals, tx_additions, npc_res = await self.get_tx_removals_and_additions(
+                        fetched_full_block, None
+                    )
 
-        assert peak is not None
-        if block_record.weight <= peak.weight:
-            # This is not a heavier block than the heaviest we have seen, so we don't change the coin set
-            return None, None, [], ([], {})
-
-        # Find the fork. if the block is just being appended, it will return the peak
-        # If no blocks in common, returns -1, and reverts all blocks
-        if block_record.prev_hash == peak.header_hash:
-            fork_height: int = peak.height
-        elif fork_point_with_peak is not None:
-            fork_height = fork_point_with_peak
-        else:
-            fork_height = find_fork_point_in_chain(self, block_record, peak)
-
-        if block_record.prev_hash != peak.header_hash:
-            roll_changes: List[CoinRecord] = await self.coin_store.rollback_to_block(fork_height)
-            for coin_record in roll_changes:
-                latest_coin_state[coin_record.name] = coin_record
-
-        # Rollback sub_epoch_summaries
-        self.__height_map.rollback(fork_height)
-        await self.block_store.rollback(fork_height)
-        self._peak_height = None if fork_height < 0 else uint32(fork_height)
-
-        # Collect all blocks from fork point to new peak
-        blocks_to_add: List[Tuple[FullBlock, BlockRecord]] = []
-        curr = block_record.header_hash
-
-        while fork_height < 0 or curr != self.height_to_hash(uint32(fork_height)):
-            fetched_full_block: Optional[FullBlock] = await self.block_store.get_full_block(curr)
-            fetched_block_record: Optional[BlockRecord] = await self.block_store.get_block_record(curr)
-            assert fetched_full_block is not None
-            assert fetched_block_record is not None
-            blocks_to_add.append((fetched_full_block, fetched_block_record))
-            if fetched_full_block.height == 0:
-                # Doing a full reorg, starting at height 0
-                break
-            curr = fetched_block_record.prev_hash
-
-        records_to_add = []
-        for fetched_full_block, fetched_block_record in reversed(blocks_to_add):
-            records_to_add.append(fetched_block_record)
-            if not fetched_full_block.is_transaction_block():
-                continue
-
-            if fetched_block_record.header_hash == block_record.header_hash:
-                tx_removals, tx_additions, npc_res = await self.get_tx_removals_and_additions(
-                    fetched_full_block, npc_result
+                assert fetched_full_block.foliage_transaction_block is not None
+                added_rec = await self.coin_store.new_block(
+                    fetched_full_block.height,
+                    fetched_full_block.foliage_transaction_block.timestamp,
+                    fetched_full_block.get_included_reward_coins(),
+                    tx_additions,
+                    tx_removals,
                 )
-            else:
-                tx_removals, tx_additions, npc_res = await self.get_tx_removals_and_additions(fetched_full_block, None)
+                removed_rec: List[Optional[CoinRecord]] = [
+                    await self.coin_store.get_coin_record(name) for name in tx_removals
+                ]
 
-            assert fetched_full_block.foliage_transaction_block is not None
-            added_rec = await self.coin_store.new_block(
-                fetched_full_block.height,
-                fetched_full_block.foliage_transaction_block.timestamp,
-                fetched_full_block.get_included_reward_coins(),
-                tx_additions,
-                tx_removals,
-            )
-            removed_rec: List[Optional[CoinRecord]] = [
-                await self.coin_store.get_coin_record(name) for name in tx_removals
-            ]
+                # Set additions first, then removals in order to handle ephemeral coin state
+                # Add in height order is also required
+                record: Optional[CoinRecord]
+                for record in added_rec:
+                    assert record
+                    latest_coin_state[record.name] = record
+                for record in removed_rec:
+                    assert record
+                    latest_coin_state[record.name] = record
 
-            # Set additions first, then removals in order to handle ephemeral coin state
-            # Add in height order is also required
-            record: Optional[CoinRecord]
-            for record in added_rec:
-                assert record
-                latest_coin_state[record.name] = record
-            for record in removed_rec:
-                assert record
-                latest_coin_state[record.name] = record
+                if npc_res is not None:
+                    hint_list: List[Tuple[bytes32, bytes]] = self.get_hint_list(npc_res)
+                    await self.hint_store.add_hints(hint_list)
+                    # There can be multiple coins for the same hint
+                    for coin_id, hint in hint_list:
+                        key = hint
+                        if key not in hint_coin_state:
+                            hint_coin_state[key] = {}
+                        hint_coin_state[key][coin_id] = latest_coin_state[coin_id]
 
-            if npc_res is not None:
-                hint_list: List[Tuple[bytes32, bytes]] = self.get_hint_list(npc_res)
-                await self.hint_store.add_hints(hint_list)
-                # There can be multiple coins for the same hint
-                for coin_id, hint in hint_list:
-                    key = hint
-                    if key not in hint_coin_state:
-                        hint_coin_state[key] = {}
-                    hint_coin_state[key][coin_id] = latest_coin_state[coin_id]
+            await self.block_store.set_in_chain([(br.header_hash,) for br in records_to_add])
 
-        await self.block_store.set_in_chain([(br.header_hash,) for br in records_to_add])
-
-        # Changes the peak to be the new peak
-        await self.block_store.set_peak(block_record.header_hash)
+            # Changes the peak to be the new peak
+            await self.block_store.set_peak(block_record.header_hash)
+            # disarm restore function. We completed successfully
+            cm.pop_all()
         return (
             uint32(max(fork_height, 0)),
             block_record.height,

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -224,6 +224,7 @@ class BlockHeightMap:
                 heights_to_delete.append(ses_included_height)
         for height in heights_to_delete:
             del self.__sub_epoch_summaries[height]
+        del self.__height_to_hash[(fork_height + 1) * 32 :]
 
     def get_ses(self, height: uint32) -> SubEpochSummary:
         return SubEpochSummary.from_bytes(self.__sub_epoch_summaries[height])

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -11,7 +11,7 @@ import time
 from argparse import Namespace
 from dataclasses import replace
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Any
+from typing import Callable, Dict, List, Optional, Tuple, Any, Union
 
 from blspy import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from chiabip158 import PyBIP158
@@ -432,7 +432,7 @@ class BlockTools:
         normalized_to_identity_cc_sp: bool = False,
         normalized_to_identity_cc_ip: bool = False,
         current_time: bool = False,
-        previous_generator: CompressorArg = None,
+        previous_generator: Optional[Union[CompressorArg, List[uint32]]] = None,
         genesis_timestamp: Optional[uint64] = None,
         force_plot_id: Optional[bytes32] = None,
     ) -> List[FullBlock]:
@@ -595,12 +595,14 @@ class BlockTools:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
 
                         if transaction_data is not None:
-                            if previous_generator is not None:
+                            if type(previous_generator) is CompressorArg:
                                 block_generator: Optional[BlockGenerator] = best_solution_generator_from_template(
                                     previous_generator, transaction_data
                                 )
                             else:
                                 block_generator = simple_solution_generator(transaction_data)
+                                if type(previous_generator) is list:
+                                    block_generator = BlockGenerator(block_generator.program, [], previous_generator)
 
                             aggregate_signature = transaction_data.aggregated_signature
                         else:
@@ -877,7 +879,7 @@ class BlockTools:
                             else:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
                         if transaction_data is not None:
-                            if previous_generator is not None:
+                            if previous_generator is not None and type(previous_generator) is CompressorArg:
                                 block_generator = best_solution_generator_from_template(
                                     previous_generator, transaction_data
                                 )

--- a/tests/core/full_node/test_block_height_map.py
+++ b/tests/core/full_node/test_block_height_map.py
@@ -368,7 +368,15 @@ class TestBlockHeightMap:
             assert height_map.get_hash(5) == gen_block_hash(5)
 
             height_map.rollback(5)
-
+            assert height_map.contains_height(0)
+            assert height_map.contains_height(1)
+            assert height_map.contains_height(2)
+            assert height_map.contains_height(3)
+            assert height_map.contains_height(4)
+            assert height_map.contains_height(5)
+            assert not height_map.contains_height(6)
+            assert not height_map.contains_height(7)
+            assert not height_map.contains_height(8)
             assert height_map.get_hash(5) == gen_block_hash(5)
 
             assert height_map.get_ses(0) == gen_ses(0)
@@ -398,8 +406,12 @@ class TestBlockHeightMap:
             assert height_map.get_hash(6) == gen_block_hash(6)
 
             height_map.rollback(6)
+            assert height_map.contains_height(6)
+            assert not height_map.contains_height(7)
 
             assert height_map.get_hash(6) == gen_block_hash(6)
+            with pytest.raises(AssertionError) as _:
+                height_map.get_hash(7)
 
             assert height_map.get_ses(0) == gen_ses(0)
             assert height_map.get_ses(2) == gen_ses(2)


### PR DESCRIPTION
When performing a reorg, we roll back existing blocks to an earlier state. This change makes us *also* roll back the height-to-hash map.

Before the height-to-hash refactor, we did also not roll this back, and I preserved this behaviour. However, there's some really subtle (and way too complex) logic in `get_block_generator()` ([here](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/consensus/blockchain.py#L889)) that determines whether or not we are currently in a reorg based on whether a height-to-hash entry exists. This can (in rare instances) lead to thinking we are *not*, when we in fact are.

This addresses the "in-main-chain" issue gene experienced last week.