### PR TITLE
Set the overflow to the last SES overflow

### DIFF
--- a/chia/wallet/wallet_weight_proof_handler.py
+++ b/chia/wallet/wallet_weight_proof_handler.py
@@ -180,10 +180,10 @@ class WalletWeightProofHandler:
 
         overflow = 0
         count = 0
-        for idx, new_ses in enumerate(new_wp.sub_epochs):
+        for new_ses in new_wp.sub_epochs:
             if new_ses.reward_chain_hash in old_ses:
                 count += 1
-                overflow += new_ses.num_blocks_overflow
+                overflow = new_ses.num_blocks_overflow
                 continue
             else:
                 break


### PR DESCRIPTION
Set the overflow to the last SES overflow instead of adding all the overflow together
Simplify the loop slightly by not using enumerate since it wasn't being used anyway

Should help with syncing by rolling back to a more recent block rather than one that is considerable older