### PR TITLE
Gh 1.3.3v2

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/setup-python@v2
       name: Install Python 3.9
       with:
-        python-version: "3.9"
+        python-version: "3.9.11"
 
     - name: Setup Node 16.x
       uses: actions/setup-node@v2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ for setuptools_scm/PEP 440 reasons.
 
 ## [Unreleased]
 
+## 1.3.3 Chia blockchain 2022-4-02
+
+### Fixed
+
+- In version 1.3.2 our patch for the OpenSSL vulnerability was not complete for the Windows installer. Thank you @xsmolasses of Core-Pool.
+- MacOS would not update openssl when installing via `install.sh`
+- A future version of Arch Linux may not get openssl updates. The current version is secure.
+- Some debugging information remained in `install.sh`
+
+
 ## 1.3.2 Chia blockchain 2022-4-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,13 @@ for setuptools_scm/PEP 440 reasons.
 
 - In version 1.3.2 our patch for the OpenSSL vulnerability was not complete for the Windows installer. Thank you @xsmolasses of Core-Pool.
 - MacOS would not update openssl when installing via `install.sh`
-- A future version of Arch Linux may not get openssl updates. The current version is secure.
 - Some debugging information remained in `install.sh`
-
 
 ## 1.3.2 Chia blockchain 2022-4-01
 
 ### Fixed
 
 - Fixed OpenSSL vulnerability CVE-2022-0778
-
 
 ## 1.3.1 Chia blockchain 2022-3-16
 

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -60,8 +60,6 @@ if (Test-Path -Path .\bladebit\) {
     mv .\bladebit\ .\venv\lib\site-packages\
 }
 
-
-
 Write-Output "   ---"
 Write-Output "Build chia-blockchain wheels"
 Write-Output "   ---"
@@ -85,8 +83,6 @@ Write-Output "Use pyinstaller to create chia .exe's"
 Write-Output "   ---"
 $SPEC_FILE = (python -c 'import chia; print(chia.PYINSTALLER_SPEC_PATH)') -join "`n"
 pyinstaller --log-level INFO $SPEC_FILE
-
-Invoke-WebRequest https://github.com/python/cpython-bin-deps/raw/7bc5363d366acd7f9c130e27cf650d5414723a99/amd64/libssl-1_1.dll -OutFile ".\dist\daemon\libssl-1_1.dll"
 
 Write-Output "   ---"
 Write-Output "Copy chia executables to chia-blockchain-gui\"

--- a/install.sh
+++ b/install.sh
@@ -146,7 +146,7 @@ if [ "$(uname)" = "Linux" ]; then
         exit 1
         ;;
       esac
-    sudo pacman ${PACMAN_AUTOMATED} -S --needed git openssl
+    sudo pacman ${PACMAN_AUTOMATED} -S --needed git
   elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
     # AMZN 2
     echo "Installing on Amazon Linux 2."

--- a/install.sh
+++ b/install.sh
@@ -172,8 +172,13 @@ if [ "$(uname)" = "Linux" ]; then
       sudo yum install -y python39 openssl
     fi
   fi
-elif [ "$(uname)" = "Darwin" ] && ! type brew >/dev/null 2>&1; then
-  echo "Installation currently requires brew on MacOS - https://brew.sh/"
+elif [ "$(uname)" = "Darwin" ]; then
+  echo "Installing on macOS."
+  if ! type brew >/dev/null 2>&1; then
+    echo "Installation currently requires brew on macOS - https://brew.sh/"
+    exit 1
+  fi
+  echo "Installing OpenSSL"
   brew install openssl
 elif [ "$(uname)" = "OpenBSD" ]; then
   export MAKE=${MAKE:-gmake}

--- a/install.sh
+++ b/install.sh
@@ -146,7 +146,7 @@ if [ "$(uname)" = "Linux" ]; then
         exit 1
         ;;
       esac
-    sudo pacman ${PACMAN_AUTOMATED} -S --needed git
+    sudo pacman ${PACMAN_AUTOMATED} -S --needed git openssl
   elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
     # AMZN 2
     echo "Installing on Amazon Linux 2."

--- a/install.sh
+++ b/install.sh
@@ -118,12 +118,10 @@ if [ "$(uname)" = "Linux" ]; then
     echo "Installing on Ubuntu pre 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.7-venv python3.7-distutils openssl
-    apt show openssl
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ] && [ "$UBUNTU_2100" = "0" ]; then
     echo "Installing on Ubuntu 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.8-venv python3-distutils openssl
-    apt show openssl
   elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_2100" = "1" ]; then
     echo "Installing on Ubuntu 21.04 or newer."
     sudo apt-get update


### PR DESCRIPTION
Correctly patch the Windows Installer as libssl.dll depends on libcrypto.dll and the earlier hobo patch did not catch that correctly.

Back port an openssl edge cases on MacOS installed via git.