### PR TITLE
Check observer addresses in farm rewards dialog

### DIFF
--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -97,7 +97,8 @@ class FarmerRpcApi:
 
     async def get_reward_targets(self, request: Dict) -> Dict:
         search_for_private_key = request["search_for_private_key"]
-        return await self.service.get_reward_targets(search_for_private_key)
+        max_ph_to_search = request.get("max_ph_to_search", 500)
+        return await self.service.get_reward_targets(search_for_private_key, max_ph_to_search)
 
     async def set_reward_targets(self, request: Dict) -> Dict:
         farmer_target, pool_target = None, None

--- a/chia/rpc/farmer_rpc_client.py
+++ b/chia/rpc/farmer_rpc_client.py
@@ -22,8 +22,11 @@ class FarmerRpcClient(RpcClient):
     async def get_signage_points(self) -> List[Dict]:
         return (await self.fetch("get_signage_points", {}))["signage_points"]
 
-    async def get_reward_targets(self, search_for_private_key: bool) -> Dict:
-        response = await self.fetch("get_reward_targets", {"search_for_private_key": search_for_private_key})
+    async def get_reward_targets(self, search_for_private_key: bool, max_ph_to_search: int = 500) -> Dict:
+        response = await self.fetch(
+            "get_reward_targets",
+            {"search_for_private_key": search_for_private_key, "max_ph_to_search": max_ph_to_search},
+        )
         return_dict = {
             "farmer_target": response["farmer_target"],
             "pool_target": response["pool_target"],

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -58,8 +58,8 @@ class WalletRpcClient(RpcClient):
     async def delete_key(self, fingerprint: int) -> None:
         return await self.fetch("delete_key", {"fingerprint": fingerprint})
 
-    async def check_delete_key(self, fingerprint: int) -> None:
-        return await self.fetch("check_delete_key", {"fingerprint": fingerprint})
+    async def check_delete_key(self, fingerprint: int, max_ph_to_search: int = 100) -> None:
+        return await self.fetch("check_delete_key", {"fingerprint": fingerprint, "max_ph_to_search": max_ph_to_search})
 
     async def delete_all_keys(self) -> None:
         return await self.fetch("delete_all_keys", {})

--- a/chia/wallet/derive_keys.py
+++ b/chia/wallet/derive_keys.py
@@ -1,7 +1,9 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Set
 
 from blspy import AugSchemeMPL, PrivateKey, G1Element
 
+from chia.consensus.coinbase import create_puzzlehash_for_pk
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32
 
 # EIP 2334 bls key derivation
@@ -76,7 +78,7 @@ def master_sk_to_pooling_authentication_sk(master: PrivateKey, pool_wallet_index
     return _derive_path(master, [12381, 8444, 6, pool_wallet_index * 10000 + index])
 
 
-def find_owner_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[Tuple[G1Element, uint32]]:
+def find_owner_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Optional[Tuple[PrivateKey, uint32]]:
     for pool_wallet_index in range(MAX_POOL_WALLETS):
         for sk in all_sks:
             try_owner_sk = master_sk_to_singleton_owner_sk(sk, uint32(pool_wallet_index))
@@ -95,3 +97,34 @@ def find_authentication_sk(all_sks: List[PrivateKey], owner_pk: G1Element) -> Op
                 # NOTE: ONLY use 0 for authentication key index to ensure compatibility
                 return master_sk_to_pooling_authentication_sk(sk, uint32(pool_wallet_index), uint32(0))
     return None
+
+
+def match_address_to_sk(
+    sk: PrivateKey, addresses_to_search: List[bytes32], max_ph_to_search: int = 500
+) -> Set[bytes32]:
+    """
+    Checks the list of given address is a derivation of the given sk within the given number of derivations
+    Returns a Set of the addresses that are derivations of the given sk
+    """
+    if sk is None or not addresses_to_search:
+        return set()
+
+    found_addresses: Set[bytes32] = set()
+    search_list: Set[bytes32] = set(addresses_to_search)
+
+    for i in range(max_ph_to_search):
+
+        phs = [
+            create_puzzlehash_for_pk(master_sk_to_wallet_sk(sk, uint32(i)).get_g1()),
+            create_puzzlehash_for_pk(master_sk_to_wallet_sk_unhardened(sk, uint32(i)).get_g1()),
+        ]
+
+        for address in search_list:
+            if address in phs:
+                found_addresses.add(address)
+
+        search_list = search_list - found_addresses
+        if not len(search_list):
+            return found_addresses
+
+    return found_addresses

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -17,7 +17,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, lock_and_load_config, save_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
-from chia.wallet.derive_keys import master_sk_to_wallet_sk
+from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from tests.setup_nodes import setup_harvester_farmer, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.rpc import validate_get_routes
@@ -181,36 +181,48 @@ async def test_farmer_reward_target_endpoints(bt, harvester_farmer_environment):
     targets_1 = await farmer_rpc_client.get_reward_targets(False)
     assert "have_pool_sk" not in targets_1
     assert "have_farmer_sk" not in targets_1
-    targets_2 = await farmer_rpc_client.get_reward_targets(True)
+    targets_2 = await farmer_rpc_client.get_reward_targets(True, 2)
     assert targets_2["have_pool_sk"] and targets_2["have_farmer_sk"]
 
-    new_ph: bytes32 = create_puzzlehash_for_pk(master_sk_to_wallet_sk(bt.farmer_master_sk, uint32(10)).get_g1())
-    new_ph_2: bytes32 = create_puzzlehash_for_pk(master_sk_to_wallet_sk(bt.pool_master_sk, uint32(472)).get_g1())
+    new_ph: bytes32 = create_puzzlehash_for_pk(master_sk_to_wallet_sk(bt.farmer_master_sk, uint32(2)).get_g1())
+    new_ph_2: bytes32 = create_puzzlehash_for_pk(master_sk_to_wallet_sk(bt.pool_master_sk, uint32(7)).get_g1())
 
     await farmer_rpc_client.set_reward_targets(encode_puzzle_hash(new_ph, "xch"), encode_puzzle_hash(new_ph_2, "xch"))
-    targets_3 = await farmer_rpc_client.get_reward_targets(True)
+    targets_3 = await farmer_rpc_client.get_reward_targets(True, 10)
     assert decode_puzzle_hash(targets_3["farmer_target"]) == new_ph
     assert decode_puzzle_hash(targets_3["pool_target"]) == new_ph_2
     assert targets_3["have_pool_sk"] and targets_3["have_farmer_sk"]
 
-    new_ph_3: bytes32 = create_puzzlehash_for_pk(master_sk_to_wallet_sk(bt.pool_master_sk, uint32(1888)).get_g1())
-    await farmer_rpc_client.set_reward_targets(None, encode_puzzle_hash(new_ph_3, "xch"))
-    targets_4 = await farmer_rpc_client.get_reward_targets(True)
-    assert decode_puzzle_hash(targets_4["farmer_target"]) == new_ph
-    assert decode_puzzle_hash(targets_4["pool_target"]) == new_ph_3
-    assert not targets_4["have_pool_sk"] and targets_3["have_farmer_sk"]
+    # limit the derivation search to 3 should fail to find the pool sk
+    targets_4 = await farmer_rpc_client.get_reward_targets(True, 3)
+    assert not targets_4["have_pool_sk"] and targets_4["have_farmer_sk"]
+
+    # check observer addresses
+    observer_farmer: bytes32 = create_puzzlehash_for_pk(
+        master_sk_to_wallet_sk_unhardened(bt.farmer_master_sk, uint32(2)).get_g1()
+    )
+    observer_pool: bytes32 = create_puzzlehash_for_pk(
+        master_sk_to_wallet_sk_unhardened(bt.pool_master_sk, uint32(7)).get_g1()
+    )
+    await farmer_rpc_client.set_reward_targets(
+        encode_puzzle_hash(observer_farmer, "xch"), encode_puzzle_hash(observer_pool, "xch")
+    )
+    targets = await farmer_rpc_client.get_reward_targets(True, 10)
+    assert decode_puzzle_hash(targets["farmer_target"]) == observer_farmer
+    assert decode_puzzle_hash(targets["pool_target"]) == observer_pool
+    assert targets["have_pool_sk"] and targets["have_farmer_sk"]
 
     root_path = farmer_api.farmer._root_path
     config = load_config(root_path, "config.yaml")
-    assert config["farmer"]["xch_target_address"] == encode_puzzle_hash(new_ph, "xch")
-    assert config["pool"]["xch_target_address"] == encode_puzzle_hash(new_ph_3, "xch")
+    assert config["farmer"]["xch_target_address"] == encode_puzzle_hash(observer_farmer, "xch")
+    assert config["pool"]["xch_target_address"] == encode_puzzle_hash(observer_pool, "xch")
 
-    new_ph_3_encoded = encode_puzzle_hash(new_ph_3, "xch")
-    added_char = new_ph_3_encoded + "a"
+    new_ph_2_encoded = encode_puzzle_hash(new_ph_2, "xch")
+    added_char = new_ph_2_encoded + "a"
     with pytest.raises(ValueError):
         await farmer_rpc_client.set_reward_targets(None, added_char)
 
-    replaced_char = new_ph_3_encoded[0:-1] + "a"
+    replaced_char = new_ph_2_encoded[0:-1] + "a"
     with pytest.raises(ValueError):
         await farmer_rpc_client.set_reward_targets(None, replaced_char)
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -26,7 +26,7 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
-from chia.wallet.derive_keys import master_sk_to_wallet_sk
+from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.transaction_sorting import SortKey
@@ -643,7 +643,37 @@ class TestWalletRpc:
             assert sk_dict["used_for_pool_rewards"] is True
 
             # Check unknown key
-            sk_dict = await client.check_delete_key(123456)
+            sk_dict = await client.check_delete_key(123456, 10)
+            assert sk_dict["fingerprint"] == 123456
+            assert sk_dict["used_for_farmer_rewards"] is False
+            assert sk_dict["used_for_pool_rewards"] is False
+
+            # Add in observer reward addresses into farmer and pool for testing delete key checks
+            # set farmer to first private key
+            sk = await wallet_node.get_key_for_fingerprint(pks[0])
+            test_ph = create_puzzlehash_for_pk(master_sk_to_wallet_sk_unhardened(sk, uint32(0)).get_g1())
+            with lock_and_load_config(wallet_node.root_path, "config.yaml") as test_config:
+                test_config["farmer"]["xch_target_address"] = encode_puzzle_hash(test_ph, "txch")
+                # set pool to second private key
+                sk = await wallet_node.get_key_for_fingerprint(pks[1])
+                test_ph = create_puzzlehash_for_pk(master_sk_to_wallet_sk_unhardened(sk, uint32(0)).get_g1())
+                test_config["pool"]["xch_target_address"] = encode_puzzle_hash(test_ph, "txch")
+                save_config(wallet_node.root_path, "config.yaml", test_config)
+
+            # Check first key
+            sk_dict = await client.check_delete_key(pks[0])
+            assert sk_dict["fingerprint"] == pks[0]
+            assert sk_dict["used_for_farmer_rewards"] is True
+            assert sk_dict["used_for_pool_rewards"] is False
+
+            # Check second key
+            sk_dict = await client.check_delete_key(pks[1])
+            assert sk_dict["fingerprint"] == pks[1]
+            assert sk_dict["used_for_farmer_rewards"] is False
+            assert sk_dict["used_for_pool_rewards"] is True
+
+            # Check unknown key
+            sk_dict = await client.check_delete_key(123456, 10)
             assert sk_dict["fingerprint"] == 123456
             assert sk_dict["used_for_farmer_rewards"] is False
             assert sk_dict["used_for_pool_rewards"] is False


### PR DESCRIPTION
The GUI farmer rewards check was not checking for observer keys and the code was duplicated from farmer and wallet, which is one reason this was missed.

Consolidated some code into new function called by both the wallet and farmer and added tests for observer keys.

Also added the ability to pass in the number of derivations to the RPC call - primarily this was so the tests can pass in much smaller numbers than the default (500) and so the tests can run much faster. However, this flexibility seems worth while regardless

(new PR because git hates me, but it is mutual)

Fixes #11036 