### PR TITLE
Move from multiprocessing to multithreading

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -643,7 +643,7 @@ class Blockchain(BlockchainInterface):
         task = asyncio.get_running_loop().run_in_executor(
             self.pool,
             _run_generator,
-            self.constants_json,
+            self.constants,
             unfinished_block,
             generator,
             height,

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -3,8 +3,7 @@ import dataclasses
 import logging
 import multiprocessing
 import traceback
-from concurrent.futures import Executor
-from concurrent.futures.process import ProcessPoolExecutor
+from concurrent.futures import Executor, ThreadPoolExecutor
 from enum import Enum
 from multiprocessing.context import BaseContext
 from pathlib import Path
@@ -47,7 +46,6 @@ from chia.util.errors import ConsensusError, Err
 from chia.util.generator_tools import get_block_header, tx_removals_and_additions
 from chia.util.inline_executor import InlineExecutor
 from chia.util.ints import uint16, uint32, uint64, uint128
-from chia.util.setproctitle import getproctitle, setproctitle
 from chia.util.streamable import recurse_jsonify
 
 log = logging.getLogger(__name__)
@@ -124,11 +122,8 @@ class Blockchain(BlockchainInterface):
             if cpu_count > 61:
                 cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
             num_workers = max(cpu_count - reserved_cores, 1)
-            self.pool = ProcessPoolExecutor(
+            self.pool = ThreadPoolExecutor(
                 max_workers=num_workers,
-                mp_context=multiprocessing_context,
-                initializer=setproctitle,
-                initargs=(f"{getproctitle()}_worker",),
             )
             log.info(f"Started {num_workers} processes for block validation")
 

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -1,5 +1,4 @@
 import asyncio
-import dataclasses
 import logging
 import multiprocessing
 import traceback
@@ -46,7 +45,6 @@ from chia.util.errors import ConsensusError, Err
 from chia.util.generator_tools import get_block_header, tx_removals_and_additions
 from chia.util.inline_executor import InlineExecutor
 from chia.util.ints import uint16, uint32, uint64, uint128
-from chia.util.streamable import recurse_jsonify
 
 log = logging.getLogger(__name__)
 
@@ -67,7 +65,6 @@ class ReceiveBlockResult(Enum):
 
 class Blockchain(BlockchainInterface):
     constants: ConsensusConstants
-    constants_json: Dict
 
     # peak of the blockchain
     _peak_height: Optional[uint32]
@@ -130,7 +127,6 @@ class Blockchain(BlockchainInterface):
         self.constants = consensus_constants
         self.coin_store = coin_store
         self.block_store = block_store
-        self.constants_json = recurse_jsonify(dataclasses.asdict(self.constants))
         self._shut_down = False
         await self._load_chain_from_store(blockchain_dir)
         self._seen_compact_proofs = set()
@@ -625,7 +621,6 @@ class Blockchain(BlockchainInterface):
     ) -> List[PreValidationResult]:
         return await pre_validate_blocks_multiprocessing(
             self.constants,
-            self.constants_json,
             self,
             blocks,
             self.pool,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -370,7 +370,7 @@ def _run_generator(
     height: uint32,
 ) -> Optional[bytes]:
     """
-    Runs the CLVM generator from bytes inputs. This is meant to be called under a ProcessPoolExecutor, in order to
+    Runs the CLVM generator from bytes inputs. This is meant to be called under a ThreadPoolExecutor, in order to
     validate the heavy parts of a block (clvm program) in a different process.
     """
     try:

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -30,7 +30,7 @@ from chia.util.condition_tools import pkm_pairs
 from chia.util.errors import Err, ValidationError
 from chia.util.generator_tools import get_block_header, tx_removals_and_additions
 from chia.util.ints import uint16, uint32, uint64
-from chia.util.streamable import Streamable, dataclass_from_dict, streamable
+from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class PreValidationResult(Streamable):
 
 
 def batch_pre_validate_blocks(
-    constants_dict: Dict,
+    constants: ConsensusConstants,
     blocks: Dict[bytes32, BlockRecord],
     full_blocks: Optional[List[FullBlock]],
     header_blocks: Optional[List[HeaderBlock]],
@@ -57,7 +57,6 @@ def batch_pre_validate_blocks(
     validate_signatures: bool,
 ) -> List[PreValidationResult]:
     results: List[PreValidationResult] = []
-    constants: ConsensusConstants = dataclass_from_dict(ConsensusConstants, constants_dict)
     if full_blocks is not None and header_blocks is not None:
         assert ValueError("Only one should be passed here")
 
@@ -158,7 +157,6 @@ def batch_pre_validate_blocks(
 
 async def pre_validate_blocks_multiprocessing(
     constants: ConsensusConstants,
-    constants_json: Dict,
     block_records: BlockchainInterface,
     blocks: Sequence[FullBlock],
     pool: Executor,
@@ -177,7 +175,6 @@ async def pre_validate_blocks_multiprocessing(
 
     Args:
         check_filter:
-        constants_json:
         pool:
         constants:
         block_records:
@@ -330,7 +327,7 @@ async def pre_validate_blocks_multiprocessing(
             asyncio.get_running_loop().run_in_executor(
                 pool,
                 batch_pre_validate_blocks,
-                constants_json,
+                constants,
                 final_pickled,
                 full_blocks,
                 header_blocks,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1647,7 +1647,6 @@ class FullNode:
         respond_unfinished_block: full_node_protocol.RespondUnfinishedBlock,
         peer: Optional[ws.WSChiaConnection],
         farmed_block: bool = False,
-        block_bytes: Optional[bytes] = None,
     ):
         """
         We have received an unfinished block, either created by us, or from another peer.
@@ -1717,11 +1716,9 @@ class FullNode:
                 raise ConsensusError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
             if block_generator is None:
                 raise ConsensusError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
-            if block_bytes is None:
-                block_bytes = bytes(block)
 
             height = uint32(0) if prev_b is None else uint32(prev_b.height + 1)
-            npc_result = await self.blockchain.run_generator(block_bytes, block_generator, height)
+            npc_result = await self.blockchain.run_generator(block, block_generator, height)
             pre_validation_time = time.time() - pre_validation_start
 
             # blockchain.run_generator throws on errors, so npc_result is

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -454,18 +454,14 @@ class FullNodeAPI:
 
     @peer_required
     @api_request
-    @bytes_required
     async def respond_unfinished_block(
         self,
         respond_unfinished_block: full_node_protocol.RespondUnfinishedBlock,
         peer: ws.WSChiaConnection,
-        respond_unfinished_block_bytes: bytes = b"",
     ) -> Optional[Message]:
         if self.full_node.sync_store.get_sync_mode():
             return None
-        await self.full_node.respond_unfinished_block(
-            respond_unfinished_block, peer, block_bytes=respond_unfinished_block_bytes
-        )
+        await self.full_node.respond_unfinished_block(respond_unfinished_block, peer)
         return None
 
     @api_request

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1,8 +1,6 @@
 import asyncio
 import json
 import logging
-import multiprocessing
-import multiprocessing.context
 import time
 from collections import defaultdict
 from pathlib import Path
@@ -26,7 +24,6 @@ from chia.types.coin_spend import CoinSpend
 from chia.types.full_block import FullBlock
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.config import process_config_start_method
 from chia.util.db_wrapper import DBWrapper
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64, uint128, uint8
@@ -104,7 +101,6 @@ class WalletStateManager:
     sync_store: WalletSyncStore
     finished_sync_up_to: uint32
     interested_store: WalletInterestedStore
-    multiprocessing_context: multiprocessing.context.BaseContext
     weight_proof_handler: WalletWeightProofHandler
     server: ChiaServer
     root_path: Path
@@ -156,11 +152,8 @@ class WalletStateManager:
         self.sync_mode = False
         self.sync_target = uint32(0)
         self.finished_sync_up_to = uint32(0)
-        multiprocessing_start_method = process_config_start_method(config=self.config, log=self.log)
-        self.multiprocessing_context = multiprocessing.get_context(method=multiprocessing_start_method)
         self.weight_proof_handler = WalletWeightProofHandler(
             constants=self.constants,
-            multiprocessing_context=self.multiprocessing_context,
         )
         self.blockchain = await WalletBlockchain.create(self.basic_store, self.constants, self.weight_proof_handler)
 

--- a/chia/wallet/wallet_weight_proof_handler.py
+++ b/chia/wallet/wallet_weight_proof_handler.py
@@ -3,8 +3,7 @@ import logging
 import pathlib
 import random
 import tempfile
-from concurrent.futures.process import ProcessPoolExecutor
-from multiprocessing.context import BaseContext
+from concurrent.futures import ThreadPoolExecutor
 from typing import IO, List, Tuple, Optional
 
 from chia.consensus.block_record import BlockRecord
@@ -25,7 +24,6 @@ from chia.types.weight_proof import (
 )
 
 from chia.util.ints import uint32
-from chia.util.setproctitle import getproctitle, setproctitle
 
 log = logging.getLogger(__name__)
 
@@ -43,16 +41,12 @@ class WalletWeightProofHandler:
     def __init__(
         self,
         constants: ConsensusConstants,
-        multiprocessing_context: BaseContext,
     ):
         self._constants = constants
         self._num_processes = 4
         self._executor_shutdown_tempfile: IO = _create_shutdown_file()
-        self._executor: ProcessPoolExecutor = ProcessPoolExecutor(
+        self._executor: ThreadPoolExecutor = ThreadPoolExecutor(
             self._num_processes,
-            mp_context=multiprocessing_context,
-            initializer=setproctitle,
-            initargs=(f"{getproctitle()}_worker",),
         )
         self._weight_proof_tasks: List[asyncio.Task] = []
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 dependencies = [
     "multidict==5.1.0",  # Avoid 5.2.0 due to Avast
     "aiofiles==0.7.0",  # Async IO for files
-    "blspy==1.0.9",  # Signature library
-    "chiavdf==1.0.5",  # timelord and vdf verification
+    "blspy==1.0.10",  # Signature library
+    "chiavdf==1.0.6",  # timelord and vdf verification
     "chiabip158==1.1",  # bip158-style wallet filters
-    "chiapos==1.0.9",  # proof of space
+    "chiapos==1.0.10",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.4",  # Currying, Program.to, other conveniences
     "clvm_rs==0.1.19",


### PR DESCRIPTION
**Do not merge**: This is only meant for testing so far.

Swaps the most `ProcessPoolExecutors` to `ThreadPoolExecutors` and drops (de)serialization which was required for the multiprocessing. There are more ways to improve this and the related parts in timelord code are still TBD but its a start at least :)