### PR TITLE
Optimize test_wallet_sync

### DIFF
--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -198,8 +198,7 @@ class TestWalletSync:
         wallets[1][0].config["trusted_peers"] = {}
 
         phs = []
-        for wallet_pair in wallets:
-            wallet_node, wallet_server = wallet_pair
+        for wallet_node, wallet_server in wallets:
             wallet = wallet_node.wallet_state_manager.main_wallet
             phs.append(await wallet.get_new_puzzlehash())
             await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -27,27 +27,20 @@ log = getLogger(__name__)
 
 
 class TestWalletSync:
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
     @pytest.mark.asyncio
-    async def test_basic_sync_wallet(self, bt, wallet_node, default_400_blocks, trusted, self_hostname):
-
-        full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
+    async def test_basic_sync_wallet(self, bt, two_wallet_nodes, default_400_blocks, self_hostname):
+        full_nodes, wallets = two_wallet_nodes
+        full_node_api = full_nodes[0]
+        full_node_server = full_node_api.full_node.server
 
         for block in default_400_blocks:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-        await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        for wallet_node, wallet_server in wallets:
+            await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
-        # The second node should eventually catch up to the first one, and have the
-        # same tip at height num_blocks - 1.
-        await time_out_assert(100, wallet_height_at_least, True, wallet_node, len(default_400_blocks) - 1)
+        for wallet_node, wallet_server in wallets:
+            await time_out_assert(100, wallet_height_at_least, True, wallet_node, len(default_400_blocks) - 1)
 
         # Tests a reorg with the wallet
         num_blocks = 30
@@ -55,181 +48,186 @@ class TestWalletSync:
         for i in range(1, len(blocks_reorg)):
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(blocks_reorg[i]))
 
-        await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
+        for wallet_node, wallet_server in wallets:
+            await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
-        await time_out_assert(
-            100, wallet_height_at_least, True, wallet_node, len(default_400_blocks) + num_blocks - 5 - 1
-        )
+        for wallet_node, wallet_server in wallets:
+            await time_out_assert(
+                100, wallet_height_at_least, True, wallet_node, len(default_400_blocks) + num_blocks - 5 - 1
+            )
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
     @pytest.mark.asyncio
-    async def test_almost_recent(self, bt, wallet_node, default_1000_blocks, trusted, self_hostname):
+    async def test_almost_recent(self, bt, two_wallet_nodes, default_400_blocks, self_hostname):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
-        full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
+        full_nodes, wallets = two_wallet_nodes
+        full_node_api = full_nodes[0]
+        full_node_server = full_node_api.full_node.server
 
-        for block in default_1000_blocks:
+        # Trusted node sync
+        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
+
+        # Untrusted node sync
+        wallets[1][0].config["trusted_peers"] = {}
+
+        base_num_blocks = 400
+        for block in default_400_blocks:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        wallet = wallet_node.wallet_state_manager.main_wallet
-        ph = await wallet.get_new_puzzlehash()
+        all_blocks = default_400_blocks
+        both_phs = []
+        for wallet_node, wallet_server in wallets:
+            wallet = wallet_node.wallet_state_manager.main_wallet
+            both_phs.append(await wallet.get_new_puzzlehash())
 
-        if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-
-        # Tests a reorg with the wallet
-        num_blocks = 20
-        new_blocks = bt.get_consecutive_blocks(
-            num_blocks, block_list_input=default_1000_blocks, pool_reward_puzzle_hash=ph
-        )
-        for i in range(1000, len(new_blocks)):
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[i]))
+        for i in range(20):
+            # Tests a reorg with the wallet
+            ph = both_phs[i % 2]
+            all_blocks = bt.get_consecutive_blocks(1, block_list_input=all_blocks, pool_reward_puzzle_hash=ph)
+            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(all_blocks[-1]))
 
         new_blocks = bt.get_consecutive_blocks(
-            test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 10, block_list_input=new_blocks
+            test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 10, block_list_input=all_blocks
         )
