### PR TITLE
Add Source and Changelog to project_urls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,10 @@ kwargs = dict(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     zip_safe=False,
+    project_urls={
+        "Source": "https://github.com/Chia-Network/chia-blockchain/",
+        "Changelog": "https://github.com/Chia-Network/chia-blockchain/blob/main/CHANGELOG.md",
+    },
 )
 
 


### PR DESCRIPTION
Tools like Renovate utilize the `project_urls` key in `setup.py` to find the project source and changelog when checking pypi releases, for example:

https://github.com/renovatebot/renovate/blob/098d22d09b099667bd96c2594a79098d0fdbe01a/lib/modules/datasource/pypi/index.ts#L114-L144

```typescript
    if (dep.info?.project_urls) {
      for (const [name, projectUrl] of Object.entries(dep.info.project_urls)) {
        const lower = name.toLowerCase();

        if (
          !dependency.sourceUrl &&
          (lower.startsWith('repo') ||
            lower === 'code' ||
            lower === 'source' ||
            githubRepoPattern.exec(projectUrl))
        ) {
          dependency.sourceUrl = projectUrl;
        }

        if (
          !dependency.changelogUrl &&
          ([
            'changelog',
            'change log',
            'changes',
            'release notes',
            'news',
            "what's new",
          ].includes(lower) ||
            changelogFilenameRegex.exec(lower))
        ) {
          // from https://github.com/pypa/warehouse/blob/418c7511dc367fb410c71be139545d0134ccb0df/warehouse/templates/packaging/detail.html#L24
          dependency.changelogUrl = projectUrl;
        }
      }
    }
```

Setting project_urls as `{"Source": "https://github.com/Chia-Network/chia-blockchain/", "Changelog": "https://raw.githubusercontent.com/Chia-Network/chia-blockchain/main/CHANGELOG.md"}` is enough to help Renovate find the release notes.

This is great for people using Renovate to keep their repositories up-to-date since one can quickly check what changed directly in the dependency bump PRs instead of having to hunt for changelogs manually.

https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls

See an example project where I pushed a test release to TestPyPI and Renovate is able to fetch the changelog inside the PR:

https://github.com/strayer/chia-project-urls-test/pull/1

Compared to how it is currently with the proper release:

https://github.com/strayer/dockerfile-chia-blockchain/pull/4

As a sideffect this will also link to the source and changelog and show Github metadata on PyPI:

<img width="267" alt="grafik" src="https://user-images.githubusercontent.com/310624/170854425-fd1490ea-a955-4845-b117-43237fff5965.png">

Note: This PR was created after initial discussion with @altendky here: https://github.com/Chia-Network/chia-blockchain/discussions/11509