### PR TITLE
Update peers.dat filename to handle different nets

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -341,7 +341,7 @@ full_node:
   database_path: db/blockchain_v2_CHALLENGE.sqlite
   # peer_db_path is deprecated and has been replaced by peers_file_path
   peer_db_path: db/peer_table_node.sqlite
-  peers_file_path: db/peers.dat
+  peers_file_path: db/peers_CHALLENGE.dat
   simulator_database_path: sim_db/simulator_blockchain_v1_CHALLENGE.sqlite
   # simulator_peer_db_path is deprecated and has been replaced by simulator_peers_file_path
   simulator_peer_db_path: sim_db/peer_table_node.sqlite


### PR DESCRIPTION
Propose including the net name, e.g. mainnet / testnet10 into the peers.dat filename, to peers_net.dat.

Lack of this has cost me hours of energy trying to switch from mainnet and sync up testnet10 and then go back.

Please test, as I haven't tested this.

Thank yee