### PR TITLE
Update setproctitle to 1.2.3 for python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ dependencies = [
     #  "keyrings.cryptfile==1.3.8",  # Secure storage for keys on Linux (Will be replaced)
     #  See https://github.com/frispete/keyrings.cryptfile/issues/15
     "PyYAML==5.4.1",  # Used for config file format
-    "setproctitle==1.2.2",  # Gives the chia processes readable names
+    "setproctitle==1.2.3",  # Gives the chia processes readable names
     "sortedcontainers==2.4.0",  # For maintaining sorted mempools
     # TODO: when moving to click 8 remove the pinning of black noted below
     "click==7.1.2",  # For the CLI


### PR DESCRIPTION
Update setproctitle to 1.2.3 for python 3.10 wheels

It appears all the wheels for 1.2.3 are now on the pypi standard repo, so I think we can stop publishing it on our aux repo