### PR TITLE
Fee estimation interface

### DIFF
--- a/chia/policy/fee_estimation.py
+++ b/chia/policy/fee_estimation.py
@@ -1,4 +1,3 @@
-
 class FeeMempoolInfo:
     """
     Information from Mempool and MempoolItems needed to estimate fees.
@@ -14,6 +13,7 @@ class FeeBlockInfo:
     """
     Information from Blockchain needed to estimate fees.
     """
+
     pass
 
 
@@ -21,8 +21,5 @@ class FeeRate:
     """
     Represents Fee in XCH per CLVM Cost. Performs XCH/mojo conversion
     """
+
     pass
-
-
-
-

--- a/chia/policy/fee_estimation.py
+++ b/chia/policy/fee_estimation.py
@@ -1,0 +1,28 @@
+
+class FeeMempoolInfo:
+    """
+    Information from Mempool and MempoolItems needed to estimate fees.
+
+    Attributes:
+        current_cost (int):This is the current capacity of the mempool, measured in XCH per CLVM Cost
+        max_cost (int): This is the maximum capacity of the mempool, measured in XCH per CLVM Cost
+
+    """
+
+
+class FeeBlockInfo:
+    """
+    Information from Blockchain needed to estimate fees.
+    """
+    pass
+
+
+class FeeRate:
+    """
+    Represents Fee in XCH per CLVM Cost. Performs XCH/mojo conversion
+    """
+    pass
+
+
+
+

--- a/chia/policy/fee_estimator.py
+++ b/chia/policy/fee_estimator.py
@@ -1,6 +1,7 @@
-import abc
+from typing_extensions import Protocol
 
 from chia.policy.fee_estimation import FeeBlockInfo, FeeMempoolInfo
+from chia.util.ints import uint64
 
 
 class FeeEstimatorConfig:
@@ -15,27 +16,23 @@ class FeeEstimatorConfig:
     blockchain_time_window  # seconds into the past to consider historical blockchain data
     """
 
+
 class MempoolState:
     """Minimum information needed to mirror state of the mempool for values we are concerned with"""
+
     total_mempool_cost: int
     min_fee_rate: float
 
 
-# We inherit only to enforce the interface, not to share behaviour
-class FeeEstimatorInterface(abc.ABC):
-    @abc.abstractmethod
-    def new_block(self, block_info: FeeBlockInfo):
+class FeeEstimatorInterface(Protocol):
+    def new_block(self, block_info: FeeBlockInfo) -> None:
         pass
 
-    @abc.abstractmethod
-    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo) -> None:
         pass
 
-    @abc.abstractmethod
-    def remove_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+    def remove_mempool_item(self, mempool_item_info: FeeMempoolInfo) -> None:
         pass
 
-    @abc.abstractmethod
-    def estimate_fee(self, cost: int, time: int):
+    def estimate_fee(self, cost: int, time: int) -> uint64:
         pass
-

--- a/chia/policy/fee_estimator.py
+++ b/chia/policy/fee_estimator.py
@@ -1,0 +1,41 @@
+import abc
+
+from chia.policy.fee_estimation import FeeBlockInfo, FeeMempoolInfo
+
+
+class FeeEstimatorConfig:
+    """
+    Holds configuration values used to tune FeeEstimator
+
+
+    mempool
+    self.max_size_in_cost: int = max_size_in_cost
+    self.total_mempool_cost: int = 0
+    get_min_fee_rate
+    blockchain_time_window  # seconds into the past to consider historical blockchain data
+    """
+
+class MempoolState:
+    """Minimum information needed to mirror state of the mempool for values we are concerned with"""
+    total_mempool_cost: int
+    min_fee_rate: float
+
+
+# We inherit only to enforce the interface, not to share behaviour
+class FeeEstimatorInterface(abc.ABC):
+    @abc.abstractmethod
+    def new_block(self, block_info: FeeBlockInfo):
+        pass
+
+    @abc.abstractmethod
+    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+        pass
+
+    @abc.abstractmethod
+    def remove_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+        pass
+
+    @abc.abstractmethod
+    def estimate_fee(self, cost: int, time: int):
+        pass
+

