### PR TITLE
execute SQL updates as chunks in _set_spent function for tx_removals

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -520,7 +520,7 @@ class CoinStore:
 
         async with self.db_wrapper.write_db() as conn:
             rows_updated: int = 0
-            for coin_names_chunk in chunks(coin_names, MAX_SQLITE_PARAMETERS):
+            for coin_names_chunk in chunks(coin_names, SQLITE_MAX_VARIABLE_NUMBER):
                 name_params = ",".join(["?"] * len(coin_names_chunk))
                 if self.db_wrapper.db_version == 2:
                     ret: Cursor = await conn.execute(

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -520,22 +520,28 @@ class CoinStore:
         if len(coin_names) == 0:
             return
 
-        updates = []
-        for coin_name in coin_names:
-            updates.append((index, self.maybe_to_hex(coin_name)))
-
         async with self.db_wrapper.write_db() as conn:
-            if self.db_wrapper.db_version == 2:
-                ret: Cursor = await conn.executemany(
-                    "UPDATE OR FAIL coin_record SET spent_index=? WHERE coin_name=? AND spent_index=0", updates
-                )
-
-            else:
-                ret = await conn.executemany(
-                    "UPDATE OR FAIL coin_record SET spent=1,spent_index=? WHERE coin_name=? AND spent_index=0",
-                    updates,
-                )
-            if ret.rowcount != len(coin_names):
+            rows_updated: int = 0
+            for coin_names_chunk in chunks(coin_names, MAX_SQLITE_PARAMETERS):
+                name_params = ",".join(["?"] * len(coin_names_chunk))
+                if self.db_wrapper.db_version == 2:
+                    ret: Cursor = await conn.execute(
+                        f"UPDATE OR FAIL coin_record INDEXED BY sqlite_autoindex_coin_record_1 "
+                        f"SET spent_index={index} "
+                        f"WHERE spent_index=0 "
+                        f"AND coin_name IN ({name_params})",
+                        coin_names_chunk,
+                    )
+                else:
+                    ret = await conn.execute(
+                        f"UPDATE OR FAIL coin_record INDEXED BY sqlite_autoindex_coin_record_1 "
+                        f"SET spent=1, spent_index={index} "
+                        f"WHERE spent_index=0 "
+                        f"AND coin_name IN ({name_params})",
+                        [name.hex() for name in coin_names_chunk],
+                    )
+                rows_updated += ret.rowcount
+            if rows_updated != len(coin_names):
                 raise ValueError(
-                    f"Invalid operation to set spent, total updates {ret.rowcount} expected {len(coin_names)}"
+                    f"Invalid operation to set spent, total updates {rows_updated} expected {len(coin_names)}"
                 )


### PR DESCRIPTION
Currently for every coin removal per tx block, one SQL Update command is executed after the other.
This could lead to up to 900 update executions per tx block.

```sql
-- list blocks with most tx_removals
sqlite> select spent_index, count(1) from coin_record 
   ...> group by spent_index order by 2 desc limit 10;
0|172132232
226075|917
225800|894
225987|893
947021|890
789903|889
1678819|887
1129746|886
1383510|885
1678869|884
```

This PR changes the issued Update statement by

- splitting given `coin_names` into `coin_names_chunk` using given constant
- executing only one SQL Update using `coin_name IN ( ... )` instead of `coin_name = x'...'`
- 

### sql log from current implementation

```sql
16:35:20.558244 RELEASE s1609854
16:35:20.564141 SAVEPOINT s1609855
16:35:20.565120 UPDATE OR FAIL coin_record SET spent_index=283422 WHERE coin_name=x'32dd4b18693a838dff8dacc37a4ba64cd4ea27a53cebac67d137a80cf18feb63' AND spent_index=0
16:35:20.565926 UPDATE OR FAIL coin_record SET spent_index=283422 WHERE coin_name=x'ccd5035f9067dd7b87f0f472f4361674976faf4b3b43b241776a2151471179f2' AND spent_index=0
...
16:35:20.623934 UPDATE OR FAIL coin_record SET spent_index=283422 WHERE coin_name=x'd6a8b8efee10ef8771d921d3ac68530414cd5a3072cf4d61176840d525a76c04' AND spent_index=0
16:35:20.624644 UPDATE OR FAIL coin_record SET spent_index=283422 WHERE coin_name=x'f02d940775d2873c195a50c260bbd3334b1ee1a053083159df90f9309dc20405' AND spent_index=0
16:35:20.625800 RELEASE s1609855
16:35:20.626943 SAVEPOINT s1609856
16:35:20.627797 UPDATE OR FAIL full_blocks SET in_main_chain=0 WHERE height>283421 AND in_main_chain=1
```
tx time from `SAVEPOINT` to `RELEASE`: 0.061659s for 103 removals on spent_index 283422

### sql log after this PRs implementation

```sql
22:29:39.108772 RELEASE s5958
22:29:39.109872 SAVEPOINT s5959
22:29:39.111652 UPDATE OR FAIL coin_record SET spent_index=283422 WHERE spent_index=0 
AND coin_name in (x'32dd4b18693a838dff8dacc37a4ba64cd4ea27a53cebac67d137a80cf18feb63',x'ccd5035f9067dd7b87f0f472f4361674976faf4b3b43b241776a2151471179f2',
...
x'f02d940775d2873c195a50c260bbd3334b1ee1a053083159df90f9309dc20405') 
22:29:39.115791 RELEASE s5959
22:29:39.116985 SAVEPOINT s5960
22:29:39.118238 UPDATE OR FAIL full_blocks SET in_main_chain=0 WHERE height>283421 AND in_main_chain=1
```
tx time from `SAVEPOINT` to `RELEASE`: 0.005919s for 103 removals on spent_index 283422