-        for i in range(1020, len(new_blocks)):
+        for i in range(base_num_blocks + 20, len(new_blocks)):
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[i]))
 
-        await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        for wallet_node, wallet_server in wallets:
+            wallet = wallet_node.wallet_state_manager.main_wallet
+            await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+            await time_out_assert(30, wallet.get_confirmed_balance, 10 * calculate_pool_reward(uint32(1000)))
 
-        await time_out_assert(30, wallet.get_confirmed_balance, 20 * calculate_pool_reward(uint32(1000)))
-
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
     @pytest.mark.asyncio
-    async def test_backtrack_sync_wallet(self, wallet_node, default_400_blocks, trusted, self_hostname):
-        full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
+    async def test_backtrack_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname):
+        full_nodes, wallets = two_wallet_nodes
+        full_node_api = full_nodes[0]
+        full_node_server = full_node_api.full_node.server
+
+        # Trusted node sync
+        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
+
+        # Untrusted node sync
+        wallets[1][0].config["trusted_peers"] = {}
+
         for block in default_400_blocks[:20]:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-        await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        for wallet_node, wallet_server in wallets:
+            await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
-        # The second node should eventually catch up to the first one, and have the
-        # same tip at height num_blocks - 1.
-        await time_out_assert(100, wallet_height_at_least, True, wallet_node, 19)
+        for wallet_node, wallet_server in wallets:
+            await time_out_assert(100, wallet_height_at_least, True, wallet_node, 19)
 
     # Tests a reorg with the wallet
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
     @pytest.mark.asyncio
-    async def test_short_batch_sync_wallet(self, wallet_node, default_400_blocks, trusted, self_hostname):
-        full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
+    async def test_short_batch_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname):
+        full_nodes, wallets = two_wallet_nodes
+        full_node_api = full_nodes[0]
+        full_node_server = full_node_api.full_node.server
+
+        # Trusted node sync
+        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
+
+        # Untrusted node sync
+        wallets[1][0].config["trusted_peers"] = {}
 
         for block in default_400_blocks[:200]:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
-        if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
 
-        await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        for wallet_node, wallet_server in wallets:
+            await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
-        # The second node should eventually catch up to the first one, and have the
-        # same tip at height num_blocks - 1.
-        await time_out_assert(100, wallet_height_at_least, True, wallet_node, 199)
-        # Tests a reorg with the wallet
+        for wallet_node, wallet_server in wallets:
+            await time_out_assert(100, wallet_height_at_least, True, wallet_node, 199)
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
     @pytest.mark.asyncio
-    async def test_long_sync_wallet(
-        self, bt, wallet_node, default_1000_blocks, default_400_blocks, trusted, self_hostname
-    ):
+    async def test_long_sync_wallet(self, bt, two_wallet_nodes, default_1000_blocks, default_400_blocks, self_hostname):
+        full_nodes, wallets = two_wallet_nodes
+        full_node_api = full_nodes[0]
+        full_node_server = full_node_api.full_node.server
 
-        full_node_api, wallet_node, full_node_server, wallet_server = wallet_node
+        # Trusted node sync
+        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
+
+        # Untrusted node sync
+        wallets[1][0].config["trusted_peers"] = {}
 
         for block in default_400_blocks:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
-        if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
 
-        await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        for wallet_node, wallet_server in wallets:
+            await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
-        # The second node should eventually catch up to the first one, and have the
-        # same tip at height num_blocks - 1.
-        await time_out_assert(600, wallet_height_at_least, True, wallet_node, len(default_400_blocks) - 1)
+        for wallet_node, wallet_server in wallets:
+            await time_out_assert(600, wallet_height_at_least, True, wallet_node, len(default_400_blocks) - 1)
 
         # Tests a long reorg
         for block in default_1000_blocks:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
+        for wallet_node, wallet_server in wallets:
+            await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
-        log.info(f"wallet node height is {wallet_node.wallet_state_manager.blockchain.get_peak_height()}")
-        await time_out_assert(600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) - 1)
+            log.info(f"wallet node height is {wallet_node.wallet_state_manager.blockchain.get_peak_height()}")
+            await time_out_assert(600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) - 1)
 
