### PR TITLE
consensus: Make `ConsensusConstants` streamable + use `byte` conversions

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -8,7 +8,7 @@ from concurrent.futures.process import ProcessPoolExecutor
 from enum import Enum
 from multiprocessing.context import BaseContext
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from chia.consensus.block_body_validation import validate_block_body
 from chia.consensus.block_header_validation import validate_unfinished_header_block
@@ -48,7 +48,6 @@ from chia.util.generator_tools import get_block_header, tx_removals_and_addition
 from chia.util.inline_executor import InlineExecutor
 from chia.util.ints import uint16, uint32, uint64, uint128
 from chia.util.setproctitle import getproctitle, setproctitle
-from chia.util.streamable import recurse_jsonify
 
 log = logging.getLogger(__name__)
 
@@ -78,7 +77,7 @@ class StateChangeSummary:
 
 class Blockchain(BlockchainInterface):
     constants: ConsensusConstants
-    constants_json: Dict[str, Any]
+    constants_bytes: bytes
 
     # peak of the blockchain
     _peak_height: Optional[uint32]
@@ -144,7 +143,7 @@ class Blockchain(BlockchainInterface):
         self.constants = consensus_constants
         self.coin_store = coin_store
         self.block_store = block_store
-        self.constants_json = recurse_jsonify(self.constants)
+        self.constants_bytes = bytes(self.constants)
         self._shut_down = False
         await self._load_chain_from_store(blockchain_dir)
         self._seen_compact_proofs = set()
