### PR TITLE
stop and join watchdog observer

### DIFF
--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -174,7 +174,8 @@ class FileKeyring(FileSystemEventHandler):
 
     def cleanup_keyring_file_watcher(self):
         if getattr(self, "keyring_observer"):
-            self.keyring_observer.unschedule_all()
+            self.keyring_observer.stop()
+            self.keyring_observer.join()
 
     def on_modified(self, event):
         self.check_if_keyring_file_modified()


### PR DESCRIPTION
Draft for:
- [x] Does not seem to actually fix the issue, even though it seems a good thing to change.  https://github.com/Chia-Network/chia-blockchain/pull/11706#issuecomment-1140589531

Note possible upstream fix for the issue at https://github.com/gorakhargosh/watchdog/pull/895 being tested in https://github.com/Chia-Network/chia-blockchain/pull/11710.

This is in accordance with the watchdog example.  For inotify at least the `.stop()` call ends up calling the remove unschedule call anyways.

https://github.com/gorakhargosh/watchdog/tree/72f2eb7203659c11c4f0703c818dcb88fe527e99#example-api-usage

This appears to be only used in test code.  This lowers the bar for trying this out in `main` to see how it holds up but also raises the question of why we aren't doing any shutdown at all for normal runs, seemingly.

This was found while looking into the following traceback we occasionally get in CI.

```python-traceback
 ____________ ERROR at teardown of TestWalletSync.test_almost_recent ____________
venv/lib/python3.10/site-packages/_pytest/runner.py:338: in from_call
    result: Optional[TResult] = func()
venv/lib/python3.10/site-packages/_pytest/runner.py:259: in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
venv/lib/python3.10/site-packages/pluggy/_hooks.py:265: in __call__
    return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
venv/lib/python3.10/site-packages/pluggy/_manager.py:80: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
venv/lib/python3.10/site-packages/_pytest/threadexception.py:88: in pytest_runtest_teardown
    yield from thread_exception_runtest_hook()
venv/lib/python3.10/site-packages/_pytest/threadexception.py:73: in thread_exception_runtest_hook
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
E   pytest.PytestUnhandledThreadExceptionWarning: Exception in thread Thread-44
E   
E   Traceback (most recent call last):
E     File "/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
E       self.run()
E     File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.10/site-packages/watchdog/observers/inotify_buffer.py", line 88, in run
E       inotify_events = self._inotify.read_events()
E     File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.10/site-packages/watchdog/observers/inotify_c.py", line 285, in read_events
E       event_buffer = os.read(self._inotify_fd, event_buffer_size)
E   OSError: [Errno 9] Bad file descriptor
```

I don't have any historical data on how often this was happening so the several CI reruns below aren't any sort of proof that the issue is actually fixed.  I just figured I'd give it a chance to still pop up and also collect a list of other flakes that are still hanging around.  So far it looks like CI is in a pretty good state right now in terms of flakes.  But yeah, the bad file descriptor issue did still show up with just this change.