--- a/chia/policy/fee_estimator_zero.py
+++ b/chia/policy/fee_estimator_zero.py
@@ -1,0 +1,20 @@
+from chia.policy.fee_estimation import FeeMempoolInfo, FeeBlockInfo
+from chia.policy.fee_estimator import FeeEstimatorInterface
+from chia.util.ints import uint64
+
+
+class FeeEstimatorZero(FeeEstimatorInterface):
+    def __init__(self, config):
+        self.config = config
+
+    def new_block(self, block_info: FeeBlockInfo):
+        pass
+
+    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+        pass
+
+    def remove_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+        pass
+
+    def estimate_fee(self, cost: int, time: int) -> uint64:
+        return 0

--- a/chia/policy/fee_estimator_zero.py
+++ b/chia/policy/fee_estimator_zero.py
@@ -1,20 +1,20 @@
-from chia.policy.fee_estimation import FeeMempoolInfo, FeeBlockInfo
-from chia.policy.fee_estimator import FeeEstimatorInterface
+from chia.policy.fee_estimation import FeeBlockInfo, FeeMempoolInfo
+from chia.policy.fee_estimator import FeeEstimatorConfig
 from chia.util.ints import uint64
 
 
-class FeeEstimatorZero(FeeEstimatorInterface):
-    def __init__(self, config):
+class FeeEstimatorZero:  # FeeEstimatorInterface Protocol
+    def __init__(self, config: FeeEstimatorConfig) -> None:
         self.config = config
 
-    def new_block(self, block_info: FeeBlockInfo):
+    def new_block(self, block_info: FeeBlockInfo) -> None:
         pass
 
-    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo) -> None:
         pass
 
-    def remove_mempool_item(self, mempool_item_info: FeeMempoolInfo):
+    def remove_mempool_item(self, mempool_item_info: FeeMempoolInfo) -> None:
         pass
 
     def estimate_fee(self, cost: int, time: int) -> uint64:
-        return 0
+        return uint64(0)

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -5,6 +5,7 @@ from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR
 from chia.full_node.full_node import FullNode
 from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
+from chia.policy.fee_estimator import FeeEstimatorConfig
 from chia.policy.fee_estimator_zero import FeeEstimatorZero
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -740,7 +741,7 @@ class FullNodeRpcApi:
             cost = uint64(request["cost"])
 
         target_times = request["target_times"]
-        estimator = FeeEstimatorZero(config=None)
+        estimator = FeeEstimatorZero(config=FeeEstimatorConfig())
         estimates = [estimator.estimate_fee(time, cost) for time in target_times]
 
         return {"estimates": estimates, "target_times": target_times}

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -1,9 +1,11 @@
 from typing import Any, Callable, Dict, List, Optional
 
 from chia.consensus.block_record import BlockRecord
+from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR
 from chia.full_node.full_node import FullNode
 from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
+from chia.policy.fee_estimator_zero import FeeEstimatorZero
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
@@ -61,6 +63,8 @@ class FullNodeRpcApi:
             "/get_all_mempool_tx_ids": self.get_all_mempool_tx_ids,
             "/get_all_mempool_items": self.get_all_mempool_items,
             "/get_mempool_item_by_tx_id": self.get_mempool_item_by_tx_id,
+            # Fee estimation
+            "/get_fee_estimate": self.get_fee_estimate,
         }
 
     async def _state_changed(self, change: str, change_data: Dict[str, Any] = None) -> List[WsRpcMessage]:
@@ -711,3 +715,32 @@ class FullNodeRpcApi:
             raise ValueError(f"Tx id 0x{tx_id.hex()} not in the mempool")
 
         return {"mempool_item": item}
