### PR TITLE
Remove special test handling for debian:bookworm around 3.10

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -197,16 +197,6 @@ jobs:
         apt-get --yes update
         apt-get install --yes git lsb-release sudo
 
-    # @TODO this step can be removed once Python 3.10 is supported
-    # Python 3.10 is now the default in bookworm, so install 3.9 specifically so install does not fail
-    - name: Prepare debian:bookworm
-      if: ${{ matrix.distribution.name == 'debian:bookworm' }}
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: |
-        apt-get update -y
-        apt-get install -y python3.9-venv
-
     - name: Prepare Fedora
       if: ${{ matrix.distribution.type == 'fedora' }}
       run: |


### PR DESCRIPTION
This ends up providing an example of the hazards of cherry picking.  This adjustment was introduced on `main` prior to adding 3.10 support.  `atari` also had broken CI so I cherry picked this helper across.  Subsequently 3.10 support was merged to `main`.
3.10 support was also cherry picked over to `release/1.3.5`.  Once released, a catch up merge was done from `release/1.3.5` into `atari`.  The merge base should have been d154105a6b35f94649f15bca4e3fb8a11a39e70e.  When looking at the diffs from that base to `atari` it saw the cherry picked addition.  When looking from the base to `1.3.5` it saw nothing.  In more detail, there was the addition and then the removal.  As such, the addition won out without conflict with the nothing.  If there had been a catch up from `main` or `release/1.3.5` prior to the addition of 3.10 support in either then this error would not have happened.