### PR TITLE
cmds: Improve `chia farm summary`

### DIFF
--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -17,14 +17,14 @@ from chia.util.network import is_localhost
 SECONDS_PER_BLOCK = (24 * 3600) / 4608
 
 
-async def get_harvesters(farmer_rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
+async def get_harvesters_summary(farmer_rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
         self_hostname = config["self_hostname"]
         if farmer_rpc_port is None:
             farmer_rpc_port = config["farmer"]["rpc_port"]
         farmer_client = await FarmerRpcClient.create(self_hostname, uint16(farmer_rpc_port), DEFAULT_ROOT_PATH, config)
-        plots = await farmer_client.get_harvesters()
+        plots = await farmer_client.get_harvesters_summary()
     except Exception as e:
         if isinstance(e, aiohttp.ClientConnectorError):
             print(f"Connection error. Check if farmer is running at {farmer_rpc_port}")
@@ -184,7 +184,7 @@ async def summary(
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
 ) -> None:
-    all_harvesters = await get_harvesters(farmer_rpc_port)
+    harvesters_summary = await get_harvesters_summary(farmer_rpc_port)
     blockchain_state = await get_blockchain_state(rpc_port)
     farmer_running = await is_farmer_running(farmer_rpc_port)
 
@@ -221,10 +221,10 @@ async def summary(
         total_plot_size = 0
         total_plots = 0
 
-    if all_harvesters is not None:
-        harvesters_local: dict = {}
-        harvesters_remote: dict = {}
-        for harvester in all_harvesters["harvesters"]:
+    if harvesters_summary is not None:
+        harvesters_local: Dict[str, Dict[str, Any]] = {}
+        harvesters_remote: Dict[str, Dict[str, Any]] = {}
+        for harvester in harvesters_summary["harvesters"]:
             ip = harvester["connection"]["host"]
             if is_localhost(ip):
                 harvesters_local[harvester["connection"]["node_id"]] = harvester
@@ -234,11 +234,12 @@ async def summary(
                 harvesters_remote[ip][harvester["connection"]["node_id"]] = harvester
 
         def process_harvesters(harvester_peers_in: dict):
-            for harvester_peer_id, plots in harvester_peers_in.items():
-                total_plot_size_harvester = sum(map(lambda x: x["file_size"], plots["plots"]))
+            for harvester_peer_id, harvester_dict in harvester_peers_in.items():
+                total_plot_size_harvester = harvester_dict["total_plot_size"]
+                plot_count_harvester = harvester_dict["plots"]
                 PlotStats.total_plot_size += total_plot_size_harvester
-                PlotStats.total_plots += len(plots["plots"])
-                print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
+                PlotStats.total_plots += plot_count_harvester
+                print(f"   {plot_count_harvester} plots of size: {format_bytes(total_plot_size_harvester)}")
 
         if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")
@@ -262,11 +263,11 @@ async def summary(
         print("Estimated network space: Unknown")
 
     minutes = -1
-    if blockchain_state is not None and all_harvesters is not None:
+    if blockchain_state is not None and harvesters_summary is not None:
         proportion = PlotStats.total_plot_size / blockchain_state["space"] if blockchain_state["space"] else -1
         minutes = int((await get_average_block_time(rpc_port) / 60) / proportion) if proportion else -1
 
-    if all_harvesters is not None and PlotStats.total_plots == 0:
+    if harvesters_summary is not None and PlotStats.total_plots == 0:
         print("Expected time to win: Never (no plots)")
     else:
         print("Expected time to win: " + format_minutes(minutes))

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -235,11 +235,15 @@ async def summary(
 
         def process_harvesters(harvester_peers_in: dict):
             for harvester_peer_id, harvester_dict in harvester_peers_in.items():
-                total_plot_size_harvester = harvester_dict["total_plot_size"]
-                plot_count_harvester = harvester_dict["plots"]
-                PlotStats.total_plot_size += total_plot_size_harvester
-                PlotStats.total_plots += plot_count_harvester
-                print(f"   {plot_count_harvester} plots of size: {format_bytes(total_plot_size_harvester)}")
+                syncing = harvester_dict["syncing"]
+                if syncing is not None and syncing["initial"]:
+                    print(f"   Loading plots: {syncing['plot_files_processed']} / {syncing['plot_files_total']}")
+                else:
+                    total_plot_size_harvester = harvester_dict["total_plot_size"]
+                    plot_count_harvester = harvester_dict["plots"]
+                    PlotStats.total_plot_size += total_plot_size_harvester
+                    PlotStats.total_plots += plot_count_harvester
+                    print(f"   {plot_count_harvester} plots of size: {format_bytes(total_plot_size_harvester)}")
 
         if len(harvesters_local) > 0:
             print(f"Local Harvester{'s' if len(harvesters_local) > 1 else ''}")


### PR DESCRIPTION
Use `get_harvester_summary` endpoint and add initial plot loading indication. Looks like below when the harvester starts up:

```
Local Harvester
   Loading plots: 2 / 11
```