### PR TITLE
farmer|gui: Enable paginated plot loading and improved state reporting

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -256,11 +256,14 @@ class Farmer:
         self.state_changed("close_connection", {})
         if connection.connection_type is NodeType.HARVESTER:
             del self.plot_sync_receivers[connection.peer_node_id]
+            self.state_changed("harvester_removed", {"node_id": connection.peer_node_id})
 
-    async def plot_sync_callback(self, peer_id: bytes32, delta: Delta) -> None:
-        log.info(f"plot_sync_callback: peer_id {peer_id}, delta {delta}")
-        if not delta.empty():
-            self.state_changed("new_plots", await self.get_harvesters())
+    async def plot_sync_callback(self, peer_id: bytes32, delta: Optional[Delta]) -> None:
+        log.debug(f"plot_sync_callback: peer_id {peer_id}, delta {delta}")
+        receiver: Receiver = self.plot_sync_receivers[peer_id]
+        harvester_updated: bool = delta is not None and not delta.empty()
+        if receiver.initial_sync() or harvester_updated:
+            self.state_changed("harvester_update", receiver.to_dict(True))
 
     async def _pool_get_pool_info(self, pool_config: PoolWalletConfig) -> Optional[Dict]:
         try:

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -47,10 +47,19 @@ class FarmerRpcApi:
                     "wallet_ui",
                 )
             )
-        elif change == "new_plots":
+        elif change == "harvester_update":
             payloads.append(
                 create_payload_dict(
-                    "get_harvesters",
+                    "harvester_update",
+                    change_data,
+                    self.service_name,
+                    "wallet_ui",
+                )
+            )
+        elif change == "harvester_removed":
+            payloads.append(
+                create_payload_dict(
+                    "harvester_removed",
                     change_data,
                     self.service_name,
                     "wallet_ui",


### PR DESCRIPTION
This PR pins the new GUI and changes the event which gets sent from the farmer to the GUI which was previously called `new_plots` with the payload of  `get_harvesters` with the plots of all harvesters.


Now with this PR the event gets renamed to `harvester_update` and it:

- Only sends a summary (basically one entry of `get_harvester_summay`) for the harvester which actually sent an update
- Is used to notify for each loaded batch during initial loading of an harvester

There is also a new state changed event called `harvester_removed` which gets triggered by the farmer if the harvester was disconnected and has the payload `{"node_id": <node_id of the harvester which was removed>}`


Based on #11342 and required #11365