### PR TITLE
Additional metrics

### DIFF
--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import aiohttp
 from blspy import AugSchemeMPL, G2Element, PrivateKey
@@ -268,6 +268,17 @@ class FarmerAPI:
                 except Exception as e:
                     self.farmer.log.error(f"Error connecting to pool: {e}")
                     return
+
+                self.farmer.state_changed(
+                    "submitted_partial",
+                    {
+                        "launcher_id": post_partial_request.payload.launcher_id.hex(),
+                        "pool_url": pool_url,
+                        "current_difficulty": pool_state_dict["current_difficulty"],
+                        "points_acknowledged_since_start": pool_state_dict["points_acknowledged_since_start"],
+                        "points_acknowledged_24h": pool_state_dict["points_acknowledged_24h"],
+                    },
+                )
 
                 return
 

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -50,9 +50,6 @@ class FarmerAPI:
     def __init__(self, farmer) -> None:
         self.farmer = farmer
 
-    def _set_state_changed_callback(self, callback: Callable):
-        self.farmer.state_changed_callback = callback
-
     @api_request
     @peer_required
     async def new_proof_of_space(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1629,6 +1629,8 @@ class FullNode:
             "k_size": block.reward_chain_block.proof_of_space.size,
             "header_hash": block.header_hash,
             "height": block.height,
+            "validation_time": validation_time,
+            "pre_validation_time": pre_validation_time,
         }
 
         if block.transactions_info is not None:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -3,7 +3,7 @@ import dataclasses
 import time
 import traceback
 from secrets import token_bytes
-from typing import Callable, Dict, List, Optional, Tuple, Set
+from typing import Dict, List, Optional, Tuple, Set
 
 from blspy import AugSchemeMPL, G2Element
 from chiabip158 import PyBIP158
@@ -53,9 +53,6 @@ class FullNodeAPI:
 
     def __init__(self, full_node) -> None:
         self.full_node = full_node
-
-    def _set_state_changed_callback(self, callback: Callable):
-        self.full_node.state_changed_callback = callback
 
     @property
     def server(self):

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import chia.server.ws_connection as ws  # lgtm [py/import-and-import-from]
 from chia.consensus.constants import ConsensusConstants
@@ -81,9 +81,9 @@ class Harvester:
     def _set_state_changed_callback(self, callback: Callable):
         self.state_changed_callback = callback
 
-    def _state_changed(self, change: str):
+    def state_changed(self, change: str, change_data: Dict[str, Any] = None):
         if self.state_changed_callback is not None:
-            self.state_changed_callback(change)
+            self.state_changed_callback(change, change_data)
 
     def _plot_refresh_callback(self, event: PlotRefreshEvents, update_result: PlotRefreshResult):
         log_function = self.log.debug if event != PlotRefreshEvents.done else self.log.info
@@ -103,7 +103,7 @@ class Harvester:
 
     def on_disconnect(self, connection: ws.WSChiaConnection):
         self.log.info(f"peer disconnected {connection.get_peer_logging()}")
-        self._state_changed("close_connection")
+        self.state_changed("close_connection")
         self.plot_manager.stop_refreshing()
         self.plot_sync_sender.stop()
 
@@ -139,7 +139,7 @@ class Harvester:
     def delete_plot(self, str_path: str):
         remove_plot(Path(str_path))
         self.plot_manager.trigger_refresh()
-        self._state_changed("plots")
+        self.state_changed("plots")
         return True
 
     async def add_plot_directory(self, str_path: str) -> bool:

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -58,7 +58,6 @@ class Harvester:
         self.plot_sync_sender = Sender(self.plot_manager)
         self._is_shutdown = False
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=config["num_threads"])
-        self.state_changed_callback = None
         self.server = None
         self.constants = constants
         self.cached_challenges = []

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -215,9 +215,10 @@ class HarvesterAPI:
         )
         pass_msg = make_msg(ProtocolMessageTypes.farming_info, farming_info)
         await peer.send_message(pass_msg)
+        found_time = time.time() - start
         self.harvester.log.info(
             f"{len(awaitables)} plots were eligible for farming {new_challenge.challenge_hash.hex()[:10]}..."
-            f" Found {total_proofs_found} proofs. Time: {time.time() - start:.5f} s. "
+            f" Found {total_proofs_found} proofs. Time: {found_time:.5f} s. "
             f"Total {self.harvester.plot_manager.plot_count()} plots"
         )
         self.harvester.state_changed("farming_info", {
@@ -225,6 +226,7 @@ class HarvesterAPI:
             "total_plots": self.harvester.plot_manager.plot_count(),
             "found_proofs": total_proofs_found,
             "eligible_plots": len(awaitables),
+            "time": found_time,
         })
 
     @api_request

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from pathlib import Path
-from typing import Callable, List, Tuple
+from typing import List, Tuple
 
 from blspy import AugSchemeMPL, G1Element, G2Element
 
@@ -220,6 +220,12 @@ class HarvesterAPI:
             f" Found {total_proofs_found} proofs. Time: {time.time() - start:.5f} s. "
             f"Total {self.harvester.plot_manager.plot_count()} plots"
         )
