### PR TITLE
Up Windows installer build timeout to 50 minutes

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Windows Installer on Windows 10 and Python 3.9
     runs-on: [windows-2019]
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     steps:
     - name: Checkout Code


### PR DESCRIPTION
Recent runs are mostly low 30s but some are close to 40 and one just timed out.