### PR TITLE
streamable: Turn `dataclass_from_dict` into `streamable_from_dict`

### DIFF
--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -8,7 +8,7 @@ from blspy import AugSchemeMPL, G2Element
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.streamable import Streamable, dataclass_from_dict, recurse_jsonify, streamable
+from chia.util.streamable import Streamable, streamable_from_dict, recurse_jsonify, streamable
 from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
 from .coin_spend import CoinSpend
@@ -95,7 +95,7 @@ class SpendBundle(Streamable):
                 warnings.warn("`coin_solutions` is now `coin_spends` in `SpendBundle.from_json_dict`")
             else:
                 raise ValueError("JSON contains both `coin_solutions` and `coin_spends`, just use `coin_spends`")
-        return dataclass_from_dict(cls, json_dict)
+        return streamable_from_dict(cls, json_dict)
 
     def to_json_dict(self, include_legacy_keys: bool = True, exclude_modern_keys: bool = True):
         if include_legacy_keys is False and exclude_modern_keys is True:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -169,7 +169,7 @@ def convert_primitive(f_type: Type[Any], item: Any) -> Any:
         raise TypeError(f"Can't convert type {type(item).__name__} to {f_type.__name__}: {e}") from e
 
 
-def dataclass_from_dict(klass: Type[_T_Streamable], item: Any) -> _T_Streamable:
+def streamable_from_dict(klass: Type[_T_Streamable], item: Any) -> _T_Streamable:
     """
     Converts a dictionary based on a dataclass, into an instance of that dataclass.
     Recursively goes through lists, optionals, and dictionaries.
@@ -658,4 +658,4 @@ class Streamable:
 
     @classmethod
     def from_json_dict(cls: Type[_T_Streamable], json_dict: Dict[str, Any]) -> _T_Streamable:
-        return dataclass_from_dict(cls, json_dict)
+        return streamable_from_dict(cls, json_dict)

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -169,7 +169,7 @@ def convert_primitive(f_type: Type[Any], item: Any) -> Any:
         raise TypeError(f"Can't convert type {type(item).__name__} to {f_type.__name__}: {e}") from e
 
 
-def dataclass_from_dict(klass: Type[Any], item: Any) -> Any:
+def dataclass_from_dict(klass: Type[_T_Streamable], item: Any) -> _T_Streamable:
     """
     Converts a dictionary based on a dataclass, into an instance of that dataclass.
     Recursively goes through lists, optionals, and dictionaries.
@@ -179,22 +179,12 @@ def dataclass_from_dict(klass: Type[Any], item: Any) -> Any:
     if not isinstance(item, dict):
         raise TypeError(f"expected: dict, actual: {type(item).__name__}")
 
-    if klass not in CONVERT_FUNCTIONS_FOR_STREAMABLE_CLASS:
-        # For non-streamable dataclasses we can't populate the cache on startup, so we do it here for convert
-        # functions only.
-        fields = create_fields_cache(klass)
-        convert_funcs = [function_to_convert_one_item(field.type) for field in fields]
-        FIELDS_FOR_STREAMABLE_CLASS[klass] = fields
-        CONVERT_FUNCTIONS_FOR_STREAMABLE_CLASS[klass] = convert_funcs
-    else:
-        fields = FIELDS_FOR_STREAMABLE_CLASS[klass]
-        convert_funcs = CONVERT_FUNCTIONS_FOR_STREAMABLE_CLASS[klass]
-
+    fields = FIELDS_FOR_STREAMABLE_CLASS[klass]
     try:
         return klass(
             **{
                 field.name: convert_func(item[field.name])
-                for field, convert_func in zip(fields, convert_funcs)
+                for field, convert_func in zip(fields, CONVERT_FUNCTIONS_FOR_STREAMABLE_CLASS[klass])
                 if field.name in item
             }
         )
@@ -224,9 +214,6 @@ def function_to_convert_one_item(f_type: Type[Any]) -> ConvertFunctionType:
         convert_inner_func = function_to_convert_one_item(inner_type)
         # Ignoring for now as the proper solution isn't obvious
         return lambda items: convert_list(convert_inner_func, items)  # type: ignore[arg-type]
-    elif dataclasses.is_dataclass(f_type):
-        # Type is a dataclass, data is a dictionary
-        return lambda item: dataclass_from_dict(f_type, item)
     elif hasattr(f_type, "from_json_dict"):
         return lambda item: f_type.from_json_dict(item)
     elif issubclass(f_type, bytes):
