### PR TITLE
Cmj.bladebit

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -788,6 +788,7 @@ class WebSocketServer:
 
         return command_args
 
+    # @TODO Do something for bladebit version 2.
     def _bladebit_plotting_command_args(self, request: Any, ignoreCount: bool) -> List[str]:
         w = request.get("w", False)  # Warm start
         m = request.get("m", False)  # Disable NUMA

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -788,6 +788,7 @@ class WebSocketServer:
     def _bladebit_plotting_command_args(self, request: Any, ignoreCount: bool) -> List[str]:
         w = request.get("w", False)  # Warm start
         m = request.get("m", False)  # Disable NUMA
+        no_cpu_affinity = request.get("no_cpu_affinity", False)
 
         command_args: List[str] = []
 
@@ -795,6 +796,8 @@ class WebSocketServer:
             command_args.append("-w")
         if m is True:
             command_args.append("-m")
+        if no_cpu_affinity is True:
+            command_args.append("--no-cpu-affinity")
 
         return command_args
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -815,6 +815,7 @@ class WebSocketServer:
         c_threads = request.get("c_threads")
         p2_threads = request.get("p2_threads")
         p3_threads = request.get("p3_threads")
+        alternate = request.get("alternate", False)
 
         command_args: List[str] = []
 
@@ -848,6 +849,8 @@ class WebSocketServer:
         if p3_threads:
             command_args.append("--p3-threads")
             command_args.append(str(p3_threads))
+        if alternate:
+            command_args.append("--alternate")
 
         return command_args
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -807,14 +807,14 @@ class WebSocketServer:
         no_cpu_affinity = request.get("no_cpu_affinity", False)
         # memo = request["memo"]
         t1 = request["t"]  # Temp directory
-        t2 = request["t2"]  # Temp2 directory
-        u = request["u"]  # Buckets
-        cache = request["cache"]
-        f1_threads = request["f1_threads"]
-        fp_threads = request["fp_threads"]
-        c_threads = request["c_threads"]
-        p2_threads = request["p2_threads"]
-        p3_threads = request["p3_threads"]
+        t2 = request.get("t2")  # Temp2 directory
+        u = request.get("u")  # Buckets
+        cache = request.get("cache")
+        f1_threads = request.get("f1_threads")
+        fp_threads = request.get("fp_threads")
+        c_threads = request.get("c_threads")
+        p2_threads = request.get("p2_threads")
+        p3_threads = request.get("p3_threads")
 
         command_args: List[str] = []
 
@@ -825,8 +825,7 @@ class WebSocketServer:
         if no_cpu_affinity is True:
             command_args.append("--no-cpu-affinity")
 
-        if t1:
-            command_args.append(f"-t{t1}")
+        command_args.append(f"-t{t1}")
         if t2:
             command_args.append(f"-2{t2}")
         if u:

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -820,26 +820,30 @@ class WebSocketServer:
         if no_cpu_affinity is True:
             command_args.append("--no-cpu-affinity")
 
-        command_args.append("diskplot")
-
         if t1:
-            command_args.append(f"-t1 {t1}")
+            command_args.append(f"-t{t1}")
         if t2:
-            command_args.append(f"-t2 {t2}")
+            command_args.append(f"-2{t2}")
         if u:
-            command_args.append(f"-b {u}")
+            command_args.append(f"-u{u}")
         if cache:
-            command_args.append(f"--cache {cache}")
+            command_args.append("--cache")
+            command_args.append(str(cache))
         if f1_threads:
-            command_args.append(f"--f1-threads {f1_threads}")
+            command_args.append("--f1-threads")
+            command_args.append(str(f1_threads))
         if fp_threads:
-            command_args.append(f"--fp-threads {fp_threads}")
+            command_args.append("--fp-threads")
+            command_args.append(str(fp_threads))
         if c_threads:
-            command_args.append(f"--c-threads {c_threads}")
+            command_args.append("--c-threads")
+            command_args.append(str(c_threads))
         if p2_threads:
-            command_args.append(f"--p2-threads {p2_threads}")
+            command_args.append("--p2-threads")
+            command_args.append(str(p2_threads))
         if p3_threads:
-            command_args.append(f"--p3-threads {p3_threads}")
+            command_args.append("--p3-threads")
+            command_args.append(str(p3_threads))
 
         return command_args
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -747,10 +747,8 @@ class WebSocketServer:
 
         if f is not None:
             command_args.append(f"-f{f}")
-
         if p is not None:
             command_args.append(f"-p{p}")
-
         if c is not None:
             command_args.append(f"-c{c}")
 
@@ -776,19 +774,15 @@ class WebSocketServer:
 
         if a is not None:
             command_args.append(f"-a{a}")
-
         if e is True:
             command_args.append("-e")
-
         if x is True:
             command_args.append("-x")
-
         if override_k is True:
             command_args.append("--override-k")
 
         return command_args
 
-    # @TODO Do something for bladebit version 2.
     def _bladebit_plotting_command_args(self, request: Any, ignoreCount: bool) -> List[str]:
         w = request.get("w", False)  # Warm start
         m = request.get("m", False)  # Disable NUMA
@@ -797,9 +791,55 @@ class WebSocketServer:
 
         if w is True:
             command_args.append("-w")
-
         if m is True:
             command_args.append("-m")
+
+        return command_args
+
+    def _bladebit2_plotting_command_args(self, request: Any, ignoreCount: bool) -> List[str]:
+        w = request.get("w", False)  # Warm start
+        m = request.get("m", False)  # Disable NUMA
+        no_cpu_affinity = request.get("no_cpu_affinity", False)
+        # memo = request["memo"]
+        t1 = request["t"]  # Temp directory
+        t2 = request["t2"]  # Temp2 directory
+        u = request["u"]  # Buckets
+        cache = request["cache"]
+        f1_threads = request["f1_threads"]
+        fp_threads = request["fp_threads"]
+        c_threads = request["c_threads"]
+        p2_threads = request["p2_threads"]
+        p3_threads = request["p3_threads"]
+
+        command_args: List[str] = []
+
+        if w is True:
+            command_args.append("-w")
+        if m is True:
+            command_args.append("-m")
+        if no_cpu_affinity is True:
+            command_args.append("--no-cpu-affinity")
+
+        command_args.append("diskplot")
+
+        if t1:
+            command_args.append(f"-t1 {t1}")
+        if t2:
+            command_args.append(f"-t2 {t2}")
+        if u:
+            command_args.append(f"-b {u}")
+        if cache:
+            command_args.append(f"--cache {cache}")
+        if f1_threads:
+            command_args.append(f"--f1-threads {f1_threads}")
+        if fp_threads:
+            command_args.append(f"--fp-threads {fp_threads}")
+        if c_threads:
+            command_args.append(f"--c-threads {c_threads}")
+        if p2_threads:
+            command_args.append(f"--p2-threads {p2_threads}")
+        if p3_threads:
+            command_args.append(f"--p3-threads {p3_threads}")
 
         return command_args
 
@@ -841,6 +881,8 @@ class WebSocketServer:
             command_args.extend(self._madmax_plotting_command_args(request, ignoreCount, index))
         elif plotter == "bladebit":
             command_args.extend(self._bladebit_plotting_command_args(request, ignoreCount))
+        elif plotter == "bladebit2":
+            command_args.extend(self._bladebit2_plotting_command_args(request, ignoreCount))
 
         return command_args
 
@@ -893,7 +935,7 @@ class WebSocketServer:
             if state is not PlotState.SUBMITTED:
                 raise Exception(f"Plot with ID {id} has no state submitted")
 
-            id = config["id"]
+            assert id == config["id"]
             delay = config["delay"]
             await asyncio.sleep(delay)
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -699,6 +699,8 @@ class WebSocketServer:
             final_words = ["Renamed final file"]
         elif plotter == "bladebit":
             final_words = ["Finished plotting in"]
