### PR TITLE
log full errors when run_as_generator() throws

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -58,8 +58,8 @@ def get_name_puzzle_conditions(
             return NPCResult(uint16(err), None, uint64(0))
         else:
             return NPCResult(None, result, uint64(result.cost + size_cost))
-    except BaseException as e:
-        log.debug(f"get_name_puzzle_condition failed: {e}")
+    except BaseException:
+        log.exception("get_name_puzzle_condition failed")
         return NPCResult(uint16(Err.GENERATOR_RUNTIME_ERROR.value), None, uint64(0))
 
 


### PR DESCRIPTION
Normal CLVM or condition parsing failures fail with an error code, not with an exception. An exception here indicates a more serious failure, typically indicative of a bug. This especially helps when debugging and troubleshooting patches.