### PR TITLE
Ms.fast test blockchain

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           repository: 'Chia-Network/test-cache'
           path: '.chia'
-          ref: '0.28.0'
+          ref: '0.29.0'
           fetch-depth: 1
 
       - name: Run install script

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node-stores.yml
+++ b/.github/workflows/build-test-macos-core-full_node-stores.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node-stores.yml
+++ b/.github/workflows/build-test-macos-core-full_node-stores.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-full_node-stores.yml
+++ b/.github/workflows/build-test-macos-core-full_node-stores.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node-stores.yml
+++ b/.github/workflows/build-test-macos-core-full_node-stores.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-plot_sync.yml
+++ b/.github/workflows/build-test-macos-plot_sync.yml
@@ -65,10 +65,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
       id: test-blocks-plots
@@ -76,14 +72,14 @@ jobs:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-plot_sync.yml
+++ b/.github/workflows/build-test-ubuntu-plot_sync.yml
@@ -65,10 +65,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
       id: test-blocks-plots
@@ -76,14 +72,14 @@ jobs:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -79,7 +79,7 @@ jobs:
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -65,21 +65,17 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1278,7 +1278,7 @@ def validate_recent_blocks(
         ses = False
         height = block.height
         for sub_slot in block.finished_sub_slots:
-            prev_challenge = challenge
+            prev_challenge = sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.challenge
             challenge = sub_slot.challenge_chain.get_hash()
             deficit = sub_slot.reward_chain.deficit
             if sub_slot.challenge_chain.subepoch_summary_hash is not None:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1504,6 +1504,10 @@ def __get_rc_sub_slot(
 
     assert segment.rc_slot_end_info is not None
     if idx != 0:
+        # this is not the first slot, ses details should not be included
+        ses_hash = None
+        new_ssi = None
+        new_diff = None
         cc_vdf_info = VDFInfo(sub_slot.cc_slot_end_info.challenge, curr_ssi, sub_slot.cc_slot_end_info.output)
         if sub_slot.icc_slot_end_info is not None:
             icc_slot_end_info = VDFInfo(

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -156,9 +156,9 @@ async def create_plots(
 
     if args.size < config["min_mainnet_k_size"] and test_private_keys is None:
         log.warning(f"Creating plots with size k={args.size}, which is less than the minimum required for mainnet")
-    if args.size < 22:
-        log.warning("k under 22 is not supported. Increasing k to 22")
-        args.size = 22
+    if args.size < 20:
+        log.warning("k under 22 is not supported. Increasing k to 21")
+        args.size = 20
 
     if keys.pool_public_key is not None:
         log.info(

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -98,7 +98,7 @@ test_constants = DEFAULT_CONSTANTS.replace(
     **{
         "MIN_PLOT_SIZE": 18,
         "MIN_BLOCKS_PER_CHALLENGE_BLOCK": 12,
-        "DIFFICULTY_STARTING": 2 ** 12,
+        "DIFFICULTY_STARTING": 2 ** 10,
         "DISCRIMINANT_SIZE_BITS": 16,
         "SUB_EPOCH_BLOCKS": 170,
         "WEIGHT_PROOF_THRESHOLD": 2,
@@ -277,7 +277,7 @@ class BlockTools:
             tmp_dir = self.temp_dir
         args = Namespace()
         # Can't go much lower than 20, since plots start having no solutions and more buggy
-        args.size = 22
+        args.size = 20
         # Uses many plots for testing, in order to guarantee proofs of space at every height
         args.num = 1
         args.buffer = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def softfork_height(request):
     return request.param
 
 
-block_format_version = "rc4"
+block_format_version = "rc5"
 
 
 @pytest.fixture(scope="session")
@@ -139,6 +139,20 @@ def default_20000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db", bt)
+
+
+@pytest.fixture(scope="session")
+def test_long_reorg_blocks(bt, default_10000_blocks):
+    from tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(
+        320,
+        f"test_blocks_long_reorg_{block_format_version}.db",
+        bt,
+        block_list_input=default_10000_blocks[:758],
+        seed=b"2",
+        time_per_block=8,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,14 +108,14 @@ block_format_version = "rc5"
 def default_400_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", bt, seed=b"alternate2")
+    return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", bt, seed=b"400")
 
 
 @pytest.fixture(scope="session")
 def default_1000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db", bt)
+    return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db", bt, seed=b"1000")
 
 
 @pytest.fixture(scope="session")
@@ -123,35 +123,62 @@ def pre_genesis_empty_slots_1000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        1000, f"pre_genesis_empty_slots_1000_blocks{block_format_version}.db", bt, seed=b"alternate2", empty_sub_slots=1
+        1000,
+        f"pre_genesis_empty_slots_1000_blocks{block_format_version}.db",
+        bt,
+        seed=b"empty_slots",
+        empty_sub_slots=1,
     )
+
+
+@pytest.fixture(scope="session")
+def default_1500_blocks(bt):
+    from tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(1500, f"test_blocks_1500_{block_format_version}.db", bt, seed=b"1500")
 
 
 @pytest.fixture(scope="session")
 def default_10000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db", bt)
+    return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db", bt, seed=b"10000")
 
 
 @pytest.fixture(scope="session")
 def default_20000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db", bt)
+    return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db", bt, seed=b"20000")
 
 
 @pytest.fixture(scope="session")
-def test_long_reorg_blocks(bt, default_10000_blocks):
+def test_long_reorg_blocks(bt, default_1500_blocks):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        320,
+        758,
         f"test_blocks_long_reorg_{block_format_version}.db",
         bt,
-        block_list_input=default_10000_blocks[:758],
-        seed=b"2",
+        block_list_input=default_1500_blocks[:320],
+        seed=b"reorg_blocks",
         time_per_block=8,
+    )
+
+
+@pytest.fixture(scope="session")
+def default_2000_blocks_compact(bt):
+    from tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(
+        2000,
+        f"test_blocks_2000_compact_{block_format_version}.db",
+        bt,
+        normalized_to_identity_cc_eos=True,
+        normalized_to_identity_icc_eos=True,
+        normalized_to_identity_cc_ip=True,
+        normalized_to_identity_cc_sp=True,
+        seed=b"2000_compact",
     )
 
 
@@ -167,6 +194,7 @@ def default_10000_blocks_compact(bt):
         normalized_to_identity_icc_eos=True,
         normalized_to_identity_cc_ip=True,
         normalized_to_identity_cc_sp=True,
+        seed=b"1000_compact",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,21 +101,21 @@ def softfork_height(request):
     return request.param
 
 
-block_format_version = "rc5"
+saved_blocks_version = "rc5"
 
 
 @pytest.fixture(scope="session")
 def default_400_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(400, f"test_blocks_400_{block_format_version}.db", bt, seed=b"400")
+    return persistent_blocks(400, f"test_blocks_400_{saved_blocks_version}.db", bt, seed=b"400")
 
 
 @pytest.fixture(scope="session")
 def default_1000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(1000, f"test_blocks_1000_{block_format_version}.db", bt, seed=b"1000")
+    return persistent_blocks(1000, f"test_blocks_1000_{saved_blocks_version}.db", bt, seed=b"1000")
 
 
 @pytest.fixture(scope="session")
@@ -124,7 +124,7 @@ def pre_genesis_empty_slots_1000_blocks(bt):
 
     return persistent_blocks(
         1000,
-        f"pre_genesis_empty_slots_1000_blocks{block_format_version}.db",
+        f"pre_genesis_empty_slots_1000_blocks{saved_blocks_version}.db",
         bt,
         seed=b"empty_slots",
         empty_sub_slots=1,
@@ -135,21 +135,21 @@ def pre_genesis_empty_slots_1000_blocks(bt):
 def default_1500_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(1500, f"test_blocks_1500_{block_format_version}.db", bt, seed=b"1500")
+    return persistent_blocks(1500, f"test_blocks_1500_{saved_blocks_version}.db", bt, seed=b"1500")
 
 
 @pytest.fixture(scope="session")
 def default_10000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(10000, f"test_blocks_10000_{block_format_version}.db", bt, seed=b"10000")
+    return persistent_blocks(10000, f"test_blocks_10000_{saved_blocks_version}.db", bt, seed=b"10000")
 
 
 @pytest.fixture(scope="session")
 def default_20000_blocks(bt):
     from tests.util.blockchain import persistent_blocks
 
-    return persistent_blocks(20000, f"test_blocks_20000_{block_format_version}.db", bt, seed=b"20000")
+    return persistent_blocks(20000, f"test_blocks_20000_{saved_blocks_version}.db", bt, seed=b"20000")
 
 
 @pytest.fixture(scope="session")
@@ -158,7 +158,7 @@ def test_long_reorg_blocks(bt, default_1500_blocks):
 
     return persistent_blocks(
         758,
-        f"test_blocks_long_reorg_{block_format_version}.db",
+        f"test_blocks_long_reorg_{saved_blocks_version}.db",
         bt,
         block_list_input=default_1500_blocks[:320],
         seed=b"reorg_blocks",
@@ -172,7 +172,7 @@ def default_2000_blocks_compact(bt):
 
     return persistent_blocks(
         2000,
-        f"test_blocks_2000_compact_{block_format_version}.db",
+        f"test_blocks_2000_compact_{saved_blocks_version}.db",
         bt,
         normalized_to_identity_cc_eos=True,
         normalized_to_identity_icc_eos=True,
@@ -188,7 +188,7 @@ def default_10000_blocks_compact(bt):
 
     return persistent_blocks(
         10000,
-        f"test_blocks_10000_compact_{block_format_version}.db",
+        f"test_blocks_10000_compact_{saved_blocks_version}.db",
         bt,
         normalized_to_identity_cc_eos=True,
         normalized_to_identity_icc_eos=True,

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -278,7 +278,7 @@ class TestFullSync:
 
     @pytest.mark.asyncio
     async def test_sync_bad_peak_while_synced(
-        self, three_nodes, default_1000_blocks, default_10000_blocks, self_hostname
+        self, three_nodes, default_1000_blocks, default_1500_blocks, self_hostname
     ):
         # Must be larger than "sync_block_behind_threshold" in the config
         num_blocks_initial = len(default_1000_blocks) - 250
@@ -292,7 +292,7 @@ class TestFullSync:
             await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
         # Node 3 syncs from a different blockchain
 
-        for block in default_10000_blocks[:1100]:
+        for block in default_1500_blocks[:1100]:
             await full_node_3.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), full_node_2.full_node.on_connect)
@@ -304,7 +304,7 @@ class TestFullSync:
         # node 2 should keep being synced and receive blocks
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_3._port)), full_node_3.full_node.on_connect)
         # trigger long sync in full node 2
-        peak_block = default_10000_blocks[1050]
+        peak_block = default_1500_blocks[1050]
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_3._port)), full_node_2.full_node.on_connect)
         con = server_2.all_connections[full_node_3.full_node.server.node_id]
         peak = full_node_protocol.NewPeak(

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1563,7 +1563,7 @@ class TestFullNodeProtocol:
             if block.challenge_chain_ip_proof.normalized_to_identity:
                 has_compact_cc_ip_vdf = True
         # Note: the below numbers depend on the block cache, so might need to be updated
-        assert cc_eos_compact_count == 4
+        assert cc_eos_compact_count == 3
         assert icc_eos_compact_count == 3
         assert has_compact_cc_sp_vdf
         assert has_compact_cc_ip_vdf

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1541,7 +1541,7 @@ class TestFullNodeProtocol:
         )
 
         # Note: the below numbers depend on the block cache, so might need to be updated
-        assert cc_eos_count == 4 and icc_eos_count == 3
+        assert cc_eos_count == 3 and icc_eos_count == 3
         for compact_proof in timelord_protocol_finished:
             await full_node_1.full_node.respond_compact_proof_of_time(compact_proof)
         stored_blocks = await full_node_1.get_all_full_blocks()

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -10,6 +10,7 @@ import pytest
 from clvm.casts import int_to_bytes
 
 from chia.consensus.block_record import BlockRecord
+from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol as fnp
 from chia.types.condition_opcodes import ConditionOpcode
@@ -155,8 +156,12 @@ class TestPerformance:
             guarantee_transaction_block=True,
         )
         block = blocks[-1]
+        if is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index):
+            sub_slots = block.finished_sub_slots[:-1]
+        else:
+            sub_slots = block.finished_sub_slots
         unfinished = UnfinishedBlock(
-            block.finished_sub_slots,
+            sub_slots,
             block.reward_chain_block.get_unfinished(),
             block.challenge_chain_sp_proof,
             block.reward_chain_sp_proof,

--- a/tests/runner_templates/checkout-test-plots.include.yml
+++ b/tests/runner_templates/checkout-test-plots.include.yml
@@ -14,6 +14,6 @@
     - name: Checkout test blocks and plots
       if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
-        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia
-        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.29.0/* ${{ github.workspace }}/.chia

--- a/tests/runner_templates/checkout-test-plots.include.yml
+++ b/tests/runner_templates/checkout-test-plots.include.yml
@@ -4,7 +4,7 @@
 
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots
+      id: test-blocks-plots-29
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
@@ -12,7 +12,7 @@
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/tests/runner_templates/checkout-test-plots.include.yml
+++ b/tests/runner_templates/checkout-test-plots.include.yml
@@ -12,7 +12,7 @@
         key: ${{ hashFiles('today.txt') }}
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit != 'true'
+      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/tests/runner_templates/checkout-test-plots.include.yml
+++ b/tests/runner_templates/checkout-test-plots.include.yml
@@ -1,18 +1,14 @@
-    - name: Daily (POC) cache key invalidation for test blocks and plots
-      id: today-date
-      run: date +%F > today.txt
-
     - name: Cache test blocks and plots
       uses: actions/cache@v2
-      id: test-blocks-plots-29
+      id: test-blocks-plots
       with:
         path: |
           ${{ github.workspace }}/.chia/blocks
           ${{ github.workspace }}/.chia/test-plots
-        key: ${{ hashFiles('today.txt') }}
+        key: 0.29.0
 
     - name: Checkout test blocks and plots
-      if: steps.test-blocks-plots-29.outputs.cache-hit == 'true'
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
       run: |
         wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.29.0.tar.gz | tar xzf -
         mkdir ${{ github.workspace }}/.chia

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import aiosqlite
 import tempfile
@@ -45,9 +45,13 @@ def persistent_blocks(
     normalized_to_identity_icc_eos: bool = False,
     normalized_to_identity_cc_sp: bool = False,
     normalized_to_identity_cc_ip: bool = False,
+    block_list_input: List[FullBlock] = None,
+    time_per_block: Optional[float] = None,
 ):
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
+    if block_list_input is None:
+        block_list_input = []
     block_path_dir = DEFAULT_ROOT_PATH.parent.joinpath("blocks")
     file_path = block_path_dir.joinpath(db_name)
 
@@ -80,6 +84,8 @@ def persistent_blocks(
         seed,
         empty_sub_slots,
         bt,
+        block_list_input,
+        time_per_block,
         normalized_to_identity_cc_eos,
         normalized_to_identity_icc_eos,
         normalized_to_identity_cc_sp,
@@ -93,6 +99,8 @@ def new_test_db(
     seed: bytes,
     empty_sub_slots: int,
     bt: BlockTools,
+    block_list_input: List[FullBlock],
+    time_per_block: Optional[float],
     normalized_to_identity_cc_eos: bool = False,  # CC_EOS,
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
@@ -101,6 +109,8 @@ def new_test_db(
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
         num_of_blocks,
+        block_list_input=block_list_input,
+        time_per_block=time_per_block,
         seed=seed,
         skip_slots=empty_sub_slots,
         normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -69,7 +69,7 @@ def persistent_blocks(
             blocks: List[FullBlock] = []
             for block_bytes in block_bytes_list:
                 blocks.append(FullBlock.from_bytes(block_bytes))
-            if len(blocks) == num_of_blocks:
+            if len(blocks) == num_of_blocks + len(block_list_input):
                 print(f"\n loaded {file_path} with {len(blocks)} blocks")
                 return blocks
         except EOFError:


### PR DESCRIPTION
Total time: 33m -> 13m. This includes installing and the whole CI process.

A few things contributed to the speed gains:
1. Changed test plots from k22 to k20. This saves time downloading the plots in many of the CI workflows. Also it saves time creating blocks for any tests that make blocks.
2. test_long_reorg now uses block cache and doesn't regenerate hundreds of blocks.
3. Test compact blockchain uses 2k blocks instead of 10k blocks. Testing with so many was unnecessary.   
4. A few other tests were optimized
5. Load fewer blocks if we can, for example don't load 10k blocks if you only need 1k, parsing them all is extremely slow.

Also I fixed a bug in the weight proof validation. An edge case was hit with this new list of blocks.