### PR TITLE
atari - type ignore revisit

### DIFF
--- a/chia/data_layer/data_layer_server.py
+++ b/chia/data_layer/data_layer_server.py
@@ -28,6 +28,7 @@ class DataLayerServer:
         self.port = self.config["host_port"]
 
         # Setup UPnP for the data_layer_service port
+        # hinting being addressed in https://github.com/Chia-Network/chia-blockchain/pull/11816
         self.upnp: UPnP = UPnP()  # type: ignore[no-untyped-call]
         self.upnp.remap(self.port)  # type: ignore[no-untyped-call]
 
@@ -41,6 +42,7 @@ class DataLayerServer:
 
     async def stop(self) -> None:
 
+        # hinting being addressed in https://github.com/Chia-Network/chia-blockchain/pull/11816
         self.upnp.release(self.port)  # type: ignore[no-untyped-call]
         # this is a blocking call, waiting for the UPnP thread to exit
         self.upnp.shutdown()  # type: ignore[no-untyped-call]

--- a/chia/data_layer/data_layer_types.py
+++ b/chia/data_layer/data_layer_types.py
@@ -54,7 +54,7 @@ class TerminalNode:
         return Program.to(self.key), Program.to(self.value)
 
     # It is unclear how to properly satisfy the generic Row normally, let alone for
-    # dict-like rows.
+    # dict-like rows.  https://github.com/python/typeshed/issues/8027
     @classmethod
     def from_row(cls, row: aiosqlite.Row) -> "TerminalNode":  # type: ignore[type-arg]
         return cls(
@@ -100,9 +100,8 @@ class ProofOfInclusion:
         )
         sibling_hashes = [layer.other_hash for layer in self.layers]
 
-        # TODO: Remove ignore when done.
-        #       https://github.com/Chia-Network/clvm/pull/102
-        #       https://github.com/Chia-Network/clvm/pull/106
+        # https://github.com/Chia-Network/clvm/pull/102
+        # https://github.com/Chia-Network/clvm/pull/106
         return Program.to([sibling_sides, sibling_hashes])  # type: ignore[no-any-return]
 
 
@@ -117,7 +116,7 @@ class InternalNode:
     atom: None = None
 
     # It is unclear how to properly satisfy the generic Row normally, let alone for