@@ -670,5 +657,5 @@ class Streamable:
         return ret
 
     @classmethod
-    def from_json_dict(cls: Any, json_dict: Dict[str, Any]) -> Any:
+    def from_json_dict(cls: Type[_T_Streamable], json_dict: Dict[str, Any]) -> _T_Streamable:
         return dataclass_from_dict(cls, json_dict)

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -96,7 +96,7 @@ def test_plain_class_not_supported() -> None:
 
 @streamable
 @dataclass(frozen=True)
-class TestDataclassFromDict1(Streamable):
+class StreamableFromDict1(Streamable):
     a: uint8
     b: str
     c: G1Element
@@ -104,9 +104,9 @@ class TestDataclassFromDict1(Streamable):
 
 @streamable
 @dataclass(frozen=True)
-class TestDataclassFromDict2(Streamable):
-    a: TestDataclassFromDict1
-    b: TestDataclassFromDict1
+class StreamableFromDict2(Streamable):
+    a: StreamableFromDict1
+    b: StreamableFromDict1
     c: uint64
 
 
@@ -248,16 +248,16 @@ def test_convert_primitive_failures(input_dict: Dict[str, Any], error: Any) -> N
 @pytest.mark.parametrize(
     "test_class, input_dict, error",
     [
-        [TestDataclassFromDict1, {"a": "asdf", "b": "2", "c": G1Element()}, TypeError],
-        [TestDataclassFromDict1, {"a": 1, "b": "2"}, KeyError],
-        [TestDataclassFromDict1, {"a": 1, "b": "2", "c": "asd"}, TypeError],
-        [TestDataclassFromDict1, {"a": 1, "b": "2", "c": "00" * G1Element.SIZE}, TypeError],
-        [TestDataclassFromDict1, {"a": [], "b": "2", "c": G1Element()}, TypeError],
-        [TestDataclassFromDict1, {"a": {}, "b": "2", "c": G1Element()}, TypeError],
-        [TestDataclassFromDict2, {"a": "asdf", "b": 12345, "c": 12345}, TypeError],
-        [TestDataclassFromDict2, {"a": 12345, "b": {"a": 1, "b": "2"}, "c": 12345}, TypeError],
-        [TestDataclassFromDict2, {"a": {"a": 1, "b": "2", "c": G1Element()}, "b": {"a": 1, "b": "2"}}, KeyError],
-        [TestDataclassFromDict2, {"a": {"a": 1, "b": "2"}, "b": {"a": 1, "b": "2"}, "c": 12345}, KeyError],
+        [StreamableFromDict1, {"a": "asdf", "b": "2", "c": G1Element()}, TypeError],
+        [StreamableFromDict1, {"a": 1, "b": "2"}, KeyError],
+        [StreamableFromDict1, {"a": 1, "b": "2", "c": "asd"}, TypeError],
+        [StreamableFromDict1, {"a": 1, "b": "2", "c": "00" * G1Element.SIZE}, TypeError],
+        [StreamableFromDict1, {"a": [], "b": "2", "c": G1Element()}, TypeError],
+        [StreamableFromDict1, {"a": {}, "b": "2", "c": G1Element()}, TypeError],
+        [StreamableFromDict2, {"a": "asdf", "b": 12345, "c": 12345}, TypeError],
+        [StreamableFromDict2, {"a": 12345, "b": {"a": 1, "b": "2"}, "c": 12345}, TypeError],
+        [StreamableFromDict2, {"a": {"a": 1, "b": "2", "c": G1Element()}, "b": {"a": 1, "b": "2"}}, KeyError],
+        [StreamableFromDict2, {"a": {"a": 1, "b": "2"}, "b": {"a": 1, "b": "2"}, "c": 12345}, KeyError],
     ],
 )
 def test_streamable_from_dict_failures(test_class: Type[Streamable], input_dict: Dict[str, Any], error: Any) -> None:

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -94,41 +94,27 @@ def test_plain_class_not_supported() -> None:
             a: PlainClass
 
 
-@dataclass
-class TestDataclassFromDict1:
-    a: int
+@streamable
+@dataclass(frozen=True)
+class TestDataclassFromDict1(Streamable):
+    a: uint8
     b: str
     c: G1Element
 
 
