### PR TITLE
Check for vulnerable openssl

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -41,6 +41,14 @@ if ([version]$pythonVersion -lt [version]"3.7.0")
 }
 Write-Output "Python version is:" $pythonVersion
 
+$openSSLVersionStr = (py -c 'import ssl; print(ssl.OPENSSL_VERSION)')
+$openSSLVersion = (py -c 'import ssl; print(ssl.OPENSSL_VERSION_NUMBER)')
+if ($openSSLVersion -lt 269488367)
+{
+    Write-Output "Found Python with OpenSSL version:" $openSSLVersionStr
+    Write-Output "Anything before 1.1.1n is vulnerable to CVE-2022-0778."
+}
+
 py -m venv venv
 
 venv\scripts\python -m pip install --upgrade pip setuptools wheel

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,7 @@ install_openssl_ubuntu () {
   sudo ./config
   sudo make install
   which openssl
+  export PATH=:/usr/local/bin:$PATH
 }
 
 # Manage npm and other install requirements on an OS specific basis

--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ install_python3_and_sqlite3_from_source_with_yum() {
   # Preparing installing Python
   echo 'yum groupinstall -y "Development Tools"'
   sudo yum groupinstall -y "Development Tools"
-  echo "sudo yum install -y openssl-devel libffi-devel bzip2-devel wget"
+  echo "sudo yum install -y openssl-devel openssl libffi-devel bzip2-devel wget"
   sudo yum install -y openssl-devel openssl libffi-devel bzip2-devel wget
 
   echo "cd $TMP_PATH"

--- a/install.sh
+++ b/install.sh
@@ -117,10 +117,15 @@ install_openssl_ubuntu () {
   wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
   tar -zxvf openssl-1.1.1n.tar.gz
   cd openssl-1.1.1n
-  sudo ./config
+  sudo ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
   sudo make install
+  echo "Original OpenSSL version"
   which openssl
-  export PATH=:/usr/local/bin:$PATH
+  openssl version -a
+  export PATH=:/usr/local/ssl:$PATH
+  which openssl
+  echo "New OpenSSL version"
+  openssl version -a
 }
 
 # Manage npm and other install requirements on an OS specific basis

--- a/install.sh
+++ b/install.sh
@@ -138,13 +138,15 @@ if [ "$(uname)" = "Linux" ]; then
     # Ubuntu
     echo "Installing on Ubuntu pre 20.04 LTS."
     sudo apt-get update
-    sudo apt-get install -y python3.7-venv python3.7-distutils
-    install_openssl_ubuntu
+    sudo apt-get install -y python3.7-venv python3.7-distutils openssl
+    audo apt show openssl
+    # install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ] && [ "$UBUNTU_2100" = "0" ]; then
     echo "Installing on Ubuntu 20.04 LTS."
     sudo apt-get update
-    sudo apt-get install -y python3.8-venv python3-distutils
-    install_openssl_ubuntu
+    sudo apt-get install -y python3.8-venv python3-distutils openssl
+    audo apt show openssl
+    # install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_2100" = "1" ]; then
     echo "Installing on Ubuntu 21.04 or newer."
     sudo apt-get update
@@ -261,7 +263,7 @@ OPENSSL_VERSION_INT=$($INSTALL_PYTHON_PATH -c 'import ssl; print(ssl.OPENSSL_VER
 echo "OpenSSL version for Python is ${OPENSSL_VERSION_STRING}"
 if [ "$OPENSSL_VERSION_INT" -lt "269488367" ]; then
   echo "WARNING: OpenSSL versions before 3.0.2, 1.1.1n, or 1.0.2zd are vulnerable to CVE-2022-0778"
-  exit 1
+  echo "Your OS may have patched OpenSSL and not updated the version to 1.1.1n"
 fi
 
 # If version of `python` and "$INSTALL_PYTHON_VERSION" does not match, clear old version

--- a/install.sh
+++ b/install.sh
@@ -122,10 +122,12 @@ install_openssl_ubuntu () {
   echo "Original OpenSSL version"
   which openssl
   openssl version -a
-  export PATH=:/usr/local/ssl:$PATH
+  export PATH=:/usr/local/ssl/bin/:$PATH
   which openssl
   echo "New OpenSSL version"
   openssl version -a
+  echo "Built OpenSSL version"
+  /usr/local/ssl/bin/openssl version -a
 }
 
 # Manage npm and other install requirements on an OS specific basis

--- a/install.sh
+++ b/install.sh
@@ -170,6 +170,7 @@ if [ "$(uname)" = "Linux" ]; then
   fi
 elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
   echo "Installation currently requires brew on MacOS - https://brew.sh/"
+  brew install openssl
 elif [ "$(uname)" = "OpenBSD" ]; then
   export MAKE=${MAKE:-gmake}
   export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}

--- a/install.sh
+++ b/install.sh
@@ -139,13 +139,13 @@ if [ "$(uname)" = "Linux" ]; then
     echo "Installing on Ubuntu pre 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.7-venv python3.7-distutils openssl
-    audo apt show openssl
+    apt show openssl
     # install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ] && [ "$UBUNTU_2100" = "0" ]; then
     echo "Installing on Ubuntu 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.8-venv python3-distutils openssl
-    audo apt show openssl
+    apt show openssl
     # install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_2100" = "1" ]; then
     echo "Installing on Ubuntu 21.04 or newer."

--- a/install.sh
+++ b/install.sh
@@ -231,6 +231,17 @@ if [ "$SQLITE_MAJOR_VER" -lt "3" ] || [ "$SQLITE_MAJOR_VER" = "3" ] && [ "$SQLIT
   exit 1
 fi
 
+# Check openssl version python will use
+OPENSSL_VERSION_STRING=$($INSTALL_PYTHON_PATH -c 'import ssl; print(ssl.OPENSSL_VERSION)')
+OPENSSL_VERSION_INT=$($INSTALL_PYTHON_PATH -c 'import ssl; print(ssl.OPENSSL_VERSION_NUMBER)')
+# There is also ssl.OPENSSL_VERSION_INFO returning a tuple
+# 1.1.1n corresponds to 269488367 as an integer
+echo "OpenSSL version for Python is ${OPENSSL_VERSION_STRING}"
+if [ "$OPENSSL_VERSION_INT" -lt "269488367" ]; then
+  echo "WARNING: OpenSSL versions before 3.0.2, 1.1.1n, or 1.0.2zd are vulnerable to CVE-2022-0778"
+  exit 1
+fi
+
 # If version of `python` and "$INSTALL_PYTHON_VERSION" does not match, clear old version
 VENV_CLEAR=""
 if [ -e venv/bin/python ]; then

--- a/install.sh
+++ b/install.sh
@@ -119,10 +119,11 @@ install_openssl_ubuntu () {
   cd openssl-1.1.1n
   sudo ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
   sudo make install
+  sudo ldconfig /usr/local/ssl/bin/
   echo "Original OpenSSL version"
   which openssl
   openssl version -a
-  export PATH=:/usr/local/ssl/bin/:$PATH
+  export PATH=:/usr/local/ssl/bin:$PATH
   which openssl
   echo "New OpenSSL version"
   openssl version -a

--- a/install.sh
+++ b/install.sh
@@ -111,6 +111,16 @@ install_python3_and_sqlite3_from_source_with_yum() {
   cd "$CURRENT_WD"
 }
 
+install_openssl_ubuntu () {
+  sudo apt-get update
+  sudo apt-get install -y build-essential checkinstall zlib1g-dev
+  wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
+  tar -zxvf openssl-1.1.1n.tar.gz
+  cd openssl-1.1.1n
+  sudo ./config
+  sudo make install
+  which openssl
+}
 
 # Manage npm and other install requirements on an OS specific basis
 if [ "$(uname)" = "Linux" ]; then
@@ -120,10 +130,12 @@ if [ "$(uname)" = "Linux" ]; then
     echo "Installing on Ubuntu pre 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.7-venv python3.7-distutils
+    install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ] && [ "$UBUNTU_2100" = "0" ]; then
     echo "Installing on Ubuntu 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.8-venv python3-distutils
+    install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_2100" = "1" ]; then
     echo "Installing on Ubuntu 21.04 or newer."
     sudo apt-get update

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ install_python3_and_sqlite3_from_source_with_yum() {
   echo 'yum groupinstall -y "Development Tools"'
   sudo yum groupinstall -y "Development Tools"
   echo "sudo yum install -y openssl-devel libffi-devel bzip2-devel wget"
-  sudo yum install -y openssl-devel libffi-devel bzip2-devel wget
+  sudo yum install -y openssl-devel openssl libffi-devel bzip2-devel wget
 
   echo "cd $TMP_PATH"
   cd "$TMP_PATH"
@@ -111,26 +111,6 @@ install_python3_and_sqlite3_from_source_with_yum() {
   cd "$CURRENT_WD"
 }
 
-install_openssl_ubuntu () {
-  sudo apt-get update
-  sudo apt-get install -y build-essential checkinstall zlib1g-dev
-  wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
-  tar -zxvf openssl-1.1.1n.tar.gz
-  cd openssl-1.1.1n
-  sudo ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
-  sudo make install
-  sudo ldconfig /usr/local/ssl/bin/
-  echo "Original OpenSSL version"
-  which openssl
-  openssl version -a
-  export PATH=:/usr/local/ssl/bin:$PATH
-  which openssl
-  echo "New OpenSSL version"
-  openssl version -a
-  echo "Built OpenSSL version"
-  /usr/local/ssl/bin/openssl version -a
-}
-
 # Manage npm and other install requirements on an OS specific basis
 if [ "$(uname)" = "Linux" ]; then
   #LINUX=1
@@ -140,21 +120,19 @@ if [ "$(uname)" = "Linux" ]; then
     sudo apt-get update
     sudo apt-get install -y python3.7-venv python3.7-distutils openssl
     apt show openssl
-    # install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ] && [ "$UBUNTU_2100" = "0" ]; then
     echo "Installing on Ubuntu 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.8-venv python3-distutils openssl
     apt show openssl
-    # install_openssl_ubuntu
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_2100" = "1" ]; then
     echo "Installing on Ubuntu 21.04 or newer."
     sudo apt-get update
-    sudo apt-get install -y python3.9-venv python3-distutils
+    sudo apt-get install -y python3.9-venv python3-distutils openssl
   elif [ "$DEBIAN" = "true" ]; then
     echo "Installing on Debian."
     sudo apt-get update
-    sudo apt-get install -y python3-venv
+    sudo apt-get install -y python3-venv openssl
   elif type pacman >/dev/null 2>&1 && [ -f "/etc/arch-release" ]; then
     # Arch Linux
     # Arch provides latest python version. User will need to manually install python 3.9 if it is not present
@@ -183,12 +161,12 @@ if [ "$(uname)" = "Linux" ]; then
   elif type yum >/dev/null 2>&1 && [ -f "/etc/redhat-release" ] && grep Rocky /etc/redhat-release; then
     echo "Installing on Rocky."
     # TODO: make this smarter about getting the latest version
-    sudo yum install --assumeyes python39
+    sudo yum install --assumeyes python39 openssl
   elif type yum >/dev/null 2>&1 && [ -f "/etc/redhat-release" ] || [ -f "/etc/fedora-release" ]; then
     # Redhat or Fedora
     echo "Installing on Redhat/Fedora."
     if ! command -v python3.9 >/dev/null 2>&1; then
-      sudo yum install -y python39
+      sudo yum install -y python39 openssl
     fi
   fi
 elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then


### PR DESCRIPTION
This checks for OpenSSL versions in the 1.1.1x class less than 1.1.1n and warns via the install script if the openssl version picked up by `import ssl` appears to be vulnerable to CVE-2022-0778