### PR TITLE
flag lgtm issues in test and benchmark code

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,3 +1,9 @@
+path_classifiers:
+  test:
+    - exclude: /
+  benchmark:
+    - exclude: /
+
 extraction:
   javascript:
     index:


### PR DESCRIPTION
It's important to not have bugs in our tests, otherwise it may not be testing what we think it is.

the lgtm config is a bit unintuitive (I think). One prerequisite to understand this change is that lgtm has a heuristic to classify files as benchmarks and tests. Furthermore, *by default* it hides alerts found in those kinds of files.

What this patch does is that it *excludes* the specified directories from being classified as tests or benchmarks respectively. By not being classified, the alerts in those files are shown.