### PR TITLE
extend benchmark to make the db-sync mode and node-profiler configurable

### DIFF
--- a/tests/tools/test_full_sync.py
+++ b/tests/tools/test_full_sync.py
@@ -14,5 +14,14 @@ def test_full_sync_test(keep_up: bool):
     file_path = os.path.realpath(__file__)
     db_file = Path(file_path).parent / "test-blockchain-db.sqlite"
     asyncio.run(
-        run_sync_test(db_file, db_version=2, profile=False, single_thread=False, test_constants=False, keep_up=keep_up)
+        run_sync_test(
+            db_file,
+            db_version=2,
+            profile=False,
+            single_thread=False,
+            test_constants=False,
+            keep_up=keep_up,
+            db_sync="off",
+            node_profiler=False,
+        )
     )

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -9,6 +9,8 @@ run_benchmark() {
    mv test-full-sync.log cpu.png cpu-usage.log plot-cpu.gnuplot "$2"
    python ./tools/test_full_sync.py analyze
    mv slow-batch-*.profile slow-batch-*.png "$2"
+   python ./chia/util/profiler.py profile-node >"$2/node-profile.txt"
+   mv profile-node "$2"
 }
 
 cd ..


### PR DESCRIPTION
example output from the node profiler:

<img width="486" alt="image" src="https://user-images.githubusercontent.com/661450/170485150-bfa51b5a-e69c-425b-819e-342392739dd1.png">
