### PR TITLE
reduce the redundant computations of coin_ids in block_body_validation

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -147,8 +147,12 @@ async def validate_block_body(
         return Err.INVALID_REWARD_COINS, None
 
     removals: List[bytes32] = []
-    coinbase_additions: List[Coin] = list(expected_reward_coins)
-    additions: List[Coin] = []
+
+    # we store coins paired with their names in order to avoid computing the
+    # coin name multiple times, we store it next to the coin while validating
+    # the block
+    coinbase_additions: List[Tuple[Coin, bytes32]] = [(c, c.name()) for c in expected_reward_coins]
+    additions: List[Tuple[Coin, bytes32]] = []
     removals_puzzle_dic: Dict[bytes32, bytes32] = {}
     cost: uint64 = uint64(0)
 
@@ -210,7 +214,8 @@ async def validate_block_body(
             removals.append(spend.coin_id)
             removals_puzzle_dic[spend.coin_id] = spend.puzzle_hash
             for puzzle_hash, amount, _ in spend.create_coin:
-                additions.append(Coin(spend.coin_id, puzzle_hash, uint64(amount)))
+                c = Coin(spend.coin_id, puzzle_hash, uint64(amount))
+                additions.append((c, c.name()))
     else:
         assert npc_result is None
 
@@ -222,8 +227,8 @@ async def validate_block_body(
     # 10. Check additions for max coin amount
     # Be careful to check for 64 bit overflows in other languages. This is the max 64 bit unsigned integer
     # We will not even reach here because Coins do type checking (uint64)
-    for coin in additions + coinbase_additions:
-        additions_dic[coin.name()] = coin
+    for coin, coin_name in additions + coinbase_additions:
+        additions_dic[coin_name] = coin
         if coin.amount < 0:
             return Err.COIN_AMOUNT_NEGATIVE, None
 
@@ -243,7 +248,7 @@ async def validate_block_body(
     # 12. The additions and removals must result in the correct filter
     byte_array_tx: List[bytearray] = []
 
-    for coin in additions + coinbase_additions:
+    for coin, _ in additions + coinbase_additions:
         byte_array_tx.append(bytearray(coin.puzzle_hash))
     for coin_name in removals:
         byte_array_tx.append(bytearray(coin_name))
@@ -256,7 +261,7 @@ async def validate_block_body(
         return Err.INVALID_TRANSACTIONS_FILTER_HASH, None
 
     # 13. Check for duplicate outputs in additions
-    addition_counter = collections.Counter(_.name() for _ in additions + coinbase_additions)
+    addition_counter = collections.Counter(coin_name for _, coin_name in additions + coinbase_additions)
     for k, v in addition_counter.items():
         if v > 1:
             return Err.DUPLICATE_OUTPUT, None
@@ -322,14 +327,16 @@ async def validate_block_body(
                 assert c_name not in removals_since_fork
                 removals_since_fork.add(c_name)
             for c in additions_in_curr:
-                assert c.name() not in additions_since_fork
+                coin_name = c.name()
+                assert coin_name not in additions_since_fork
                 assert curr.foliage_transaction_block is not None
-                additions_since_fork[c.name()] = (c, curr.height, curr.foliage_transaction_block.timestamp)
+                additions_since_fork[coin_name] = (c, curr.height, curr.foliage_transaction_block.timestamp)
 
             for coinbase_coin in curr.get_included_reward_coins():
-                assert coinbase_coin.name() not in additions_since_fork
+                coin_name = coinbase_coin.name()
+                assert coin_name not in additions_since_fork
                 assert curr.foliage_transaction_block is not None
-                additions_since_fork[coinbase_coin.name()] = (
+                additions_since_fork[coin_name] = (
                     coinbase_coin,
                     curr.height,
                     curr.foliage_transaction_block.timestamp,
@@ -409,7 +416,7 @@ async def validate_block_body(
         removed += unspent.coin.amount
 
     added = 0
-    for coin in additions:
+    for coin, _ in additions:
         added += coin.amount
 
     # 16. Check that the total coin amount for added is <= removed

--- a/chia/consensus/block_root_validation.py
+++ b/chia/consensus/block_root_validation.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from chia_rs import compute_merkle_set_root
 
@@ -10,7 +10,7 @@ from chia.util.errors import Err
 def validate_block_merkle_roots(
     block_additions_root: bytes32,
     block_removals_root: bytes32,
-    tx_additions: Optional[List[Coin]] = None,
+    tx_additions: Optional[List[Tuple[Coin, bytes32]]] = None,
     tx_removals: Optional[List[bytes32]] = None,
 ) -> Optional[Err]:
     if tx_removals is None:
@@ -21,11 +21,11 @@ def validate_block_merkle_roots(
     # Create addition Merkle set
     puzzlehash_coins_map: Dict[bytes32, List[bytes32]] = {}
 
-    for coin in tx_additions:
+    for coin, coin_name in tx_additions:
         if coin.puzzle_hash in puzzlehash_coins_map:
-            puzzlehash_coins_map[coin.puzzle_hash].append(coin.name())
+            puzzlehash_coins_map[coin.puzzle_hash].append(coin_name)
         else:
-            puzzlehash_coins_map[coin.puzzle_hash] = [coin.name()]
+            puzzlehash_coins_map[coin.puzzle_hash] = [coin_name]
 
     # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
     additions_merkle_items: List[bytes32] = []


### PR DESCRIPTION
`coin.name()` contributes materially to the CPU cost of the main thread during sync and block validation.
after my serialization optimization (which hasn't landed yet) it's >30% of the CPU usage (not wall clock time) when syncing *full blocks* (i.e. blocks with the maximum number of coins).

This will likely not make this problem go away, but mitigate it some.