### PR TITLE
Use log formatter to avoid serialisation

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -220,7 +220,7 @@ class WebSocketServer:
 
         while True:
             msg = await ws.receive()
-            self.log.debug(f"Received message: {msg}")
+            self.log.debug("Received message: %s", msg)
             if msg.type == WSMsgType.TEXT:
                 try:
                     decoded = json.loads(msg.data)

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -220,7 +220,7 @@ class WebSocketServer:
 
         while True:
             msg = await ws.receive()
-            self.log.debug("Received message: %s", msg)
+            self.log.debug(f"Received message: {msg}")
             if msg.type == WSMsgType.TEXT:
                 try:
                     decoded = json.loads(msg.data)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -99,7 +99,7 @@ class WeightProofHandler:
             if ses_height > tip_height:
                 break
             ses = self.blockchain.get_ses(ses_height)
-            log.debug(f"handle sub epoch summary {sub_epoch_n} at height: {ses_height} ses {ses}")
+            log.debug("handle sub epoch summary %s at height: %s ses %s", sub_epoch_n, ses_height, ses)
             sub_epoch_data.append(_create_sub_epoch_data(ses))
         return sub_epoch_data
 

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -99,7 +99,7 @@ class WeightProofHandler:
             if ses_height > tip_height:
                 break
             ses = self.blockchain.get_ses(ses_height)
-            log.debug("handle sub epoch summary %s at height: %s ses %s", sub_epoch_n, ses_height, ses)
+            log.debug(f"handle sub epoch summary {sub_epoch_n} at height: {ses_height} ses {ses}")
             sub_epoch_data.append(_create_sub_epoch_data(ses))
         return sub_epoch_data
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -358,7 +358,7 @@ class WalletNode:
             try:
                 peer, item = None, None
                 item = await self.new_peak_queue.get()
-                self.log.debug(f"Pulled from queue: {item}")
+                self.log.debug("Pulled from queue: %s", item)
                 assert item is not None
                 if item.item_type == NewPeakQueueTypes.COIN_ID_SUBSCRIPTION:
                     # Subscriptions are the highest priority, because we don't want to process any more peaks or

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -358,7 +358,7 @@ class WalletNode:
             try:
                 peer, item = None, None
                 item = await self.new_peak_queue.get()
-                self.log.debug("Pulled from queue: %s", item)
+                self.log.debug(f"Pulled from queue: {item}")
                 assert item is not None
                 if item.item_type == NewPeakQueueTypes.COIN_ID_SUBSCRIPTION:
                     # Subscriptions are the highest priority, because we don't want to process any more peaks or


### PR DESCRIPTION
```
In [5]: class Obj:
   ...: ...     def __init__(self):
   ...: ...         self.counter = 0
   ...: ...     def __str__(self):
   ...: ...         self.counter += 1
   ...: ...         return str(self.counter)
   ...:

In [6]: import logging

In [7]: o = Obj()

In [8]: print(o)
1

In [9]: print(o)
2

In [10]: logging.error("log")
ERROR:root:log

In [11]: logging.debug("log")

In [12]: logging.debug(f"obj is: {o}")

In [13]: print(o)
4

In [14]: logging.debug("obj is: %s", o)

In [16]: print(o)
5
```

given that daemon is serialising every message that comes in, this could have major impact on CPU for low end nodes