+        self.harvester.state_changed("farming_info", {
+            "challenge_hash": new_challenge.challenge_hash.hex(),
+            "total_plots": self.harvester.plot_manager.plot_count(),
+            "found_proofs": total_proofs_found,
+            "eligible_plots": len(awaitables),
+        })
 
     @api_request
     async def request_signatures(self, request: harvester_protocol.RequestSignatures):

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -27,9 +27,6 @@ class HarvesterAPI:
     def __init__(self, harvester: Harvester):
         self.harvester = harvester
 
-    def _set_state_changed_callback(self, callback: Callable):
-        self.harvester.state_changed_callback = callback
-
     @peer_required
     @api_request
     async def harvester_handshake(

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -221,13 +221,16 @@ class HarvesterAPI:
             f" Found {total_proofs_found} proofs. Time: {found_time:.5f} s. "
             f"Total {self.harvester.plot_manager.plot_count()} plots"
         )
-        self.harvester.state_changed("farming_info", {
-            "challenge_hash": new_challenge.challenge_hash.hex(),
-            "total_plots": self.harvester.plot_manager.plot_count(),
-            "found_proofs": total_proofs_found,
-            "eligible_plots": len(awaitables),
-            "time": found_time,
-        })
+        self.harvester.state_changed(
+            "farming_info",
+            {
+                "challenge_hash": new_challenge.challenge_hash.hex(),
+                "total_plots": self.harvester.plot_manager.plot_count(),
+                "found_proofs": total_proofs_found,
+                "eligible_plots": len(awaitables),
+                "time": found_time,
+            },
+        )
 
     @api_request
     async def request_signatures(self, request: harvester_protocol.RequestSignatures):

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -24,37 +24,48 @@ class FarmerRpcApi:
         }
 
     async def _state_changed(self, change: str, change_data: Dict) -> List[WsRpcMessage]:
+        payloads = []
+
         if change == "new_signage_point":
             sp_hash = change_data["sp_hash"]
             data = await self.get_signage_point({"sp_hash": sp_hash.hex()})
-            return [
+            payloads.append(
                 create_payload_dict(
                     "new_signage_point",
                     data,
                     self.service_name,
                     "wallet_ui",
                 )
-            ]
+            )
         elif change == "new_farming_info":
-            return [
+            payloads.append(
                 create_payload_dict(
                     "new_farming_info",
                     change_data,
                     self.service_name,
                     "wallet_ui",
                 )
-            ]
+            )
         elif change == "new_plots":
-            return [
+            payloads.append(
                 create_payload_dict(
                     "get_harvesters",
                     change_data,
                     self.service_name,
                     "wallet_ui",
                 )
-            ]
+            )
+        elif change == "submitted_partial":
+            payloads.append(
+                create_payload_dict(
+                    "submitted_partial",
+                    change_data,
+                    self.service_name,
+                    "metrics",
+                )
+            )
 
-        return []
+        return payloads
 
     async def get_signage_point(self, request: Dict) -> Dict:
         sp_hash = hexstr_to_bytes(request["sp_hash"])

--- a/chia/rpc/harvester_rpc_api.py
+++ b/chia/rpc/harvester_rpc_api.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List
 
 from chia.harvester.harvester import Harvester
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
@@ -19,12 +19,21 @@ class HarvesterRpcApi:
             "/remove_plot_directory": self.remove_plot_directory,
         }
 
-    async def _state_changed(self, change: str) -> List[WsRpcMessage]:
+    async def _state_changed(self, change: str, change_data: Dict[str, Any] = None) -> List[WsRpcMessage]:
+        if change_data is None:
+            change_data = {}
+
+        payloads = []
+
         if change == "plots":
             data = await self.get_plots({})
             payload = create_payload_dict("get_plots", data, self.service_name, "wallet_ui")
-            return [payload]
-        return []
+            payloads.append(payload)
+
+        if change == "farming_info":
+            payloads.append(create_payload_dict("farming_info", change_data, self.service_name, "metrics"))
+
+        return payloads
 
     async def get_plots(self, request: Dict) -> Dict:
         plots, failed_to_open, not_found = self.service.get_plots()

--- a/chia/seeder/crawler_api.py
+++ b/chia/seeder/crawler_api.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Optional
 
 import chia.server.ws_connection as ws
 from chia.full_node.full_node import full_node_protocol, wallet_protocol

--- a/chia/seeder/crawler_api.py
+++ b/chia/seeder/crawler_api.py
@@ -13,9 +13,6 @@ class CrawlerAPI:
     def __init__(self, crawler):
         self.crawler = crawler
 
-    def _set_state_changed_callback(self, callback: Callable):
-        self.crawler.state_changed_callback = callback
-
     def __getattr__(self, attr_name: str):
         async def invoke(*args, **kwargs):
             pass


### PR DESCRIPTION
Adds additional `state_changed` events for the farmer and harvester. Also adds `validation_time` and `pre_validation_time` to the existing `block` event on the full node.

Finally, there were a few instances of `def _set_state_changed_callback` being defined in `{service}_api` files, but this is never actually used. The only place `_set_state_changed_callback` is called is in the [rpc_server](https://github.com/Chia-Network/chia-blockchain/blob/25ab0c90cb34cd048463082801c3cc26bfac389a/chia/rpc/rpc_server.py#L318). It actually calls ` rpc_server.rpc_api.service._set_state_changed_callback(...)`, calling the function on the service, not the API itself, so the function definition on the api and service was unnecessary and confusing, when trying to reason about the code.