+        elif plotter == "bladebit2":
+            final_words = ["Finished plotting in"]
         elif plotter == "madmax":
             temp_dir = config["temp_dir"]
             final_dir = config["final_dir"]

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -152,6 +152,7 @@ progress = {
 def install_bladebit(root_path: Path, override: bool = False, commit: Optional[str] = None):
     if not override and os.path.exists(get_bladebit_executable_path(root_path)):
         print("Bladebit plotter already installed.")
+        print("You can override it with -o option")
         return
 
     if not is_bladebit_supported():

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -259,8 +259,14 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
 
     if bladebit_git_repos_exist:
         if commit:
-            run_command(["git", "fetch", "origin"], "Failed to fetch origin", cwd=bladebit_path)
-            run_command(["git", "checkout", "-f", commit], f"Failed to reset to {commit}", cwd=bladebit_path)
+            run_command(["git", "reset", "--hard"], "Failed to reset head", cwd=bladebit_path)
+            run_command(["git", "clean", "-fd"], "Failed to clean working tree", cwd=bladebit_path)
+            from datetime import datetime
+            now = datetime.now().strftime("%Y%m%d%H%M%S")
+            run_command(["git", "branch", "-m", now], f"Failed to rename branch to {now}", cwd=bladebit_path)
+            run_command(["git", "fetch", "origin", "--prune"], "Failed to fetch remote branches ", cwd=bladebit_path)
+            run_command(["git", "checkout", "-f", commit], f"Failed to checkout {commit}", cwd=bladebit_path)
+            run_command(["git", "branch", "-D", now], f"Failed to delete branch {now}", cwd=bladebit_path)
         elif override:
             run_command(["git", "fetch", "origin"], "Failed to fetch origin", cwd=bladebit_path)
             run_command(

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -285,6 +285,11 @@ def plot_bladebit(args, chia_root_path, root_path, version: int):
         call_args.append("-v")
     if args.nonuma:
         call_args.append("-m")
+    if args.memo:
+        call_args.append("--memo")
+        call_args.append(args.memo)
+    if version > 1:
+        call_args.append("diskplot")
     if args.buckets is not None:
         call_args.append("-b")
         call_args.append(str(args.buckets))

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -231,7 +231,34 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
     )
 
 
-def plot_bladebit(args, chia_root_path, root_path, version: int):
+def plot_bladebit(args, chia_root_path, root_path):
+    (found, version_or_exception) = get_bladebit_version(root_path)
+    if found is None:
+        print(f"Error: {version_or_exception}")
+        return
+
+    version = None
+    if args.plotter == "bladebit":
+        version = 1
+        if found and version_or_exception[0] != "1":
+            print(
+                f"You're trying to run bladebit version 1"
+                f" but currently version {'.'.join(version_or_exception)} is installed"
+            )
+            return
+    elif args.plotter == "bladebit2":
+        version = 2
+        if found and version_or_exception[0] != "2":
+            print(
+                f"You're trying to run bladebit version 2"
+                f" but currently version {'.'.join(version_or_exception)} is installed"
+            )
+            return
+
+    if version is None:
+        print(f"Unknown version of bladebit: {args.plotter}")
+        return
+
     # When neither bladebit installed from git nor bladebit bundled with installer is available,
     # install bladebit from git repos.
     if not os.path.exists(get_bladebit_executable_path(root_path)):

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -239,7 +239,7 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
                     "install",
                     "-y",
                     "cmake",
-                    "numa-devel",
+                    "numactl-devel",
                     "git",
                 ],
                 "Could not install dependencies",

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -313,18 +313,18 @@ def plot_bladebit(args, chia_root_path, root_path):
         call_args.append("-v")
     if args.nonuma:
         call_args.append("-m")
-    if args.memo:
+    if args.memo is not None and args.memo != b"":
         call_args.append("--memo")
         call_args.append(args.memo)
     if version > 1:
         call_args.append("diskplot")
-    if args.buckets is not None:
+    if args.buckets:
         call_args.append("-b")
         call_args.append(str(args.buckets))
-    if args.tmpdir is not None:
+    if args.tmpdir:
         call_args.append("-t1")
         call_args.append(str(args.tmpdir))
-    if args.tmpdir2 is not None:
+    if args.tmpdir2:
         call_args.append("-t2")
         call_args.append(str(args.tmpdir2))
     if args.no_cpu_affinity:
@@ -332,19 +332,19 @@ def plot_bladebit(args, chia_root_path, root_path):
     if args.cache is not None:
         call_args.append("--cache")
         call_args.append(str(args.cache))
-    if args.f1_threads is not None:
+    if args.f1_threads:
         call_args.append("--f1-threads")
         call_args.append(str(args.f1_threads))
-    if args.fp_threads is not None:
+    if args.fp_threads:
         call_args.append("--fp-threads")
         call_args.append(str(args.fp_threads))
-    if args.c_threads is not None:
+    if args.c_threads:
         call_args.append("--c-threads")
         call_args.append(str(args.c_threads))
-    if args.p2_threads is not None:
+    if args.p2_threads:
         call_args.append("--p2-threads")
         call_args.append(str(args.p2_threads))
-    if args.p3_threads is not None:
+    if args.p3_threads:
         call_args.append("--p3-threads")
         call_args.append(str(args.p3_threads))
 

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -297,7 +297,7 @@ def plot_bladebit(args, chia_root_path, root_path):
             if version == 1:
                 commit = "ad85a8f2cf99ca4c757932a21d937fdc9c7ae0ef"
             elif version == 2:
-                commit = "disk-plot"
+                commit = "develop"
             else:
                 print(f"Unknown bladebit version {version}")
                 return

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -191,14 +191,14 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
             run_command(
                 ["git", "clone", "--recursive", "--branch", commit, bladebit_git_origin_url],
                 "Could not clone bladebit repository",
-                cwd=os.fspath(root_path)
+                cwd=os.fspath(root_path),
             )
         else:
             print("Cloning repository and its submodules.")
             run_command(
                 ["git", "clone", "--recursive", bladebit_git_origin_url],
                 "Could not clone bladebit repository",
-                cwd=os.fspath(root_path)
+                cwd=os.fspath(root_path),
             )
 
     build_path: str = os.fspath(Path(bladebit_path) / "build")

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -240,7 +240,7 @@ def plot_bladebit(args, chia_root_path, root_path, version: int):
             if version == 1:
                 commit = "ad85a8f2cf99ca4c757932a21d937fdc9c7ae0ef"
             elif version == 2:
