### PR TITLE
Uses the new `from_bytes_unchecked` method in blspy, to improve perfo…

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -129,9 +129,10 @@ def dataclass_from_dict(klass: Type[Any], d: Any) -> Any:
     elif klass.__name__ in unhashable_types:
         # Type is unhashable (bls type), so cast from hex string
         if hasattr(klass, "from_bytes_unchecked"):
-            return klass.from_bytes_unchecked(hexstr_to_bytes(d))
+            from_bytes_method: Callable[[bytes], Any] = klass.from_bytes_unchecked
         else:
-            return klass.from_bytes(hexstr_to_bytes(d))
+            from_bytes_method = klass.from_bytes
+        return from_bytes_method(hexstr_to_bytes(d))
     else:
         # Type is a primitive, cast with correct class
         return klass(d)
@@ -432,7 +433,7 @@ class Streamable:
                 item = f_type(item)
             except (TypeError, AttributeError, ValueError):
                 if hasattr(f_type, "from_bytes_unchecked"):
-                    from_bytes_method: Callable = f_type.from_bytes_unchecked
+                    from_bytes_method: Callable[[bytes], Any] = f_type.from_bytes_unchecked
                 else:
                     from_bytes_method = f_type.from_bytes
                 try:

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -538,11 +538,11 @@ def test_parse_size_hints() -> None:
 
     # EOF
     with pytest.raises(AssertionError):
-        parse_size_hints(io.BytesIO(b"133"), TestFromBytes, 4)
+        parse_size_hints(io.BytesIO(b"133"), TestFromBytes, 4, False)
 
     # error in underlying type
     with pytest.raises(ValueError):
-        parse_size_hints(io.BytesIO(b"1337"), FailFromBytes, 4)
+        parse_size_hints(io.BytesIO(b"1337"), FailFromBytes, 4, False)
 
 
 def test_parse_str() -> None:

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -534,7 +534,7 @@ class FailFromBytes:
 
 
 def test_parse_size_hints() -> None:
-    assert parse_size_hints(io.BytesIO(b"1337"), TestFromBytes, 4).b == b"1337"
+    assert parse_size_hints(io.BytesIO(b"1337"), TestFromBytes, 4, False).b == b"1337"
 
     # EOF
     with pytest.raises(AssertionError):


### PR DESCRIPTION
…rmance. Based on this change: https://github.com/Chia-Network/bls-signatures/pull/328. 
FullBlock.from_bytes improved from 2600 µs to 954 µs.


TODO: 
- [x] Update blspy version (windows fix) once released
- [x] Consider changing from_json as well
