### PR TITLE
remove the cache from CoinStore

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -8,7 +8,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
-from chia.util.lru_cache import LRUCache
 from chia.util.chunks import chunks
 import time
 import logging
@@ -21,18 +20,14 @@ MAX_SQLITE_PARAMETERS = 900
 class CoinStore:
     """
     This object handles CoinRecords in DB.
-    A cache is maintained for quicker access to recent coins.
     """
 
-    coin_record_cache: LRUCache
-    cache_size: uint32
     db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper2, cache_size: uint32 = uint32(60000)):
+    async def create(cls, db_wrapper: DBWrapper2):
         self = cls()
 
-        self.cache_size = cache_size
         self.db_wrapper = db_wrapper
 
         async with self.db_wrapper.write_db() as conn:
@@ -81,7 +76,6 @@ class CoinStore:
 
             await conn.execute("CREATE INDEX IF NOT EXISTS coin_parent_index on coin_record(coin_parent)")
 
-        self.coin_record_cache = LRUCache(cache_size)
         return self
 
     async def num_unspent(self) -> int:
@@ -161,10 +155,6 @@ class CoinStore:
 
     # Checks DB and DiffStores for CoinRecord with coin_name and returns it
     async def get_coin_record(self, coin_name: bytes32) -> Optional[CoinRecord]:
-        cached = self.coin_record_cache.get(coin_name)
-        if cached is not None:
-            return cached
-
         async with self.db_wrapper.read_db() as conn:
             async with conn.execute(
                 "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
@@ -174,9 +164,7 @@ class CoinStore:
                 row = await cursor.fetchone()
                 if row is not None:
                     coin = self.row_to_coin(row)
-                    record = CoinRecord(coin, row[0], row[1], row[2], row[6])
-                    self.coin_record_cache.put(record.coin.name(), record)
-                    return record
+                    return CoinRecord(coin, row[0], row[1], row[2], row[6])
         return None
 
     async def get_coin_records(self, names: List[bytes32]) -> List[CoinRecord]:
@@ -184,14 +172,6 @@ class CoinStore:
             return []
 
         coins: List[CoinRecord] = []
-        new_names: List[bytes32] = []
-        for n in names:
-            cached = self.coin_record_cache.get(n)
-            if cached is not None:
-                coins.append(cached)
-            else:
-                new_names.append(n)
-        names = new_names
 
         if len(names) == 0:
             return coins
@@ -218,7 +198,6 @@ class CoinStore:
                     coin = self.row_to_coin(row)
                     record = CoinRecord(coin, row[0], row[1], row[2], row[6])
                     coins.append(record)
-                    self.coin_record_cache.put(record.coin.name(), record)
 
         return coins
 
@@ -452,23 +431,6 @@ class CoinStore:
         Note that block_index can be negative, in which case everything is rolled back
         Returns the list of coin records that have been modified
         """
-        # Update memory cache
-        delete_queue: List[bytes32] = []
-        for coin_name, coin_record in list(self.coin_record_cache.cache.items()):
-            if int(coin_record.spent_block_index) > block_index:
-                new_record = CoinRecord(
-                    coin_record.coin,
-                    coin_record.confirmed_block_index,
-                    uint32(0),
-                    coin_record.coinbase,
-                    coin_record.timestamp,
-                )
-                self.coin_record_cache.put(coin_record.coin.name(), new_record)
-            if int(coin_record.confirmed_block_index) > block_index:
-                delete_queue.append(coin_name)
-
-        for coin_name in delete_queue:
-            self.coin_record_cache.remove(coin_name)
 
         coin_changes: Dict[bytes32, CoinRecord] = {}
         # Add coins that are confirmed in the reverted blocks to the list of updated coins.
@@ -506,13 +468,12 @@ class CoinStore:
                 )
         return list(coin_changes.values())
 
-    # Store CoinRecord in DB and ram cache
+    # Store CoinRecord in DB
     async def _add_coin_records(self, records: List[CoinRecord]) -> None:
 
         if self.db_wrapper.db_version == 2:
             values2 = []
             for record in records:
-                self.coin_record_cache.put(record.coin.name(), record)
                 values2.append(
                     (
                         record.coin.name(),
@@ -534,7 +495,6 @@ class CoinStore:
         else:
             values = []
             for record in records:
-                self.coin_record_cache.put(record.coin.name(), record)
                 values.append(
                     (
                         record.coin.name().hex(),
@@ -559,20 +519,10 @@ class CoinStore:
     async def _set_spent(self, coin_names: List[bytes32], index: uint32):
 
         assert len(coin_names) == 0 or index > 0
-        # if this coin is in the cache, mark it as spent in there
         updates = []
         for coin_name in coin_names:
-            r = self.coin_record_cache.get(coin_name)
-            if r is not None:
-                if r.spent_block_index != uint32(0):
-                    raise ValueError(f"Coin already spent in cache: {coin_name}")
-
-                self.coin_record_cache.put(
-                    r.name, CoinRecord(r.coin, r.confirmed_block_index, index, r.coinbase, r.timestamp)
-                )
             updates.append((index, self.maybe_to_hex(coin_name)))
 
-        assert len(updates) == len(coin_names)
         async with self.db_wrapper.write_db() as conn:
             if self.db_wrapper.db_version == 2:
                 ret: Cursor = await conn.executemany(

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -8,7 +8,7 @@ from tests.setup_nodes import test_constants
 from tests.util.temp_file import TempFile
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.ints import uint32, uint64
+from chia.util.ints import uint64
 from chia.cmds.db_upgrade_func import convert_v1_to_v2
 from chia.util.db_wrapper import DBWrapper2
 from chia.full_node.block_store import BlockStore
@@ -62,7 +62,7 @@ class TestDbUpgrade:
             await db_wrapper1.add_connection(await aiosqlite.connect(in_file))
             try:
                 block_store1 = await BlockStore.create(db_wrapper1)
-                coin_store1 = await CoinStore.create(db_wrapper1, uint32(0))
+                coin_store1 = await CoinStore.create(db_wrapper1)
                 if with_hints:
                     hint_store1 = await HintStore.create(db_wrapper1)
                     for h in hints:
@@ -95,12 +95,12 @@ class TestDbUpgrade:
 
             try:
                 block_store1 = await BlockStore.create(db_wrapper1)
-                coin_store1 = await CoinStore.create(db_wrapper1, uint32(0))
+                coin_store1 = await CoinStore.create(db_wrapper1)
                 if with_hints:
                     hint_store1 = await HintStore.create(db_wrapper1)
 
                 block_store2 = await BlockStore.create(db_wrapper2)
-                coin_store2 = await CoinStore.create(db_wrapper2, uint32(0))
+                coin_store2 = await CoinStore.create(db_wrapper2)
                 hint_store2 = await HintStore.create(db_wrapper2)
 
                 if with_hints:

--- a/tests/core/test_db_validation.py
+++ b/tests/core/test_db_validation.py
@@ -17,7 +17,7 @@ from chia.full_node.hint_store import HintStore
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.util.db_wrapper import DBWrapper2
-from chia.util.ints import uint32, uint64
+from chia.util.ints import uint64
 from tests.setup_nodes import test_constants
 from tests.util.temp_file import TempFile
 
@@ -139,7 +139,7 @@ async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
             await conn.execute("INSERT INTO database_version VALUES (2)")
 
         block_store = await BlockStore.create(db_wrapper)
-        coin_store = await CoinStore.create(db_wrapper, uint32(0))
+        coin_store = await CoinStore.create(db_wrapper)
         hint_store = await HintStore.create(db_wrapper)
 
         bc = await Blockchain.create(coin_store, block_store, test_constants, hint_store, Path("."), reserved_cores=0)


### PR DESCRIPTION
It appears the cost of maintaining the cache outweighs the gains. The speedups are modest, but the simplification and reduced testing are notable.

I got these completion times in the `test_full_sync.py` benchmark (lower is better):

| test | with cache | without cache | without/with |
| --- | --- | --- | --- |
| sync, M1 SSD | 131.41s | 119.10s | 0.906 |
| keepup, M1 SSD | 545.53s | 539.13s | 0.988 |
| sync, RPi SSD | 1042.15s | 836.03s | 0.802 |
| keepup, RPi SSD | 3484.43s | 3004.41s | 0.862 |
| sync, RPi HDD | 875.52s | 839.01s | 0.958 |
| keepup, RPi HDD | 3058.92s | 3003.23s | 0.982 |
| sync, AMD HDD | 176.70s | 164.44s | 0.931 |
| keepup, AMD HDD | 912.31s | 900.00s | 0.987 |
| sync, AMD SDD | 172.96s | 162.45s | 0.939 |
| keepup, AMD SDD | 915.38s | 899.90s | 0.983 |

removing the cache performs slightly better consistently.