### PR TITLE
improve error message when a block is missing from the blockchain database

### DIFF
--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -186,7 +186,7 @@ class BlockHeightMap:
             while height > window_end:
                 if prev_hash not in ordered:
                     raise ValueError(
-                        f"block with header hash {prev_hash.hex()} is missing from your blockchain database"
+                        f"block with header hash is missing from your blockchain database: {prev_hash.hex()}"
                     )
                 entry = ordered[prev_hash]
                 assert height == entry[0] + 1

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -184,6 +184,10 @@ class BlockHeightMap:
                             ordered[bytes32.fromhex(r[0])] = (r[2], bytes32.fromhex(r[1]), r[3])
 
             while height > window_end:
+                if prev_hash not in ordered:
+                    raise ValueError(
+                        f"block with header hash {prev_hash.hex()} is missing from your blockchain database"
+                    )
                 entry = ordered[prev_hash]
                 assert height == entry[0] + 1
                 height = entry[0]


### PR DESCRIPTION
On startup, we traverse the whole chain from peak to genesis, to build a height-to-hash map (unless we have a cached version of it).

If we find a missing link in the chain during this traversal, currently it manifests as a `KeyError` (see https://github.com/Chia-Network/chia-blockchain/issues/10883). This patch improves the error message.