### PR TITLE
restore missing hints being stored as None (instead of 0-length bytes)

### DIFF
--- a/chia/full_node/hint_management.py
+++ b/chia/full_node/hint_management.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from chia.consensus.blockchain import StateChangeSummary
 from chia.types.blockchain_format.coin import Coin
@@ -14,7 +14,7 @@ def get_hints_and_subscription_coin_ids(
     # Returns the hints that we need to add to the DB, and the coin ids that need to be looked up
 
     # Finds the coin IDs that we need to lookup in order to notify wallets of hinted transactions
-    hint: bytes
+    hint: Optional[bytes]
     hints_to_add: List[Tuple[bytes32, bytes]] = []
 
     # Goes through additions and removals for each block and flattens to a map and a set
@@ -40,6 +40,8 @@ def get_hints_and_subscription_coin_ids(
                     addition_coin_name = addition_coin.name()
                     add_if_coin_subscription(addition_coin_name)
                     add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
+                    if hint is None:
+                        continue
                     if len(hint) == 32:
                         add_if_ph_subscription(bytes32(hint), addition_coin_name)
 

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -271,8 +271,11 @@ class SerializedProgram:
         # implement streamable in rust
         spends = []
         for s in conds.spends:
+            create_coins = []
+            for ph, amount, hint in s.create_coin:
+                create_coins.append((ph, amount, None if hint == b"" else hint))
             spends.append(
-                Spend(s.coin_id, s.puzzle_hash, s.height_relative, s.seconds_relative, s.create_coin, s.agg_sig_me)
+                Spend(s.coin_id, s.puzzle_hash, s.height_relative, s.seconds_relative, create_coins, s.agg_sig_me)
             )
 
         ret = SpendBundleConditions(

--- a/chia/types/spend_bundle_conditions.py
+++ b/chia/types/spend_bundle_conditions.py
@@ -15,7 +15,7 @@ class Spend(Streamable):
     puzzle_hash: bytes32
     height_relative: Optional[uint32]
     seconds_relative: uint64
-    create_coin: List[Tuple[bytes32, uint64, bytes]]
+    create_coin: List[Tuple[bytes32, uint64, Optional[bytes]]]
     agg_sig_me: List[Tuple[bytes48, bytes]]
 
 

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -2055,7 +2055,7 @@ class TestGeneratorConditions:
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 2
         for s in npc_result.conds.spends:
-            assert s.create_coin == [(puzzle_hash.encode("ascii"), 10, b"")]
+            assert s.create_coin == [(puzzle_hash.encode("ascii"), 10, None)]
 
     def test_create_coin_different_puzzhash(self, softfork_height):
         # CREATE_COIN
@@ -2067,8 +2067,8 @@ class TestGeneratorConditions:
         )
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
-        assert (puzzle_hash_1.encode("ascii"), 5, b"") in npc_result.conds.spends[0].create_coin
-        assert (puzzle_hash_2.encode("ascii"), 5, b"") in npc_result.conds.spends[0].create_coin
+        assert (puzzle_hash_1.encode("ascii"), 5, None) in npc_result.conds.spends[0].create_coin
+        assert (puzzle_hash_2.encode("ascii"), 5, None) in npc_result.conds.spends[0].create_coin
 
     def test_create_coin_different_amounts(self, softfork_height):
         # CREATE_COIN
@@ -2080,8 +2080,8 @@ class TestGeneratorConditions:
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
         coins = npc_result.conds.spends[0].create_coin
-        assert (puzzle_hash.encode("ascii"), 5, b"") in coins
-        assert (puzzle_hash.encode("ascii"), 4, b"") in coins
+        assert (puzzle_hash.encode("ascii"), 5, None) in coins
+        assert (puzzle_hash.encode("ascii"), 4, None) in coins
 
     def test_create_coin_with_hint(self, softfork_height):
         # CREATE_COIN

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -112,7 +112,7 @@ class TestROM:
             puzzle_hash=bytes32.fromhex("9dcf97a184f32623d11a73124ceb99a5709b083721e878a16d78f596718ba7b2"),
             height_relative=None,
             seconds_relative=0,
-            create_coin=[(bytes([0] * 31 + [1]), 500, b"")],
+            create_coin=[(bytes([0] * 31 + [1]), 500, None)],
             agg_sig_me=[],
         )
 


### PR DESCRIPTION
going from using `None` -> `b""` for a missing hint happened in the most recent API update of the rust library (`chia_rs`). This restores storing missing hints as `None` in the conditions data structure.

this was the last patch: https://github.com/Chia-Network/chia-blockchain/pull/8862