### PR TITLE
Remove is not None and length assertion in select_coins()

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -451,7 +451,6 @@ class CATWallet:
             exclude,
             min_coin_amount,
         )
-        assert coins is not None and len(coins) > 0
         assert sum(c.amount for c in coins) >= amount
         return coins
 

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -274,7 +274,6 @@ class Wallet:
             exclude,
             min_coin_amount,
         )
-        assert coins is not None and len(coins) > 0
         assert sum(c.amount for c in coins) >= amount
         return coins
 


### PR DESCRIPTION
The `coins is not None` check seems unneeded since `select_coins()` is hinted to return `Set[Coin]`.  The length requirement needlessly restricts from being able to request a zero amount.  Either situation would either trigger an exception in the next assert, or trigger the assert itself for non-zero amounts requested.

Draft for:
- [x] Checking for other cases, such as the mentioned CAT wallet
  - DID wallet has this in `main` as well but DID and NFT wallets in the branch do not need changed in regards to this topic so we'll leave the `main` DID wallet untouched.