-        await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
+            await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
         # Tests a short reorg
         num_blocks = 30
         blocks_reorg = bt.get_consecutive_blocks(num_blocks, block_list_input=default_1000_blocks[:-5])
 
-        for i in range(1, len(blocks_reorg)):
+        for i in range(len(blocks_reorg) - num_blocks - 10, len(blocks_reorg)):
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(blocks_reorg[i]))
 
-        await time_out_assert(
-            600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) + num_blocks - 5 - 1
-        )
+        for wallet_node, wallet_server in wallets:
+            await time_out_assert(
+                600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) + num_blocks - 5 - 1
+            )
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
     @pytest.mark.asyncio
-    async def test_wallet_reorg_sync(self, bt, wallet_node_simulator, default_400_blocks, trusted, self_hostname):
+    async def test_wallet_reorg_sync(self, bt, two_wallet_nodes, default_400_blocks, self_hostname):
         num_blocks = 5
-        full_nodes, wallets = wallet_node_simulator
+        full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
-        wallet_node, server_2 = wallets[0]
-        fn_server = full_node_api.full_node.server
-        wsm: WalletStateManager = wallet_node.wallet_state_manager
-        wallet = wsm.main_wallet
-        ph = await wallet.get_new_puzzlehash()
+        full_node_server = full_node_api.full_node.server
 
-        if trusted:
-            wallet_node.config["trusted_peers"] = {fn_server.node_id.hex(): fn_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
+        # Trusted node sync
+        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
 
-        await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
+        # Untrusted node sync
+        wallets[1][0].config["trusted_peers"] = {}
+
+        phs = []
+        for wallet_pair in wallets:
+            wallet_node, wallet_server = wallet_pair
+            wallet = wallet_node.wallet_state_manager.main_wallet
+            phs.append(await wallet.get_new_puzzlehash())
+            await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
         # Insert 400 blocks
         for block in default_400_blocks:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
         # Farm few more with reward
+        for i in range(0, num_blocks - 1):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(phs[0]))
+
         for i in range(0, num_blocks):
