### PR TITLE
Updated warning about CHIA_ROOT being set when running init

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -430,6 +430,9 @@ def chia_init(
     protected Keychain. When launching the daemon from the GUI, we want the GUI to
     handle unlocking the keychain.
     """
+    if os.environ.get("CHIA_ROOT", None) is not None:
+        print(f"CHIA_ROOT is set to {os.environ['CHIA_ROOT']}.")
+
     print(f"Chia directory {root_path}")
     if root_path.is_dir() and Path(root_path / "config" / "config.yaml").exists():
         # This is reached if CHIA_ROOT is set, or if user has run chia init twice

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -430,13 +430,6 @@ def chia_init(
     protected Keychain. When launching the daemon from the GUI, we want the GUI to
     handle unlocking the keychain.
     """
-    if os.environ.get("CHIA_ROOT", None) is not None:
-        print(
-            f"warning, your CHIA_ROOT is set to {os.environ['CHIA_ROOT']}. "
-            f"Please unset the environment variable and run chia init again\n"
-            f"or manually migrate config.yaml"
-        )
-
     print(f"Chia directory {root_path}")
     if root_path.is_dir() and Path(root_path / "config" / "config.yaml").exists():
         # This is reached if CHIA_ROOT is set, or if user has run chia init twice

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -430,8 +430,9 @@ def chia_init(
     protected Keychain. When launching the daemon from the GUI, we want the GUI to
     handle unlocking the keychain.
     """
-    if os.environ.get("CHIA_ROOT", None) is not None:
-        print(f"CHIA_ROOT is set to {os.environ['CHIA_ROOT']}.")
+    chia_root = os.environ.get("CHIA_ROOT", None)
+    if chia_root is not None:
+        print(f"CHIA_ROOT is set to {chia_root}")
 
     print(f"Chia directory {root_path}")
     if root_path.is_dir() and Path(root_path / "config" / "config.yaml").exists():


### PR DESCRIPTION
The part that instructs the user to remove CHIA_ROOT is no longer necessary, but leaving the output that CHIA_ROOT is set, for clarity