### PR TITLE
tests: Avoid using `match` of `pytest.raises` together with paths

### DIFF
--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -40,6 +40,7 @@ from tests.block_tools import get_plot_dir
 from tests.plot_sync.test_delta import dummy_plot
 from tests.setup_nodes import setup_harvester_farmer, test_constants
 from tests.time_out_assert import time_out_assert, time_out_assert_custom_interval
+from tests.util.misc import assert_rpc_error
 from tests.util.rpc import validate_get_routes
 
 log = logging.getLogger(__name__)
@@ -569,14 +570,14 @@ async def test_harvester_add_plot_directory(harvester_farmer_environment) -> Non
     test_path = Path(root_path / "test_path").resolve()
 
     # The test_path doesn't exist at this point
-    with pytest.raises(ValueError, match=f"Path doesn't exist: {test_path}"):
+    with assert_rpc_error(f"Path doesn't exist: {test_path}"):
         await harvester_rpc_client.add_plot_directory(str(test_path))
 
     # Create a file at the test_path and make sure it detects this
     with open(test_path, "w"):
         pass
 
-    with pytest.raises(ValueError, match=f"Path is not a directory: {test_path}"):
+    with assert_rpc_error(f"Path is not a directory: {test_path}"):
         await harvester_rpc_client.add_plot_directory(str(test_path))
 
     # Drop the file, make it a directory and make sure it gets added properly.
@@ -585,7 +586,7 @@ async def test_harvester_add_plot_directory(harvester_farmer_environment) -> Non
 
     await assert_added(test_path)
 
-    with pytest.raises(ValueError, match=f"Path already added: {test_path}"):
+    with assert_rpc_error(f"Path already added: {test_path}"):
         await harvester_rpc_client.add_plot_directory(str(test_path))
 
     # Add another one and make sure they are still both there.

--- a/tests/util/misc.py
+++ b/tests/util/misc.py
@@ -13,6 +13,7 @@ from time import thread_time
 from types import TracebackType
 from typing import Callable, Iterator, List, Optional, Type, Union
 
+import pytest
 from typing_extensions import final
 
 
@@ -276,3 +277,10 @@ class _AssertRuntime:
 # decorator, this is just here to retain the function-style naming as the public
 # interface.  Hopefully we can switch away from the class at some point.
 assert_runtime = _AssertRuntime
+
+
+@contextlib.contextmanager
+def assert_rpc_error(error: str) -> Iterator[None]:
+    with pytest.raises(ValueError) as exception_info:
+        yield
+    assert error in exception_info.value.args[0]["error"]


### PR DESCRIPTION
Fixes failures like below. See https://github.com/Chia-Network/chia-blockchain/actions/runs/2386606563 for a test run against #10681.

 
```
______________________ test_harvester_add_plot_directory 
______________________
[gw1] win32 -- Python 3.7.9 
d:\a\chia-blockchain\chia-blockchain\venv\scripts\python.exe
tests\core\test_farmer_harvester_rpc.py:573: in 
test_harvester_add_plot_directory
    await harvester_rpc_client.add_plot_directory(str(test_path))
chia\rpc\harvester_rpc_client.py:25: in add_plot_directory
    return (await self.fetch("add_plot_directory", {"dirname": 
dirname}))["success"]
chia\rpc\rpc_client.py:49: in fetch
    raise ValueError(res_json)
E   ValueError: {'error': "Path doesn't exist: 
C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\popen-gw1\\test_harvester_add_plot_direct0\\harvester\\test_path", 
'success': False}

During handling of the above exception, another exception occurred:
tests\core\test_farmer_harvester_rpc.py:573: in 
test_harvester_add_plot_directory
    await harvester_rpc_client.add_plot_directory(str(test_path))
C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\re.py:185: in search
    return _compile(pattern, flags).search(string)
C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\re.py:288: in _compile
    p = sre_compile.compile(pattern, flags)
C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\sre_compile.py:764: in 
compile
    p = sre_parse.parse(p, flags)
C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\sre_parse.py:924: in 
parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\sre_parse.py:420: in 
_parse_sub
    not nested and not items))
C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\sre_parse.py:501: in 
_parse
    code = _escape(source, this, state)
C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\sre_parse.py:369: in 
_escape
    raise source.error("incomplete escape %s" % escape, len(escape))
E   re.error: incomplete escape \U at position 22
```