### PR TITLE
Handle ephemeral ports and dual stack (ipv4 & ipv6)

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import ipaddress
 import json
 import logging
 import traceback
@@ -12,6 +13,7 @@ from chia.server.outbound_message import NodeType
 from chia.server.server import ssl_context_for_client, ssl_context_for_server
 from chia.types.peer_info import PeerInfo
 from chia.util.byte_types import hexstr_to_bytes
+from chia.util.config import load_config
 from chia.util.ints import uint16
 from chia.util.json_util import dict_to_json_str
 from chia.util.ws_message import create_payload, create_payload_dict, format_response, pong
@@ -328,7 +330,23 @@ async def start_rpc_server(
 
     site = web.TCPSite(runner, self_hostname, int(rpc_port), ssl_context=rpc_server.ssl_context)
     await site.start()
-    rpc_port = runner.addresses[0][1]
+
+    #
+    # On a dual-stack system, we want to get the (first) IPv4 port unless
+    # prefer_ipv6 is set in which case we use the IPv6 port
+    #
+    if rpc_port == 0:
+        rpc_port = runner.addresses[0][1]  # Set the port by default to the first thing
+        global_config = load_config(root_path, "config.yaml")
+        prefer_ipv6 = global_config.get("prefer_ipv6", False)
+        for x in runner.addresses:
+            ip_addy = ipaddress.ip_address(x[0])
+            if ip_addy.version == 6 and prefer_ipv6:
+                rpc_port = x[1]
+                break
+            elif ip_addy.version == 4 and not prefer_ipv6:
+                rpc_port = x[1]
+                break
 
     async def cleanup():
         await rpc_server.stop()

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -28,10 +28,9 @@ from chia.server.ssl_context import private_ssl_paths, public_ssl_paths
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
-from chia.util.config import load_config
 from chia.util.errors import Err, ProtocolError
 from chia.util.ints import uint16
-from chia.util.network import is_in_network, is_localhost
+from chia.util.network import is_in_network, is_localhost, select_port
 from chia.util.ssl_check import verify_ssl_certs_and_keys
 
 max_message_size = 50 * 1024 * 1024  # 50MB
@@ -279,17 +278,7 @@ class ChiaServer:
         # prefer_ipv6 is set in which case we use the IPv6 port
         #
         if self._port == 0:
-            global_config = load_config(self.root_path, "config.yaml")
-            prefer_ipv6 = global_config.get("prefer_ipv6", False)
-            self._port = self.runner.addresses[0][1]  # sets the default to handle some edge cases
-            for x in self.runner.addresses:
-                ip_addy = ip_address(x[0])
-                if ip_addy.version == 6 and prefer_ipv6:
-                    self._port = x[1]
-                    break
-                elif ip_addy.version == 4 and not prefer_ipv6:
-                    self._port = x[1]
-                    break
+            self._port = select_port(self.root_path, self.runner.addresses)
 
         self.log.info(f"Started listening on port: {self._port}")
 

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -1,5 +1,4 @@
 import asyncio
-import ipaddress
 import logging
 import ssl
 import time
@@ -284,7 +283,7 @@ class ChiaServer:
             prefer_ipv6 = global_config.get("prefer_ipv6", False)
             self._port = self.runner.addresses[0][1]  # sets the default to handle some edge cases
             for x in self.runner.addresses:
-                ip_addy = ipaddress.ip_address(x[0])
+                ip_addy = ip_address(x[0])
                 if ip_addy.version == 6 and prefer_ipv6:
                     self._port = x[1]
                     break

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -1,9 +1,11 @@
 import socket
+from pathlib import Path
 from ipaddress import ip_address, IPv4Network, IPv6Network
 from typing import Iterable, List, Tuple, Union, Any, Optional, Dict
 from chia.server.outbound_message import NodeType
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
+from chia.util.config import load_config
 from chia.util.ints import uint16
 
 
@@ -84,3 +86,21 @@ def is_trusted_inner(peer_host: str, peer_node_id: bytes32, trusted_peers: Dict,
         return False
 
     return True
+
+
+def select_port(root_path: Path, addresses: List[Any]) -> uint16:
+    global_config = load_config(root_path, "config.yaml")
+    prefer_ipv6 = global_config.get("prefer_ipv6", False)
+    selected_port: uint16
+    for address_string, port in addresses:
+        address = ip_address(address_string)
+        if address.version == 6 and prefer_ipv6:
+            selected_port = port
+            break
+        elif address.version == 4 and not prefer_ipv6:
+            selected_port = port
+            break
+    else:
+        selected_port = addresses[0][1]  # no matches, just use the first one in the list
+
+    return selected_port

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -92,7 +92,8 @@ def select_port(root_path: Path, addresses: List[Any]) -> uint16:
     global_config = load_config(root_path, "config.yaml")
     prefer_ipv6 = global_config.get("prefer_ipv6", False)
     selected_port: uint16
-    for address_string, port in addresses:
+    for x in addresses:
+        address_string, port = x[0], x[1]
         address = ip_address(address_string)
         if address.version == 6 and prefer_ipv6:
             selected_port = port

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -92,8 +92,7 @@ def select_port(root_path: Path, addresses: List[Any]) -> uint16:
     global_config = load_config(root_path, "config.yaml")
     prefer_ipv6 = global_config.get("prefer_ipv6", False)
     selected_port: uint16
-    for x in addresses:
-        address_string, port = x[0], x[1]
+    for address_string, port, *_ in addresses:
         address = ip_address(address_string)
         if address.version == 6 and prefer_ipv6:
             selected_port = port


### PR DESCRIPTION
Handle cases of ephemeral ports while using `host=""` and a dual-stack system where the server will listen to multiple ports and the code needs to make sure it is consistent on which port it is using

When using port 0 as an ephemeral port like used in the tests - the system will pick a port to use, However, in a dual-stack (ipv4 & ipv6) system, 2 ports will be picked, one listening on the IPv4 stack and a different port for IPv6. The tests only need one, but they need to connect to the correct one - if the service advertises the IPv6 port, but the caller uses IPv4 to connect, it will fail to connect.

This is only a problem in the test code that uses 0 port - when you request a specific port (like in normal usage via config.yaml), the system will listen to that port on both IPv4 and IPv6 - so this is limited to cases when using port 0 which today is limited to CI.

Code is written to handle cases where `prefer_ipv6` is true, which should exercise the IPv6 stack, however, this is not tested in CI and so this is untested.

Fixes #11628