### PR TITLE
Improved UX for plotnft claim

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -234,7 +234,7 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
             return None
 
     print("Transaction not yet submitted to nodes")
-    print(f"Do 'chia wallet get_transaction -f {fingerprint} -tx 0x{tx_id}' to get status")
+    print(f"To get status, use command: 'chia wallet get_transaction -f {fingerprint} -tx 0x{tx_id}'")
 
 
 async def get_address(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -234,7 +234,7 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
             return None
 
     print("Transaction not yet submitted to nodes")
-    print(f"To get status, use command: 'chia wallet get_transaction -f {fingerprint} -tx 0x{tx_id}'")
+    print(f"To get status, use command: chia wallet get_transaction -f {fingerprint} -tx 0x{tx_id}")
 
 
 async def get_address(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:


### PR DESCRIPTION
Small UX qol improvement: Makes it easier to copy the `chia wallet get_transaction` command provided after claiming plotnft rewards.

Currently, after claiming rewards this message is given:
```
Will claim rewards for wallet ID: 2.
Transaction submitted to nodes: [('825c03dee4a470e20ffebe6add2ea6e1ab05f0120ea6e596da56317a27b6e80d', 1, None)]
Do chia wallet get_transaction -f 478512361 -tx 0xc76cabfc548d85ae3c70d44788cacdf56dfc1dcd889ad2798c64753b46443655 to get status
```
One would copy the command and paste it in to check. However, when selecting, it's very easy to make the mistake of copying `to get status` after the command.

With this change, it's clear that you select everything after the colon, and you will not select any text that is not part of the command.

New message will be: 
```
To get status, use command: chia wallet get_transaction -f 478512361 -tx 0xc76cabfc548d85ae3c70d44788cacdf56dfc1dcd889ad2798c64753b46443655
```