-    # dict-like rows.
+    # dict-like rows.  https://github.com/python/typeshed/issues/8027
     @classmethod
     def from_row(cls, row: aiosqlite.Row) -> "InternalNode":  # type: ignore[type-arg]
         return cls(
@@ -154,7 +153,7 @@ class Root:
     status: Status
 
     # It is unclear how to properly satisfy the generic Row normally, let alone for
-    # dict-like rows.
+    # dict-like rows.  https://github.com/python/typeshed/issues/8027
     @classmethod
     def from_row(cls, row: aiosqlite.Row) -> "Root":  # type: ignore[type-arg]
         raw_node_hash = row["node_hash"]

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -15,7 +15,7 @@ async def _debug_dump(db: aiosqlite.Connection, description: str = "") -> None:
 
 
 # It is unclear how to properly satisfy the generic Row normally, let alone for
-# dict-like rows.
+# dict-like rows.  https://github.com/python/typeshed/issues/8027
 def row_to_node(row: aiosqlite.Row) -> Node:  # type: ignore[type-arg]
     cls = node_type_to_class[row["node_type"]]
     return cls.from_row(row=row)

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -199,7 +199,10 @@ class DataStore:
                 raise Exception(f"Requested insertion of node with matching hash but other values differ: {node_hash}")
 
     async def _insert_internal_node(self, left_hash: bytes32, right_hash: bytes32) -> bytes32:
-        node_hash = Program.to((left_hash, right_hash)).get_tree_hash(left_hash, right_hash)
+        # forcing type hint here for:
+        # https://github.com/Chia-Network/clvm/pull/102
+        # https://github.com/Chia-Network/clvm/pull/106
+        node_hash: bytes32 = Program.to((left_hash, right_hash)).get_tree_hash(left_hash, right_hash)
 
         await self._insert_node(
             node_hash=node_hash.hex(),
@@ -210,7 +213,7 @@ class DataStore:
             value=None,
         )
 
-        return node_hash  # type: ignore[no-any-return]
+        return node_hash
 
     async def _insert_ancestor_table(
         self,
@@ -250,7 +253,10 @@ class DataStore:
                     )
 
     async def _insert_terminal_node(self, key: bytes, value: bytes) -> bytes32:
-        node_hash = Program.to((key, value)).get_tree_hash()
+        # forcing type hint here for:
+        # https://github.com/Chia-Network/clvm/pull/102
+        # https://github.com/Chia-Network/clvm/pull/106
+        node_hash: bytes32 = Program.to((key, value)).get_tree_hash()
 
         await self._insert_node(
             node_hash=node_hash.hex(),
@@ -261,7 +267,7 @@ class DataStore:
             value=value.hex(),
         )
 
-        return node_hash  # type: ignore[no-any-return]
+        return node_hash
 
     async def change_root_status(self, root: Root, status: Status = Status.PENDING) -> None:
         async with self.db_wrapper.locked_transaction(lock=True):

--- a/chia/data_layer/dl_wallet_store.py
+++ b/chia/data_layer/dl_wallet_store.py
@@ -15,7 +15,7 @@ _T_DataLayerStore = TypeVar("_T_DataLayerStore", bound="DataLayerStore")
 
 
 # It is unclear how to properly satisfy the generic Row normally, let alone for
-# dict-like rows.
+# dict-like rows.  https://github.com/python/typeshed/issues/8027
 def _row_to_singleton_record(row: Row) -> SingletonRecord:  # type: ignore[type-arg]
     return SingletonRecord(
         bytes32(row[0]),

--- a/chia/wallet/db_wallet/db_wallet_puzzles.py
+++ b/chia/wallet/db_wallet/db_wallet_puzzles.py
@@ -32,9 +32,9 @@ def create_host_layer_puzzle(innerpuz_hash: bytes32, current_root: bytes32) -> P
 
 
 def solve_data_layer_to_report(amount: uint64) -> Program:
-    # TODO: Fix hint errors and remove ignore
-    #  Returning Any from function declared to return "Program"
-    return Program.to(  # type: ignore
+    # https://github.com/Chia-Network/clvm/pull/102
+    # https://github.com/Chia-Network/clvm/pull/106
+    return Program.to(  # type: ignore[no-any-return]
         [
             1,
             amount,
@@ -44,9 +44,9 @@ def solve_data_layer_to_report(amount: uint64) -> Program:
 
 
 def solve_data_layer_to_update(inner_puzzle: Program, inner_solution: Program) -> Program:
-    # TODO: Fix hint errors and remove ignore
-    #  Returning Any from function declared to return "Program"
-    return Program.to(  # type: ignore
+    # https://github.com/Chia-Network/clvm/pull/102
+    # https://github.com/Chia-Network/clvm/pull/106
+    return Program.to(  # type: ignore[no-any-return]
         [
             0,
             inner_solution,
@@ -74,9 +74,9 @@ def create_offer_fullpuz(
 def solve_dl_offer_for_claim(
     offer_amount: uint64, inner_puzzle_hash: bytes32, root: bytes32, proof_of_inclusion: Program
 ) -> Program:
-    # TODO: Fix hint errors and remove ignore
-    #  Returning Any from function declared to return "Program"
-    return Program.to(  # type: ignore
+    # https://github.com/Chia-Network/clvm/pull/102
+    # https://github.com/Chia-Network/clvm/pull/106
+    return Program.to(  # type: ignore[no-any-return]
         [
             1,
             offer_amount,
@@ -88,9 +88,9 @@ def solve_dl_offer_for_claim(
 
 
 def solve_dl_offer_for_recover(offer_amount: uint64) -> Program:
-    # TODO: Fix hint errors and remove ignore
-    #  Returning Any from function declared to return "Program"
-    return Program.to(  # type: ignore
+    # https://github.com/Chia-Network/clvm/pull/102
+    # https://github.com/Chia-Network/clvm/pull/106
+    return Program.to(  # type: ignore[no-any-return]
         [
             0,
             offer_amount,

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -79,6 +79,7 @@ def chia_data_fixture(chia_root: ChiaRoot, chia_daemon: None, scripts_path: path
 
 @pytest.fixture(name="create_example", params=[add_0123_example, add_01234567_example])
 def create_example_fixture(request: SubRequest) -> Callable[[DataStore, bytes32], Awaitable[Example]]:
+    # https://github.com/pytest-dev/pytest/issues/8763
     return request.param  # type: ignore[no-any-return]
 
 

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -91,6 +91,7 @@ async def test_create_tree_fails_for_not_bytes32(raw_data_store: DataStore, leng
 
     # TODO: require a more specific exception
     with pytest.raises(Exception):
+        # type ignore since we are trying to intentionally pass a bad argument
         await raw_data_store.create_tree(tree_id=bad_tree_id)  # type: ignore[arg-type]
 
 
@@ -213,9 +214,9 @@ async def test_insert_terminal_node_does_nothing_if_matching(data_store: DataSto
 async def test_build_a_tree(
     data_store: DataStore,
     tree_id: bytes32,
-    create_example: Callable[[DataStore, bytes32], Example],
+    create_example: Callable[[DataStore, bytes32], Awaitable[Example]],
 ) -> None:
-    example = await create_example(data_store=data_store, tree_id=tree_id)  # type: ignore
+    example = await create_example(data_store, tree_id)
 
     await _debug_dump(db=data_store.db, description="final")
     actual = await data_store.get_tree_as_program(tree_id=tree_id)

--- a/tests/wallet/db_wallet/test_db_clvm.py
+++ b/tests/wallet/db_wallet/test_db_clvm.py
@@ -52,23 +52,21 @@ class TestDLLifecycle:
         return self.get_merkle_tree(string).calculate_root()
 
     def hash_merkle_value(self, string: str) -> bytes32:
-        # TODO: Fix hint errors and remove ignore
-        #  Returning Any from function declared to return "bytes32"
-        return Program.to(string).get_tree_hash()  # type: ignore
+        # https://github.com/Chia-Network/clvm/pull/102
+        # https://github.com/Chia-Network/clvm/pull/106
+        return Program.to(string).get_tree_hash()  # type: ignore[no-any-return]
 
     def get_merkle_proof(self, string: str) -> Program:
-        # TODO: Fix hint errors and remove ignore
-        #  Returning Any from function declared to return "Program"
-        return Program.to(self.get_merkle_tree(string).generate_proof(self.hash_merkle_value(string)))  # type: ignore
+        proof = self.get_merkle_tree(string).generate_proof(self.hash_merkle_value(string))
+        # https://github.com/Chia-Network/clvm/pull/102
+        # https://github.com/Chia-Network/clvm/pull/106
+        return Program.to(proof)  # type: ignore[no-any-return]
 
     @pytest_asyncio.fixture(scope="function")
     async def setup_sim_and_singleton(self) -> SetupArgs:
-        # TODO: Fix hint errors and remove ignore
-        #  Call to untyped function "create" in typed context
-        sim = await SpendSim.create()  # type: ignore
-        # TODO: Fix hint errors and remove ignore
-        #  Call to untyped function "SimClient" in typed context
-        sim_client = SimClient(sim)  # type: ignore
+        # https://github.com/Chia-Network/chia-blockchain/pull/11819
+        sim = await SpendSim.create()  # type: ignore[no-untyped-call]
+        sim_client = SimClient(sim)  # type: ignore[no-untyped-call]
         await sim.farm_block()
         await sim.farm_block(ACS_PH)
         fund_coin = (await sim_client.get_coin_records_by_puzzle_hash(ACS_PH))[0].coin
@@ -153,9 +151,8 @@ class TestDLLifecycle:
             new_singleton = (await sim_client.get_coin_records_by_parent_ids([singleton.name()]))[0].coin
             assert new_singleton.puzzle_hash == singleton.puzzle_hash
         finally:
-            # TODO: Fix hint errors and remove ignore
-            #  Call to untyped function "close" in typed context
-            await sim.close()  # type: ignore
+            # https://github.com/Chia-Network/chia-blockchain/pull/11819
+            await sim.close()  # type: ignore[no-untyped-call]
 
     @pytest.mark.asyncio()
     async def test_update(self, setup_sim_and_singleton: SetupArgs) -> None:
@@ -201,9 +198,8 @@ class TestDLLifecycle:
                 ).get_tree_hash()
             )
         finally:
-            # TODO: Fix hint errors and remove ignore
-            #  Call to untyped function "close" in typed context
-            await sim.close()  # type: ignore
+            # https://github.com/Chia-Network/chia-blockchain/pull/11819
+            await sim.close()  # type: ignore[no-untyped-call]
 
     @pytest.mark.asyncio()
     async def test_offer_cant_claim(self, setup_sim_and_singleton: SetupArgs) -> None:
@@ -249,9 +245,8 @@ class TestDLLifecycle:
             with pytest.raises(ValueError, match="clvm raise"):
                 offer_cs.puzzle_reveal.to_program().run(offer_cs.solution.to_program())
         finally:
-            # TODO: Fix hint errors and remove ignore
-            #  Call to untyped function "close" in typed context
-            await sim.close()  # type: ignore
+            # https://github.com/Chia-Network/chia-blockchain/pull/11819
+            await sim.close()  # type: ignore[no-untyped-call]
 
     @pytest.mark.asyncio()
     async def test_offer_can_claim(self, setup_sim_and_singleton: SetupArgs) -> None:
@@ -298,9 +293,8 @@ class TestDLLifecycle:
             offer_reward = (await sim_client.get_coin_records_by_parent_ids([good_offer_coin.name()]))[0].coin
             assert offer_reward.puzzle_hash == ACS_2_PH
         finally:
-            # TODO: Fix hint errors and remove ignore
-            #  Call to untyped function "close" in typed context
-            await sim.close()  # type: ignore
+            # https://github.com/Chia-Network/chia-blockchain/pull/11819
+            await sim.close()  # type: ignore[no-untyped-call]
 
     @pytest.mark.asyncio()
     async def test_offer_recovery(self, setup_sim_and_singleton: SetupArgs) -> None:
@@ -340,9 +334,8 @@ class TestDLLifecycle:
             offer_reward = (await sim_client.get_coin_records_by_parent_ids([bad_offer_coin.name()]))[0].coin
             assert offer_reward.puzzle_hash == ACS_PH
         finally:
-            # TODO: Fix hint errors and remove ignore
-            #  Call to untyped function "close" in typed context
-            await sim.close()  # type: ignore
+            # https://github.com/Chia-Network/chia-blockchain/pull/11819
+            await sim.close()  # type: ignore[no-untyped-call]
 
     def test_cost(self) -> None:
         import json


### PR DESCRIPTION
Some hints are being handled in https://github.com/Chia-Network/chia-blockchain/pull/11816 and https://github.com/Chia-Network/chia-blockchain/pull/11819.  Links to them were added adjacent to the relevant remaining type ignores.  Once merged to `main` and eventually to `long_lived/atari` mypy will complain about the unneeded ignores and we can remove them.

Given that the data layer offers wallet is not used at present, I did not revisit the type ignores there.