### PR TITLE
harvester: Tweak `get_plots` RPC

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -118,13 +118,12 @@ class Harvester:
                     {
                         "filename": str(path),
                         "size": prover.get_size(),
-                        "plot-seed": prover.get_id(),  # Deprecated
                         "plot_id": prover.get_id(),
                         "pool_public_key": plot_info.pool_public_key,
                         "pool_contract_puzzle_hash": plot_info.pool_contract_puzzle_hash,
                         "plot_public_key": plot_info.plot_public_key,
                         "file_size": plot_info.file_size,
-                        "time_modified": plot_info.time_modified,
+                        "time_modified": int(plot_info.time_modified),
                     }
                 )
             self.log.debug(


### PR DESCRIPTION
This is a basically a breaking change to `get_plots` RPC method but i think its not an issue because its not longer used by the GUI/Farmer and third party probably don't rely on `plot-seed`. 

Truncating `time_modified` was mostly done because it helps to simplify tests in #11245. But it also leads to the plot list of a harvester in `get_harvester` match the output of `get_plots` from the same harvester.