### PR TITLE
only check the version once in installer build workflows

### DIFF
--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -109,6 +109,8 @@ jobs:
         sh install.sh
 
     - name: Build arm64 .deb package
+      env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
         . ./activate
         ldd --version

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -152,6 +152,8 @@ jobs:
         sudo apt-get install -y jq
 
     - name: Build .deb package
+      env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
         . ./activate
         ldd --version

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -112,6 +112,8 @@ jobs:
         sh install.sh
 
     - name: Build .rpm package
+      env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
         . ./activate
         ldd --version

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -137,6 +137,7 @@ jobs:
 
     - name: Build MacOS DMG
       env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
         NOTARIZE: ${{ steps.check_secrets.outputs.HAS_APPLE_SECRET }}
         APPLE_NOTARIZE_USERNAME: "${{ secrets.APPLE_NOTARIZE_USERNAME }}"
         APPLE_NOTARIZE_PASSWORD: "${{ secrets.APPLE_NOTARIZE_PASSWORD }}"

--- a/.github/workflows/build-macos-m1-installer.yml
+++ b/.github/workflows/build-macos-m1-installer.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Build MacOS DMG
         env:
+          CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
           NOTARIZE: ${{ steps.check_secrets.outputs.HAS_APPLE_SECRET }}
           APPLE_NOTARIZE_USERNAME: "${{ secrets.APPLE_NOTARIZE_USERNAME }}"
           APPLE_NOTARIZE_PASSWORD: "${{ secrets.APPLE_NOTARIZE_PASSWORD }}"

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -145,6 +145,7 @@ jobs:
 
     - name: Build Windows installer with build_scripts\build_windows.ps1
       env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
         WIN_CODE_SIGN_PASS: ${{ secrets.WIN_CODE_SIGN_PASS }}
         HAS_SECRET: ${{ steps.check_secrets.outputs.HAS_SIGNING_SECRET }}
       run: |

--- a/build_scripts/build_linux_deb.sh
+++ b/build_scripts/build_linux_deb.sh
@@ -13,11 +13,8 @@ else
 	DIR_NAME="chia-blockchain-linux-arm64"
 fi
 
-pip install setuptools_scm
-# The environment variable CHIA_INSTALLER_VERSION needs to be defined
 # If the env variable NOTARIZE and the username and password variables are
 # set, this will attempt to Notarize the signed DMG
-CHIA_INSTALLER_VERSION=$(python installer-version.py)
 
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
 	echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."

--- a/build_scripts/build_linux_rpm.sh
+++ b/build_scripts/build_linux_rpm.sh
@@ -14,11 +14,8 @@ else
 	DIR_NAME="chia-blockchain-linux-arm64"
 fi
 
-pip install setuptools_scm
-# The environment variable CHIA_INSTALLER_VERSION needs to be defined
 # If the env variable NOTARIZE and the username and password variables are
 # set, this will attempt to Notarize the signed DMG
-CHIA_INSTALLER_VERSION=$(python installer-version.py)
 
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
 	echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."

--- a/build_scripts/build_macos.sh
+++ b/build_scripts/build_macos.sh
@@ -2,11 +2,8 @@
 
 set -o errexit -o nounset
 
-pip install setuptools_scm
-# The environment variable CHIA_INSTALLER_VERSION needs to be defined.
 # If the env variable NOTARIZE and the username and password variables are
 # set, this will attempt to Notarize the signed DMG.
-CHIA_INSTALLER_VERSION=$(python installer-version.py)
 
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
 	echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."

--- a/build_scripts/build_macos_m1.sh
+++ b/build_scripts/build_macos_m1.sh
@@ -2,11 +2,8 @@
 
 set -o errexit -o nounset
 
-pip install setuptools_scm
-# The environment variable CHIA_INSTALLER_VERSION needs to be defined.
 # If the env variable NOTARIZE and the username and password variables are
 # set, this will attempt to Notarize the signed DMG.
-CHIA_INSTALLER_VERSION=$(python installer-version.py)
 
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
 	echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -32,12 +32,9 @@ python -m pip install --upgrade pip
 pip install wheel pep517
 pip install pywin32
 pip install pyinstaller==4.9
-pip install setuptools_scm
 
 Write-Output "   ---"
-Write-Output "Get CHIA_INSTALLER_VERSION"
 # The environment variable CHIA_INSTALLER_VERSION needs to be defined
-$env:CHIA_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
 
 if (-not (Test-Path env:CHIA_INSTALLER_VERSION)) {
   $env:CHIA_INSTALLER_VERSION = '0.0.0'


### PR DESCRIPTION
Broken out from https://github.com/Chia-Network/chia-blockchain/pull/11077.

Checked by observing that `Chia Installer Version is` (or `Chia Version is` on Windows, to be made consistent separately) in each of the following workflows shows the expected version, `1.2.51` in this case.  This occurs after the changed code has been run so downstream can be expected to be unchanged.  The file names inside the GitHub Actions `.zip` artifacts also look like clean `1.2.51` without any `.dev`.

https://github.com/Chia-Network/release-test-chia-blockchain/runs/5887324925?check_suite_focus=true
https://github.com/Chia-Network/release-test-chia-blockchain/runs/5887324124?check_suite_focus=true
https://github.com/Chia-Network/release-test-chia-blockchain/runs/5887322146?check_suite_focus=true
https://github.com/Chia-Network/release-test-chia-blockchain/runs/5887320557?check_suite_focus=true
https://github.com/Chia-Network/release-test-chia-blockchain/runs/5887324576?check_suite_focus=true
https://github.com/Chia-Network/release-test-chia-blockchain/runs/5887322344?check_suite_focus=true