### PR TITLE
Faster full node tests

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1264,8 +1264,9 @@ class FullNodeAPI:
         )
         # Waits for the transaction to go into the mempool, times out after 45 seconds.
         status, error = None, None
-        for i in range(450):
-            await asyncio.sleep(0.1)
+        sleep_time = 0.01
+        for i in range(int(45 / sleep_time)):
+            await asyncio.sleep(sleep_time)
             for potential_name, potential_status, potential_error in self.full_node.transaction_responses:
                 if spend_name == potential_name:
                     status = potential_status

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,7 +206,7 @@ async def five_nodes(db_version, self_hostname):
         yield _
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture(scope="function")
 async def wallet_nodes(bt):
     async_gen = setup_simulators_and_wallets(2, 1, {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 400000000})
     nodes, wallets = await async_gen.__anext__()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,6 +343,66 @@ async def wallet_and_node():
         yield _
 
 
+@pytest_asyncio.fixture(scope="function")
+async def one_node_one_block(bt, wallet_a):
+    async_gen = setup_simulators_and_wallets(1, 0, {})
+    nodes, _ = await async_gen.__anext__()
+    full_node_1 = nodes[0]
+    server_1 = full_node_1.full_node.server
+
+    reward_ph = wallet_a.get_new_puzzlehash()
+    blocks = bt.get_consecutive_blocks(
+        1,
+        guarantee_transaction_block=True,
+        farmer_reward_puzzle_hash=reward_ph,
+        pool_reward_puzzle_hash=reward_ph,
+        genesis_timestamp=10000,
+        time_per_block=10,
+    )
+    assert blocks[0].height == 0
+
+    for block in blocks:
+        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+
+    await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
+
+    yield full_node_1, server_1
+
+    async for _ in async_gen:
+        yield _
+
+
+@pytest_asyncio.fixture(scope="function")
+async def two_nodes_one_block(bt, wallet_a):
+    async_gen = setup_simulators_and_wallets(2, 0, {})
+    nodes, _ = await async_gen.__anext__()
+    full_node_1 = nodes[0]
+    full_node_2 = nodes[1]
+    server_1 = full_node_1.full_node.server
+    server_2 = full_node_2.full_node.server
+
+    reward_ph = wallet_a.get_new_puzzlehash()
+    blocks = bt.get_consecutive_blocks(
+        1,
+        guarantee_transaction_block=True,
+        farmer_reward_puzzle_hash=reward_ph,
+        pool_reward_puzzle_hash=reward_ph,
+        genesis_timestamp=10000,
+        time_per_block=10,
+    )
+    assert blocks[0].height == 0
+
+    for block in blocks:
+        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+
+    await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
+
+    yield full_node_1, full_node_2, server_1, server_2
+
+    async for _ in async_gen:
+        yield _
+
+
 # TODO: Ideally, the db_version should be the (parameterized) db_version
 # fixture, to test all versions of the database schema. This doesn't work
 # because of a hack in shutting down the full node, which means you cannot run
@@ -448,34 +508,6 @@ async def timelord(bt):
     rpc_port = find_available_listen_port("rpc")
     vdf_port = find_available_listen_port("vdf")
     async for _ in setup_timelord(timelord_port, node_port, rpc_port, vdf_port, False, test_constants, bt):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="module")
-async def two_nodes_mempool(bt, wallet_a):
-    async_gen = setup_simulators_and_wallets(2, 1, {})
-    nodes, _ = await async_gen.__anext__()
-    full_node_1 = nodes[0]
-    full_node_2 = nodes[1]
-    server_1 = full_node_1.full_node.server
-    server_2 = full_node_2.full_node.server
-
-    reward_ph = wallet_a.get_new_puzzlehash()
-    blocks = bt.get_consecutive_blocks(
-        3,
-        guarantee_transaction_block=True,
-        farmer_reward_puzzle_hash=reward_ph,
-        pool_reward_puzzle_hash=reward_ph,
-    )
-
-    for block in blocks:
-        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
-
-    await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
-
-    yield full_node_1, full_node_2, server_1, server_2
-
-    async for _ in async_gen:
         yield _
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,7 @@ async def five_nodes(db_version, self_hostname):
 
 @pytest_asyncio.fixture(scope="module")
 async def wallet_nodes(bt):
-    async_gen = setup_simulators_and_wallets(2, 1, {"MEMPOOL_BLOCK_BUFFER": 2, "MAX_BLOCK_COST_CLVM": 400000000})
+    async_gen = setup_simulators_and_wallets(2, 1, {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 400000000})
     nodes, wallets = await async_gen.__anext__()
     full_node_1 = nodes[0]
     full_node_2 = nodes[1]

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -43,7 +43,7 @@ bt = create_block_tools(constants=test_constants, keychain=keychain)
 log = logging.getLogger(__name__)
 
 
-@pytest_asyncio.fixture(scope="function", params=[1, 2])
+@pytest_asyncio.fixture(scope="function", params=[2])
 async def empty_blockchain(request):
     bc1, db_wrapper, db_path = await create_blockchain(test_constants, request.param)
     yield bc1

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -43,7 +43,7 @@ bt = create_block_tools(constants=test_constants, keychain=keychain)
 log = logging.getLogger(__name__)
 
 
-@pytest_asyncio.fixture(scope="function", params=[2])
+@pytest_asyncio.fixture(scope="function", params=[1, 2])
 async def empty_blockchain(request):
     bc1, db_wrapper, db_path = await create_blockchain(test_constants, request.param)
     yield bc1

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1226,9 +1226,10 @@ class TestFullNodeProtocol:
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fbh_sig)
         block_2 = recursive_replace(block_2, "transactions_generator", None)
 
-        await full_node_2.full_node.respond_block(fnp.RespondBlock(block_2), dummy_peer)
+        rb_task = asyncio.create_task(full_node_2.full_node.respond_block(fnp.RespondBlock(block_2), dummy_peer))
 
         await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 1))
