### PR TITLE
Fix targeting for arm64 to not land on native arm64 mac runners

### DIFF
--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     name: Linux ARM64 installer on Python 3.8
-    runs-on: [ARM64]
+    runs-on: [Linux, ARM64]
     container: chianetwork/ubuntu-18.04-builder:latest
     timeout-minutes: 120
     strategy:


### PR DESCRIPTION
Need to specifically target a combination of linux + arm64, since native m1 runners (also arm64) will be online