### PR TITLE
Update plotters installation to include an `apt update`

### DIFF
--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -128,6 +128,15 @@ def install_bladebit(root_path):
             [
                 "sudo",
                 "apt",
+                "update",
+                "-y",
+            ],
+            "Could not update get package information from apt",
+        )
+        run_command(
+            [
+                "sudo",
+                "apt",
                 "install",
                 "-y",
                 "build-essential",

--- a/chia/plotters/madmax.py
+++ b/chia/plotters/madmax.py
@@ -79,6 +79,15 @@ def install_madmax(plotters_root_path: Path):
                 [
                     "sudo",
                     "apt",
+                    "update",
+                    "-y",
+                ],
+                "Could not update get package information from apt",
+            )
+            run_command(
+                [
+                    "sudo",
+                    "apt",
                     "install",
                     "-y",
                     "libsodium-dev",


### PR DESCRIPTION
The Madmax and Bladebit plotters are installed automatically when a user tries to use them with the `chia plotters` command.  On  Ubuntu (or similar Linux distros), this means calling `apt` to install dependencies.  Previously, the code jumps straight into an `apt install`, but this causes a failure when trying to install Madmax or Bladebit in our [Chia Docker container](https://github.com/Chia-Network/chia-docker) since Docker does not have any repository information cached or pre-loaded.  This PR adds a step to do `apt update` before calling `apt install` so that repo data is refreshed first, ensuring that the installation command can be completed successfully.  