### PR TITLE
Improve detection of disconnected websocket between services

### DIFF
--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -67,7 +67,7 @@ class DaemonProxy:
         request_id = request["request_id"]
         self._request_dict[request_id] = asyncio.Event()
         string = dict_to_json_str(request)
-        if self.websocket is None:
+        if self.websocket is None or self.websocket.closed:
             raise Exception("Websocket is not connected")
         asyncio.create_task(self.websocket.send_str(string))
 

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -51,7 +51,7 @@ class RpcServer:
             await self.client_session.close()
 
     async def _state_changed(self, *args):
-        if self.websocket is None:
+        if self.websocket is None or self.websocket.closed:
             return None
         payloads: List[Dict] = await self.rpc_api._state_changed(*args)
 
@@ -70,7 +70,7 @@ class RpcServer:
         for payload in payloads:
             if "success" not in payload["data"]:
                 payload["data"]["success"] = True
-            if self.websocket is None:
+            if self.websocket is None or self.websocket.closed:
                 return None
             try:
                 await self.websocket.send_str(dict_to_json_str(payload))
@@ -79,7 +79,7 @@ class RpcServer:
                 self.log.warning(f"Sending data failed. Exception {tb}.")
 
     def state_changed(self, *args):
-        if self.websocket is None:
+        if self.websocket is None or self.websocket.closed:
             return None
         asyncio.create_task(self._state_changed(*args))
 


### PR DESCRIPTION
When running `chia wallet show`, I got the error
`No keys loaded. Run 'chia keys generate' or import a key`

The problem is that the keychain_proxy is not able to  get the RPC call `get_key_for_fingerprint` because the websocket is not connected.