### PR TITLE
install.sh is not upgrading OpenSSL on MacOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -167,10 +167,12 @@ if [ "$(uname)" = "Linux" ]; then
       sudo yum install -y python39 openssl
     fi
   fi
-elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
-  echo "Installation currently requires brew on MacOS - https://brew.sh/"
-  exit 1
 elif [ "$(uname)" = "Darwin" ]; then
+  echo "Installing on macOS."
+  if ! type brew >/dev/null 2>&1; then
+    echo "Installation currently requires brew on macOS - https://brew.sh/"
+    exit 1
+  fi
   echo "Installing OpenSSL"
   brew install openssl
 elif [ "$(uname)" = "OpenBSD" ]; then

--- a/install.sh
+++ b/install.sh
@@ -169,6 +169,8 @@ if [ "$(uname)" = "Linux" ]; then
   fi
 elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
   echo "Installation currently requires brew on MacOS - https://brew.sh/"
+elif [ "$(uname)" = "Darwin" ]; then
+  echo "Installing OpenSSL"
   brew install openssl
 elif [ "$(uname)" = "OpenBSD" ]; then
   export MAKE=${MAKE:-gmake}

--- a/install.sh
+++ b/install.sh
@@ -169,6 +169,7 @@ if [ "$(uname)" = "Linux" ]; then
   fi
 elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
   echo "Installation currently requires brew on MacOS - https://brew.sh/"
+  exit 1
 elif [ "$(uname)" = "Darwin" ]; then
   echo "Installing OpenSSL"
   brew install openssl


### PR DESCRIPTION
Unfortunately, git install users on MacOS are not getting the `brew install openssl` correctly.

Install.sh will now exit if it can not find `brew`

This may be worth back porting to latest.