### PR TITLE
Non Hobo patch the winstaller for CVE-2022-0778 (#10995)

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/setup-python@v2
       name: Install Python 3.9
       with:
-        python-version: "3.9"
+        python-version: "3.9.11"
 
     - name: Setup Node 16.x
       uses: actions/setup-node@v2.4.1


### PR DESCRIPTION
libssl.dll calls libcrypto.dll where the vulnerability actually is so use a patched version of Python 3.9 instead of the quick and dirty .dll fix.