### PR TITLE
Fix a few additional flaky tests

### DIFF
--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -39,9 +39,8 @@ def cleanup_keyring(keyring: TempKeyring):
 
 @pytest_asyncio.fixture(scope="function")
 async def custom_block_tools() -> BlockTools:
-    temp_keyring = TempKeyring()
-    keychain = temp_keyring.get_keychain()
-    atexit.register(cleanup_keyring, temp_keyring)  # Attempt to cleanup the temp keychain
+    with TempKeyring() as keychain:
+        yield await create_block_tools_async(constants=test_constants, keychain=keychain)
 
     return await create_block_tools_async(constants=test_constants, keychain=keychain)
 

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -32,10 +32,6 @@ test_constants = test_constants_original.replace(**{"DISCRIMINANT_SIZE_BITS": 32
 log = logging.getLogger(__name__)
 
 
-def cleanup_keyring(keyring: TempKeyring):
-    keyring.cleanup()
-
-
 @pytest_asyncio.fixture(scope="function")
 async def custom_block_tools():
     with TempKeyring() as keychain:

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -19,7 +19,7 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.block_cache import BlockCache
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
-from tests.block_tools import get_signage_point, create_block_tools, BlockTools, create_block_tools_async
+from tests.block_tools import get_signage_point, BlockTools, create_block_tools_async
 from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block,
     _validate_and_add_block_no_error,
@@ -27,7 +27,6 @@ from tests.blockchain.blockchain_test_utils import (
 from tests.setup_nodes import test_constants as test_constants_original
 from tests.util.blockchain import create_blockchain
 from tests.util.keyring import TempKeyring
-from tests.setup_nodes import test_constants
 
 
 test_constants = test_constants_original.replace(**{"DISCRIMINANT_SIZE_BITS": 32, "SUB_SLOT_ITERS_STARTING": 2 ** 12})

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -19,7 +19,7 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.block_cache import BlockCache
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
-from tests.block_tools import get_signage_point, create_block_tools
+from tests.block_tools import get_signage_point, create_block_tools, BlockTools, create_block_tools_async
 from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block,
     _validate_and_add_block_no_error,
@@ -27,20 +27,24 @@ from tests.blockchain.blockchain_test_utils import (
 from tests.setup_nodes import test_constants as test_constants_original
 from tests.util.blockchain import create_blockchain
 from tests.util.keyring import TempKeyring
+from tests.setup_nodes import test_constants
+
+
+test_constants = test_constants_original.replace(**{"DISCRIMINANT_SIZE_BITS": 32, "SUB_SLOT_ITERS_STARTING": 2 ** 12})
+log = logging.getLogger(__name__)
 
 
 def cleanup_keyring(keyring: TempKeyring):
     keyring.cleanup()
 
 
-temp_keyring = TempKeyring()
-keychain = temp_keyring.get_keychain()
-atexit.register(cleanup_keyring, temp_keyring)  # Attempt to cleanup the temp keychain
-test_constants = test_constants_original.replace(**{"DISCRIMINANT_SIZE_BITS": 32, "SUB_SLOT_ITERS_STARTING": 2 ** 12})
-bt = create_block_tools(constants=test_constants, keychain=keychain)
+@pytest_asyncio.fixture(scope="function")
+async def custom_block_tools() -> BlockTools:
+    temp_keyring = TempKeyring()
+    keychain = temp_keyring.get_keychain()
+    atexit.register(cleanup_keyring, temp_keyring)  # Attempt to cleanup the temp keychain
 
-
-log = logging.getLogger(__name__)
+    return await create_block_tools_async(constants=test_constants, keychain=keychain)
 
 
 @pytest_asyncio.fixture(scope="function", params=[1, 2])
@@ -63,9 +67,9 @@ async def empty_blockchain_with_original_constants(request):
 
 class TestFullNodeStore:
     @pytest.mark.asyncio
-    async def test_basic_store(self, empty_blockchain, normalized_to_identity: bool = False):
+    async def test_basic_store(self, empty_blockchain, custom_block_tools, normalized_to_identity: bool = False):
         blockchain = empty_blockchain
-        blocks = bt.get_consecutive_blocks(
+        blocks = custom_block_tools.get_consecutive_blocks(
             10,
             seed=b"1234",
             normalized_to_identity_cc_eos=normalized_to_identity,
@@ -121,7 +125,7 @@ class TestFullNodeStore:
             store.remove_unfinished_block(unf_block.partial_hash)
             assert store.get_unfinished_block(unf_block.partial_hash) is None
 
-        blocks = bt.get_consecutive_blocks(
+        blocks = custom_block_tools.get_consecutive_blocks(
             1,
             skip_slots=5,
             normalized_to_identity_cc_ip=normalized_to_identity,
@@ -201,7 +205,7 @@ class TestFullNodeStore:
         )
 
         # Test adding non genesis peak directly
-        blocks = bt.get_consecutive_blocks(
+        blocks = custom_block_tools.get_consecutive_blocks(
             2,
             skip_slots=2,
             normalized_to_identity_cc_eos=normalized_to_identity,
@@ -209,7 +213,7 @@ class TestFullNodeStore:
             normalized_to_identity_cc_ip=normalized_to_identity,
             normalized_to_identity_cc_sp=normalized_to_identity,
         )
-        blocks = bt.get_consecutive_blocks(
+        blocks = custom_block_tools.get_consecutive_blocks(
             3,
             block_list_input=blocks,
             normalized_to_identity_cc_eos=normalized_to_identity,
@@ -225,7 +229,7 @@ class TestFullNodeStore:
             assert res.added_eos is None
 
         # Add reorg blocks
-        blocks_reorg = bt.get_consecutive_blocks(
+        blocks_reorg = custom_block_tools.get_consecutive_blocks(
             20,
             normalized_to_identity_cc_eos=normalized_to_identity,
             normalized_to_identity_icc_eos=normalized_to_identity,
@@ -250,7 +254,7 @@ class TestFullNodeStore:
                 assert res.added_eos is None
 
         # Add slots to the end
-        blocks_2 = bt.get_consecutive_blocks(
+        blocks_2 = custom_block_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks_reorg,
             skip_slots=2,
@@ -282,7 +286,7 @@ class TestFullNodeStore:
 
         blocks = blocks_reorg
         while True:
-            blocks = bt.get_consecutive_blocks(
+            blocks = custom_block_tools.get_consecutive_blocks(
                 1,
                 block_list_input=blocks,
                 normalized_to_identity_cc_eos=normalized_to_identity,
@@ -312,7 +316,7 @@ class TestFullNodeStore:
         assert len(store.finished_sub_slots) == 2
 
         # Add slots to the end, except for the last one, which we will use to test invalid SP
-        blocks_2 = bt.get_consecutive_blocks(
+        blocks_2 = custom_block_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks,
             skip_slots=3,
@@ -441,7 +445,7 @@ class TestFullNodeStore:
             )
             assert store.new_signage_point(uint8(i), blockchain, None, peak.sub_slot_iters, sp)
 
-        blocks_3 = bt.get_consecutive_blocks(
+        blocks_3 = custom_block_tools.get_consecutive_blocks(
             1,
             skip_slots=2,
             normalized_to_identity_cc_eos=normalized_to_identity,
@@ -471,14 +475,14 @@ class TestFullNodeStore:
                 assert store.new_signage_point(uint8(i), blockchain, None, peak.sub_slot_iters, sp)
 
         # Test adding signage points after genesis
-        blocks_4 = bt.get_consecutive_blocks(
+        blocks_4 = custom_block_tools.get_consecutive_blocks(
             1,
             normalized_to_identity_cc_eos=normalized_to_identity,
             normalized_to_identity_icc_eos=normalized_to_identity,
             normalized_to_identity_cc_ip=normalized_to_identity,
             normalized_to_identity_cc_sp=normalized_to_identity,
         )
-        blocks_5 = bt.get_consecutive_blocks(
+        blocks_5 = custom_block_tools.get_consecutive_blocks(
             1,
             block_list_input=blocks_4,
             skip_slots=1,
@@ -519,7 +523,7 @@ class TestFullNodeStore:
 
         # Test future EOS cache
         store.initialize_genesis_sub_slot()
-        blocks = bt.get_consecutive_blocks(
+        blocks = custom_block_tools.get_consecutive_blocks(
             1,
             normalized_to_identity_cc_eos=normalized_to_identity,
             normalized_to_identity_icc_eos=normalized_to_identity,
@@ -528,7 +532,7 @@ class TestFullNodeStore:
         )
         await _validate_and_add_block_no_error(blockchain, blocks[-1])
         while True:
-            blocks = bt.get_consecutive_blocks(
+            blocks = custom_block_tools.get_consecutive_blocks(
                 1,
                 block_list_input=blocks,
                 normalized_to_identity_cc_eos=normalized_to_identity,
@@ -562,7 +566,7 @@ class TestFullNodeStore:
 
         # Test future IP cache
         store.initialize_genesis_sub_slot()
-        blocks = bt.get_consecutive_blocks(
+        blocks = custom_block_tools.get_consecutive_blocks(
             60,
             normalized_to_identity_cc_ip=normalized_to_identity,
             normalized_to_identity_cc_sp=normalized_to_identity,
@@ -624,13 +628,15 @@ class TestFullNodeStore:
         log.warning("Starting loop")
         while True:
             log.warning("Looping")
-            blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1)
+            blocks = custom_block_tools.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1)
             await _validate_and_add_block_no_error(blockchain, blocks[-1])
             peak = blockchain.get_peak()
             sub_slots = await blockchain.get_sp_and_ip_sub_slots(peak.header_hash)
             store.new_peak(peak, blocks[-1], sub_slots[0], sub_slots[1], None, blockchain)
 
-            blocks = bt.get_consecutive_blocks(2, block_list_input=blocks, guarantee_transaction_block=True)
+            blocks = custom_block_tools.get_consecutive_blocks(
+                2, block_list_input=blocks, guarantee_transaction_block=True
+            )
 
             i3 = blocks[-3].reward_chain_block.signage_point_index
             i2 = blocks[-2].reward_chain_block.signage_point_index
@@ -660,7 +666,7 @@ class TestFullNodeStore:
                         test_constants,
                         blockchain,
                         peak,
-                        uint128(peak.ip_sub_slot_total_iters(bt.constants)),
+                        uint128(peak.ip_sub_slot_total_iters(custom_block_tools.constants)),
                         uint8(i),
                         finished_sub_slots,
                         peak.sub_slot_iters,
@@ -682,7 +688,9 @@ class TestFullNodeStore:
 
                 for i in range(i2, test_constants.NUM_SPS_SUB_SLOT):
                     if is_overflow_block(test_constants, uint8(i)):
-                        blocks_alt = bt.get_consecutive_blocks(1, block_list_input=blocks[:-1], skip_slots=1)
+                        blocks_alt = custom_block_tools.get_consecutive_blocks(
+                            1, block_list_input=blocks[:-1], skip_slots=1
+                        )
                         finished_sub_slots = blocks_alt[-1].finished_sub_slots
                     else:
                         finished_sub_slots = []
@@ -690,7 +698,7 @@ class TestFullNodeStore:
                         test_constants,
                         blockchain,
                         peak,
-                        uint128(peak.ip_sub_slot_total_iters(bt.constants)),
+                        uint128(peak.ip_sub_slot_total_iters(custom_block_tools.constants)),
                         uint8(i),
                         finished_sub_slots,
                         peak.sub_slot_iters,
@@ -729,8 +737,8 @@ class TestFullNodeStore:
                     await _validate_and_add_block_no_error(blockchain, block)
 
     @pytest.mark.asyncio
-    async def test_basic_store_compact_blockchain(self, empty_blockchain):
-        await self.test_basic_store(empty_blockchain, True)
+    async def test_basic_store_compact_blockchain(self, empty_blockchain, custom_block_tools):
+        await self.test_basic_store(empty_blockchain, custom_block_tools, True)
 
     @pytest.mark.asyncio
     async def test_long_chain_slots(self, empty_blockchain_with_original_constants, default_1000_blocks):

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -1,4 +1,3 @@
-import atexit
 import logging
 from secrets import token_bytes
 from typing import List, Optional
@@ -19,7 +18,7 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.block_cache import BlockCache
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
-from tests.block_tools import get_signage_point, BlockTools, create_block_tools_async
+from tests.block_tools import get_signage_point, create_block_tools_async
 from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block,
     _validate_and_add_block_no_error,
@@ -38,11 +37,9 @@ def cleanup_keyring(keyring: TempKeyring):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def custom_block_tools() -> BlockTools:
+async def custom_block_tools():
     with TempKeyring() as keychain:
         yield await create_block_tools_async(constants=test_constants, keychain=keychain)
-
-    return await create_block_tools_async(constants=test_constants, keychain=keychain)
 
 
 @pytest_asyncio.fixture(scope="function", params=[1, 2])

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -3,20 +3,17 @@ These are quick-to-run test that check spends can be added to the blockchain whe
 or that they're failing for the right reason when they're invalid.
 """
 
-import atexit
 import logging
 import time
 
 from typing import List, Optional, Tuple
 
 import pytest
-import pytest_asyncio
 
 from blspy import G2Element
 
 from clvm_tools.binutils import assemble
 
-from chia.consensus.constants import ConsensusConstants
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.program import Program
 from chia.types.coin_record import CoinRecord
@@ -26,7 +23,7 @@ from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
 from chia.util.ints import uint32
-from tests.block_tools import create_block_tools, test_constants, BlockTools
+from tests.block_tools import BlockTools
 from tests.util.keyring import TempKeyring
 
 from .ram_db import create_ram_blockchain

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -10,6 +10,7 @@ import time
 from typing import List, Optional, Tuple
 
 import pytest
+import pytest_asyncio
 
 from blspy import G2Element
 
@@ -25,7 +26,7 @@ from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
 from chia.util.ints import uint32
-from tests.block_tools import create_block_tools, test_constants
+from tests.block_tools import create_block_tools, test_constants, BlockTools
 from tests.util.keyring import TempKeyring
 
 from .ram_db import create_ram_blockchain
@@ -34,12 +35,6 @@ from ...blockchain.blockchain_test_utils import _validate_and_add_block
 
 def cleanup_keyring(keyring: TempKeyring):
     keyring.cleanup()
-
-
-temp_keyring = TempKeyring()
-keychain = temp_keyring.get_keychain()
-atexit.register(cleanup_keyring, temp_keyring)  # Attempt to cleanup the temp keychain
-bt = create_block_tools(constants=test_constants, keychain=keychain)
 
 
 log = logging.getLogger(__name__)
@@ -52,7 +47,7 @@ EASY_PUZZLE = Program.to(assemble("1"))
 EASY_PUZZLE_HASH = EASY_PUZZLE.get_tree_hash()
 
 
-def initial_blocks(block_count: int = 4) -> List[FullBlock]:
+async def initial_blocks(bt, block_count: int = 4) -> List[FullBlock]:
     blocks = bt.get_consecutive_blocks(
         block_count,
         guarantee_transaction_block=True,
@@ -63,7 +58,7 @@ def initial_blocks(block_count: int = 4) -> List[FullBlock]:
 
 
 async def check_spend_bundle_validity(
-    constants: ConsensusConstants,
+    bt: BlockTools,
     blocks: List[FullBlock],
     spend_bundle: SpendBundle,
     expected_err: Optional[Err] = None,
@@ -73,6 +68,7 @@ async def check_spend_bundle_validity(
     `SpendBundle`, and then invokes `receive_block` to ensure that it's accepted (if `expected_err=None`)
     or fails with the correct error code.
     """
+    constants = bt.constants
     db_wrapper, blockchain = await create_ram_blockchain(constants)
     try:
         for block in blocks:
@@ -106,9 +102,9 @@ async def check_spend_bundle_validity(
 
 
 async def check_conditions(
-    condition_solution: Program, expected_err: Optional[Err] = None, spend_reward_index: int = -2
+    bt: BlockTools, condition_solution: Program, expected_err: Optional[Err] = None, spend_reward_index: int = -2
 ):
-    blocks = initial_blocks()
+    blocks = await initial_blocks(bt)
     coin = list(blocks[spend_reward_index].get_included_reward_coins())[0]
 
     coin_spend = CoinSpend(coin, EASY_PUZZLE, condition_solution)
@@ -116,63 +112,63 @@ async def check_conditions(
 
     # now let's try to create a block with the spend bundle and ensure that it doesn't validate
 
-    await check_spend_bundle_validity(bt.constants, blocks, spend_bundle, expected_err=expected_err)
+    await check_spend_bundle_validity(bt, blocks, spend_bundle, expected_err=expected_err)
 
 
 class TestConditions:
     @pytest.mark.asyncio
-    async def test_invalid_block_age(self):
+    async def test_invalid_block_age(self, bt):
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_HEIGHT_RELATIVE[0]} 2))"))
-        await check_conditions(conditions, expected_err=Err.ASSERT_HEIGHT_RELATIVE_FAILED)
+        await check_conditions(bt, conditions, expected_err=Err.ASSERT_HEIGHT_RELATIVE_FAILED)
 
     @pytest.mark.asyncio
-    async def test_valid_block_age(self):
+    async def test_valid_block_age(self, bt):
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_HEIGHT_RELATIVE[0]} 1))"))
-        await check_conditions(conditions)
+        await check_conditions(bt, conditions)
 
     @pytest.mark.asyncio
-    async def test_invalid_block_height(self):
+    async def test_invalid_block_height(self, bt):
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE[0]} 4))"))
-        await check_conditions(conditions, expected_err=Err.ASSERT_HEIGHT_ABSOLUTE_FAILED)
+        await check_conditions(bt, conditions, expected_err=Err.ASSERT_HEIGHT_ABSOLUTE_FAILED)
 
     @pytest.mark.asyncio
-    async def test_valid_block_height(self):
+    async def test_valid_block_height(self, bt):
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE[0]} 3))"))
-        await check_conditions(conditions)
+        await check_conditions(bt, conditions)
 
     @pytest.mark.asyncio
-    async def test_invalid_my_id(self):
-        blocks = initial_blocks()
+    async def test_invalid_my_id(self, bt):
+        blocks = await initial_blocks(bt)
         coin = list(blocks[-2].get_included_reward_coins())[0]
         wrong_name = bytearray(coin.name())
         wrong_name[-1] ^= 1
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_MY_COIN_ID[0]} 0x{wrong_name.hex()}))"))
-        await check_conditions(conditions, expected_err=Err.ASSERT_MY_COIN_ID_FAILED)
+        await check_conditions(bt, conditions, expected_err=Err.ASSERT_MY_COIN_ID_FAILED)
 
     @pytest.mark.asyncio
-    async def test_valid_my_id(self):
-        blocks = initial_blocks()
+    async def test_valid_my_id(self, bt):
+        blocks = await initial_blocks(bt)
         coin = list(blocks[-2].get_included_reward_coins())[0]
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_MY_COIN_ID[0]} 0x{coin.name().hex()}))"))
-        await check_conditions(conditions)
+        await check_conditions(bt, conditions)
 
     @pytest.mark.asyncio
-    async def test_invalid_seconds_absolute(self):
+    async def test_invalid_seconds_absolute(self, bt):
         # TODO: make the test suite not use `time.time` so we can more accurately
         # set `time_now` to make it minimal while still failing
         time_now = int(time.time()) + 3000
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_SECONDS_ABSOLUTE[0]} {time_now}))"))
-        await check_conditions(conditions, expected_err=Err.ASSERT_SECONDS_ABSOLUTE_FAILED)
+        await check_conditions(bt, conditions, expected_err=Err.ASSERT_SECONDS_ABSOLUTE_FAILED)
 
     @pytest.mark.asyncio
-    async def test_valid_seconds_absolute(self):
+    async def test_valid_seconds_absolute(self, bt):
         time_now = int(time.time())
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_SECONDS_ABSOLUTE[0]} {time_now}))"))
-        await check_conditions(conditions)
+        await check_conditions(bt, conditions)
 
     @pytest.mark.asyncio
-    async def test_invalid_coin_announcement(self):
-        blocks = initial_blocks()
+    async def test_invalid_coin_announcement(self, bt):
+        blocks = await initial_blocks(bt)
         coin = list(blocks[-2].get_included_reward_coins())[0]
         announce = Announcement(coin.name(), b"test_bad")
         conditions = Program.to(
@@ -181,11 +177,11 @@ class TestConditions:
                 f"({ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT[0]} 0x{announce.name().hex()}))"
             )
         )
