### PR TITLE
Fix multiple offered CATs in aggregated offers

### DIFF
--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -315,7 +315,7 @@ class Offer:
 
         if spendable_cats:
             completion_spends += unsigned_spend_bundle_for_spendable_cats(CAT_MOD, spendable_cats).coin_spends
-                
+
         return SpendBundle.aggregate([SpendBundle(completion_spends, G2Element()), self.bundle])
 
     def to_spend_bundle(self) -> SpendBundle:


### PR DESCRIPTION
Offer files which have been combined/aggregated with ```Offer.aggregate``` and offer the same CAT, currently fail with ```ValueError: input and output amounts don't match``` when taking the offer.

This happens because the spends in ```unsigned_spend_bundle_for_spendable_cats``` are checked separately.

This pull request changes the process so that ```unsigned_spend_bundle_for_spendable_cats``` is only called once and for all offered CATs together.