### PR TITLE
simplify install.sh ubuntu version tracking

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ if $UBUNTU; then
     UBUNTU_PRE_2004=1
   elif [ "$(echo "$LSB_RELEASE<21" | bc)" = "1" ]; then
     UBUNTU_2000=1
-  elif [ "$(echo "$LSB_RELEASE<22" | bc)" = "1" ]; then
+  else
     UBUNTU_2100=1
   fi
 fi
@@ -132,7 +132,7 @@ if [ "$(uname)" = "Linux" ]; then
     sudo apt-get update
     sudo apt-get install -y python3.8-venv python3-distutils openssl
   elif [ "$UBUNTU_2100" = "1" ]; then
-    echo "Installing on Ubuntu 21.04."
+    echo "Installing on Ubuntu 21.04 or newer."
     sudo apt-get update
     sudo apt-get install -y python3.9-venv python3-distutils openssl
   elif [ "$DEBIAN" = "true" ]; then

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,10 @@ fi
 # Get submodules
 git submodule update --init mozilla-ca
 
-UBUNTU_PRE_2004=false
+UBUNTU_PRE_2004=0
+UBUNTU_2000=0
+UBUNTU_2100=0
+
 if $UBUNTU; then
   LSB_RELEASE=$(lsb_release -rs)
   # In case Ubuntu minimal does not come with bc
@@ -64,8 +67,13 @@ if $UBUNTU; then
     sudo apt install bc -y
   fi
   # Mint 20.04 responds with 20 here so 20 instead of 20.04
-  UBUNTU_PRE_2004=$(echo "$LSB_RELEASE<20" | bc)
-  UBUNTU_2100=$(echo "$LSB_RELEASE>=21" | bc)
+  if [ $(echo "$LSB_RELEASE<20" | bc) = "1" ]; then
+    UBUNTU_PRE_2004=1
+  elif [ $(echo "$LSB_RELEASE<21" | bc) = "1" ]; then
+    UBUNTU_2000=1
+  elif [ $(echo "$LSB_RELEASE<22" | bc) = "1" ]; then
+    UBUNTU_2100=1
+  fi
 fi
 
 install_python3_and_sqlite3_from_source_with_yum() {
@@ -114,17 +122,17 @@ install_python3_and_sqlite3_from_source_with_yum() {
 # Manage npm and other install requirements on an OS specific basis
 if [ "$(uname)" = "Linux" ]; then
   #LINUX=1
-  if [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "1" ]; then
+  if [ "$UBUNTU_PRE_2004" = "1" ]; then
     # Ubuntu
     echo "Installing on Ubuntu pre 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.7-venv python3.7-distutils openssl
-  elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_PRE_2004" = "0" ] && [ "$UBUNTU_2100" = "0" ]; then
+  elif [ "$UBUNTU_2000" = "1" ]; then
     echo "Installing on Ubuntu 20.04 LTS."
     sudo apt-get update
     sudo apt-get install -y python3.8-venv python3-distutils openssl
-  elif [ "$UBUNTU" = "true" ] && [ "$UBUNTU_2100" = "1" ]; then
-    echo "Installing on Ubuntu 21.04 or newer."
+  elif [ "$UBUNTU_2100" = "1" ]; then
+    echo "Installing on Ubuntu 21.04."
     sudo apt-get update
     sudo apt-get install -y python3.9-venv python3-distutils openssl
   elif [ "$DEBIAN" = "true" ]; then

--- a/install.sh
+++ b/install.sh
@@ -67,11 +67,11 @@ if $UBUNTU; then
     sudo apt install bc -y
   fi
   # Mint 20.04 responds with 20 here so 20 instead of 20.04
-  if [ $(echo "$LSB_RELEASE<20" | bc) = "1" ]; then
+  if [ "$(echo "$LSB_RELEASE<20" | bc)" = "1" ]; then
     UBUNTU_PRE_2004=1
-  elif [ $(echo "$LSB_RELEASE<21" | bc) = "1" ]; then
+  elif [ "$(echo "$LSB_RELEASE<21" | bc)" = "1" ]; then
     UBUNTU_2000=1
-  elif [ $(echo "$LSB_RELEASE<22" | bc) = "1" ]; then
+  elif [ "$(echo "$LSB_RELEASE<22" | bc)" = "1" ]; then
     UBUNTU_2100=1
   fi
 fi


### PR DESCRIPTION
An alternative simplification to https://github.com/Chia-Network/chia-blockchain/pull/11279.  This one is intended to not change any corner cases, just simplify the code in preparation for extending to support Ubuntu 22.04.

Draft for:
- [x] Adding Linux Mint to `install.sh` test matrix.  For example, they provide Python 3.10 for `python3` in their 21 version unlike Ubuntu.  https://github.com/Chia-Network/chia-blockchain/pull/11295