### PR TITLE
transition to using chia_rs module

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -1,7 +1,6 @@
 import logging
-
 from typing import Dict, Optional
-from clvm_rs import MEMPOOL_MODE, COND_CANON_INTS, NO_NEG_DIV
+from chia_rs import MEMPOOL_MODE, COND_CANON_INTS, NO_NEG_DIV, STRICT_ARGS_COUNT
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.cost_calculator import NPCResult
@@ -43,7 +42,8 @@ def get_name_puzzle_conditions(
     assert (MEMPOOL_MODE & NO_NEG_DIV) != 0
 
     if mempool_mode:
-        flags = MEMPOOL_MODE
+        # Don't apply the strict args count rule yet
+        flags = MEMPOOL_MODE & (~STRICT_ARGS_COUNT)
     elif unwrap(height) >= DEFAULT_CONSTANTS.SOFT_FORK_HEIGHT:
         # conditions must use integers in canonical encoding (i.e. no redundant
         # leading zeros)

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -5,7 +5,7 @@ from clvm import SExp
 from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
 from clvm.serialize import sexp_from_stream, sexp_to_stream
-from clvm_rs import MEMPOOL_MODE, run_chia_program, serialized_length, run_generator2
+from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, run_generator
 from clvm_tools.curry import curry, uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -222,7 +222,7 @@ class SerializedProgram:
     def run_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
         return self._run(max_cost, 0, *args)
 
-    # returns an optional error code and an optional SpendBundleConditions
+    # returns an optional error code and an optional SpendBundleConditions (from chia_rs)
     # exactly one of those will hold a value
     def run_as_generator(
         self, max_cost: int, flags: int, *args
@@ -238,7 +238,7 @@ class SerializedProgram:
         else:
             serialized_args += _serialize(args[0])
 
-        err, conds = run_generator2(
+        err, conds = run_generator(
             self._buf,
             serialized_args,
             max_cost,

--- a/chia/types/spend_bundle_conditions.py
+++ b/chia/types/spend_bundle_conditions.py
@@ -7,7 +7,7 @@ from chia.util.streamable import Streamable, streamable
 
 
 # the Spend and SpendBundleConditions classes are mirrors of native types, returned by
-# run_generator2
+# run_generator
 @dataclass(frozen=True)
 @streamable
 class Spend(Streamable):

--- a/chia/util/full_block_utils.py
+++ b/chia/util/full_block_utils.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional
 
 from blspy import G1Element, G2Element
-from clvm_rs import serialized_length
+from chia_rs import serialized_length
 
 from chia.types.blockchain_format.program import SerializedProgram
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ dependencies = [
     "chiapos==1.0.9",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.4",  # Currying, Program.to, other conveniences
-    "clvm_rs==0.1.19",
+    "chia_rs==0.1.1",
     "clvm-tools-rs==0.1.7",  # Rust implementation of clvm_tools
     "aiohttp==3.7.4",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/wallet/test_singleton.py
+++ b/tests/wallet/test_singleton.py
@@ -51,7 +51,7 @@ def test_only_odd_coins():
     try:
         cost, result = SINGLETON_MOD.run_with_cost(INFINITE_COST, solution)
     except Exception as e:
-        assert e.args == ("clvm raise",)
+        assert e.args == ("clvm raise", "80")
     else:
         assert False
 
@@ -84,7 +84,7 @@ def test_only_one_odd_coin_created():
     try:
         cost, result = SINGLETON_MOD.run_with_cost(INFINITE_COST, solution)
     except Exception as e:
-        assert e.args == ("clvm raise",)
+        assert e.args == ("clvm raise", "80")
     else:
         assert False
     solution = Program.to(

--- a/tools/analyze-chain.py
+++ b/tools/analyze-chain.py
@@ -10,7 +10,7 @@ from typing import List
 from time import time
 
 
-from clvm_rs import run_generator2, MEMPOOL_MODE
+from chia_rs import run_generator, MEMPOOL_MODE
 
 from chia.types.full_block import FullBlock
 from chia.types.blockchain_format.program import Program
@@ -21,7 +21,7 @@ from chia.util.ints import uint32
 GENERATOR_ROM = bytes(get_generator())
 
 
-# returns an optional error code and an optional PySpendBundleConditions (from clvm_rs)
+# returns an optional error code and an optional PySpendBundleConditions (from chia_rs)
 # exactly one of those will hold a value and the number of seconds it took to
 # run
 def run_gen(env_data: bytes, block_program_args: bytes, flags: uint32):
@@ -36,7 +36,7 @@ def run_gen(env_data: bytes, block_program_args: bytes, flags: uint32):
 
     try:
         start_time = time()
-        err, result = run_generator2(
+        err, result = run_generator(
             GENERATOR_ROM,
             env_data,
             max_cost,

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -42,7 +42,7 @@ from typing import List, Tuple, Dict
 
 import click
 
-from clvm_rs import COND_CANON_INTS, NO_NEG_DIV
+from chia_rs import COND_CANON_INTS, NO_NEG_DIV
 
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS


### PR DESCRIPTION
we have separated core CLVM functionality (executing clvm programs) from the higher level Chia functions (parsing and partially validate conditions, with more to come) into two separate projects. We now have `clvm_rs` and `chia_rs`. The latter exports all functions from both libraries.

This patch changes our dependency from `clvm_rs` to `chia_rs`. One note worthy change is that the `MEMPOOL_MODE` in the new version is stricter, where it requires the number of arguments to conditions to match what we use. This rule is being disabled by this patch in order to preserve the current behavior. In order to enable it, we'll also need to update tests, so I'm putting that in a separate PR.