### PR TITLE
optimize Program.curry()

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -88,6 +88,22 @@ class Program(SExp):
         cost, r = self.run_with_cost(INFINITE_COST, args)
         return r
 
+    # Replicates the curry function from clvm_tools, taking advantage of *args
+    # being a list.  We iterate through args in reverse building the code to
+    # create a clvm list.
+    #
+    # Given arguments to a function addressable by the '1' reference in clvm
+    #
+    # fixed_args = 1
+    #
+    # Each arg is prepended as fixed_args = (c (q . arg) fixed_args)
+    #
+    # The resulting argument list is interpreted with apply (2)
+    #
+    # (2 (1 . self) rest)
+    #
+    # Resulting in a function which places its own arguments after those
+    # curried in in the form of a proper list.
     def curry(self, *args) -> "Program":
         fixed_args: Any = 1
         for arg in reversed(args):

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -1,12 +1,12 @@
 import io
-from typing import List, Set, Tuple, Optional
+from typing import List, Set, Tuple, Optional, Any
 
 from clvm import SExp
 from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
 from clvm.serialize import sexp_from_stream, sexp_to_stream
 from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, run_generator
-from clvm_tools.curry import curry, uncurry
+from clvm_tools.curry import uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.hash import std_hash
@@ -89,8 +89,10 @@ class Program(SExp):
         return r
 
     def curry(self, *args) -> "Program":
-        cost, r = curry(self, list(args))
-        return Program.to(r)
+        fixed_args: Any = 1
+        for arg in reversed(args):
+            fixed_args = [4, (1, arg), fixed_args]
+        return Program.to([2, (1, self), fixed_args])
 
     def uncurry(self) -> Tuple["Program", "Program"]:
         r = uncurry(self)

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -1,12 +1,12 @@
 import io
-from typing import List, Set, Tuple, Optional
+from typing import List, Set, Tuple, Optional, Any
 
 from clvm import SExp
 from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
 from clvm.serialize import sexp_from_stream, sexp_to_stream
 from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, run_generator
-from clvm_tools.curry import curry, uncurry
+from clvm_tools.curry import uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.hash import std_hash
@@ -89,8 +89,10 @@ class Program(SExp):
         return r
 
     def curry(self, *args) -> "Program":
-        cost, r = curry(self, list(args))
-        return Program.to(r)
+        fixed_args = 1
+        for i in reversed(range(len(args))):
+            fixed_args = [4, (1, args[i]), fixed_args]
+        return Program.to([2, (1, self), fixed_args])
 
     def uncurry(self) -> Tuple["Program", "Program"]:
         r = uncurry(self)

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -88,6 +88,22 @@ class Program(SExp):
         cost, r = self.run_with_cost(INFINITE_COST, args)
         return r
 
+    # Replicates the curry function from clvm_tools, taking advantage of *args
+    # being a list.  We iterate through args in reverse building the code to
+    # create a clvm list.
+    #
+    # Given arguments to a function addressable by the '1' reference in clvm
+    #
+    # fixed_args = 1
+    #
+    # Each arg is prepended as fixed_args = (c (q . arg) fixed_args)
+    #
+    # The resulting argument list is interpreted with apply (2)
+    #
+    # (2 (1 . self) rest)
+    #
+    # Resulting in a function which places its own arguments after those
+    # curried in in the form of a proper list.
     def curry(self, *args) -> "Program":
         fixed_args = 1
         for i in reversed(range(len(args))):


### PR DESCRIPTION
This is Arty's implementation.

This speeds up generating wallet puzzle hashes by quite a lot. In my test program that's very heavy on generating transactions to new puzzle hashes, it brings the total time spent in `curry()` from 22% to 1.6%.