### PR TITLE
add tests.util.misc.assert_maximum_duration for benchmark assertions

### DIFF
--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -2238,10 +2238,10 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_ladder(self, opcode, softfork_height):
+    def test_duplicate_large_integer_ladder(self, request, opcode, softfork_height):
         condition = SINGLE_ARG_INT_LADDER_COND.format(opcode=opcode.value[0], num=28, filler="0x00")
 
-        with assert_runtime(seconds=0.7):
+        with assert_runtime(seconds=0.7, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2268,10 +2268,10 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer(self, opcode, softfork_height):
+    def test_duplicate_large_integer(self, request, opcode, softfork_height):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
-        with assert_runtime(seconds=1.1):
+        with assert_runtime(seconds=1.1, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2299,10 +2299,10 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_substr(self, opcode, softfork_height):
+    def test_duplicate_large_integer_substr(self, request, opcode, softfork_height):
         condition = SINGLE_ARG_INT_SUBSTR_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
-        with assert_runtime(seconds=1.1):
+        with assert_runtime(seconds=1.1, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2330,12 +2330,12 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_substr_tail(self, opcode, softfork_height):
+    def test_duplicate_large_integer_substr_tail(self, request, opcode, softfork_height):
         condition = SINGLE_ARG_INT_SUBSTR_TAIL_COND.format(
             opcode=opcode.value[0], num=280, val="0xffffffff", filler="0x00"
         )
 
-        with assert_runtime(seconds=0.3):
+        with assert_runtime(seconds=0.3, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2363,21 +2363,21 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_negative(self, opcode, softfork_height):
+    def test_duplicate_large_integer_negative(self, request, opcode, softfork_height):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0xff")
 
-        with assert_runtime(seconds=1):
+        with assert_runtime(seconds=1, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
 
     @pytest.mark.benchmark
-    def test_duplicate_reserve_fee(self, softfork_height):
+    def test_duplicate_reserve_fee(self, request, softfork_height):
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
-        with assert_runtime(seconds=1):
+        with assert_runtime(seconds=1, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2388,11 +2388,11 @@ class TestMaliciousGenerators:
             assert npc_result.conds.reserve_fee == 100 * 280000
 
     @pytest.mark.benchmark
-    def test_duplicate_reserve_fee_negative(self, softfork_height):
+    def test_duplicate_reserve_fee_negative(self, request: pytest.FixtureRequest, softfork_height):
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=200000, val=100, filler="0xff")
 
-        with assert_runtime(seconds=0.8):
+        with assert_runtime(seconds=0.8, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         # RESERVE_FEE conditions fail unconditionally if they have a negative
@@ -2404,10 +2404,10 @@ class TestMaliciousGenerators:
         "opcode", [ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT]
     )
     @pytest.mark.benchmark
-    def test_duplicate_coin_announces(self, opcode, softfork_height):
+    def test_duplicate_coin_announces(self, request, opcode, softfork_height):
         condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
 
-        with assert_runtime(seconds=7):
+        with assert_runtime(seconds=7, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error is None
@@ -2416,28 +2416,28 @@ class TestMaliciousGenerators:
         # TODO: optimize clvm to make this run in < 1 second
 
     @pytest.mark.benchmark
-    def test_create_coin_duplicates(self, softfork_height):
+    def test_create_coin_duplicates(self, request: pytest.FixtureRequest, softfork_height):
         # CREATE_COIN
         # this program will emit 6000 identical CREATE_COIN conditions. However,
         # we'll just end up looking at two of them, and fail at the first
         # duplicate
         condition = CREATE_COIN.format(num=600000)
 
-        with assert_runtime(seconds=0.8):
+        with assert_runtime(seconds=0.8, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error == Err.DUPLICATE_OUTPUT.value
         assert npc_result.conds is None
 
     @pytest.mark.benchmark
-    def test_many_create_coin(self, softfork_height):
+    def test_many_create_coin(self, request, softfork_height):
         # CREATE_COIN
         # this program will emit many CREATE_COIN conditions, all with different
         # amounts.
         # the number 6095 was chosen carefully to not exceed the maximum cost
         condition = CREATE_UNIQUE_COINS.format(num=6094)
 
-        with assert_runtime(seconds=0.2):
+        with assert_runtime(seconds=0.2, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error is None

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -46,7 +46,7 @@ from chia.types.generator_types import BlockGenerator
 from blspy import G1Element
 from chia.types.spend_bundle_conditions import SpendBundleConditions, Spend
 
-from tests.util.misc import assert_maximum_duration
+from tests.util.misc import assert_runtime
 from tests.wallet_tools import WalletTool
 
 BURN_PUZZLE_HASH = bytes32(b"0" * 32)
@@ -2241,7 +2241,7 @@ class TestMaliciousGenerators:
     def test_duplicate_large_integer_ladder(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_LADDER_COND.format(opcode=opcode.value[0], num=28, filler="0x00")
 
-        with assert_maximum_duration(seconds=0.7):
+        with assert_runtime(seconds=0.7):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2271,7 +2271,7 @@ class TestMaliciousGenerators:
     def test_duplicate_large_integer(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
-        with assert_maximum_duration(seconds=1.1):
+        with assert_runtime(seconds=1.1):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2302,7 +2302,7 @@ class TestMaliciousGenerators:
     def test_duplicate_large_integer_substr(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_SUBSTR_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
-        with assert_maximum_duration(seconds=1.1):
+        with assert_runtime(seconds=1.1):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2335,7 +2335,7 @@ class TestMaliciousGenerators:
             opcode=opcode.value[0], num=280, val="0xffffffff", filler="0x00"
         )
 
-        with assert_maximum_duration(seconds=0.3):
+        with assert_runtime(seconds=0.3):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2366,7 +2366,7 @@ class TestMaliciousGenerators:
     def test_duplicate_large_integer_negative(self, opcode, softfork_height):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0xff")
 
-        with assert_maximum_duration(seconds=1):
+        with assert_runtime(seconds=1):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error is None
@@ -2377,7 +2377,7 @@ class TestMaliciousGenerators:
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
-        with assert_maximum_duration(seconds=1):
+        with assert_runtime(seconds=1):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         if softfork_height >= 2300000:
@@ -2392,7 +2392,7 @@ class TestMaliciousGenerators:
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=200000, val=100, filler="0xff")
 
-        with assert_maximum_duration(seconds=0.8):
+        with assert_runtime(seconds=0.8):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         # RESERVE_FEE conditions fail unconditionally if they have a negative
@@ -2407,7 +2407,7 @@ class TestMaliciousGenerators:
     def test_duplicate_coin_announces(self, opcode, softfork_height):
         condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
 
-        with assert_maximum_duration(seconds=7):
+        with assert_runtime(seconds=7):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error is None
@@ -2423,7 +2423,7 @@ class TestMaliciousGenerators:
         # duplicate
         condition = CREATE_COIN.format(num=600000)
 
-        with assert_maximum_duration(seconds=0.8):
+        with assert_runtime(seconds=0.8):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error == Err.DUPLICATE_OUTPUT.value
@@ -2437,7 +2437,7 @@ class TestMaliciousGenerators:
         # the number 6095 was chosen carefully to not exceed the maximum cost
         condition = CREATE_UNIQUE_COINS.format(num=6094)
 
-        with assert_maximum_duration(seconds=0.2):
+        with assert_runtime(seconds=0.2):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
 
         assert npc_result.error is None

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -70,11 +70,10 @@ class TestMempoolPerformance:
         await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[-3]))
 
         for idx, block in enumerate(blocks):
-            start_t_2 = time.time()
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
-            end_t_2 = time.time()
-            duration = end_t_2 - start_t_2
             if idx >= len(blocks) - 3:
-                assert duration < 0.1
+                duration = 0.1
             else:
-                assert duration < 0.001
+                duration = 0.001
+
+            with assert_maximum_duration(seconds=duration):
+                await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -35,7 +35,9 @@ log = logging.getLogger(__name__)
 class TestMempoolPerformance:
     @pytest.mark.asyncio
     @pytest.mark.benchmark
-    async def test_mempool_update_performance(self, bt, wallet_nodes_mempool_perf, default_400_blocks, self_hostname):
+    async def test_mempool_update_performance(
+        self, request, bt, wallet_nodes_mempool_perf, default_400_blocks, self_hostname
+    ):
         blocks = default_400_blocks
         full_nodes, wallets = wallet_nodes_mempool_perf
         wallet_node = wallets[0][0]
@@ -75,5 +77,5 @@ class TestMempoolPerformance:
             else:
                 duration = 0.001
 
-            with assert_runtime(seconds=duration):
+            with assert_runtime(seconds=duration, label=request.node.name):
                 await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -1,7 +1,6 @@
 # flake8: noqa: F811, F401
 
 import logging
-import time
 
 import pytest
 
@@ -12,6 +11,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_node import WalletNode
 from tests.connection_utils import connect_and_get_peer
 from tests.time_out_assert import time_out_assert
+from tests.util.misc import assert_maximum_duration
 
 
 def wallet_height_at_least(wallet_node, h):

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -11,7 +11,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_node import WalletNode
 from tests.connection_utils import connect_and_get_peer
 from tests.time_out_assert import time_out_assert
-from tests.util.misc import assert_maximum_duration
+from tests.util.misc import assert_runtime
 
 
 def wallet_height_at_least(wallet_node, h):
@@ -75,5 +75,5 @@ class TestMempoolPerformance:
             else:
                 duration = 0.001
 
-            with assert_maximum_duration(seconds=duration):
+            with assert_runtime(seconds=duration):
                 await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -5,7 +5,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 from tests.connection_utils import connect_and_get_peer
 from tests.time_out_assert import time_out_assert
-from tests.util.misc import assert_maximum_duration
+from tests.util.misc import assert_runtime
 
 
 class TestNodeLoad:
@@ -24,7 +24,7 @@ class TestNodeLoad:
 
         await time_out_assert(10, num_connections, 1)
 
-        with assert_maximum_duration(seconds=100) as results_future:
+        with assert_runtime(seconds=100) as results_future:
             for i in range(1, num_blocks):
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
                 await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -28,4 +28,4 @@ class TestNodeLoad:
             for i in range(1, num_blocks):
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
                 await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
-        print(f"Time taken to process {num_blocks} is {duration_manager.results().duration}")
+        print(f"Time taken to process {num_blocks} is {duration_manager.result(timeout=0).duration}")

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -24,8 +24,8 @@ class TestNodeLoad:
 
         await time_out_assert(10, num_connections, 1)
 
-        with assert_maximum_duration(seconds=100) as duration_manager:
+        with assert_maximum_duration(seconds=100) as results_future:
             for i in range(1, num_blocks):
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
                 await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
-        print(f"Time taken to process {num_blocks} is {duration_manager.result(timeout=0).duration}")
+        print(f"Time taken to process {num_blocks} is {results_future.result(timeout=0).duration}")

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -24,7 +24,8 @@ class TestNodeLoad:
 
         await time_out_assert(10, num_connections, 1)
 
-        with assert_maximum_duration(seconds=100):
+        with assert_maximum_duration(seconds=100) as duration_manager:
             for i in range(1, num_blocks):
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
                 await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
+        print(f"Time taken to process {num_blocks} is {duration_manager.results().duration}")

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from chia.protocols import full_node_protocol
@@ -7,6 +5,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 from tests.connection_utils import connect_and_get_peer
 from tests.time_out_assert import time_out_assert
+from tests.util.misc import assert_maximum_duration
 
 
 class TestNodeLoad:
@@ -25,9 +24,7 @@ class TestNodeLoad:
 
         await time_out_assert(10, num_connections, 1)
 
-        start_unf = time.time()
-        for i in range(1, num_blocks):
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
-            await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
-        print(f"Time taken to process {num_blocks} is {time.time() - start_unf}")
-        assert time.time() - start_unf < 100
+        with assert_maximum_duration(seconds=100):
+            for i in range(1, num_blocks):
+                await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
+                await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -10,7 +10,7 @@ from tests.util.misc import assert_runtime
 
 class TestNodeLoad:
     @pytest.mark.asyncio
-    async def test_blocks_load(self, bt, two_nodes, self_hostname):
+    async def test_blocks_load(self, request: pytest.FixtureRequest, bt, two_nodes, self_hostname):
         num_blocks = 50
         full_node_1, full_node_2, server_1, server_2 = two_nodes
         blocks = bt.get_consecutive_blocks(num_blocks)
@@ -24,7 +24,7 @@ class TestNodeLoad:
 
         await time_out_assert(10, num_connections, 1)
 
-        with assert_runtime(seconds=100) as runtime_results_future:
+        with assert_runtime(seconds=100, label=request.node.name) as runtime_results_future:
             for i in range(1, num_blocks):
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
                 await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -24,8 +24,9 @@ class TestNodeLoad:
 
         await time_out_assert(10, num_connections, 1)
 
-        with assert_runtime(seconds=100) as results_future:
+        with assert_runtime(seconds=100) as runtime_results_future:
             for i in range(1, num_blocks):
                 await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
                 await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
-        print(f"Time taken to process {num_blocks} is {results_future.result(timeout=0).duration}")
+        runtime_results = runtime_results_future.result(timeout=0)
+        print(f"Time taken to process {num_blocks} is {runtime_results.duration}")

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -20,7 +20,7 @@ from tests.connection_utils import add_dummy_connection
 from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.node_height import node_height_at_least
 from tests.time_out_assert import time_out_assert
-from tests.util.misc import assert_maximum_duration
+from tests.util.misc import assert_runtime
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_maximum_duration(seconds=0.001, message="mempool"):
+        with assert_runtime(seconds=0.001, message="mempool"):
             num_tx: int = 0
             for spend_bundle, spend_bundle_id in zip(spend_bundles, spend_bundle_ids):
                 num_tx += 1
@@ -173,7 +173,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_maximum_duration(seconds=0.1, message="unfinished"):
+        with assert_runtime(seconds=0.1, message="unfinished"):
             res = await full_node_1.respond_unfinished_block(fnp.RespondUnfinishedBlock(unfinished), fake_peer)
 
         log.warning(f"Res: {res}")
@@ -184,7 +184,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_maximum_duration(seconds=0.1, message="full block"):
+        with assert_runtime(seconds=0.1, message="full block"):
             # No transactions generator, the full node already cached it from the unfinished block
             block_small = dataclasses.replace(block, transactions_generator=None)
             res = await full_node_1.full_node.respond_block(fnp.RespondBlock(block_small))

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -116,7 +116,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_maximum_duration(seconds=0.001):
+        with assert_maximum_duration(seconds=0.001, message="mempool"):
             num_tx: int = 0
             for spend_bundle, spend_bundle_id in zip(spend_bundles, spend_bundle_ids):
                 num_tx += 1
@@ -173,7 +173,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_maximum_duration(seconds=0.1):
+        with assert_maximum_duration(seconds=0.1, message="unfinished"):
             res = await full_node_1.respond_unfinished_block(fnp.RespondUnfinishedBlock(unfinished), fake_peer)
 
         log.warning(f"Res: {res}")
@@ -184,7 +184,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_maximum_duration(seconds=0.1):
+        with assert_maximum_duration(seconds=0.1, message="full block"):
             # No transactions generator, the full node already cached it from the unfinished block
             block_small = dataclasses.replace(block, transactions_generator=None)
             res = await full_node_1.full_node.respond_block(fnp.RespondBlock(block_small))

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -173,7 +173,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_runtime(seconds=0.1, label=f"{request.node.label} - unfinished"):
+        with assert_runtime(seconds=0.1, label=f"{request.node.name} - unfinished"):
             res = await full_node_1.respond_unfinished_block(fnp.RespondUnfinishedBlock(unfinished), fake_peer)
 
         log.warning(f"Res: {res}")
@@ -184,7 +184,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_runtime(seconds=0.1, label=f"{request.node.label} - full block"):
+        with assert_runtime(seconds=0.1, label=f"{request.node.name} - full block"):
             # No transactions generator, the full node already cached it from the unfinished block
             block_small = dataclasses.replace(block, transactions_generator=None)
             res = await full_node_1.full_node.respond_block(fnp.RespondBlock(block_small))

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -184,7 +184,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_maximum_duration(seconds=0.001):
+        with assert_maximum_duration(seconds=0.1):
             # No transactions generator, the full node already cached it from the unfinished block
             block_small = dataclasses.replace(block, transactions_generator=None)
             res = await full_node_1.full_node.respond_block(fnp.RespondBlock(block_small))

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -20,6 +20,7 @@ from tests.connection_utils import add_dummy_connection
 from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.node_height import node_height_at_least
 from tests.time_out_assert import time_out_assert
+from tests.util.misc import assert_maximum_duration
 
 log = logging.getLogger(__name__)
 

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -116,7 +116,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_runtime(seconds=0.001, message="mempool"):
+        with assert_runtime(seconds=0.001, label="mempool"):
             num_tx: int = 0
             for spend_bundle, spend_bundle_id in zip(spend_bundles, spend_bundle_ids):
                 num_tx += 1
@@ -173,7 +173,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_runtime(seconds=0.1, message="unfinished"):
+        with assert_runtime(seconds=0.1, label="unfinished"):
             res = await full_node_1.respond_unfinished_block(fnp.RespondUnfinishedBlock(unfinished), fake_peer)
 
         log.warning(f"Res: {res}")
@@ -184,7 +184,7 @@ class TestPerformance:
         pr = cProfile.Profile()
         pr.enable()
 
-        with assert_runtime(seconds=0.1, message="full block"):
+        with assert_runtime(seconds=0.1, label="full block"):
             # No transactions generator, the full node already cached it from the unfinished block
             block_small = dataclasses.replace(block, transactions_generator=None)
             res = await full_node_1.full_node.respond_block(fnp.RespondBlock(block_small))

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -12,7 +12,7 @@ from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.generator_types import BlockGenerator
 from chia.wallet.puzzles import p2_delegated_puzzle_or_hidden_puzzle
 from tests.setup_nodes import test_constants
-from tests.util.misc import assert_maximum_duration
+from tests.util.misc import assert_runtime
 
 from .make_block_generator import make_block_generator
 
@@ -196,7 +196,7 @@ class TestCostCalculation:
         generator_bytes = large_block_generator(LARGE_BLOCK_COIN_CONSUMED_COUNT)
         program = SerializedProgram.from_bytes(generator_bytes)
 
-        with assert_maximum_duration(seconds=0.5):
+        with assert_runtime(seconds=0.5):
             generator = BlockGenerator(program, [], [])
             npc_result = get_name_puzzle_conditions(
                 generator,
@@ -261,7 +261,7 @@ class TestCostCalculation:
             p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)
         )
 
-        with assert_maximum_duration(seconds=0.1):
+        with assert_runtime(seconds=0.1):
             total_cost = 0
             for i in range(0, 1000):
                 cost, result = puzzle_program.run_with_cost(test_constants.MAX_BLOCK_COST_CLVM, solution_program)

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -191,12 +191,12 @@ class TestCostCalculation:
 
     @pytest.mark.asyncio
     @pytest.mark.benchmark
-    async def test_tx_generator_speed(self, softfork_height):
+    async def test_tx_generator_speed(self, request, softfork_height):
         LARGE_BLOCK_COIN_CONSUMED_COUNT = 687
         generator_bytes = large_block_generator(LARGE_BLOCK_COIN_CONSUMED_COUNT)
         program = SerializedProgram.from_bytes(generator_bytes)
 
-        with assert_runtime(seconds=0.5):
+        with assert_runtime(seconds=0.5, label=request.node.name):
             generator = BlockGenerator(program, [], [])
             npc_result = get_name_puzzle_conditions(
                 generator,
@@ -247,7 +247,7 @@ class TestCostCalculation:
 
     @pytest.mark.asyncio
     @pytest.mark.benchmark
-    async def test_standard_tx(self):
+    async def test_standard_tx(self, request: pytest.FixtureRequest):
         # this isn't a real public key, but we don't care
         public_key = bytes.fromhex(
             "af949b78fa6a957602c3593a3d6cb7711e08720415dad83" "1ab18adacaa9b27ec3dda508ee32e24bc811c0abc5781ae21"
@@ -261,7 +261,7 @@ class TestCostCalculation:
             p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)
         )
 
-        with assert_runtime(seconds=0.1):
+        with assert_runtime(seconds=0.1, label=request.node.name):
             total_cost = 0
             for i in range(0, 1000):
                 cost, result = puzzle_program.run_with_cost(test_constants.MAX_BLOCK_COST_CLVM, solution_program)

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import dataclasses
 import enum

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -7,6 +7,11 @@ from types import TracebackType
 from typing import Callable, Optional, Type
 
 
+def caller_file_and_line(distance: int = 2) -> str:
+    caller = getframeinfo(stack()[distance][0])
+    return f"{caller.filename}:{caller.lineno}"
+
+
 @dataclass(frozen=True)
 class AssertMaximumDurationResults:
     start: float
@@ -42,11 +47,6 @@ class AssertMaximumDurationResults:
         return f"{self.percent():.0f} %"
 
 
-def debuginfo(distance: int = 2) -> str:
-    caller = getframeinfo(stack()[distance][0])
-    return f"{caller.filename}:{caller.lineno}"
-
-
 @dataclass
 class AssertMaximumDuration:
     seconds: float
@@ -56,7 +56,7 @@ class AssertMaximumDuration:
     results: Optional[AssertMaximumDurationResults] = None
 
     def __enter__(self) -> None:
-        self.entry_line = debuginfo()
+        self.entry_line = caller_file_and_line()
         gc.collect()
         self.start = self.clock()
 

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -48,8 +48,8 @@ def manage_gc(mode: GcMode) -> Iterator[None]:
                 gc.disable()
 
 
-def caller_file_and_line(distance: int = 2) -> str:
-    caller = getframeinfo(stack()[distance][0])
+def caller_file_and_line(distance: int = 1) -> str:
+    caller = getframeinfo(stack()[distance + 1][0])
     return f"{caller.filename}:{caller.lineno}"
 
 
@@ -226,12 +226,6 @@ class AssertMaximumDuration:
     _results: Optional[AssertRuntimeResults] = None
     runtime_manager: Optional[contextlib.AbstractContextManager[Future[RuntimeResults]]] = None
     runtime_results_callable: Optional[Future[RuntimeResults]] = None
-
-    def results(self) -> AssertRuntimeResults:
-        if self._results is None:
-            raise Exception("runtime results not yet available")
-
-        return self._results
 
     def __enter__(self) -> Future[AssertRuntimeResults]:
         self.entry_line = caller_file_and_line()

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -2,7 +2,7 @@ import gc
 from dataclasses import dataclass
 from inspect import getframeinfo, stack
 from textwrap import dedent
-from time import perf_counter
+from time import thread_time
 from types import TracebackType
 from typing import Callable, Optional, Type
 
@@ -90,5 +90,5 @@ class AssertMaximumDuration:
             assert self.results.passed(), self.results.message()
 
 
-def assert_maximum_duration(seconds: float, clock: Callable[[], float] = perf_counter) -> AssertMaximumDuration:
+def assert_maximum_duration(seconds: float, clock: Callable[[], float] = thread_time) -> AssertMaximumDuration:
     return AssertMaximumDuration(seconds=seconds, clock=clock)

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -1,0 +1,17 @@
+import contextlib
+import gc
+from time import perf_counter
+from typing import Callable, Iterator
+
+
+@contextlib.contextmanager
+def assert_maximum_duration(seconds: float, clock: Callable[[], float] = perf_counter) -> Iterator[None]:
+    __tracebackhide__ = True
+
+    gc.collect()
+    start = clock()
+    yield
+    end = clock()
+    duration = end - start
+    print(f"run time: {duration}")
+    assert duration < seconds

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -59,13 +59,13 @@ class RuntimeResults:
     entry_line: str
     overhead: float
 
-    def block(self, message: str = "") -> str:
+    def block(self, label: str = "") -> str:
         # The entry line is reported starting at the beginning of the line to trigger
         # PyCharm to highlight as a link to the source.
 
         return dedent(
             f"""\
-            Measuring runtime: {message}
+            Measuring runtime: {label}
             {self.entry_line}
                 run time: {self.duration}
                 overhead: {self.overhead}
@@ -98,13 +98,13 @@ class AssertRuntimeResults:
             overhead=overhead,
         )
 
-    def block(self, message: str = "") -> str:
+    def block(self, label: str = "") -> str:
         # The entry line is reported starting at the beginning of the line to trigger
         # PyCharm to highlight as a link to the source.
 
         return dedent(
             f"""\
-            Asserting maximum duration: {message}
+            Asserting maximum duration: {label}
             {self.entry_line}
                 run time: {self.duration}
                 overhead: {self.overhead}
@@ -147,7 +147,7 @@ def measure_overhead(
 
 @contextlib.contextmanager
 def measure_runtime(
-    message: str = "",
+    label: str = "",
     clock: Callable[[], float] = thread_time,
     gc_mode: GcMode = GcMode.disable,
     calibrate: bool = True,
@@ -186,7 +186,7 @@ def measure_runtime(
             results_future.set_result(results)
 
             if print_results:
-                print(results.block(message=message))
+                print(results.block(label=label))
 
 
 @final
@@ -215,7 +215,7 @@ class _AssertRuntime:
     # https://github.com/pytest-dev/pytest/issues/2057
 
     seconds: float
-    message: str = ""
+    label: str = ""
     clock: Callable[[], float] = thread_time
     gc_mode: GcMode = GcMode.disable
     calibrate: bool = True
@@ -265,7 +265,7 @@ class _AssertRuntime:
         self.results_callable.set_result(results)
 
         if self.print:
-            print(results.block(message=self.message))
+            print(results.block(label=self.label))
 
         if exc_type is None:
             __tracebackhide__ = True

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -1,17 +1,82 @@
-import contextlib
+from dataclasses import dataclass
 import gc
+from inspect import getframeinfo, stack
+from textwrap import dedent
 from time import perf_counter
-from typing import Callable, Iterator
+from typing import Callable, Optional
 
 
-@contextlib.contextmanager
-def assert_maximum_duration(seconds: float, clock: Callable[[], float] = perf_counter) -> Iterator[None]:
-    __tracebackhide__ = True
+@dataclass(frozen=True)
+class AssertMaximumDurationResults:
+    start: float
+    end: float
+    duration: float
+    limit: float
+    ratio: float
+    entry_line: str
 
-    gc.collect()
-    start = clock()
-    yield
-    end = clock()
-    duration = end - start
-    print(f"run time: {duration}")
-    assert duration < seconds
+    def block(self) -> str:
+        # The entry line is reported starting at the beginning of the line to trigger
+        # PyCharm to highlight as a link to the source.
+        return dedent(f"""\
+            Asserting maximum duration:
+            {self.entry_line}
+                run time: {self.duration}
+                 allowed: {self.limit}
+                 percent: {self.percent_str()}
+            """)
+
+    def message(self) -> str:
+        return f"{self.duration} seconds not less than {self.limit} seconds ( {self.percent_str()} )"
+
+    def passed(self) -> bool:
+        return self.duration < self.limit
+
+    def percent(self) -> float:
+        return self.ratio * 100
+
+    def percent_str(self) -> str:
+        return f"{self.percent():.0f} %"
+
+
+def debuginfo(distance=2):
+    caller = getframeinfo(stack()[distance][0])
+    return f"{caller.filename}:{caller.lineno}"
+
+
+@dataclass
+class AssertMaximumDuration:
+    seconds: float
+    clock: Callable[[], float]
+    start: Optional[float] = None
+    entry_line: Optional[str] = None
+    results: Optional[AssertMaximumDurationResults] = None
+
+    def __enter__(self) -> None:
+        self.entry_line = debuginfo()
+        gc.collect()
+        self.start = self.clock()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        end = self.clock()
+        duration = end - self.start
+        ratio = duration / self.seconds
+
+        self.results = AssertMaximumDurationResults(
+            start=self.start,
+            end=end,
+            duration=duration,
+            limit=self.seconds,
+            ratio=ratio,
+            entry_line=self.entry_line,
+        )
+
+        print(self.results.block())
+
+        if exc_type is None:
+            __tracebackhide__ = True
+            assert self.results.passed(), self.results.message()
+
+
+def assert_maximum_duration(seconds: float, clock: Callable[[], float] = perf_counter) -> AssertMaximumDuration:
+    return AssertMaximumDuration(seconds=seconds, clock=clock)

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -55,12 +55,15 @@ class AssertMaximumDurationResults:
     ratio: float
     entry_line: str
 
-    def block(self) -> str:
+    def block(self, message: str = "") -> str:
         # The entry line is reported starting at the beginning of the line to trigger
         # PyCharm to highlight as a link to the source.
+
+        heading = " ".join(["Asserting maximum duration:", message])
+
         return dedent(
             f"""\
-            Asserting maximum duration:
+            {heading}
             {self.entry_line}
                 run time: {self.duration}
                  allowed: {self.limit}
@@ -92,9 +95,18 @@ class AssertMaximumDuration:
     multiprocessed code.  Disabling garbage collection, or forcing it ahead of time,
     makes the benchmark not identify any issues the code may introduce in terms of
     actually causing relevant gc slowdowns.  And so on...
+
+    Produces output of the following form.
+
+        Asserting maximum duration: full block
+        /home/altendky/repos/chia-blockchain/tests/core/full_node/test_performance.py:187
+            run time: 0.027789528900002837
+            allowed: 0.1
+            percent: 28 %
     """
 
     seconds: float
+    message: str
     clock: Callable[[], float]
     gc_mode: GcMode
     calibrate: bool
@@ -159,7 +171,7 @@ class AssertMaximumDuration:
         self._results = results
 
         if self.print:
-            print(results.block())
+            print(results.block(message=self.message))
 
         if exc_type is None:
             __tracebackhide__ = True
@@ -168,8 +180,9 @@ class AssertMaximumDuration:
 
 def assert_maximum_duration(
     seconds: float,
+    message: str = "",
     clock: Callable[[], float] = thread_time,
     gc_mode: GcMode = GcMode.disable,
     calibrate: bool = True,
 ) -> AssertMaximumDuration:
-    return AssertMaximumDuration(seconds=seconds, clock=clock, gc_mode=gc_mode, calibrate=calibrate)
+    return AssertMaximumDuration(seconds=seconds, message=message, clock=clock, gc_mode=gc_mode, calibrate=calibrate)

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -10,7 +10,7 @@ from statistics import mean
 from textwrap import dedent
 from time import thread_time
 from types import TracebackType
-from typing import Callable, Iterator, List, Optional, Type
+from typing import Callable, Iterator, List, Optional, Type, final
 
 
 class GcMode(enum.Enum):
@@ -86,6 +86,7 @@ class AssertMaximumDurationResults:
         return f"{self.percent():.0f} %"
 
 
+@final
 @dataclasses.dataclass
 class AssertMaximumDuration:
     """Prepare for, measure, and assert about the time taken by code in the context.
@@ -136,13 +137,15 @@ class AssertMaximumDuration:
 
         return compensation
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> AssertMaximumDuration:
         self.entry_line = caller_file_and_line()
         if self.calibrate:
             self.compensation = self.calibrate_compensation()
         self.gc_manager = gc_mode(mode=self.gc_mode)
         self.gc_manager.__enter__()
         self.start = self.clock()
+
+        return self
 
     def __exit__(
         self,

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import gc
+from dataclasses import dataclass
 from inspect import getframeinfo, stack
 from textwrap import dedent
 from time import perf_counter
@@ -18,13 +18,15 @@ class AssertMaximumDurationResults:
     def block(self) -> str:
         # The entry line is reported starting at the beginning of the line to trigger
         # PyCharm to highlight as a link to the source.
-        return dedent(f"""\
+        return dedent(
+            f"""\
             Asserting maximum duration:
             {self.entry_line}
                 run time: {self.duration}
                  allowed: {self.limit}
                  percent: {self.percent_str()}
-            """)
+            """
+        )
 
     def message(self) -> str:
         return f"{self.duration} seconds not less than {self.limit} seconds ( {self.percent_str()} )"

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -10,7 +10,9 @@ from statistics import mean
 from textwrap import dedent
 from time import thread_time
 from types import TracebackType
-from typing import Callable, Iterator, List, Optional, Type, final
+from typing import Callable, Iterator, List, Optional, Type
+
+from typing_extensions import final
 
 
 class GcMode(enum.Enum):

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -173,7 +173,7 @@ def measure_runtime(
     else:
         overhead = 0
 
-    results_future = Future[RuntimeResults]()
+    results_future: Future[RuntimeResults] = Future()
 
     with manage_gc(mode=gc_mode):
         start = clock()
@@ -251,7 +251,7 @@ class _AssertMaximumDuration:
             clock=self.clock, gc_mode=self.gc_mode, calibrate=False, print_results=False
         )
         self.runtime_results_callable = self.runtime_manager.__enter__()
-        self.results_callable = Future[AssertRuntimeResults]()
+        self.results_callable: Future[AssertRuntimeResults] = Future()
 
         return self.results_callable
 

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -191,7 +191,7 @@ def measure_runtime(
 
 @final
 @dataclasses.dataclass
-class _AssertMaximumDuration:
+class _AssertRuntime:
     """Prepare for, measure, and assert about the time taken by code in the context.
 
     Defaults are set for single-threaded CPU usage timing without garbage collection.
@@ -275,4 +275,4 @@ class _AssertMaximumDuration:
 # Related to the comment above about needing a class vs. using the context manager
 # decorator, this is just here to retain the function-style naming as the public
 # interface.  Hopefully we can switch away from the class at some point.
-assert_maximum_duration = _AssertMaximumDuration
+assert_runtime = _AssertRuntime


### PR DESCRIPTION
Draft for:
- [x] Discussion around garbage collecting's effect on the timing 'accuracy'
- [x] Add back some logging/printing
- [x] Double check all the times
- [x] Review options related to explicit garbage collection
- [ ] Review duration limits against present times on the actual benchmark runners
- [ ] ~~How do each of garbage collection and perf counter contribute to the improved consistency relative to the irrelevant but relevant commits~~
- [x] Separate measurement from assertion (maybe)
- [x] Check and account for induced overhead.
- [x] Think through the api around `assert_maximum_duration()`
- [x] Review type error ignores and at least provide an explanatory comment if they are deemed appropriate