### PR TITLE
cmds: Adjust stop daemon output

### DIFF
--- a/chia/cmds/stop.py
+++ b/chia/cmds/stop.py
@@ -17,7 +17,7 @@ async def async_stop(root_path: Path, group: str, stop_daemon: bool) -> int:
     if stop_daemon:
         r = await daemon.exit()
         await daemon.close()
-        if "data" in r and "success" in r["data"] and r["data"]["success"]:
+        if r.get("data", {}).get("success", False):
             print("Daemon stopped")
         else:
             print(f"Stop daemon failed {r}")

--- a/chia/cmds/stop.py
+++ b/chia/cmds/stop.py
@@ -17,7 +17,10 @@ async def async_stop(root_path: Path, group: str, stop_daemon: bool) -> int:
     if stop_daemon:
         r = await daemon.exit()
         await daemon.close()
-        print(f"daemon: {r}")
+        if "data" in r and "success" in r["data"] and r["data"]["success"]:
+            print("Daemon stopped")
+        else:
+            print(f"Stop daemon failed {r}")
         return 0
 
     return_val = 0


### PR DESCRIPTION
Stopping the daemon without this patch prints:

```
daemon: {'ack': True, 'command': 'exit', 'data': {'success': True}, 
'destination': 'client', 'origin': 'daemon', 'request_id': 'some 
request_id hash here'}
```

Stopping the daemon with this patch prints: 

```
Daemon stopped
```

and if it fails:

```
Stop daemon failed {'ack': True, 'command': 'exit', 'data': {'success': 
True}, 
'destination': 'client', 'origin': 'daemon', 'request_id': 'some 
request_id hash here'}
```