+        rb_task.cancel()
 
     @pytest.mark.asyncio
     async def test_request_unfinished_block(self, wallet_nodes, bt, self_hostname):

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -97,7 +97,7 @@ async def get_block_path(full_node: FullNodeAPI):
 
 class TestFullNodeBlockCompression:
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("tx_size", [10000, 3000000000000])
+    @pytest.mark.parametrize("tx_size", [3000000000000])
     async def test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, bt, self_hostname):
         nodes, wallets = setup_two_nodes_and_wallet
         server_1 = nodes[0].full_node.server
@@ -153,7 +153,6 @@ class TestFullNodeBlockCompression:
             return tx.confirmed
 
         await time_out_assert(30, check_transaction_confirmed, True, tr)
-        await asyncio.sleep(2)
 
         # Confirm generator is not compressed
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
@@ -182,7 +181,6 @@ class TestFullNodeBlockCompression:
         await time_out_assert(30, wallet_is_synced, True, wallet_node_1, full_node_1)
 
         await time_out_assert(10, check_transaction_confirmed, True, tr)
-        await asyncio.sleep(2)
 
         # Confirm generator is compressed
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
@@ -254,7 +252,6 @@ class TestFullNodeBlockCompression:
         await time_out_assert(30, wallet_is_synced, True, wallet_node_1, full_node_1)
 
         await time_out_assert(10, check_transaction_confirmed, True, tr)
-        await asyncio.sleep(2)
 
         # Confirm generator is compressed
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
@@ -300,7 +297,6 @@ class TestFullNodeBlockCompression:
         await time_out_assert(30, wallet_is_synced, True, wallet_node_1, full_node_1)
 
         await time_out_assert(10, check_transaction_confirmed, True, new_tr)
-        await asyncio.sleep(2)
 
         # Confirm generator is not compressed, #CAT creation has a cat spend
         all_blocks = await full_node_1.get_all_full_blocks()
@@ -356,7 +352,7 @@ class TestFullNodeBlockCompression:
         blockchain = empty_blockchain
         all_blocks: List[FullBlock] = await full_node_1.get_all_full_blocks()
         assert height == len(all_blocks) - 1
-
+        print(f"height: {height}")
         assert full_node_1.full_node.full_node_store.previous_generator is not None
         if test_reorgs:
             reog_blocks = bt.get_consecutive_blocks(14)
@@ -364,7 +360,7 @@ class TestFullNodeBlockCompression:
                 for reorg_block in reog_blocks[:r]:
                     await _validate_and_add_block_no_error(blockchain, reorg_block)
                 for i in range(1, height):
-                    for batch_size in range(1, height):
+                    for batch_size in range(1, height, 3):
                         results = await blockchain.pre_validate_blocks_multiprocessing(
                             all_blocks[:i], {}, batch_size, validate_signatures=False
                         )
@@ -376,7 +372,7 @@ class TestFullNodeBlockCompression:
                 for block in all_blocks[:r]:
                     await _validate_and_add_block_no_error(blockchain, block)
                 for i in range(1, height):
-                    for batch_size in range(1, height):
+                    for batch_size in range(1, height, 3):
                         results = await blockchain.pre_validate_blocks_multiprocessing(
                             all_blocks[:i], {}, batch_size, validate_signatures=False
                         )

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -834,6 +834,7 @@ class TestFullNodeProtocol:
         await full_node_1.new_transaction(new_transaction, fake_peer)
         await time_out_assert(10, new_transaction_not_requested, True, incoming_queue, new_transaction)
 
+        print(f"FULL NODE HEIGHT: {start_height + 1} {full_node_1.full_node.blockchain.get_peak_height()}")
         await time_out_assert(10, node_height_at_least, True, full_node_1, start_height + 1)
         await time_out_assert(10, node_height_at_least, True, full_node_2, start_height + 1)
 

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1,6 +1,5 @@
 import asyncio
 import dataclasses
-import logging
 import random
 import time
 from secrets import token_bytes
@@ -51,8 +50,6 @@ from tests.core.node_height import node_height_at_least
 from tests.pools.test_pool_rpc import wallet_is_synced
 from tests.setup_nodes import test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
-
-log = logging.getLogger(__name__)
 
 
 async def new_transaction_not_requested(incoming, new_spend):
@@ -352,7 +349,6 @@ class TestFullNodeBlockCompression:
         blockchain = empty_blockchain
         all_blocks: List[FullBlock] = await full_node_1.get_all_full_blocks()
         assert height == len(all_blocks) - 1
-        print(f"height: {height}")
         assert full_node_1.full_node.full_node_store.previous_generator is not None
         if test_reorgs:
             reog_blocks = bt.get_consecutive_blocks(14)
@@ -781,12 +777,9 @@ class TestFullNodeProtocol:
     @pytest.mark.asyncio
     async def test_new_transaction_and_mempool(self, wallet_nodes, bt, self_hostname):
         full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver = wallet_nodes
-        blocks = await full_node_1.get_all_full_blocks()
-
         wallet_ph = wallet_a.get_new_puzzlehash()
         blocks = bt.get_consecutive_blocks(
-            10,
-            block_list_input=blocks,
+            3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=wallet_ph,
             pool_reward_puzzle_hash=wallet_ph,
@@ -802,66 +795,51 @@ class TestFullNodeProtocol:
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         incoming_queue, node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         fake_peer = server_1.all_connections[node_id]
-        # Mempool has capacity of 100, make 110 unspent coins that we can use
         puzzle_hashes = []
 
         # Makes a bunch of coins
-        start_t0 = time.time()
-        for i in range(5):
-            conditions_dict: Dict = {ConditionOpcode.CREATE_COIN: []}
-            # This should fit in one transaction
-            start_t1 = time.time()
-            for _ in range(100):
-                receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
-                puzzle_hashes.append(receiver_puzzlehash)
-                output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [receiver_puzzlehash, int_to_bytes(100000000)])
+        conditions_dict: Dict = {ConditionOpcode.CREATE_COIN: []}
+        # This should fit in one transaction
+        for _ in range(100):
+            receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+            puzzle_hashes.append(receiver_puzzlehash)
+            output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [receiver_puzzlehash, int_to_bytes(10000000000)])
 
