### PR TITLE
Add wallet_id as derivation_paths primary key with puzzle_hash

### DIFF
--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -40,11 +40,12 @@ class WalletPuzzleStore:
                 "CREATE TABLE IF NOT EXISTS derivation_paths("
                 "derivation_index int,"
                 " pubkey text,"
-                " puzzle_hash text PRIMARY KEY,"
+                " puzzle_hash text,"
                 " wallet_type int,"
                 " wallet_id int,"
                 " used tinyint,"
-                " hardened tinyint)"
+                " hardened tinyint,"
+                " PRIMARY KEY(puzzle_hash, wallet_id))"
             )
         )
         await self.db_connection.execute(


### PR DESCRIPTION
In https://github.com/Chia-Network/chia-blockchain/pull/10273 (released in 1.3.4) the `derivation_paths` table was given a primary key by correcting the typo `PRIMARY_KEY`.  Up until then when `WalletPuzzleStore.add_derivation_paths()` executed `INSERT OR REPLACE INTO derivation_paths` every new row was considered unique since there was no primary key to match.  With the correction, any addition would replace instead of inserting if the puzzle hash matched.  This means that adding the same puzzle hash for new wallet id would replace the existing entry.  This does not seem like the intended behavior and caused trouble in the datalayer work.

Draft for:
- [x] General discussion
- [x] Consideration of implications to 1.3.4
  - It seems that the issue is not exercised by current main or released code.
- [x] Should this be included in 1.3.5
  - No need to rush this out.
- [ ] How to handle migration
  - Properly...
  - There is no change to other queries so no need to track versioning for basic functionality.  This change can be put in place now such that it affects new DBs.  In the future we may choose to force an upgrade on this.