### PR TITLE
Optimize std_hash in coin.py

### DIFF
--- a/chia/types/blockchain_format/coin.py
+++ b/chia/types/blockchain_format/coin.py
@@ -28,7 +28,9 @@ class Coin(Streamable):
         # significant bit is set, to encode it as a positive number. This
         # despite "amount" being unsigned. This way, a CLVM program can generate
         # these hashes easily.
-        return std_hash(self.parent_coin_info + self.puzzle_hash + int_to_bytes(self.amount))
+        return std_hash(
+            self.parent_coin_info + self.puzzle_hash + int_to_bytes(self.amount), skip_bytes_conversion=True
+        )
 
     def name(self) -> bytes32:
         return self.get_hash()
@@ -60,4 +62,4 @@ def hash_coin_ids(coin_ids: List[bytes32]) -> bytes32:
     for name in coin_ids:
         buffer.extend(name)
 
-    return std_hash(buffer)
+    return std_hash(buffer, skip_bytes_conversion=True)

--- a/chia/util/hash.py
+++ b/chia/util/hash.py
@@ -1,10 +1,13 @@
-import blspy
+from hashlib import sha256
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 
 
-def std_hash(b) -> bytes32:
+def std_hash(b, skip_bytes_conversion: bool = False) -> bytes32:
     """
     The standard hash used in many places.
     """
-    return bytes32(blspy.Util.hash256(bytes(b)))
+    if skip_bytes_conversion:
+        return bytes32(sha256(b).digest())
+    else:
+        return bytes32(sha256(bytes(b)).digest())


### PR DESCRIPTION
constructing a bytes object from a bytes object is not necessary. In these cases we are passing in bytes so we don't need to convert. These are also the places where `std_hash` is called the most.

Also, using hashlib instead of calling into C++ is more efficient.

This makes `std_hash` around 25% faster

test_full_sync
| before | after | after/before |
| --- | --- | --- |
| 119s | 116s |  0.975 |

Another thing to improve would be not checking the size when constructing a bytes32 here. It's very slow for some reason (calling len(bytes)). However I'm not sure how to add an optional arg to the constructor of bytes32