### PR TITLE
Correct naming of Windows installer artifacts (the GitHub Actions ones)

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -158,13 +158,13 @@ jobs:
     - name: Upload Windows exe's to artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: chia-installers-windows-exe-intel
+        name: Windows-Exe
         path: ${{ github.workspace }}\chia-blockchain-gui\Chia-win32-x64\
 
     - name: Upload Installer to artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: Windows-Installers
+        name: chia-installers-windows-exe-intel
         path: ${{ github.workspace }}\chia-blockchain-gui\release-builds\
 
     - name: Install AWS CLI


### PR DESCRIPTION
The wrong artifact was renamed in https://github.com/Chia-Network/chia-blockchain/pull/11096.  This corrects that.