### PR TITLE
Add get_unconfirmed_transactions wallet RPC

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -185,6 +185,25 @@ def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int, new_ad
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, get_address))
 
 
+@wallet_cmd.command("get_unconfirmed_transactions", short_help="Return all pending transactions for this wallet ID")
+@click.option(
+    "-wp",
+    "--wallet-rpc-port",
+    help="Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml",
+    type=int,
+    default=None,
+)
+@click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
+@click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
+@click.option("--verbose", "-v", count=True, type=int)
+def get_unconfirmed_transactions_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int, verbose: bool) -> None:
+    extra_params = {"id": id, "verbose": verbose}
+    import asyncio
+    from chia.cmds.wallet_funcs import execute_with_wallet, get_unconfirmed_transactions
+
+    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, get_unconfirmed_transactions))
+
+
 @wallet_cmd.command(
     "delete_unconfirmed_transactions", short_help="Deletes all unconfirmed transactions for this wallet ID"
 )

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -189,7 +189,7 @@ def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int, new_ad
 @click.option(
     "-wp",
     "--wallet-rpc-port",
-    help="Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml",
+    help="Set the port where the wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml",
     type=int,
     default=None,
 )

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -108,6 +108,18 @@ async def get_transaction(args: dict, wallet_client: WalletRpcClient, fingerprin
     )
 
 
+async def get_wallet_info(wallet_id: int, wallet_client: WalletRpcClient, config: Dict) -> Tuple[WalletType, int, str]:
+    wallet_type = await get_wallet_type(wallet_id=wallet_id, wallet_client=wallet_client)
+    mojo_per_unit = get_mojo_per_unit(wallet_type=wallet_type)
+    name = await get_name_for_wallet_id(
+        config=config,
+        wallet_type=wallet_type,
+        wallet_id=wallet_id,
+        wallet_client=wallet_client,
+    )
+    return wallet_type, mojo_per_unit, name
+
+
 async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["id"]
     paginate = args["paginate"]
@@ -124,14 +136,7 @@ async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerpri
         print("There are no transactions to this address")
 
     try:
-        wallet_type = await get_wallet_type(wallet_id=wallet_id, wallet_client=wallet_client)
-        mojo_per_unit = get_mojo_per_unit(wallet_type=wallet_type)
-        name = await get_name_for_wallet_id(
-            config=config,
-            wallet_type=wallet_type,
-            wallet_id=wallet_id,
-            wallet_client=wallet_client,
-        )
+        wallet_type, mojo_per_unit, name = await get_wallet_info(wallet_id, wallet_client, config)
     except LookupError as e:
         print(e.args[0])
         return
@@ -221,6 +226,26 @@ async def get_address(args: dict, wallet_client: WalletRpcClient, fingerprint: i
     new_address: bool = args.get("new_address", False)
     res = await wallet_client.get_next_address(wallet_id, new_address)
     print(res)
+
+
+async def get_unconfirmed_transactions(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
+    wallet_id = args["id"]
+    verbose = args.get("verbose", 0)
+    txs = await wallet_client.get_unconfirmed_transactions(wallet_id)
+    if len(txs) == 0:
+        print(f"There are no pending transactions for wallet id {wallet_id} on key {fingerprint}")
+    else:
+        config = load_config(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+        address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
+        wallet_type, mojo_per_unit, name = await get_wallet_info(wallet_id, wallet_client, config)
+        for tx in txs:
+            print_transaction(
+                tx,
+                verbose=(verbose > 0),
+                name=name,
+                address_prefix=address_prefix,
+                mojo_per_unit=mojo_per_unit,
+            )
 
 
 async def delete_unconfirmed_transactions(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -79,6 +79,7 @@ class WalletRpcApi:
             "/get_wallet_balance": self.get_wallet_balance,
             "/get_transaction": self.get_transaction,
             "/get_transactions": self.get_transactions,
+            "/get_unconfirmed_transactions": self.get_unconfirmed_transactions,
             "/get_transaction_count": self.get_transaction_count,
             "/get_next_address": self.get_next_address,
             "/send_transaction": self.send_transaction,
@@ -675,6 +676,20 @@ class WalletRpcApi:
         return {
             "transaction": (await self._convert_tx_puzzle_hash(tr)).to_json_dict_convenience(self.service.config),
             "transaction_id": tr.name,
+        }
+
+    async def get_unconfirmed_transactions(self, request: Dict) -> Dict:
+        assert self.service.wallet_state_manager is not None
+
+        wallet_id = int(request["wallet_id"])
+
+        transactions = await self.service.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(wallet_id)
+        return {
+            "transactions": [
+                (await self._convert_tx_puzzle_hash(tr)).to_json_dict_convenience(self.service.config)
+                for tr in transactions
+            ],
+            "wallet_id": wallet_id,
         }
 
     async def get_transactions(self, request: Dict) -> Dict:

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -173,6 +173,13 @@ class WalletRpcClient(RpcClient):
 
         return TransactionRecord.from_json_dict_convenience(response["transaction"])
 
+    async def get_unconfirmed_transactions(self, wallet_id: str) -> List[TransactionRecord]:
+        res = await self.fetch(
+            "get_unconfirmed_transactions",
+            {"wallet_id": wallet_id},
+        )
+        return [TransactionRecord.from_json_dict_convenience(tx) for tx in res["transactions"]]
+
     async def delete_unconfirmed_transactions(self, wallet_id: str) -> None:
         await self.fetch(
             "delete_unconfirmed_transactions",


### PR DESCRIPTION
The immediate use of this RPC is to help end users understand the current state of their "stuck" transactions. For example, is it still being considered by the wallet for re-submission to other nodes, or has it been dropped?

There are so many ways to implement this - I started out making this a filter on the `get_transactions_between` call to the DB. But looking a little closer, we use a cache above the DB, and `get_unconfirmed_transactions` is what wallets actually call to determine if they have pending transactions, so I thought it would be better to wire this command to that method.