-        await check_conditions(conditions, expected_err=Err.ASSERT_ANNOUNCE_CONSUMED_FAILED)
+        await check_conditions(bt, conditions, expected_err=Err.ASSERT_ANNOUNCE_CONSUMED_FAILED)
 
     @pytest.mark.asyncio
-    async def test_valid_coin_announcement(self):
-        blocks = initial_blocks()
+    async def test_valid_coin_announcement(self, bt):
+        blocks = await initial_blocks(bt)
         coin = list(blocks[-2].get_included_reward_coins())[0]
         announce = Announcement(coin.name(), b"test")
         conditions = Program.to(
@@ -194,10 +190,10 @@ class TestConditions:
                 f"({ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT[0]} 0x{announce.name().hex()}))"
             )
         )
-        await check_conditions(conditions)
+        await check_conditions(bt, conditions)
 
     @pytest.mark.asyncio
-    async def test_invalid_puzzle_announcement(self):
+    async def test_invalid_puzzle_announcement(self, bt):
         announce = Announcement(EASY_PUZZLE_HASH, b"test_bad")
         conditions = Program.to(
             assemble(
@@ -205,10 +201,10 @@ class TestConditions:
                 f"({ConditionOpcode.ASSERT_PUZZLE_ANNOUNCEMENT[0]} 0x{announce.name().hex()}))"
             )
         )
