### PR TITLE
Add libgmp-dev to Bladebit installation

### DIFF
--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -143,6 +143,7 @@ def install_bladebit(root_path):
                 "cmake",
                 "libnuma-dev",
                 "git",
+                "libgmp-dev",
             ],
             "Could not install dependencies",
         )


### PR DESCRIPTION
In our [Chia Docker container](https://github.com/Chia-Network/chia-docker), `chia plotters install bladebit` was failing with an error about a missing gmp library.  I found the library comes from the package `libgmp-dev` which was not installing automatically as a dependency.  This PR adds libgmp-dev to the list of packages installed by `apt` and now the Bladebit installation completes successfully in Docker. 

(I assume most full systems have this gmp library installed vs Docker, which has a minimal set of packages installed, and this is why we haven't seen it fail elsewhere.  It is good to have the full set of dependencies installed regardless for reliability).  