-            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(phs[1]))
 
         # Confirm we have the funds
         funds = sum(
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        await time_out_assert(5, wallet.get_confirmed_balance, funds)
-
-        async def get_tx_count(wallet_id):
+        async def get_tx_count(wsm, wallet_id):
             txs = await wsm.get_all_transactions(wallet_id)
             return len(txs)
 
-        await time_out_assert(5, get_tx_count, 2 * (num_blocks - 1), 1)
+        for wallet_node, wallet_server in wallets:
+            wallet = wallet_node.wallet_state_manager.main_wallet
+            await time_out_assert(5, wallet.get_confirmed_balance, funds)
+            await time_out_assert(5, get_tx_count, 2 * (num_blocks - 1), wallet_node.wallet_state_manager, 1)
 
         # Reorg blocks that carry reward
         num_blocks = 30
@@ -238,31 +236,25 @@ class TestWalletSync:
         for block in blocks_reorg[-30:]:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        await time_out_assert(5, get_tx_count, 0, 1)
-        await time_out_assert(5, wallet.get_confirmed_balance, 0)
+        for wallet_node, wallet_server in wallets:
+            wallet = wallet_node.wallet_state_manager.main_wallet
+            await time_out_assert(5, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
+            await time_out_assert(5, wallet.get_confirmed_balance, 0)
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [False],
-    )
     @pytest.mark.asyncio
-    async def test_wallet_reorg_get_coinbase(
-        self, bt, wallet_node_simulator, default_400_blocks, trusted, self_hostname
-    ):
-        full_nodes, wallets = wallet_node_simulator
+    async def test_wallet_reorg_get_coinbase(self, bt, two_wallet_nodes, default_400_blocks, self_hostname):
+        full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
-        wallet_node, server_2 = wallets[0]
-        fn_server = full_node_api.full_node.server
-        wsm = wallet_node.wallet_state_manager
-        wallet = wallet_node.wallet_state_manager.main_wallet
-        ph = await wallet.get_new_puzzlehash()
+        full_node_server = full_node_api.full_node.server
 
-        if trusted:
-            wallet_node.config["trusted_peers"] = {fn_server.node_id.hex(): fn_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
+        # Trusted node sync
+        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
 
-        await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
+        # Untrusted node sync
+        wallets[1][0].config["trusted_peers"] = {}
+
+        for wallet_node, wallet_server in wallets:
+            await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
         # Insert 400 blocks
         for block in default_400_blocks:
@@ -275,30 +267,37 @@ class TestWalletSync:
         for block in blocks_reorg[:-5]:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        async def get_tx_count(wallet_id):
+        async def get_tx_count(wsm, wallet_id):
             txs = await wsm.get_all_transactions(wallet_id)
             return len(txs)
 
-        await time_out_assert(10, get_tx_count, 0, 1)
-        await time_out_assert(30, wallet_is_synced, True, wallet_node, full_node_api)
+        for wallet_node, wallet_server in wallets:
+            await time_out_assert(10, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
+            await time_out_assert(30, wallet_is_synced, True, wallet_node, full_node_api)
 
         num_blocks_reorg_1 = 40
-        blocks_reorg_1 = bt.get_consecutive_blocks(
-            1, pool_reward_puzzle_hash=ph, farmer_reward_puzzle_hash=ph, block_list_input=blocks_reorg[:-30]
-        )
-        blocks_reorg_2 = bt.get_consecutive_blocks(num_blocks_reorg_1, block_list_input=blocks_reorg_1)
+        all_blocks_reorg_2 = blocks_reorg[:-30]
+        for wallet_node, wallet_server in wallets:
+            wallet = wallet_node.wallet_state_manager.main_wallet
+            ph = await wallet.get_new_puzzlehash()
+            all_blocks_reorg_2 = bt.get_consecutive_blocks(
+                1, pool_reward_puzzle_hash=ph, farmer_reward_puzzle_hash=ph, block_list_input=all_blocks_reorg_2
+            )
+        blocks_reorg_2 = bt.get_consecutive_blocks(num_blocks_reorg_1, block_list_input=all_blocks_reorg_2)
 
-        for block in blocks_reorg_2[-41:]:
-            await asyncio.sleep(0.4)
+        for block in blocks_reorg_2[-44:]:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
-        await disconnect_all_and_reconnect(server_2, fn_server, self_hostname)
+        for wallet_node, wallet_server in wallets:
+            await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
         # Confirm we have the funds
-        funds = calculate_pool_reward(uint32(len(blocks_reorg_1))) + calculate_base_farmer_reward(
-            uint32(len(blocks_reorg_1))
+        funds = calculate_pool_reward(uint32(len(all_blocks_reorg_2))) + calculate_base_farmer_reward(
+            uint32(len(all_blocks_reorg_2))
         )
 
-        await time_out_assert(60, wallet_is_synced, True, wallet_node, full_node_api)
-        await time_out_assert(20, get_tx_count, 2, 1)
-        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        for wallet_node, wallet_server in wallets:
+            wallet = wallet_node.wallet_state_manager.main_wallet
+            await time_out_assert(60, wallet_is_synced, True, wallet_node, full_node_api)
+            await time_out_assert(20, get_tx_count, 2, wallet_node.wallet_state_manager, 1)
+            await time_out_assert(20, wallet.get_confirmed_balance, funds)

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -33,6 +33,12 @@ class TestWalletSync:
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
 
+        # Trusted node sync
+        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
+
+        # Untrusted node sync
+        wallets[1][0].config["trusted_peers"] = {}
+
         for block in default_400_blocks:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
 


### PR DESCRIPTION
Running every test twice with two modes is wasteful, we can share a lot of the slow stuff