### PR TITLE
postinst/prerm scripts with the UI .deb

### DIFF
--- a/build_scripts/assets/deb/postinst.sh
+++ b/build_scripts/assets/deb/postinst.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Post install script for the UI .deb to place symlinks in places to allow the CLI to work similarly in both versions
+
+set -e
+
+ln -s /usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon/chia /usr/bin/chia || true
+ln -s /usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon /opt/chia || true

--- a/build_scripts/assets/deb/prerm.sh
+++ b/build_scripts/assets/deb/prerm.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Pre remove script for the UI .deb to clean up the symlinks from the installer
+
+set -e
+
+unlink /usr/bin/chia || true
+unlink /opt/chia || true

--- a/build_scripts/build_linux_deb.sh
+++ b/build_scripts/build_linux_deb.sh
@@ -98,8 +98,10 @@ cd ../../../build_scripts || exit
 echo "Create chia-$CHIA_INSTALLER_VERSION.deb"
 rm -rf final_installer
 mkdir final_installer
-electron-installer-debian --src dist/$DIR_NAME/ --dest final_installer/ \
---arch "$PLATFORM" --options.version $CHIA_INSTALLER_VERSION --options.bin chia-blockchain --options.name chia-blockchain
+electron-installer-debian --src "dist/$DIR_NAME/" \
+  --arch "$PLATFORM" \
+  --options.version "$CHIA_INSTALLER_VERSION" \
+  --config deb-options.json
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 	echo >&2 "electron-installer-debian failed!"

--- a/build_scripts/deb-options.json
+++ b/build_scripts/deb-options.json
@@ -1,0 +1,9 @@
+{
+  "dest": "final_installer/",
+  "bin": "chia-blockchain",
+  "name": "chia-blockchain",
+  "scripts": {
+    "postinst": "assets/deb/postinst.sh",
+    "prerm": "assets/deb/prerm.sh"
+  }
+}


### PR DESCRIPTION
Adds a post install and pre remove script that creates/cleans up symlinks so that `chia` is in path by default (for CLI usage) and `/opt/chia` in both the UI and CLI version points to the same set of files


`/usr/bin/chia` -> `/usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon/chia`
`/opt/chia` -> `/usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon`
