### PR TITLE
improve generate_chain

### DIFF
--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -2067,3 +2067,22 @@ def create_block_tools(
     asyncio.get_event_loop().run_until_complete(bt.setup_plots())
 
     return bt
+
+
+def make_unfinished_block(block: FullBlock, constants: ConsensusConstants) -> UnfinishedBlock:
+    if is_overflow_block(constants, block.reward_chain_block.signage_point_index):
+        finished_ss = block.finished_sub_slots[:-1]
+    else:
+        finished_ss = block.finished_sub_slots
+
+    return UnfinishedBlock(
+        finished_ss,
+        block.reward_chain_block.get_unfinished(),
+        block.challenge_chain_sp_proof,
+        block.reward_chain_sp_proof,
+        block.foliage,
+        block.foliage_transaction_block,
+        block.transactions_info,
+        block.transactions_generator,
+        block.transactions_generator_ref_list,
+    )

--- a/tests/tools/test_full_sync.py
+++ b/tests/tools/test_full_sync.py
@@ -4,10 +4,15 @@ import asyncio
 import os
 from pathlib import Path
 
+import pytest
+
 from tools.test_full_sync import run_sync_test
 
 
-def test_full_sync_test():
+@pytest.mark.parametrize("keep_up", [True, False])
+def test_full_sync_test(keep_up: bool):
     file_path = os.path.realpath(__file__)
     db_file = Path(file_path).parent / "test-blockchain-db.sqlite"
-    asyncio.run(run_sync_test(db_file, db_version=2, profile=False, single_thread=False, test_constants=False))
+    asyncio.run(
+        run_sync_test(db_file, db_version=2, profile=False, single_thread=False, test_constants=False, keep_up=keep_up)
+    )

--- a/tools/cpu_utilization.py
+++ b/tools/cpu_utilization.py
@@ -60,6 +60,8 @@ def main(pid: int, output: str, threads: bool) -> None:
 
             time.sleep(0.05)
             step += 1
+    except psutil.NoSuchProcess:
+        pass
     except KeyboardInterrupt:
         pass
 

--- a/tools/generate_chain.py
+++ b/tools/generate_chain.py
@@ -1,17 +1,19 @@
 import cProfile
 import random
 import sqlite3
+import sys
 import time
 from contextlib import closing, contextmanager
 from pathlib import Path
-from typing import Iterator, List
+from typing import Iterator, List, Optional
 
+import click
 import zstd
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.spend_bundle import SpendBundle
 from chia.util.chia_logging import initialize_logging
-from chia.util.ints import uint64
+from chia.util.ints import uint32, uint64
 from chia.util.path import mkdir
 from tests.block_tools import create_block_tools
 from tests.util.keyring import TempKeyring
@@ -19,7 +21,7 @@ from tools.test_constants import test_constants
 
 
 @contextmanager
-def enable_profiler(profile: bool) -> Iterator[None]:
+def enable_profiler(profile: bool, counter: int) -> Iterator[None]:
     if not profile:
         yield
         return
@@ -28,107 +30,92 @@ def enable_profiler(profile: bool) -> Iterator[None]:
         yield
 
     pr.create_stats()
-    pr.dump_stats("generate-chain.profile")
+    pr.dump_stats(f"generate-chain-{counter}.profile")
 
 
-root_path = Path("./test-chain").resolve()
-mkdir(root_path)
-with TempKeyring() as keychain:
+@click.command()
+@click.option("--length", type=int, default=None, required=False, help="the number of blocks to generate")
+@click.option(
+    "--fill-rate",
+    type=int,
+    default=100,
+    required=False,
+    help="the transaction fill rate of blocks. Specified in percent of max block cost",
+)
+@click.option("--profile", is_flag=True, required=False, default=False, help="dump CPU profile at the end")
+@click.option(
+    "--block-refs",
+    type=bool,
+    required=False,
+    default=True,
+    help="include a long list of block references in each transaction block",
+)
+@click.option(
+    "--output", type=str, required=False, default=None, help="the filename to write the resulting sqlite database to"
+)
+def main(length: int, fill_rate: int, profile: bool, block_refs: bool, output: Optional[str]) -> None:
 
-    bt = create_block_tools(constants=test_constants, root_path=root_path, keychain=keychain)
-    initialize_logging(
-        "generate_chain", {"log_level": "DEBUG", "log_stdout": False, "log_syslog": False}, root_path=root_path
-    )
+    if fill_rate < 0 or fill_rate > 100:
+        print("fill-rate must be within [0, 100]")
+        sys.exit(1)
 
-    with closing(sqlite3.connect("stress-test-blockchain.sqlite")) as db:
+    if not length:
+        if block_refs:
+            # we won't have full reflist until after 512 transaction blocks
+            length = 1500
+        else:
+            # the cost of looking up coins will be deflated because there are so
+            # few, but a longer chain takes longer to make and test
+            length = 500
 
-        print("initializing v2 block store")
-        db.execute(
-            "CREATE TABLE full_blocks("
-            "header_hash blob PRIMARY KEY,"
-            "prev_hash blob,"
-            "height bigint,"
-            "in_main_chain tinyint,"
-            "block blob)"
+    if length <= 0:
+        print("the output blockchain must have at least length 1")
+        sys.exit(1)
+
+    if output is None:
+        output = f"stress-test-blockchain-{length}-{fill_rate}{'-refs' if block_refs else ''}.sqlite"
+
+    root_path = Path("./test-chain").resolve()
+    mkdir(root_path)
+    with TempKeyring() as keychain:
+
+        bt = create_block_tools(constants=test_constants, root_path=root_path, keychain=keychain)
+        initialize_logging(
+            "generate_chain", {"log_level": "DEBUG", "log_stdout": False, "log_syslog": False}, root_path=root_path
         )
 
-        wallet = bt.get_farmer_wallet_tool()
-        coinbase_puzzlehash = wallet.get_new_puzzlehash()
+        print(f"writing blockchain to {output}")
+        with closing(sqlite3.connect(output)) as db:
 
-        blocks = bt.get_consecutive_blocks(
-            3,
-            farmer_reward_puzzle_hash=coinbase_puzzlehash,
-            pool_reward_puzzle_hash=coinbase_puzzlehash,
-            guarantee_transaction_block=True,
-            genesis_timestamp=uint64(1234567890),
-            time_per_block=30,
-        )
-
-        unspent_coins: List[Coin] = []
-
-        for b in blocks:
-            for coin in b.get_included_reward_coins():
-                if coin.puzzle_hash == coinbase_puzzlehash:
-                    unspent_coins.append(coin)
             db.execute(
-                "INSERT INTO full_blocks VALUES(?, ?, ?, ?, ?)",
-                (
-                    b.header_hash,
-                    b.prev_header_hash,
-                    b.height,
-                    1,  # in_main_chain
-                    zstd.compress(bytes(b)),
-                ),
+                "CREATE TABLE full_blocks("
+                "header_hash blob PRIMARY KEY,"
+                "prev_hash blob,"
+                "height bigint,"
+                "in_main_chain tinyint,"
+                "block blob)"
             )
-        db.commit()
 
-        # build 2000 transaction blocks
-        with enable_profiler(False):
-            for k in range(2000):
+            wallet = bt.get_farmer_wallet_tool()
+            farmer_puzzlehash = wallet.get_new_puzzlehash()
+            pool_puzzlehash = wallet.get_new_puzzlehash()
+            transaction_blocks: List[uint32] = []
 
-                start_time = time.monotonic()
+            blocks = bt.get_consecutive_blocks(
+                3,
+                farmer_reward_puzzle_hash=farmer_puzzlehash,
+                pool_reward_puzzle_hash=pool_puzzlehash,
+                keep_going_until_tx_block=True,
+                genesis_timestamp=uint64(1234567890),
+                use_timestamp_residual=True,
+            )
 
-                print(f"block: {len(blocks)} unspent: {len(unspent_coins)}")
-                new_coins: List[Coin] = []
-                spend_bundles: List[SpendBundle] = []
-                for i in range(1010):
-                    if unspent_coins == []:
-                        break
-                    c = unspent_coins.pop(random.randrange(len(unspent_coins)))
-                    receiver = wallet.get_new_puzzlehash()
-                    bundle = wallet.generate_signed_transaction(uint64(c.amount // 2), receiver, c)
-                    new_coins.extend(bundle.additions())
-                    spend_bundles.append(bundle)
+            unspent_coins: List[Coin] = []
 
-                coinbase_puzzlehash = wallet.get_new_puzzlehash()
-                blocks = bt.get_consecutive_blocks(
-                    1,
-                    blocks,
-                    farmer_reward_puzzle_hash=coinbase_puzzlehash,
-                    pool_reward_puzzle_hash=coinbase_puzzlehash,
-                    guarantee_transaction_block=True,
-                    transaction_data=SpendBundle.aggregate(spend_bundles),
-                    time_per_block=30,
-                )
-
-                b = blocks[-1]
+            for b in blocks:
                 for coin in b.get_included_reward_coins():
-                    if coin.puzzle_hash == coinbase_puzzlehash:
+                    if coin.puzzle_hash in [farmer_puzzlehash, pool_puzzlehash]:
                         unspent_coins.append(coin)
-                unspent_coins.extend(new_coins)
-
-                if b.transactions_info:
-                    fill_rate = b.transactions_info.cost / test_constants.MAX_BLOCK_COST_CLVM
-                else:
-                    fill_rate = 0
-
-                end_time = time.monotonic()
-
-                print(
-                    f"included {i} spend bundles. fill_rate: {fill_rate*100:.1f}% "
-                    f"new coins: {len(new_coins)} time: {end_time - start_time:0.2f}s"
-                )
-
                 db.execute(
                     "INSERT INTO full_blocks VALUES(?, ?, ?, ?, ?)",
                     (
@@ -139,4 +126,104 @@ with TempKeyring() as keychain:
                         zstd.compress(bytes(b)),
                     ),
                 )
-                db.commit()
+            db.commit()
+
+            b = blocks[-1]
+
+            num_tx_per_block = int(1010 * fill_rate / 100)
+
+            while True:
+                with enable_profiler(profile, b.height):
+                    start_time = time.monotonic()
+
+                    new_coins: List[Coin] = []
+                    spend_bundles: List[SpendBundle] = []
+                    i = 0
+                    for i in range(num_tx_per_block):
+                        if unspent_coins == []:
+                            break
+                        c = unspent_coins.pop(random.randrange(len(unspent_coins)))
+                        receiver = wallet.get_new_puzzlehash()
+                        bundle = wallet.generate_signed_transaction(uint64(c.amount // 2), receiver, c)
+                        new_coins.extend(bundle.additions())
+                        spend_bundles.append(bundle)
+
+                    block_references: List[uint32]
+                    if block_refs:
+                        block_references = random.sample(transaction_blocks, min(len(transaction_blocks), 512))
+                        random.shuffle(block_references)
+                    else:
+                        block_references = []
+
+                    farmer_puzzlehash = wallet.get_new_puzzlehash()
+                    pool_puzzlehash = wallet.get_new_puzzlehash()
+                    prev_num_blocks = len(blocks)
+                    blocks = bt.get_consecutive_blocks(
+                        1,
+                        blocks,
+                        farmer_reward_puzzle_hash=farmer_puzzlehash,
+                        pool_reward_puzzle_hash=pool_puzzlehash,
+                        keep_going_until_tx_block=True,
+                        transaction_data=SpendBundle.aggregate(spend_bundles),
+                        previous_generator=block_references,
+                        use_timestamp_residual=True,
+                    )
+                    prev_tx_block = b
+                    prev_block = blocks[-2]
+                    b = blocks[-1]
+                    height = b.height
+                    assert b.is_transaction_block()
+                    transaction_blocks.append(height)
+
+                    for bl in blocks[prev_num_blocks:]:
+                        for coin in bl.get_included_reward_coins():
+                            unspent_coins.append(coin)
+                    unspent_coins.extend(new_coins)
+
+                    if b.transactions_info:
+                        actual_fill_rate = b.transactions_info.cost / test_constants.MAX_BLOCK_COST_CLVM
+                        if b.transactions_info.cost > test_constants.MAX_BLOCK_COST_CLVM:
+                            print(f"COST EXCEEDED: {b.transactions_info.cost}")
+                    else:
+                        actual_fill_rate = 0
+
+                    end_time = time.monotonic()
+                    if prev_tx_block is not None:
+                        assert b.foliage_transaction_block
+                        assert prev_tx_block.foliage_transaction_block
+                        ts = b.foliage_transaction_block.timestamp - prev_tx_block.foliage_transaction_block.timestamp
+                    else:
+                        ts = 0
+
+                    print(
+                        f"height: {b.height} "
+                        f"spends: {i+1} "
+                        f"refs: {len(block_references)} "
+                        f"fill_rate: {actual_fill_rate*100:.1f}% "
+                        f"new coins: {len(new_coins)} "
+                        f"unspent: {len(unspent_coins)} "
+                        f"difficulty: {b.weight - prev_block.weight} "
+                        f"timestamp: {ts} "
+                        f"time: {end_time - start_time:0.2f}s "
+                        f"tx-block-ratio: {len(transaction_blocks)*100/b.height:0.0f}% "
+                    )
+
+                    new_blocks = [
+                        (
+                            b.header_hash,
+                            b.prev_header_hash,
+                            b.height,
+                            1,  # in_main_chain
+                            zstd.compress(bytes(b)),
+                        )
+                        for b in blocks[prev_num_blocks:]
+                    ]
+                    db.executemany("INSERT INTO full_blocks VALUES(?, ?, ?, ?, ?)", new_blocks)
+                    db.commit()
+                    if height >= length:
+                        break
+
+
+if __name__ == "__main__":
+    # pylint: disable = no-value-for-parameter
+    main()

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+run_benchmark() {
+   python ./tools/test_full_sync.py run $3 --profile --test-constants $1 &
+   test_pid=$!
+   python ./tools/cpu_utilization.py $test_pid
+   mkdir -p $2
+   mv test-full-sync.log cpu.png cpu-usage.log plot-cpu.gnuplot $2
+   python ./tools/test_full_sync.py analyze
+   mv slow-batch-*.profile slow-batch-*.png $2
+}
+
+cd ..
+
+run_benchmark stress-test-blockchain-1500-0-refs.sqlite $1-sync-empty ""
+run_benchmark stress-test-blockchain-1500-0-refs.sqlite $1-keepup-empty --keep-up
+
+run_benchmark stress-test-blockchain-500-100.sqlite $1-sync-full ""
+run_benchmark stress-test-blockchain-500-100.sqlite $1-keepup-full --keep-up

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -1,19 +1,20 @@
 #!/bin/sh
 
 run_benchmark() {
-   python ./tools/test_full_sync.py run $3 --profile --test-constants $1 &
+   # shellcheck disable=SC2086
+   python ./tools/test_full_sync.py run $3 --profile --test-constants "$1" &
    test_pid=$!
    python ./tools/cpu_utilization.py $test_pid
-   mkdir -p $2
-   mv test-full-sync.log cpu.png cpu-usage.log plot-cpu.gnuplot $2
+   mkdir -p "$2"
+   mv test-full-sync.log cpu.png cpu-usage.log plot-cpu.gnuplot "$2"
    python ./tools/test_full_sync.py analyze
-   mv slow-batch-*.profile slow-batch-*.png $2
+   mv slow-batch-*.profile slow-batch-*.png "$2"
 }
 
 cd ..
 
-run_benchmark stress-test-blockchain-1500-0-refs.sqlite $1-sync-empty ""
-run_benchmark stress-test-blockchain-1500-0-refs.sqlite $1-keepup-empty --keep-up
+run_benchmark stress-test-blockchain-1500-0-refs.sqlite "$1-sync-empty" ""
+run_benchmark stress-test-blockchain-1500-0-refs.sqlite "$1-keepup-empty" --keep-up
 
-run_benchmark stress-test-blockchain-500-100.sqlite $1-sync-full ""
-run_benchmark stress-test-blockchain-500-100.sqlite $1-keepup-full --keep-up
+run_benchmark stress-test-blockchain-500-100.sqlite "$1-sync-full" ""
+run_benchmark stress-test-blockchain-500-100.sqlite "$1-keepup-full" --keep-up

--- a/tools/test_constants.py
+++ b/tools/test_constants.py
@@ -2,8 +2,9 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 
 test_constants = DEFAULT_CONSTANTS.replace(
     **{
-        "MIN_PLOT_SIZE": 20,
+        "MIN_PLOT_SIZE": 18,
         "MIN_BLOCKS_PER_CHALLENGE_BLOCK": 12,
+        "DIFFICULTY_STARTING": 2 ** 9,
         "DISCRIMINANT_SIZE_BITS": 16,
         "SUB_EPOCH_BLOCKS": 170,
         "WEIGHT_PROOF_THRESHOLD": 2,

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -3,21 +3,29 @@
 import asyncio
 import cProfile
 import logging
+import os
 import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, List
 
 import aiosqlite
 import click
 import zstd
 
+import chia.server.ws_connection as ws
 from chia.cmds.init_funcs import chia_init
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.full_node import FullNode
+from chia.protocols import full_node_protocol
+from chia.server.outbound_message import Message, NodeType
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
+from chia.types.peer_info import PeerInfo
 from chia.util.config import load_config
+from chia.util.ints import uint16
+from tests.block_tools import make_unfinished_block
 from tools.test_constants import test_constants as TEST_CONSTANTS
 
 
@@ -42,12 +50,30 @@ def enable_profiler(profile: bool, counter: int) -> Iterator[None]:
         receive_start_time = time.monotonic()
         yield
 
-    if time.monotonic() - receive_start_time > 10:
+    if time.monotonic() - receive_start_time > 5:
         pr.create_stats()
         pr.dump_stats(f"slow-batch-{counter:05d}.profile")
 
 
-async def run_sync_test(file: Path, db_version, profile: bool, single_thread: bool, test_constants: bool) -> None:
+class FakeServer:
+    async def send_to_all(self, messages: List[Message], node_type: NodeType):
+        pass
+
+    async def send_to_all_except(self, messages: List[Message], node_type: NodeType, exclude: bytes32):
+        pass
+
+
+class FakePeer:
+    def get_peer_logging(self) -> PeerInfo:
+        return PeerInfo("0.0.0.0", uint16(0))
+
+    def __init__(self):
+        self.peer_node_id = bytes([0] * 32)
+
+
+async def run_sync_test(
+    file: Path, db_version, profile: bool, single_thread: bool, test_constants: bool, keep_up: bool
+) -> None:
 
     logger = logging.getLogger()
     logger.setLevel(logging.WARNING)
@@ -84,10 +110,15 @@ async def run_sync_test(file: Path, db_version, profile: bool, single_thread: bo
 
         try:
             await full_node._start()
+            full_node.set_server(FakeServer())  # type: ignore[arg-type]
+
+            peer: ws.WSChiaConnection = FakePeer()  # type: ignore[assignment]
 
             print()
             counter = 0
             height = 0
+            monotonic = 0
+            prev_hash = None
             async with aiosqlite.connect(file) as in_db:
                 await in_db.execute("pragma query_only")
                 rows = await in_db.execute(
@@ -97,33 +128,67 @@ async def run_sync_test(file: Path, db_version, profile: bool, single_thread: bo
                 block_batch = []
 
                 start_time = time.monotonic()
+                logger.warning(f"starting test {start_time}")
+                worst_batch_height = None
+                worst_batch_time_per_block = None
                 async for r in rows:
+                    batch_start_time = time.monotonic()
                     with enable_profiler(profile, counter):
                         block = FullBlock.from_bytes(zstd.decompress(r[2]))
-
                         block_batch.append(block)
+
+                        assert block.height == monotonic
+                        monotonic += 1
+                        assert prev_hash is None or block.prev_header_hash == prev_hash
+                        prev_hash = block.header_hash
+
                         if len(block_batch) < 32:
                             continue
 
-                        success, advanced_peak, fork_height, coin_changes = await full_node.receive_block_batch(
-                            block_batch, None, None  # type: ignore[arg-type]
-                        )
-                        end_height = block_batch[-1].height
-                        full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
+                        if keep_up:
+                            for b in block_batch:
+                                await full_node.respond_unfinished_block(
+                                    full_node_protocol.RespondUnfinishedBlock(make_unfinished_block(b, constants)), peer
+                                )
+                                await full_node.respond_block(full_node_protocol.RespondBlock(b))
+                        else:
+                            success, advanced_peak, fork_height, coin_changes = await full_node.receive_block_batch(
+                                block_batch, peer, None
+                            )
+                            end_height = block_batch[-1].height
+                            full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
-                    assert success
-                    assert advanced_peak
+                            if not success:
+                                raise RuntimeError("failed to ingest block batch")
+
+                            assert advanced_peak
+
+                        time_per_block = (time.monotonic() - batch_start_time) / len(block_batch)
+                        if not worst_batch_height or worst_batch_time_per_block > time_per_block:
+                            worst_batch_height = height
+                            worst_batch_time_per_block = time_per_block
+
                     counter += len(block_batch)
                     height += len(block_batch)
-                    print(f"\rheight {height} {counter/(time.monotonic() - start_time):0.2f} blocks/s   ", end="")
+                    print(
+                        f"\rheight {height} {time_per_block:0.2f} s/block   ",
+                        end="",
+                    )
+                    batch_start_time = time.monotonic()
                     block_batch = []
                     if check_log.exit_with_failure:
                         raise RuntimeError("error printed to log. exiting")
 
                     if counter >= 100000:
-                        start_time = time.monotonic()
+                        batch_start_time = time.monotonic()
                         counter = 0
                         print()
+                end_time = time.monotonic()
+                logger.warning(f"test completed at {end_time}")
+                logger.warning(f"duration: {end_time - start_time:0.2f} s")
+                logger.warning(f"worst time-per-block: {worst_batch_time_per_block:0.2f} s")
+                logger.warning(f"worst height: {worst_batch_height}")
+                logger.warning(f"end-height: {height}")
         finally:
             print("closing full node")
             full_node._close()
@@ -153,11 +218,19 @@ def main() -> None:
     default=False,
     help="run node in a single process, to include validation in profiles",
 )
-def run(file: Path, db_version: int, profile: bool, single_thread: bool, test_constants: bool) -> None:
+@click.option(
+    "--keep-up",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="pass blocks to the full node as if we're staying synced, rather than syncing",
+)
+def run(file: Path, db_version: int, profile: bool, single_thread: bool, test_constants: bool, keep_up: bool) -> None:
     """
     The FILE parameter should point to an existing blockchain database file (in v2 format)
     """
-    asyncio.run(run_sync_test(Path(file), db_version, profile, single_thread, test_constants))
+    print(f"PID: {os.getpid()}")
+    asyncio.run(run_sync_test(Path(file), db_version, profile, single_thread, test_constants, keep_up))
 
 
 @main.command("analyze", short_help="generate call stacks for all profiles dumped to current directory")


### PR DESCRIPTION
`./tools/generate_chain.py` is made a proper command line tool using `click`. The test constants are updated to be more similar to mainnet.
`./tools/test_full_sync.py` gets a anew feature to ingest blocks via the normal, "stay in sync" code path. this allows performance testing of both syncing and staying in sync.
This patch also adds another profiling tool, `cpu_utilization.py`, which measures CPU usage of a process as well as its child processes. This helps spot inefficiencies in our parallelization.

The changes to `generate_chain.py` is best reviewed ignoring whitespace, since a lot of code changed indentation level.