### PR TITLE
Set keychain_proxy to None in await_closed() to support reinitialization

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -140,7 +140,7 @@ class Farmer:
         self.harvester_cache: Dict[str, Dict[str, HarvesterCacheEntry]] = {}
 
     async def ensure_keychain_proxy(self) -> KeychainProxy:
-        if not self.keychain_proxy:
+        if self.keychain_proxy is None:
             if self.local_keychain:
                 self.keychain_proxy = wrap_local_keychain(self.local_keychain, log=self.log)
             else:
@@ -219,6 +219,7 @@ class Farmer:
             await self.update_pool_state_task
         if self.keychain_proxy is not None:
             await self.keychain_proxy.close()
+            self.keychain_proxy = None
             await asyncio.sleep(0.5)  # https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
         self.started = False
 

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -212,14 +212,15 @@ class Farmer:
     def _close(self):
         self._shut_down = True
 
-    async def _await_closed(self):
+    async def _await_closed(self, shutting_down: bool = True):
         if self.cache_clear_task is not None:
             await self.cache_clear_task
         if self.update_pool_state_task is not None:
             await self.update_pool_state_task
-        if self.keychain_proxy is not None:
-            await self.keychain_proxy.close()
+        if shutting_down and self.keychain_proxy is not None:
+            proxy = self.keychain_proxy
             self.keychain_proxy = None
+            await proxy.close()
             await asyncio.sleep(0.5)  # https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
         self.started = False
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -157,7 +157,7 @@ class WalletRpcApi:
         """
         if self.service is not None:
             self.service._close()
-            peers_close_task: Optional[asyncio.Task] = await self.service._await_closed()
+            peers_close_task: Optional[asyncio.Task] = await self.service._await_closed(shutting_down=False)
             if peers_close_task is not None:
                 await peers_close_task
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -259,7 +259,7 @@ class WalletNode:
         if self._secondary_peer_sync_task is not None:
             self._secondary_peer_sync_task.cancel()
 
-    async def _await_closed(self):
+    async def _await_closed(self, shutting_down: bool = True):
         self.log.info("self._await_closed")
 
         if self.server is not None:
@@ -269,9 +269,10 @@ class WalletNode:
         if self.wallet_state_manager is not None:
             await self.wallet_state_manager._await_closed()
             self.wallet_state_manager = None
-        if self.keychain_proxy is not None:
-            await self.keychain_proxy.close()
+        if shutting_down and self.keychain_proxy is not None:
+            proxy = self.keychain_proxy
             self.keychain_proxy = None
+            await proxy.close()
             await asyncio.sleep(0.5)  # https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
         self.logged_in = False
         self.wallet_peers = None

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -143,7 +143,7 @@ class WalletNode:
         self.LONG_SYNC_THRESHOLD = 200
 
     async def ensure_keychain_proxy(self) -> KeychainProxy:
-        if not self.keychain_proxy:
+        if self.keychain_proxy is None:
             if self.local_keychain:
                 self.keychain_proxy = wrap_local_keychain(self.local_keychain, log=self.log)
             else:
@@ -271,6 +271,7 @@ class WalletNode:
             self.wallet_state_manager = None
         if self.keychain_proxy is not None:
             await self.keychain_proxy.close()
+            self.keychain_proxy = None
             await asyncio.sleep(0.5)  # https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
         self.logged_in = False
         self.wallet_peers = None


### PR DESCRIPTION
When `_await_closed()` is called in the wallet (or farmer), `self.keychain_proxy` was being closed, but not set to `None`. In the wallet case, using `chia wallet show` to select a key and "log in" has the effect of closing the current wallet node (destroying the keychain proxy) and then creating a new wallet node. Because the old keychain_proxy instance was not reset to None, the new wallet node wasn't able to communicate with the keychain.

`_await_closed()` now takes an optional `shutting_down` param to control whether the keychain proxy is closed. When the process is terminating, `shutting_down` will be set to `True`, but when `wallet_rpc_api` makes calls to `_await_closed` it will pass `shutting_down=False` to keep the keychain proxy alive.
