### PR TITLE
harvester: Use a set instead of a list to speed up availability checks

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -232,9 +232,9 @@ class PlotManager:
 
                 plot_filenames: Dict[Path, List[Path]] = get_plot_filenames(self.root_path)
                 plot_directories: Set[Path] = set(plot_filenames.keys())
-                plot_paths: List[Path] = []
+                plot_paths: Set[Path] = set()
                 for paths in plot_filenames.values():
-                    plot_paths += paths
+                    plot_paths.update(paths)
 
                 total_result: PlotRefreshResult = PlotRefreshResult()
                 total_size = len(plot_paths)
@@ -274,7 +274,7 @@ class PlotManager:
                 for filename in filenames_to_remove:
                     del self.plot_filename_paths[filename]
 
-                for remaining, batch in list_to_batches(plot_paths, self.refresh_parameter.batch_size):
+                for remaining, batch in list_to_batches(list(plot_paths), self.refresh_parameter.batch_size):
                     batch_result: PlotRefreshResult = self.refresh_batch(batch, plot_directories)
                     if not self._refreshing_enabled:
                         self.log.debug("refresh_plots: Aborted")


### PR DESCRIPTION
For large farms the `something not in list` lookups here https://github.com/Chia-Network/chia-blockchain/blob/36a610f038f1ca70cd436e0061432b97364146a8/chia/plotting/manager.py#L257



 slow down the plot availability checks a lot, see the following output of the script below. This seems to lead to slow lookups during plot refreshing on really large farms >20k plots.

```
list: took 92.89824509620667 for 20000 plots
set: took 0.2513918876647949 for 20000 plots
```

```python
import time
from pathlib import Path
from secrets import token_bytes

plot_paths_list = []
plot_paths_set = set()


def run(container, plot_count=20000):
    plot_filename_paths = {}
    for i in range(0, plot_count):
        path_str = token_bytes(10).hex()
        path = Path(f"{path_str}")
        if isinstance(container, set):
            container.add(path)
        else:
            container.append(path)
        plot_filename_paths[path_str] = (path_str[0:5], {})
    start = time.time()

    for plot_filename, paths_entry in plot_filename_paths.items():
        loaded_path, _ = paths_entry
        loaded_plot = Path(loaded_path) / Path(plot_filename)
        if loaded_plot in container:
            raise Exception

    converted = list(container)

    print(f"{type(container).__name__}: took {time.time() - start} for {len(converted)} plots")


run(plot_paths_list)
run(plot_paths_set)
```
