### PR TITLE
harvester: Introduce `recursive_plot_scan`

### DIFF
--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -121,20 +121,9 @@ def get_filenames(directory: Path, recursive: bool) -> List[Path]:
         return []
     all_files: List[Path] = []
     try:
-        if recursive:
-            all_files = [
-                child
-                for child in directory.rglob("*.plot")
-                if child.is_file() and child.suffix == ".plot" and not child.name.startswith("._")
-            ]
-        else:
-            for child in directory.iterdir():
-                if not child.is_dir():
-                    # If it is a file ending in .plot, add it - work around MacOS ._ files
-                    if child.suffix == ".plot" and not child.name.startswith("._"):
-                        all_files.append(child)
-                else:
-                    log.debug(f"Not checking subdirectory {child}, subdirectories not added by default")
+        glob_function = directory.rglob if recursive else directory.glob
+        all_files = [child for child in glob_function("*.plot") if child.is_file() and not child.name.startswith("._")]
+        log.debug(f"get_filenames: {len(all_files)} files found in {directory}, recursive: {recursive}")
     except Exception as e:
         log.warning(f"Error reading directory {directory} {e}")
     return all_files

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -70,9 +70,11 @@ def get_plot_directories(root_path: Path, config: Dict = None) -> List[str]:
 def get_plot_filenames(root_path: Path) -> Dict[Path, List[Path]]:
     # Returns a map from directory to a list of all plots in the directory
     all_files: Dict[Path, List[Path]] = {}
-    for directory_name in get_plot_directories(root_path):
+    config = load_config(root_path, "config.yaml")
+    recursive_scan: bool = config["harvester"].get("recursive_plot_scan", False)
+    for directory_name in get_plot_directories(root_path, config):
         directory = Path(directory_name).resolve()
-        all_files[directory] = get_filenames(directory)
+        all_files[directory] = get_filenames(directory, recursive_scan)
     return all_files
 
 
@@ -109,7 +111,7 @@ def remove_plot(path: Path):
         path.unlink()
 
 
-def get_filenames(directory: Path) -> List[Path]:
+def get_filenames(directory: Path, recursive: bool) -> List[Path]:
     try:
         if not directory.exists():
             log.warning(f"Directory: {directory} does not exist.")
@@ -119,13 +121,20 @@ def get_filenames(directory: Path) -> List[Path]:
         return []
     all_files: List[Path] = []
     try:
-        for child in directory.iterdir():
-            if not child.is_dir():
-                # If it is a file ending in .plot, add it - work around MacOS ._ files
-                if child.suffix == ".plot" and not child.name.startswith("._"):
-                    all_files.append(child)
-            else:
-                log.debug(f"Not checking subdirectory {child}, subdirectories not added by default")
+        if recursive:
+            all_files = [
+                child
+                for child in directory.rglob("*.plot")
+                if child.is_file() and child.suffix == ".plot" and not child.name.startswith("._")
+            ]
+        else:
+            for child in directory.iterdir():
+                if not child.is_dir():
+                    # If it is a file ending in .plot, add it - work around MacOS ._ files
+                    if child.suffix == ".plot" and not child.name.startswith("._"):
+                        all_files.append(child)
+                else:
+                    log.debug(f"Not checking subdirectory {child}, subdirectories not added by default")
     except Exception as e:
         log.warning(f"Error reading directory {directory} {e}")
     return all_files

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -195,6 +195,7 @@ harvester:
 
   # Plots are searched for in the following directories
   plot_directories: []
+  recursive_plot_scan: False # If True the harvester scans plots recursively in the provided directories.
 
   ssl:
     private_crt:  "config/ssl/harvester/private_harvester.crt"

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -19,7 +19,7 @@ from chia.plotting.util import (
     remove_plot,
     remove_plot_directory,
 )
-from chia.util.config import create_default_chia_config
+from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
 from chia.util.path import mkdir
 from tests.block_tools import get_plot_dir
 from tests.plotting.util import get_test_plots
@@ -605,4 +605,42 @@ async def test_callback_event_raises(test_plot_environment, event_to_raise: Plot
     expected_result.removed = []
     expected_result.processed = len(env.dir_1) + len(env.dir_2)
     expected_result.remaining = 0
+    await env.refresh_tester.run(expected_result)
+
+
+@pytest.mark.asyncio
+async def test_recursive_plot_scan(test_plot_environment: TestEnvironment) -> None:
+    env: TestEnvironment = test_plot_environment
+    # Create a directory tree with some subdirectories containing plots, others not.
+    root_plot_dir = env.root_path / "root"
+    sub_dir_0: TestDirectory = TestDirectory(root_plot_dir / "0", env.dir_1.plots[0:2])
+    sub_dir_0_1: TestDirectory = TestDirectory(sub_dir_0.path / "1", env.dir_1.plots[2:3])
+    sub_dir_1: TestDirectory = TestDirectory(root_plot_dir / "1", [])
+    sub_dir_1_0: TestDirectory = TestDirectory(sub_dir_1.path / "0", [])
+    sub_dir_1_0_1: TestDirectory = TestDirectory(sub_dir_1_0.path / "1", env.dir_1.plots[3:7])
+
+    # List of all the plots in the directory tree
+    expected_plot_list = sub_dir_0.plot_info_list() + sub_dir_0_1.plot_info_list() + sub_dir_1_0_1.plot_info_list()
+
+    # Adding the root without `recursive_plot_scan` and running a test should not load any plots (match an empty result)
+    expected_result = PlotRefreshResult()
+    add_plot_directory(env.root_path, str(root_plot_dir))
+    await env.refresh_tester.run(expected_result)
+
+    # Set the recursive scan flag in the config
+    with lock_and_load_config(env.root_path, "config.yaml") as config:
+        config["harvester"]["recursive_plot_scan"] = True
+        save_config(env.root_path, "config.yaml", config)
+
+    # With the flag enabled it should load all expected plots
+    expected_result.loaded = expected_plot_list  # type: ignore[assignment]
+    expected_result.removed = []
+    expected_result.processed = len(expected_plot_list)
+    expected_result.remaining = 0
+    await env.refresh_tester.run(expected_result)
+
+    # Adding the subdirectories also should not lead to some failure or duplicated loading
+    add_plot_directory(env.root_path, str(sub_dir_0_1.path))
+    add_plot_directory(env.root_path, str(sub_dir_1_0_1.path))
+    expected_result.loaded = []
     await env.refresh_tester.run(expected_result)

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -634,9 +634,7 @@ async def test_recursive_plot_scan(test_plot_environment: TestEnvironment) -> No
 
     # With the flag enabled it should load all expected plots
     expected_result.loaded = expected_plot_list  # type: ignore[assignment]
-    expected_result.removed = []
     expected_result.processed = len(expected_plot_list)
-    expected_result.remaining = 0
     await env.refresh_tester.run(expected_result)
 
     # Adding the subdirectories also should not lead to some failure or duplicated loading


### PR DESCRIPTION
This adds the new config option `harvester.recursive_plot_scan` which if enabled (set to `True`) tells the harvester to scan for plots recursively in the directories in `harvester.plot_directories`.