### PR TITLE
Automatically create NFT wallet

### DIFF
--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -86,6 +86,7 @@ class NFTWallet:
         wallet: Wallet,
         did_wallet_id: uint32 = None,
         name: str = "",
+        in_transaction: bool = False,
     ) -> _T_NFTWallet:
         """
         This must be called under the wallet state manager lock
@@ -96,9 +97,8 @@ class NFTWallet:
         self.wallet_state_manager = wallet_state_manager
         self.nft_wallet_info = NFTWalletInfo([], did_wallet_id)
         info_as_string = json.dumps(self.nft_wallet_info.to_json_dict())
-
         wallet_info = await wallet_state_manager.user_store.create_wallet(
-            "NFT Wallet" if not name else name, uint32(WalletType.NFT.value), info_as_string
+            "NFT Wallet" if not name else name, uint32(WalletType.NFT.value), info_as_string, in_transaction=in_transaction
         )
 
         if wallet_info is None:
@@ -106,12 +106,12 @@ class NFTWallet:
         self.wallet_info = wallet_info
         self.wallet_id = self.wallet_info.id
         self.log.debug("NFT wallet id: %r and standard wallet id: %r", self.wallet_id, self.standard_wallet.wallet_id)
-        await self.wallet_state_manager.add_new_wallet(self, self.wallet_info.id)
+
+        await self.wallet_state_manager.add_new_wallet(self, self.wallet_info.id, in_transaction=in_transaction)
         self.log.debug("Generated a new NFT wallet: %s", self.__dict__)
         if not did_wallet_id:
             # default profile wallet
             self.log.debug("Standard NFT wallet created")
-
         else:
             # TODO: handle DID wallet puzhash
             raise NotImplementedError()

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -98,7 +98,10 @@ class NFTWallet:
         self.nft_wallet_info = NFTWalletInfo([], did_wallet_id)
         info_as_string = json.dumps(self.nft_wallet_info.to_json_dict())
         wallet_info = await wallet_state_manager.user_store.create_wallet(
-            "NFT Wallet" if not name else name, uint32(WalletType.NFT.value), info_as_string, in_transaction=in_transaction
+            "NFT Wallet" if not name else name,
+            uint32(WalletType.NFT.value),
+            info_as_string,
+            in_transaction=in_transaction,
         )
 
         if wallet_info is None:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -737,7 +737,7 @@ class WalletStateManager:
                 self, self.main_wallet, name="NFT Wallet", in_transaction=True
             )
             self.log.error("Create NFT wallet")
-            wallet_id = nft_wallet.wallet_id
+            wallet_id = uint32(nft_wallet.wallet_id)
             wallet_type = WalletType.NFT
 
         return wallet_id, wallet_type

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -736,7 +736,6 @@ class WalletStateManager:
             nft_wallet: NFTWallet = await NFTWallet.create_new_nft_wallet(
                 self, self.main_wallet, name="NFT Wallet", in_transaction=True
             )
-            self.log.error("Create NFT wallet")
             wallet_id = uint32(nft_wallet.wallet_id)
             wallet_type = WalletType.NFT
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -730,6 +730,16 @@ class WalletStateManager:
                     wallet_id = wallet_info.id
                     wallet_type = WalletType.NFT
                     break
+        if wallet_id is None:
+            # TODO Modify this for NFT1
+            self.log.info("Cannot find a NFT wallet, creating a new one.")
+            nft_wallet: NFTWallet = await NFTWallet.create_new_nft_wallet(
+                self, self.main_wallet, name="NFT Wallet", in_transaction=True
+            )
+            self.log.error("Create NFT wallet")
+            wallet_id = nft_wallet.wallet_id
+            wallet_type = WalletType.NFT
+
         return wallet_id, wallet_type
 
     async def new_coin_state(

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -14,6 +14,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
+from chia.wallet.util.wallet_types import WalletType
 from tests.time_out_assert import time_out_assert, time_out_assert_not_none
 
 
@@ -22,6 +23,95 @@ async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:
     if tx is None:
         return False
     return True
+
+@pytest.mark.parametrize(
+    "trusted",
+    [True],
+)
+@pytest.mark.asyncio
+async def test_nft_wallet_creation_automatically(two_wallet_nodes: Any, trusted: Any) -> None:
+    num_blocks = 5
+    full_nodes, wallets = two_wallet_nodes
+    full_node_api = full_nodes[0]
+    full_node_server = full_node_api.server
+    wallet_node_0, server_0 = wallets[0]
+    wallet_node_1, server_1 = wallets[1]
+    wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
+    wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
+
+    ph = await wallet_0.get_new_puzzlehash()
+    ph1 = await wallet_1.get_new_puzzlehash()
+
+    if trusted:
+        wallet_node_0.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+        wallet_node_1.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+    else:
+        wallet_node_0.config["trusted_peers"] = {}
+        wallet_node_1.config["trusted_peers"] = {}
+
+    await server_0.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+    await server_1.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+    funds = sum(
+        [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
+    )
+
+    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+    await time_out_assert(15, wallet_0.get_pending_change_balance, 0)
+    nft_wallet_0 = await NFTWallet.create_new_nft_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, name="NFT WALLET 1"
+    )
+    metadata = Program.to(
+        [
+            ("u", ["https://www.chia.net/img/branding/chia-logo.svg"]),
+            ("h", "0xD4584AD463139FA8C0D9F68F4B59F185"),
+        ]
+    )
+
+    tr = await nft_wallet_0.generate_new_nft(metadata)
+    assert tr
+    assert tr.spend_bundle
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, tr.spend_bundle.name())
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
+
+    await asyncio.sleep(5)
+    coins = nft_wallet_0.nft_wallet_info.my_nft_coins
+    assert len(coins) == 1, "nft not generated"
+
+    sb = await nft_wallet_0.transfer_nft(coins[0], ph1)
+
+    assert sb is not None
+    await asyncio.sleep(3)
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
+
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
+    await asyncio.sleep(5)
+
+    assert len(wallet_node_1.wallet_state_manager.wallets) == 2
+    # Get the new NFT wallet
+    nft_wallets = await wallet_node_1.wallet_state_manager.get_all_wallet_info_entries(WalletType.NFT)
+    assert len(nft_wallets) == 1
+    nft_wallet_1: NFTWallet = wallet_node_1.wallet_state_manager.wallets[nft_wallets[0].id]
+    coins = nft_wallet_0.nft_wallet_info.my_nft_coins
+    assert len(coins) == 0
+    coins = nft_wallet_1.nft_wallet_info.my_nft_coins
+    assert len(coins) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -24,6 +24,7 @@ async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:
         return False
     return True
 
+
 @pytest.mark.parametrize(
     "trusted",
     [True],


### PR DESCRIPTION
This fix should cover 2 cases:
1.  Resync database will not create NFT wallet and add NFT
2. Transfer a NFT to others who doesn't create a NFT Wallet