### PR TITLE
fix performance tests

### DIFF
--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -77,4 +77,4 @@ class TestMempoolPerformance:
             if idx >= len(blocks) - 3:
                 assert duration < 0.1
             else:
-                assert duration < 0.0003
+                assert duration < 0.001

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -187,6 +187,7 @@ class TestCostCalculation:
         assert npc_result.error is None
 
     @pytest.mark.asyncio
+    @pytest.mark.benchmark
     async def test_tx_generator_speed(self, softfork_height):
         LARGE_BLOCK_COIN_CONSUMED_COUNT = 687
         generator_bytes = large_block_generator(LARGE_BLOCK_COIN_CONSUMED_COUNT)
@@ -207,7 +208,7 @@ class TestCostCalculation:
         assert len(npc_result.npc_list) == LARGE_BLOCK_COIN_CONSUMED_COUNT
         log.info(f"Time spent: {duration}")
 
-        assert duration < 2
+        assert duration < 0.5
 
     @pytest.mark.asyncio
     async def test_clvm_max_cost(self, softfork_height):
@@ -246,6 +247,7 @@ class TestCostCalculation:
         assert npc_result.cost > 10000000
 
     @pytest.mark.asyncio
+    @pytest.mark.benchmark
     async def test_standard_tx(self):
         # this isn't a real public key, but we don't care
         public_key = bytes.fromhex(
@@ -270,4 +272,4 @@ class TestCostCalculation:
         duration = time_end - time_start
 
         log.info(f"Time spent: {duration}")
-        assert duration < 3
+        assert duration < 0.1


### PR DESCRIPTION
There were two performance tests that hadn't been marked as such. I also bumped the time limit on the mempool performance test since it seems to have a lot of jitter in CI.