### PR TITLE
Fix trailing bytes shown in CAT asset ID row when using `chia wallet show`

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -484,7 +484,9 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
             print(f"Balances, fingerprint: {fingerprint}")
         for summary in summaries_response:
             indent: str = "   "
-            asset_id = summary["data"]
+            # asset_id currently contains both the asset ID and TAIL program bytes concatenated together.
+            # A future RPC update may split them apart, but for now we'll show the first 32 bytes (64 chars)
+            asset_id = summary["data"][:64]
             wallet_id = summary["id"]
             balances = await wallet_client.get_wallet_balance(wallet_id)
             typ = WalletType(int(summary["type"]))
@@ -501,9 +503,7 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
             print(f"{indent}{'-Spendable:'.ljust(23)} {spendable_balance}")
             print(f"{indent}{'-Type:'.ljust(23)} {typ.name}")
             if len(asset_id) > 0:
-                # asset_id currently contains both the asset ID and TAIL program bytes concatenated together.
-                # A future RPC update may split them apart, but for now we'll show the first 32 bytes (64 chars)
-                print(f"{indent}{'-Asset ID:'.ljust(23)} {asset_id[:64]}")
+                print(f"{indent}{'-Asset ID:'.ljust(23)} {asset_id}")
             print(f"{indent}{'-Wallet ID:'.ljust(23)} {wallet_id}")
 
     print(" ")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -501,7 +501,9 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
             print(f"{indent}{'-Spendable:'.ljust(23)} {spendable_balance}")
             print(f"{indent}{'-Type:'.ljust(23)} {typ.name}")
             if len(asset_id) > 0:
-                print(f"{indent}{'-Asset ID:'.ljust(23)} {asset_id}")
+                # asset_id currently contains both the asset ID and TAIL program bytes concatenated together.
+                # A future RPC update may split them apart, but for now we'll show the first 32 bytes (64 chars)
+                print(f"{indent}{'-Asset ID:'.ljust(23)} {asset_id[:64]}")
             print(f"{indent}{'-Wallet ID:'.ljust(23)} {wallet_id}")
 
     print(" ")


### PR DESCRIPTION
A wallet RPC change is needed to properly separate out the asset ID from the TAIL program returned by `get_all_wallet_info_entries()`. For now, this change will just fix the display of the asset ID when `chia wallet show` is used.