### PR TITLE
Quick fix for improper v2 DB initialization when targeting testnet

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -202,6 +202,7 @@ class FullNode:
                             # this is a new DB file. Make it v2
                             async with self.db_wrapper.write_db() as w_conn:
                                 await set_db_version_async(w_conn, 2)
+                                self.db_wrapper.db_version = 2
                         except sqlite3.OperationalError:
                             # it could be a database created with "chia init", which is
                             # empty except it has the database_version table


### PR DESCRIPTION
This may not be the best way to handle this, but it works as a quick fix.

Issue #10951