### PR TITLE
Updated Help description

### DIFF
--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -30,7 +30,15 @@ def plotnft_cmd() -> None:
     type=int,
     default=None,
 )
-@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=False)
+@click.option(
+    "-i",
+    "--id",
+    help="ID of the Pooling wallet in use",
+    type=int,
+    default=None,
+    show_default=True,
+    required=False
+)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
     import asyncio
@@ -103,7 +111,15 @@ def create_cmd(
 
 @plotnft_cmd.command("join", short_help="Join a plot NFT to a Pool")
 @click.option("-y", "--yes", help="No prompts", is_flag=True)
-@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
+@click.option(
+    "-i",
+    "--id",
+    help="ID of the Pooling wallet to store pool rewards",
+    type=int,
+    default=None,
+    show_default=True,
+    required=True
+)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-u", "--pool_url", help="HTTPS host:port of the pool to join", type=str, required=True)
 @click.option(
@@ -134,7 +150,15 @@ def join_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, fee: int
 
 @plotnft_cmd.command("leave", short_help="Leave a pool and return to self-farming")
 @click.option("-y", "--yes", help="No prompts", is_flag=True)
-@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
+@click.option(
+    "-i",
+    "--id",
+    help="ID of the Pooling wallet currently used to store pool rewards for the plotnft",
+    type=int,
+    default=None,
+    show_default=True,
+    required=True
+)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(
     "-m",
@@ -163,7 +187,15 @@ def self_pool_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, fee
 
 
 @plotnft_cmd.command("inspect", short_help="Get Detailed plotnft information as JSON")
-@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
+@click.option(
+    "-i",
+    "--id",
+    help="ID of the Pooling wallet to use",
+    type=int,
+    default=None,
+    show_default=True,
+    required=True
+)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(
     "-wp",
@@ -182,7 +214,15 @@ def inspect(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
 
 
 @plotnft_cmd.command("claim", short_help="Claim rewards from a plot NFT")
-@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
+@click.option(
+    "-i",
+    "--id",
+    help="ID of the Pooling wallet to claim rewards from",
+    type=int,
+    default=None,
+    show_default=True,
+    required=True
+)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(
     "-m",

--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -31,13 +31,7 @@ def plotnft_cmd() -> None:
     default=None,
 )
 @click.option(
-    "-i",
-    "--id",
-    help="ID of the Pooling wallet in use",
-    type=int,
-    default=None,
-    show_default=True,
-    required=False
+    "-i", "--id", help="ID of the Pooling wallet in use", type=int, default=None, show_default=True, required=False
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
@@ -118,7 +112,7 @@ def create_cmd(
     type=int,
     default=None,
     show_default=True,
-    required=True
+    required=True,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-u", "--pool_url", help="HTTPS host:port of the pool to join", type=str, required=True)
@@ -157,7 +151,7 @@ def join_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, fee: int
     type=int,
     default=None,
     show_default=True,
-    required=True
+    required=True,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(
@@ -188,13 +182,7 @@ def self_pool_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, fee
 
 @plotnft_cmd.command("inspect", short_help="Get Detailed plotnft information as JSON")
 @click.option(
-    "-i",
-    "--id",
-    help="ID of the Pooling wallet to use",
-    type=int,
-    default=None,
-    show_default=True,
-    required=True
+    "-i", "--id", help="ID of the Pooling wallet to use", type=int, default=None, show_default=True, required=True
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(
@@ -221,7 +209,7 @@ def inspect(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
     type=int,
     default=None,
     show_default=True,
-    required=True
+    required=True,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -21,7 +21,7 @@ def wallet_cmd() -> None:
     default=None,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-@click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
+@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-tx", "--tx_id", help="transaction id to search for", type=str, required=True)
 @click.option("--verbose", "-v", count=True, type=int)
 def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, tx_id: str, verbose: int) -> None:
@@ -41,7 +41,7 @@ def get_transaction_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: in
     default=None,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-@click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
+@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option(
     "-o",
     "--offset",
@@ -129,7 +129,7 @@ def get_transactions_cmd(
     default=None,
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
-@click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
+@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-a", "--amount", help="How much chia to send, in XCH", type=str, required=True)
 @click.option("-e", "--memo", help="Additional memo for the transaction", type=str, default=None)
 @click.option(
@@ -196,7 +196,7 @@ def show_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_type: Opti
     type=int,
     default=None,
 )
-@click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
+@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option(
     "-n/-l",
@@ -226,7 +226,7 @@ def get_address_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int, new_ad
     type=int,
     default=None,
 )
-@click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
+@click.option("-i", "--id", help="ID of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 def delete_unconfirmed_transactions_cmd(wallet_rpc_port: Optional[int], id, fingerprint: int) -> None:
     extra_params = {"id": id}


### PR DESCRIPTION
Updated the CLI's `help` command outputs to be less ambiguous in terms of which wallet to use. Specifically the help commands for `plotnft claim`, `plotnft join` and `plotnft leave`

Also updated `wallet.py` `help` commands for consistency in the use of 'Id' vs 'ID'.