### PR TITLE
make the protocol regression test also ensure all messages are covered

### DIFF
--- a/tests/util/test_network_protocol_files.py
+++ b/tests/util/test_network_protocol_files.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import pytest
+from typing import Any, List, Set
 from tests.util.build_network_protocol_files import get_network_protocol_filename
 from chia.protocols import (
     farmer_protocol,
@@ -12,6 +13,7 @@ from chia.protocols import (
     pool_protocol,
     timelord_protocol,
     wallet_protocol,
+    shared_protocol,
 )
 from tests.util.network_protocol_data import *
 
@@ -505,17 +507,192 @@ def parse_timelord_protocol(input_bytes):
     return input_bytes
 
 
-class TestNetworkProtocolFiles:
-    def test_network_protocol_files(self):
-        filename = get_network_protocol_filename()
-        assert os.path.exists(filename)
-        with open(filename, "rb") as f:
-            input_bytes = f.read()
-        input_bytes = parse_farmer_protocol(input_bytes)
-        input_bytes = parse_full_node_protocol(input_bytes)
-        input_bytes = parse_wallet_protocol(input_bytes)
-        input_bytes = parse_harvester_protocol(input_bytes)
-        input_bytes = parse_introducer_protocol(input_bytes)
-        input_bytes = parse_pool_protocol(input_bytes)
-        input_bytes = parse_timelord_protocol(input_bytes)
-        assert input_bytes == b""
+def test_network_protocol_files() -> None:
+    filename = get_network_protocol_filename()
+    assert os.path.exists(filename)
+    with open(filename, "rb") as f:
+        input_bytes = f.read()
+    input_bytes = parse_farmer_protocol(input_bytes)
+    input_bytes = parse_full_node_protocol(input_bytes)
+    input_bytes = parse_wallet_protocol(input_bytes)
+    input_bytes = parse_harvester_protocol(input_bytes)
+    input_bytes = parse_introducer_protocol(input_bytes)
+    input_bytes = parse_pool_protocol(input_bytes)
+    input_bytes = parse_timelord_protocol(input_bytes)
+    assert input_bytes == b""
+
+
+def types_in_module(mod: Any) -> Set[str]:
+    ret: List[str] = []
+    mod_name = mod.__name__
+    for sym in dir(mod):
+        obj = getattr(mod, sym)
+        if hasattr(obj, "__module__") and obj.__module__ == mod_name:
+            ret.append(sym)
+    return set(ret)
+
+
+def test_missing_messages_state_machine() -> None:
+    from chia.protocols.protocol_state_machine import NO_REPLY_EXPECTED, VALID_REPLY_MESSAGE_MAP
+
+    assert (
+        len(VALID_REPLY_MESSAGE_MAP) == 10
+    ), "A message was added to the protocol state machine. Make sure to update the protocol message regression test to include the new message"
+    assert (
+        len(NO_REPLY_EXPECTED) == 7
+    ), "A message was added to the protocol state machine. Make sure to update the protocol message regression test to include the new message"
+
+
+def test_missing_messages() -> None:
+
+    wallet_msgs = {
+        "CoinState",
+        "CoinStateUpdate",
+        "NewPeakWallet",
+        "PuzzleSolutionResponse",
+        "RegisterForCoinUpdates",
+        "RegisterForPhUpdates",
+        "RejectAdditionsRequest",
+        "RejectHeaderBlocks",
+        "RejectHeaderRequest",
+        "RejectPuzzleSolution",
+        "RejectRemovalsRequest",
+        "RequestAdditions",
+        "RequestBlockHeader",
+        "RequestChildren",
+        "RequestHeaderBlocks",
+        "RequestPuzzleSolution",
+        "RequestRemovals",
+        "RequestSESInfo",
+        "RespondAdditions",
+        "RespondBlockHeader",
+        "RespondChildren",
+        "RespondHeaderBlocks",
+        "RespondPuzzleSolution",
+        "RespondRemovals",
+        "RespondSESInfo",
+        "RespondToCoinUpdates",
+        "RespondToPhUpdates",
+        "SendTransaction",
+        "TransactionAck",
+    }
+
+    farmer_msgs = {
+        "DeclareProofOfSpace",
+        "FarmingInfo",
+        "NewSignagePoint",
+        "RequestSignedValues",
+        "SignedValues",
+    }
+
+    full_node_msgs = {
+        "NewCompactVDF",
+        "NewPeak",
+        "NewSignagePointOrEndOfSubSlot",
+        "NewTransaction",
+        "NewUnfinishedBlock",
+        "RejectBlock",
+        "RejectBlocks",
+        "RequestBlock",
+        "RequestBlocks",
+        "RequestCompactVDF",
+        "RequestMempoolTransactions",
+        "RequestPeers",
+        "RequestProofOfWeight",
+        "RequestSignagePointOrEndOfSubSlot",
+        "RequestTransaction",
+        "RequestUnfinishedBlock",
+        "RespondBlock",
+        "RespondBlocks",
+        "RespondCompactVDF",
+        "RespondEndOfSubSlot",
+        "RespondPeers",
+        "RespondProofOfWeight",
+        "RespondSignagePoint",
+        "RespondTransaction",
+        "RespondUnfinishedBlock",
+    }
+
+    harvester_msgs = {
+        "HarvesterHandshake",
+        "NewProofOfSpace",
+        "NewSignagePointHarvester",
+        "Plot",
+        "PlotSyncDone",
+        "PlotSyncError",
+        "PlotSyncIdentifier",
+        "PlotSyncPathList",
+        "PlotSyncPlotList",
+        "PlotSyncResponse",
+        "PlotSyncStart",
+        "PoolDifficulty",
+        "RequestPlots",
+        "RequestSignatures",
+        "RespondPlots",
+        "RespondSignatures",
+    }
+
+    introducer_msgs = {"RequestPeersIntroducer", "RespondPeersIntroducer"}
+
+    pool_msgs = {
+        "AuthenticationPayload",
+        "ErrorResponse",
+        "GetFarmerResponse",
+        "GetPoolInfoResponse",
+        "PoolErrorCode",
+        "PostFarmerPayload",
+        "PostFarmerRequest",
+        "PostFarmerResponse",
+        "PostPartialPayload",
+        "PostPartialRequest",
+        "PostPartialResponse",
+        "PutFarmerPayload",
+        "PutFarmerRequest",
+        "PutFarmerResponse",
+        "get_current_authentication_token",
+        "validate_authentication_token",
+    }
+
+    timelord_msgs = {
+        "NewEndOfSubSlotVDF",
+        "NewInfusionPointVDF",
+        "NewPeakTimelord",
+        "NewSignagePointVDF",
+        "NewUnfinishedBlockTimelord",
+        "RequestCompactProofOfTime",
+        "RespondCompactProofOfTime",
+    }
+
+    shared_msgs = {"Handshake", "Capability"}
+
+    assert (
+        types_in_module(wallet_protocol) == wallet_msgs
+    ), "message types were added or removed from wallet_protocol. Make sure to update the protocol message regression test to include the new message"
+
+    assert (
+        types_in_module(farmer_protocol) == farmer_msgs
+    ), "message types were added or removed from farmer_protocol. Make sure to update the protocol message regression test to include the new message"
+
+    assert (
+        types_in_module(full_node_protocol) == full_node_msgs
+    ), "message types were added or removed from full_node_protocol. Make sure to update the protocol message regression test to include the new message"
+
+    assert (
+        types_in_module(harvester_protocol) == harvester_msgs
+    ), "message types were added or removed from harvester_protocol. Make sure to update the protocol message regression test to include the new message"
+
+    assert (
+        types_in_module(introducer_protocol) == introducer_msgs
+    ), "message types were added or removed from introducer_protocol. Make sure to update the protocol message regression test to include the new message"
+
+    assert (
+        types_in_module(pool_protocol) == pool_msgs
+    ), "message types were added or removed from pool_protocol. Make sure to update the protocol message regression test to include the new message"
+
+    assert (
+        types_in_module(timelord_protocol) == timelord_msgs
+    ), "message types were added or removed from timelord_protocol. Make sure to update the protocol message regression test to include the new message"
+
+    assert (
+        types_in_module(shared_protocol) == shared_msgs
+    ), "message types were added or removed from shared_protocol. Make sure to update the protocol message regression test to include the new message"


### PR DESCRIPTION
Whenever we add a new message type, we also need to add that type to the protocol regression test. that test ensures the encoding of message types remain compatible over time.