### PR TITLE
fix memory leak in test_full_sync

### DIFF
--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -103,6 +103,8 @@ async def run_sync_test(file: Path, db_version, profile: bool, single_thread: bo
                         success, advanced_peak, fork_height, coin_changes = await full_node.receive_block_batch(
                             block_batch, None, None  # type: ignore[arg-type]
                         )
+                        end_height = block_batch[-1].height
+                        full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
                     assert success
                     assert advanced_peak


### PR DESCRIPTION
In the real full node, the full sync function (that also pulls down blocks from peers) call this function periodically to clear out the cached `BlockRecords`. Without doing this, the process starts to use a lot of memory and slows down over time.

A proper fix to this would be to factor out the `BlockRecord` cache, make it evict entries by itself, and unit test it.