### PR TITLE
make recurse_jsonify() work directly on types

### DIFF
--- a/benchmarks/jsonify.py
+++ b/benchmarks/jsonify.py
@@ -1,0 +1,23 @@
+import random
+from time import perf_counter
+
+from tests.util.test_full_block_utils import get_full_blocks
+
+random.seed(123456789)
+
+
+def main() -> None:
+    total_time = 0.0
+    counter = 0
+    for block in get_full_blocks():
+        start = perf_counter()
+        block.to_json_dict()
+        end = perf_counter()
+        total_time += end - start
+        counter += 1
+
+    print(f"total time: {total_time:0.2f}s ({counter} iterations)")
+
+
+if __name__ == "__main__":
+    main()

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -144,7 +144,7 @@ class Blockchain(BlockchainInterface):
         self.constants = consensus_constants
         self.coin_store = coin_store
         self.block_store = block_store
-        self.constants_json = recurse_jsonify(dataclasses.asdict(self.constants))
+        self.constants_json = recurse_jsonify(self.constants)
         self._shut_down = False
         await self._load_chain_from_store(blockchain_dir)
         self._seen_compact_proofs = set()

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1573,7 +1573,7 @@ def _get_curr_diff_ssi(constants: ConsensusConstants, idx, summaries):
 
 
 def vars_to_bytes(constants: ConsensusConstants, summaries: List[SubEpochSummary], weight_proof: WeightProof):
-    constants_dict = recurse_jsonify(dataclasses.asdict(constants))
+    constants_dict = recurse_jsonify(constants)
     wp_recent_chain_bytes = bytes(RecentChainData(weight_proof.recent_chain_data))
     wp_segment_bytes = bytes(SubEpochSegments(weight_proof.sub_epoch_segments))
     summary_bytes = []

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, Dict, Sequence, Union
 
 from chia.util.streamable import recurse_jsonify
