### PR TITLE
increment the dirty counter when setting height-to-hash map entries

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -296,8 +296,8 @@ class Blockchain(BlockchainInterface):
                 )
                 raise
 
-            # This is done outside the try-except in case it fails, since we do not want to revert anything if it does
-            await self.__height_map.maybe_flush()
+        # This is done outside the try-except in case it fails, since we do not want to revert anything if it does
+        await self.__height_map.maybe_flush()
 
         if state_change_summary is not None:
             # new coin records added

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -130,9 +130,8 @@ class BlockHeightMap:
     def update_height(self, height: uint32, header_hash: bytes32, ses: Optional[SubEpochSummary]):
         # we're only updating the last hash. If we've reorged, we already rolled
         # back, making this the new peak
-        idx = height * 32
-        assert idx <= len(self.__height_to_hash)
-        self.__height_to_hash[idx : idx + 32] = header_hash
+        assert height * 32 <= len(self.__height_to_hash)
+        self.__set_hash(height, header_hash)
         if ses is not None:
             self.__sub_epoch_summaries[height] = bytes(ses)
 


### PR DESCRIPTION
make sure we use `__set_hash()` when updating the height-to-hash map. That's where we increment the `__dirty` counter, which in turn triggers flushing of this map to disk.

Currently, we don't end up flushing this to disk during sync.