### PR TITLE
optimize hash_coin_list()

### DIFF
--- a/.github/workflows/build-test-macos-core.yml
+++ b/.github/workflows/build-test-macos-core.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Test core code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" tests/core/test_cost_calculation.py tests/core/test_crawler_rpc.py tests/core/test_daemon_rpc.py tests/core/test_db_conversion.py tests/core/test_db_validation.py tests/core/test_farmer_harvester_rpc.py tests/core/test_filter.py tests/core/test_full_node_rpc.py tests/core/test_merkle_set.py tests/core/test_setproctitle.py
+        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" tests/core/test_coins.py tests/core/test_cost_calculation.py tests/core/test_crawler_rpc.py tests/core/test_daemon_rpc.py tests/core/test_db_conversion.py tests/core/test_db_validation.py tests/core/test_farmer_harvester_rpc.py tests/core/test_filter.py tests/core/test_full_node_rpc.py tests/core/test_merkle_set.py tests/core/test_setproctitle.py
 
     - name: Process coverage data
       run: |

--- a/.github/workflows/build-test-ubuntu-core.yml
+++ b/.github/workflows/build-test-ubuntu-core.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Test core code with pytest
       run: |
         . ./activate
-        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" -p no:monitor tests/core/test_cost_calculation.py tests/core/test_crawler_rpc.py tests/core/test_daemon_rpc.py tests/core/test_db_conversion.py tests/core/test_db_validation.py tests/core/test_farmer_harvester_rpc.py tests/core/test_filter.py tests/core/test_full_node_rpc.py tests/core/test_merkle_set.py tests/core/test_setproctitle.py
+        venv/bin/coverage run --rcfile=.coveragerc --module pytest --durations=10  -n 4 -m "not benchmark" -p no:monitor tests/core/test_coins.py tests/core/test_cost_calculation.py tests/core/test_crawler_rpc.py tests/core/test_daemon_rpc.py tests/core/test_db_conversion.py tests/core/test_db_validation.py tests/core/test_farmer_harvester_rpc.py tests/core/test_filter.py tests/core/test_full_node_rpc.py tests/core/test_merkle_set.py tests/core/test_setproctitle.py
 
     - name: Process coverage data
       run: |

--- a/chia/consensus/block_root_validation.py
+++ b/chia/consensus/block_root_validation.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 
-from chia.types.blockchain_format.coin import Coin, hash_coin_list
+from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.errors import Err
 from chia.util.merkle_set import MerkleSet
