### PR TITLE
Optimize BLS verification when public key is repeated

### DIFF
--- a/chia/util/cached_bls.py
+++ b/chia/util/cached_bls.py
@@ -23,17 +23,19 @@ def get_pairings(cache: LRUCache, pks: List[bytes48], msgs: Sequence[bytes], for
             if missing_count > len(pks) // 2:
                 return []
         pairings.append(pairing)
+
+    # G1Element.from_bytes can be expensive due to subgroup check, so we avoid recomputing it with this cache
     pk_bytes_to_g1: Dict[bytes48, G1Element] = {}
     for i, pairing in enumerate(pairings):
         if pairing is None:
             aug_msg = pks[i] + msgs[i]
             aug_hash: G2Element = AugSchemeMPL.g2_from_message(aug_msg)
 
-            if pks[i] in pk_bytes_to_g1:
-                pk_parsed: G1Element = pk_bytes_to_g1[pks[i]]
-            else:
+            pk_parsed: Optional[G1Element] = pk_bytes_to_g1.get(pks[i])
+            if pk_parsed is None:
                 pk_parsed = G1Element.from_bytes(pks[i])
                 pk_bytes_to_g1[pks[i]] = pk_parsed
+
             pairing = pk_parsed.pair(aug_hash)
 
             h = bytes(std_hash(aug_msg))

--- a/chia/util/cached_bls.py
+++ b/chia/util/cached_bls.py
@@ -1,5 +1,5 @@
 import functools
-from typing import List, Optional, Sequence, Dict
+from typing import Dict, List, Optional, Sequence
 
 from blspy import AugSchemeMPL, G1Element, G2Element, GTElement
 

--- a/chia/util/cached_bls.py
+++ b/chia/util/cached_bls.py
@@ -1,5 +1,5 @@
 import functools
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Dict
 
 from blspy import AugSchemeMPL, G1Element, G2Element, GTElement
 
@@ -23,12 +23,19 @@ def get_pairings(cache: LRUCache, pks: List[bytes48], msgs: Sequence[bytes], for
             if missing_count > len(pks) // 2:
                 return []
         pairings.append(pairing)
-
+    pk_bytes_to_g1: Dict[bytes48, G1Element] = {}
     for i, pairing in enumerate(pairings):
         if pairing is None:
             aug_msg = pks[i] + msgs[i]
             aug_hash: G2Element = AugSchemeMPL.g2_from_message(aug_msg)
-            pairing = G1Element.from_bytes(pks[i]).pair(aug_hash)
+
+            if pks[i] in pk_bytes_to_g1:
+                pk_parsed: G1Element = pk_bytes_to_g1[pks[i]]
+            else:
+                pk_pblack chia tests && mypy chia tests && flake8 chia tests
+arsed = G1Element.from_bytes(pks[i])
+                pk_bytes_to_g1[pks[i]] = pk_parsed
+            pairing = pk_parsed.pair(aug_hash)
 
             h = bytes(std_hash(aug_msg))
             cache.put(h, pairing)

--- a/chia/util/cached_bls.py
+++ b/chia/util/cached_bls.py
@@ -32,8 +32,7 @@ def get_pairings(cache: LRUCache, pks: List[bytes48], msgs: Sequence[bytes], for
             if pks[i] in pk_bytes_to_g1:
                 pk_parsed: G1Element = pk_bytes_to_g1[pks[i]]
             else:
-                pk_pblack chia tests && mypy chia tests && flake8 chia tests
-arsed = G1Element.from_bytes(pks[i])
+                pk_parsed = G1Element.from_bytes(pks[i])
                 pk_bytes_to_g1[pks[i]] = pk_parsed
             pairing = pk_parsed.pair(aug_hash)
 

--- a/tests/core/util/test_cached_bls.py
+++ b/tests/core/util/test_cached_bls.py
@@ -1,5 +1,3 @@
-import time
-
 from blspy import AugSchemeMPL, G1Element
 from chia.util import cached_bls
 from chia.util.hash import std_hash

--- a/tests/core/util/test_cached_bls.py
+++ b/tests/core/util/test_cached_bls.py
@@ -1,40 +1,56 @@
-import unittest
+import time
+
 from blspy import AugSchemeMPL, G1Element
 from chia.util import cached_bls
+from chia.util.hash import std_hash
 from chia.util.lru_cache import LRUCache
 
 
-class TestCachedBLS(unittest.TestCase):
-    def test_cached_bls(self):
-        n_keys = 10
-        seed = b"a" * 31
-        sks = [AugSchemeMPL.key_gen(seed + bytes([i])) for i in range(n_keys)]
-        pks = [bytes(sk.get_g1()) for sk in sks]
+def test_cached_bls():
+    n_keys = 10
+    seed = b"a" * 31
+    sks = [AugSchemeMPL.key_gen(seed + bytes([i])) for i in range(n_keys)]
+    pks = [bytes(sk.get_g1()) for sk in sks]
 
-        msgs = [("msg-%d" % (i,)).encode() for i in range(n_keys)]
-        sigs = [AugSchemeMPL.sign(sk, msg) for sk, msg in zip(sks, msgs)]
-        agg_sig = AugSchemeMPL.aggregate(sigs)
+    msgs = [("msg-%d" % (i,)).encode() for i in range(n_keys)]
+    sigs = [AugSchemeMPL.sign(sk, msg) for sk, msg in zip(sks, msgs)]
+    agg_sig = AugSchemeMPL.aggregate(sigs)
 
-        pks_half = pks[: n_keys // 2]
-        msgs_half = msgs[: n_keys // 2]
-        sigs_half = sigs[: n_keys // 2]
-        agg_sig_half = AugSchemeMPL.aggregate(sigs_half)
+    pks_half = pks[: n_keys // 2]
+    msgs_half = msgs[: n_keys // 2]
+    sigs_half = sigs[: n_keys // 2]
+    agg_sig_half = AugSchemeMPL.aggregate(sigs_half)
 
-        assert AugSchemeMPL.aggregate_verify([G1Element.from_bytes(pk) for pk in pks], msgs, agg_sig)
+    assert AugSchemeMPL.aggregate_verify([G1Element.from_bytes(pk) for pk in pks], msgs, agg_sig)
 
-        # Verify with empty cache and populate it
-        assert cached_bls.aggregate_verify(pks_half, msgs_half, agg_sig_half, True)
-        # Verify with partial cache hit
-        assert cached_bls.aggregate_verify(pks, msgs, agg_sig, True)
-        # Verify with full cache hit
-        assert cached_bls.aggregate_verify(pks, msgs, agg_sig)
+    # Verify with empty cache and populate it
+    assert cached_bls.aggregate_verify(pks_half, msgs_half, agg_sig_half, True)
+    # Verify with partial cache hit
+    assert cached_bls.aggregate_verify(pks, msgs, agg_sig, True)
+    # Verify with full cache hit
+    assert cached_bls.aggregate_verify(pks, msgs, agg_sig)
 
-        # Use a small cache which can not accommodate all pairings
-        local_cache = LRUCache(n_keys // 2)
-        # Verify signatures and cache pairings one at a time
-        for pk, msg, sig in zip(pks_half, msgs_half, sigs_half):
-            assert cached_bls.aggregate_verify([pk], [msg], sig, True, local_cache)
-        # Verify the same messages with aggregated signature (full cache hit)
-        assert cached_bls.aggregate_verify(pks_half, msgs_half, agg_sig_half, False, local_cache)
-        # Verify more messages (partial cache hit)
-        assert cached_bls.aggregate_verify(pks, msgs, agg_sig, False, local_cache)
+    # Use a small cache which can not accommodate all pairings
+    local_cache = LRUCache(n_keys // 2)
+    # Verify signatures and cache pairings one at a time
+    for pk, msg, sig in zip(pks_half, msgs_half, sigs_half):
+        assert cached_bls.aggregate_verify([pk], [msg], sig, True, local_cache)
+    # Verify the same messages with aggregated signature (full cache hit)
+    assert cached_bls.aggregate_verify(pks_half, msgs_half, agg_sig_half, False, local_cache)
+    # Verify more messages (partial cache hit)
+    assert cached_bls.aggregate_verify(pks, msgs, agg_sig, False, local_cache)
+
+
+def test_cached_bls_repeat_pk():
+    n_keys = 400
+    seed = b"a" * 32
+    sks = [AugSchemeMPL.key_gen(seed) for i in range(n_keys)] + [AugSchemeMPL.key_gen(std_hash(seed))]
+    pks = [bytes(sk.get_g1()) for sk in sks]
+
+    msgs = [("msg-%d" % (i,)).encode() for i in range(n_keys + 1)]
+    sigs = [AugSchemeMPL.sign(sk, msg) for sk, msg in zip(sks, msgs)]
+    agg_sig = AugSchemeMPL.aggregate(sigs)
+
+    assert AugSchemeMPL.aggregate_verify([G1Element.from_bytes(pk) for pk in pks], msgs, agg_sig)
+
+    assert cached_bls.aggregate_verify(pks, msgs, agg_sig, force_cache=True)


### PR DESCRIPTION
Many times, one address pay out to many other addresses, so the same public key is used repeatedly (pool payouts, dust etc).
Before we were performing the subgroup check many times. 

In this change we optimize with a cache to only convert from bytes -> G1Element once per pk. It obtains a 10% validation speedup  with 1000 public keys.