### PR TITLE
Remove multidict from setup.py for python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 dependencies = [
-    "multidict==5.1.0",  # Avoid 5.2.0 due to Avast
+    "multidict==6.0.2",  # Avoid 5.2.0 due to Avast
     "aiofiles==0.7.0",  # Async IO for files
     "blspy==1.0.10",  # Signature library
     "chiavdf==1.0.6",  # timelord and vdf verification

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup
 
 dependencies = [
-    "multidict==6.0.2",  # Avoid 5.2.0 due to Avast
     "aiofiles==0.7.0",  # Async IO for files
     "blspy==1.0.10",  # Signature library
     "chiavdf==1.0.6",  # timelord and vdf verification


### PR DESCRIPTION
Removed multidict from setup.py and allow it to get pulled in from aiohttp. This will pull in the current version which is 6.0.2.

Tested with Avast One - no issues