### PR TITLE
farmer|rpc|tests: Implement paginated harvester plot endpoints

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -650,10 +650,10 @@ class Farmer:
 
         return {"harvesters": harvesters}
 
-    def get_receiver(self, peer_id: bytes32) -> Receiver:
-        receiver: Optional[Receiver] = self.plot_sync_receivers.get(peer_id)
+    def get_receiver(self, node_id: bytes32) -> Receiver:
+        receiver: Optional[Receiver] = self.plot_sync_receivers.get(node_id)
         if receiver is None:
-            raise KeyError(f"Receiver missing for {peer_id}")
+            raise KeyError(f"Receiver missing for {node_id}")
         return receiver
 
     async def _periodically_update_pool_state_task(self):

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -650,6 +650,12 @@ class Farmer:
 
         return {"harvesters": harvesters}
 
+    def get_receiver(self, peer_id: bytes32) -> Receiver:
+        receiver: Optional[Receiver] = self.plot_sync_receivers.get(peer_id)
+        if receiver is None:
+            raise KeyError(f"Receiver missing for {peer_id}")
+        return receiver
+
     async def _periodically_update_pool_state_task(self):
         time_slept: uint64 = uint64(0)
         config_path: Path = config_path_for_filename(self._root_path, "config.yaml")

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -15,7 +15,7 @@ from chia.util.ws_message import WsRpcMessage, create_payload_dict
 
 
 class PaginatedRequestData(Protocol):
-    peer_id: bytes32
+    node_id: bytes32
     page: int
     page_size: int
 
@@ -28,7 +28,7 @@ class FilterItem:
 
 @dataclasses.dataclass
 class PlotInfoRequestData:
-    peer_id: bytes32
+    node_id: bytes32
     page: int
     page_size: int
     filter: List[FilterItem] = dataclasses.field(default_factory=list)
@@ -38,7 +38,7 @@ class PlotInfoRequestData:
 
 @dataclasses.dataclass
 class PlotPathRequestData:
-    peer_id: bytes32
+    node_id: bytes32
     page: int
     page_size: int
     filter: List[str] = dataclasses.field(default_factory=list)
@@ -48,7 +48,7 @@ class PlotPathRequestData:
 def paginated_plot_request(source: List[Any], request: PaginatedRequestData) -> Dict[str, object]:
     paginator: Paginator = Paginator(source, request.page_size)
     return {
-        "peer_id": request.peer_id.hex(),
+        "node_id": request.node_id.hex(),
         "page": request.page,
         "page_count": paginator.page_count(),
         "total_count": len(source),
@@ -224,7 +224,7 @@ class FarmerRpcApi:
     async def get_harvester_plots_valid(self, request_dict: Dict[str, object]) -> Dict[str, object]:
         # TODO: Consider having a extra List[PlotInfo] in Receiver to avoid rebuilding the list for each call
         request = dataclass_from_dict(PlotInfoRequestData, request_dict)
-        plot_list = list(self.service.get_receiver(request.peer_id).plots().values())
+        plot_list = list(self.service.get_receiver(request.node_id).plots().values())
         # Apply filter
         plot_list = [
             plot for plot in plot_list if all(plot_matches_filter(plot, filter_item) for filter_item in request.filter)
@@ -241,7 +241,7 @@ class FarmerRpcApi:
         self, source_func: Callable[[Receiver], List[str]], request_dict: Dict[str, object]
     ) -> Dict[str, object]:
         request: PlotPathRequestData = dataclass_from_dict(PlotPathRequestData, request_dict)
-        receiver = self.service.get_receiver(request.peer_id)
+        receiver = self.service.get_receiver(request.node_id)
         source = source_func(receiver)
         request = dataclass_from_dict(PlotPathRequestData, request_dict)
         # Apply filter

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -242,8 +242,7 @@ class FarmerRpcApi:
         source = source_func(receiver)
         request = dataclass_from_dict(PlotPathRequestData, request_dict)
         # Apply filter
-        for filter_item in request.filter:
-            source = [plot for plot in source if filter_item in plot]
+        source = [plot for plot in source if all(filter_item in plot for filter_item in request.filter)]
         # Apply reverse
         source = sorted(source, reverse=request.reverse)
         return paginated_plot_request(source, request)

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -9,7 +9,6 @@ from chia.plot_sync.receiver import Receiver
 from chia.protocols.harvester_protocol import Plot
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.misc import KeyValue
 from chia.util.paginator import Paginator
 from chia.util.streamable import dataclass_from_dict
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
@@ -22,11 +21,17 @@ class PaginatedRequestData(Protocol):
 
 
 @dataclasses.dataclass
+class FilterItem:
+    key: str
+    value: Optional[str]
+
+
+@dataclasses.dataclass
 class PlotInfoRequestData:
     peer_id: bytes32
     page: int
     page_size: int
-    filter: List[KeyValue] = dataclasses.field(default_factory=list)
+    filter: List[FilterItem] = dataclasses.field(default_factory=list)
     sort_key: str = "filename"
     reverse: bool = False
 
@@ -51,7 +56,7 @@ def paginated_plot_request(source: List[Any], request: PaginatedRequestData) -> 
     }
 
 