@@ -81,4 +80,5 @@ def get_list_or_len(list_in: Sequence[object], length: bool) -> Union[int, Seque
 
 
 def dataclass_to_json_dict(instance: Any) -> Dict[str, Any]:
-    return recurse_jsonify(dataclasses.asdict(instance))
+    ret: Dict[str, Any] = recurse_jsonify(instance)
+    return ret

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -5,21 +5,7 @@ import io
 import pprint
 import sys
 from enum import Enum
-from typing import (
-    Any,
-    BinaryIO,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    get_type_hints,
-    overload,
-)
+from typing import Any, BinaryIO, Callable, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, Union, get_type_hints
 
 from blspy import G1Element, G2Element, PrivateKey
 from typing_extensions import Literal
@@ -138,54 +124,38 @@ def dataclass_from_dict(klass: Type[Any], d: Any) -> Any:
         return klass(d)
 
 
-@overload
-def recurse_jsonify(d: Union[List[Any], Tuple[Any, ...]]) -> List[Any]:
-    ...
-
-
-@overload
-def recurse_jsonify(d: Dict[str, Any]) -> Dict[str, Any]:
-    ...
-
-
-def recurse_jsonify(d: Union[List[Any], Tuple[Any, ...], Dict[str, Any]]) -> Union[List[Any], Dict[str, Any]]:
+def recurse_jsonify(d: Any) -> Any:
     """
     Makes bytes objects and unhashable types into strings with 0x, and makes large ints into
     strings.
     """
-    if isinstance(d, list) or isinstance(d, tuple):
+    if dataclasses.is_dataclass(d):
+        new_dict = {}
+        for field in dataclasses.fields(d):
+            new_dict[field.name] = recurse_jsonify(getattr(d, field.name))
+        return new_dict
+
+    elif isinstance(d, list) or isinstance(d, tuple):
         new_list = []
         for item in d:
-            if type(item).__name__ in unhashable_types or issubclass(type(item), bytes):
-                item = f"0x{bytes(item).hex()}"
-            if isinstance(item, dict):
-                item = recurse_jsonify(item)
-            if isinstance(item, list):
-                item = recurse_jsonify(item)
-            if isinstance(item, tuple):
-                item = recurse_jsonify(item)
-            if isinstance(item, Enum):
-                item = item.name
-            if isinstance(item, int) and type(item) in big_ints:
-                item = int(item)
-            new_list.append(item)
-        d = new_list
+            new_list.append(recurse_jsonify(item))
+        return new_list
 
-    else:
-        for key, value in d.items():
-            if type(value).__name__ in unhashable_types or issubclass(type(value), bytes):
-                d[key] = f"0x{bytes(value).hex()}"
-            if isinstance(value, dict):
-                d[key] = recurse_jsonify(value)
-            if isinstance(value, list):
-                d[key] = recurse_jsonify(value)
-            if isinstance(value, tuple):
-                d[key] = recurse_jsonify(value)
-            if isinstance(value, Enum):
-                d[key] = value.name
-            if isinstance(value, int) and type(value) in big_ints:
-                d[key] = int(value)
-    return d
+    elif isinstance(d, dict):
+        new_dict = {}
+        for name, val in d.items():
+            new_dict[name] = recurse_jsonify(val)
+        return new_dict
+
+    elif type(d).__name__ in unhashable_types or issubclass(type(d), bytes):
+        return f"0x{bytes(d).hex()}"
+    elif isinstance(d, Enum):
+        return d.name
+    elif isinstance(d, int):
+        return int(d)
+    elif d is None or type(d) == str:
+        return d
+    raise ValueError(f"failed to jsonify {d} (type: {type(d)})")
 
 
 def parse_bool(f: BinaryIO) -> bool:
@@ -570,13 +540,14 @@ class Streamable:
         return bytes(f.getvalue())
 
     def __str__(self: Any) -> str:
-        return pp.pformat(recurse_jsonify(dataclasses.asdict(self)))
+        return pp.pformat(self.to_json_dict())
 
     def __repr__(self: Any) -> str:
-        return pp.pformat(recurse_jsonify(dataclasses.asdict(self)))
+        return pp.pformat(self.to_json_dict())
 
     def to_json_dict(self) -> Dict[str, Any]:
-        return recurse_jsonify(dataclasses.asdict(self))
+        ret: Dict[str, Any] = recurse_jsonify(self)
+        return ret
 
     @classmethod
     def from_json_dict(cls: Any, json_dict: Dict[str, Any]) -> Any:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -540,10 +540,10 @@ class Streamable:
         return bytes(f.getvalue())
 
     def __str__(self: Any) -> str:
-        return pp.pformat(self.to_json_dict())
+        return pp.pformat(recurse_jsonify(self))
 
     def __repr__(self: Any) -> str:
-        return pp.pformat(self.to_json_dict())
+        return pp.pformat(recurse_jsonify(self))
 
     def to_json_dict(self) -> Dict[str, Any]:
         ret: Dict[str, Any] = recurse_jsonify(self)

--- a/tests/util/test_full_block_utils.py
+++ b/tests/util/test_full_block_utils.py
@@ -1,4 +1,5 @@
 import random
+from typing import Iterator
 
 import pytest
 
@@ -196,7 +197,7 @@ def get_finished_sub_slots():
     yield [s for s in get_end_of_sub_slot()]
 
 
-def get_full_blocks():
+def get_full_blocks() -> Iterator[FullBlock]:
 
     random.seed(123456789)
 


### PR DESCRIPTION
circumventing the dataclasses.asdict() step. This enables simpler integration of non dataclasses into the Streamable and JSON protocols. Specifically, it opens the door for allowing native rust types to participate in `Streamable` (which includes json conversion).

As a bonus, this change avoids creating an intermediate dictionary, before converting it into JSON form.

A dictionary in JSON form is one that only contains `Dict`, `List`, `str` and `int`. `bytes32` objects are turned into hexadecimal strings.

This patch has a counterpart in `chia_rs`: https://github.com/Chia-Network/chia_rs/pull/18

**EDIT:**

I added a benchmark to ensure this doesn't make it more expensive to generate JSON messages. The benchmark calls `to_json_dict()` on `FullNode` objects of varying kinds (32768 combinations) timing those calls.

| before | after | after/before |
| --- | --- | --- |
| 336.15s | 101.90s | 0.303 |

So, a material speed-up