### PR TITLE
farmer: Make `Plot{Info|Path}RequestData` streamable + use `from_json_dict`

### DIFF
--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -1,6 +1,8 @@
 import dataclasses
 import operator
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
+
+from typing_extensions import Protocol
 
 from chia.farmer.farmer import Farmer
 from chia.plot_sync.receiver import Receiver
@@ -11,6 +13,20 @@ from chia.util.ints import uint32
 from chia.util.paginator import Paginator
 from chia.util.streamable import Streamable, streamable
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
+
+
+class PaginatedRequestData(Protocol):
+    @property
+    def node_id(self) -> bytes32:
+        pass
+
+    @property
+    def page(self) -> uint32:
+        pass
+
+    @property
+    def page_size(self) -> uint32:
+        pass
 
 
 @streamable
@@ -39,9 +55,6 @@ class PlotPathRequestData(Streamable):
     page_size: uint32
     filter: List[str] = dataclasses.field(default_factory=list)
     reverse: bool = False
-
-
-PaginatedRequestData = Union[PlotInfoRequestData, PlotPathRequestData]
 
 
 def paginated_plot_request(source: List[Any], request: PaginatedRequestData) -> Dict[str, object]:

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -9,7 +9,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint32
 from chia.util.paginator import Paginator
-from chia.util.streamable import Streamable, dataclass_from_dict, streamable
+from chia.util.streamable import Streamable, streamable
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
 
 
@@ -231,7 +231,7 @@ class FarmerRpcApi:
 
     async def get_harvester_plots_valid(self, request_dict: Dict[str, object]) -> Dict[str, object]:
         # TODO: Consider having a extra List[PlotInfo] in Receiver to avoid rebuilding the list for each call
-        request = dataclass_from_dict(PlotInfoRequestData, request_dict)
+        request = PlotInfoRequestData.from_json_dict(request_dict)
         plot_list = list(self.service.get_receiver(request.node_id).plots().values())
         # Apply filter
         plot_list = [
@@ -248,7 +248,7 @@ class FarmerRpcApi:
     def paginated_plot_path_request(
         self, source_func: Callable[[Receiver], List[str]], request_dict: Dict[str, object]
     ) -> Dict[str, object]:
-        request: PlotPathRequestData = dataclass_from_dict(PlotPathRequestData, request_dict)
+        request: PlotPathRequestData = PlotPathRequestData.from_json_dict(request_dict)
         receiver = self.service.get_receiver(request.node_id)
         source = source_func(receiver)
         # Apply filter

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -1,48 +1,47 @@
 import dataclasses
 import operator
-from typing import Any, Callable, Dict, List, Optional
-
-from typing_extensions import Protocol
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from chia.farmer.farmer import Farmer
 from chia.plot_sync.receiver import Receiver
 from chia.protocols.harvester_protocol import Plot
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
+from chia.util.ints import uint32
 from chia.util.paginator import Paginator
-from chia.util.streamable import dataclass_from_dict
+from chia.util.streamable import Streamable, dataclass_from_dict, streamable
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
 
 
-class PaginatedRequestData(Protocol):
-    node_id: bytes32
-    page: int
-    page_size: int
-
-
-@dataclasses.dataclass
-class FilterItem:
+@streamable
+@dataclasses.dataclass(frozen=True)
+class FilterItem(Streamable):
     key: str
     value: Optional[str]
 
 
-@dataclasses.dataclass
-class PlotInfoRequestData:
+@streamable
+@dataclasses.dataclass(frozen=True)
+class PlotInfoRequestData(Streamable):
     node_id: bytes32
-    page: int
-    page_size: int
+    page: uint32
+    page_size: uint32
     filter: List[FilterItem] = dataclasses.field(default_factory=list)
     sort_key: str = "filename"
     reverse: bool = False
 
 
-@dataclasses.dataclass
-class PlotPathRequestData:
+@streamable
+@dataclasses.dataclass(frozen=True)
+class PlotPathRequestData(Streamable):
     node_id: bytes32
-    page: int
-    page_size: int
+    page: uint32
+    page_size: uint32
     filter: List[str] = dataclasses.field(default_factory=list)
     reverse: bool = False
+
+
+PaginatedRequestData = Union[PlotInfoRequestData, PlotPathRequestData]
 
 
 def paginated_plot_request(source: List[Any], request: PaginatedRequestData) -> Dict[str, object]:

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import operator
 import time
@@ -463,9 +464,11 @@ async def test_farmer_get_harvester_plots_endpoints(
 
     request: PaginatedRequestData
     if endpoint == FarmerRpcClient.get_harvester_plots_valid:
-        request = PlotInfoRequestData(harvester_id, 0, -1, cast(List[FilterItem], filtering), sort_key, reverse)
+        request = PlotInfoRequestData(
+            harvester_id, uint32(0), uint32(0), cast(List[FilterItem], filtering), sort_key, reverse
+        )
     else:
-        request = PlotPathRequestData(harvester_id, 0, -1, cast(List[str], filtering), reverse)
+        request = PlotPathRequestData(harvester_id, uint32(0), uint32(0), cast(List[str], filtering), reverse)
 
     def add_plot_directories(prefix: str, count: int) -> List[Path]:
         new_paths = []
@@ -523,10 +526,10 @@ async def test_farmer_get_harvester_plots_endpoints(
     await wait_for_plot_sync(receiver, last_sync_id)
 
     for page_size in [1, int(total_count / 2), total_count - 1, total_count, total_count + 1, 100]:
-        request.page_size = page_size
+        request = dataclasses.replace(request, page_size=uint32(page_size))
         expected_page_count = ceil(total_count / page_size)
         for page in range(expected_page_count):
-            request.page = page
+            request = dataclasses.replace(request, page=uint32(page))
             page_result = await endpoint(farmer_rpc_client, request)
             offset = page * page_size
             expected_plots = plots[offset : offset + page_size]


### PR DESCRIPTION
Another preparation to restrict `dataclass_from_dict` to streamable classes. 

Based on:
- #11755 