### PR TITLE
limit test output on CI

### DIFF
--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test blockchain code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/blockchain/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-clvm.yml
+++ b/.github/workflows/build-test-macos-clvm.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Test clvm code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/clvm/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-cmds.yml
+++ b/.github/workflows/build-test-macos-core-cmds.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-cmds code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/cmds/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-consensus.yml
+++ b/.github/workflows/build-test-macos-core-consensus.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-consensus code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/consensus/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-custom_types.yml
+++ b/.github/workflows/build-test-macos-core-custom_types.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-custom_types code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/custom_types/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Test core-daemon code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/daemon/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-full_node-full_sync code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-full_node-stores.yml
+++ b/.github/workflows/build-test-macos-core-full_node-stores.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-full_node-stores code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/stores/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/stores/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-full_node code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-server code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/server/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-ssl code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/ssl/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core-util code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/util/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test core code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test farmer_harvester code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/farmer_harvester/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-generator.yml
+++ b/.github/workflows/build-test-macos-generator.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test generator code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/generator/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test plotting code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/plotting/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test pools code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0 -n 2 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/pools/test_*.py --durations=10  -n 2 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Test simulation code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/simulation/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-tools.yml
+++ b/.github/workflows/build-test-macos-tools.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test tools code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/tools/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-util.yml
+++ b/.github/workflows/build-test-macos-util.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test util code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/util/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test wallet-cat_wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-did_wallet.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test wallet-did_wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/did_wallet/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-rl_wallet.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test wallet-rl_wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test wallet-rpc code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rpc/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test wallet-simple_sync code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/simple_sync/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test wallet-sync code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0 -n 0 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/sync/test_*.py --durations=10  -n 0 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Test weight_proof code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/weight_proof/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test blockchain code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/blockchain/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/blockchain/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-clvm.yml
+++ b/.github/workflows/build-test-ubuntu-clvm.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Test clvm code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/clvm/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/clvm/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-cmds.yml
+++ b/.github/workflows/build-test-ubuntu-core-cmds.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-cmds code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/cmds/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/cmds/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-consensus code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/consensus/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/consensus/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-custom_types code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/custom_types/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/custom_types/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Test core-daemon code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/daemon/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/daemon/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-full_node-full_sync code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/full_sync/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-full_node-stores code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/stores/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/stores/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-full_node code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/test_*.py -s -v --durations 0 -n 4 -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/full_node/test_*.py --durations=10  -n 4 -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-server code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/server/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/server/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-ssl code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/ssl/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/ssl/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core-util code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/util/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/util/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test core code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/core/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test farmer_harvester code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/farmer_harvester/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/farmer_harvester/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test generator code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/generator/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/generator/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test plotting code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/plotting/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/plotting/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test pools code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/pools/test_*.py -s -v --durations 0 -n 2 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/pools/test_*.py --durations=10  -n 2 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Test simulation code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/simulation/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/simulation/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-tools.yml
+++ b/.github/workflows/build-test-ubuntu-tools.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test tools code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/tools/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/tools/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test util code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/util/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/util/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test wallet-cat_wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/cat_wallet/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test wallet-did_wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/did_wallet/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/did_wallet/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test wallet-rl_wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rl_wallet/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test wallet-rpc code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rpc/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/rpc/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test wallet-simple_sync code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/simple_sync/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/simple_sync/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test wallet-sync code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/sync/test_*.py -s -v --durations 0 -n 0 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/sync/test_*.py --durations=10  -n 0 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test wallet code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/wallet/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Test weight_proof code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/weight_proof/test_*.py -s -v --durations 0 -n 4 -m "not benchmark" -p no:monitor
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test tests/weight_proof/test_*.py --durations=10  -n 4 -m "not benchmark" -p no:monitor
 
     - name: Process coverage data
       run: |

--- a/tests/runner_templates/build-test-macos
+++ b/tests/runner_templates/build-test-macos
@@ -79,7 +79,7 @@ INSTALL_TIMELORD
     - name: Test TEST_NAME code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS -m "not benchmark"
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test TEST_DIR --durations=10 PYTEST_PARALLEL_ARGS -m "not benchmark"
 
     - name: Process coverage data
       run: |

--- a/tests/runner_templates/build-test-ubuntu
+++ b/tests/runner_templates/build-test-ubuntu
@@ -78,7 +78,7 @@ INSTALL_TIMELORD
     - name: Test TEST_NAME code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test TEST_DIR -s -v --durations 0PYTEST_PARALLEL_ARGS -m "not benchmark" DISABLE_PYTEST_MONITOR
+        venv/bin/coverage run --rcfile=.coveragerc ./venv/bin/py.test TEST_DIR --durations=10 PYTEST_PARALLEL_ARGS -m "not benchmark" DISABLE_PYTEST_MONITOR
 
     - name: Process coverage data
       run: |


### PR DESCRIPTION
by dropping -s and -v. Also, only print the 10 slowest tests, instead of all.

The relevant changes are down here: https://github.com/Chia-Network/chia-blockchain/pull/10959/files#diff-a1ba19578b59bb0e3f08301748324ea5d678bacef69f461df8479f94efd88395