### PR TITLE
Add support for excluding coins in `create_signed_transaction` wallet rpc

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1699,6 +1699,10 @@ class WalletRpcApi:
         if "coins" in request and len(request["coins"]) > 0:
             coins = set([Coin.from_json_dict(coin_json) for coin_json in request["coins"]])
 
+        exclude_coins = None
+        if "exclude_coins" in request and len(request["exclude_coins"]) > 0:
+            exclude_coins = set([Coin.from_json_dict(coin_json) for coin_json in request["exclude_coins"]])
+
         coin_announcements: Optional[Set[Announcement]] = None
         if (
             "coin_announcements" in request
@@ -1740,6 +1744,7 @@ class WalletRpcApi:
                     bytes32(puzzle_hash_0),
                     fee,
                     coins=coins,
+                    exclude_coins=exclude_coins,
                     ignore_max_send_amount=True,
                     primaries=additional_outputs,
                     memos=memos_0,
@@ -1753,6 +1758,7 @@ class WalletRpcApi:
                 bytes32(puzzle_hash_0),
                 fee,
                 coins=coins,
+                exclude_coins=exclude_coins,
                 ignore_max_send_amount=True,
                 primaries=additional_outputs,
                 memos=memos_0,

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -208,6 +208,7 @@ class WalletRpcClient(RpcClient):
         coin_announcements: Optional[List[Announcement]] = None,
         puzzle_announcements: Optional[List[Announcement]] = None,
         min_coin_amount: uint64 = uint64(0),
+        exclude_coins: Optional[List[Coin]] = None,
     ) -> TransactionRecord:
         # Converts bytes to hex for puzzle hashes
         additions_hex = []
@@ -245,6 +246,10 @@ class WalletRpcClient(RpcClient):
         if coins is not None and len(coins) > 0:
             coins_json = [c.to_json_dict() for c in coins]
             request["coins"] = coins_json
+
+        if exclude_coins is not None and len(exclude_coins) > 0:
+            exclude_coins_json = [exclude_coin.to_json_dict() for exclude_coin in exclude_coins]
+            request["exclude_coins"] = exclude_coins_json
 
         response: Dict = await self.fetch("create_signed_transaction", request)
         return TransactionRecord.from_json_dict_convenience(response["signed_tx"])

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -291,6 +291,7 @@ class Wallet:
         memos: Optional[List[bytes]] = None,
         negative_change_allowed: bool = False,
         min_coin_amount: Optional[uint64] = None,
+        exclude_coins: Optional[Set[Coin]] = None,
     ) -> List[CoinSpend]:
         """
         Generates a unsigned transaction in form of List(Puzzle, Solutions)
@@ -312,7 +313,14 @@ class Wallet:
                 raise ValueError(f"Can't send more than {max_send} in a single transaction")
             self.log.debug("Got back max send amount: %s", max_send)
         if coins is None:
-            coins = await self.select_coins(uint64(total_amount), min_coin_amount=min_coin_amount)
+            exclude_coins_list: Optional[List[Coin]] = None
+            if exclude_coins is not None:
+                exclude_coins_list = list(exclude_coins)
+            coins = await self.select_coins(
+                uint64(total_amount), min_coin_amount=min_coin_amount, exclude=exclude_coins_list
+            )
+        elif exclude_coins is not None:
+            raise ValueError("Can't exclude coins when also specifically including coins")
         assert len(coins) > 0
         self.log.info(f"coins is not None {coins}")
         spend_value = sum([coin.amount for coin in coins])
@@ -418,6 +426,7 @@ class Wallet:
         memos: Optional[List[bytes]] = None,
         negative_change_allowed: bool = False,
         min_coin_amount: Optional[uint64] = None,
+        exclude_coins: Optional[Set[Coin]] = None,
     ) -> TransactionRecord:
         """
         Use this to generate transaction.
@@ -443,6 +452,7 @@ class Wallet:
             memos,
             negative_change_allowed,
             min_coin_amount,
+            exclude_coins=exclude_coins,
         )
         assert len(transaction) > 0
         self.log.info("About to sign a transaction: %s", transaction)

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -416,6 +416,39 @@ async def test_create_signed_transaction_with_puzzle_announcement(wallet_rpc_env
 
 
 @pytest.mark.asyncio
+async def test_create_signed_transaction_with_exclude_coins(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+    wallet_1: Wallet = env.wallet_1.wallet
+    wallet_1_rpc: WalletRpcClient = env.wallet_1.rpc_client
+    full_node_api: FullNodeSimulator = env.full_node.api
+    full_node_rpc: FullNodeRpcClient = env.full_node.rpc_client
+    await generate_funds(full_node_api, env.wallet_1)
+
+    async def it_does_not_include_the_excluded_coins() -> None:
+        selected_coins = await wallet_1_rpc.select_coins(amount=250000000000, wallet_id=1)
+        assert len(selected_coins) == 1
+        outputs = await create_tx_outputs(wallet_1, [(uint64(250000000000), None)])
+
+        tx = await wallet_1_rpc.create_signed_transaction(outputs, exclude_coins=selected_coins)
+
+        assert len(tx.removals) == 1
+        assert tx.removals[0] != selected_coins[0]
+        assert tx.removals[0].amount == uint64(1750000000000)
+        await assert_push_tx_error(full_node_rpc, tx)
+
+    async def it_throws_an_error_when_all_spendable_coins_are_excluded() -> None:
+        selected_coins = await wallet_1_rpc.select_coins(amount=1750000000000, wallet_id=1)
+        assert len(selected_coins) == 1
+        outputs = await create_tx_outputs(wallet_1, [(uint64(1750000000000), None)])
+
+        with pytest.raises(ValueError):
+            await wallet_1_rpc.create_signed_transaction(outputs, exclude_coins=selected_coins)
+
+    await it_does_not_include_the_excluded_coins()
+    await it_throws_an_error_when_all_spendable_coins_are_excluded()
+
+
+@pytest.mark.asyncio
 async def test_send_transaction_multi(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
 


### PR DESCRIPTION
Currently it is not possible to exclude specific coins in the `create_signed_transaction` wallet rpc api, only to select specific coins (allow vs deny list).

This PR adds a new option `exclude_coins` to the `create_signed_transaction` wallet rpc api, which gets passed down into the `select_coins()` method, which already supports exclusion of coins.

This PR is missing tests because i don't understand the current testing methods and their dependencies, it seems all tests use data of previous tests and are not contained in single test methods with each their own setup and teardown. If possible i'd want to add tests ofc.