### PR TITLE
fix test_full_sync.py to only feed the blocks in the main chain

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -502,6 +502,7 @@ def chia_init(
             db_path_replaced = new_db_path.replace("CHALLENGE", config["selected_network"])
             db_path = path_from_root(root_path, db_path_replaced)
 
+            mkdir(db_path.parent)
             with sqlite3.connect(db_path) as connection:
                 set_db_version(connection, 1)
 


### PR DESCRIPTION
to the node. This avoids an exception thrown by `receive_block()`, and the test doesn't have to handle it.

Also, there was a missing `mkdir()` for the v1 database case in `chia init`.