-def plot_matches_filter(plot: Plot, filter_item: KeyValue) -> bool:
+def plot_matches_filter(plot: Plot, filter_item: FilterItem) -> bool:
     plot_attribute = getattr(plot, filter_item.key)
     if filter_item.value is None:
         return plot_attribute is None

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -227,8 +227,7 @@ class FarmerRpcApi:
             request = dataclass_from_dict(PlotInfoRequestData, request_dict)
             plot_list = list(self.service.get_receiver(request.peer_id).plots().values())
             # Apply filter
-            for filter_item in request.filter:
-                plot_list = [plot for plot in plot_list if is_filter_match(plot, filter_item)]
+            plot_list = [plot for plot in plot_list if all(is_filter_match(plot, filter_item) for filter_item in request.filter)]
             restricted_sort_keys: List[str] = ["pool_contract_puzzle_hash", "pool_public_key", "plot_public_key"]
             # Apply sort_key and reverse if sort_key is not restricted
             if request.sort_key in restricted_sort_keys:

--- a/chia/rpc/farmer_rpc_client.py
+++ b/chia/rpc/farmer_rpc_client.py
@@ -1,7 +1,9 @@
 from typing import Any, Dict, List, Optional
 
+from chia.rpc.farmer_rpc_api import PlotInfoRequestData, PlotPathRequestData
 from chia.rpc.rpc_client import RpcClient
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.misc import dataclass_to_json_dict
 
 
 class FarmerRpcClient(RpcClient):
@@ -57,6 +59,18 @@ class FarmerRpcClient(RpcClient):
 
     async def get_harvesters_summary(self) -> Dict[str, object]:
         return await self.fetch("get_harvesters_summary", {})
+
+    async def get_harvester_plots_valid(self, request: PlotInfoRequestData) -> Dict[str, Any]:
+        return await self.fetch("get_harvester_plots_valid", dataclass_to_json_dict(request))
+
+    async def get_harvester_plots_invalid(self, request: PlotPathRequestData) -> Dict[str, Any]:
+        return await self.fetch("get_harvester_plots_invalid", dataclass_to_json_dict(request))
+
+    async def get_harvester_plots_keys_missing(self, request: PlotPathRequestData) -> Dict[str, Any]:
+        return await self.fetch("get_harvester_plots_keys_missing", dataclass_to_json_dict(request))
+
+    async def get_harvester_plots_duplicates(self, request: PlotPathRequestData) -> Dict[str, Any]:
+        return await self.fetch("get_harvester_plots_duplicates", dataclass_to_json_dict(request))
 
     async def get_pool_login_link(self, launcher_id: bytes32) -> Optional[str]:
         try:

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -1,4 +1,7 @@
-from typing import Sequence, Union
+import dataclasses
+from typing import Any, Dict, Optional, Sequence, Union
+
+from chia.util.streamable import recurse_jsonify
 
 
 def format_bytes(bytes: int) -> str:
@@ -75,3 +78,13 @@ def prompt_yes_no(prompt: str = "(y/n) ") -> bool:
 
 def get_list_or_len(list_in: Sequence[object], length: bool) -> Union[int, Sequence[object]]:
     return len(list_in) if length else list_in
+
+
+def dataclass_to_json_dict(instance: Any) -> Dict[str, Any]:
+    return recurse_jsonify(dataclasses.asdict(instance))
+
+
+@dataclasses.dataclass
+class KeyValue:
+    key: str
+    value: Optional[str]

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Sequence, Union
 
 from chia.util.streamable import recurse_jsonify
 
