### PR TITLE
tests: Split up and improve `test_wallet_rpc.py`

### DIFF
--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 from operator import attrgetter
-from typing import Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 import pytest_asyncio
@@ -78,7 +78,7 @@ async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: Wallet
     assert full_node_api.full_node.mempool_manager.get_spendbundle(spend_bundle.name()) is None
 
 
-async def generate_funds(full_node_api: FullNodeSimulator, wallet_bundle: WalletBundle, num_blocks: int = 5):
+async def generate_funds(full_node_api: FullNodeSimulator, wallet_bundle: WalletBundle, num_blocks: int = 1):
     wallet_id = 1
     initial_balances = await wallet_bundle.rpc_client.get_wallet_balance(str(wallet_id))
     ph: bytes32 = decode_puzzle_hash(await wallet_bundle.rpc_client.get_next_address(str(wallet_id), True))
@@ -189,6 +189,17 @@ async def wallet_rpc_environment(two_wallet_nodes, request, bt: BlockTools, self
     await rpc_cleanup_node()
 
 
+async def create_tx_outputs(wallet: Wallet, output_args: List[Tuple[int, Optional[List[str]]]]) -> List[Dict[str, Any]]:
+    outputs = []
+    for args in output_args:
+        output = {"amount": uint64(args[0]), "puzzle_hash": await wallet.get_new_puzzlehash()}
+        if args[1] is not None:
+            assert len(args[1]) > 0
+            output["memos"] = args[1]
+        outputs.append(output)
+    return outputs
+
+
 async def assert_wallet_types(client: WalletRpcClient, expected: Dict[WalletType, int]) -> None:
     for wallet_type in WalletType:
         wallets = await client.get_wallets(wallet_type)
@@ -197,6 +208,32 @@ async def assert_wallet_types(client: WalletRpcClient, expected: Dict[WalletType
             assert wallet_count == expected.get(wallet_type, 0)
             for wallet in wallets:
                 assert wallet["type"] == wallet_type.value
+
+
+def assert_tx_amounts(
+    tx: TransactionRecord, outputs: List[Dict[str, Any]], *, amount_fee: uint64, change_expected: bool
+) -> None:
+    assert tx.fee_amount == amount_fee
+    assert tx.amount == sum(output["amount"] for output in outputs)
+    expected_additions = len(outputs) if change_expected is None else len(outputs) + 1
+    assert len(tx.additions) == expected_additions
+    addition_amounts = [addition.amount for addition in tx.additions]
+    removal_amounts = [removal.amount for removal in tx.removals]
+    for output in outputs:
+        assert output["amount"] in addition_amounts
+    assert (sum(removal_amounts) - sum(addition_amounts)) == amount_fee
+
+
+async def assert_push_tx_error(node_rpc: FullNodeRpcClient, tx: TransactionRecord):
+    spend_bundle = tx.spend_bundle
+    assert spend_bundle is not None
+    # check error for a ASSERT_ANNOUNCE_CONSUMED_FAILED and if the error is not there throw a value error
+    try:
+        await node_rpc.push_tx(spend_bundle)
+    except ValueError as error:
+        error_string = error.args[0]["error"]  # noqa:  # pylint: disable=E1126
+        if error_string.find("ASSERT_ANNOUNCE_CONSUMED_FAILED") == -1:
+            raise ValueError from error
 
 
 async def tx_in_mempool(client: WalletRpcClient, transaction_id: bytes32):
@@ -213,23 +250,16 @@ async def get_unconfirmed_balance(client: WalletRpcClient, wallet_id: int):
 
 
 @pytest.mark.asyncio
-async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
+async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
 
-    wallet: Wallet = env.wallet_1.wallet
     wallet_2: Wallet = env.wallet_2.wallet
-
     wallet_node: WalletNode = env.wallet_1.node
-
     full_node_api: FullNodeSimulator = env.full_node.api
-
     client: WalletRpcClient = env.wallet_1.rpc_client
-    client_2: WalletRpcClient = env.wallet_2.rpc_client
-    client_node: FullNodeRpcClient = env.full_node.rpc_client
 
     generated_funds = await generate_funds(full_node_api, env.wallet_1)
 
-    ph_2 = await wallet_2.get_new_puzzlehash()
     addr = encode_puzzle_hash(await wallet_2.get_new_puzzlehash(), "txch")
     tx_amount = uint64(15600000)
     with pytest.raises(ValueError):
@@ -256,13 +286,88 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
 
     await time_out_assert(5, get_confirmed_balance, generated_funds - tx_amount, client, 1)
 
-    # Tests offline signing
-    ph_3 = await wallet_2.get_new_puzzlehash()
-    ph_4 = await wallet_2.get_new_puzzlehash()
-    ph_5 = await wallet_2.get_new_puzzlehash()
 
-    # Test basic transaction to one output and coin announcement
-    signed_tx_amount = 888000
+@pytest.mark.parametrize(
+    "output_args, fee, select_coin",
+    [
+        ([(348026, None)], 0, False),
+        ([(1270495230, ["memo_1"]), (902347, ["memo_2"])], 1, True),
+        ([(84920, ["memo_1_0", "memo_1_1"]), (1, ["memo_2_0"])], 0, False),
+        ([(32058710, ["memo_1_0", "memo_1_1"]), (1, ["memo_2_0"]), (923, ["memo_3_0", "memo_3_1"])], 32804, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_signed_transaction(
+    wallet_rpc_environment: WalletRpcTestEnvironment,
+    output_args: List[Tuple[int, Optional[List[str]]]],
+    fee: int,
+    select_coin: bool,
+):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    wallet_2: Wallet = env.wallet_2.wallet
+    wallet_1_node: WalletNode = env.wallet_1.node
+    wallet_1_rpc: WalletRpcClient = env.wallet_1.rpc_client
+    full_node_api: FullNodeSimulator = env.full_node.api
+    full_node_rpc: FullNodeRpcClient = env.full_node.rpc_client
+
+    generated_funds = await generate_funds(full_node_api, env.wallet_1)
+
+    outputs = await create_tx_outputs(wallet_2, output_args)
+    amount_outputs = sum(output["amount"] for output in outputs)
+    amount_fee = uint64(fee)
+    amount_total = amount_outputs + amount_fee
+
+    selected_coin = None
+    if select_coin:
+        selected_coin = await wallet_1_rpc.select_coins(amount=amount_total, wallet_id=1)
+        assert len(selected_coin) == 1
+
+    tx = await wallet_1_rpc.create_signed_transaction(
+        outputs,
+        coins=selected_coin,
+        fee=amount_fee,
+    )
+    assert_tx_amounts(tx, outputs, amount_fee=amount_fee, change_expected=not select_coin)
+
+    # Farm the transaction and make sure the wallet balance reflects it correct
+    spend_bundle = tx.spend_bundle
+    assert spend_bundle is not None
+    push_res = await full_node_rpc.push_tx(spend_bundle)
+    assert push_res["success"]
+    await farm_transaction(full_node_api, wallet_1_node, spend_bundle)
+    await time_out_assert(5, get_confirmed_balance, generated_funds - amount_total, wallet_1_rpc, 1)
+
+    # Validate the memos
+    for output in outputs:
+        if "memos" in outputs:
+            found: bool = False
+            for addition in spend_bundle.additions():
+                if addition.amount == output["amount"] and addition.puzzle_hash.hex() == output["puzzle_hash"]:
+                    cr: Optional[CoinRecord] = await full_node_rpc.get_coin_record_by_name(addition.name())
+                    assert cr is not None
+                    spend: Optional[CoinSpend] = await full_node_rpc.get_puzzle_and_solution(
+                        addition.parent_coin_info, cr.confirmed_block_index
+                    )
+                    assert spend is not None
+                    sb: SpendBundle = SpendBundle([spend], G2Element())
+                    assert compute_memos(sb) == {addition.name(): [memo.encode() for memo in output["memos"]]}
+                    found = True
+            assert found
+
+
+@pytest.mark.asyncio
+async def test_create_signed_transaction_with_coin_announcement(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    wallet_2: Wallet = env.wallet_2.wallet
+    full_node_api: FullNodeSimulator = env.full_node.api
+    client: WalletRpcClient = env.wallet_1.rpc_client
+    client_node: FullNodeRpcClient = env.full_node.rpc_client
+
+    await generate_funds(full_node_api, env.wallet_1)
+
+    signed_tx_amount = uint64(888000)
     tx_coin_announcements = [
         Announcement(
             std_hash(b"coin_id_1"),
@@ -274,26 +379,26 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
             bytes(Program.to("a string")),
         ),
     ]
+    outputs = await create_tx_outputs(wallet_2, [(signed_tx_amount, None)])
     tx_res: TransactionRecord = await client.create_signed_transaction(
-        [{"amount": signed_tx_amount, "puzzle_hash": ph_3}], coin_announcements=tx_coin_announcements
+        outputs, coin_announcements=tx_coin_announcements
     )
-    spend_bundle = tx_res.spend_bundle
-    assert spend_bundle is not None
+    assert_tx_amounts(tx_res, outputs, amount_fee=uint64(0), change_expected=False)
+    await assert_push_tx_error(client_node, tx_res)
 
-    assert tx_res.fee_amount == 0
-    assert tx_res.amount == signed_tx_amount
-    assert len(tx_res.additions) == 2  # The output and the change
-    assert any([addition.amount == signed_tx_amount for addition in tx_res.additions])
-    # check error for a ASSERT_ANNOUNCE_CONSUMED_FAILED and if the error is not there throw a value error
-    try:
-        push_res = await client_node.push_tx(spend_bundle)
-    except ValueError as error:
-        error_string = error.args[0]["error"]  # noqa:  # pylint: disable=E1126
-        if error_string.find("ASSERT_ANNOUNCE_CONSUMED_FAILED") == -1:
-            raise ValueError from error
 
-    # # Test basic transaction to one output and puzzle announcement
-    signed_tx_amount = 888000
+@pytest.mark.asyncio
+async def test_create_signed_transaction_with_puzzle_announcement(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    wallet_2: Wallet = env.wallet_2.wallet
+    full_node_api: FullNodeSimulator = env.full_node.api
+    client: WalletRpcClient = env.wallet_1.rpc_client
+    client_node: FullNodeRpcClient = env.full_node.rpc_client
+
+    await generate_funds(full_node_api, env.wallet_1)
+
+    signed_tx_amount = uint64(888000)
     tx_puzzle_announcements = [
         Announcement(
             std_hash(b"puzzle_hash_1"),
@@ -305,120 +410,68 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
             bytes(Program.to("a string")),
         ),
     ]
-    tx_res = await client.create_signed_transaction(
-        [{"amount": signed_tx_amount, "puzzle_hash": ph_3}], puzzle_announcements=tx_puzzle_announcements
-    )
-    spend_bundle = tx_res.spend_bundle
-    assert spend_bundle is not None
+    outputs = await create_tx_outputs(wallet_2, [(signed_tx_amount, None)])
+    tx_res = await client.create_signed_transaction(outputs, puzzle_announcements=tx_puzzle_announcements)
+    assert_tx_amounts(tx_res, outputs, amount_fee=uint64(0), change_expected=True)
+    await assert_push_tx_error(client_node, tx_res)
 
-    assert tx_res.fee_amount == 0
-    assert tx_res.amount == signed_tx_amount
-    assert len(tx_res.additions) == 2  # The output and the change
-    assert any([addition.amount == signed_tx_amount for addition in tx_res.additions])
-    # check error for a ASSERT_ANNOUNCE_CONSUMED_FAILED and if the error is not there throw a value error
-    try:
-        push_res = await client_node.push_tx(spend_bundle)
-    except ValueError as error:
-        error_string = error.args[0]["error"]  # noqa:  # pylint: disable=E1126
-        if error_string.find("ASSERT_ANNOUNCE_CONSUMED_FAILED") == -1:
-            raise ValueError from error
 
-    # Test basic transaction to one output
-    signed_tx_amount = 888000
-    tx_res = await client.create_signed_transaction(
-        [{"amount": signed_tx_amount, "puzzle_hash": ph_3, "memos": ["My memo"]}]
-    )
+@pytest.mark.asyncio
+async def test_send_transaction_multi(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
 
-    assert tx_res.fee_amount == 0
-    assert tx_res.amount == signed_tx_amount
-    assert len(tx_res.additions) == 2  # The output and the change
-    assert any([addition.amount == signed_tx_amount for addition in tx_res.additions])
+    wallet_2: Wallet = env.wallet_2.wallet
+    wallet_node: WalletNode = env.wallet_1.node
+    full_node_api: FullNodeSimulator = env.full_node.api
+    client: WalletRpcClient = env.wallet_1.rpc_client
 
-    spend_bundle = tx_res.spend_bundle
-    assert spend_bundle is not None
+    generated_funds = await generate_funds(full_node_api, env.wallet_1)
 
-    push_res = await client.push_tx(spend_bundle)
-    assert push_res["success"]
-    assert await get_confirmed_balance(client, 1) == generated_funds - tx_amount
-
-    await farm_transaction(full_node_api, wallet_node, spend_bundle)
-
-    await time_out_assert(5, get_confirmed_balance, generated_funds - tx_amount - signed_tx_amount, client, 1)
-
-    # Test transaction to two outputs, from a specified coin, with a fee
-    coin_to_spend = None
-    for addition in tx_res.additions:
-        if addition.amount != signed_tx_amount:
-            coin_to_spend = addition
-    assert coin_to_spend is not None
-
-    tx_res = await client.create_signed_transaction(
-        [{"amount": 444, "puzzle_hash": ph_4, "memos": ["hhh"]}, {"amount": 999, "puzzle_hash": ph_5}],
-        coins=[coin_to_spend],
-        fee=uint64(100),
-    )
-    spend_bundle = tx_res.spend_bundle
-    assert spend_bundle is not None
-
-    assert tx_res.fee_amount == 100
-    assert tx_res.amount == 444 + 999
-    assert len(tx_res.additions) == 3  # The outputs and the change
-    assert any([addition.amount == 444 for addition in tx_res.additions])
-    assert any([addition.amount == 999 for addition in tx_res.additions])
-    assert sum([rem.amount for rem in tx_res.removals]) - sum([ad.amount for ad in tx_res.additions]) == 100
-
-    push_res = await client_node.push_tx(spend_bundle)
-    assert push_res["success"]
-
-    await farm_transaction(full_node_api, wallet_node, spend_bundle)
-
-    found: bool = False
-    for addition in spend_bundle.additions():
-        if addition.amount == 444:
-            cr: Optional[CoinRecord] = await client_node.get_coin_record_by_name(addition.name())
-            assert cr is not None
-            spend: Optional[CoinSpend] = await client_node.get_puzzle_and_solution(
-                addition.parent_coin_info, cr.confirmed_block_index
-            )
-            assert spend is not None
-            sb: SpendBundle = SpendBundle([spend], G2Element())
-            assert compute_memos(sb) == {addition.name(): [b"hhh"]}
-            found = True
-    assert found
-
-    new_balance = generated_funds - tx_amount - signed_tx_amount - 444 - 999 - 100
-    await time_out_assert(5, get_confirmed_balance, new_balance, client, 1)
+    outputs = await create_tx_outputs(wallet_2, [(uint64(1), ["memo_1"]), (uint64(2), ["memo_2"])])
+    amount_outputs = sum(output["amount"] for output in outputs)
+    amount_fee = uint64(amount_outputs + 1)
 
     send_tx_res: TransactionRecord = await client.send_transaction_multi(
         "1",
-        [
-            {"amount": 555, "puzzle_hash": ph_4, "memos": ["FiMemo"]},
-            {"amount": 666, "puzzle_hash": ph_5, "memos": ["SeMemo"]},
-        ],
-        fee=uint64(200),
+        outputs,
+        fee=amount_fee,
     )
     spend_bundle = send_tx_res.spend_bundle
     assert spend_bundle is not None
     assert send_tx_res is not None
-    assert send_tx_res.fee_amount == 200
-    assert send_tx_res.amount == 555 + 666
-    assert len(send_tx_res.additions) == 3  # The outputs and the change
-    assert any([addition.amount == 555 for addition in send_tx_res.additions])
-    assert any([addition.amount == 666 for addition in send_tx_res.additions])
-    assert sum([rem.amount for rem in send_tx_res.removals]) - sum([ad.amount for ad in send_tx_res.additions]) == 200
+
+    assert_tx_amounts(send_tx_res, outputs, amount_fee=amount_fee, change_expected=True)
 
     await farm_transaction(full_node_api, wallet_node, spend_bundle)
 
-    new_balance = new_balance - 555 - 666 - 200
-    await time_out_assert(5, get_confirmed_balance, new_balance, client, 1)
+    await time_out_assert(5, get_confirmed_balance, generated_funds - amount_outputs - amount_fee, client, 1)
 
-    address = await client.get_next_address("1", True)
-    assert len(address) > 10
+    # Checks that the memo can be retrieved
+    tx_confirmed = await client.get_transaction("1", send_tx_res.name)
+    assert tx_confirmed.confirmed
+    memos = tx_confirmed.get_memos()
+    assert len(memos) == len(outputs)
+    for output in outputs:
+        assert [output["memos"][0].encode()] in memos.values()
+    spend_bundle = send_tx_res.spend_bundle
+    assert spend_bundle is not None
+    for key in memos.keys():
+        assert key in [a.name() for a in spend_bundle.additions()]
 
-    transactions = await client.get_transactions("1")
-    assert len(transactions) > 1
+
+@pytest.mark.asyncio
+async def test_get_transactions(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    wallet: Wallet = env.wallet_1.wallet
+    wallet_node: WalletNode = env.wallet_1.node
+    full_node_api: FullNodeSimulator = env.full_node.api
+    client: WalletRpcClient = env.wallet_1.rpc_client
+
+    await generate_funds(full_node_api, env.wallet_1, 5)
 
     all_transactions = await client.get_transactions("1")
+    assert len(all_transactions) >= 10
     # Test transaction pagination
     some_transactions = await client.get_transactions("1", 0, 5)
     some_transactions_2 = await client.get_transactions("1", 5, 10)
@@ -432,7 +485,9 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert all_transactions == sorted(all_transactions, key=attrgetter("confirmed_at_height"), reverse=True)
 
     # Test RELEVANCE
-    await client.send_transaction("1", uint64(1), encode_puzzle_hash(ph_2, "txch"))  # Create a pending tx
+    await client.send_transaction(
+        "1", uint64(1), encode_puzzle_hash(await wallet.get_new_puzzlehash(), "txch")
+    )  # Create a pending tx
 
     all_transactions = await client.get_transactions("1", sort_key=SortKey.RELEVANCE)
     sorted_transactions = sorted(all_transactions, key=attrgetter("created_at_time"), reverse=True)
@@ -446,22 +501,6 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
     sorted_transactions = sorted(sorted_transactions, key=attrgetter("confirmed"), reverse=True)
     assert all_transactions == sorted_transactions
 
-    # Checks that the memo can be retrieved
-    tx_confirmed = await client.get_transaction("1", send_tx_res.name)
-    assert tx_confirmed.confirmed
-    if isinstance(tx_confirmed, SpendBundle):
-        memos = compute_memos(tx_confirmed)
-    else:
-        memos = tx_confirmed.get_memos()
-    assert len(memos) == 2
-    print(memos)
-    assert [b"FiMemo"] in memos.values()
-    assert [b"SeMemo"] in memos.values()
-    spend_bundle = send_tx_res.spend_bundle
-    assert spend_bundle is not None
-    assert list(memos.keys())[0] in [a.name() for a in spend_bundle.additions()]
-    assert list(memos.keys())[1] in [a.name() for a in spend_bundle.additions()]
-
     # Test get_transactions to address
     ph_by_addr = await wallet.get_new_puzzlehash()
     await client.send_transaction("1", uint64(1), encode_puzzle_hash(ph_by_addr, "txch"))
@@ -471,13 +510,35 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert len(tx_for_address) == 1
     assert tx_for_address[0].to_puzzle_hash == ph_by_addr
 
-    # Test coin selection
-    selected_coins = await client.select_coins(amount=1, wallet_id=1)
-    assert len(selected_coins) > 0
 
-    ##############
-    # CATS       #
-    ##############
+@pytest.mark.asyncio
+async def test_get_transaction_count(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    full_node_api: FullNodeSimulator = env.full_node.api
+    client: WalletRpcClient = env.wallet_1.rpc_client
+
+    await generate_funds(full_node_api, env.wallet_1)
+
+    all_transactions = await client.get_transactions("1")
+    assert len(all_transactions) > 0
+    transaction_count = await client.get_transaction_count("1")
+    assert transaction_count == len(all_transactions)
+
+
+@pytest.mark.asyncio
+async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    wallet_node: WalletNode = env.wallet_1.node
+
+    client: WalletRpcClient = env.wallet_1.rpc_client
+    client_2: WalletRpcClient = env.wallet_2.rpc_client
+
+    full_node_api: FullNodeSimulator = env.full_node.api
+
+    await generate_funds(full_node_api, env.wallet_1, 1)
+    await generate_funds(full_node_api, env.wallet_2, 1)
 
     # Creates a CAT wallet with 100 mojos and a CAT with 20 mojos
     await client.create_new_cat_and_wallet(uint64(100))
@@ -512,6 +573,8 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert should_be_none is None
     assert name == next(iter(DEFAULT_CATS.items()))[1]["name"]
 
+    # TODO: Investigate why farming only one block here makes it flaky
+    await farm_transaction_block(full_node_api, wallet_node)
     await farm_transaction_block(full_node_api, wallet_node)
 
     await time_out_assert(10, get_confirmed_balance, 20, client, cat_0_id)
@@ -559,9 +622,59 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
     selected_coins = await client.select_coins(amount=1, wallet_id=cat_0_id)
     assert len(selected_coins) > 0
 
-    ##########
-    # Offers #
-    ##########
+
+@pytest.mark.asyncio
+async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    wallet_node: WalletNode = env.wallet_1.node
+
+    client: WalletRpcClient = env.wallet_1.rpc_client
+    client_2: WalletRpcClient = env.wallet_2.rpc_client
+
+    full_node_api: FullNodeSimulator = env.full_node.api
+
+    await generate_funds(full_node_api, env.wallet_1, 1)
+    await generate_funds(full_node_api, env.wallet_2, 1)
+
+    # Creates a CAT wallet with 100 mojos and a CAT with 20 mojos
+    await client.create_new_cat_and_wallet(uint64(100))
+    res = await client.create_new_cat_and_wallet(uint64(20))
+    assert res["success"]
+    cat_0_id = res["wallet_id"]
+    asset_id = bytes32.fromhex(res["asset_id"])
+    assert len(asset_id) > 0
+
+    # TODO: Investigate why farming only one block here makes it flaky
+    await farm_transaction_block(full_node_api, wallet_node)
+    await farm_transaction_block(full_node_api, wallet_node)
+
+    await time_out_assert(10, get_confirmed_balance, 20, client, cat_0_id)
+
+    # Creates a second wallet with the same CAT
+    res = await client_2.create_wallet_for_existing_cat(asset_id)
+    assert res["success"]
+    cat_1_id = res["wallet_id"]
+    cat_1_asset_id = bytes.fromhex(res["asset_id"])
+    assert cat_1_asset_id == asset_id
+
+    await assert_wallet_types(client, {WalletType.STANDARD_WALLET: 1, WalletType.CAT: 2})
+    await assert_wallet_types(client_2, {WalletType.STANDARD_WALLET: 1, WalletType.CAT: 1})
+
+    await farm_transaction_block(full_node_api, wallet_node)
+
+    bal_1 = await client_2.get_wallet_balance(cat_1_id)
+    assert bal_1["confirmed_wallet_balance"] == 0
+
+    addr_0 = await client.get_next_address(cat_0_id, False)
+    addr_1 = await client_2.get_next_address(cat_1_id, False)
+
+    assert addr_0 != addr_1
+
+    tx_res = await client.cat_spend(cat_0_id, uint64(4), addr_1, uint64(0), ["the cat memo"])
+    spend_bundle = tx_res.spend_bundle
+    assert spend_bundle is not None
+    await farm_transaction(full_node_api, wallet_node, spend_bundle)
 
     # Create an offer of 5 chia for one CAT
     offer, trade_record = await client.create_offer_for_ids({uint32(1): -5, cat_0_id: 1}, validate_only=True)
@@ -571,6 +684,8 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
 
     offer, trade_record = await client.create_offer_for_ids({uint32(1): -5, cat_0_id: 1}, fee=uint64(1))
     assert offer is not None
+
+    col = await client.get_cat_asset_id(cat_0_id)
 
     summary = await client.get_offer_summary(offer)
     assert summary == {"offered": {"xch": 5}, "requested": {col.hex(): 1}, "fees": 1}
@@ -632,26 +747,28 @@ async def test_wallet_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
     all_offers = await client.get_all_offers(include_completed=True, start=0, end=50)
     assert len(all_offers) == 2
 
-    # Keys and addresses
+
+@pytest.mark.asyncio
+async def test_key_and_address_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
+    env: WalletRpcTestEnvironment = wallet_rpc_environment
+
+    wallet: Wallet = env.wallet_1.wallet
+    wallet_node: WalletNode = env.wallet_1.node
+    client: WalletRpcClient = env.wallet_1.rpc_client
 
     address = await client.get_next_address("1", True)
     assert len(address) > 10
 
-    all_transactions = await client.get_transactions("1")
-
-    some_transactions = await client.get_transactions("1", 0, 5)
-    some_transactions_2 = await client.get_transactions("1", 5, 10)
-    assert len(all_transactions) > 1
-    assert some_transactions == all_transactions[0:5]
-    assert some_transactions_2 == all_transactions[5:10]
-
-    transaction_count = await client.get_transaction_count("1")
-    assert transaction_count == len(all_transactions)
-
     pks = await client.get_public_keys()
     assert len(pks) == 1
 
+    await generate_funds(env.full_node.api, env.wallet_1)
+
     assert (await client.get_height_info()) > 0
+
+    ph = await wallet.get_new_puzzlehash()
+    addr = encode_puzzle_hash(ph, "txch")
+    tx_amount = uint64(15600000)
 
     created_tx = await client.send_transaction("1", tx_amount, addr)
 


### PR DESCRIPTION
This PR breaks up the one big test into smaller ones, see below. It also refactors/improves some things here and there (there is still much more room for improvements). This makes the test run a bit slower on CI for now because it now requires separate test environment setups for each test and we have the trusted/untrusted parameterization now for each of those: 5min (this PR) 1min (main).

```
test_send_transaction
test_create_signed_transaction
test_create_signed_transaction_with_coin_announcement
test_create_signed_transaction_with_puzzle_announcement
test_send_transaction_multi
test_get_transactions
test_get_transaction_count
test_cat_endpoints
test_offer_endpoints
test_key_and_address_endpoints
```

The following tests can still be split up more:

```
test_get_transactions
test_cat_endpoints
test_offer_endpoints
test_key_and_address_endpoints
```

@mariano54 I still think that we don't really need the trusted/untrusted parameterization for those tests :) Can you please revisit this topic and let me know what you think because overall this interface should not depend on the sync mode, right?