-        await check_conditions(conditions, expected_err=Err.ASSERT_ANNOUNCE_CONSUMED_FAILED)
+        await check_conditions(bt, conditions, expected_err=Err.ASSERT_ANNOUNCE_CONSUMED_FAILED)
 
     @pytest.mark.asyncio
-    async def test_valid_puzzle_announcement(self):
+    async def test_valid_puzzle_announcement(self, bt):
         announce = Announcement(EASY_PUZZLE_HASH, b"test")
         conditions = Program.to(
             assemble(
@@ -216,4 +212,4 @@ class TestConditions:
                 f"({ConditionOpcode.ASSERT_PUZZLE_ANNOUNCEMENT[0]} 0x{announce.name().hex()}))"
             )
         )
-        await check_conditions(conditions)
+        await check_conditions(bt, conditions)

--- a/tests/wallet/test_singleton_lifecycle.py
+++ b/tests/wallet/test_singleton_lifecycle.py
@@ -2,6 +2,7 @@ import asyncio
 
 from typing import List, Tuple
 
+import pytest
 from blspy import G2Element
 from clvm_tools import binutils
 
@@ -16,7 +17,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
 from chia.wallet.puzzles.load_clvm import load_clvm
 
-from tests.core.full_node.test_conditions import bt, check_spend_bundle_validity, initial_blocks
+from tests.core.full_node.test_conditions import check_spend_bundle_validity, initial_blocks
 
 
 SINGLETON_MOD = load_clvm("singleton_top_layer.clvm")