-                conditions_dict[ConditionOpcode.CREATE_COIN].append(output)
+            conditions_dict[ConditionOpcode.CREATE_COIN].append(output)
 
-            log.warning(f"Time for creating PHs: {time.time() - start_t1}")
-            start_t1 = time.time()
-            spend_bundle = wallet_a.generate_signed_transaction(
-                100,
-                puzzle_hashes[0],
-                get_future_reward_coins(blocks[1 + i])[0],
-                condition_dic=conditions_dict,
-            )
-            log.warning(f"Time for creating bundle: {time.time() - start_t1}")
-            start_t1 = time.time()
-            assert spend_bundle is not None
-            cost_result = await full_node_1.full_node.mempool_manager.pre_validate_spendbundle(
-                spend_bundle, None, spend_bundle.name()
-            )
-            log.warning(f"Time for validating bundle: {time.time() - start_t1}")
-            start_t1 = time.time()
-            log.info(f"Cost result: {cost_result.cost}")
+        spend_bundle = wallet_a.generate_signed_transaction(
+            100,
+            puzzle_hashes[0],
+            get_future_reward_coins(blocks[1])[0],
+            condition_dic=conditions_dict,
+        )
+        assert spend_bundle is not None
+        cost_result = await full_node_1.full_node.mempool_manager.pre_validate_spendbundle(
+            spend_bundle, None, spend_bundle.name()
+        )
 
-            new_transaction = fnp.NewTransaction(spend_bundle.get_hash(), uint64(100), uint64(100))
+        new_transaction = fnp.NewTransaction(spend_bundle.get_hash(), uint64(100), uint64(100))
 
-            await full_node_1.new_transaction(new_transaction, fake_peer)
-            await time_out_assert(10, new_transaction_requested, True, incoming_queue, new_transaction)
+        await full_node_1.new_transaction(new_transaction, fake_peer)
+        await time_out_assert(10, new_transaction_requested, True, incoming_queue, new_transaction)
 
-            respond_transaction_2 = fnp.RespondTransaction(spend_bundle)
-            await full_node_1.respond_transaction(respond_transaction_2, peer)
+        respond_transaction_2 = fnp.RespondTransaction(spend_bundle)
+        await full_node_1.respond_transaction(respond_transaction_2, peer)
 
-            blocks = bt.get_consecutive_blocks(
-                1,
-                block_list_input=blocks,
-                guarantee_transaction_block=True,
-                transaction_data=spend_bundle,
-            )
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), peer)
+        blocks = bt.get_consecutive_blocks(
+            1,
+            block_list_input=blocks,
+            guarantee_transaction_block=True,
+            transaction_data=spend_bundle,
+        )
+        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), None)
 
-            # Already seen
-            await full_node_1.new_transaction(new_transaction, fake_peer)
-            await time_out_assert(10, new_transaction_not_requested, True, incoming_queue, new_transaction)
-            log.warning(f"Time for rest: {time.time() - start_t1}")
-        log.warning(f"Time for entire loop: {time.time() - start_t0}")
-        start_t0 = time.time()
+        # Already seen
+        await full_node_1.new_transaction(new_transaction, fake_peer)
+        await time_out_assert(10, new_transaction_not_requested, True, incoming_queue, new_transaction)
 
-        await time_out_assert(10, node_height_at_least, True, full_node_1, start_height + 5)
-
-        spend_bundles = []
+        await time_out_assert(10, node_height_at_least, True, full_node_1, start_height + 1)
+        await time_out_assert(10, node_height_at_least, True, full_node_2, start_height + 1)
 
         included_tx = 0
         not_included_tx = 0
@@ -869,41 +847,42 @@ class TestFullNodeProtocol:
         successful_bundle: Optional[SpendBundle] = None
 
         # Fill mempool
-        log.warning(f"Total n phs: {len(puzzle_hashes)}")
-        for puzzle_hash in puzzle_hashes[1:]:
-            start_t1 = time.time()
-            coin_record = (await full_node_1.full_node.coin_store.get_coin_records_by_puzzle_hash(True, puzzle_hash))[0]
-            receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
-            if puzzle_hash == puzzle_hashes[-1]:
+        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
+        group_size = 3  # We will generate transaction bundles of this size (* standard transaction of around 3-4M cost)
+        for i in range(1, len(puzzle_hashes), group_size):
+            phs_to_use = [puzzle_hashes[i + j] for j in range(group_size) if (i + j) < len(puzzle_hashes)]
+            coin_records = [
+                (await full_node_1.full_node.coin_store.get_coin_records_by_puzzle_hash(True, puzzle_hash))[0]
+                for puzzle_hash in phs_to_use
+            ]
+
+            last_iteration = (i == len(puzzle_hashes) - group_size) or len(phs_to_use) < group_size
+            if last_iteration:
                 force_high_fee = True
-                fee = 100000000  # 100 million (20 fee per cost)
+                fee = 100000000 * group_size  # 100 million * group_size (20 fee per cost)
             else:
                 force_high_fee = False
-                fee = random.randint(1, 100000000)
-            log.info(f"Section 1: {time.time() - start_t1}")
-            start_t1 = time.time()
-            spend_bundle = wallet_receiver.generate_signed_transaction(
-                uint64(500), receiver_puzzlehash, coin_record.coin, fee=fee
-            )
+                fee = random.randint(1, 100000000 * group_size)
+            spend_bundles = [
+                wallet_receiver.generate_signed_transaction(uint64(500), receiver_puzzlehash, coin_record.coin, fee=0)
+                for coin_record in coin_records[1:]
+            ] + [
+                wallet_receiver.generate_signed_transaction(
+                    uint64(500), receiver_puzzlehash, coin_records[0].coin, fee=fee
+                )
+            ]
+            spend_bundle = SpendBundle.aggregate(spend_bundles)
+            assert spend_bundle.fees() == fee
             respond_transaction = wallet_protocol.SendTransaction(spend_bundle)