@@ -82,9 +82,3 @@ def get_list_or_len(list_in: Sequence[object], length: bool) -> Union[int, Seque
 
 def dataclass_to_json_dict(instance: Any) -> Dict[str, Any]:
     return recurse_jsonify(dataclasses.asdict(instance))
-
-
-@dataclasses.dataclass
-class KeyValue:
-    key: str
-    value: Optional[str]

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -1,12 +1,26 @@
 import logging
+import operator
 import time
+from math import ceil
+from os import mkdir
+from pathlib import Path
+from shutil import copy
+from typing import Any, Awaitable, Callable, Dict, List, Union, cast
 
 import pytest
 import pytest_asyncio
 
 from chia.consensus.coinbase import create_puzzlehash_for_pk
+from chia.plot_sync.receiver import Receiver
+from chia.plotting.util import add_plot_directory
 from chia.protocols import farmer_protocol
-from chia.rpc.farmer_rpc_api import FarmerRpcApi
+from chia.rpc.farmer_rpc_api import (
+    FarmerRpcApi,
+    PaginatedRequestData,
+    PlotInfoRequestData,
+    PlotPathRequestData,
+    is_filter_match,
+)
 from chia.rpc.farmer_rpc_client import FarmerRpcClient
 from chia.rpc.harvester_rpc_api import HarvesterRpcApi
 from chia.rpc.harvester_rpc_client import HarvesterRpcClient
@@ -17,14 +31,24 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, lock_and_load_config, save_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
-from chia.util.misc import get_list_or_len
+from chia.util.misc import KeyValue, get_list_or_len
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
+from tests.block_tools import get_plot_dir
+from tests.plot_sync.test_delta import dummy_plot
 from tests.setup_nodes import setup_harvester_farmer, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from tests.util.rpc import validate_get_routes
 from tests.util.socket import find_available_listen_port
 
 log = logging.getLogger(__name__)
+
+
+async def wait_for_plot_sync(receiver: Receiver, previous_last_sync_id: uint64) -> None:
+    def wait():
+        current_last_sync_id = receiver.last_sync().sync_id
+        return current_last_sync_id != 0 and current_last_sync_id != previous_last_sync_id
+
+    await time_out_assert(30, wait)
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -367,3 +391,158 @@ async def test_farmer_get_pool_state_plot_count(harvester_farmer_environment, se
 
     await time_out_assert(15, remove_all_and_validate, False)
     assert (await farmer_rpc_client.get_pool_state())["pool_state"][0]["plot_count"] == 0
+
+
+@pytest.mark.parametrize(
+    "filter_item, match",
+    [
+        (KeyValue("filename", "1"), True),
+        (KeyValue("filename", "12"), True),
+        (KeyValue("filename", "123"), True),
+        (KeyValue("filename", "1234"), False),
+        (KeyValue("filename", "23"), True),
+        (KeyValue("filename", "3"), True),
+        (KeyValue("filename", "0123"), False),
+        (KeyValue("pool_contract_puzzle_hash", None), True),
+        (KeyValue("pool_contract_puzzle_hash", "1"), False),
+    ],
+)
+def test_is_filter_match(filter_item: KeyValue, match: bool):
+    assert is_filter_match(dummy_plot("123"), filter_item) == match
+    assert is_filter_match({"filename": "123", "pool_contract_puzzle_hash": None}, filter_item) == match
+
+
+@pytest.mark.parametrize(
+    "endpoint, filtering, sort_key, reverse, expected_plot_count",
+    [
+        (FarmerRpcClient.get_harvester_plots_valid, [], "filename", False, 20),
+        (FarmerRpcClient.get_harvester_plots_valid, [], "size", True, 20),
+        (
+            FarmerRpcClient.get_harvester_plots_valid,
+            [KeyValue("pool_contract_puzzle_hash", None)],
+            "file_size",
+            True,
+            15,
+        ),
+        (
+            FarmerRpcClient.get_harvester_plots_valid,
+            [KeyValue("size", "20"), KeyValue("filename", "81")],
+            "plot_id",
+            False,
+            4,
+        ),
+        (FarmerRpcClient.get_harvester_plots_invalid, [], None, True, 13),
+        (FarmerRpcClient.get_harvester_plots_invalid, ["invalid_0"], None, False, 6),
+        (FarmerRpcClient.get_harvester_plots_invalid, ["inval", "lid_1/"], None, False, 2),
+        (FarmerRpcClient.get_harvester_plots_keys_missing, [], None, True, 3),
+        (FarmerRpcClient.get_harvester_plots_keys_missing, ["keys_missing_1"], None, False, 2),
+        (FarmerRpcClient.get_harvester_plots_duplicates, [], None, True, 7),
+        (FarmerRpcClient.get_harvester_plots_duplicates, ["duplicates_0"], None, False, 3),
+    ],
+)
+@pytest.mark.asyncio
+async def test_farmer_get_harvester_plots_endpoints(
+    harvester_farmer_environment: Any,
+    endpoint: Callable[[FarmerRpcClient, PaginatedRequestData], Awaitable[Dict[str, Any]]],
+    filtering: Union[List[KeyValue], List[str]],
+    sort_key: str,
+    reverse: bool,
+    expected_plot_count: int,
+) -> None:
+    (
+        farmer_service,
+        farmer_rpc_api,
+        farmer_rpc_client,
+        harvester_service,
+        harvester_rpc_api,
+        harvester_rpc_client,
+    ) = harvester_farmer_environment
+
+    harvester = harvester_service._node
+    harvester_id = harvester_service._server.node_id
+    receiver = farmer_service._api.farmer.plot_sync_receivers[harvester_id]
+
+    if receiver.initial_sync():
+        await wait_for_plot_sync(receiver, receiver.last_sync().sync_id)
+
+    harvester_plots = (await harvester_rpc_client.get_plots())["plots"]
+    plots = []
+
+    request: PaginatedRequestData
+    if endpoint == FarmerRpcClient.get_harvester_plots_valid:
+        request = PlotInfoRequestData(harvester_id, 0, -1, cast(List[KeyValue], filtering), sort_key, reverse)
+    else:
+        request = PlotPathRequestData(harvester_id, 0, -1, cast(List[str], filtering), reverse)
+
+    def add_plot_directories(prefix: str, count: int) -> List[Path]:
+        new_paths = []
+        for i in range(count):
+            new_paths.append(harvester.root_path / f"{prefix}_{i}")
+            mkdir(new_paths[-1])
+            add_plot_directory(harvester.root_path, str(new_paths[-1]))
+        return new_paths
+
+    # Generate the plot data and
+    if endpoint == FarmerRpcClient.get_harvester_plots_valid:
+        plots = harvester_plots
+    elif endpoint == FarmerRpcClient.get_harvester_plots_invalid:
+        invalid_paths = add_plot_directories("invalid", 3)
+        for dir_index, r in [(0, range(0, 6)), (1, range(6, 8)), (2, range(8, 13))]:
+            plots += [str(invalid_paths[dir_index] / f"{i}.plot") for i in r]
+        for plot in plots:
+            with open(plot, "w"):
+                pass
+    elif endpoint == FarmerRpcClient.get_harvester_plots_keys_missing:
+        keys_missing_plots = [path for path in (Path(get_plot_dir()) / "not_in_keychain").iterdir() if path.is_file()]
+        keys_missing_paths = add_plot_directories("keys_missing", 2)
+        for dir_index, copy_plots in [(0, keys_missing_plots[:1]), (1, keys_missing_plots[1:3])]:
+            for plot in copy_plots:
+                copy(plot, keys_missing_paths[dir_index])
+                plots.append(str(keys_missing_paths[dir_index] / plot.name))
+
+    elif endpoint == FarmerRpcClient.get_harvester_plots_duplicates:
+        duplicate_paths = add_plot_directories("duplicates", 2)
+        for dir_index, r in [(0, range(0, 3)), (1, range(3, 7))]:
+            for i in r:
+                plot_path = Path(harvester_plots[i]["filename"])
+                plots.append(str(duplicate_paths[dir_index] / plot_path.name))
+                copy(plot_path, plots[-1])
+
+    # Sort and filter the data
+    if endpoint == FarmerRpcClient.get_harvester_plots_valid:
+        for filter_item in filtering:
+            assert isinstance(filter_item, KeyValue)
+            plots = [plot for plot in plots if is_filter_match(plot, filter_item)]
+        plots.sort(key=operator.itemgetter(sort_key, "plot_id"), reverse=reverse)
+    else:
+        for filter_item in filtering:
+            plots = [plot for plot in plots if filter_item in plot]
+        plots.sort(reverse=reverse)
+
+    total_count = len(plots)
+    assert total_count > 0
+    assert len(plots) == total_count == expected_plot_count
+
+    last_sync_id = receiver.last_sync().sync_id
+
+    harvester.plot_manager.trigger_refresh()
+    harvester.plot_manager.start_refreshing()
+
+    await wait_for_plot_sync(receiver, last_sync_id)
+
+    for page_size in [1, int(total_count / 2), total_count - 1, total_count, total_count + 1, 100]:
+        request.page_size = page_size
+        expected_page_count = ceil(total_count / page_size)
+        for page in range(expected_page_count):
+            request.page = page
+            page_result = await endpoint(farmer_rpc_client, request)
+            offset = page * page_size
+            expected_plots = plots[offset : offset + page_size]
+            assert page_result == {
+                "success": True,
+                "peer_id": harvester_id.hex(),
+                "page": page,
+                "page_count": expected_page_count,
+                "total_count": total_count,
+                "plots": expected_plots,
+            }

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -541,7 +541,7 @@ async def test_farmer_get_harvester_plots_endpoints(
             expected_plots = plots[offset : offset + page_size]
             assert page_result == {
                 "success": True,
-                "peer_id": harvester_id.hex(),
+                "node_id": harvester_id.hex(),
                 "page": page,
                 "page_count": expected_page_count,
                 "total_count": total_count,

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -520,8 +520,7 @@ async def test_farmer_get_harvester_plots_endpoints(
         plots.sort(reverse=reverse)
 
     total_count = len(plots)
-    assert total_count > 0
-    assert len(plots) == total_count == expected_plot_count
+    assert total_count == expected_plot_count
 
     last_sync_id = receiver.last_sync().sync_id
 


### PR DESCRIPTION
This PR introduces four new farmer RPC endpoints which provide paginated results as well as a `filter`, `sort_key` and `reverse` option: 

- `get_harvester_plots_valid` -> To query the valid plot which are used for the farming
- `get_harvester_plots_invalid` -> To query invalid plots (the ones the harvester couldn't load for whatever reason)
- `get_harvester_plots_keys_missing` -> To query the plots where the farmer is missing the related keys
- `get_harvester_plots_duplicates` -> To query the plots which are duplicated on the harvester


### Request data
The request data for the valid plots endpoint is slightly different because it returns all attributes of a plot, the other endpoints only return the paths of the plots.

#### Valid plots endpoint

```
@dataclasses.dataclass
class PlotInfoRequestData:
    node_id: bytes32
    page: int
    page_size: int
    filter: List[FilterItem] = dataclasses.field(default_factory=list)
    sort_key: str = "filename"
    reverse: bool = False
```

- `node_id` is the node id of the harvester to query plots from 
- `page` the page to query
- `page_size` the number of element per size
- `filter` is a list of key/value pairs which allows to filter any attribute of the plot. (see class `KeyValue` and `Plot` below) The filters will be applied in the same order they are in the list. 
- `sort_key` allows to sort the plot data by any of the keys available in the plot data. See class `Plot` below.
- `reverse` allows to revert the order of the sorting


##### Filter class
```
@dataclasses.dataclass
class FilterItem:
    key: str
    value: str
```


##### Plot class

```
@streamable
@dataclass(frozen=True)
class Plot(Streamable):
    filename: str
    size: uint8
    plot_id: bytes32
    pool_public_key: Optional[G1Element]
    pool_contract_puzzle_hash: Optional[bytes32]
    plot_public_key: G1Element
    file_size: uint64
    time_modified: uint64
```

#### Other plot endpoints 

```
@dataclasses.dataclass
class PlotPathRequestData:
    node_id: bytes32
    page: int
    page_size: int
    filter: List[str] = dataclasses.field(default_factory=list)
    reverse: bool = False
```

- `node_id` is the node id of the harvester to query plots from 
- `page` the page to query
- `page_size` the number of element per size
- `filter` is a list of strings which allows to filter for the path. The filters will be applied in the same order they are in the list. 
- `reverse` allows to revert the order of the sorting


### Valid plots example request

```
chia rpc farmer get_harvester_plots_valid '{"node_id": "0xb429aab1fe8686c6163ae442fa45ddcdef301d751adfa6855c
54f2d4d6a1a747", "page": 2, "page_size": 1, "filter": [{"key": "filename", "value": "27-19-4"}], "sort_key": "time_modified", "reverse": 1}'
{
    "page": 2,
    "page_count": 5,
    "node_id": "b429aab1fe8686c6163ae442fa45ddcdef301d751adfa6855c54f2d4d6a1a747",
    "plots": [
        {
            "file_size": 671906245,
            "filename": "/Users/dustinface/chia/plots/testnet10/plot-k25-2022-02-27-19-44-748597cd5d19e21515df1873267ea6ba8e66526f6bd9aa4e15f33c5955bb27bd.plot",
            "plot_id": "0x748597cd5d19e21515df1873267ea6ba8e66526f6bd9aa4e15f33c5955bb27bd",
            "plot_public_key": "0x928df0d5eaab39a3530c1e1925730b0e1b21e485ddc457d9de6ef4f403e7710fe897bc40f0306cc1ba29d423f9bfdc6f",
            "pool_contract_puzzle_hash": "0x9af69ba2e65b27eef27ae5e5293899a7e4d93bf781f6a8c13db1af06af905cfa",
            "pool_public_key": null,
            "size": 25,
            "time_modified": 1645987573
        }
    ],
    "success": true,
    "total_count": 5
}
```

Based on #11247 and #11342