### PR TITLE
have pyinstaller check platlib for dll's, not ROOT

### DIFF
--- a/chia/pyinstaller.spec
+++ b/chia/pyinstaller.spec
@@ -2,6 +2,7 @@
 import importlib
 import pathlib
 import platform
+import sysconfig
 
 from pkg_resources import get_distribution
 
@@ -98,7 +99,7 @@ if THIS_IS_WINDOWS:
 
 if THIS_IS_WINDOWS:
     chia_mod = importlib.import_module("chia")
-    dll_paths = ROOT / "*.dll"
+    dll_paths = pathlib.Path(sysconfig.get_path("platlib")) / "*.dll"
 
     binaries = [
         (


### PR DESCRIPTION
I believe we mean to find the `site-packages/*.dll` files not those a couple directories up from the `chia` package.  This differs, for example, when the `chia` source is found such as when using an `--editable` install.

Extracted from https://github.com/Chia-Network/chia-blockchain/pull/11077.