### PR TITLE
allow bigger chunks of bind variables per SQL statement 

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -771,13 +771,13 @@ class Blockchain(BlockchainInterface):
             return None
         return header_dict[header_hash]
 
-    async def get_block_records_at(self, heights: List[uint32], batch_size: int = 900) -> List[BlockRecord]:
+    async def get_block_records_at(self, heights: List[uint32], batch_size: int = 32700) -> List[BlockRecord]:
         """
         gets block records by height (only blocks that are part of the chain)
         """
         records: List[BlockRecord] = []
         hashes: List[bytes32] = []
-        assert batch_size < 999  # sqlite in python 3.7 has a limit on 999 variables in queries
+        assert batch_size < 32710  # sqlite in python 3.7 has a limit on 999 variables in queries
         for height in heights:
             header_hash: Optional[bytes32] = self.height_to_hash(height)
             if header_hash is None:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -771,13 +771,13 @@ class Blockchain(BlockchainInterface):
             return None
         return header_dict[header_hash]
 
-    async def get_block_records_at(self, heights: List[uint32], batch_size: int = 32700) -> List[BlockRecord]:
+    async def get_block_records_at(self, heights: List[uint32], batch_size: int = 900) -> List[BlockRecord]:
         """
         gets block records by height (only blocks that are part of the chain)
         """
         records: List[BlockRecord] = []
         hashes: List[bytes32] = []
-        assert batch_size < 32710  # sqlite in python 3.7 has a limit on 999 variables in queries
+        assert batch_size < 999  # sqlite in python 3.7 has a limit on 999 variables in queries
         for height in heights:
             header_hash: Optional[bytes32] = self.height_to_hash(height)
             if header_hash is None:

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -15,7 +15,6 @@ import logging
 log = logging.getLogger(__name__)
 
 
-
 class CoinStore:
     """
     This object handles CoinRecords in DB.

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -14,7 +14,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-MAX_SQLITE_PARAMETERS = 900
+MAX_SQLITE_PARAMETERS = 32700
 
 
 class CoinStore:

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -14,8 +14,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-MAX_SQLITE_PARAMETERS = 32700
-
 
 class CoinStore:
     """
@@ -178,7 +176,7 @@ class CoinStore:
 
         async with self.db_wrapper.read_db() as conn:
             cursors: List[Cursor] = []
