### PR TITLE
apt show not needed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,12 +119,10 @@ if [ "$(uname)" = "Linux" ]; then
     echo "Installing on Ubuntu pre 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.7-venv python3.7-distutils openssl
-    apt show openssl
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ] && [ "$UBUNTU_2100" = "0" ]; then
     echo "Installing on Ubuntu 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.8-venv python3-distutils openssl
-    apt show openssl
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_2100" = "1" ]; then
     echo "Installing on Ubuntu 21.04 or newer."
     sudo apt-get update


### PR DESCRIPTION
I left `apt show openssl` in install.sh as extraneous debug information to confirm that we are getting patched versions of openssl. That is no longer needed.