### PR TITLE
Add support for multiple of the same CAT in aggregate offers

### DIFF
--- a/chia/wallet/puzzle_drivers.py
+++ b/chia/wallet/puzzle_drivers.py
@@ -64,6 +64,8 @@ def decode_info_value(cls: Any, value: Any) -> Any:
     elif isinstance(value, list):
         return [decode_info_value(cls, v) for v in value]
     else:
+        if value == "()":  # special case
+            return Program.to([])
         expression: SExp = assemble(value)  # type: ignore
         if expression.atom is None:
             return Program(expression)

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -40,6 +40,10 @@ class TradeManager:
                 {
                     "coin": bytes
                     "parent_spend": bytes
+                    "siblings": List[bytes]  # other coins of the same type being offered
+                    "sibling_spends": List[bytes]  # The parent spends for the siblings
+                    "sibling_puzzles": List[Program]  # The inner puzzles of the siblings (always OFFER_MOD)
+                    "sibling_solutions": List[Program]  # The inner solution of the siblings
                 }
             )
 

--- a/tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -210,23 +210,45 @@ class TestOfferLifecycle:
             assert not chia_offer.is_valid()
 
             # Create a RED Offer for XCH
+            red_coins_1 = red_coins[0:1]
+            red_coins_2 = red_coins[1:]
             red_requested_payments: Dict[Optional[bytes32], List[Payment]] = {
                 None: [
                     Payment(acs_ph, 300, [b"red memo"]),
-                    Payment(acs_ph, 400, [b"red memo"]),
+                    Payment(acs_ph, 350, [b"red memo"]),
                 ]
             }
 
             red_requested_payments: Dict[Optional[bytes32], List[NotarizedPayment]] = Offer.notarize_payments(
-                red_requested_payments, red_coins
+                red_requested_payments, red_coins_1
             )
             red_announcements: List[Announcement] = Offer.calculate_announcements(red_requested_payments, driver_dict)
-            red_secured_bundle: SpendBundle = generate_secure_bundle(red_coins, red_announcements, 350, tail_str="red")
+            red_secured_bundle: SpendBundle = generate_secure_bundle(
+                red_coins_1, red_announcements, sum([c.amount for c in red_coins_1]), tail_str="red"
+            )
             red_offer = Offer(red_requested_payments, red_secured_bundle, driver_dict)
             assert not red_offer.is_valid()
 
+            red_requested_payments_2: Dict[Optional[bytes32], List[Payment]] = {
+                None: [
+                    Payment(acs_ph, 50, [b"red memo"]),
+                ]
+            }
+
+            red_requested_payments_2: Dict[Optional[bytes32], List[NotarizedPayment]] = Offer.notarize_payments(
+                red_requested_payments_2, red_coins_2
+            )
+            red_announcements_2: List[Announcement] = Offer.calculate_announcements(
+                red_requested_payments_2, driver_dict
+            )
+            red_secured_bundle_2: SpendBundle = generate_secure_bundle(
+                red_coins_2, red_announcements_2, sum([c.amount for c in red_coins_2]), tail_str="red"
+            )
+            red_offer_2 = Offer(red_requested_payments_2, red_secured_bundle_2, driver_dict)
+            assert not red_offer_2.is_valid()
+
             # Test aggregation of offers
-            new_offer = Offer.aggregate([chia_offer, red_offer])
+            new_offer = Offer.aggregate([chia_offer, red_offer, red_offer_2])
             assert new_offer.get_offered_amounts() == {None: 1000, str_to_tail_hash("red"): 350}
             assert new_offer.get_requested_amounts() == {None: 700, str_to_tail_hash("red"): 300}
             assert new_offer.is_valid()


### PR DESCRIPTION
This is a rewrite of #11411 but on top of the newly generalized offer drivers.  Thanks @roseiliend for the notice of this bug and the test.

Previously, aggregating two offers that offered the same type of CAT would fail due to the lack of supply accounting between them.  By adding a few more fields to standard offer `Solver` we can make sure the CATs know about their siblings and can send their aggregate amount however they please.