-            for names_chunk in chunks(names, MAX_SQLITE_PARAMETERS):
+            for names_chunk in chunks(names, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
                 names_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     names_db = tuple(names_chunk)
@@ -346,7 +344,7 @@ class CoinStore:
 
         coins = set()
         async with self.db_wrapper.read_db() as conn:
-            for puzzles in chunks(puzzle_hashes, MAX_SQLITE_PARAMETERS):
+            for puzzles in chunks(puzzle_hashes, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
                 puzzle_hashes_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     puzzle_hashes_db = tuple(puzzles)
@@ -378,7 +376,7 @@ class CoinStore:
 
         coins = set()
         async with self.db_wrapper.read_db() as conn:
-            for ids in chunks(parent_ids, MAX_SQLITE_PARAMETERS):
+            for ids in chunks(parent_ids, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
                 parent_ids_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     parent_ids_db = tuple(ids)
@@ -409,7 +407,7 @@ class CoinStore:
 
         coins = set()
         async with self.db_wrapper.read_db() as conn:
-            for ids in chunks(coin_ids, MAX_SQLITE_PARAMETERS):
+            for ids in chunks(coin_ids, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
                 coin_ids_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     coin_ids_db = tuple(ids)

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -15,6 +15,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
+
 class CoinStore:
     """
     This object handles CoinRecords in DB.

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -6,7 +6,7 @@ from chia.protocols.wallet_protocol import CoinState
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.ints import uint32, uint64
 from chia.util.chunks import chunks
 import time
@@ -176,7 +176,7 @@ class CoinStore:
 
         async with self.db_wrapper.read_db() as conn:
             cursors: List[Cursor] = []
-            for names_chunk in chunks(names, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
+            for names_chunk in chunks(names, SQLITE_MAX_VARIABLE_NUMBER):
                 names_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     names_db = tuple(names_chunk)
@@ -344,7 +344,7 @@ class CoinStore:
 
         coins = set()
         async with self.db_wrapper.read_db() as conn:
-            for puzzles in chunks(puzzle_hashes, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
+            for puzzles in chunks(puzzle_hashes, SQLITE_MAX_VARIABLE_NUMBER):
                 puzzle_hashes_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     puzzle_hashes_db = tuple(puzzles)
@@ -376,7 +376,7 @@ class CoinStore:
 
         coins = set()
         async with self.db_wrapper.read_db() as conn:
-            for ids in chunks(parent_ids, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
+            for ids in chunks(parent_ids, SQLITE_MAX_VARIABLE_NUMBER):
                 parent_ids_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     parent_ids_db = tuple(ids)
@@ -407,7 +407,7 @@ class CoinStore:
 
         coins = set()
         async with self.db_wrapper.read_db() as conn:
-            for ids in chunks(coin_ids, self.db_wrapper.SQLITE_MAX_VARIABLE_NUMBER):
+            for ids in chunks(coin_ids, SQLITE_MAX_VARIABLE_NUMBER):
                 coin_ids_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
                     coin_ids_db = tuple(ids)

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -7,6 +7,11 @@ from typing import AsyncIterator, Dict, Optional
 import aiosqlite
 
 
+if aiosqlite.sqlite_version_info < (3, 32, 0):
+    SQLITE_MAX_VARIABLE_NUMBER = 900
+else:
+    SQLITE_MAX_VARIABLE_NUMBER = 32700
+
 class DBWrapper:
     """
     This object handles HeaderBlocks and Blocks stored in DB used by wallet.
@@ -42,7 +47,6 @@ class DBWrapper2:
     _in_use: Dict[asyncio.Task, aiosqlite.Connection]
     _current_writer: Optional[asyncio.Task]
     _savepoint_name: int
-    SQLITE_MAX_VARIABLE_NUMBER: int
 
     async def add_connection(self, c: aiosqlite.Connection) -> None:
         # this guarantees that reader connections can only be used for reading
@@ -60,10 +64,6 @@ class DBWrapper2:
         self._in_use = {}
         self._current_writer = None
         self._savepoint_name = 0
-        if aiosqlite.sqlite_version_info < (3, 32, 0):
-            self.SQLITE_MAX_VARIABLE_NUMBER = 999
-        else:
-            self.SQLITE_MAX_VARIABLE_NUMBER = 32766
 
 
     async def close(self) -> None:

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -42,6 +42,7 @@ class DBWrapper2:
     _in_use: Dict[asyncio.Task, aiosqlite.Connection]
     _current_writer: Optional[asyncio.Task]
     _savepoint_name: int
+    SQLITE_MAX_VARIABLE_NUMBER: int
 
     async def add_connection(self, c: aiosqlite.Connection) -> None:
         # this guarantees that reader connections can only be used for reading
@@ -59,6 +60,11 @@ class DBWrapper2:
         self._in_use = {}
         self._current_writer = None
         self._savepoint_name = 0
+        if aiosqlite.sqlite_version_info < (3, 32, 0):
+            self.SQLITE_MAX_VARIABLE_NUMBER = 999
+        else:
+            self.SQLITE_MAX_VARIABLE_NUMBER = 32766
+
 
     async def close(self) -> None:
         while self._num_read_connections > 0:

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -65,7 +65,6 @@ class DBWrapper2:
         self._current_writer = None
         self._savepoint_name = 0
 
-
     async def close(self) -> None:
         while self._num_read_connections > 0:
             await (await self._read_connections.get()).close()

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -6,11 +6,11 @@ from typing import AsyncIterator, Dict, Optional
 
 import aiosqlite
 
-
 if aiosqlite.sqlite_version_info < (3, 32, 0):
     SQLITE_MAX_VARIABLE_NUMBER = 900
 else:
     SQLITE_MAX_VARIABLE_NUMBER = 32700
+
 
 class DBWrapper:
     """


### PR DESCRIPTION
I'd suggest to use parameter limits according to the SQLite version the full node is running with.
This is achieved using a dbwrapper constant and replacing the currently used constant  `MAX_SQLITE_PARAMETERS`.

To match the parameter name used  [in sqlite itself](https://www.sqlite.org/lang_expr.html#varparam), I also renamed the constant to `SQLITE_MAX_VARIABLE_NUMBER`.

### Performance impact
We should expect a slight improvement, also less parsing and syscalls.

This was tested using my ansible roles and the standard `long sync` operation on full node from main branch, starting from height 1537152 to 1556960. This should cover a short enough period with dust and regular tx in between.

System|Testcase|Runtime|%
---|---|---|---
RPi4B-8G|main|4h03m48s|100%
RPi4B-8G|PR|3h52m07s|95,21%

Test Limitation: Each sync test was only done 1x, variations can be high on such tests.

### Limits In SQLite:
SQLite versions < 3.32.0 allow up to 999 bind variables per single SQL statement
with versions >= 3.32.0 up to 32766 bind variables are possible
[Manual](https://www.sqlite.org/limits.html#max_variable_number)

### Identified enforced limits in chia

- minimal SQLite version for chia is 3.8
- in `full_node/coin_store.py` a constant `MAX_SQLITE_PARAMETERS = 900` is set and used to split parameter in chunks
- in `consensus/blockchain.py` 
  - the function `get_block_records_at` is using a default `batch_size: int = 900` and
  later in the function an `assert batch_size < 999`
  - `get_block_records_at` is calling the function `get_block_records_by_hash` in `full_node/block_store.py`
  - `get_block_records_by_hash` is not using `chia.util.chunks` right now, so not as easy to change
