### PR TITLE
tests: Skip `plot_sync_callback` if `delta` is `None`

### DIFF
--- a/tests/plot_sync/test_plot_sync.py
+++ b/tests/plot_sync/test_plot_sync.py
@@ -179,7 +179,9 @@ class Environment:
         self.remove_directory(harvester_index, self.dir_invalid, State.invalid)
         self.remove_directory(harvester_index, self.dir_duplicates, State.duplicates)
 
-    async def plot_sync_callback(self, peer_id: bytes32, delta: Delta) -> None:
+    async def plot_sync_callback(self, peer_id: bytes32, delta: Optional[Delta]) -> None:
+        if delta is None:
+            return
         harvester: Optional[Harvester] = self.get_harvester(peer_id)
         assert harvester is not None
         expected = self.expected[self.harvesters.index(harvester)]


### PR DESCRIPTION
This reduces a lot pointless error logs when running plot sync tests.