### PR TITLE
lookup coins in large batches

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -382,7 +382,7 @@ async def validate_block_body(
     if len(unspent_records) != len(removals_from_db):
         # some coins could not be found in the DB. We need to find out which
         # ones and look for them in additions_since_fork
-        found = set([u.name for u in unspent_records])
+        found: Set[bytes32] = set([u.name for u in unspent_records])
         for rem in removals_from_db:
             if rem in found:
                 continue

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -340,6 +340,9 @@ async def validate_block_body(
             assert curr is not None
 
     removal_coin_records: Dict[bytes32, CoinRecord] = {}
+    # the removed coins we need to look up from the DB
+    # i.e. all non-ephemeral coins
+    removals_from_db: List[bytes32] = []
     for rem in removals:
         if rem in additions_dic:
             # Ephemeral coin
@@ -353,35 +356,53 @@ async def validate_block_body(
             )
             removal_coin_records[new_unspent.name] = new_unspent
         else:
-            unspent = await coin_store.get_coin_record(rem)
-            if unspent is not None and unspent.confirmed_block_index <= fork_h:
-                # Spending something in the current chain, confirmed before fork
-                # (We ignore all coins confirmed after fork)
-                if unspent.spent == 1 and unspent.spent_block_index <= fork_h:
-                    # Check for coins spent in an ancestor block
-                    return Err.DOUBLE_SPEND, None
-                removal_coin_records[unspent.name] = unspent
-            else:
-                # This coin is not in the current heaviest chain, so it must be in the fork
-                if rem not in additions_since_fork:
-                    # Check for spending a coin that does not exist in this fork
-                    log.error(f"Err.UNKNOWN_UNSPENT: COIN ID: {rem} NPC RESULT: {npc_result}")
-                    return Err.UNKNOWN_UNSPENT, None
-                new_coin, confirmed_height, confirmed_timestamp = additions_since_fork[rem]
-                new_coin_record: CoinRecord = CoinRecord(
-                    new_coin,
-                    confirmed_height,
-                    uint32(0),
-                    False,
-                    confirmed_timestamp,
-                )
-                removal_coin_records[new_coin_record.name] = new_coin_record
-
             # This check applies to both coins created before fork (pulled from coin_store),
             # and coins created after fork (additions_since_fork)
             if rem in removals_since_fork:
                 # This coin was spent in the fork
                 return Err.DOUBLE_SPEND_IN_FORK, None
+            removals_from_db.append(rem)
+
+    unspent_records = await coin_store.get_coin_records(removals_from_db)
+
+    # some coin spends we need to ensure exist in the fork branch. Both coins we
+    # can't find in the DB, but also coins that were spent after the fork point
+    look_in_fork: List[bytes32] = []
+    for unspent in unspent_records:
+        if unspent.confirmed_block_index <= fork_h:
+            # Spending something in the current chain, confirmed before fork
+            # (We ignore all coins confirmed after fork)
+            if unspent.spent == 1 and unspent.spent_block_index <= fork_h:
+                # Check for coins spent in an ancestor block
+                return Err.DOUBLE_SPEND, None
+            removal_coin_records[unspent.name] = unspent
+        else:
+            look_in_fork.append(unspent.name)
+
+    if len(unspent_records) != len(removals_from_db):
+        # some coins could not be found in the DB. We need to find out which
+        # ones and look for them in additions_since_fork
+        found = set([u.name for u in unspent_records])
+        for rem in removals_from_db:
+            if rem in found:
+                continue
+            look_in_fork.append(rem)
+
+    for rem in look_in_fork:
+        # This coin is not in the current heaviest chain, so it must be in the fork
+        if rem not in additions_since_fork:
+            # Check for spending a coin that does not exist in this fork
+            log.error(f"Err.UNKNOWN_UNSPENT: COIN ID: {rem} NPC RESULT: {npc_result}")
+            return Err.UNKNOWN_UNSPENT, None
+        new_coin, confirmed_height, confirmed_timestamp = additions_since_fork[rem]
+        new_coin_record: CoinRecord = CoinRecord(
+            new_coin,
+            confirmed_height,
+            uint32(0),
+            False,
+            confirmed_timestamp,
+        )
+        removal_coin_records[new_coin_record.name] = new_coin_record
 
     removed = 0
     for unspent in removal_coin_records.values():

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -410,9 +410,7 @@ class Blockchain(BlockchainInterface):
                 tx_additions,
                 tx_removals,
             )
-            removed_rec: List[Optional[CoinRecord]] = [
-                await self.coin_store.get_coin_record(name) for name in tx_removals
-            ]
+            removed_rec: List[CoinRecord] = await self.coin_store.get_coin_records(tx_removals)
 
             # Set additions first, then removals in order to handle ephemeral coin state
             # Add in height order is also required

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -411,6 +411,7 @@ class Blockchain(BlockchainInterface):
                 tx_removals,
             )
             removed_rec: List[CoinRecord] = await self.coin_store.get_coin_records(tx_removals)
