### PR TITLE
implement a python-level tree_id length check for now

### DIFF
--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -128,6 +128,10 @@ class DataStore:
     async def _insert_root(
         self, tree_id: bytes32, node_hash: Optional[bytes32], status: Status, generation: Optional[int] = None
     ) -> None:
+        # This should be replaced by an SQLite schema level check.
+        # https://github.com/Chia-Network/chia-blockchain/pull/9284
+        tree_id = bytes32(tree_id)
+
         if generation is None:
             existing_generation = await self.get_tree_generation(tree_id=tree_id, lock=False)
 

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -83,7 +83,6 @@ async def test_create_tree_accepts_bytes32(raw_data_store: DataStore) -> None:
     await raw_data_store.create_tree(tree_id=tree_id)
 
 
-@pytest.mark.xfail(strict=True)
 @pytest.mark.parametrize(argnames=["length"], argvalues=[[length] for length in [*range(0, 32), *range(33, 48)]])
 @pytest.mark.asyncio
 async def test_create_tree_fails_for_not_bytes32(raw_data_store: DataStore, length: int) -> None:


### PR DESCRIPTION
The real fix is the SQLite schema level checks such as in https://github.com/Chia-Network/chia-blockchain/pull/9284, but for now we'll go for the Python-level check.