-            log.info(f"Section 2: {time.time() - start_t1}")
-            start_t1 = time.time()
 
             await full_node_1.send_transaction(respond_transaction)
 
-            log.info(f"Section 3: {time.time() - start_t1}")
-            start_t1 = time.time()
             request = fnp.RequestTransaction(spend_bundle.get_hash())
             req = await full_node_1.request_transaction(request)
-            log.info(f"Section 4: {time.time() - start_t1}")
-            start_t1 = time.time()
 
             fee_rate_for_small = full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(10)
             fee_rate_for_med = full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(5000000)
             fee_rate_for_large = full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(50000000)
-            log.info(f"Min fee rate (10): {fee_rate_for_small}")
-            log.info(f"Min fee rate (5000000): {fee_rate_for_med}")
-            log.info(f"Min fee rate (50000000): {fee_rate_for_large}")
             if fee_rate_for_large > fee_rate_for_med:
                 seen_bigger_transaction_has_high_fee = True
 
@@ -915,14 +894,11 @@ class TestFullNodeProtocol:
                 if force_high_fee:
                     successful_bundle = spend_bundle
             else:
-                assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(10000000)
-                assert full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(10000000) > 0
+                assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(5000000 * group_size)
+                assert full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(5000000 * group_size) > 0
                 assert not force_high_fee
                 not_included_tx += 1
-            log.info(f"Section 5: {time.time() - start_t1}")
-        log.warning(f"Time for entire 2nd loop: {time.time() - start_t0}")
-        start_t0 = time.time()
-        log.info(f"Included: {included_tx}, not included: {not_included_tx}")
+        assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(10000000 * group_size)
 
         assert included_tx > 0
         assert not_included_tx > 0
@@ -931,6 +907,8 @@ class TestFullNodeProtocol:
         # Mempool is full
         new_transaction = fnp.NewTransaction(token_bytes(32), 10000000, uint64(1))
         await full_node_1.new_transaction(new_transaction, fake_peer)
+        assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(10000000 * group_size)
+        assert full_node_2.full_node.mempool_manager.mempool.at_full_capacity(10000000 * group_size)
 
         await time_out_assert(10, new_transaction_not_requested, True, incoming_queue, new_transaction)
 
@@ -960,11 +938,11 @@ class TestFullNodeProtocol:
         # Reorg the blockchain
         blocks = await full_node_1.get_all_full_blocks()
         blocks = bt.get_consecutive_blocks(
-            3,
+            2,
             block_list_input=blocks[:-1],
             guarantee_transaction_block=True,
         )
-        for block in blocks[-3:]:
+        for block in blocks[-2:]:
             await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
 
         # Can now resubmit a transaction after the reorg
@@ -973,7 +951,6 @@ class TestFullNodeProtocol:
         )
         assert err is None
         assert status == MempoolInclusionStatus.SUCCESS
-        log.warning(f"Time for entire 3rd section: {time.time() - start_t0}")
 
     @pytest.mark.asyncio
     async def test_request_respond_transaction(self, wallet_nodes, bt, self_hostname):

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -814,10 +814,6 @@ class TestFullNodeProtocol:
             condition_dic=conditions_dict,
         )
         assert spend_bundle is not None
-        cost_result = await full_node_1.full_node.mempool_manager.pre_validate_spendbundle(
-            spend_bundle, None, spend_bundle.name()
-        )
-
         new_transaction = fnp.NewTransaction(spend_bundle.get_hash(), uint64(100), uint64(100))
 
         await full_node_1.new_transaction(new_transaction, fake_peer)
@@ -880,7 +876,6 @@ class TestFullNodeProtocol:
             request = fnp.RequestTransaction(spend_bundle.get_hash())
             req = await full_node_1.request_transaction(request)
 
-            fee_rate_for_small = full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(10)
             fee_rate_for_med = full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(5000000)
             fee_rate_for_large = full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(50000000)
             if fee_rate_for_large > fee_rate_for_med:

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional, Tuple, Callable
 
 from clvm.casts import int_to_bytes
 import pytest
-import pytest_asyncio
 
 import chia.server.ws_connection as ws
 
@@ -39,7 +38,6 @@ from chia.util.recursive_replace import recursive_replace
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.connection_utils import connect_and_get_peer, add_dummy_connection
 from tests.core.node_height import node_height_at_least
-from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from chia.types.blockchain_format.program import Program, INFINITE_COST
 from chia.consensus.cost_calculator import NPCResult
@@ -286,7 +284,7 @@ class TestMempoolManager:
 
         full_node_1, server_1 = one_node_one_block
         _ = await next_block(full_node_1, wallet_a, bt)
-        coin = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -253,7 +253,7 @@ class TestMempoolManager:
             (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0, MempoolInclusionStatus.PENDING),
             (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 1, MempoolInclusionStatus.PENDING),
             # the absolute height and seconds tests require fresh full nodes to
-            # run the test on. The fixture (one_node_one_block) creates 3 blocks,
+            # run the test on. The fixture (one_node_one_block) creates a block,
             # then condition_tester2 creates another 3 blocks
             (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 4, MempoolInclusionStatus.SUCCESS),
             (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 5, MempoolInclusionStatus.SUCCESS),

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -37,7 +37,7 @@ from blspy import G2Element
 
 from chia.util.recursive_replace import recursive_replace
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
-from tests.connection_utils import connect_and_get_peer
+from tests.connection_utils import connect_and_get_peer, add_dummy_connection
 from tests.core.node_height import node_height_at_least
 from tests.setup_nodes import setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