+            assert len(removed_rec) == len(tx_removals)
 
             # Set additions first, then removals in order to handle ephemeral coin state
             # Add in height order is also required
@@ -419,7 +420,6 @@ class Blockchain(BlockchainInterface):
                 assert record
                 latest_coin_state[record.name] = record
             for record in removed_rec:
-                assert record
                 latest_coin_state[record.name] = record
 
             if npc_res is not None:

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -183,7 +183,19 @@ class CoinStore:
         if len(names) == 0:
             return []
 
-        coins = set()
+        coins: List[CoinRecord] = []
+        new_names: List[bytes32] = []
+        for n in names:
+            cached = self.coin_record_cache.get(n)
+            if cached is not None:
+                coins.append(cached)
+            else:
+                new_names.append(n)
+        names = new_names
+
+        if len(names) == 0:
+            return coins
+
         async with self.db_wrapper.read_db() as conn:
             cursors: List[Awaitable[Cursor]] = []
             for names_chunk in chunks(names, MAX_SQLITE_PARAMETERS):
@@ -205,9 +217,11 @@ class CoinStore:
                 cursor = await cur_handle
                 for row in await cursor.fetchall():
                     coin = self.row_to_coin(row)
-                    coins.add(CoinRecord(coin, row[0], row[1], row[2], row[6]))
+                    record = CoinRecord(coin, row[0], row[1], row[2], row[6])
+                    coins.append(record)
+                    self.coin_record_cache.put(record.coin.name(), record)
 
-        return list(coins)
+        return coins
 
     async def get_coins_added_at_height(self, height: uint32) -> List[CoinRecord]:
         async with self.db_wrapper.read_db() as conn:

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -208,7 +208,7 @@ class CoinStore:
                     conn.execute(
                         f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                         f"coin_parent, amount, timestamp FROM coin_record "
-                        f'WHERE coin_name in ({"?," * (len(names_db) - 1)}?) ',
+                        f'WHERE coin_name in ({",".join(["?"] * len(names_db))}) ',
                         names_db,
                     )
                 )

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -2001,12 +2001,10 @@ class TestBodyValidation:
             "transactions_info",
             None,
         )
-        try:
+        with pytest.raises(AssertionError):
             await _validate_and_add_block_multi_error(
                 b, block, [Err.IS_TRANSACTION_BLOCK_BUT_NO_DATA, Err.INVALID_FOLIAGE_BLOCK_PRESENCE]
             )
-        except AssertionError:
-            return None
 
     @pytest.mark.asyncio
     async def test_invalid_transactions_info_hash(self, empty_blockchain, bt):
@@ -3239,10 +3237,8 @@ async def test_chain_failed_rollback(empty_blockchain, bt):
     await b.coin_store.rollback_to_block(2)
     print(f"{await b.coin_store.get_coin_record(spend_bundle.coin_spends[0].coin.name())}")
 
-    try:
+    with pytest.raises(ValueError):
         await _validate_and_add_block(b, blocks_reorg_chain[-1])
-    except ValueError:
-        pass
 
     assert b.get_peak().height == 19
 


### PR DESCRIPTION
rather than one at a time, in block_body_validation. This gives a modest speedup during sync.

7.09% -> 2.24%

EDIT: although, this profile only measures CPU time, not iowait. It's not clear that this saves any wall-clock time.

benchmarked on raspberry PI:

with this patch:
![slow-batch-00448](https://user-images.githubusercontent.com/661450/165599672-21ee4b03-e94e-4e0c-aad0-4e4198336418.png)

prior to this patch:
![slow-batch-00448](https://user-images.githubusercontent.com/661450/165520387-18594c56-2c51-4361-a0de-d88ab0dbfe67.png)

