### PR TITLE
farmer|rpc: Some changes to `get_harvesters{_summary}` RPC endpoints

### DIFF
--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -40,7 +40,7 @@ class Sync:
     plots_processed: uint32 = uint32(0)
     plots_total: uint32 = uint32(0)
     delta: Delta = field(default_factory=Delta)
-    time_done: float = 0
+    time_done: Optional[float] = None
 
     def bump_next_message_id(self) -> None:
         self.next_message_id = uint64(self.next_message_id + 1)
@@ -289,7 +289,7 @@ class Receiver:
         await self._process(self._sync_done, ProtocolMessageTypes.plot_sync_done, data)
 
     def to_dict(self, counts_only: bool = False) -> Dict[str, Any]:
-        result: Dict[str, Any] = {
+        return {
             "connection": {
                 "node_id": self._connection.peer_node_id,
                 "host": self._connection.peer_host,
@@ -299,7 +299,5 @@ class Receiver:
             "failed_to_open_filenames": get_list_or_len(self._invalid, counts_only),
             "no_key_filenames": get_list_or_len(self._keys_missing, counts_only),
             "duplicates": get_list_or_len(self._duplicates, counts_only),
+            "last_sync_time": self._last_sync.time_done,
         }
-        if self._last_sync.time_done != 0:
-            result["last_sync_time"] = self._last_sync.time_done
-        return result

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -302,6 +302,13 @@ class Receiver:
         await self._process(self._sync_done, ProtocolMessageTypes.plot_sync_done, data)
 
     def to_dict(self, counts_only: bool = False) -> Dict[str, Any]:
+        syncing = None
+        if self._current_sync.in_progress():
+            syncing = {
+                "initial": self.initial_sync(),
+                "plot_files_processed": self._current_sync.plots_processed,
+                "plot_files_total": self._current_sync.plots_total,
+            }
         return {
             "connection": {
                 "node_id": self._connection.peer_node_id,
@@ -313,12 +320,6 @@ class Receiver:
             "no_key_filenames": get_list_or_len(self._keys_missing, counts_only),
             "duplicates": get_list_or_len(self._duplicates, counts_only),
             "total_plot_size": self._total_plot_size,
-            "syncing": {
-                "initial": self.initial_sync(),
-                "plot_files_processed": self._current_sync.plots_processed,
-                "plot_files_total": self._current_sync.plots_total,
-            }
-            if self._current_sync.in_progress()
-            else None,
+            "syncing": syncing,
             "last_sync_time": self._last_sync.time_done,
         }

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -315,8 +315,8 @@ class Receiver:
             "total_plot_size": self._total_plot_size,
             "syncing": {
                 "initial": self.initial_sync(),
-                "plot_files_processed": self.current_sync().plots_processed,
-                "plot_files_total": self.current_sync().plots_total,
+                "plot_files_processed": self._current_sync.plots_processed,
+                "plot_files_total": self._current_sync.plots_total,
             }
             if self._current_sync.in_progress()
             else None,

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -42,6 +42,9 @@ class Sync:
     delta: Delta = field(default_factory=Delta)
     time_done: Optional[float] = None
 
+    def in_progress(self) -> bool:
+        return self.sync_id != 0
+
     def bump_next_message_id(self) -> None:
         self.next_message_id = uint64(self.next_message_id + 1)
 
@@ -87,6 +90,9 @@ class Receiver:
 
     def last_sync(self) -> Sync:
         return self._last_sync
+
+    def initial_sync(self) -> bool:
+        return self._last_sync.sync_id == 0
 
     def plots(self) -> Dict[str, Plot]:
         return self._plots
@@ -299,5 +305,12 @@ class Receiver:
             "failed_to_open_filenames": get_list_or_len(self._invalid, counts_only),
             "no_key_filenames": get_list_or_len(self._keys_missing, counts_only),
             "duplicates": get_list_or_len(self._duplicates, counts_only),
+            "syncing": {
+                "initial": self.initial_sync(),
+                "plot_files_processed": self.current_sync().plots_processed,
+                "plot_files_total": self.current_sync().plots_total,
+            }
+            if self._current_sync.in_progress()
+            else None,
             "last_sync_time": self._last_sync.time_done,
         }

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -60,6 +60,7 @@ class Receiver:
     _invalid: List[str]
     _keys_missing: List[str]
     _duplicates: List[str]
+    _total_plot_size: int
     _update_callback: Callable[[bytes32, Delta], Coroutine[Any, Any, None]]
 
     def __init__(
@@ -72,6 +73,7 @@ class Receiver:
         self._invalid = []
         self._keys_missing = []
         self._duplicates = []
+        self._total_plot_size = 0
         self._update_callback = update_callback  # type: ignore[assignment, misc]
 
     def reset(self) -> None:
@@ -81,6 +83,7 @@ class Receiver:
         self._invalid.clear()
         self._keys_missing.clear()
         self._duplicates.clear()
+        self._total_plot_size = 0
 
     def connection(self) -> WSChiaConnection:
         return self._connection
@@ -105,6 +108,9 @@ class Receiver:
 
     def duplicates(self) -> List[str]:
         return self._duplicates
+
+    def total_plot_size(self) -> int:
+        return self._total_plot_size
 
     async def _process(
         self, method: Callable[[_T_Streamable], Any], message_type: ProtocolMessageTypes, message: Any
@@ -282,6 +288,7 @@ class Receiver:
         self._invalid = self._current_sync.delta.invalid.additions.copy()
         self._keys_missing = self._current_sync.delta.keys_missing.additions.copy()
         self._duplicates = self._current_sync.delta.duplicates.additions.copy()
+        self._total_plot_size = sum(plot.file_size for plot in self._plots.values())
         # Save current sync as last sync and create a new current sync
         self._last_sync = self._current_sync
         self._current_sync = Sync()
@@ -305,6 +312,7 @@ class Receiver:
             "failed_to_open_filenames": get_list_or_len(self._invalid, counts_only),
             "no_key_filenames": get_list_or_len(self._keys_missing, counts_only),
             "duplicates": get_list_or_len(self._duplicates, counts_only),
+            "total_plot_size": self._total_plot_size,
             "syncing": {
                 "initial": self.initial_sync(),
                 "plot_files_processed": self.current_sync().plots_processed,

--- a/tests/plot_sync/test_receiver.py
+++ b/tests/plot_sync/test_receiver.py
@@ -263,11 +263,14 @@ async def test_to_dict(counts_only: bool) -> None:
 
         sync_data = receiver.to_dict()["syncing"]
         if state == State.done:
-            assert sync_data is None
+            expected_sync_data = None
         else:
-            assert sync_data["initial"]
-            assert sync_data["plot_files_processed"] == expected_plot_files_processed
-            assert sync_data["plot_files_total"] == expected_plot_files_total
+            expected_sync_data = {
+                "initial": True,
+                "plot_files_processed": expected_plot_files_processed,
+                "plot_files_total": expected_plot_files_total,
+            }
+        assert sync_data == expected_sync_data
 
     plot_sync_dict_3 = receiver.to_dict(counts_only)
     assert get_list_or_len(sync_steps[State.loaded].args[0], counts_only) == plot_sync_dict_3["plots"]
@@ -290,10 +293,11 @@ async def test_to_dict(counts_only: bool) -> None:
             uint32(1),
         )
     )
-    sync_data = receiver.to_dict()["syncing"]
-    assert not sync_data["initial"]
-    assert sync_data["plot_files_processed"] == 0
-    assert sync_data["plot_files_total"] == 1
+    assert receiver.to_dict()["syncing"] == {
+        "initial": False,
+        "plot_files_processed": 0,
+        "plot_files_total": 1,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/plot_sync/test_receiver.py
+++ b/tests/plot_sync/test_receiver.py
@@ -235,7 +235,7 @@ async def test_to_dict(counts_only: bool) -> None:
     assert get_list_or_len(plot_sync_dict_1["plots"], not counts_only) == 10
     assert get_list_or_len(plot_sync_dict_1["failed_to_open_filenames"], not counts_only) == 0
     assert get_list_or_len(plot_sync_dict_1["no_key_filenames"], not counts_only) == 0
-    assert "last_sync_time" not in plot_sync_dict_1
+    assert plot_sync_dict_1["last_sync_time"] is None
     assert plot_sync_dict_1["connection"] == {
         "node_id": receiver.connection().peer_node_id,
         "host": receiver.connection().peer_host,

--- a/tests/plot_sync/test_receiver.py
+++ b/tests/plot_sync/test_receiver.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import random
 import time
 from secrets import token_bytes
 from typing import Any, Callable, List, Tuple, Type, Union
@@ -168,7 +169,7 @@ def plot_sync_setup() -> Tuple[Receiver, List[SyncStepData]]:
             pool_contract_puzzle_hash=None,
             pool_public_key=None,
             plot_public_key=G1Element(),
-            file_size=uint64(0),
+            file_size=uint64(random.randint(0, 100)),
             time_modified=uint64(0),
         )
         for x in path_list
@@ -176,6 +177,7 @@ def plot_sync_setup() -> Tuple[Receiver, List[SyncStepData]]:
 
     # Manually add the plots we want to remove in tests
     receiver._plots = {plot_info.filename: plot_info for plot_info in plot_info_list[0:10]}
+    receiver._total_plot_size = sum(plot.file_size for plot in receiver._plots.values())
 
     sync_steps: List[SyncStepData] = [
         SyncStepData(State.idle, receiver.sync_started, PlotSyncStart, False, uint64(0), uint32(len(plot_info_list))),
@@ -235,6 +237,7 @@ async def test_to_dict(counts_only: bool) -> None:
     assert get_list_or_len(plot_sync_dict_1["plots"], not counts_only) == 10
     assert get_list_or_len(plot_sync_dict_1["failed_to_open_filenames"], not counts_only) == 0
     assert get_list_or_len(plot_sync_dict_1["no_key_filenames"], not counts_only) == 0
+    assert plot_sync_dict_1["total_plot_size"] == sum(plot.file_size for plot in receiver.plots().values())
     assert plot_sync_dict_1["syncing"] is None
     assert plot_sync_dict_1["last_sync_time"] is None
     assert plot_sync_dict_1["connection"] == {
@@ -274,6 +277,7 @@ async def test_to_dict(counts_only: bool) -> None:
     assert get_list_or_len(sync_steps[State.keys_missing].args[0], counts_only) == plot_sync_dict_3["no_key_filenames"]
     assert get_list_or_len(sync_steps[State.duplicates].args[0], counts_only) == plot_sync_dict_3["duplicates"]
 
+    assert plot_sync_dict_3["total_plot_size"] == sum(plot.file_size for plot in receiver.plots().values())
     assert plot_sync_dict_3["last_sync_time"] > 0
     assert plot_sync_dict_3["syncing"] is None
 


### PR DESCRIPTION
This is part of the farm GUI enhancements and changes the output of a harvester entry in the `get_harvesters` farmer RPC as well as in the output of the `get_harvesters_summary` endpoint introduced in #11245.

Changes:
- Adds the new field `syncing` which contains either `null` if there is no sync in progress or the following object during a sync event
```
{
  "initial": True if the this is the first sync from the harvester to the farmer and False if its just an repeated/diff sync
  "plot_files_processed": Number of plots already processed
  "plot_files_total": Number of all plot files which will be processed in this sync event
}
```
- Adds the new filed `total_plot_size` which contains the sum of file sizes for all valid plots of the harvester.
- Always include the `last_sync_time` field and set it to `null` if the receiver is not yet synced. The field was prior to this patch just not included if the receiver wasn't synced.

Based on #11267