### PR TITLE
Non Hobo patch the winstaller for CVE-2022-0778

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/setup-python@v2
       name: Install Python 3.9
       with:
-        python-version: "3.9"
+        python-version: "3.9.11"
 
     - name: Setup Node 16.x
       uses: actions/setup-node@v3


### PR DESCRIPTION
This should make sure that the openssl that accompanies the Windows Installer has CVE-2022-0778 fixed.

Note that we will need to unpin this at some point to continue to get bug fixes to 3.9 on Windows or we will have to handle creating a miniupnpc wheel for python 3.10 for Windows.