### PR TITLE
restrict click to < 8.1 for black (#10923)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
     rev: 21.12b0
     hooks:
     -   id: black
+        additional_dependencies: ['click<8.1']
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:


### PR DESCRIPTION
https://github.com/pallets/click/issues/2225

Doing this instead of updating since updating black will change several
files due to some formatting change.  I would like to take that on
separately from unbreaking CI.