### PR TITLE
Fix issue with missing coins

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -58,9 +58,9 @@ async def subscribe_to_phs(
     """
     msg = wallet_protocol.RegisterForPhUpdates(puzzle_hashes, uint32(max(min_height, uint32(0))))
     all_coins_state: Optional[RespondToPhUpdates] = await peer.register_interest_in_puzzle_hash(msg)
-    if all_coins_state is not None:
-        return all_coins_state.coin_states
-    return []
+    if all_coins_state is None:
+        raise ValueError(f"None response from peer {peer.peer_host} for register_interest_in_puzzle_hash")
+    return all_coins_state.coin_states
 
 
 async def subscribe_to_coin_updates(
@@ -73,9 +73,10 @@ async def subscribe_to_coin_updates(
     """
     msg = wallet_protocol.RegisterForCoinUpdates(coin_names, uint32(max(0, min_height)))
     all_coins_state: Optional[RespondToCoinUpdates] = await peer.register_interest_in_coin(msg)
-    if all_coins_state is not None:
-        return all_coins_state.coin_states
-    return []
+
+    if all_coins_state is None:
+        raise ValueError(f"None response from peer {peer.peer_host} for register_interest_in_coin")
+    return all_coins_state.coin_states
 
 
 def validate_additions(

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -57,7 +57,7 @@ async def subscribe_to_phs(
     Tells full nodes that we are interested in puzzle hashes, and returns the response.
     """
     msg = wallet_protocol.RegisterForPhUpdates(puzzle_hashes, uint32(max(min_height, uint32(0))))
-    all_coins_state: Optional[RespondToPhUpdates] = await peer.register_interest_in_puzzle_hash(msg, timeout=120)
+    all_coins_state: Optional[RespondToPhUpdates] = await peer.register_interest_in_puzzle_hash(msg, timeout=300)
     if all_coins_state is None:
         raise ValueError(f"None response from peer {peer.peer_host} for register_interest_in_puzzle_hash")
     return all_coins_state.coin_states
@@ -72,7 +72,7 @@ async def subscribe_to_coin_updates(
     Tells full nodes that we are interested in coin ids, and returns the response.
     """
     msg = wallet_protocol.RegisterForCoinUpdates(coin_names, uint32(max(0, min_height)))
-    all_coins_state: Optional[RespondToCoinUpdates] = await peer.register_interest_in_coin(msg, timeout=120)
+    all_coins_state: Optional[RespondToCoinUpdates] = await peer.register_interest_in_coin(msg, timeout=300)
 
     if all_coins_state is None:
         raise ValueError(f"None response from peer {peer.peer_host} for register_interest_in_coin")

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -57,7 +57,7 @@ async def subscribe_to_phs(
     Tells full nodes that we are interested in puzzle hashes, and returns the response.
     """
     msg = wallet_protocol.RegisterForPhUpdates(puzzle_hashes, uint32(max(min_height, uint32(0))))
-    all_coins_state: Optional[RespondToPhUpdates] = await peer.register_interest_in_puzzle_hash(msg)
+    all_coins_state: Optional[RespondToPhUpdates] = await peer.register_interest_in_puzzle_hash(msg, timeout=120)
     if all_coins_state is None:
         raise ValueError(f"None response from peer {peer.peer_host} for register_interest_in_puzzle_hash")
     return all_coins_state.coin_states
@@ -72,7 +72,7 @@ async def subscribe_to_coin_updates(
     Tells full nodes that we are interested in coin ids, and returns the response.
     """
     msg = wallet_protocol.RegisterForCoinUpdates(coin_names, uint32(max(0, min_height)))
-    all_coins_state: Optional[RespondToCoinUpdates] = await peer.register_interest_in_coin(msg)
+    all_coins_state: Optional[RespondToCoinUpdates] = await peer.register_interest_in_coin(msg, timeout=120)
 
     if all_coins_state is None:
         raise ValueError(f"None response from peer {peer.peer_host} for register_interest_in_coin")

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -707,9 +707,11 @@ class WalletNode:
         for states in chunks(items, chunk_size):
             if self.server is None:
                 self.log.error("No server")
+                await asyncio.gather(*all_tasks)
                 return False
             if peer.peer_node_id not in self.server.all_connections:
                 self.log.error(f"Disconnected from peer {peer.peer_node_id} host {peer.peer_host}")
+                await asyncio.gather(*all_tasks)
                 return False
             if trusted:
                 async with self.wallet_state_manager.db_wrapper.lock:
@@ -737,6 +739,7 @@ class WalletNode:
                     await asyncio.sleep(0.1)
                     if self._shut_down:
                         self.log.info("Terminating receipt and validation due to shut down request")
+                        await asyncio.gather(*all_tasks)
                         return False
                 concurrent_tasks_cs_heights.append(last_change_height_cs(states[0]))
                 all_tasks.append(asyncio.create_task(receive_and_validate(states, idx, concurrent_tasks_cs_heights)))


### PR DESCRIPTION
For very large wallets, `register_interest_in_puzzle_hash` can take a long time, due to a large amount of data being downloaded. If it timed out, it would return [], and syncing would continue. It would quickly succeed syncing, and then set the height in long_sync, to a really high height. Subsequent syncs would start syncing from that very high height.

Eventually, a secondary sync might happen and the missing coins should show up anyway, without this change. If you have so many coins that it always times out, you would be in trouble. The  timeout was also changed from 60 -> 300 to reduce the chance of this happening.