### PR TITLE
remove setting of SCM_VERSION in install-version.py

### DIFF
--- a/build_scripts/installer-version.py
+++ b/build_scripts/installer-version.py
@@ -1,4 +1,3 @@
-import os
 import sys
 
 from setuptools_scm import get_version
@@ -10,7 +9,6 @@ def main():
 
     scm_full_version = get_version(root="..", relative_to=__file__)
     # scm_full_version = "1.0.5.dev22"
-    os.environ["SCM_VERSION"] = scm_full_version
 
     left_full_version = scm_full_version.split("+")
     version = left_full_version[0].split(".")


### PR DESCRIPTION
This seems unused internally and I am not aware of any scenario where it would get inherited back out to other processes.

Extracted from https://github.com/Chia-Network/chia-blockchain/pull/11077.