### PR TITLE
Fix Newer block issue

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -468,9 +468,16 @@ class FullNodeRpcApi:
         newer_block_bytes = bytes32.from_hexstr(newer_block_hex)
         older_block_bytes = bytes32.from_hexstr(older_block_hex)
 
-        newer_block: BlockRecord = self.service.blockchain.block_record(newer_block_bytes)
-        older_block: BlockRecord = self.service.blockchain.block_record(older_block_bytes)
-
+        newer_block = await self.service.block_store.get_block_record(newer_block_bytes)
+        if newer_block is None:
+            # It's possible that the peak block has not yet been committed to the DB, so as a fallback, check memory
+            try:
+                newer_block = self.service.blockchain.block_record(newer_block_bytes)
+            except KeyError:
+                raise ValueError(f"Newer block {newer_block_hex} not found")
+        older_block = await self.service.block_store.get_block_record(older_block_bytes)
+        if older_block is None:
+            raise ValueError(f"Older block {older_block_hex} not found")
         delta_weight = newer_block.weight - older_block.weight
 
         delta_iters = newer_block.total_iters - older_block.total_iters

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -468,12 +468,9 @@ class FullNodeRpcApi:
         newer_block_bytes = bytes32.from_hexstr(newer_block_hex)
         older_block_bytes = bytes32.from_hexstr(older_block_hex)
 
-        newer_block = await self.service.block_store.get_block_record(newer_block_bytes)
-        if newer_block is None:
-            raise ValueError(f"Newer block {newer_block_hex} not found")
-        older_block = await self.service.block_store.get_block_record(older_block_bytes)
-        if older_block is None:
-            raise ValueError(f"Older block {older_block_hex} not found")
+        newer_block: BlockRecord = self.service.blockchain.block_record(newer_block_bytes)
+        older_block: BlockRecord = self.service.blockchain.block_record(older_block_bytes)
+
         delta_weight = newer_block.weight - older_block.weight
 
         delta_iters = newer_block.total_iters - older_block.total_iters


### PR DESCRIPTION
In blockchain.py, the order of making updates is:
1. add block record to DB
2. add block record to memory
3. set peak height
4. commit DB transaction

The problem that we saw, might have been related to making a DB request for the peak block between 3 and 4. If instead of fetching from the DB, we fetch the block record from memory, we are guaranteed that it will be in memory 