### PR TITLE
Keep daemon websocket alive during keyring unlock

### DIFF
--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -1,4 +1,5 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import os
 import subprocess
 import sys
@@ -37,7 +38,8 @@ async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProx
         if await connection.is_keyring_locked():
             passphrase = Keychain.get_cached_master_passphrase()
             if not Keychain.master_passphrase_is_valid(passphrase):
-                passphrase = await asyncio.get_running_loop().run_in_executor(None, get_current_passphrase)
+                with ThreadPoolExecutor(max_workers=1, thread_name_prefix="get_current_passphrase") as executor:
+                    passphrase = await asyncio.get_running_loop().run_in_executor(executor, get_current_passphrase)
 
         if passphrase:
             print("Unlocking daemon keyring")

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -45,6 +45,7 @@ async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProx
                     # create a new connection, unlock the keyring, and then close the old connection.
                     old_connection = connection
                     connection = await connect_to_daemon_and_validate(root_path)
+                    assert connection is not None
 
         if passphrase is not None:
             print("Unlocking daemon keyring")

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -21,7 +21,7 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
 
 
 async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProxy]:
-    connection = await connect_to_daemon_and_validate(root_path)
+    connection: Optional[DaemonProxy] = await connect_to_daemon_and_validate(root_path)
     if connection is None:
         print("Starting daemon")
         # launch a daemon
@@ -32,16 +32,27 @@ async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProx
         await asyncio.sleep(1)
         # it prints "daemon: listening"
         connection = await connect_to_daemon_and_validate(root_path)
-    if connection:
-        passphrase = None
+    if connection is not None:
+        old_connection: Optional[DaemonProxy] = None
+        passphrase: Optional[str] = None
         if await connection.is_keyring_locked():
             passphrase = Keychain.get_cached_master_passphrase()
             if not Keychain.master_passphrase_is_valid(passphrase):
                 passphrase = get_current_passphrase()
+                if passphrase is not None:
+                    # While waiting for for the user to enter their passphrase, it's possible that
+                    # the daemon connection has timed-out. We can't reliably detect this, so we'll
+                    # create a new connection, unlock the keyring, and then close the old connection.
+                    old_connection = connection
+                    connection = await connect_to_daemon_and_validate(root_path)
 
-        if passphrase:
+        if passphrase is not None:
             print("Unlocking daemon keyring")
             await connection.unlock_keyring(passphrase)
+
+        # Close the original connection (which may have already timed-out)
+        if old_connection is not None:
+            await old_connection.close()
 
         return connection
     return None


### PR DESCRIPTION
When prompting to unlock the keyring during daemon launch, it's possible that the daemon websocket connection will  timeout before the user has entered their passphrase. ~We can't quickly detect that the connection has timed-out, so instead we now reconnect after collecting the passphrase, unlock the keyring, and then close the old connection.~ We now collect the passphrase on a separate thread to keep the websocket connection alive and happy.

Testing notes:

Previously, running `chia start farmer`, waiting 60+ seconds at the passphrase prompt, and then entering the passphrase would lead to a 30 second delay before an exception was raised indicating that the daemon connection had been closed.

With the patch, running `chia start farmer`, waiting 60+ seconds at passphrase prompt, and then entering the passphrase --> services started as expected

Tested on macOS, Windows, and Linux