### PR TITLE
Add `chia.wallet.nft_wallet` to packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ kwargs = dict(
         "chia.wallet.rl_wallet",
         "chia.wallet.cat_wallet",
         "chia.wallet.did_wallet",
+        "chia.wallet.nft_wallet",
         "chia.wallet.settings",
         "chia.wallet.trading",
         "chia.wallet.util",


### PR DESCRIPTION
Without this change, the `nft_wallet` package is not included when installing the latest `main_dids` through `pip`.