### PR TITLE
harvester: Sort `plot_paths` before splitting it into batches

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -178,7 +178,7 @@ class PlotManager:
                 for filename in filenames_to_remove:
                     del self.plot_filename_paths[filename]
 
-                for remaining, batch in list_to_batches(list(plot_paths), self.refresh_parameter.batch_size):
+                for remaining, batch in list_to_batches(sorted(list(plot_paths)), self.refresh_parameter.batch_size):
                     batch_result: PlotRefreshResult = self.refresh_batch(batch, plot_directories)
                     if not self._refreshing_enabled:
                         self.log.debug("refresh_plots: Aborted")


### PR DESCRIPTION
After changing `plot_paths` to be a set in #11204 the plots are loaded out of order. Sorting the list before splitting it to batches recovers the load order. 

Fixes #11499