### PR TITLE
daemon|util: Don't remove from list while iterating

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -613,7 +613,7 @@ class WebSocketServer:
 
         response = create_payload("keyring_status_changed", keyring_status, "daemon", destination)
 
-        for websocket in websockets:
+        for websocket in websockets.copy():
             try:
                 await websocket.send_str(response)
             except Exception as e:
@@ -672,7 +672,7 @@ class WebSocketServer:
 
         response = create_payload("state_changed", message, service, "wallet_ui")
 
-        for websocket in websockets:
+        for websocket in websockets.copy():
             try:
                 await websocket.send_str(response)
             except Exception as e:

--- a/chia/util/check_fork_next_block.py
+++ b/chia/util/check_fork_next_block.py
@@ -15,7 +15,7 @@ async def check_fork_next_block(
         potential_peek = uint32(our_peak_height + 1)
         # This is the fork point in SES in the case where no fork was detected
         if blockchain.get_peak_height() is not None and fork_point_height == max_fork_ses_height:
-            for peer in peers_with_peak:
+            for peer in peers_with_peak.copy():
                 if peer.closed:
                     peers_with_peak.remove(peer)
                     continue


### PR DESCRIPTION
See commit messages. Initially i discovered the issue in the daemon, then i reviewed the rest of the codebase to see if its done like this in other cases, while doing that i found the one in `check_fork_next_block`.


Also see the below script missing to print `3` is the root issue this PR fixes.

```
items = [1,2,3,4]

for item in items:
    print(item)
    try:
        if item == 2:
            raise Exception
    except Exception:
        items.remove(item)
```