### PR TITLE
Fix race condition, blockchain can change between two calls to get_peak

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -781,7 +781,7 @@ class FullNodeAPI:
             def get_pool_sig(_1, _2) -> Optional[G2Element]:
                 return request.pool_signature
 
-            prev_b: Optional[BlockRecord] = self.full_node.blockchain.get_peak()
+            prev_b: Optional[BlockRecord] = peak
 
             # Finds the previous block from the signage point, ensuring that the reward chain VDF is correct
             if prev_b is not None:


### PR DESCRIPTION
The prev block was inconsistent with the peak used to build the bundle from the mempool. If the peak changes in between those two calls (line 743 and 784), then we can create an invalid block, leading to failed validation and fallback to empty block.

This is pretty hard to test because we would need to add a block right in between those two points. I have provided this fix to some large farmers to test it. It's not clear if it really fixes is, but it's a zero risk change.