### PR TITLE
types: `SpendBundle.from_json_dict` -> `SpendBundle.create_from_dict`

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -624,7 +624,7 @@ class FullNodeRpcApi:
         if "spend_bundle" not in request:
             raise ValueError("Spend bundle not in request")
 
-        spend_bundle = SpendBundle.from_json_dict(request["spend_bundle"])
+        spend_bundle = SpendBundle.create_from_dict(request["spend_bundle"])
         spend_name = spend_bundle.name()
 
         if self.service.mempool_manager.get_spendbundle(spend_name) is not None:

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -87,13 +87,13 @@ class SpendBundle(Streamable):
     #  4. remove all code below this point
 
     @classmethod
-    def from_json_dict(cls, json_dict):
+    def create_from_dict(cls, json_dict):
         if "coin_solutions" in json_dict:
             if "coin_spends" not in json_dict:
                 json_dict = dict(
                     aggregated_signature=json_dict["aggregated_signature"], coin_spends=json_dict["coin_solutions"]
                 )
-                warnings.warn("`coin_solutions` is now `coin_spends` in `SpendBundle.from_json_dict`")
+                warnings.warn("`coin_solutions` is now `coin_spends` in `SpendBundle.create_from_dict`")
             else:
                 raise ValueError("JSON contains both `coin_solutions` and `coin_spends`, just use `coin_spends`")
         return dataclass_from_dict(cls, json_dict)

--- a/tests/core/custom_types/test_spend_bundle.py
+++ b/tests/core/custom_types/test_spend_bundle.py
@@ -21,7 +21,7 @@ class TestStructStream(unittest.TestCase):
         """
             % NULL_SIGNATURE
         )
-        spend_bundle = SpendBundle.from_json_dict(json.loads(JSON))
+        spend_bundle = SpendBundle.create_from_dict(json.loads(JSON))
         json_1 = json.loads(JSON)
         json_2 = spend_bundle.to_json_dict(include_legacy_keys=True, exclude_modern_keys=True)
         assert json_1 == json_2
@@ -36,7 +36,7 @@ class TestStructStream(unittest.TestCase):
         """
             % NULL_SIGNATURE
         )
-        spend_bundle = SpendBundle.from_json_dict(json.loads(JSON))
+        spend_bundle = SpendBundle.create_from_dict(json.loads(JSON))
         json_1 = json.loads(JSON)
         json_2 = spend_bundle.to_json_dict(include_legacy_keys=False, exclude_modern_keys=False)
         assert json_1 == json_2
@@ -50,7 +50,7 @@ class TestStructStream(unittest.TestCase):
     def test_dont_use_both_legacy_and_modern(self):
         json_1 = BLANK_SPEND_BUNDLE.to_json_dict(include_legacy_keys=True, exclude_modern_keys=False)
         with self.assertRaises(ValueError):
-            SpendBundle.from_json_dict(json_1)
+            SpendBundle.create_from_dict(json_1)
 
 
 def round_trip(spend_bundle: SpendBundle, **kwargs):
@@ -69,8 +69,8 @@ def round_trip(spend_bundle: SpendBundle, **kwargs):
     if "coin_spends" in json_dict and "coin_solutions" in json_dict:
         del json_dict["coin_solutions"]
 
-    sb = SpendBundle.from_json_dict(json_dict)
+    sb = SpendBundle.create_from_dict(json_dict)
     json_dict_2 = sb.to_json_dict()
-    sb = SpendBundle.from_json_dict(json_dict_2)
+    sb = SpendBundle.create_from_dict(json_dict_2)
     json_dict_3 = sb.to_json_dict()
     assert json_dict_2 == json_dict_3

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -159,12 +159,12 @@ class TestRpc:
             assert len(await client.get_all_mempool_items()) == 1
             assert len(await client.get_all_mempool_tx_ids()) == 1
             assert (
-                SpendBundle.from_json_dict(list((await client.get_all_mempool_items()).values())[0]["spend_bundle"])
+                SpendBundle.create_from_dict(list((await client.get_all_mempool_items()).values())[0]["spend_bundle"])
                 == spend_bundle
             )
             assert (await client.get_all_mempool_tx_ids())[0] == spend_bundle.name()
             assert (
-                SpendBundle.from_json_dict(
+                SpendBundle.create_from_dict(
                     (await client.get_mempool_item_by_tx_id(spend_bundle.name()))["spend_bundle"]
                 )
                 == spend_bundle


### PR DESCRIPTION
Im open for other names (initially i had `from_json_dict_custom`) but at the end this is to avoid replacing the original `SpendBundle.from_json_dict` as preparation for #11763.