-@dataclass
-class TestDataclassFromDict2:
+@streamable
+@dataclass(frozen=True)
+class TestDataclassFromDict2(Streamable):
     a: TestDataclassFromDict1
     b: TestDataclassFromDict1
-    c: float
+    c: uint64
 
 
-def test_pure_dataclasses_in_dataclass_from_dict() -> None:
-
-    d1_dict = {"a": 1, "b": "2", "c": str(G1Element())}
-
-    d1: TestDataclassFromDict1 = dataclass_from_dict(TestDataclassFromDict1, d1_dict)
-    assert d1.a == 1
-    assert d1.b == "2"
-    assert d1.c == G1Element()
-
-    d2_dict = {"a": d1, "b": d1_dict, "c": 1.2345}
-
-    d2: TestDataclassFromDict2 = dataclass_from_dict(TestDataclassFromDict2, d2_dict)
-    assert d2.a == d1
-    assert d2.b == d1
-    assert d2.c == 1.2345
-
-
-@dataclass
-class ConvertTupleFailures:
-    a: Tuple[int, int]
-    b: Tuple[int, Tuple[int, int]]
+@streamable
+@dataclass(frozen=True)
+class ConvertTupleFailures(Streamable):
+    a: Tuple[uint8, uint8]
+    b: Tuple[uint8, Tuple[uint8, uint8]]
 
 
 @pytest.mark.parametrize(
@@ -152,10 +138,11 @@ def test_convert_tuple_failures(input_dict: Dict[str, Any], error: Any) -> None:
         dataclass_from_dict(ConvertTupleFailures, input_dict)
 
 
-@dataclass
-class ConvertListFailures:
-    a: List[int]
-    b: List[List[int]]
+@streamable
+@dataclass(frozen=True)
+class ConvertListFailures(Streamable):
+    a: List[uint8]
+    b: List[List[uint8]]
 
 
 @pytest.mark.parametrize(
@@ -175,8 +162,9 @@ def test_convert_list_failures(input_dict: Dict[str, Any], error: Any) -> None:
         dataclass_from_dict(ConvertListFailures, input_dict)
 
 
-@dataclass
-class ConvertByteTypeFailures:
+@streamable
+@dataclass(frozen=True)
+class ConvertByteTypeFailures(Streamable):
     a: bytes4
     b: bytes
 
@@ -204,8 +192,9 @@ def test_convert_byte_type_failures(input_dict: Dict[str, Any], error: Any) -> N
         dataclass_from_dict(ConvertByteTypeFailures, input_dict)
 
 
-@dataclass
-class ConvertUnhashableTypeFailures:
+@streamable
+@dataclass(frozen=True)
+class ConvertUnhashableTypeFailures(Streamable):
     a: G1Element
 
 
@@ -234,9 +223,10 @@ class NoStrClass:
         raise RuntimeError("No string")
 
 
-@dataclass
-class ConvertPrimitiveFailures:
-    a: int
+@streamable
+@dataclass(frozen=True)
+class ConvertPrimitiveFailures(Streamable):
+    a: uint8
     b: uint8
     c: str
 
@@ -264,13 +254,13 @@ def test_convert_primitive_failures(input_dict: Dict[str, Any], error: Any) -> N
         [TestDataclassFromDict1, {"a": 1, "b": "2", "c": "00" * G1Element.SIZE}, TypeError],
         [TestDataclassFromDict1, {"a": [], "b": "2", "c": G1Element()}, TypeError],
         [TestDataclassFromDict1, {"a": {}, "b": "2", "c": G1Element()}, TypeError],
-        [TestDataclassFromDict2, {"a": "asdf", "b": 1.2345, "c": 1.2345}, TypeError],
-        [TestDataclassFromDict2, {"a": 1.2345, "b": {"a": 1, "b": "2"}, "c": 1.2345}, TypeError],
+        [TestDataclassFromDict2, {"a": "asdf", "b": 12345, "c": 12345}, TypeError],
+        [TestDataclassFromDict2, {"a": 12345, "b": {"a": 1, "b": "2"}, "c": 12345}, TypeError],
         [TestDataclassFromDict2, {"a": {"a": 1, "b": "2", "c": G1Element()}, "b": {"a": 1, "b": "2"}}, KeyError],
-        [TestDataclassFromDict2, {"a": {"a": 1, "b": "2"}, "b": {"a": 1, "b": "2"}, "c": 1.2345}, KeyError],
+        [TestDataclassFromDict2, {"a": {"a": 1, "b": "2"}, "b": {"a": 1, "b": "2"}, "c": 12345}, KeyError],
     ],
 )
