### PR TITLE
early return from _set_spent function

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -141,8 +141,7 @@ class CoinStore:
             additions.append(reward_coin_r)
 
         await self._add_coin_records(additions)
-        if len(tx_removals) > 0:
-            await self._set_spent(tx_removals, height)
+        await self._set_spent(tx_removals, height)
 
         end = time.monotonic()
         log.log(
@@ -520,6 +519,10 @@ class CoinStore:
     async def _set_spent(self, coin_names: List[bytes32], index: uint32):
 
         assert len(coin_names) == 0 or index > 0
+
+        if len(coin_names) == 0:
+            return
+
         updates = []
         for coin_name in coin_names:
             updates.append((index, self.maybe_to_hex(coin_name)))

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -141,7 +141,8 @@ class CoinStore:
             additions.append(reward_coin_r)
 
         await self._add_coin_records(additions)
-        await self._set_spent(tx_removals, height)
+        if len(tx_removals) > 0:
+            await self._set_spent(tx_removals, height)
 
         end = time.monotonic()
         log.log(


### PR DESCRIPTION
return early when there are no coin removals to be done, saving a few cpu cycles for every tx block. 