### PR TITLE
single thread executor

### DIFF
--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import traceback
-from concurrent.futures.process import ProcessPoolExecutor
+from concurrent.futures import Executor
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -171,7 +171,7 @@ async def pre_validate_blocks_multiprocessing(
     constants_json: Dict,
     block_records: BlockchainInterface,
     blocks: Sequence[FullBlock],
-    pool: ProcessPoolExecutor,
+    pool: Executor,
     check_filter: bool,
     npc_results: Dict[uint32, NPCResult],
     get_block_generator: Callable[[BlockInfo, Optional[Dict[bytes32, FullBlock]]], Awaitable[Optional[BlockGenerator]]],

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -204,6 +204,7 @@ class FullNode:
         self.log.info("Initializing blockchain from disk")
         start_time = time.time()
         reserved_cores = self.config.get("reserved_cores", 0)
+        single_threaded = self.config.get("single_threaded", False)
         multiprocessing_start_method = process_config_start_method(config=self.config, log=self.log)
         self.multiprocessing_context = multiprocessing.get_context(method=multiprocessing_start_method)
         self.blockchain = await Blockchain.create(
@@ -214,11 +215,13 @@ class FullNode:
             blockchain_dir=self.db_path.parent,
             reserved_cores=reserved_cores,
             multiprocessing_context=self.multiprocessing_context,
+            single_threaded=single_threaded,
         )
         self.mempool_manager = MempoolManager(
             coin_store=self.coin_store,
             consensus_constants=self.constants,
             multiprocessing_context=self.multiprocessing_context,
+            single_threaded=single_threaded,
         )
 
         # Blocks are validated under high priority, and transactions under low priority. This guarantees blocks will

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -361,6 +361,11 @@ full_node:
   # this reserved core count.
   reserved_cores: 0
 
+  # set this to true to not offload heavy lifting into separate child processes.
+  # this option is mostly useful when profiling, since only the main process is
+  # profiled.
+  single_threaded: False
+
   # How often to initiate outbound connections to other full nodes.
   peer_connect_interval: 30
   # How long to wait for a peer connection

--- a/chia/util/inline_executor.py
+++ b/chia/util/inline_executor.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from concurrent.futures import Executor, Future
+from typing import Callable, TypeVar
+
+_T = TypeVar("_T")
+
+
+class InlineExecutor(Executor):
+    _closing: bool = False
+
+    def submit(self, fn: Callable[..., _T], *args, **kwargs) -> Future[_T]:  # type: ignore
+        if self._closing:
+            raise RuntimeError("executor shutting down")
+
+        f: Future[_T] = Future()
+        try:
+            f.set_result(fn(*args, **kwargs))
+        except BaseException as e:  # lgtm[py/catch-base-exception]
+            f.set_exception(e)
+        return f
+
+    def close(self) -> None:
+        self._closing = True

--- a/tests/tools/test_full_sync.py
+++ b/tests/tools/test_full_sync.py
@@ -10,4 +10,4 @@ from tools.test_full_sync import run_sync_test
 def test_full_sync_test():
     file_path = os.path.realpath(__file__)
     db_file = Path(file_path).parent / "test-blockchain-db.sqlite"
-    asyncio.run(run_sync_test(db_file, db_version=2, profile=False))
+    asyncio.run(run_sync_test(db_file, db_version=2, profile=False, single_thread=False))

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -46,7 +46,7 @@ def enable_profiler(profile: bool, counter: int) -> Iterator[None]:
         pr.dump_stats(f"slow-batch-{counter:05d}.profile")
 
 
-async def run_sync_test(file: Path, db_version, profile: bool) -> None:
+async def run_sync_test(file: Path, db_version, profile: bool, single_thread: bool) -> None:
 
     logger = logging.getLogger()
     logger.setLevel(logging.WARNING)
@@ -69,6 +69,9 @@ async def run_sync_test(file: Path, db_version, profile: bool) -> None:
 
         overrides = config["network_overrides"]["constants"][config["selected_network"]]
         constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
+        if single_thread:
+            config["full_node"]["single_threaded"] = True
+        config["full_node"]["db_sync"] = "off"
         full_node = FullNode(
             config["full_node"],
             root_path=root_path,
@@ -88,13 +91,13 @@ async def run_sync_test(file: Path, db_version, profile: bool) -> None:
 
                 start_time = time.monotonic()
                 async for r in rows:
-                    block = FullBlock.from_bytes(zstd.decompress(r[2]))
-
-                    block_batch.append(block)
-                    if len(block_batch) < 32:
-                        continue
-
                     with enable_profiler(profile, counter):
+                        block = FullBlock.from_bytes(zstd.decompress(r[2]))
+
+                        block_batch.append(block)
+                        if len(block_batch) < 32:
+                            continue
+
                         success, advanced_peak, fork_height, coin_changes = await full_node.receive_block_batch(
                             block_batch, None, None  # type: ignore[arg-type]
                         )
@@ -121,8 +124,15 @@ def main() -> None:
 @click.argument("file", type=click.Path(), required=True)
 @click.option("--db-version", type=int, required=False, default=2, help="the version of the specified db file")
 @click.option("--profile", is_flag=True, required=False, default=False, help="dump CPU profiles for slow batches")
-def run(file: Path, db_version: int, profile: bool) -> None:
-    asyncio.run(run_sync_test(Path(file), db_version, profile))
+@click.option(
+    "--single-thread",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="run node in a single process, to include validation in profiles",
+)
+def run(file: Path, db_version: int, profile: bool, single_thread: bool) -> None:
+    asyncio.run(run_sync_test(Path(file), db_version, profile, single_thread))
 
 
 @main.command("analyze", short_help="generate call stacks for all profiles dumped to current directory")


### PR DESCRIPTION
this adds an option to run the full node in single-thread mode. This is primarily useful when profiling, since we only profile the main process.