### PR TITLE
Replace MerkleSet with the rust implementation

### DIFF
--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import blspy
 from blspy import G1Element, G2Element
+from chia_rs import compute_merkle_set_root
 from chiabip158 import PyBIP158
 
 from chia.consensus.block_record import BlockRecord
@@ -28,7 +29,6 @@ from chia.types.generator_types import BlockGenerator
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
-from chia.util.merkle_set import MerkleSet
 from chia.util.prev_transaction_block import get_prev_transaction_block
 from chia.util.recursive_replace import recursive_replace
 
@@ -198,12 +198,7 @@ def create_foliage(
         bip158: PyBIP158 = PyBIP158(byte_array_tx)
         encoded = bytes(bip158.GetEncoded())
 
-        removal_merkle_set = MerkleSet()
-        addition_merkle_set = MerkleSet()
-
-        # Create removal Merkle set
-        for coin_name in tx_removals:
-            removal_merkle_set.add_already_hashed(coin_name)
+        additions_merkle_items: List[bytes32] = []
 
         # Create addition Merkle set
         puzzlehash_coin_map: Dict[bytes32, List[bytes32]] = {}
@@ -216,11 +211,11 @@ def create_foliage(
 
         # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
         for puzzle, coin_ids in puzzlehash_coin_map.items():
-            addition_merkle_set.add_already_hashed(puzzle)
-            addition_merkle_set.add_already_hashed(hash_coin_ids(coin_ids))
+            additions_merkle_items.append(puzzle)
+            additions_merkle_items.append(hash_coin_ids(coin_ids))
 
-        additions_root = addition_merkle_set.get_root()
-        removals_root = removal_merkle_set.get_root()
+        additions_root = bytes32(compute_merkle_set_root(additions_merkle_items))
+        removals_root = bytes32(compute_merkle_set_root(tx_removals))
 
         generator_hash = bytes32([0] * 32)
         if block_generator is not None:

--- a/chia/consensus/block_root_validation.py
+++ b/chia/consensus/block_root_validation.py
@@ -1,9 +1,10 @@
 from typing import Dict, List, Optional
 
+from chia_rs import compute_merkle_set_root
+
 from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.errors import Err
-from chia.util.merkle_set import MerkleSet
 
 
 def validate_block_merkle_roots(
@@ -16,12 +17,6 @@ def validate_block_merkle_roots(
         tx_removals = []
     if tx_additions is None:
         tx_additions = []
-    removal_merkle_set = MerkleSet()
-    addition_merkle_set = MerkleSet()
-
-    # Create removal Merkle set
-    for coin_name in tx_removals:
-        removal_merkle_set.add_already_hashed(coin_name)
 
     # Create addition Merkle set
     puzzlehash_coins_map: Dict[bytes32, List[bytes32]] = {}
@@ -33,12 +28,13 @@ def validate_block_merkle_roots(
             puzzlehash_coins_map[coin.puzzle_hash] = [coin.name()]
 
     # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
+    additions_merkle_items: List[bytes32] = []
     for puzzle, coin_ids in puzzlehash_coins_map.items():
-        addition_merkle_set.add_already_hashed(puzzle)
-        addition_merkle_set.add_already_hashed(hash_coin_ids(coin_ids))
+        additions_merkle_items.append(puzzle)
+        additions_merkle_items.append(hash_coin_ids(coin_ids))
 
-    additions_root = addition_merkle_set.get_root()
-    removals_root = removal_merkle_set.get_root()
+    additions_root = bytes32(compute_merkle_set_root(additions_merkle_items))
+    removals_root = bytes32(compute_merkle_set_root(tx_removals))
 
     if block_additions_root != additions_root:
         return Err.BAD_ADDITION_ROOT

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import random
 from typing import List, Optional, Tuple, Union, Dict
+from chia_rs import compute_merkle_set_root
 
 from chia.consensus.constants import ConsensusConstants
 from chia.protocols import wallet_protocol
@@ -86,14 +87,14 @@ def validate_additions(
 ):
     if proofs is None:
         # Verify root
-        additions_merkle_set = MerkleSet()
+        additions_merkle_items: List[bytes32] = []
 
         # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
         for puzzle_hash, coins_l in coins:
-            additions_merkle_set.add_already_hashed(puzzle_hash)
-            additions_merkle_set.add_already_hashed(hash_coin_ids([c.name() for c in coins_l]))
+            additions_merkle_items.append(puzzle_hash)
+            additions_merkle_items.append(hash_coin_ids([c.name() for c in coins_l]))
 
-        additions_root = additions_merkle_set.get_root()
+        additions_root = bytes32(compute_merkle_set_root(additions_merkle_items))
         if root != additions_root:
             return False
     else:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ dependencies = [
     "chiapos==1.0.10",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.4",  # Currying, Program.to, other conveniences
-    "chia_rs==0.1.1",
+    "chia_rs==0.1.2",
     "clvm-tools-rs==0.1.9",  # Rust implementation of clvm_tools
     "aiohttp==3.8.1",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -81,7 +81,6 @@ from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
 from chia.util.keychain import Keychain, bytes_to_mnemonic
-from chia.util.merkle_set import MerkleSet
 from chia.util.prev_transaction_block import get_prev_transaction_block
 from chia.util.path import mkdir
 from chia.util.vdf_prover import get_vdf_info_and_proof
@@ -95,6 +94,7 @@ from chia.wallet.derive_keys import (
     master_sk_to_pool_sk,
     master_sk_to_wallet_sk,
 )
+from chia_rs import compute_merkle_set_root
 
 test_constants = DEFAULT_CONSTANTS.replace(
     **{
@@ -1790,12 +1790,7 @@ def create_test_foliage(
         bip158: PyBIP158 = PyBIP158(byte_array_tx)
         encoded = bytes(bip158.GetEncoded())
 
-        removal_merkle_set = MerkleSet()
-        addition_merkle_set = MerkleSet()
-
-        # Create removal Merkle set
-        for coin_name in tx_removals:
-            removal_merkle_set.add_already_hashed(coin_name)
+        additions_merkle_items: List[bytes32] = []
 
         # Create addition Merkle set
         puzzlehash_coin_map: Dict[bytes32, List[bytes32]] = {}
@@ -1808,11 +1803,11 @@ def create_test_foliage(
 
         # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
         for puzzle, coin_ids in puzzlehash_coin_map.items():
-            addition_merkle_set.add_already_hashed(puzzle)
-            addition_merkle_set.add_already_hashed(hash_coin_ids(coin_ids))
+            additions_merkle_items.append(puzzle)
+            additions_merkle_items.append(hash_coin_ids(coin_ids))
 
-        additions_root = addition_merkle_set.get_root()
-        removals_root = removal_merkle_set.get_root()
+        additions_root = bytes32(compute_merkle_set_root(additions_merkle_items))
+        removals_root = bytes32(compute_merkle_set_root(tx_removals))
 
         generator_hash = bytes32([0] * 32)
         if block_generator is not None:

--- a/tests/core/test_merkle_set.py
+++ b/tests/core/test_merkle_set.py
@@ -1,7 +1,11 @@
 import itertools
+import random
 from hashlib import sha256
+from itertools import permutations
+from typing import List
 
 import pytest
+from chia_rs import compute_merkle_set_root
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.merkle_set import MerkleSet, confirm_included_already_hashed
@@ -52,13 +56,22 @@ async def test_merkle_set_invalid_hash_size():
     with pytest.raises(AssertionError):
         merkle_set.add_already_hashed(bytes([0x80] + [0] * 32))
 
+    with pytest.raises(ValueError, match="could not convert slice to array"):
+        compute_merkle_set_root([bytes([0x80] + [0] * 32)])
+
     # this is too small
     with pytest.raises(AssertionError):
         merkle_set.add_already_hashed(bytes([0x80] + [0] * 30))
 
+    with pytest.raises(ValueError, match="could not convert slice to array"):
+        compute_merkle_set_root([bytes([0x80] + [0] * 30)])
+
     # empty
     with pytest.raises(AssertionError):
         merkle_set.add_already_hashed(b"")
+
+    with pytest.raises(ValueError, match="could not convert slice to array"):
+        compute_merkle_set_root([b""])
 
 
 @pytest.mark.asyncio
@@ -66,6 +79,7 @@ async def test_merkle_set_1():
     a = bytes32([0x80] + [0] * 31)
     merkle_set = MerkleSet()
     merkle_set.add_already_hashed(a)
+    assert merkle_set.get_root() == bytes32(compute_merkle_set_root([a]))
     assert merkle_set.get_root() == sha256(b"\1" + a).digest()
 
 
@@ -75,12 +89,14 @@ async def test_merkle_set_duplicate():
     merkle_set = MerkleSet()
     merkle_set.add_already_hashed(a)
     merkle_set.add_already_hashed(a)
+    assert merkle_set.get_root() == bytes32(compute_merkle_set_root([a, a]))
     assert merkle_set.get_root() == sha256(b"\1" + a).digest()
 
 
 @pytest.mark.asyncio
 async def test_merkle_set_0():
     merkle_set = MerkleSet()
+    assert merkle_set.get_root() == bytes32(compute_merkle_set_root([]))
     assert merkle_set.get_root() == bytes32([0] * 32)
 
 
@@ -91,6 +107,7 @@ async def test_merkle_set_2():
     merkle_set = MerkleSet()
     merkle_set.add_already_hashed(a)
     merkle_set.add_already_hashed(b)
+    assert merkle_set.get_root() == bytes32(compute_merkle_set_root([a, b]))
     assert merkle_set.get_root() == hashdown(b"\1\1" + b + a)
 
 
@@ -101,6 +118,7 @@ async def test_merkle_set_2_reverse():
     merkle_set = MerkleSet()
     merkle_set.add_already_hashed(b)
     merkle_set.add_already_hashed(a)
+    assert merkle_set.get_root() == bytes32(compute_merkle_set_root([b, a]))
     assert merkle_set.get_root() == hashdown(b"\1\1" + b + a)
 
 
@@ -109,11 +127,13 @@ async def test_merkle_set_3():
     a = bytes32([0x80] + [0] * 31)
     b = bytes32([0x70] + [0] * 31)
     c = bytes32([0x71] + [0] * 31)
-    merkle_set = MerkleSet()
-    merkle_set.add_already_hashed(a)
-    merkle_set.add_already_hashed(b)
-    merkle_set.add_already_hashed(c)
-    assert merkle_set.get_root() == hashdown(b"\2\1" + hashdown(b"\1\1" + b + c) + a)
+    values = [a, b, c]
+    for vals in permutations(values):
+        merkle_set = MerkleSet()
+        for v in vals:
+            merkle_set.add_already_hashed(v)
+        assert merkle_set.get_root() == bytes32(compute_merkle_set_root(list(vals)))
+        assert merkle_set.get_root() == hashdown(b"\2\1" + hashdown(b"\1\1" + b + c) + a)
     # this tree looks like this:
     #
     #        o
@@ -129,12 +149,13 @@ async def test_merkle_set_4():
     b = bytes32([0x70] + [0] * 31)
     c = bytes32([0x71] + [0] * 31)
     d = bytes32([0x81] + [0] * 31)
-    merkle_set = MerkleSet()
-    merkle_set.add_already_hashed(a)
-    merkle_set.add_already_hashed(b)
-    merkle_set.add_already_hashed(c)
-    merkle_set.add_already_hashed(d)
-    assert merkle_set.get_root() == hashdown(b"\2\2" + hashdown(b"\1\1" + b + c) + hashdown(b"\1\1" + a + d))
+    values = [a, b, c, d]
+    for vals in permutations(values):
+        merkle_set = MerkleSet()
+        for v in vals:
+            merkle_set.add_already_hashed(v)
+        assert merkle_set.get_root() == bytes32(compute_merkle_set_root(list(vals)))
+        assert merkle_set.get_root() == hashdown(b"\2\2" + hashdown(b"\1\1" + b + c) + hashdown(b"\1\1" + a + d))
     # this tree looks like this:
     #
     #        o
@@ -154,13 +175,6 @@ async def test_merkle_set_5():
     d = bytes32([0xCA] + [0] * 31)
     e = bytes32([0x20] + [0] * 31)
 
-    merkle_set = MerkleSet()
-    merkle_set.add_already_hashed(a)
-    merkle_set.add_already_hashed(b)
-    merkle_set.add_already_hashed(c)
-    merkle_set.add_already_hashed(d)
-    merkle_set.add_already_hashed(e)
-
     # build the expected tree bottom up, since that's simpler
     expected = hashdown(b"\1\1" + e + c)
     expected = hashdown(b"\2\1" + expected + b)
@@ -171,7 +185,14 @@ async def test_merkle_set_5():
     expected = hashdown(b"\2\1" + expected + a)
     expected = hashdown(b"\2\1" + expected + d)
 
-    assert merkle_set.get_root() == expected
+    values = [a, b, c, d, e]
+    for vals in permutations(values):
+        merkle_set = MerkleSet()
+        for v in vals:
+            merkle_set.add_already_hashed(v)
+
+        assert merkle_set.get_root() == bytes32(compute_merkle_set_root(list(vals)))
+        assert merkle_set.get_root() == expected
     # this tree looks like this:
     #
     #             o
@@ -191,3 +212,112 @@ async def test_merkle_set_5():
     #   o   b
     #  / \
     # e   c
+
+
+@pytest.mark.asyncio
+async def test_merkle_left_edge():
+    BLANK = bytes32([0] * 32)
+    a = bytes32([0x80] + [0] * 31)
+    b = bytes32([0] * 31 + [1])
+    c = bytes32([0] * 31 + [2])
+    d = bytes32([0] * 31 + [3])
+    values = [a, b, c, d]
+
+    expected = hashdown(b"\1\1" + c + d)
+    expected = hashdown(b"\1\2" + b + expected)
+
+    for _ in range(253):
+        expected = hashdown(b"\2\0" + expected + BLANK)
+
+    expected = hashdown(b"\2\1" + expected + a)
+
+    for vals in permutations(values):
+        merkle_set = MerkleSet()
+        for v in vals:
+            merkle_set.add_already_hashed(v)
+        assert merkle_set.get_root() == bytes32(compute_merkle_set_root(list(vals)))
+        assert merkle_set.get_root() == expected
+    # this tree looks like this:
+    #           o
+    #          / \
+    #         o   a
+    #        / \
+    #       o   E
+    #      / \
+    #     .   E
+    #     .
+    #     .
+    #    / \
+    #   o   E
+    #  / \
+    # b   o
+    #    / \
+    #   c   d
+
+
+@pytest.mark.asyncio
+async def test_merkle_right_edge():
+    BLANK = bytes32([0] * 32)
+    a = bytes32([0x40] + [0] * 31)
+    b = bytes32([0xFF] * 31 + [0xFF])
+    c = bytes32([0xFF] * 31 + [0xFE])
+    d = bytes32([0xFF] * 31 + [0xFD])
+    values = [a, b, c, d]
+
+    expected = hashdown(b"\1\1" + c + b)
+    expected = hashdown(b"\1\2" + d + expected)
+
+    for _ in range(253):
+        expected = hashdown(b"\0\2" + BLANK + expected)
+
+    expected = hashdown(b"\1\2" + a + expected)
+
+    for vals in permutations(values):
+        merkle_set = MerkleSet()
+        for v in vals:
+            merkle_set.add_already_hashed(v)
+        assert merkle_set.get_root() == bytes32(compute_merkle_set_root(list(vals)))
+        assert merkle_set.get_root() == expected
+    # this tree looks like this:
+    #           o
+    #          / \
+    #         a   o
+    #            / \
+    #           E   o
+    #              / \
+    #             E   o
+    #                 .
+    #                 .
+    #                 .
+    #                 o
+    #                / \
+    #               d   o
+    #                  / \
+    #                 c   b
+
+
+def rand_hash(rng: random.Random) -> bytes32:
+    ret = bytearray(32)
+    for i in range(32):
+        ret[i] = rng.getrandbits(8)
+    return bytes32(ret)
+
+
+@pytest.mark.asyncio
+async def test_merkle_set_random_regression():
+    rng = random.Random()
+    rng.seed(123456)
+    for i in range(100):
+        size = rng.randint(0, 4000)
+        values: List[bytes32] = [rand_hash(rng) for _ in range(size)]
+        print(f"iter: {i}/100 size: {size}")
+
+        for _ in range(10):
+            rng.shuffle(values)
+            merkle_set = MerkleSet()
+            for v in values:
+                merkle_set.add_already_hashed(v)
+
+            python_root = merkle_set.get_root()
+            rust_root = bytes32(compute_merkle_set_root(values))
+            assert rust_root == python_root


### PR DESCRIPTION
of computing the merkle root. This saves about 20% of the CPU work in the main thread when validating blocks.

The new implementation of the merkle set root function is found here:

   https://github.com/Chia-Network/chia_rs/blob/main/src/merkle_set.rs