### PR TITLE
Speedup preparing test blocks and plots

### DIFF
--- a/.github/workflows/build-test-macos-blockchain.yml
+++ b/.github/workflows/build-test-macos-blockchain.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-daemon.yml
+++ b/.github/workflows/build-test-macos-core-daemon.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-macos-core-full_node-full_sync.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-full_node-stores.yml
+++ b/.github/workflows/build-test-macos-core-full_node-stores.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-full_node.yml
+++ b/.github/workflows/build-test-macos-core-full_node.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-server.yml
+++ b/.github/workflows/build-test-macos-core-server.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-ssl.yml
+++ b/.github/workflows/build-test-macos-core-ssl.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core-util.yml
+++ b/.github/workflows/build-test-macos-core-util.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-farmer_harvester.yml
+++ b/.github/workflows/build-test-macos-farmer_harvester.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-plotting.yml
+++ b/.github/workflows/build-test-macos-plotting.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-pools.yml
+++ b/.github/workflows/build-test-macos-pools.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-simulation.yml
+++ b/.github/workflows/build-test-macos-simulation.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-macos-wallet-cat_wallet.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-rpc.yml
+++ b/.github/workflows/build-test-macos-wallet-rpc.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-macos-wallet-simple_sync.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet-sync.yml
+++ b/.github/workflows/build-test-macos-wallet-sync.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-wallet.yml
+++ b/.github/workflows/build-test-macos-wallet.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-macos-weight_proof.yml
+++ b/.github/workflows/build-test-macos-weight_proof.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-blockchain.yml
+++ b/.github/workflows/build-test-ubuntu-blockchain.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-daemon.yml
+++ b/.github/workflows/build-test-ubuntu-core-daemon.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-full_sync.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node-stores.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-full_node.yml
+++ b/.github/workflows/build-test-ubuntu-core-full_node.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-server.yml
+++ b/.github/workflows/build-test-ubuntu-core-server.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-ssl.yml
+++ b/.github/workflows/build-test-ubuntu-core-ssl.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core-util.yml
+++ b/.github/workflows/build-test-ubuntu-core-util.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-farmer_harvester.yml
+++ b/.github/workflows/build-test-ubuntu-farmer_harvester.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-plotting.yml
+++ b/.github/workflows/build-test-ubuntu-plotting.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-pools.yml
+++ b/.github/workflows/build-test-ubuntu-pools.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-simulation.yml
+++ b/.github/workflows/build-test-ubuntu-simulation.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-cat_wallet.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-rpc.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-rpc.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-simple_sync.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet-sync.yml
+++ b/.github/workflows/build-test-ubuntu-wallet-sync.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-wallet.yml
+++ b/.github/workflows/build-test-ubuntu-wallet.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/.github/workflows/build-test-ubuntu-weight_proof.yml
+++ b/.github/workflows/build-test-ubuntu-weight_proof.yml
@@ -65,13 +65,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia
 
     - name: Run install script
       env:

--- a/tests/runner_templates/checkout-test-plots.include.yml
+++ b/tests/runner_templates/checkout-test-plots.include.yml
@@ -1,7 +1,19 @@
-    - name: Checkout test blocks and plots
-      uses: actions/checkout@v3
+    - name: Daily (POC) cache key invalidation for test blocks and plots
+      id: today-date
+      run: date +%F > today.txt
+
+    - name: Cache test blocks and plots
+      uses: actions/cache@v2
+      id: test-blocks-plots
       with:
-        repository: 'Chia-Network/test-cache'
-        path: '.chia'
-        ref: '0.28.0'
-        fetch-depth: 1
+        path: |
+          ${{ github.workspace }}/.chia/blocks
+          ${{ github.workspace }}/.chia/test-plots
+        key: ${{ hashFiles('today.txt') }}
+
+    - name: Checkout test blocks and plots
+      if: steps.test-blocks-plots.outputs.cache-hit != 'true'
+      run: |
+        wget -qO- https://github.com/Chia-Network/test-cache/archive/refs/tags/0.28.0.tar.gz | tar xzf -
+        mkdir ${{ github.workspace }}/.chia
+        mv ${{ github.workspace }}/test-cache-0.28.0/* ${{ github.workspace }}/.chia


### PR DESCRIPTION
Achieved by opting for a release download instead of a shallow git clone, and also by putting a caching layer on top of that.