### PR TITLE
Add RPC API for get any NFT

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -573,7 +573,7 @@ def nft_add_uri_cmd(
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-i", "--id", help="Id of the NFT wallet to use", type=int, required=True)
 @click.option("-ni", "--nft-coin-id", help="Id of the NFT coin to transfer", type=str, required=True)
-@click.option("-aa", "--artist-address", help="Target artist's wallet address", type=str, required=True)
+@click.option("-ta", "--target-address", help="Target recipient wallet address", type=str, required=True)
 @click.option(
     "-m",
     "--fee",
@@ -588,7 +588,7 @@ def nft_transfer_cmd(
     fingerprint: int,
     id: int,
     nft_coin_id: str,
-    artist_address: str,
+    target_address: str,
     fee: str,
 ) -> None:
     import asyncio
@@ -597,7 +597,7 @@ def nft_transfer_cmd(
     extra_params = {
         "wallet_id": id,
         "nft_coin_id": nft_coin_id,
-        "artist_address": artist_address,
+        "target_address": target_address,
         "fee": fee,
     }
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, transfer_nft))

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -709,9 +709,9 @@ async def transfer_nft(args: Dict, wallet_client: WalletRpcClient, fingerprint: 
     try:
         wallet_id = args["wallet_id"]
         nft_coin_id = args["nft_coin_id"]
-        artist_address = args["artist_address"]
+        target_address = args["target_address"]
         fee = args["fee"]
-        response = await wallet_client.transfer_nft(wallet_id, nft_coin_id, artist_address, fee)
+        response = await wallet_client.transfer_nft(wallet_id, nft_coin_id, target_address, fee)
         spend_bundle = response["spend_bundle"]
         print(f"NFT transferred successfully with spend bundle: {spend_bundle}")
     except Exception as e:

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -17,8 +17,6 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint32, uint64, uint128
 from chia.util.log_exceptions import log_exceptions
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
-from chia.wallet.nft_wallet.nft_info import NFTInfo
-from chia.wallet.nft_wallet.nft_puzzles import get_nft_info_from_puzzle
 
 
 def coin_record_dict_backwards_compat(coin_record: Dict[str, Any]):
@@ -59,7 +57,6 @@ class FullNodeRpcApi:
             "/get_coin_records_by_hint": self.get_coin_records_by_hint,
             "/push_tx": self.push_tx,
             "/get_puzzle_and_solution": self.get_puzzle_and_solution,
-            "/get_nft_info": self.get_nft_info,
             # Mempool
             "/get_all_mempool_tx_ids": self.get_all_mempool_tx_ids,
             "/get_all_mempool_items": self.get_all_mempool_items,
@@ -669,37 +666,6 @@ class FullNodeRpcApi:
         puzzle_ser: SerializedProgram = SerializedProgram.from_program(Program.to(puzzle))
         solution_ser: SerializedProgram = SerializedProgram.from_program(Program.to(solution))
         return {"coin_solution": CoinSpend(coin_record.coin, puzzle_ser, solution_ser)}
-
-    async def get_nft_info(self, request: Dict) -> Optional[Dict]:
-        # coin_id should be the latest ID of the unspent NFT coin
-        if "coin_id" not in request:
-            raise ValueError("Coin ID is required.")
-        coin_id = bytes32.from_hexstr(request["coin_id"])
-        # Get coin state
-        coin_record: Optional[CoinRecord] = await self.service.blockchain.coin_store.get_coin_record(coin_id)
-        if coin_record is None:
-            raise ValueError(f"Coin record 0x{coin_id.hex()} not found")
-        if request.get("latest", True) and coin_record.spent:
-            raise ValueError(f"Coin 0x{coin_id.hex()} is spent. Please input an unspent coin ID.")
-        # Get parent coin
-        parent_coin_record: Optional[CoinRecord] = await self.service.blockchain.coin_store.get_coin_record(
-            coin_record.coin.parent_coin_info
-        )
-        assert parent_coin_record is not None
-        res = await self.get_puzzle_and_solution(
-            {"coin_id": parent_coin_record.name.hex(), "height": parent_coin_record.spent_block_index}
-        )
-        assert res is not None
-        coin_spend: CoinSpend = res["coin_solution"]
-        # convert to NFTInfo
-        try:
-            nft_info: NFTInfo = get_nft_info_from_puzzle(
-                Program.from_bytes(bytes(coin_spend.puzzle_reveal)), parent_coin_record.coin
-            )
-        except Exception as e:
-            raise ValueError(f"The coin is not a NFT. {e}")
-        else:
-            return {"nft_info": nft_info}
 
     async def get_additions_and_removals(self, request: Dict) -> Optional[Dict]:
         if "header_hash" not in request:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1377,7 +1377,8 @@ class WalletRpcApi:
             raise ValueError("Coin ID is required.")
         coin_id = bytes32.from_hexstr(request["coin_id"])
         peer = self.service.wallet_state_manager.wallet_node.get_full_node_peer()
-
+        if peer is None:
+            raise ValueError("Cannot find a full node peer.")
         # Get coin state
         coin_state_list: List[CoinState] = await self.service.wallet_state_manager.wallet_node.get_coin_state(
             [coin_id], peer=peer

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1401,9 +1401,6 @@ class WalletRpcApi:
         if parent_coin_state_list is None or len(parent_coin_state_list) < 1:
             raise ValueError(f"Parent coin record 0x{coin_state.coin.parent_coin_info.hex()} not found")
         parent_coin_state: CoinState = parent_coin_state_list[0]
-
-        if peer is None:
-            raise ValueError("Cannot find a valid full node connection.")
         coin_spend: CoinSpend = await self.service.wallet_state_manager.wallet_node.fetch_puzzle_solution(
             peer, parent_coin_state.spent_height, parent_coin_state.coin
         )

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1391,8 +1391,12 @@ class WalletRpcApi:
                 coin_state_list = await self.service.wallet_state_manager.wallet_node.fetch_children(
                     peer, coin_state.coin.name()
                 )
-                if len(coin_state_list) != 1:
-                    raise ValueError("This is not a singleton, multiple children coins found.")
+                odd_coin = 0
+                for coin in coin_state_list:
+                    if coin.coin.amount % 2 == 1:
+                        odd_coin += 1
+                    if odd_coin > 1:
+                        raise ValueError("This is not a singleton, multiple children coins found.")
                 coin_state = coin_state_list[0]
         # Get parent coin
         parent_coin_state_list: List[CoinState] = await self.service.wallet_state_manager.wallet_node.get_coin_state(

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -37,9 +37,10 @@ from chia.wallet.derive_keys import (
     match_address_to_sk,
 )
 from chia.wallet.did_wallet.did_wallet import DIDWallet
+from chia.wallet.nft_wallet import nft_puzzles
 from chia.wallet.nft_wallet.nft_info import NFTInfo
-from chia.wallet.nft_wallet.nft_puzzles import get_nft_info_from_puzzle
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
+from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
 from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.rl_wallet.rl_wallet import RLWallet
@@ -1349,7 +1350,7 @@ class WalletRpcApi:
         nfts = nft_wallet.get_current_nfts()
         nft_info_list = []
         for nft in nfts:
-            nft_info_list.append(get_nft_info_from_puzzle(nft.full_puzzle, nft.coin))
+            nft_info_list.append(nft_puzzles.get_nft_info_from_puzzle(nft.full_puzzle, nft.coin))
         return {"wallet_id": wallet_id, "success": True, "nft_list": nft_info_list}
 
     async def nft_transfer_nft(self, request):
@@ -1410,9 +1411,28 @@ class WalletRpcApi:
         )
         # convert to NFTInfo
         try:
-            nft_info: NFTInfo = get_nft_info_from_puzzle(
-                Program.from_bytes(bytes(coin_spend.puzzle_reveal)), parent_coin_state.coin
-            )
+            # Check if the metadata is updated
+            inner_solution: Program = Program.from_bytes(bytes(coin_spend.solution)).rest().rest().first().first()
+            full_puzzle: Program = Program.from_bytes(bytes(coin_spend.puzzle_reveal))
+            update_condition = None
+            for condition in inner_solution.rest().first().rest().as_iter():
+                if condition.first().as_int() == -24:
+                    update_condition = condition
+                    break
+            if update_condition is not None:
+                uncurried_nft: UncurriedNFT = UncurriedNFT.uncurry(full_puzzle)
+                metadata: Program = uncurried_nft.metadata
+                metadata = nft_puzzles.update_metadata(metadata, update_condition)
+                # Note: This is not the actual unspent NFT full puzzle.
+                # There is no way to rebuild the full puzzle in a different wallet.
+                # But it shouldn't have impact on generating the NFTInfo, since inner_puzzle is not used there.
+                full_puzzle = nft_puzzles.create_full_puzzle(
+                    uncurried_nft.singleton_launcher_id,
+                    metadata,
+                    uncurried_nft.metdata_updater_hash,
+                    uncurried_nft.inner_puzzle,
+                )
+            nft_info: NFTInfo = nft_puzzles.get_nft_info_from_puzzle(full_puzzle, coin_state.coin)
         except Exception as e:
             raise ValueError(f"The coin is not a NFT. {e}")
         else:

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -586,11 +586,11 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_add_uri", request)
         return response
 
-    async def transfer_nft(self, wallet_id, nft_coin_id, artist_address, fee):
+    async def transfer_nft(self, wallet_id, nft_coin_id, target_address, fee):
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
             "nft_coin_id": nft_coin_id,
-            "target_address": artist_address,
+            "target_address": target_address,
             "fee": fee,
         }
         response = await self.fetch("nft_transfer_nft", request)

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -586,6 +586,11 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_add_uri", request)
         return response
 
+    async def get_nft_info(self, coin_id: bytes32, latest: bool = False):
+        request: Dict[str, Any] = {"coin_id": coin_id.hex(), "latest": latest}
+        response = await self.fetch("nft_get_info", request)
+        return response
+
     async def transfer_nft(self, wallet_id, nft_coin_id, target_address, fee):
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -586,7 +586,7 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_add_uri", request)
         return response
 
-    async def get_nft_info(self, coin_id: bytes32, latest: bool = False):
+    async def get_nft_info(self, coin_id: bytes32, latest: bool = True):
         request: Dict[str, Any] = {"coin_id": coin_id.hex(), "latest": latest}
         response = await self.fetch("nft_get_info", request)
         return response

--- a/chia/wallet/did_wallet/did_wallet_puzzles.py
+++ b/chia/wallet/did_wallet/did_wallet_puzzles.py
@@ -1,4 +1,3 @@
-from clvm_tools.binutils import assemble
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.program import Program
 from typing import List, Optional, Tuple, Iterator, Dict
@@ -205,7 +204,7 @@ def metadata_to_program(metadata: Dict) -> Program:
     """
     kv_list = []
     for key, value in metadata.items():
-        kv_list.append((assemble(key), assemble(value)))
+        kv_list.append((key, value))
     return Program.to(kv_list)
 
 

--- a/chia/wallet/nft_wallet/nft_puzzles.py
+++ b/chia/wallet/nft_wallet/nft_puzzles.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Dict
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -99,3 +100,43 @@ def get_nft_info_from_puzzle(puzzle: Program, nft_coin: Coin) -> NFTInfo:
         uint64(1),
     )
     return nft_info
+
+
+def metadata_to_program(metadata: Dict[bytes, Any]) -> Program:
+    """
+    Convert the metadata dict to a Chialisp program
+    :param metadata: User defined metadata
+    :return: Chialisp program
+    """
+    kv_list = []
+    for key, value in metadata.items():
+        kv_list.append((key, value))
+    program: Program = Program.to(kv_list)
+    return program
+
+
+def program_to_metadata(program: Program) -> Dict[bytes, Any]:
+    """
+    Convert a program to a metadata dict
+    :param program: Chialisp program contains the metadata
+    :return: Metadata dict
+    """
+    metadata = {}
+    for kv_pair in program.as_iter():
+        metadata[kv_pair.first().as_atom()] = kv_pair.rest().as_python()
+    return metadata
+
+
+def update_metadata(metadata: Program, update_condition: Program) -> Program:
+    """
+    Apply conditions of metadata updater to the previous metadata
+    :param metadata: Previous metadata
+    :param update_condition: Update metadata conditions
+    :return: Updated metadata
+    """
+    new_metadata = program_to_metadata(metadata)
+    print(f"Before Updated metadata {new_metadata}")
+    # TODO Modify this for supporting other fields
+    new_metadata[b"u"].insert(0, update_condition.rest().rest().first().atom)
+    print(f"Updated metadata {new_metadata}")
+    return metadata_to_program(new_metadata)

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -179,8 +179,8 @@ class Wallet:
         public_key = await self.hack_populate_secret_key_for_puzzle_hash(puzzle_hash)
         return puzzle_for_pk(bytes(public_key))
 
-    async def get_new_puzzle(self) -> Program:
-        dr = await self.wallet_state_manager.get_unused_derivation_record(self.id())
+    async def get_new_puzzle(self, in_transaction: bool = False) -> Program:
+        dr = await self.wallet_state_manager.get_unused_derivation_record(self.id(), in_transaction=in_transaction)
         return puzzle_for_pk(bytes(dr.pubkey))
 
     async def get_puzzle_hash(self, new: bool) -> bytes32:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -326,7 +326,7 @@ class WalletStateManager:
         if unused > 0:
             await self.puzzle_store.set_used_up_to(uint32(unused - 1), in_transaction)
 
-    async def update_wallet_puzzle_hashes(self, wallet_id):
+    async def update_wallet_puzzle_hashes(self, wallet_id, in_transaction=False):
         derivation_paths: List[DerivationRecord] = []
         target_wallet = self.wallets[wallet_id]
         last: Optional[uint32] = await self.puzzle_store.get_last_derivation_path_for_wallet(wallet_id)
@@ -353,7 +353,7 @@ class WalletStateManager:
                     False,
                 )
             )
-        await self.puzzle_store.add_derivation_paths(derivation_paths)
+        await self.puzzle_store.add_derivation_paths(derivation_paths, in_transaction=in_transaction)
 
     async def get_unused_derivation_record(
         self, wallet_id: uint32, in_transaction=False, hardened=False

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -22,8 +22,12 @@ async def get_wallet_num(wallet_manager):
 
 
 class TestDIDWallet:
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
     @pytest.mark.asyncio
-    async def test_creation_from_backup_file(self, self_hostname, three_wallet_nodes):
+    async def test_creation_from_backup_file(self, self_hostname, three_wallet_nodes, trusted):
         num_blocks = 5
         full_nodes, wallets = three_wallet_nodes
         full_node_api = full_nodes[0]
@@ -38,7 +42,20 @@ class TestDIDWallet:
         ph = await wallet_0.get_new_puzzlehash()
         ph1 = await wallet_1.get_new_puzzlehash()
         ph2 = await wallet_2.get_new_puzzlehash()
-
+        if trusted:
+            wallet_node_0.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_1.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_2.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node_0.config["trusted_peers"] = {}
+            wallet_node_1.config["trusted_peers"] = {}
+            wallet_node_2.config["trusted_peers"] = {}
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -171,8 +188,12 @@ class TestDIDWallet:
         await time_out_assert(45, did_wallet_2.get_confirmed_balance, 0)
         await time_out_assert(45, did_wallet_2.get_unconfirmed_balance, 0)
 
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
     @pytest.mark.asyncio
-    async def test_did_recovery_with_multiple_backup_dids(self, self_hostname, two_wallet_nodes):
+    async def test_did_recovery_with_multiple_backup_dids(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -183,7 +204,16 @@ class TestDIDWallet:
         wallet2 = wallet_node_2.wallet_state_manager.main_wallet
 
         ph = await wallet.get_new_puzzlehash()
-
+        if trusted:
+            wallet_node.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_2.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node.config["trusted_peers"] = {}
+            wallet_node_2.config["trusted_peers"] = {}
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
 
@@ -310,8 +340,12 @@ class TestDIDWallet:
         await time_out_assert(15, did_wallet_3.get_confirmed_balance, 0)
         await time_out_assert(15, did_wallet_3.get_unconfirmed_balance, 0)
 
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
     @pytest.mark.asyncio
-    async def test_did_recovery_with_empty_set(self, self_hostname, two_wallet_nodes):
+    async def test_did_recovery_with_empty_set(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -321,7 +355,16 @@ class TestDIDWallet:
         wallet = wallet_node.wallet_state_manager.main_wallet
 
         ph = await wallet.get_new_puzzlehash()
-
+        if trusted:
+            wallet_node.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_2.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node.config["trusted_peers"] = {}
+            wallet_node_2.config["trusted_peers"] = {}
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
 
@@ -367,8 +410,12 @@ class TestDIDWallet:
         else:
             assert False
 
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
     @pytest.mark.asyncio
-    async def test_did_attest_after_recovery(self, self_hostname, two_wallet_nodes):
+    async def test_did_attest_after_recovery(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -378,7 +425,16 @@ class TestDIDWallet:
         wallet = wallet_node.wallet_state_manager.main_wallet
         wallet2 = wallet_node_2.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
-
+        if trusted:
+            wallet_node.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_2.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node.config["trusted_peers"] = {}
+            wallet_node_2.config["trusted_peers"] = {}
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         for i in range(1, num_blocks):
@@ -532,8 +588,12 @@ class TestDIDWallet:
         "with_recovery",
         [True, False],
     )
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
     @pytest.mark.asyncio
-    async def test_did_transfer(self, two_wallet_nodes, with_recovery):
+    async def test_did_transfer(self, two_wallet_nodes, with_recovery, trusted):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -544,13 +604,16 @@ class TestDIDWallet:
         wallet2 = wallet_node_2.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
 
-        wallet_node.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-
-        wallet_node_2.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
+        if trusted:
+            wallet_node.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_2.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node.config["trusted_peers"] = {}
+            wallet_node_2.config["trusted_peers"] = {}
 
         await server_2.start_client(PeerInfo("localhost", uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo("localhost", uint16(server_1._port)), None)
@@ -615,8 +678,12 @@ class TestDIDWallet:
         assert metadata["Twitter"] == "Test"
         assert metadata["GitHub"] == "测试"
 
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
     @pytest.mark.asyncio
-    async def test_update_recovery_list(self, two_wallet_nodes):
+    async def test_update_recovery_list(self, two_wallet_nodes, trusted):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -626,13 +693,16 @@ class TestDIDWallet:
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
 
-        wallet_node.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-
-        wallet_node_2.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
+        if trusted:
+            wallet_node.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_2.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node.config["trusted_peers"] = {}
+            wallet_node_2.config["trusted_peers"] = {}
 
         await server_2.start_client(PeerInfo("localhost", uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo("localhost", uint16(server_1._port)), None)
@@ -670,8 +740,12 @@ class TestDIDWallet:
         assert did_wallet_1.did_info.backup_ids[0] == bytes(ph)
         assert did_wallet_1.did_info.num_of_backup_ids_needed == 1
 
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
     @pytest.mark.asyncio
-    async def test_update_metadata(self, two_wallet_nodes):
+    async def test_update_metadata(self, two_wallet_nodes, trusted):
         num_blocks = 5
         full_nodes, wallets = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -680,14 +754,16 @@ class TestDIDWallet:
         wallet_node_2, server_3 = wallets[1]
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
-
-        wallet_node.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-
-        wallet_node_2.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
+        if trusted:
+            wallet_node.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_2.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node.config["trusted_peers"] = {}
+            wallet_node_2.config["trusted_peers"] = {}
 
         await server_2.start_client(PeerInfo("localhost", uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo("localhost", uint16(server_1._port)), None)

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -29,7 +29,7 @@ async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:
 
 @pytest.mark.parametrize(
     "trusted",
-    [True],
+    [True, False],
 )
 @pytest.mark.asyncio
 async def test_nft_wallet_creation_automatically(two_wallet_nodes: Any, trusted: Any) -> None:
@@ -116,7 +116,7 @@ async def test_nft_wallet_creation_automatically(two_wallet_nodes: Any, trusted:
 
 @pytest.mark.parametrize(
     "trusted",
-    [True],
+    [True, False],
 )
 @pytest.mark.asyncio
 async def test_nft_wallet_creation_and_transfer(two_wallet_nodes: Any, trusted: Any) -> None:
@@ -247,7 +247,7 @@ async def test_nft_wallet_creation_and_transfer(two_wallet_nodes: Any, trusted: 
 
 @pytest.mark.parametrize(
     "trusted",
-    [True],
+    [True, False],
 )
 @pytest.mark.asyncio
 async def test_nft_wallet_rpc_creation_and_list(two_wallet_nodes: Any, trusted: Any) -> None:
@@ -335,7 +335,7 @@ async def test_nft_wallet_rpc_creation_and_list(two_wallet_nodes: Any, trusted: 
 
 @pytest.mark.parametrize(
     "trusted",
-    [True],
+    [True, False],
 )
 @pytest.mark.asyncio
 async def test_nft_wallet_rpc_update_metadata(two_wallet_nodes: Any, trusted: Any) -> None:
@@ -364,10 +364,10 @@ async def test_nft_wallet_rpc_update_metadata(two_wallet_nodes: Any, trusted: An
 
     await server_0.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
-
+    await asyncio.sleep(5)
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-
+    await asyncio.sleep(5)
     api_0 = WalletRpcApi(wallet_node_0)
     nft_wallet_0 = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(nft_wallet_0, dict)

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -279,7 +279,7 @@ async def test_nft_wallet_rpc_creation_and_list(two_wallet_nodes: Any, trusted: 
 
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-
+    await asyncio.sleep(5)
     api_0 = WalletRpcApi(wallet_node_0)
     nft_wallet_0 = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(nft_wallet_0, dict)

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -688,6 +688,9 @@ class TestWalletRpc:
             assert nft_info_1 == nft_info
             nft_info_1 = (await client.get_nft_info(nft_id))["nft_info"]
             assert nft_info_1["nft_coin_id"] == nft_wallet_1.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
+            # Cross-check NFT
+            nft_info_2 = (await client_2.list_nfts(nft_wallet_id_1))["nft_list"][0]
+            assert nft_info_1 == nft_info_2
 
             # Keys and addresses
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -668,22 +668,26 @@ class TestWalletRpc:
             for i in range(0, 5):
                 await client.farm_block(encode_puzzle_hash(ph, "txch"))
                 await asyncio.sleep(0.5)
-
+            await asyncio.sleep(5)
             nft_wallet: NFTWallet = wallet_node.wallet_state_manager.wallets[nft_wallet_id]
             nft_id = nft_wallet.get_current_nfts()[0].coin.name()
-            nft_info = (await client.get_nft_info(nft_id, True))["nft_info"]
+            nft_info = (await client.get_nft_info(nft_id))["nft_info"]
             assert nft_info["nft_coin_id"] == nft_wallet.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
 
             res = await client.transfer_nft(nft_wallet_id, nft_id.hex(), addr, 0)
             assert res["success"]
+            await asyncio.sleep(3)
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
+            await asyncio.sleep(5)
 
-            await asyncio.sleep(1)
-            for i in range(0, 5):
-                await client_2.farm_block(encode_puzzle_hash(ph_2, "txch"))
-                await asyncio.sleep(0.5)
-
-            nft_info_1 = (await client.get_nft_info(nft_id))["nft_info"]
+            nft_wallet_id_1 = (
+                await wallet_node_2.wallet_state_manager.get_all_wallet_info_entries(wallet_type=WalletType.NFT)
+            )[0].id
+            nft_wallet_1: NFTWallet = wallet_node_2.wallet_state_manager.wallets[nft_wallet_id_1]
+            nft_info_1 = (await client.get_nft_info(nft_id, False))["nft_info"]
             assert nft_info_1 == nft_info
+            nft_info_1 = (await client.get_nft_info(nft_id))["nft_info"]
+            assert nft_info_1["nft_coin_id"] == nft_wallet_1.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
 
             # Keys and addresses
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -672,7 +672,7 @@ class TestWalletRpc:
             nft_wallet: NFTWallet = wallet_node.wallet_state_manager.wallets[nft_wallet_id]
             nft_id = nft_wallet.get_current_nfts()[0].coin.name()
             nft_info = (await client.get_nft_info(nft_id))["nft_info"]
-            assert nft_info["nft_coin_id"] == nft_wallet.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
+            assert nft_info["nft_coin_id"] == nft_wallet.get_current_nfts()[0].coin.name().hex().upper()
 
             res = await client.transfer_nft(nft_wallet_id, nft_id.hex(), addr, 0)
             assert res["success"]
@@ -687,7 +687,7 @@ class TestWalletRpc:
             nft_info_1 = (await client.get_nft_info(nft_id, False))["nft_info"]
             assert nft_info_1 == nft_info
             nft_info_1 = (await client.get_nft_info(nft_id))["nft_info"]
-            assert nft_info_1["nft_coin_id"] == nft_wallet_1.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
+            assert nft_info_1["nft_coin_id"] == nft_wallet_1.get_current_nfts()[0].coin.name().hex().upper()
             # Cross-check NFT
             nft_info_2 = (await client_2.list_nfts(nft_wallet_id_1))["nft_list"][0]
             assert nft_info_1 == nft_info_2

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -671,8 +671,11 @@ class TestWalletRpc:
 
             nft_wallet: NFTWallet = wallet_node.wallet_state_manager.wallets[nft_wallet_id]
             nft_id = nft_wallet.get_current_nfts()[0].coin.name()
-            nft_info = (await full_node_rpc_api.get_nft_info({"coin_id": nft_id.hex()}))["nft_info"]
-            assert nft_info.nft_coin_id == nft_wallet.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
+            if trusted:
+                # It is intended to use different client to get NFT info
+                # This only supports trusted
+                nft_info = (await client_2.get_nft_info(nft_id, True))["nft_info"]
+                assert nft_info["nft_coin_id"] == nft_wallet.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
 
             res = await client.transfer_nft(nft_wallet_id, nft_id.hex(), addr, 0)
             assert res["success"]
@@ -681,9 +684,9 @@ class TestWalletRpc:
             for i in range(0, 5):
                 await client_2.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
-
-            nft_info_1 = (await full_node_rpc_api.get_nft_info({"coin_id": nft_id.hex(), "latest": False}))["nft_info"]
-            assert nft_info_1 == nft_info
+            if trusted:
+                nft_info_1 = (await client.get_nft_info(nft_id))["nft_info"]
+                assert nft_info_1 == nft_info
 
             # Keys and addresses
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -31,6 +31,7 @@ from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
+from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.transaction_sorting import SortKey
@@ -650,6 +651,39 @@ class TestWalletRpc:
             assert did_wallet_2.get_my_DID() == did_id_0
             metadata = json.loads(did_wallet_2.did_info.metadata)
             assert metadata["Twitter"] == "Https://test"
+
+            # NFT
+            res = await client.create_new_nft_wallet(None)
+            nft_wallet_id = res["wallet_id"]
+            ph = await wallet.get_new_puzzlehash()
+            res = await client.mint_nft(
+                nft_wallet_id,
+                None,
+                "0xD4584AD463139FA8C0D9F68F4B59F185",
+                ["https://www.chia.net/img/branding/chia-logo.svg"],
+                0,
+            )
+            assert res["success"]
+            await asyncio.sleep(1)
+            for i in range(0, 5):
+                await client.farm_block(encode_puzzle_hash(ph, "txch"))
+                await asyncio.sleep(0.5)
+
+            nft_wallet: NFTWallet = wallet_node.wallet_state_manager.wallets[nft_wallet_id]
+            nft_id = nft_wallet.get_current_nfts()[0].coin.name()
+            nft_info = (await full_node_rpc_api.get_nft_info({"coin_id": nft_id.hex()}))["nft_info"]
+            assert nft_info.nft_coin_id == nft_wallet.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
+
+            res = await client.transfer_nft(nft_wallet_id, nft_id.hex(), addr, 0)
+            assert res["success"]
+
+            await asyncio.sleep(1)
+            for i in range(0, 5):
+                await client_2.farm_block(encode_puzzle_hash(ph_2, "txch"))
+                await asyncio.sleep(0.5)
+
+            nft_info_1 = (await full_node_rpc_api.get_nft_info({"coin_id": nft_id.hex(), "latest": False}))["nft_info"]
+            assert nft_info_1 == nft_info
 
             # Keys and addresses
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -671,11 +671,8 @@ class TestWalletRpc:
 
             nft_wallet: NFTWallet = wallet_node.wallet_state_manager.wallets[nft_wallet_id]
             nft_id = nft_wallet.get_current_nfts()[0].coin.name()
-            if trusted:
-                # It is intended to use different client to get NFT info
-                # This only supports trusted
-                nft_info = (await client_2.get_nft_info(nft_id, True))["nft_info"]
-                assert nft_info["nft_coin_id"] == nft_wallet.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
+            nft_info = (await client.get_nft_info(nft_id, True))["nft_info"]
+            assert nft_info["nft_coin_id"] == nft_wallet.get_current_nfts()[0].coin.parent_coin_info.hex().upper()
 
             res = await client.transfer_nft(nft_wallet_id, nft_id.hex(), addr, 0)
             assert res["success"]
@@ -684,9 +681,9 @@ class TestWalletRpc:
             for i in range(0, 5):
                 await client_2.farm_block(encode_puzzle_hash(ph_2, "txch"))
                 await asyncio.sleep(0.5)
-            if trusted:
-                nft_info_1 = (await client.get_nft_info(nft_id))["nft_info"]
-                assert nft_info_1 == nft_info
+
+            nft_info_1 = (await client.get_nft_info(nft_id))["nft_info"]
+            assert nft_info_1 == nft_info
 
             # Keys and addresses
 


### PR DESCRIPTION
The input coin id should be the only valid unspent NFT coin id. The API will fetch the puzzle reveal of its parent coin. For check the history of the NFT, set latest = False. The reason we do in this way is because it is more efficient. Since there is only one parent for a coin but one coin can have multiple children.