### PR TITLE
Allow services to set a non-default max request body size limit

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -308,12 +308,15 @@ async def start_rpc_server(
     root_path: Path,
     net_config,
     connect_to_daemon=True,
+    max_request_body_size=None,
 ):
     """
     Starts an HTTP server with the following RPC methods, to be used by local clients to
     query the node.
     """
-    app = web.Application()
+    if max_request_body_size is None:
+        max_request_body_size = 1024 ** 2
+    app = web.Application(client_max_size=max_request_body_size)
     rpc_server = RpcServer(rpc_api, rpc_api.service_name, stop_cb, root_path, net_config)
     rpc_server.rpc_api.service._set_state_changed_callback(rpc_server.state_changed)
     app.add_routes([web.post(route, wrap_http_handler(func)) for (route, func) in rpc_server.get_routes().items()])

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -54,6 +54,7 @@ class Service:
         connect_to_daemon=True,
         running_new_process=True,
         service_name_prefix="",
+        max_request_body_size: Optional[int] = None,
     ) -> None:
         self.root_path = root_path
         self.config = load_config(root_path, "config.yaml")
@@ -67,6 +68,7 @@ class Service:
         self._rpc_task: Optional[asyncio.Task] = None
         self._rpc_close_task: Optional[asyncio.Task] = None
         self._network_id: str = network_id
+        self.max_request_body_size = max_request_body_size
         self._running_new_process = running_new_process
 
         # when we start this service as a component of an existing process,
@@ -179,6 +181,7 @@ class Service:
                     self.root_path,
                     self.config,
                     self._connect_to_daemon,
+                    max_request_body_size=self.max_request_body_size,
                 )
             )
 


### PR DESCRIPTION
This was introduced for the data layer and is being submitted here to reduce the not-datalayer-specific diff against main.