### PR TITLE
Expose transaction sorting options to CLI

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Tuple
 import click
 
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.transaction_sorting import SortKey
 
 
 @click.group("wallet", short_help="Manage your wallet")
@@ -65,6 +66,25 @@ def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: in
     default=None,
     help="Prompt for each page of data.  Defaults to true for interactive consoles, otherwise false.",
 )
+@click.option(
+    "--sort-by-height",
+    "sort_key",
+    flag_value=SortKey.CONFIRMED_AT_HEIGHT,
+    help="Sort transactions by height",
+)
+@click.option(
+    "--sort-by-relevance",
+    "sort_key",
+    flag_value=SortKey.RELEVANCE,
+    default=True,
+    help="Sort transactions by {confirmed, height, time}",
+)
+@click.option(
+    "--reverse",
+    is_flag=True,
+    default=False,
+    help="Reverse the transaction ordering",
+)
 def get_transactions_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -73,8 +93,19 @@ def get_transactions_cmd(
     limit: int,
     verbose: bool,
     paginate: Optional[bool],
+    sort_key: SortKey,
+    reverse: bool,
 ) -> None:
-    extra_params = {"id": id, "verbose": verbose, "offset": offset, "paginate": paginate, "limit": limit}
+    extra_params = {
+        "id": id,
+        "verbose": verbose,
+        "offset": offset,
+        "paginate": paginate,
+        "limit": limit,
+        "sort_key": sort_key,
+        "reverse": reverse,
+    }
+
     import asyncio
     from .wallet_funcs import execute_with_wallet, get_transactions
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -115,9 +115,13 @@ async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerpri
         paginate = sys.stdout.isatty()
     offset = args["offset"]
     limit = args["limit"]
+    sort_key = args["sort_key"]
+    reverse = args["reverse"]
+
     txs: List[TransactionRecord] = await wallet_client.get_transactions(
-        wallet_id, start=offset, end=(offset + limit), reverse=True
+        wallet_id, start=offset, end=(offset + limit), sort_key=sort_key, reverse=reverse
     )
+
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
     address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
     if len(txs) == 0:


### PR DESCRIPTION
In 1.3 the GUI and back-end were updated with some new sorting options for transactions. Specifically one can sort by height (`order by confirmed_at_height {ASC}`) or "relevance" (`order by confirmed {ASC}, confirmed_at_height {DESC}, created_at_time {DESC}`)

The GUI uses relevance by default.

This PR exposes these options to the CLI for `get_transactions` with `--sort-by-height` and `--sort-by-relevance` with relevance as the default. This should make get_transactions return the same list in the same order as the GUI displays them

For completeness, also expose the `--reverse` option which reverses the order of the sort