-def test_dataclass_from_dict_failures(test_class: Type[Any], input_dict: Dict[str, Any], error: Any) -> None:
+def test_dataclass_from_dict_failures(test_class: Type[Streamable], input_dict: Dict[str, Any], error: Any) -> None:
 
     with pytest.raises(error):
         dataclass_from_dict(test_class, input_dict)

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -19,7 +19,6 @@ from chia.util.ints import uint8, uint32, uint64
 from chia.util.streamable import (
     DefinitionError,
     Streamable,
-    dataclass_from_dict,
     is_type_List,
     is_type_SpecificOptional,
     is_type_Tuple,
@@ -32,6 +31,7 @@ from chia.util.streamable import (
     parse_tuple,
     parse_uint32,
     streamable,
+    streamable_from_dict,
     write_uint32,
 )
 from tests.block_tools import BlockTools
@@ -135,7 +135,7 @@ class ConvertTupleFailures(Streamable):
 def test_convert_tuple_failures(input_dict: Dict[str, Any], error: Any) -> None:
 
     with pytest.raises(error):
-        dataclass_from_dict(ConvertTupleFailures, input_dict)
+        streamable_from_dict(ConvertTupleFailures, input_dict)
 
 
 @streamable
@@ -159,7 +159,7 @@ class ConvertListFailures(Streamable):
 def test_convert_list_failures(input_dict: Dict[str, Any], error: Any) -> None:
 
     with pytest.raises(error):
-        dataclass_from_dict(ConvertListFailures, input_dict)
+        streamable_from_dict(ConvertListFailures, input_dict)
 
 
 @streamable
@@ -189,7 +189,7 @@ class ConvertByteTypeFailures(Streamable):
 def test_convert_byte_type_failures(input_dict: Dict[str, Any], error: Any) -> None:
 
     with pytest.raises(error):
-        dataclass_from_dict(ConvertByteTypeFailures, input_dict)
+        streamable_from_dict(ConvertByteTypeFailures, input_dict)
 
 
 @streamable
@@ -215,7 +215,7 @@ class ConvertUnhashableTypeFailures(Streamable):
 def test_convert_unhashable_type_failures(input_dict: Dict[str, Any], error: Any) -> None:
 
     with pytest.raises(error):
-        dataclass_from_dict(ConvertUnhashableTypeFailures, input_dict)
+        streamable_from_dict(ConvertUnhashableTypeFailures, input_dict)
 
 
 class NoStrClass:
@@ -242,7 +242,7 @@ class ConvertPrimitiveFailures(Streamable):
 def test_convert_primitive_failures(input_dict: Dict[str, Any], error: Any) -> None:
 
     with pytest.raises(error):
-        dataclass_from_dict(ConvertPrimitiveFailures, input_dict)
+        streamable_from_dict(ConvertPrimitiveFailures, input_dict)
 
 
 @pytest.mark.parametrize(
@@ -260,10 +260,10 @@ def test_convert_primitive_failures(input_dict: Dict[str, Any], error: Any) -> N
         [TestDataclassFromDict2, {"a": {"a": 1, "b": "2"}, "b": {"a": 1, "b": "2"}, "c": 12345}, KeyError],
     ],
 )
-def test_dataclass_from_dict_failures(test_class: Type[Streamable], input_dict: Dict[str, Any], error: Any) -> None:
+def test_streamable_from_dict_failures(test_class: Type[Streamable], input_dict: Dict[str, Any], error: Any) -> None:
 
     with pytest.raises(error):
-        dataclass_from_dict(test_class, input_dict)
+        streamable_from_dict(test_class, input_dict)
 
 
 @streamable


### PR DESCRIPTION
This PR changes the behaviour of the original `dataclass_from_dict` to only work with valid streamable compatible classes and renames it `streamable_from_dict` to make sure we use the same types and pattern wherever we convert dicts to classes.

Based on: 
- #10652
- #11807
- #11848
- #11851 
- #11759  
- #11760
- #11762   