-                commit = "disk_plot"
+                commit = "disk-plot"
             else:
                 raise f"Unknown bladebit version {version}"
 

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -154,7 +154,10 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
     if sys.platform.startswith("linux"):
         run_command(
             [
-                "sudo", "apt", "install", "-y",
+                "sudo",
+                "apt",
+                "install",
+                "-y",
                 "build-essential",
                 "cmake",
                 "libnuma-dev",
@@ -177,21 +180,26 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
             run_command(["git", "checkout", "-f", commit], f"Failed to reset to {commit}", cwd=bladebit_path)
         elif override:
             run_command(["git", "fetch", "origin"], "Failed to fetch origin", cwd=bladebit_path)
-            run_command(["git", "reset", "--hard", "origin/master"]
-                        , "Failed to reset to origin/master", cwd=bladebit_path)
+            run_command(
+                ["git", "reset", "--hard", "origin/master"], "Failed to reset to origin/master", cwd=bladebit_path
+            )
         else:
             # Rebuild with existing files
             pass
     else:
         if commit:
-            run_command([
-                "git", "clone", "--recursive", "--branch", commit, bladebit_git_origin_url
-            ], "Could not clone bladebit repository", cwd=os.fspath(root_path))
+            run_command(
+                ["git", "clone", "--recursive", "--branch", commit, bladebit_git_origin_url],
+                "Could not clone bladebit repository",
+                cwd=os.fspath(root_path)
+            )
         else:
             print("Cloning repository and its submodules.")
-            run_command([
-                "git", "clone", "--recursive", bladebit_git_origin_url
-            ], "Could not clone bladebit repository", cwd=os.fspath(root_path))
+            run_command(
+                ["git", "clone", "--recursive", bladebit_git_origin_url],
+                "Could not clone bladebit repository",
+                cwd=os.fspath(root_path)
+            )
 
     build_path: str = os.fspath(Path(bladebit_path) / "build")
 

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -122,57 +122,57 @@ progress = {
 
 
 def install_bladebit(root_path):
-    if is_bladebit_supported():
-        print("Installing dependencies.")
-        run_command(
-            [
-                "sudo",
-                "apt",
-                "update",
-                "-y",
-            ],
-            "Could not update get package information from apt",
-        )
-        run_command(
-            [
-                "sudo",
-                "apt",
-                "install",
-                "-y",
-                "build-essential",
-                "cmake",
-                "libnuma-dev",
-                "git",
-                "libgmp-dev",
-            ],
-            "Could not install dependencies",
-        )
-
-        print("Cloning repository and its submodules.")
-        run_command(
-            [
-                "git",
-                "clone",
-                "--recursive",
-                "https://github.com/Chia-Network/bladebit.git",
-            ],
-            "Could not clone bladebit repository",
-            cwd=os.fspath(root_path),
-        )
-
-        bladebit_path: str = os.fspath(root_path.joinpath("bladebit"))
-        build_path: str = os.fspath(Path(bladebit_path) / "build")
-
-        print("Build bladebit.")
-        run_command(["mkdir", build_path], "Failed to create build directory", cwd=bladebit_path)
-        run_command(["cmake", ".."], "Failed to generate build config", cwd=build_path)
-        run_command(
-            ["cmake", "--build", ".", "--target", "bladebit", "--config", "Release"],
-            "Building bladebit failed",
-            cwd=build_path,
-        )
-    else:
+    if not is_bladebit_supported():
         raise RuntimeError("Platform not supported yet for bladebit plotter.")
+
+    print("Installing dependencies.")
+    run_command(
+        [
+            "sudo",
+            "apt",
+            "update",
+            "-y",
+        ],
+        "Could not update get package information from apt",
+    )
+    run_command(
+        [
+            "sudo",
+            "apt",
+            "install",
+            "-y",
+            "build-essential",
+            "cmake",
+            "libnuma-dev",
+            "git",
+            "libgmp-dev",
+        ],
+        "Could not install dependencies",
+    )
+
+    print("Cloning repository and its submodules.")
+    run_command(
+        [
+            "git",
+            "clone",
+            "--recursive",
+            "https://github.com/Chia-Network/bladebit.git",
+        ],
+        "Could not clone bladebit repository",
+        cwd=os.fspath(root_path),
+    )
+
+    bladebit_path: str = os.fspath(root_path.joinpath("bladebit"))
+    build_path: str = os.fspath(Path(bladebit_path) / "build")
+
+    print("Build bladebit.")
+    run_command(["mkdir", build_path], "Failed to create build directory", cwd=bladebit_path)
+    run_command(["cmake", ".."], "Failed to generate build config", cwd=build_path)
+    run_command(
+        ["cmake", "--build", ".", "--target", "bladebit", "--config", "Release"],
+        "Building bladebit failed",
+        cwd=build_path,
+    )
 
 
 def plot_bladebit(args, chia_root_path, root_path):

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -239,6 +239,8 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
                     "install",
                     "-y",
                     "cmake",
+                    "gcc-c++",
+                    "gmp-devel",
                     "numactl-devel",
                     "git",
                 ],

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -121,7 +121,12 @@ progress = {
 }
 
 
-def install_bladebit(root_path):
+def install_bladebit(root_path: Path):
+    if os.path.exists(root_path / "bladebit/.bin/release/bladebit"):
+        print("Bladebit plotter already installed.")
+        return
+
+    print("Installing bladebit plotter.")
     if not is_bladebit_supported():
         raise RuntimeError("Platform not supported yet for bladebit plotter.")
 

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -250,7 +250,7 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
     build_path: str = os.fspath(Path(bladebit_path) / "build")
 
     print("Build bladebit.")
-    if not os.path.exists(bladebit_path):
+    if not os.path.exists(build_path):
         run_command(["mkdir", build_path], "Failed to create build directory", cwd=bladebit_path)
     run_command(["cmake", ".."], "Failed to generate build config", cwd=build_path)
     run_command(

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -6,7 +6,7 @@ import sys
 import logging
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union, List
+from typing import Any, Dict, Optional, Tuple
 from chia.plotting.create_plots import resolve_plot_keys
 from chia.plotters.plotters_util import run_plotter, run_command, check_git_repository, check_git_ref
 
@@ -74,7 +74,7 @@ def get_bladebit_executable_path(plotters_root_path: Path) -> Path:
     return get_bladebit_exec_package_path()
 
 
-def get_bladebit_version(plotters_root_path: Path) -> Union[Tuple[None, Exception], Tuple[bool, List[str]]]:
+def get_bladebit_version(plotters_root_path: Path):
     bladebit_executable_path = get_bladebit_executable_path(plotters_root_path)
     if bladebit_executable_path.exists():
         try:
@@ -270,7 +270,8 @@ def plot_bladebit(args, chia_root_path, root_path):
             elif version == 2:
                 commit = "disk-plot"
             else:
-                raise f"Unknown bladebit version {version}"
+                print(f"Unknown bladebit version {version}")
+                return
 
             install_bladebit(root_path, True, commit)
         except Exception as e:

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -14,6 +14,7 @@ from chia.plotters.plotters_util import (
     check_git_repository,
     check_git_ref,
     reset_loop_policy_for_windows,
+    get_linux_distro,
 )
 
 log = logging.getLogger(__name__)
@@ -204,20 +205,48 @@ def install_bladebit(root_path: Path, override: bool = False, commit: Optional[s
         raise RuntimeError("Automatic install not supported on Windows")
 
     if sys.platform.startswith("linux"):
-        run_command(
-            [
-                "sudo",
-                "apt",
-                "install",
-                "-y",
-                "build-essential",
-                "cmake",
-                "libnuma-dev",
-                "git",
-                "libgmp-dev",
-            ],
-            "Could not install dependencies",
-        )
+        distro = get_linux_distro()
+        if distro == "debian":
+            run_command(
+                [
+                    "sudo",
+                    "apt",
+                    "install",
+                    "-y",
+                    "build-essential",
+                    "cmake",
+                    "libnuma-dev",
+                    "git",
+                    "libgmp-dev",
+                ],
+                "Could not install dependencies",
+            )
+        elif distro == "redhat":
+            run_command(
+                [
+                    "sudo",
+                    "yum",
+                    "groupinstall",
+                    "-y",
+                    "Development Tools",
+                ],
+                "Could not install Development Tools",
+            )
+            run_command(
+                [
+                    "sudo",
+                    "yum",
+                    "install",
+                    "-y",
+                    "cmake",
+                    "numa-devel",
+                    "git",
+                ],
+                "Could not install dependencies",
+            )
+        else:
+            print("Unknown Linux distribution detected")
+            print("Tried to build with cmake anyway but it may require manual build if it fails")
     elif sys.platform in ["darwin"]:
         # 'brew' is a requirement for chia on macOS, so it should be available.
         run_command(["brew", "install", "cmake"], "Could not install dependencies")

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -416,6 +416,8 @@ def plot_bladebit(args, chia_root_path, root_path):
     if args.p3_threads:
         call_args.append("--p3-threads")
         call_args.append(str(args.p3_threads))
+    if args.alternate:
+        call_args.append("--alternate")
 
     call_args.append(args.finaldir)
 

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -218,7 +218,7 @@ def plot_bladebit(args, chia_root_path, root_path):
         "-n",
         str(args.count),
         "-f",
-        bytes(plot_keys.farmer_public_key).hex()
+        bytes(plot_keys.farmer_public_key).hex(),
     ]
     if plot_keys.pool_public_key is not None:
         call_args.append("-p")

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -8,7 +8,13 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 from chia.plotting.create_plots import resolve_plot_keys
-from chia.plotters.plotters_util import run_plotter, run_command, check_git_repository, check_git_ref
+from chia.plotters.plotters_util import (
+    run_plotter,
+    run_command,
+    check_git_repository,
+    check_git_ref,
+    reset_loop_policy_for_windows,
+)
 
 log = logging.getLogger(__name__)
 
@@ -306,6 +312,9 @@ def plot_bladebit(args, chia_root_path, root_path):
         except Exception as e:
             print(f"Exception while installing bladebit plotter: {e}")
             return
+
+    if sys.platform in ["win32", "cygwin"]:
+        reset_loop_policy_for_windows()
 
     plot_keys = asyncio.run(
         resolve_plot_keys(

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -17,16 +17,19 @@ BLADEBIT_PLOTTER_DIR = "bladebit"
 
 
 def is_bladebit_supported() -> bool:
-    return sys.platform.startswith("linux") or sys.platform in ["win32", "cygwin"]
+    # bladebit >= 2.0.0 now supports MacOS
+    return sys.platform.startswith("linux") or sys.platform in ["win32", "cygwin", "darwin"]
 
 
 def meets_memory_requirement(plotters_root_path: Path) -> Tuple[bool, Optional[str]]:
     have_enough_memory: bool = False
     warning_string: Optional[str] = None
-    if get_bladebit_executable_path(plotters_root_path).exists():
+
+    bladebit_executable_path = get_bladebit_executable_path(plotters_root_path)
+    if bladebit_executable_path.exists():
         try:
             proc = run_command(
-                [os.fspath(get_bladebit_executable_path(plotters_root_path)), "--memory-json"],
+                [os.fspath(bladebit_executable_path), "--memory-json"],
                 "Failed to call bladebit with --memory-json option",
                 capture_output=True,
                 text=True,
@@ -51,16 +54,24 @@ def get_bladebit_package_path() -> Path:
     return Path(os.path.dirname(sys.executable)) / "bladebit"
 
 
+def get_bladebit_exec_install_path(plotters_root_path: Path) -> Path:
+    bladebit_install_dir = get_bladebit_install_path(plotters_root_path)
+    build_dir = "build/Release" if sys.platform in ["win32", "cygwin"] else "build"
+    bladebit_exec = "bladebit.exe" if sys.platform in ["win32", "cygwin"] else "bladebit"
+    return bladebit_install_dir / build_dir / bladebit_exec
+
+
+def get_bladebit_exec_package_path() -> Path:
+    bladebit_package_dir = get_bladebit_package_path()
+    bladebit_exec = "bladebit.exe" if sys.platform in ["win32", "cygwin"] else "bladebit"
+    return bladebit_package_dir / bladebit_exec
+
+
 def get_bladebit_executable_path(plotters_root_path: Path) -> Path:
-    bladebit_dir: Path = get_bladebit_package_path()
-    bladebit_exec: str = "bladebit"
-    build_dir: str = "build"
-    if sys.platform in ["win32", "cygwin"]:
-        bladebit_exec = "bladebit.exe"
-        build_dir = "build/Release"
-    if not bladebit_dir.exists():
-        bladebit_dir = get_bladebit_install_path(plotters_root_path) / build_dir
-    return bladebit_dir / bladebit_exec
+    bladebit_exec_path = get_bladebit_exec_install_path(plotters_root_path)
+    if bladebit_exec_path.exists():
+        return bladebit_exec_path
+    return get_bladebit_exec_package_path()
 
 
 def get_bladebit_install_info(plotters_root_path: Path) -> Optional[Dict[str, Any]]:
@@ -68,11 +79,12 @@ def get_bladebit_install_info(plotters_root_path: Path) -> Optional[Dict[str, An
     installed: bool = False
     supported: bool = is_bladebit_supported()
 
-    if get_bladebit_executable_path(plotters_root_path).exists():
+    bladebit_executable_path = get_bladebit_executable_path(plotters_root_path)
+    if bladebit_executable_path.exists():
         version: Optional[str] = None
         try:
             proc = run_command(
-                [os.fspath(get_bladebit_executable_path(plotters_root_path)), "--version"],
+                [os.fspath(bladebit_executable_path), "--version"],
                 "Failed to call bladebit with --version option",
                 capture_output=True,
                 text=True,
@@ -199,14 +211,15 @@ def plot_bladebit(args, chia_root_path, root_path):
             args.connect_to_daemon,
         )
     )
-    call_args = []
-    call_args.append(os.fspath(get_bladebit_executable_path(root_path)))
-    call_args.append("-t")
-    call_args.append(str(args.threads))
-    call_args.append("-n")
-    call_args.append(str(args.count))
-    call_args.append("-f")
-    call_args.append(bytes(plot_keys.farmer_public_key).hex())
+    call_args = [
+        os.fspath(get_bladebit_executable_path(root_path)),
+        "-t",
+        str(args.threads),
+        "-n",
+        str(args.count),
+        "-f",
+        bytes(plot_keys.farmer_public_key).hex()
+    ]
     if plot_keys.pool_public_key is not None:
         call_args.append("-p")
         call_args.append(bytes(plot_keys.pool_public_key).hex())
@@ -223,6 +236,7 @@ def plot_bladebit(args, chia_root_path, root_path):
     if args.nonuma:
         call_args.append("-m")
     call_args.append(args.finaldir)
+
     try:
         asyncio.run(run_plotter(chia_root_path, args.plotter, call_args, progress))
     except Exception as e:

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -127,7 +127,7 @@ def get_bladebit_install_info(plotters_root_path: Path) -> Optional[Dict[str, An
     return info
 
 
-progress = {
+progress_bladebit1 = {
     "Finished F1 sort": 0.01,
     "Finished forward propagating table 2": 0.06,
     "Finished forward propagating table 3": 0.12,
@@ -146,6 +146,35 @@ progress = {
     "Finished compressing tables 4 and 5": 0.85,
     "Finished compressing tables 5 and 6": 0.92,
     "Finished compressing tables 6 and 7": 0.98,
+}
+
+
+progress_bladebit2 = {
+    # "Running Phase 1": 0.01,
+    "Finished f1 generation in ": 0.01,
+    "Completed table 2 in ": 0.06,
+    "Completed table 3 in ": 0.12,
+    "Completed table 4 in ": 0.2,
+    "Completed table 5 in ": 0.28,
+    "Completed table 6 in ": 0.36,
+    "Completed table 7 in ": 0.42,
+    # "Finished Phase 1 ": 0.43,
+    # "Running Phase 2": 0.43,
+    "Finished marking table 6 in ": 0.43,
+    "Finished marking table 5 in ": 0.48,
+    "Finished marking table 4 in ": 0.51,
+    "Finished marking table 3 in ": 0.55,
+    "Finished marking table 2 in ": 0.58,
+    # "Finished Phase 2 ": 0.59,
+    # "Running Phase 3": 0.60,
+    "Finished compressing tables 1 and 2 in ": 0.66,
+    "Finished compressing tables 2 and 3 in ": 0.73,
+    "Finished compressing tables 3 and 4 in ": 0.79,
+    "Finished compressing tables 4 and 5 in ": 0.85,
+    "Finished compressing tables 5 and 6 in ": 0.92,
+    "Finished compressing tables 6 and 7 in ": 0.98,
+    # "Finished Phase 3 ": 0.99,
+    "Finished writing plot ": 0.99,
 }
 
 
@@ -351,6 +380,7 @@ def plot_bladebit(args, chia_root_path, root_path):
     call_args.append(args.finaldir)
 
     try:
+        progress = progress_bladebit1 if version == 1 else progress_bladebit2
         asyncio.run(run_plotter(chia_root_path, args.plotter, call_args, progress))
     except Exception as e:
         print(f"Exception while plotting: {e} {type(e)}")

--- a/chia/plotters/madmax.py
+++ b/chia/plotters/madmax.py
@@ -292,14 +292,14 @@ def dir_with_trailing_slash(dir: str) -> str:
 
 
 def plot_madmax(args, chia_root_path: Path, plotters_root_path: Path):
-    if sys.platform in ["win32", "cygwin"]:
-        reset_loop_policy_for_windows()
-    else:
+    if sys.platform != "win32" and sys.platform != "cygwin":
         import resource
 
         # madMAx has a ulimit -n requirement > 296:
         # "Cannot open at least 296 files, please raise maximum open file limit in OS."
         resource.setrlimit(resource.RLIMIT_NOFILE, (512, 512))
+    else:
+        reset_loop_policy_for_windows()
 
     if not os.path.exists(get_madmax_executable_path_for_ksize(plotters_root_path, args.size)):
         print("Installing madmax plotter.")

--- a/chia/plotters/madmax.py
+++ b/chia/plotters/madmax.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 from chia.plotting.create_plots import resolve_plot_keys
-from chia.plotters.plotters_util import run_plotter, run_command
+from chia.plotters.plotters_util import run_plotter, run_command, reset_loop_policy_for_windows
 
 log = logging.getLogger(__name__)
 
@@ -181,7 +181,9 @@ def dir_with_trailing_slash(dir: str) -> str:
 
 
 def plot_madmax(args, chia_root_path: Path, plotters_root_path: Path):
-    if sys.platform != "win32" and sys.platform != "cygwin":
+    if sys.platform in ["win32", "cygwin"]:
+        reset_loop_policy_for_windows()
+    else:
         import resource
 
         # madMAx has a ulimit -n requirement > 296:

--- a/chia/plotters/madmax.py
+++ b/chia/plotters/madmax.py
@@ -72,79 +72,85 @@ def get_madmax_install_info(plotters_root_path: Path) -> Optional[Dict[str, Any]
 
 
 def install_madmax(plotters_root_path: Path):
-    if is_madmax_supported():
-        print("Installing dependencies.")
-        if sys.platform.startswith("linux"):
-            run_command(
-                [
-                    "sudo",
-                    "apt",
-                    "update",
-                    "-y",
-                ],
-                "Could not update get package information from apt",
-            )
-            run_command(
-                [
-                    "sudo",
-                    "apt",
-                    "install",
-                    "-y",
-                    "libsodium-dev",
-                    "cmake",
-                    "g++",
-                    "git",
-                    "build-essential",
-                ],
-                "Could not install dependencies",
-            )
-        if sys.platform.startswith("darwin"):
-            run_command(
-                [
-                    "brew",
-                    "install",
-                    "libsodium",
-                    "cmake",
-                    "git",
-                    "autoconf",
-                    "automake",
-                    "libtool",
-                    "wget",
-                ],
-                "Could not install dependencies",
-            )
-        run_command(["git", "--version"], "Error checking Git version.")
+    if os.path.exists(plotters_root_path / "madmax-plotter/build/chia_plot"):
+        print("Madmax plotter already installed.")
+        return
 
-        print("Cloning git repository.")
-        run_command(
-            [
-                "git",
-                "clone",
-                "https://github.com/Chia-Network/chia-plotter-madmax.git",
-                MADMAX_PLOTTER_DIR,
-            ],
-            "Could not clone madmax git repository",
-            cwd=os.fspath(plotters_root_path),
-        )
+    print("Installing madmax plotter.")
 
-        print("Installing git submodules.")
-        madmax_path: str = os.fspath(get_madmax_install_path(plotters_root_path))
-        run_command(
-            [
-                "git",
-                "submodule",
-                "update",
-                "--init",
-                "--recursive",
-            ],
-            "Could not initialize git submodules",
-            cwd=madmax_path,
-        )
-
-        print("Running install script.")
-        run_command(["./make_devel.sh"], "Error while running install script", cwd=madmax_path)
-    else:
+    if not is_madmax_supported():
         raise RuntimeError("Platform not supported yet for madmax plotter.")
+
+    print("Installing dependencies.")
+    if sys.platform.startswith("linux"):
+        run_command(
+            [
+                "sudo",
+                "apt",
+                "update",
+                "-y",
+            ],
+            "Could not update get package information from apt",
+        )
+        run_command(
+            [
+                "sudo",
+                "apt",
+                "install",
+                "-y",
+                "libsodium-dev",
+                "cmake",
+                "g++",
+                "git",
+                "build-essential",
+            ],
+            "Could not install dependencies",
+        )
+    if sys.platform.startswith("darwin"):
+        run_command(
+            [
+                "brew",
+                "install",
+                "libsodium",
+                "cmake",
+                "git",
+                "autoconf",
+                "automake",
+                "libtool",
+                "wget",
+            ],
+            "Could not install dependencies",
+        )
+    run_command(["git", "--version"], "Error checking Git version.")
+
+    print("Cloning git repository.")
+    run_command(
+        [
+            "git",
+            "clone",
+            "https://github.com/Chia-Network/chia-plotter-madmax.git",
+            MADMAX_PLOTTER_DIR,
+        ],
+        "Could not clone madmax git repository",
+        cwd=os.fspath(plotters_root_path),
+    )
+
+    print("Installing git submodules.")
+    madmax_path: str = os.fspath(get_madmax_install_path(plotters_root_path))
+    run_command(
+        [
+            "git",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ],
+        "Could not initialize git submodules",
+        cwd=madmax_path,
+    )
+
+    print("Running install script.")
+    run_command(["./make_devel.sh"], "Error while running install script", cwd=madmax_path)
 
 
 progress = {

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -1,6 +1,7 @@
 import argparse
 import binascii
 import os
+from pathlib import Path
 from enum import Enum
 from chia.plotters.bladebit import get_bladebit_install_info, plot_bladebit, install_bladebit
 from chia.plotters.chiapos import get_chiapos_install_info, plot_chia
@@ -313,7 +314,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
             )
 
 
-def install_plotter(plotter, root_path):
+def install_plotter(plotter: str, root_path: Path):
     if plotter == "chiapos":
         print("Chiapos already installed. No action taken.")
         return

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -396,7 +396,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
                 "--alternate",
                 action="store_true",
                 help="Halves the temp2 cache size requirements by alternating bucket writing methods between tables",
-                default=False
+                default=False,
             )
 
 

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -11,7 +11,6 @@ from chia.plotters.chiapos import get_chiapos_install_info, plot_chia
 from chia.plotters.madmax import get_madmax_install_info, plot_madmax, install_madmax
 from pathlib import Path
 from typing import Any, Dict, Optional
-from argparse import Namespace
 
 
 class Options(Enum):
@@ -392,7 +391,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
             )
 
 
-def install_plotter(args: Namespace, root_path: Path):
+def install_plotter(args: argparse.Namespace, root_path: Path):
     plotter = args.install_plotter
     override = args.override
     commit = args.commit

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -39,10 +39,9 @@ class Options(Enum):
     CONNECT_TO_DAEMON = 26
 
 
-chia_plotter = [
+chia_plotter_options = [
     Options.TMP_DIR,
     Options.TMP_DIR2,
-    Options.FINAL_DIR,
     Options.K,
     Options.MEMO,
     Options.ID,
@@ -59,9 +58,10 @@ chia_plotter = [
     Options.PLOT_COUNT,
     Options.EXCLUDE_FINAL_DIR,
     Options.CONNECT_TO_DAEMON,
+    Options.FINAL_DIR,
 ]
 
-madmax_plotter = [
+madmax_plotter_options = [
     Options.K,
     Options.PLOT_COUNT,
     Options.NUM_THREADS,
@@ -69,7 +69,6 @@ madmax_plotter = [
     Options.MADMAX_NUM_BUCKETS_PHRASE3,
     Options.TMP_DIR,
     Options.TMP_DIR2,
-    Options.FINAL_DIR,
     Options.MADMAX_WAITFORCOPY,
     Options.POOLKEY,
     Options.FARMERKEY,
@@ -77,9 +76,10 @@ madmax_plotter = [
     Options.MADMAX_TMPTOGGLE,
     Options.MADMAX_RMULTI2,
     Options.CONNECT_TO_DAEMON,
+    Options.FINAL_DIR,
 ]
 
-bladebit_plotter = [
+bladebit_plotter_options = [
     Options.NUM_THREADS,
     Options.PLOT_COUNT,
     Options.FARMERKEY,
@@ -88,9 +88,9 @@ bladebit_plotter = [
     Options.ID,
     Options.BLADEBIT_WARMSTART,
     Options.BLADEBIT_NONUMA,
-    Options.FINAL_DIR,
     Options.VERBOSE,
     Options.CONNECT_TO_DAEMON,
+    Options.FINAL_DIR,
 ]
 
 
@@ -377,11 +377,11 @@ def call_plotters(root_path: Path, args):
         except Exception as e:
             print(f"Cannot create plotters root path {root_path} {type(e)} {e}.")
 
-    plotters = argparse.ArgumentParser(description="Available options.")
+    plotters = argparse.ArgumentParser("chia plotters", description="Available options.")
     subparsers = plotters.add_subparsers(help="Available options", dest="plotter")
-    build_parser(subparsers, root_path, chia_plotter, "chiapos", "Chiapos Plotter")
-    build_parser(subparsers, root_path, madmax_plotter, "madmax", "Madmax Plotter")
-    build_parser(subparsers, root_path, bladebit_plotter, "bladebit", "Bladebit Plotter")
+    build_parser(subparsers, root_path, chia_plotter_options, "chiapos", "Chiapos Plotter")
+    build_parser(subparsers, root_path, madmax_plotter_options, "madmax", "Madmax Plotter")
+    build_parser(subparsers, root_path, bladebit_plotter_options, "bladebit", "Bladebit Plotter")
     install_parser = subparsers.add_parser("install", description="Install custom plotters.")
     build_install_parser(install_parser)
 

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -496,8 +496,12 @@ def get_available_plotters(root_path) -> Dict[str, Any]:
 
     if chiapos is not None:
         plotters["chiapos"] = chiapos
-    if bladebit is not None:
-        plotters["bladebit"] = bladebit
+    if bladebit and bladebit["version"] is not None:
+        bladebit_major_version = bladebit["version"].split(".")[0]
+        if bladebit_major_version == "2":
+            plotters["bladebit2"] = bladebit
+        else:
+            plotters["bladebit"] = bladebit
     if madmax is not None:
         plotters["madmax"] = madmax
 
@@ -510,5 +514,7 @@ def show_plotters_version(root_path: Path):
         print(f"chiapos: {info['chiapos']['version']}")
     if "bladebit" in info and "version" in info["bladebit"]:
         print(f"bladebit: {info['bladebit']['version']}")
+    if "bladebit2" in info and "version" in info["bladebit2"]:
+        print(f"bladebit: {info['bladebit2']['version']}")
     if "madmax" in info and "version" in info["madmax"]:
         print(f"madmax: {info['madmax']['version']}")

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -384,6 +384,7 @@ def call_plotters(root_path: Path, args):
     build_parser(subparsers, root_path, bladebit_plotter_options, "bladebit", "Bladebit Plotter")
     install_parser = subparsers.add_parser("install", description="Install custom plotters.")
     build_install_parser(install_parser)
+    subparsers.add_parser("version", description="Show plotter versions")
 
     args = plotters.parse_args(args)
 
@@ -395,6 +396,8 @@ def call_plotters(root_path: Path, args):
         plot_bladebit(args, chia_root_path, root_path)
     if args.plotter == "install":
         install_plotter(args, root_path)
+    if args.plotter == "version":
+        show_plotters_version(chia_root_path)
 
 
 def get_available_plotters(root_path) -> Dict[str, Any]:
@@ -412,3 +415,13 @@ def get_available_plotters(root_path) -> Dict[str, Any]:
         plotters["madmax"] = madmax
 
     return plotters
+
+
+def show_plotters_version(root_path: Path):
+    info = get_available_plotters(root_path)
+    if "chiapos" in info and "version" in info["chiapos"]:
+        print(f"chiapos: {info['chiapos']['version']}")
+    if "bladebit" in info and "version" in info["bladebit"]:
+        print(f"bladebit: {info['bladebit']['version']}")
+    if "madmax" in info and "version" in info["madmax"]:
+        print(f"madmax: {info['madmax']['version']}")

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -5,7 +5,6 @@ from enum import Enum
 from chia.plotters.bladebit import (
     get_bladebit_install_info,
     plot_bladebit,
-    get_bladebit_version,
     install_bladebit,
 )
 from chia.plotters.chiapos import get_chiapos_install_info, plot_chia

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -47,6 +47,7 @@ class Options(Enum):
     BLADEBIT_C_THREAD = 31
     BLADEBIT_P2_THREAD = 32
     BLADEBIT_P3_THREAD = 33
+    BLADEBIT_ALTERNATE = 34
 
 
 chia_plotter_options = [
@@ -122,6 +123,7 @@ bladebit2_plotter_options = [
     Options.BLADEBIT_C_THREAD,
     Options.BLADEBIT_P2_THREAD,
     Options.BLADEBIT_P3_THREAD,
+    Options.BLADEBIT_ALTERNATE,
     Options.TMP_DIR,
     Options.TMP_DIR2,
     Options.NUM_BUCKETS,
@@ -388,6 +390,13 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
                 "--p3-threads",
                 type=int,
                 help="Override the thread count for Phase 3",
+            )
+        if option is Options.BLADEBIT_ALTERNATE:
+            parser.add_argument(
+                "--alternate",
+                action="store_true",
+                help="Halves the temp2 cache size requirements by alternating bucket writing methods between tables",
+                default=False
             )
 
 

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -485,14 +485,18 @@ def call_plotters(root_path: Path, args):
 
         if args.plotter == "bladebit":
             if found and version_or_exception[0] != "1":
-                print(f"You're trying to run bladebit version 1"
-                      f" but currently version {'.'.join(version_or_exception)} is installed")
+                print(
+                    f"You're trying to run bladebit version 1"
+                    f" but currently version {'.'.join(version_or_exception)} is installed"
+                )
                 return
             plot_bladebit(args, chia_root_path, root_path, version=1)
         if args.plotter == "bladebit2":
             if found and version_or_exception[0] != "2":
-                print(f"You're trying to run bladebit version 2"
-                      f" but currently version {'.'.join(version_or_exception)} is installed")
+                print(
+                    f"You're trying to run bladebit version 2"
+                    f" but currently version {'.'.join(version_or_exception)} is installed"
+                )
                 return
             plot_bladebit(args, chia_root_path, root_path, version=2)
     if args.plotter == "install":

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -124,6 +124,10 @@ bladebit2_plotter_options = [
     Options.BLADEBIT_C_THREAD,
     Options.BLADEBIT_P2_THREAD,
     Options.BLADEBIT_P3_THREAD,
+    Options.TMP_DIR,
+    Options.TMP_DIR2,
+    Options.NUM_BUCKETS,
+    Options.MEMO,
 ]
 
 
@@ -299,7 +303,6 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
             )
         if option is Options.BLADEBIT_NONUMA:
             parser.add_argument(
-                "-m",
                 "--nonuma",
                 action="store_true",
                 help="Disable numa",

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -402,7 +402,7 @@ def install_plotter(args: Namespace, root_path: Path):
         return
     elif plotter == "madmax":
         try:
-            install_madmax(root_path)
+            install_madmax(root_path, override, commit)
         except Exception as e:
             print(f"Exception while installing madmax plotter: {e}")
         return

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -412,7 +412,7 @@ def install_plotter(args: Namespace, root_path: Path):
         return
     elif plotter == "bladebit2":
         try:
-            install_bladebit(root_path, override, commit or "disk_plot")
+            install_bladebit(root_path, override, commit or "disk-plot")
         except Exception as e:
             print(f"Exception while installing bladebit plotter: {e}")
         return

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -357,7 +357,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
         if option is Options.BLADEBIT_CACHE:
             parser.add_argument(
                 "--cache",
-                type=int,
+                type=str,
                 help="Size of cache to reserve for I/O",
             )
         if option is Options.BLADEBIT_F1_THREAD:

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -481,27 +481,7 @@ def call_plotters(root_path: Path, args):
     if args.plotter == "madmax":
         plot_madmax(args, chia_root_path, root_path)
     if args.plotter.startswith("bladebit"):
-        (found, version_or_exception) = get_bladebit_version(root_path)
-        if found is None:
-            print(f"Error: {version_or_exception}")
-            return
-
-        if args.plotter == "bladebit":
-            if found and version_or_exception[0] != "1":
-                print(
-                    f"You're trying to run bladebit version 1"
-                    f" but currently version {'.'.join(version_or_exception)} is installed"
-                )
-                return
-            plot_bladebit(args, chia_root_path, root_path, version=1)
-        if args.plotter == "bladebit2":
-            if found and version_or_exception[0] != "2":
-                print(
-                    f"You're trying to run bladebit version 2"
-                    f" but currently version {'.'.join(version_or_exception)} is installed"
-                )
-                return
-            plot_bladebit(args, chia_root_path, root_path, version=2)
+        plot_bladebit(args, chia_root_path, root_path)
     if args.plotter == "install":
         install_plotter(args, root_path)
     if args.plotter == "version":

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -1,7 +1,6 @@
 import argparse
 import binascii
 import os
-from pathlib import Path
 from enum import Enum
 from chia.plotters.bladebit import get_bladebit_install_info, plot_bladebit, install_bladebit
 from chia.plotters.chiapos import get_chiapos_install_info, plot_chia
@@ -319,25 +318,17 @@ def install_plotter(plotter: str, root_path: Path):
         print("Chiapos already installed. No action taken.")
         return
     elif plotter == "madmax":
-        if not os.path.exists(root_path / "madmax-plotter/build/chia_plot"):
-            print("Installing madmax plotter.")
-            try:
-                install_madmax(root_path)
-            except Exception as e:
-                print(f"Exception while installing madmax plotter: {e}")
-            return
-        else:
-            print("Madmax plotter already installed.")
+        try:
+            install_madmax(root_path)
+        except Exception as e:
+            print(f"Exception while installing madmax plotter: {e}")
+        return
     elif plotter == "bladebit":
-        if not os.path.exists(root_path / "bladebit/.bin/release/bladebit"):
-            print("Installing bladebit plotter.")
-            try:
-                install_bladebit(root_path)
-            except Exception as e:
-                print(f"Exception while installing bladebit plotter: {e}")
-                return
-        else:
-            print("Bladebit plotter already installed.")
+        try:
+            install_bladebit(root_path)
+        except Exception as e:
+            print(f"Exception while installing bladebit plotter: {e}")
+        return
     else:
         print("Unknown plotter. No action taken.")
         return

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -7,6 +7,7 @@ from chia.plotters.chiapos import get_chiapos_install_info, plot_chia
 from chia.plotters.madmax import get_madmax_install_info, plot_madmax, install_madmax
 from pathlib import Path
 from typing import Any, Dict, Optional
+from argparse import Namespace
 
 
 class Options(Enum):
@@ -313,7 +314,11 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
             )
 
 
-def install_plotter(plotter: str, root_path: Path):
+def install_plotter(args: Namespace, root_path: Path):
+    plotter = args.install_plotter
+    override = args.override
+    commit = args.commit
+
     if plotter == "chiapos":
         print("Chiapos already installed. No action taken.")
         return
@@ -325,13 +330,33 @@ def install_plotter(plotter: str, root_path: Path):
         return
     elif plotter == "bladebit":
         try:
-            install_bladebit(root_path)
+            install_bladebit(root_path, override, commit)
         except Exception as e:
             print(f"Exception while installing bladebit plotter: {e}")
         return
     else:
         print("Unknown plotter. No action taken.")
         return
+
+
+def build_install_parser(subparsers):
+    subparsers.add_argument(
+        "install_plotter", type=str, help="The plotters available for installing. Choose from madmax or bladebit."
+    )
+    subparsers.add_argument(
+        "-o",
+        "--override",
+        action="store_true",
+        help="Override existing install",
+        default=False,
+    )
+    subparsers.add_argument(
+        "-c",
+        "--commit",
+        type=str,
+        help="Git branch/tag/hash of plotter's git repository",
+        default=None,
+    )
 
 
 def call_plotters(root_path: Path, args):
@@ -351,15 +376,15 @@ def call_plotters(root_path: Path, args):
             os.mkdir(root_path)
         except Exception as e:
             print(f"Cannot create plotters root path {root_path} {type(e)} {e}.")
+
     plotters = argparse.ArgumentParser(description="Available options.")
     subparsers = plotters.add_subparsers(help="Available options", dest="plotter")
     build_parser(subparsers, root_path, chia_plotter, "chiapos", "Chiapos Plotter")
     build_parser(subparsers, root_path, madmax_plotter, "madmax", "Madmax Plotter")
     build_parser(subparsers, root_path, bladebit_plotter, "bladebit", "Bladebit Plotter")
     install_parser = subparsers.add_parser("install", description="Install custom plotters.")
-    install_parser.add_argument(
-        "install_plotter", type=str, help="The plotters available for installing. Choose from madmax or bladebit."
-    )
+    build_install_parser(install_parser)
+
     args = plotters.parse_args(args)
 
     if args.plotter == "chiapos":
@@ -369,7 +394,7 @@ def call_plotters(root_path: Path, args):
     if args.plotter == "bladebit":
         plot_bladebit(args, chia_root_path, root_path)
     if args.plotter == "install":
-        install_plotter(args.install_plotter, root_path)
+        install_plotter(args, root_path)
 
 
 def get_available_plotters(root_path) -> Dict[str, Any]:

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -496,7 +496,7 @@ def get_available_plotters(root_path) -> Dict[str, Any]:
 
     if chiapos is not None:
         plotters["chiapos"] = chiapos
-    if bladebit and bladebit["version"] is not None:
+    if bladebit and bladebit.get("version") is not None:
         bladebit_major_version = bladebit["version"].split(".")[0]
         if bladebit_major_version == "2":
             plotters["bladebit2"] = bladebit

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -414,7 +414,7 @@ def install_plotter(args: Namespace, root_path: Path):
         return
     elif plotter == "bladebit2":
         try:
-            install_bladebit(root_path, override, commit or "disk-plot")
+            install_bladebit(root_path, override, commit or "develop")
         except Exception as e:
             print(f"Exception while installing bladebit plotter: {e}")
         return

--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -139,3 +139,24 @@ def check_git_ref(git_ref: str):
 
 def reset_loop_policy_for_windows():
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+
+def get_linux_distro():
+    result = subprocess.run(["sh", "-c", "type apt"])
+    if result.returncode == 0:
+        return "debian"
+    result = subprocess.run(["sh", "-c", "type yum"])
+    if result.returncode == 0:
+        return "redhat"
+    return "unknown"
+
+
+def is_libsodium_available_on_redhat_like_os():
+    result = subprocess.run(["ls", "/usr/include/sodium.h"])
+    if result.returncode == 0:
+        return True
+    result = subprocess.run(["sudo", "yum", "info", "libsodium-devel"])
+    if result.returncode != 0:
+        return False
+    result = subprocess.run(["sudo", "yum", "install", "-y", "libsodium-devel"])
+    return result.returncode == 0

--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -4,6 +4,7 @@ import json
 import signal
 import subprocess
 import sys
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Iterator, Optional, TextIO
@@ -105,3 +106,30 @@ def run_command(args, exc_description, *, check=True, **kwargs) -> subprocess.Co
     except Exception as e:
         raise RuntimeError(f"{exc_description} {e}")
     return proc
+
+
+def check_git_repository(git_dir: str, expected_origin_url: str):
+    command = ["git", "remote", "get-url", "origin"]
+    try:
+        proc = subprocess.run(command, capture_output=True, check=True, text=True, cwd=git_dir)
+        return proc.stdout.strip() == expected_origin_url
+    except Exception as e:
+        print(f"Error while executing \"{' '.join(command)}\"")
+        print(e)
+        return False
+
+
+# If raw value of `git_ref` is passed to command string `git reset --hard {git_ref}` without any check,
+# it would be a security risk. This check will eliminate unusual ref string before it is used.
+# See https://git-scm.com/docs/git-check-ref-format (This check is stricter than the specification)
+def check_git_ref(git_ref: str):
+    if len(git_ref) > 50:
+        return False
+
+    test = re.match(r"[^\w.@/-]", git_ref) \
+        or re.match(r"\.\.", git_ref) \
+        or re.match(r"\.$", git_ref) \
+        or re.match(r"@\{", git_ref) \
+        or re.match(r"^@$", git_ref)
+
+    return False if test else True

--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -1,10 +1,10 @@
 import asyncio
 import contextlib
 import json
+import re
 import signal
 import subprocess
 import sys
-import re
 from datetime import datetime
 from pathlib import Path
 from typing import Iterator, Optional, TextIO

--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -160,3 +160,14 @@ def is_libsodium_available_on_redhat_like_os():
         return False
     result = subprocess.run(["sudo", "yum", "install", "-y", "libsodium-devel"])
     return result.returncode == 0
+
+
+def git_clean_checkout(commit: str, plotter_dir: str):
+    run_command(["git", "reset", "--hard"], "Failed to reset head", cwd=plotter_dir)
+    run_command(["git", "clean", "-fd"], "Failed to clean working tree", cwd=plotter_dir)
+    from datetime import datetime
+    now = datetime.now().strftime("%Y%m%d%H%M%S")
+    run_command(["git", "branch", "-m", now], f"Failed to rename branch to {now}", cwd=plotter_dir)
+    run_command(["git", "fetch", "origin", "--prune"], "Failed to fetch remote branches ", cwd=plotter_dir)
+    run_command(["git", "checkout", "-f", commit], f"Failed to checkout {commit}", cwd=plotter_dir)
+    run_command(["git", "branch", "-D", now], f"Failed to delete branch {now}", cwd=plotter_dir)

--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -135,3 +135,7 @@ def check_git_ref(git_ref: str):
     )
 
     return False if test else True
+
+
+def reset_loop_policy_for_windows():
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())

--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -165,7 +165,6 @@ def is_libsodium_available_on_redhat_like_os():
 def git_clean_checkout(commit: str, plotter_dir: str):
     run_command(["git", "reset", "--hard"], "Failed to reset head", cwd=plotter_dir)
     run_command(["git", "clean", "-fd"], "Failed to clean working tree", cwd=plotter_dir)
-    from datetime import datetime
     now = datetime.now().strftime("%Y%m%d%H%M%S")
     run_command(["git", "branch", "-m", now], f"Failed to rename branch to {now}", cwd=plotter_dir)
     run_command(["git", "fetch", "origin", "--prune"], "Failed to fetch remote branches ", cwd=plotter_dir)

--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -126,10 +126,12 @@ def check_git_ref(git_ref: str):
     if len(git_ref) > 50:
         return False
 
-    test = re.match(r"[^\w.@/-]", git_ref) \
-        or re.match(r"\.\.", git_ref) \
-        or re.match(r"\.$", git_ref) \
-        or re.match(r"@\{", git_ref) \
+    test = (
+        re.match(r"[^\w.@/-]", git_ref)
+        or re.match(r"\.\.", git_ref)
+        or re.match(r"\.$", git_ref)
+        or re.match(r"@\{", git_ref)
         or re.match(r"^@$", git_ref)
+    )
 
     return False if test else True


### PR DESCRIPTION
# Summary
This PR is made to prepare new `bladebit` and its new options.
Will poke around `chia plotters install bladebit` command.

# Important changes
## Windows/Ubuntu users who install GUI app from installer are now able to integrate `bladebit` installed from git source code.
Currently the chia app always searches for bladebit bundled in chia app folder(s.t. %LocalAppData%\chia-blockchain\app-1.x.x\resources\app.asar.unpacked\daemon\bladebit\bladebit.exe) and never looks into `$CHIA_ROOT/plotters/bladebit`.  
This makes it difficult to use non-bundled version of `bladebit` with CLI/GUI.
This PR will make the app first search `$CHIA_ROOT/plotters/bladebit` and if it doesn't exist then it goes for bundled `bladebit`.

## Enabled bladebit update
Currently if bladebit is already installed on `$CHIA_ROOT/plotters/bladebit`, it won't update/override existing bladebit.  
But after applying this PR, you can speficy `-o/--override` option to update/override installed bladebit.  
example: `chia plotters install bladebit -o`

## Enabled to specify git branch/tag/commit on installing bladebit from GitHub
You can speficy a commit of https://github.com/Chia-Network/bladebit by adding `-c/--commit` option like this:  
`chia plotters install bladebit --commit a65f438f1e3acefca287dbc4bc14b2b141db6ee6`

## Added `chia plotters version` command
```shell
$ chia plotters version
chiapos: 1.0.9
bladebit: 2.0.0.dev
```

## Added `chia plotters install bladebit2` command
If you already have `bladebit` installed by `chia plotters install bladebit` command, you can override it with:
`chia plotters install bladebit2 -o`

## Added `chia plotters bladebit2` command family
You can set options for `bladebit2` now.
`chia plotters bladebit2 [-r|--threads <n>] [-n|--count <number-of-plots-to-create>] [-f|--farmerkey <farmer-public-key>] [-p|--pool-key <pool-public-key>] [-c|--contract <pool-contract-address>] [-w|--warmstart] [-i|--id <plot-id>] [-v|--verbose] [-m|--nonuma] [-u|--buckets <n>] [-2 <t2 dir>] [--no-cpu-affinity] [--cache <n>] [--f1-threads <n>] [--fp-threads <n>] [--c-threads <n>] [--p2-threads <n>] [--p3-threads <n>] [-a|--alternate] -t <t1 dir>
 -d <out_dir>`

# Confirmed to work
|OS|arch|Result|
|---|---|---|
|Windows 10|x86_64|OK|
|Ubuntu 22.04|x86_64|OK|
|Amazon Linux 2|x86_64|No (cmake version available via yum is too old)|
|RHEL 8.5|x86_64|OK|
|Fedora 35|x86_64|OK|
|macOS M1|arm64|OK|

# How to try new bladebit
Currently new bladebit(version 2) will at least run on Windows, macOS, Ubuntu.
Additionally, you need NodeJS>=16 when you run the GUI.
The below is command line snippets for challengers.
```bash
### You can skip the lines below if you already have the git repo ###
cd /tmp # Any directory you like
mkdir bb2-test && cd bb2-test
git clone https://github.com/Chia-Network/chia-blockchain
cd chia-blockchain
### You can skip until here ###

### For macOS/Ubuntu users ###
git checkout cmj.bladebit
sh install.sh
. ./activate
sh install-gui.sh origin/cmj.bladebit 
chia plotters install bladebit2 # This installs bladebit2 to $CHIA_ROOT/plotters/bladebit
chia plotters version # Make sure bb2 is installed
bash start-gui.sh

### For Windows users ###
git checkout cmj.bladebit
install.ps1
. venv\Scripts\Activate.ps1
# This only "git clone" bladebit2 to $CHIA_ROOT/plotters/bladebit (Usually <UserDir>\.chia\mainnet\plotters)
chia plotters install bladebit2
# Launch VisualStudio >= 2019 on $CHIA_ROOT/plotters/bladebit folder
# On the Developer PowerShell console in Visual Studio:
#
# PS> pwd     # Check whether you are in ...\plotters\bladebit folder.
# PS> mkdir build
# PS> cd build
# PS> cmake ..
# PS> cmake --build . --target bladebit --config Release
#
chia plotters version # Make sure bb2 is installed
cd chia-blockchain-gui
npm ci
npm run build
npx lerna run dev:fast --scope=@chia/gui
```