@@ -77,37 +77,6 @@ def generate_test_spend_bundle(
     transaction = wallet_a.generate_signed_transaction(amount, new_puzzle_hash, coin, condition_dic, fee)
     assert transaction is not None
     return transaction
-
-
-@pytest_asyncio.fixture(scope="function")
-async def two_nodes_mempool(bt, wallet_a):
-    async_gen = setup_simulators_and_wallets(2, 1, {})
-    nodes, _ = await async_gen.__anext__()
-    full_node_1 = nodes[0]
-    full_node_2 = nodes[1]
-    server_1 = full_node_1.full_node.server
-    server_2 = full_node_2.full_node.server
-
-    reward_ph = wallet_a.get_new_puzzlehash()
-    blocks = bt.get_consecutive_blocks(
-        3,
-        guarantee_transaction_block=True,
-        farmer_reward_puzzle_hash=reward_ph,
-        pool_reward_puzzle_hash=reward_ph,
-        genesis_timestamp=10000,
-        time_per_block=10,
-    )
-    assert blocks[0].height == 0
-
-    for block in blocks:
-        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
-
-    await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
-
-    yield full_node_1, full_node_2, server_1, server_2
-
-    async for _ in async_gen:
-        yield _
 
 
 def make_item(idx: int, cost: uint64 = uint64(80)) -> MempoolItem:
@@ -187,9 +156,12 @@ class TestPendingTxCache:
 
 class TestMempool:
     @pytest.mark.asyncio
-    async def test_basic_mempool(self, bt, two_nodes_mempool, wallet_a):
+    async def test_basic_mempool(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
 
         max_mempool_cost = 40000000 * 5
         mempool = Mempool(max_mempool_cost)
@@ -251,11 +223,12 @@ async def next_block(full_node_1, wallet_a, bt) -> Coin:
 
 class TestMempoolManager:
     @pytest.mark.asyncio
-    async def test_basic_mempool_manager(self, bt, two_nodes_mempool, wallet_a, self_hostname):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_basic_mempool_manager(self, bt, two_nodes_one_block, wallet_a, self_hostname):
+        full_node_1, full_node_2, server_1, server_2 = two_nodes_one_block
 
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         spend_bundle = generate_test_spend_bundle(wallet_a, coin)
         assert spend_bundle is not None
@@ -282,7 +255,7 @@ class TestMempoolManager:
             (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0, MempoolInclusionStatus.PENDING),
             (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 1, MempoolInclusionStatus.PENDING),
             # the absolute height and seconds tests require fresh full nodes to
-            # run the test on. The fixture (two_nodes_mempool) creates 3 blocks,
+            # run the test on. The fixture (one_node_one_block) creates 3 blocks,
             # then condition_tester2 creates another 3 blocks
             (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 4, MempoolInclusionStatus.SUCCESS),
             (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 5, MempoolInclusionStatus.SUCCESS),
@@ -295,7 +268,7 @@ class TestMempoolManager:
             (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10052, MempoolInclusionStatus.FAILED),
         ],
     )
-    async def test_ephemeral_timelock(self, bt, two_nodes_mempool, wallet_a, opcode, lock_value, expected):
+    async def test_ephemeral_timelock(self, bt, one_node_one_block, wallet_a, opcode, lock_value, expected):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
 
             conditions = {opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)])]}
@@ -311,8 +284,10 @@ class TestMempoolManager:
             bundle = SpendBundle.aggregate([tx1, tx2])
             return bundle
 
-        full_node_1, _, server_1, _ = two_nodes_mempool
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        full_node_1, server_1 = one_node_one_block
+        _ = await next_block(full_node_1, wallet_a, bt)
+        coin = await next_block(full_node_1, wallet_a, bt)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         print(f"status: {status}")
@@ -329,7 +304,7 @@ class TestMempoolManager:
     # this test makes sure that one spend successfully asserts the announce from
     # another spend, even though the assert condition is duplicated 100 times
     @pytest.mark.asyncio
