### PR TITLE
Simplify Blockchain.get_header_blocks_in_range()

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -765,7 +765,7 @@ class Blockchain(BlockchainInterface):
         if peak_height is None:
             return {}
 
-        for height in range(start, min(stop, peak_height + 1)):
+        for height in range(start, min(stop, peak_height) + 1):
             # TODO: address hint error and remove ignore
             #       error: Incompatible types in assignment (expression has type "Optional[bytes32]", variable has
             #       type "bytes32")  [assignment]

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -760,14 +760,19 @@ class Blockchain(BlockchainInterface):
     ) -> Dict[bytes32, HeaderBlock]:
         blocks: List[FullBlock] = []
         uncached_hashes: List[bytes32] = []
-        for height in range(start, min(stop, self.get_peak_height() + 1):
+
+        peak_height = self.get_peak_height()
+        if peak_height is None:
+            return {}
+
+        for height in range(start, min(stop, peak_height + 1)):
             # TODO: address hint error and remove ignore
             #       error: Incompatible types in assignment (expression has type "Optional[bytes32]", variable has
             #       type "bytes32")  [assignment]
             header_hash: bytes32 = self.height_to_hash(uint32(height))  # type: ignore[assignment]
-            block = self.block_store.block_cache.get(hash)
+            block = self.block_store.block_cache.get(header_hash)
             if block is None:
-                uncached_hashes.append(hash)
+                uncached_hashes.append(header_hash)
             else:
                 blocks.append(block)
 


### PR DESCRIPTION
1. Avoid a copy
2. Avoid reiteration
3. Avoid continuing iteration when all remaining heights will be ignored
4. Avoid removal from a list which is O(n)
   - First it searches to find the item, then it has to shift the rest of the items after that down an index.

I have not profiled nor benchmarked anything.  This is an off the cuff optimization opportunity that I figured I would just write.  It may or may not be worth changing.