### PR TITLE
Use context manager for locking clvm files

### DIFF
--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -6,7 +6,7 @@ import pathlib
 
 import pkg_resources
 from chia.types.blockchain_format.program import Program, SerializedProgram
-from chia.util.lock import with_lock
+from chia.util.lock import lock_by_path
 from clvm_tools_rs import compile_clvm as compile_clvm_rust
 
 
@@ -67,10 +67,8 @@ def compile_clvm_in_lock(full_path, output, search_paths):
 
 
 def compile_clvm(full_path, output, search_paths=[]):
-    def do_compile():
+    with lock_by_path(f"{full_path}.lock"):
         compile_clvm_in_lock(full_path, output, search_paths)
-
-    with_lock(f"{full_path}.lock", do_compile)
 
 
 def load_serialized_clvm(clvm_filename, package_or_requirement=__name__) -> SerializedProgram:


### PR DESCRIPTION
Context managers for this form avoid needing to create a callable and having to pass it through another function.

Also note that we have intend to use the filelock library in the future so our own locking mechanism could be replaced by that.