### PR TITLE
Prepare test blocks and plots only for tests that need them

### DIFF
--- a/.github/workflows/build-test-macos-core-cmds.yml
+++ b/.github/workflows/build-test-macos-core-cmds.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-consensus.yml
+++ b/.github/workflows/build-test-macos-core-consensus.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-custom_types.yml
+++ b/.github/workflows/build-test-macos-core-custom_types.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-generator.yml
+++ b/.github/workflows/build-test-macos-generator.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-tools.yml
+++ b/.github/workflows/build-test-macos-tools.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-util.yml
+++ b/.github/workflows/build-test-macos-util.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-did_wallet.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-rl_wallet.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-cmds.yml
+++ b/.github/workflows/build-test-ubuntu-core-cmds.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-consensus.yml
+++ b/.github/workflows/build-test-ubuntu-core-consensus.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-custom_types.yml
+++ b/.github/workflows/build-test-ubuntu-core-custom_types.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-generator.yml
+++ b/.github/workflows/build-test-ubuntu-generator.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-tools.yml
+++ b/.github/workflows/build-test-ubuntu-tools.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-util.yml
+++ b/.github/workflows/build-test-ubuntu-util.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-did_wallet.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rl_wallet.yml
@@ -65,13 +65,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
-      with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+# Omitted checking out blocks and plots repo Chia-Network/test-cache
 
     - name: Run install script
       env:

--- a/tests/blockchain/config.py
+++ b/tests/blockchain/config.py
@@ -1,2 +1,3 @@
 parallel = True
 job_timeout = 60
+checkout_blocks_and_plots = True

--- a/tests/core/config.py
+++ b/tests/core/config.py
@@ -1,1 +1,2 @@
 parallel = True
+checkout_blocks_and_plots = True

--- a/tests/core/full_node/config.py
+++ b/tests/core/full_node/config.py
@@ -2,3 +2,4 @@
 parallel = True
 job_timeout = 50
 check_resource_usage = True
+checkout_blocks_and_plots = True

--- a/tests/core/full_node/full_sync/config.py
+++ b/tests/core/full_node/full_sync/config.py
@@ -1,2 +1,3 @@
 job_timeout = 60
 parallel = True
+checkout_blocks_and_plots = True

--- a/tests/core/full_node/stores/config.py
+++ b/tests/core/full_node/stores/config.py
@@ -2,3 +2,4 @@
 parallel = True
 job_timeout = 40
 check_resource_usage = True
+checkout_blocks_and_plots = True

--- a/tests/core/server/config.py
+++ b/tests/core/server/config.py
@@ -1,2 +1,1 @@
-install_timelord = True
 checkout_blocks_and_plots = True

--- a/tests/core/ssl/config.py
+++ b/tests/core/ssl/config.py
@@ -1,1 +1,2 @@
 parallel = True
+checkout_blocks_and_plots = True

--- a/tests/core/util/config.py
+++ b/tests/core/util/config.py
@@ -1,1 +1,2 @@
 parallel = True
+checkout_blocks_and_plots = True

--- a/tests/farmer_harvester/config.py
+++ b/tests/farmer_harvester/config.py
@@ -1,2 +1,1 @@
-install_timelord = True
 checkout_blocks_and_plots = True

--- a/tests/plotting/config.py
+++ b/tests/plotting/config.py
@@ -1,2 +1,3 @@
 parallel = True
 install_timelord = False
+checkout_blocks_and_plots = True

--- a/tests/pools/config.py
+++ b/tests/pools/config.py
@@ -1,2 +1,3 @@
 parallel = 2
 job_timeout = 60
+checkout_blocks_and_plots = True

--- a/tests/simulation/config.py
+++ b/tests/simulation/config.py
@@ -1,2 +1,3 @@
 job_timeout = 60
 install_timelord = True
+checkout_blocks_and_plots = True

--- a/tests/testconfig.py
+++ b/tests/testconfig.py
@@ -10,7 +10,7 @@ oses = ["ubuntu", "macos"]
 
 # Defaults are conservative.
 parallel: Union[bool, int, Literal["auto"]] = False
-checkout_blocks_and_plots = True
+checkout_blocks_and_plots = False
 install_timelord = False
 check_resource_usage = False
 job_timeout = 30

--- a/tests/wallet/cat_wallet/config.py
+++ b/tests/wallet/cat_wallet/config.py
@@ -1,2 +1,3 @@
 # flake8: noqa: E501
 job_timeout = 50
+checkout_blocks_and_plots = True

--- a/tests/wallet/config.py
+++ b/tests/wallet/config.py
@@ -1,3 +1,4 @@
 # flake8: noqa: E501
 job_timeout = 40
 parallel = True
+checkout_blocks_and_plots = True

--- a/tests/wallet/rpc/config.py
+++ b/tests/wallet/rpc/config.py
@@ -1,2 +1,1 @@
-install_timelord = True
 checkout_blocks_and_plots = True

--- a/tests/wallet/simple_sync/config.py
+++ b/tests/wallet/simple_sync/config.py
@@ -1,2 +1,1 @@
-install_timelord = True
 checkout_blocks_and_plots = True

--- a/tests/wallet/sync/config.py
+++ b/tests/wallet/sync/config.py
@@ -1,1 +1,2 @@
 job_timeout = 60
+checkout_blocks_and_plots = True

--- a/tests/weight_proof/config.py
+++ b/tests/weight_proof/config.py
@@ -1,1 +1,2 @@
 parallel = True
+checkout_blocks_and_plots = True


### PR DESCRIPTION
This saves us a couple more hours of CI running time.