### PR TITLE
Wallet Allow Unsynced

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -510,16 +510,17 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
 
     is_synced: bool = await wallet_client.get_synced()
     is_syncing: bool = await wallet_client.get_sync_status()
+    allow_unsynced_node: bool = config.get("allow_unsynced_full_node", False)
 
     print(f"Wallet height: {await wallet_client.get_height_info()}")
     if is_syncing:
         print("Sync status: Syncing...")
-    elif is_synced:
+    elif is_synced or allow_unsynced_node:
         print("Sync status: Synced")
     else:
         print("Sync status: Not synced")
 
-    if not is_syncing and is_synced:
+    if not is_syncing and (is_synced or allow_unsynced_node):
         if len(summaries_response) == 0:
             type_hint = " " if wallet_type is None else f" from type {wallet_type.name} "
             print(f"\nNo wallets{type_hint}available for fingerprint: {fingerprint}")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -506,16 +506,17 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
         wallet_type = WalletType(args["type"])
     summaries_response = await wallet_client.get_wallets(wallet_type)
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    wallet_config = config.get("wallet", {})
     address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
 
     is_synced: bool = await wallet_client.get_synced()
     is_syncing: bool = await wallet_client.get_sync_status()
-    allow_unsynced_node: bool = config.get("allow_unsynced_full_node", False)
+    allow_unsynced_node: bool = wallet_config.get("allow_unsynced_full_node", False)
 
     print(f"Wallet height: {await wallet_client.get_height_info()}")
     if is_syncing:
         print("Sync status: Syncing...")
-    elif is_synced or allow_unsynced_node:
+    elif is_synced:
         print("Sync status: Synced")
     else:
         print("Sync status: Not synced")

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -501,6 +501,9 @@ wallet:
   multiprocessing_start_method: default
 
   testing: False
+  # Allow unsynced full node will allow syncing the wallet from an unsynced full node
+  # Useful in edge cases like syncing an offline wallet from a backup/snapshot of a full node DB w/ an offline node
+  allow_unsynced_full_node: False
   # v2 used by the light wallet sync protocol
   database_path: wallet/db/blockchain_wallet_v2_CHALLENGE_KEY.sqlite
   # wallet_peers_path is deprecated and has been replaced by wallet_peers_file_path

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -889,7 +889,8 @@ class WalletNode:
         header_block: HeaderBlock = response.header_block
 
         latest_timestamp: Optional[uint64] = await self.is_peer_synced(peer, header_block, request_time)
-        if latest_timestamp is None:
+        allow_unsynced_node = self.config.get("allow_unsynced_full_node", False)
+        if latest_timestamp is None and not allow_unsynced_node:
             if trusted:
                 self.log.debug(f"Trusted peer {peer.get_peer_info()} is not synced.")
                 return


### PR DESCRIPTION
Allows syncing from an unsynced node, if this configuration flag is set. Useful in cases like syncing an offline cold wallet. With this enabled, and chia installed from the cli deb, or some other method, a backup DB can be provided to the node via USB or some other method, this configuration option enabled, and the wallet will sync up to the point of the DB provided. 