### PR TITLE
Bump clvm_tools_rs version for clvm stepper and add a test

### DIFF
--- a/.github/workflows/build-test-macos-clvm.yml
+++ b/.github/workflows/build-test-macos-clvm.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Test clvm code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" tests/clvm/test_chialisp_deserialization.py tests/clvm/test_clvm_compilation.py tests/clvm/test_program.py tests/clvm/test_puzzle_compression.py tests/clvm/test_puzzles.py tests/clvm/test_serialized_program.py tests/clvm/test_singletons.py tests/clvm/test_spend_sim.py
+        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" tests/clvm/test_chialisp_deserialization.py tests/clvm/test_clvm_compilation.py tests/clvm/test_clvm_step.py tests/clvm/test_program.py tests/clvm/test_puzzle_compression.py tests/clvm/test_puzzles.py tests/clvm/test_serialized_program.py tests/clvm/test_singletons.py tests/clvm/test_spend_sim.py
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-clvm.yml
+++ b/.github/workflows/build-test-ubuntu-clvm.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Test clvm code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" -p no:monitor tests/clvm/test_chialisp_deserialization.py tests/clvm/test_clvm_compilation.py tests/clvm/test_program.py tests/clvm/test_puzzle_compression.py tests/clvm/test_puzzles.py tests/clvm/test_serialized_program.py tests/clvm/test_singletons.py tests/clvm/test_spend_sim.py
+        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" -p no:monitor tests/clvm/test_chialisp_deserialization.py tests/clvm/test_clvm_compilation.py tests/clvm/test_clvm_step.py tests/clvm/test_program.py tests/clvm/test_puzzle_compression.py tests/clvm/test_puzzles.py tests/clvm/test_serialized_program.py tests/clvm/test_singletons.py tests/clvm/test_spend_sim.py
 
     - name: Process coverage data
       run: |

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ dependencies = [
     "clvm==0.9.7",
     "clvm_tools==0.4.4",  # Currying, Program.to, other conveniences
     "chia_rs==0.1.1",
-    "clvm-tools-rs==0.1.7",  # Rust implementation of clvm_tools
+    "clvm-tools-rs==0.1.9",  # Rust implementation of clvm_tools
     "aiohttp==3.8.1",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks
     "bitstring==3.1.9",  # Binary data management library

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+import json
+from clvm_tools_rs import start_clvm_program
+
+factorial = 'ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080'
+
+class TestRunProgram(TestCase):
+    def test_simple_program_run(self):
+        p = start_clvm_program(factorial, 'ff0580', {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de":"factorial"})
+
+        last = None
+        location = None
+
+        while not p.is_ended():
+            step_result = p.step()
+            if step_result is not None:
+                last = step_result
+                self.assertTrue('Failure' not in last)
+
+                if 'Operator-Location' in last:
+                    location = last['Operator-Location']
+
+        self.assertEqual(int(last['Final']), 120)
+        self.assertTrue(location.startswith('factorial'))

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
 from clvm_tools_rs import start_clvm_program
 
-factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02" \
-    + "ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ff" \
+factorial = (
+    "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02"
+    + "ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ff"
     + "ff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
 
 

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -8,7 +8,9 @@ factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02fff
 
 class TestRunProgram(TestCase):
     def test_simple_program_run(self):
-        p = start_clvm_program(factorial, "ff0580", {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de":"factorial"})
+        p = start_clvm_program(
+            factorial, "ff0580", {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de":"factorial"}
+        )
 
         last = None
         location = None

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -13,11 +13,11 @@ factorial_sym = {factorial_function_hash: "factorial"}
 
 
 class TestRunProgram(TestCase):
-    def test_simple_program_run(self):
+    def test_simple_program_run(self) -> None:
         p = start_clvm_program(factorial, "ff0580", factorial_sym)
 
-        last = None
-        location = None
+        last: Optional[Any] = None
+        location: Optional[Any] = None
 
         while not p.is_ended():
             step_result = p.step()
@@ -28,5 +28,9 @@ class TestRunProgram(TestCase):
                 if "Operator-Location" in last:
                     location = last["Operator-Location"]
 
-        self.assertEqual(int(last["Final"]), 120)
-        self.assertTrue(location.startswith("factorial"))
+        self.assertTrue(last is not None)
+        self.assertTrue(location is not None)
+        if last is not None and location is not None:
+            self.assertTrue("Final" in last)
+            self.assertEqual(int(last["Final"]), 120)
+            self.assertTrue(location.startswith("factorial"))

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -4,9 +4,7 @@ from clvm_tools_rs import start_clvm_program
 factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
 
 
-factorial_sym = {
-    "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de": "factorial"
-}
+factorial_sym = {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de": "factorial"}
 
 
 class TestRunProgram(TestCase):

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -1,10 +1,14 @@
 from unittest import TestCase
 from clvm_tools_rs import start_clvm_program
 
-factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
+factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02" + \
+    "ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ff" + \
+    "ff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
 
 
-factorial_sym = {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de": "factorial"}
+factorial_function_hash = "de3687023fa0a095d65396f59415a859" + \
+    "dd46fc84ed00504bf4c9724fca08c9de"
+factorial_sym = {factorial_function_hash: "factorial"}
 
 
 class TestRunProgram(TestCase):

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -5,7 +5,7 @@ factorial = (
     "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02"
     + "ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ff"
     + "ff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
-
+)
 
 factorial_function_hash = "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de"
 factorial_sym = {factorial_function_hash: "factorial"}

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from clvm_tools_rs import start_clvm_program
 
 factorial = (

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -1,13 +1,12 @@
 from unittest import TestCase
 from clvm_tools_rs import start_clvm_program
 
-factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02" + \
-    "ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ff" + \
-    "ff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
+factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02" \
+    + "ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ff" \
+    + "ff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
 
 
-factorial_function_hash = "de3687023fa0a095d65396f59415a859" + \
-    "dd46fc84ed00504bf4c9724fca08c9de"
+factorial_function_hash = "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de"
 factorial_sym = {factorial_function_hash: "factorial"}
 
 

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -1,16 +1,17 @@
 from unittest import TestCase
-
-import json
 from clvm_tools_rs import start_clvm_program
 
 factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
 
 
+factorial_sym = {
+    "de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de": "factorial"
+}
+
+
 class TestRunProgram(TestCase):
     def test_simple_program_run(self):
-        p = start_clvm_program(
-            factorial, "ff0580", {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de":"factorial"}
-        )
+        p = start_clvm_program(factorial, "ff0580", factorial_sym)
 
         last = None
         location = None

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -1,3 +1,4 @@
+from typing import Any, Optional
 from unittest import TestCase
 
 from clvm_tools_rs import start_clvm_program

--- a/tests/clvm/test_clvm_step.py
+++ b/tests/clvm/test_clvm_step.py
@@ -3,11 +3,12 @@ from unittest import TestCase
 import json
 from clvm_tools_rs import start_clvm_program
 
-factorial = 'ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080'
+factorial = "ff02ffff01ff02ff02ffff04ff02ffff04ff05ff80808080ffff04ffff01ff02ffff03ffff09ff05ffff010180ffff01ff0101ffff01ff12ff05ffff02ff02ffff04ff02ffff04ffff11ff05ffff010180ff808080808080ff0180ff018080"
+
 
 class TestRunProgram(TestCase):
     def test_simple_program_run(self):
-        p = start_clvm_program(factorial, 'ff0580', {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de":"factorial"})
+        p = start_clvm_program(factorial, "ff0580", {"de3687023fa0a095d65396f59415a859dd46fc84ed00504bf4c9724fca08c9de":"factorial"})
 
         last = None
         location = None
@@ -16,10 +17,10 @@ class TestRunProgram(TestCase):
             step_result = p.step()
             if step_result is not None:
                 last = step_result
-                self.assertTrue('Failure' not in last)
+                self.assertTrue("Failure" not in last)
 
-                if 'Operator-Location' in last:
-                    location = last['Operator-Location']
+                if "Operator-Location" in last:
+                    location = last["Operator-Location"]
 
-        self.assertEqual(int(last['Final']), 120)
-        self.assertTrue(location.startswith('factorial'))
+        self.assertEqual(int(last["Final"]), 120)
+        self.assertTrue(location.startswith("factorial"))


### PR DESCRIPTION
Bump to clvm_tools_rs release which adds a python clvm stepper object based on clvm_tools_rs' cldb.  This can be used to step through clvm code in a logical order, and giving as much details as possible.
Adds a test for this.