### PR TITLE
Type check DID Wallet

### DIFF
--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -69,7 +69,7 @@ class DIDWallet:
             raise ValueError("Cannot require more IDs than are known.")
         self.did_info = DIDInfo(None, backups_ids, num_of_backup_ids_needed, [], None, None, None, None, False)
         info_as_string = json.dumps(self.did_info.to_json_dict())
-        new_wallet_info = await wallet_state_manager.user_store.create_wallet(
+        new_wallet_info: Optional[WalletInfo] = await wallet_state_manager.user_store.create_wallet(
             "DID Wallet", WalletType.DISTRIBUTED_ID.value, info_as_string
         )
         if new_wallet_info is None:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -631,7 +631,7 @@ class DIDWallet:
             + self.wallet_state_manager.constants.AGG_SIG_ME_ADDITIONAL_DATA
         )
         pubkey = did_wallet_puzzles.get_pubkey_from_innerpuz(innerpuz)
-        index = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pubkey)
+        index: Optional[uint32] = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pubkey)
         if index is None:
             raise RuntimeError(f"Could not find index for pubkey {pubkey}")
         private = master_sk_to_wallet_sk_unhardened(self.wallet_state_manager.private_key, index)

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -705,7 +705,7 @@ class DIDWallet:
         to_sign = Program.to([innerpuz.get_tree_hash(), coin.amount, messages]).get_tree_hash()
         message = to_sign + coin.name() + self.wallet_state_manager.constants.AGG_SIG_ME_ADDITIONAL_DATA
         pubkey = did_wallet_puzzles.get_pubkey_from_innerpuz(innerpuz)
-        index = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pubkey)
+        index: Optional[uint32] = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pubkey)
         if index is None:
             raise RuntimeError(f"Could not find index for pubkey {pubkey}")
         private = master_sk_to_wallet_sk_unhardened(self.wallet_state_manager.private_key, index)

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -206,9 +206,9 @@ class DIDWallet:
         self.log.info(f"Confirmed balance for did wallet is {amount}")
         return uint128(amount)
 
-    async def get_pending_change_balance(self) -> uint64:
+    async def get_pending_change_balance(self) -> uint128:
         unconfirmed_tx = await self.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(self.id())
-        addition_amount = 0
+        addition_amount: uint128 = uint128(0)
 
         for record in unconfirmed_tx:
             our_spend = False
@@ -224,7 +224,7 @@ class DIDWallet:
                 if await self.wallet_state_manager.does_coin_belong_to_wallet(coin, self.id()):
                     addition_amount += coin.amount
 
-        return uint64(addition_amount)
+        return uint128(addition_amount)
 
     async def get_unconfirmed_balance(self, record_list=None) -> uint128:
         return await self.wallet_state_manager.get_unconfirmed_balance(self.id())

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -562,7 +562,7 @@ class DIDWallet:
             + self.wallet_state_manager.constants.AGG_SIG_ME_ADDITIONAL_DATA
         )
         pubkey = did_wallet_puzzles.get_pubkey_from_innerpuz(innerpuz)
-        index = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pubkey)
+        index: Optional[uint32] = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pubkey)
         if index is None:
             raise RuntimeError(f"Could not find index for pubkey {pubkey}")
         private = master_sk_to_wallet_sk_unhardened(self.wallet_state_manager.private_key, index)

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1024,7 +1024,7 @@ class DIDWallet:
         return spend_bundle
 
     async def get_spendable_balance(self, unspent_records=None) -> uint128:
-        spendable_am = await self.wallet_state_manager.get_confirmed_spendable_balance_for_wallet(
+        spendable_am: uint128 = await self.wallet_state_manager.get_confirmed_spendable_balance_for_wallet(
             self.wallet_info.id, unspent_records
         )
         return spendable_am

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -153,7 +153,7 @@ class DIDWallet:
         self.did_info = DIDInfo(None, [], uint64(0), [], None, None, None, None, False)
         info_as_string = json.dumps(self.did_info.to_json_dict())
 
-        new_wallet_info = await wallet_state_manager.user_store.create_wallet(
+        new_wallet_info: Optional[WalletInfo] = await wallet_state_manager.user_store.create_wallet(
             "DID Wallet", WalletType.DISTRIBUTED_ID.value, info_as_string
         )
         if new_wallet_info is None:


### PR DESCRIPTION
This patch contains 3 types of changes:

Use wider uint128 for values representing a wallet balance
Check for possible None from user_store.create_wallet
A look at the type of the second argument of self.wallet_state_manager.get_unconfirmed_balance