@@ -608,7 +607,7 @@ class Blockchain(BlockchainInterface):
     ) -> List[PreValidationResult]:
         return await pre_validate_blocks_multiprocessing(
             self.constants,
-            self.constants_json,
+            self.constants_bytes,
             self,
             blocks,
             self.pool,
@@ -624,7 +623,7 @@ class Blockchain(BlockchainInterface):
         task = asyncio.get_running_loop().run_in_executor(
             self.pool,
             _run_generator,
-            self.constants_json,
+            self.constants_bytes,
             unfinished_block,
             bytes(generator),
             height,

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -4,13 +4,15 @@ from typing import Any
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
-from chia.util.ints import uint8, uint32, uint64, uint128
+from chia.util.ints import uint8, uint16, uint32, uint64, uint128
+from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)
 
 
+@streamable
 @dataclasses.dataclass(frozen=True)
-class ConsensusConstants:
+class ConsensusConstants(Streamable):
     SLOT_BLOCKS_TARGET: uint32  # How many blocks to target per sub-slot
     MIN_BLOCKS_PER_CHALLENGE_BLOCK: uint8  # How many blocks must be created per slot (to make challenge sb)
     # Max number of blocks that can be infused into a sub-slot.
@@ -26,15 +28,15 @@ class ConsensusConstants:
     SUB_EPOCH_BLOCKS: uint32  # The number of blocks per sub-epoch
     EPOCH_BLOCKS: uint32  # The number of blocks per sub-epoch, must be a multiple of SUB_EPOCH_BLOCKS
 
-    SIGNIFICANT_BITS: int  # The number of bits to look at in difficulty and min iters. The rest are zeroed
-    DISCRIMINANT_SIZE_BITS: int  # Max is 1024 (based on ClassGroupElement int size)
-    NUMBER_ZERO_BITS_PLOT_FILTER: int  # H(plot id + challenge hash + signage point) must start with these many zeroes
-    MIN_PLOT_SIZE: int
-    MAX_PLOT_SIZE: int
-    SUB_SLOT_TIME_TARGET: int  # The target number of seconds per sub-slot
-    NUM_SP_INTERVALS_EXTRA: int  # The difference between signage point and infusion point (plus required_iters)
-    MAX_FUTURE_TIME: int  # The next block can have a timestamp of at most these many seconds more
-    NUMBER_OF_TIMESTAMPS: int  # Than the average of the last NUMBER_OF_TIMESTAMPS blocks
+    SIGNIFICANT_BITS: uint8  # The number of bits to look at in difficulty and min iters. The rest are zeroed
+    DISCRIMINANT_SIZE_BITS: uint32  # Max is 1024 (based on ClassGroupElement int size)
+    NUMBER_ZERO_BITS_PLOT_FILTER: uint16  # H(plot id + challenge hash + signage point) must start with these many zeroes # noqa: E501
+    MIN_PLOT_SIZE: uint16
+    MAX_PLOT_SIZE: uint16
+    SUB_SLOT_TIME_TARGET: uint32  # The target number of seconds per sub-slot
+    NUM_SP_INTERVALS_EXTRA: uint16  # The difference between signage point and infusion point (plus required_iters)
+    MAX_FUTURE_TIME: uint32  # The next block can have a timestamp of at most these many seconds more
+    NUMBER_OF_TIMESTAMPS: uint16  # Than the average of the last NUMBER_OF_TIMESTAMPS blocks
     # Used as the initial cc rc challenges, as well as first block back pointers, and first SES back pointer
     # We override this value based on the chain being run (testnet0, testnet1, mainnet, etc)
     GENESIS_CHALLENGE: bytes32
@@ -42,21 +44,21 @@ class ConsensusConstants:
     AGG_SIG_ME_ADDITIONAL_DATA: bytes
     GENESIS_PRE_FARM_POOL_PUZZLE_HASH: bytes32  # The block at height must pay out to this pool puzzle hash
     GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: bytes32  # The block at height must pay out to this farmer puzzle hash
-    MAX_VDF_WITNESS_SIZE: int  # The maximum number of classgroup elements within an n-wesolowski proof
+    MAX_VDF_WITNESS_SIZE: uint16  # The maximum number of classgroup elements within an n-wesolowski proof
     # Size of mempool = 10x the size of block
-    MEMPOOL_BLOCK_BUFFER: int
+    MEMPOOL_BLOCK_BUFFER: uint32
     # Max coin amount uint(1 << 64). This allows coin amounts to fit in 64 bits. This is around 18M chia.
-    MAX_COIN_AMOUNT: int
+    MAX_COIN_AMOUNT: uint64
     # Max block cost in clvm cost units
-    MAX_BLOCK_COST_CLVM: int
+    MAX_BLOCK_COST_CLVM: uint64
     # Cost per byte of generator program
-    COST_PER_BYTE: int
+    COST_PER_BYTE: uint64
 
     WEIGHT_PROOF_THRESHOLD: uint8
     WEIGHT_PROOF_RECENT_BLOCKS: uint32
     MAX_BLOCK_COUNT_PER_REQUESTS: uint32
     BLOCKS_CACHE_SIZE: uint32
-    NETWORK_TYPE: int
+    NETWORK_TYPE: uint8
     MAX_GENERATOR_SIZE: uint32
     MAX_GENERATOR_REF_LIST_SIZE: uint32
     POOL_SUB_SLOT_ITERS: uint64

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -29,7 +29,7 @@ class ConsensusConstants(Streamable):
     EPOCH_BLOCKS: uint32  # The number of blocks per sub-epoch, must be a multiple of SUB_EPOCH_BLOCKS
 
     SIGNIFICANT_BITS: uint8  # The number of bits to look at in difficulty and min iters. The rest are zeroed
-    DISCRIMINANT_SIZE_BITS: uint32  # Max is 1024 (based on ClassGroupElement int size)
+    DISCRIMINANT_SIZE_BITS: uint16  # Max is 1024 (based on ClassGroupElement int size)
     NUMBER_ZERO_BITS_PLOT_FILTER: uint16  # H(plot id + challenge hash + signage point) must start with these many zeroes # noqa: E501
     MIN_PLOT_SIZE: uint16
     MAX_PLOT_SIZE: uint16

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -183,7 +183,7 @@ async def pre_validate_blocks_multiprocessing(
 
     Args:
         check_filter:
-        constants_json:
+        constants_bytes:
         pool:
         constants:
         block_records:

--- a/chia/wallet/wallet_weight_proof_handler.py
+++ b/chia/wallet/wallet_weight_proof_handler.py
@@ -102,7 +102,7 @@ class WalletWeightProofHandler:
             log.error("failed weight proof sub epoch sample validation")
             return False, uint32(0), [], []
 
-        constants, summary_bytes, wp_segment_bytes, wp_recent_chain_bytes = vars_to_bytes(
+        constants_bytes, summary_bytes, wp_segment_bytes, wp_recent_chain_bytes = vars_to_bytes(
             self._constants, summaries, weight_proof
         )
         await asyncio.sleep(0)  # break up otherwise multi-second sync code
@@ -111,7 +111,7 @@ class WalletWeightProofHandler:
         recent_blocks_validation_task: asyncio.Future = asyncio.get_running_loop().run_in_executor(
             self._executor,
             _validate_recent_blocks_and_get_records,
-            constants,
+            constants_bytes,
             wp_recent_chain_bytes,
             summary_bytes,
             pathlib.Path(self._executor_shutdown_tempfile.name),
@@ -119,7 +119,7 @@ class WalletWeightProofHandler:
         try:
             if not skip_segment_validation:
                 segments_validated, vdfs_to_validate = _validate_sub_epoch_segments(
-                    constants, rng, wp_segment_bytes, summary_bytes
+                    constants_bytes, rng, wp_segment_bytes, summary_bytes
                 )
                 await asyncio.sleep(0)  # break up otherwise multi-second sync code
 
@@ -135,7 +135,7 @@ class WalletWeightProofHandler:
                     vdf_task: asyncio.Future = asyncio.get_running_loop().run_in_executor(
                         self._executor,
                         _validate_vdf_batch,
-                        constants,
+                        constants_bytes,
                         byte_chunks,
                         pathlib.Path(self._executor_shutdown_tempfile.name),
                     )

--- a/tools/analyze-chain.py
+++ b/tools/analyze-chain.py
@@ -14,6 +14,7 @@ from chia_rs import run_generator, MEMPOOL_MODE
 
 from chia.types.full_block import FullBlock
 from chia.types.blockchain_format.program import Program
+from chia.util.ints import uint64
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.wallet.puzzles.rom_bootstrap_generator import get_generator
 
@@ -29,7 +30,7 @@ def run_gen(env_data: bytes, block_program_args: bytes, flags: int):
 
     # we don't charge for the size of the generator ROM. However, we do charge
     # cost for the operations it executes
-    max_cost -= len(env_data) * cost_per_byte
+    max_cost = uint64(max_cost - len(env_data) * cost_per_byte)
 
     env_data = b"\xff" + env_data + b"\xff" + block_program_args + b"\x80"
 


### PR DESCRIPTION
This is preparation to restrict `dataclass_from_dict` to streamable classes only. 6f374fb2828f410abd8357ed49166455d47bed69 is not absolutely required for that but since its possible after 176482917b3c6b9823ded303aa62d6c2698d9c6e i think it makes sense to be consistent with the other things passed around and the naming of `vars_to_bytes` and `bytes_to_vars`. 