-    async def test_coin_announcement_duplicate_consumed(self, bt, two_nodes_mempool, wallet_a):
+    async def test_coin_announcement_duplicate_consumed(self, bt, one_node_one_block, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
@@ -342,8 +317,8 @@ class TestMempoolManager:
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        full_node_1, server_1 = one_node_one_block
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -353,7 +328,7 @@ class TestMempoolManager:
     # this test makes sure that one spend successfully asserts the announce from
     # another spend, even though the create announcement is duplicated 100 times
     @pytest.mark.asyncio
-    async def test_coin_duplicate_announcement_consumed(self, bt, two_nodes_mempool, wallet_a):
+    async def test_coin_duplicate_announcement_consumed(self, bt, one_node_one_block, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
@@ -366,8 +341,8 @@ class TestMempoolManager:
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        full_node_1, server_1 = one_node_one_block
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -375,9 +350,9 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_double_spend(self, bt, two_nodes_mempool, wallet_a, self_hostname):
+    async def test_double_spend(self, bt, two_nodes_one_block, wallet_a, self_hostname):
         reward_ph = wallet_a.get_new_puzzlehash()
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, full_node_2, server_1, server_2 = two_nodes_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
         blocks = bt.get_consecutive_blocks(
@@ -436,10 +411,10 @@ class TestMempoolManager:
         assert node.full_node.mempool_manager.get_spendbundle(sb.name()) is None
 
     @pytest.mark.asyncio
-    async def test_double_spend_with_higher_fee(self, bt, two_nodes_mempool, wallet_a, self_hostname):
+    async def test_double_spend_with_higher_fee(self, bt, two_nodes_one_block, wallet_a, self_hostname):
         reward_ph = wallet_a.get_new_puzzlehash()
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, full_node_2, server_1, server_2 = two_nodes_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height if len(blocks) > 0 else -1
         blocks = bt.get_consecutive_blocks(
@@ -513,10 +488,10 @@ class TestMempoolManager:
         self.assert_sb_not_in_pool(full_node_1, sb3)
 
     @pytest.mark.asyncio
-    async def test_invalid_signature(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_signature(self, bt, one_node_one_block, wallet_a):
         reward_ph = wallet_a.get_new_puzzlehash()
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height if len(blocks) > 0 else -1
         blocks = bt.get_consecutive_blocks(
@@ -547,7 +522,7 @@ class TestMempoolManager:
     async def condition_tester(
         self,
         bt,
-        two_nodes_mempool,
+        one_node_one_block,
         wallet_a,
         dic: Dict[ConditionOpcode, List[ConditionWithArgs]],
         fee: int = 0,
@@ -555,7 +530,7 @@ class TestMempoolManager:
         coin: Optional[Coin] = None,
     ):
         reward_ph = wallet_a.get_new_puzzlehash()
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
         blocks = bt.get_consecutive_blocks(
@@ -565,7 +540,12 @@ class TestMempoolManager:
             farmer_reward_puzzle_hash=reward_ph,
             pool_reward_puzzle_hash=reward_ph,
         )
-        peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
+        _, dummy_node_id = await add_dummy_connection(server_1, bt.config["self_hostname"], 100)
+        dummy_peer = None
+        for node_id, wsc in server_1.all_connections.items():
+            if node_id == dummy_node_id:
+                dummy_peer = wsc
+                break
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
@@ -580,13 +560,13 @@ class TestMempoolManager:
 
         tx1: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle1)
 
-        status, err = await respond_transaction(full_node_1, tx1, peer, test=True)
-        return blocks, spend_bundle1, peer, status, err
+        status, err = await respond_transaction(full_node_1, tx1, dummy_peer, test=True)
+        return blocks, spend_bundle1, dummy_peer, status, err
 
     @pytest.mark.asyncio
-    async def condition_tester2(self, bt, two_nodes_mempool, wallet_a, test_fun: Callable[[Coin, Coin], SpendBundle]):
+    async def condition_tester2(self, bt, one_node_one_block, wallet_a, test_fun: Callable[[Coin, Coin], SpendBundle]):
         reward_ph = wallet_a.get_new_puzzlehash()
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height if len(blocks) > 0 else -1
         blocks = bt.get_consecutive_blocks(
@@ -597,7 +577,12 @@ class TestMempoolManager:
             pool_reward_puzzle_hash=reward_ph,
             time_per_block=10,
         )
-        peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
+        _, dummy_node_id = await add_dummy_connection(server_1, bt.config["self_hostname"], 100)
+        dummy_peer = None
+        for node_id, wsc in server_1.all_connections.items():
+            if node_id == dummy_node_id:
+                dummy_peer = wsc
+                break
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
@@ -610,14 +595,14 @@ class TestMempoolManager:
         bundle = test_fun(coin_1, coin_2)
 
         tx1: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(bundle)
-        status, err = await respond_transaction(full_node_1, tx1, peer, test=True)
+        status, err = await respond_transaction(full_node_1, tx1, dummy_peer, test=True)
 
         return blocks, bundle, status, err
 
     @pytest.mark.asyncio
-    async def test_invalid_block_index(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_block_index(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
         cvp = ConditionWithArgs(
@@ -625,7 +610,7 @@ class TestMempoolManager:
             [int_to_bytes(start_height + 5)],
         )
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert sb1 is None
         # the transaction may become valid later
@@ -633,13 +618,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.PENDING
 
     @pytest.mark.asyncio
-    async def test_block_index_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_block_index_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert sb1 is None
         # the transaction may become valid later
@@ -647,49 +632,49 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_block_index(self, bt, two_nodes_mempool, wallet_a):
+    async def test_correct_block_index(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(1)])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_block_index_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_block_index_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(1), b"garbage"])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_negative_block_index(self, bt, two_nodes_mempool, wallet_a):
+    async def test_negative_block_index(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(-1)])
         dic = {ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_invalid_block_age(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_block_age(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(5)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_HEIGHT_RELATIVE_FAILED
         assert sb1 is None
@@ -697,12 +682,12 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.PENDING
 
     @pytest.mark.asyncio
-    async def test_block_age_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_block_age_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
         assert sb1 is None
@@ -710,13 +695,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_block_age(self, bt, two_nodes_mempool, wallet_a):
+    async def test_correct_block_age(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(1)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, num_blocks=4
+            bt, one_node_one_block, wallet_a, dic, num_blocks=4
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -725,14 +710,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_block_age_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_block_age_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(1), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, num_blocks=4
+            bt, one_node_one_block, wallet_a, dic, num_blocks=4
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -741,13 +726,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_negative_block_age(self, bt, two_nodes_mempool, wallet_a):
+    async def test_negative_block_age(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_RELATIVE, [int_to_bytes(-1)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, num_blocks=4
+            bt, one_node_one_block, wallet_a, dic, num_blocks=4
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -756,14 +741,17 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_correct_my_id(self, bt, two_nodes_mempool, wallet_a):
+    async def test_correct_my_id(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin.name()])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -772,15 +760,18 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_id_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_id_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin.name(), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -789,15 +780,18 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_invalid_my_id(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_my_id(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         coin_2 = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [coin_2.name()])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -806,13 +800,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_my_id_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_id_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_COIN_ID, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
@@ -820,100 +814,100 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_time_exceeds(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_exceeds(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         # 5 seconds should be before the next block
         time_now = full_node_1.full_node.blockchain.get_peak().timestamp + 5
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_fail(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_fail(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         time_now = full_node_1.full_node.blockchain.get_peak().timestamp + 1000
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_SECONDS_ABSOLUTE_FAILED
         assert sb1 is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_height_pending(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_height_pending(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         print(full_node_1.full_node.blockchain.get_peak())
         current_height = full_node_1.full_node.blockchain.get_peak().height
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, [int_to_bytes(current_height + 4)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_HEIGHT_ABSOLUTE_FAILED
         assert sb1 is None
         assert status == MempoolInclusionStatus.PENDING
 
     @pytest.mark.asyncio
-    async def test_assert_time_negative(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_negative(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         time_now = -1
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
         assert sb1 is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_time_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         time_now = full_node_1.full_node.blockchain.get_peak().timestamp + 5
 
         # garbage at the end of the argument list is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, [int_to_bytes(time_now), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
         assert sb1 is spend_bundle1
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_exceeds(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_relative_exceeds(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         time_relative = 3
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [int_to_bytes(time_relative)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.ASSERT_SECONDS_RELATIVE_FAILED
@@ -933,15 +927,15 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_relative_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         time_relative = 0
 
         # garbage at the end of the arguments is ignored
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [int_to_bytes(time_relative), b"garbage"])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -949,13 +943,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_relative_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err == Err.INVALID_CONDITION
@@ -963,14 +957,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_time_relative_negative(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_time_relative_negative(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         time_relative = -3
 
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_SECONDS_RELATIVE, [int_to_bytes(time_relative)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
         assert err is None
@@ -979,7 +973,7 @@ class TestMempoolManager:
 
     # ensure one spend can assert a coin announcement from another spend
     @pytest.mark.asyncio
-    async def test_correct_coin_announcement_consumed(self, bt, two_nodes_mempool, wallet_a):
+    async def test_correct_coin_announcement_consumed(self, bt, one_node_one_block, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             cvp = ConditionWithArgs(ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT, [announce.name()])
@@ -992,8 +986,8 @@ class TestMempoolManager:
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        full_node_1, server_1 = one_node_one_block
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -1003,7 +997,7 @@ class TestMempoolManager:
     # ensure one spend can assert a coin announcement from another spend, even
     # though the conditions have garbage (ignored) at the end
     @pytest.mark.asyncio
-    async def test_coin_announcement_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_coin_announcement_garbage(self, bt, one_node_one_block, wallet_a):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             announce = Announcement(coin_2.name(), b"test")
             # garbage at the end is ignored
@@ -1018,8 +1012,8 @@ class TestMempoolManager:
             bundle = SpendBundle.aggregate([spend_bundle1, spend_bundle2])
             return bundle
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        full_node_1, server_1 = one_node_one_block
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -1027,8 +1021,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_coin_announcement_missing_arg(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_coin_announcement_missing_arg(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             # missing arg here
@@ -1041,15 +1035,15 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         assert err == Err.INVALID_CONDITION
         assert full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name()) is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_coin_announcement_missing_arg2(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_coin_announcement_missing_arg2(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.name(), b"test")
@@ -1063,15 +1057,15 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         assert err == Err.INVALID_CONDITION
         assert full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name()) is None
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_coin_announcement_too_big(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_coin_announcement_too_big(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.name(), bytes([1] * 10000))
@@ -1087,7 +1081,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         assert err == Err.ASSERT_ANNOUNCE_CONSUMED_FAILED
         assert full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name()) is None
@@ -1105,8 +1099,8 @@ class TestMempoolManager:
     # ensure an assert coin announcement is rejected if it doesn't match the
     # create announcement
     @pytest.mark.asyncio
-    async def test_invalid_coin_announcement_rejected(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_invalid_coin_announcement_rejected(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.name(), b"test")
@@ -1125,7 +1119,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1134,8 +1128,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_coin_announcement_rejected_two(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_invalid_coin_announcement_rejected_two(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_1.name(), b"test")
@@ -1152,7 +1146,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err == Err.ASSERT_ANNOUNCE_CONSUMED_FAILED
@@ -1160,8 +1154,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_puzzle_announcement(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_correct_puzzle_announcement(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.puzzle_hash, bytes(0x80))
@@ -1177,7 +1171,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1186,8 +1180,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_puzzle_announcement_garbage(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_puzzle_announcement_garbage(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.puzzle_hash, bytes(0x80))
@@ -1203,7 +1197,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
         assert err is None
@@ -1211,8 +1205,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_puzzle_announcement_missing_arg(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_puzzle_announcement_missing_arg(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             # missing arg here
@@ -1228,7 +1222,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1237,8 +1231,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_puzzle_announcement_missing_arg2(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_puzzle_announcement_missing_arg2(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.puzzle_hash, b"test")
@@ -1256,7 +1250,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1265,8 +1259,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_puzzle_announcement_rejected(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_invalid_puzzle_announcement_rejected(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.puzzle_hash, bytes("test", "utf-8"))
@@ -1285,7 +1279,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1294,8 +1288,8 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_puzzle_announcement_rejected_two(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_invalid_puzzle_announcement_rejected_two(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
 
         def test_fun(coin_1: Coin, coin_2: Coin):
             announce = Announcement(coin_2.puzzle_hash, b"test")
@@ -1314,7 +1308,7 @@ class TestMempoolManager:
 
             return SpendBundle.aggregate([spend_bundle1, spend_bundle2])
 
-        blocks, bundle, status, err = await self.condition_tester2(bt, two_nodes_mempool, wallet_a, test_fun)
+        blocks, bundle, status, err = await self.condition_tester2(bt, one_node_one_block, wallet_a, test_fun)
 
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(bundle.name())
 
@@ -1323,13 +1317,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_fee_condition(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(10)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, fee=10
+            bt, one_node_one_block, wallet_a, dic, fee=10
         )
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1338,14 +1332,14 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_fee_condition_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         # garbage at the end of the arguments is ignored
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(10), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, fee=10
+            bt, one_node_one_block, wallet_a, dic, fee=10
         )
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1354,23 +1348,23 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_missing_arg(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_assert_fee_condition_missing_arg(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, fee=10
+            bt, one_node_one_block, wallet_a, dic, fee=10
         )
         assert err == Err.INVALID_CONDITION
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_negative_fee(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_assert_fee_condition_negative_fee(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(-1)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, fee=10
+            bt, one_node_one_block, wallet_a, dic, fee=10
         )
         assert err == Err.RESERVE_FEE_CONDITION_FAILED
         assert status == MempoolInclusionStatus.FAILED
@@ -1383,12 +1377,12 @@ class TestMempoolManager:
         )
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_fee_too_large(self, bt, two_nodes_mempool, wallet_a):
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+    async def test_assert_fee_condition_fee_too_large(self, bt, one_node_one_block, wallet_a):
+        full_node_1, server_1 = one_node_one_block
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(2 ** 64)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, fee=10
+            bt, one_node_one_block, wallet_a, dic, fee=10
         )
         assert err == Err.RESERVE_FEE_CONDITION_FAILED
         assert status == MempoolInclusionStatus.FAILED
@@ -1401,14 +1395,14 @@ class TestMempoolManager:
         )
 
     @pytest.mark.asyncio
-    async def test_assert_fee_condition_wrong_fee(self, bt, two_nodes_mempool, wallet_a):
+    async def test_assert_fee_condition_wrong_fee(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
 
         cvp = ConditionWithArgs(ConditionOpcode.RESERVE_FEE, [int_to_bytes(10)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, fee=9
+            bt, one_node_one_block, wallet_a, dic, fee=9
         )
         mempool_bundle = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1417,9 +1411,9 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_stealing_fee(self, bt, two_nodes_mempool, wallet_a):
+    async def test_stealing_fee(self, bt, two_nodes_one_block, wallet_a):
         reward_ph = wallet_a.get_new_puzzlehash()
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, full_node_2, server_1, server_2 = two_nodes_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
         blocks = bt.get_consecutive_blocks(
@@ -1430,7 +1424,6 @@ class TestMempoolManager:
             pool_reward_puzzle_hash=reward_ph,
         )
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
         peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
 
         for block in blocks:
@@ -1474,9 +1467,9 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_double_spend_same_bundle(self, bt, two_nodes_mempool, wallet_a):
+    async def test_double_spend_same_bundle(self, bt, two_nodes_one_block, wallet_a):
         reward_ph = wallet_a.get_new_puzzlehash()
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, full_node_2, server_1, server_2 = two_nodes_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
         blocks = bt.get_consecutive_blocks(
@@ -1520,9 +1513,9 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_agg_sig_condition(self, bt, two_nodes_mempool, wallet_a):
+    async def test_agg_sig_condition(self, bt, one_node_one_block, wallet_a):
         reward_ph = wallet_a.get_new_puzzlehash()
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         start_height = blocks[-1].height
         blocks = bt.get_consecutive_blocks(
@@ -1568,14 +1561,17 @@ class TestMempoolManager:
         # assert sb is spend_bundle
 
     @pytest.mark.asyncio
-    async def test_correct_my_parent(self, bt, two_nodes_mempool, wallet_a):
+    async def test_correct_my_parent(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin.parent_coin_info])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1585,15 +1581,18 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_parent_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_parent_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin.parent_coin_info, b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1603,13 +1602,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_parent_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_parent_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1618,15 +1617,18 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_my_parent(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_my_parent(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         coin_2 = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PARENT_ID, [coin_2.parent_coin_info])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1636,14 +1638,17 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_my_puzhash(self, bt, two_nodes_mempool, wallet_a):
+    async def test_correct_my_puzhash(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [coin.puzzle_hash])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1653,15 +1658,18 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_puzhash_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_puzhash_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [coin.puzzle_hash, b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1671,13 +1679,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_puzhash_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_puzhash_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1686,14 +1694,17 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_my_puzhash(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_my_puzhash(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_PUZZLEHASH, [Program.to([]).get_tree_hash()])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1703,14 +1714,17 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_correct_my_amount(self, bt, two_nodes_mempool, wallet_a):
+    async def test_correct_my_amount(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(coin.amount)])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1720,15 +1734,18 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_amount_garbage(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_amount_garbage(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
+
+        _ = await next_block(full_node_1, wallet_a, bt)
+        _ = await next_block(full_node_1, wallet_a, bt)
         coin = await next_block(full_node_1, wallet_a, bt)
         # garbage at the end of the arguments list is allowed but stripped
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(coin.amount), b"garbage"])
         dic = {cvp.opcode: [cvp]}
         blocks, spend_bundle1, peer, status, err = await self.condition_tester(
-            bt, two_nodes_mempool, wallet_a, dic, coin=coin
+            bt, one_node_one_block, wallet_a, dic, coin=coin
         )
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
@@ -1738,13 +1755,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_my_amount_missing_arg(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_amount_missing_arg(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1753,13 +1770,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_invalid_my_amount(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_my_amount(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(1000)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1768,13 +1785,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_negative_my_amount(self, bt, two_nodes_mempool, wallet_a):
+    async def test_negative_my_amount(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(-1)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -1783,13 +1800,13 @@ class TestMempoolManager:
         assert status == MempoolInclusionStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_my_amount_too_large(self, bt, two_nodes_mempool, wallet_a):
+    async def test_my_amount_too_large(self, bt, one_node_one_block, wallet_a):
 
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
         blocks = await full_node_1.get_all_full_blocks()
         cvp = ConditionWithArgs(ConditionOpcode.ASSERT_MY_AMOUNT, [int_to_bytes(2 ** 64)])
         dic = {cvp.opcode: [cvp]}
-        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, two_nodes_mempool, wallet_a, dic)
+        blocks, spend_bundle1, peer, status, err = await self.condition_tester(bt, one_node_one_block, wallet_a, dic)
 
         sb1 = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle1.name())
 
@@ -2436,7 +2453,7 @@ class TestMaliciousGenerators:
         assert run_time < 0.2
 
     @pytest.mark.asyncio
-    async def test_invalid_coin_spend_coin(self, bt, two_nodes_mempool, wallet_a):
+    async def test_invalid_coin_spend_coin(self, bt, one_node_one_block, wallet_a):
         reward_ph = wallet_a.get_new_puzzlehash()
         blocks = bt.get_consecutive_blocks(
             5,
@@ -2444,7 +2461,7 @@ class TestMaliciousGenerators:
             farmer_reward_puzzle_hash=reward_ph,
             pool_reward_puzzle_hash=reward_ph,
         )
-        full_node_1, full_node_2, server_1, server_2 = two_nodes_mempool
+        full_node_1, server_1 = one_node_one_block
 
         for block in blocks:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))


### PR DESCRIPTION
22 -> 12 mins approximately

For optimal speed, we still need to merge:
https://github.com/Chia-Network/chia-blockchain/pull/10978
or 
https://github.com/Chia-Network/chia-blockchain/pull/10847

There is one real code change here, and that is for the full node to loop with fine grained sleep when someone is sending a transaction, instead of the slow 100ms sleep from before. This will also improve UX of sending TXs. 