@@ -96,8 +97,9 @@ def p2_singleton_puzzle_hash(launcher_id: Program, launcher_puzzle_hash: bytes32
     return p2_singleton_puzzle(launcher_id, launcher_puzzle_hash).get_tree_hash()
 
 
-def test_only_odd_coins_0():
-    blocks = initial_blocks()
+@pytest.mark.asyncio
+async def test_only_odd_coins_0(bt):
+    blocks = await initial_blocks(bt)
     farmed_coin = list(blocks[-1].get_included_reward_coins())[0]
 
     metadata = [("foo", "bar")]
@@ -113,7 +115,7 @@ def test_only_odd_coins_0():
     conditions = Program.to(condition_list)
     coin_spend = CoinSpend(farmed_coin, ANYONE_CAN_SPEND_PUZZLE, conditions)
     spend_bundle = SpendBundle.aggregate([launcher_spend_bundle, SpendBundle([coin_spend], G2Element())])
-    coins_added, coins_removed = asyncio.run(check_spend_bundle_validity(bt.constants, blocks, spend_bundle))
+    coins_added, coins_removed = await check_spend_bundle_validity(bt, blocks, spend_bundle)
 
     coin_set_added = set([_.coin for _ in coins_added])
     coin_set_removed = set([_.coin for _ in coins_removed])

--- a/tests/wallet/test_singleton_lifecycle.py
+++ b/tests/wallet/test_singleton_lifecycle.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from typing import List, Tuple
 
 import pytest


### PR DESCRIPTION
The problem was that block tools was being created outside of an async context, and running the async functions using `get_running_loop` can potentially use the wrong loop.

Fixes the following flaky test files:
* test_full_node_store
* test_singleton_lifecycle