@@ -24,18 +24,18 @@ def validate_block_merkle_roots(
         removal_merkle_set.add_already_hashed(coin_name)
 
     # Create addition Merkle set
-    puzzlehash_coins_map: Dict[bytes32, List[Coin]] = {}
+    puzzlehash_coins_map: Dict[bytes32, List[bytes32]] = {}
 
     for coin in tx_additions:
         if coin.puzzle_hash in puzzlehash_coins_map:
-            puzzlehash_coins_map[coin.puzzle_hash].append(coin)
+            puzzlehash_coins_map[coin.puzzle_hash].append(coin.name())
         else:
-            puzzlehash_coins_map[coin.puzzle_hash] = [coin]
+            puzzlehash_coins_map[coin.puzzle_hash] = [coin.name()]
 
     # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
-    for puzzle, coins in puzzlehash_coins_map.items():
+    for puzzle, coin_ids in puzzlehash_coins_map.items():
         addition_merkle_set.add_already_hashed(puzzle)
-        addition_merkle_set.add_already_hashed(hash_coin_list(coins))
+        addition_merkle_set.add_already_hashed(hash_coin_ids(coin_ids))
 
     additions_root = addition_merkle_set.get_root()
     removals_root = removal_merkle_set.get_root()

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -27,7 +27,7 @@ from chia.protocols.wallet_protocol import (
     RespondSESInfo,
 )
 from chia.server.outbound_message import Message, make_msg
-from chia.types.blockchain_format.coin import Coin, hash_coin_list
+from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.pool_target import PoolTarget
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -1154,14 +1154,14 @@ class FullNodeAPI:
             # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
             for puzzle, coins in puzzlehash_coins_map.items():
                 addition_merkle_set.add_already_hashed(puzzle)
-                addition_merkle_set.add_already_hashed(hash_coin_list(coins))
+                addition_merkle_set.add_already_hashed(hash_coin_ids([c.name() for c in coins]))
 
             assert addition_merkle_set.get_root() == block.foliage_transaction_block.additions_root
             for puzzle_hash in request.puzzle_hashes:
                 result, proof = addition_merkle_set.is_included_already_hashed(puzzle_hash)
                 if puzzle_hash in puzzlehash_coins_map:
                     coins_map.append((puzzle_hash, puzzlehash_coins_map[puzzle_hash]))
-                    hash_coin_str = hash_coin_list(puzzlehash_coins_map[puzzle_hash])
+                    hash_coin_str = hash_coin_ids([c.name() for c in puzzlehash_coins_map[puzzle_hash]])
                     result_2, proof_2 = addition_merkle_set.is_included_already_hashed(hash_coin_str)
                     assert result
                     assert result_2

--- a/chia/types/blockchain_format/coin.py
+++ b/chia/types/blockchain_format/coin.py
@@ -53,11 +53,11 @@ class Coin(Streamable):
         assert False
 
 
-def hash_coin_list(coin_list: List[Coin]) -> bytes32:
-    coin_list.sort(key=lambda x: x.name_str, reverse=True)
+def hash_coin_ids(coin_ids: List[bytes32]) -> bytes32:
+    coin_ids.sort(reverse=True)
     buffer = bytearray()
 
-    for coin in coin_list:
-        buffer.extend(coin.name())
+    for name in coin_ids:
+        buffer.extend(name)
 
     return std_hash(buffer)

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -20,7 +20,7 @@ from chia.protocols.wallet_protocol import (
     RequestHeaderBlocks,
 )
 from chia.server.ws_connection import WSChiaConnection
-from chia.types.blockchain_format.coin import hash_coin_list, Coin
+from chia.types.blockchain_format.coin import hash_coin_ids, Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
@@ -91,7 +91,7 @@ def validate_additions(
         # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
         for puzzle_hash, coins_l in coins:
             additions_merkle_set.add_already_hashed(puzzle_hash)
-            additions_merkle_set.add_already_hashed(hash_coin_list(coins_l))
+            additions_merkle_set.add_already_hashed(hash_coin_ids([c.name() for c in coins_l]))
 
         additions_root = additions_merkle_set.get_root()
         if root != additions_root:
@@ -118,7 +118,7 @@ def validate_additions(
                     assert coin_list_proof is not None
                     included = confirm_included_already_hashed(
                         root,
-                        hash_coin_list(coin_list_1),
+                        hash_coin_ids([c.name() for c in coin_list_1]),
                         coin_list_proof,
                     )
                     if included is False:

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -53,7 +53,7 @@ from chia.plotting.util import PlotsRefreshParameter, PlotRefreshResult, PlotRef
 from chia.plotting.manager import PlotManager
 from chia.server.server import ssl_context_for_client
 from chia.types.blockchain_format.classgroup import ClassgroupElement
-from chia.types.blockchain_format.coin import Coin, hash_coin_list
+from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.foliage import Foliage, FoliageBlockData, FoliageTransactionBlock, TransactionsInfo
 from chia.types.blockchain_format.pool_target import PoolTarget
 from chia.types.blockchain_format.program import INFINITE_COST
@@ -1798,18 +1798,18 @@ def create_test_foliage(
             removal_merkle_set.add_already_hashed(coin_name)
 
         # Create addition Merkle set
-        puzzlehash_coin_map: Dict[bytes32, List[Coin]] = {}
+        puzzlehash_coin_map: Dict[bytes32, List[bytes32]] = {}
 
         for coin in tx_additions:
             if coin.puzzle_hash in puzzlehash_coin_map:
-                puzzlehash_coin_map[coin.puzzle_hash].append(coin)
+                puzzlehash_coin_map[coin.puzzle_hash].append(coin.name())
             else:
-                puzzlehash_coin_map[coin.puzzle_hash] = [coin]
+                puzzlehash_coin_map[coin.puzzle_hash] = [coin.name()]
 
         # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
-        for puzzle, coins in puzzlehash_coin_map.items():
+        for puzzle, coin_ids in puzzlehash_coin_map.items():
             addition_merkle_set.add_already_hashed(puzzle)
-            addition_merkle_set.add_already_hashed(hash_coin_list(coins))
+            addition_merkle_set.add_already_hashed(hash_coin_ids(coin_ids))
 
         additions_root = addition_merkle_set.get_root()
         removals_root = removal_merkle_set.get_root()

--- a/tests/core/test_coins.py
+++ b/tests/core/test_coins.py
@@ -1,0 +1,31 @@
+from itertools import permutations
+
+from benchmarks.utils import rand_hash
+from chia.types.blockchain_format.coin import hash_coin_ids
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.hash import std_hash
+
+
+def test_hash_coin_ids_empty() -> None:
+    assert hash_coin_ids([]) == std_hash(b"")
+
+
+def test_hash_coin_ids() -> None:
+    A = bytes32([1] + [0] * 31)
+    B = bytes32([2] + [0] * 31)
+    C = bytes32([3] + [0] * 31)
+    D = bytes32([4] + [0] * 31)
+    E = bytes32([254] + [0] * 31)
+    F = bytes32([255] + [0] * 31)
+
+    expected = std_hash(F + E + D + C + B + A)
+
+    for i in permutations([A, B, C, D, E, F]):
+        assert hash_coin_ids(list(i)) == expected
+
+
+def test_sorting() -> None:
+    for _ in range(5000):
+        h1 = rand_hash()
+        h2 = rand_hash()
+        assert (h1 < h2) == (h1.hex() < h2.hex())


### PR DESCRIPTION
by sorting pure coin_ids, rather than Coins that need to compute its name multiple times during sorting, and also by sorting the actual binary coin names, not hexadecimal strings