+
+    async def get_fee_estimate(self, request: Dict) -> Optional[Dict]:
+        if "spend_bundle" in request and "cost" in request:
+            raise ValueError("Request must contain ONLY 'spend_bundle' or 'cost'")
+        if "spend_bundle" not in request and "cost" not in request:
+            raise ValueError("Request must contain 'spend_bundle' or 'cost'")
+        if "target_times" not in request:
+            raise ValueError("Request must contain 'target_times' array")
+        if any([t < 0 for t in request["target_times"]]):
+            raise ValueError("'target_times' array members must be non-negative")
+
+        cost = 0
+        if "spend_bundle" in request:
+            spend_bundle = SpendBundle.from_json_dict(request["spend_bundle"])
+            spend_name = spend_bundle.name()
+            npc_result: NPCResult = await self.service.mempool_manager.pre_validate_spendbundle(
+                spend_bundle, None, spend_name
+            )
+            if npc_result.error is not None:
+                raise RuntimeError(f"Spend Bundle failed validation: {npc_result.error}")
+            cost = npc_result.cost
+        if "cost" in request:
+            cost = uint64(request["cost"])
+
+        target_times = request["target_times"]
+        estimator = FeeEstimatorZero(config=None)
+        estimates = [estimator.estimate_fee(time, cost) for time in target_times]
+
+        return {"estimates": estimates, "target_times": target_times}

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -250,3 +250,11 @@ class FullNodeRpcClient(RpcClient):
                 }
         except Exception:
             return None
+
+    async def get_fee_estimate(
+        self,
+        target_times: Optional[List[int]],
+        cost: Optional[int],
+    ) -> Optional[Dict]:
+        response = await self.fetch("get_fee_estimate", {})
+        return response

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -6,7 +6,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint64
+from chia.util.ints import uint64, uint32
 from chia.util.streamable import Streamable, streamable
 
 
@@ -21,6 +21,7 @@ class MempoolItem(Streamable):
     additions: List[Coin]
     removals: List[Coin]
     program: SerializedProgram
+    # first_seen_height: uint32  # Block at which this SpendBundle entered our mempool
 
     def __lt__(self, other):
         return self.fee_per_cost < other.fee_per_cost

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -6,7 +6,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint64, uint32
+from chia.util.ints import uint64
 from chia.util.streamable import Streamable, streamable
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,6 @@ from tests.util.socket import find_available_listen_port
 from tests.wallet_tools import WalletTool
 
 
-
-
 @pytest.fixture(scope="session")
 def get_keychain():
     with TempKeyring() as keychain:
@@ -644,5 +642,5 @@ async def setup_node_rpc(
 
 
 @pytest.fixture(scope="module")
-def wallet_a(bt):
+def wallet_a(bt) -> WalletTool:
     return bt.get_pool_wallet_tool()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -612,7 +612,6 @@ async def setup_node_rpc(
 ) -> AsyncGenerator[Tuple[FullNodeRpcClient, FullNodeRpcApi], None]:
     full_node_api = setup_one_node[0][0]
     server_1 = full_node_api.full_node.server
-    test_rpc_port = find_available_listen_port()
 
     def stop_node_cb():
         full_node_api._close()
@@ -635,7 +634,7 @@ async def setup_node_rpc(
 
     client = await FullNodeRpcClient.create(self_hostname, test_rpc_port, bt.root_path, bt.config)
     await validate_get_routes(client, full_node_rpc_api)
-    state = await client.get_blockchain_state()
+    await client.get_blockchain_state()
 
     yield client, full_node_rpc_api
 

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -53,11 +53,6 @@ BURN_PUZZLE_HASH = bytes32(b"0" * 32)
 BURN_PUZZLE_HASH_2 = bytes32(b"1" * 32)
 
 
-@pytest.fixture(scope="module")
-def wallet_a(bt):
-    return bt.get_pool_wallet_tool()
-
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/policy/test_fee_estimation_rpc.py
+++ b/tests/policy/test_fee_estimation_rpc.py
@@ -1,0 +1,123 @@
+import pytest
+
+from chia.types.blockchain_format.coin import Coin
+from chia.types.blockchain_format.sized_bytes import bytes32
+
+
+@pytest.mark.asyncio
+async def test_get_blockchain_state(setup_node_rpc):
+    # Confirm full node setup correctly
+    client, _ = setup_node_rpc
+    response = await client.get_blockchain_state()
+    assert response["genesis_challenge_initialized"] is True
+
+
+@pytest.mark.asyncio
+async def test_empty_request(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(ValueError):
+        response = await full_node_rpc_api.get_fee_estimate({})
+
+
+@pytest.mark.asyncio
+async def test_no_target_times(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(ValueError):
+        response = await full_node_rpc_api.get_fee_estimate({"cost": 1})
+
+
+@pytest.mark.asyncio
+async def test_negative_time(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(ValueError):
+        response = await full_node_rpc_api.get_fee_estimate({"cost": 1, "target_times": [-1]})
+
+
+@pytest.mark.asyncio
+async def test_negative_cost(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(ValueError):
+        response = await full_node_rpc_api.get_fee_estimate({"cost": -1, "target_times": [1]})
+
+# TODO:
+# Time out of range
+# Cost out of range
+
+
+@pytest.mark.asyncio
+async def test_no_cost_or_tx(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(ValueError):
+        response = await full_node_rpc_api.get_fee_estimate({"target_times": []})
+
+
+@pytest.mark.asyncio
+async def test_both_cost_and_tx(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(ValueError):
+        response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": 1, "spend_bundle": "80"})
+
+
+@pytest.mark.asyncio
+async def test_target_times_invalid_type(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(TypeError):
+        response = await full_node_rpc_api.get_fee_estimate({"target_times": 1, "cost": 1})
+
+
+@pytest.mark.asyncio
+async def test_cost_invalid_type(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(ValueError):
+        response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": "a lot"})
+
+
+@pytest.mark.asyncio
+async def test_tx_invalid_type(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    with pytest.raises(TypeError):
+        response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "spend_bundle": 1})
+#####################
+
+
+@pytest.mark.asyncio
+async def test_empty_target_times(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": 1})
+    assert response == {'estimates': [], 'target_times': []}
+
+
+@pytest.mark.asyncio
+async def test_cost(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    response = await full_node_rpc_api.get_fee_estimate({"target_times": [1], "cost": 1})
+    assert response == {'estimates': [0], 'target_times': [1]}
+
+
+@pytest.mark.asyncio
+async def test_tx(setup_node_rpc, wallet_a):
+    client, full_node_rpc_api = setup_node_rpc
+    my_puzzle_hash = wallet_a.get_new_puzzlehash()
+    recevier_puzzle_hash = bytes32(b"0" * 32)
+    coin_to_spend = Coin(bytes32(b"0" * 32), my_puzzle_hash, 1750000000000)
+    spend_bundle = wallet_a.generate_signed_transaction(coin_to_spend.amount, recevier_puzzle_hash, coin_to_spend)
+    response = await full_node_rpc_api.get_fee_estimate({"target_times": [1], "spend_bundle": spend_bundle.to_json_dict()})
+    assert response == {'estimates': [0], 'target_times': [1]}
+
+
+@pytest.mark.asyncio
+async def test_multiple(setup_node_rpc):
+    client, full_node_rpc_api = setup_node_rpc
+    response = await full_node_rpc_api.get_fee_estimate({"target_times": [1, 5, 10, 15, 60, 120, 180, 240], "cost": 1})
+    assert response == {'estimates': [0, 0, 0, 0, 0, 0, 0, 0], 'target_times': [1, 5, 10, 15, 60, 120, 180, 240]}
+
+
+# TODO:
+# Specify algo
+# load config
+# return min / max fee rate
+# return current fee rate
+# return predicted fee rates
+
+# TODO: client & command line
+#assert response["success"] is True

--- a/tests/policy/test_fee_estimation_rpc.py
+++ b/tests/policy/test_fee_estimation_rpc.py
@@ -1,11 +1,17 @@
+from typing import Tuple
+
 import pytest
 
+from chia.rpc.full_node_rpc_api import FullNodeRpcApi
+from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint64
+from tests.wallet_tools import WalletTool
 
 
 @pytest.mark.asyncio
-async def test_get_blockchain_state(setup_node_rpc):
+async def test_get_blockchain_state(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     # Confirm full node setup correctly
     client, _ = setup_node_rpc
     response = await client.get_blockchain_state()
@@ -13,31 +19,32 @@ async def test_get_blockchain_state(setup_node_rpc):
 
 
 @pytest.mark.asyncio
-async def test_empty_request(setup_node_rpc):
+async def test_empty_request(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(ValueError):
-        response = await full_node_rpc_api.get_fee_estimate({})
+        await full_node_rpc_api.get_fee_estimate({})
 
 
 @pytest.mark.asyncio
-async def test_no_target_times(setup_node_rpc):
+async def test_no_target_times(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(ValueError):
-        response = await full_node_rpc_api.get_fee_estimate({"cost": 1})
+        await full_node_rpc_api.get_fee_estimate({"cost": 1})
 
 
 @pytest.mark.asyncio
-async def test_negative_time(setup_node_rpc):
+async def test_negative_time(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(ValueError):
-        response = await full_node_rpc_api.get_fee_estimate({"cost": 1, "target_times": [-1]})
+        await full_node_rpc_api.get_fee_estimate({"cost": 1, "target_times": [-1]})
 
 
 @pytest.mark.asyncio
-async def test_negative_cost(setup_node_rpc):
+async def test_negative_cost(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(ValueError):
-        response = await full_node_rpc_api.get_fee_estimate({"cost": -1, "target_times": [1]})
+        await full_node_rpc_api.get_fee_estimate({"cost": -1, "target_times": [1]})
+
 
 # TODO:
 # Time out of range
@@ -45,79 +52,83 @@ async def test_negative_cost(setup_node_rpc):
 
 
 @pytest.mark.asyncio
-async def test_no_cost_or_tx(setup_node_rpc):
+async def test_no_cost_or_tx(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(ValueError):
-        response = await full_node_rpc_api.get_fee_estimate({"target_times": []})
+        await full_node_rpc_api.get_fee_estimate({"target_times": []})
 
 
 @pytest.mark.asyncio
-async def test_both_cost_and_tx(setup_node_rpc):
+async def test_both_cost_and_tx(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(ValueError):
-        response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": 1, "spend_bundle": "80"})
+        await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": 1, "spend_bundle": "80"})
 
 
 @pytest.mark.asyncio
-async def test_target_times_invalid_type(setup_node_rpc):
+async def test_target_times_invalid_type(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(TypeError):
-        response = await full_node_rpc_api.get_fee_estimate({"target_times": 1, "cost": 1})
+        await full_node_rpc_api.get_fee_estimate({"target_times": 1, "cost": 1})
 
 
 @pytest.mark.asyncio
-async def test_cost_invalid_type(setup_node_rpc):
+async def test_cost_invalid_type(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(ValueError):
-        response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": "a lot"})
+        await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": "a lot"})
 
 
 @pytest.mark.asyncio
-async def test_tx_invalid_type(setup_node_rpc):
+async def test_tx_invalid_type(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     with pytest.raises(TypeError):
-        response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "spend_bundle": 1})
+        await full_node_rpc_api.get_fee_estimate({"target_times": [], "spend_bundle": 1})
+
+
 #####################
 
 
 @pytest.mark.asyncio
-async def test_empty_target_times(setup_node_rpc):
+async def test_empty_target_times(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     response = await full_node_rpc_api.get_fee_estimate({"target_times": [], "cost": 1})
-    assert response == {'estimates': [], 'target_times': []}
+    assert response == {"estimates": [], "target_times": []}
 
 
 @pytest.mark.asyncio
-async def test_cost(setup_node_rpc):
+async def test_cost(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     response = await full_node_rpc_api.get_fee_estimate({"target_times": [1], "cost": 1})
-    assert response == {'estimates': [0], 'target_times': [1]}
+    assert response == {"estimates": [0], "target_times": [1]}
 
 
 @pytest.mark.asyncio
-async def test_tx(setup_node_rpc, wallet_a):
+async def test_tx(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi], wallet_a: WalletTool) -> None:
     client, full_node_rpc_api = setup_node_rpc
     my_puzzle_hash = wallet_a.get_new_puzzlehash()
     recevier_puzzle_hash = bytes32(b"0" * 32)
-    coin_to_spend = Coin(bytes32(b"0" * 32), my_puzzle_hash, 1750000000000)
+    coin_to_spend = Coin(bytes32(b"0" * 32), my_puzzle_hash, uint64(1750000000000))
     spend_bundle = wallet_a.generate_signed_transaction(coin_to_spend.amount, recevier_puzzle_hash, coin_to_spend)
-    response = await full_node_rpc_api.get_fee_estimate({"target_times": [1], "spend_bundle": spend_bundle.to_json_dict()})
-    assert response == {'estimates': [0], 'target_times': [1]}
+    response = await full_node_rpc_api.get_fee_estimate(
+        {"target_times": [1], "spend_bundle": spend_bundle.to_json_dict()}
+    )
+    assert response == {"estimates": [0], "target_times": [1]}
 
 
 @pytest.mark.asyncio
-async def test_multiple(setup_node_rpc):
+async def test_multiple(setup_node_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_rpc
     response = await full_node_rpc_api.get_fee_estimate({"target_times": [1, 5, 10, 15, 60, 120, 180, 240], "cost": 1})
-    assert response == {'estimates': [0, 0, 0, 0, 0, 0, 0, 0], 'target_times': [1, 5, 10, 15, 60, 120, 180, 240]}
+    assert response == {"estimates": [0, 0, 0, 0, 0, 0, 0, 0], "target_times": [1, 5, 10, 15, 60, 120, 180, 240]}
 
 
-# TODO:
-# Specify algo
+# TODO: Tests for
+# Each algo
 # load config
 # return min / max fee rate
 # return current fee rate
 # return predicted fee rates
 
 # TODO: client & command line
-#assert response["success"] is True
+# assert response["success"] is True


### PR DESCRIPTION
The purpose of this PR is to provide a versatile interface for fee estimation for the following uses:
* Chia UI users
* 3rd party wallets
* Large farmers
* command line use

Design considerations

Note the ability to return multiple estimates in one request.
Fee estimates are denominated in seconds (instead of blocks)
Note that we do not store any state information, so estimators must re-run their inputs when the client starts.

The API is different from the Bitcoin RPC in these major respects:
* Transaction cost is a required input (explicit or implicit)
* The fee for a transaction of a certain cost is returned, not a fee rate
* There are no [hard-coded settings](https://github.com/bitcoin/bitcoin/blob/master/src/rpc/fees.cpp)

We also intend to return max fee, min fee, and fee rate with each call.
Jeff had the idea to use a state update to notify the UI when the fee estimates change. The UI can then store a historical
Jeff also had the idea of displaying the current fee rate in the UI.
I like this idea, because it can help the user form an intuition about the rates passively.

One thing I would like input on:

What is the default maximum time window we should attempt to return an estimate for? 24 hours?

While researching blockchain fee estimation, I found out that big users like Pool Operators and exchanges do not use the bitcoin fee estimator. It does not take into consideration daily and weekly cycles that might allow those users to process many transactions at a time when fees are at their daily or weekly minimum.

I think that particular issue is out of scope for this estimator, but the current design makes it MUCH easier for those users to plug in custom code by implementing the `FeeEstimatorInterface`. On a related note, for ease of future expansion, I am mildly advocating for an RPC parameter `estimation_method` that could allow us to select other algorithms.

Note that we require a cost or a SpendBundle to calculate our fee estimates, instead of passing. This decision is a little more involved than it looks. Yes, it makes it easier for the caller. But the more important reason is that there can be some subtlety on the edge cases when the mempool is ALMOST full.

Further, the Fee Rate can be retrieved by passing a cost of 1.

I like the idea of introducing a new type to represent FeeRate, as bitcoin does [here](https://github.com/bitcoin/bitcoin/blob/master/src/policy/feerate.cpp). Let me know what you think.


