### PR TITLE
Enables "claiming" of NFT-did

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1399,6 +1399,20 @@ class WalletRpcApi:
                 return {"wallet_id": wallet.wallet_id, "wallet_info": wallet.wallet_info, "success": True}
         return {"error": f"Cannot find a NFT wallet DID = {did_id}", "success": False}
 
+    async def nft_set_nft_did(self, request):
+        assert self.service.wallet_state_manager is not None
+        wallet_id = uint32(request["wallet_id"])
+        nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
+        try:
+            did_id = bytes32.fromhex(request["did_id"])
+            nft_coin_info = nft_wallet.get_nft_coin_by_id(bytes32.from_hexstr(request["nft_coin_id"]))
+            fee = uint64(request.get("fee", 0))
+            spend_bundle = await nft_wallet.set_nft_did(nft_coin_info, did_id, fee=fee)
+            return {"wallet_id": wallet_id, "success": True, "spend_bundle": spend_bundle}
+        except Exception as e:
+            log.exception(f"Failed to set DID on NFT: {e}")
+            return {"success": False, "error": str(e)}
+
     async def nft_transfer_nft(self, request):
         assert self.service.wallet_state_manager is not None
         wallet_id = uint32(request["wallet_id"])

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -139,6 +139,7 @@ class WalletRpcApi:
             "/nft_get_info": self.nft_get_info,
             "/nft_transfer_nft": self.nft_transfer_nft,
             "/nft_add_uri": self.nft_add_uri,
+            "/nft_set_nft_did": self.nft_set_nft_did,
             # RL wallet
             "/rl_set_user_info": self.rl_set_user_info,
             "/send_clawback_transaction:": self.send_clawback_transaction,

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -631,6 +631,16 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_add_uri", request)
         return response
 
+    async def set_nft_did(self, wallet_id, nft_coin_id, did_id, fee):
+        request: Dict[str, Any] = {
+            "wallet_id": wallet_id,
+            "nft_coin_id": nft_coin_id,
+            "did_id": did_id,
+            "fee": fee,
+        }
+        response = await self.fetch("nft_set_nft_did", request)
+        return response
+
     async def get_nft_info(self, coin_id: bytes32, latest: bool = True):
         request: Dict[str, Any] = {"coin_id": coin_id.hex(), "latest": latest}
         response = await self.fetch("nft_get_info", request)

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -716,8 +716,14 @@ class WalletStateManager:
         """
         wallet_id = None
         wallet_type = None
-        did_id = uncurried_nft.owner_did
-        self.log.debug("Handling NFT: %s， DID: %s", coin_spend, did_id)
+        did_id = None
+        if uncurried_nft.supports_did:
+            # extract the latest did_id from solution
+            solution = coin_spend.solution.to_program()
+            did_id = solution.at("rrfffrfrrfrf").atom
+            if not did_id:
+                did_id = None
+        self.log.debug("Handling NFT: %s， DID: %s", uncurried_nft.singleton_launcher_id, did_id)
         for wallet_info in await self.get_all_wallet_info_entries(wallet_type=WalletType.NFT):
             nft_wallet_info: NFTWalletInfo = NFTWalletInfo.from_json_dict(json.loads(wallet_info.data))
             if nft_wallet_info.did_id == did_id:

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Any
 
 import pytest
@@ -19,6 +20,9 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.wallet_types import WalletType
 from tests.time_out_assert import time_out_assert, time_out_assert_not_none
+
+logging.getLogger("aiosqlite").setLevel(logging.INFO)  # Too much logging on debug level
+logging.getLogger("chia.wallet.wallet_puzzle_store").setLevel(logging.INFO)  # Too much logging on debug level
 
 
 async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:
@@ -802,3 +806,136 @@ async def test_nft_rpc_mint(two_wallet_nodes: Any, trusted: Any) -> None:
     assert did_nft.series_total == st
     assert did_nft.series_number == sn
     assert did_nft.royalty_percentage == royalty_percentage
+
+
+@pytest.mark.parametrize(
+    "trusted",
+    [True, False],
+)
+@pytest.mark.asyncio
+async def test_nft_setting_did(two_wallet_nodes: Any, trusted: Any) -> None:
+    num_blocks = 3
+    full_nodes, wallets = two_wallet_nodes
+    full_node_api: FullNodeSimulator = full_nodes[0]
+    full_node_server = full_node_api.server
+    wallet_node_0, server_0 = wallets[0]
+    wallet_node_1, server_1 = wallets[1]
+    wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
+    api_0 = WalletRpcApi(wallet_node_0)
+    ph = await wallet_0.get_new_puzzlehash()
+
+    if trusted:
+        wallet_node_0.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+        wallet_node_1.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+    else:
+        wallet_node_0.config["trusted_peers"] = {}
+        wallet_node_1.config["trusted_peers"] = {}
+
+    await server_0.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+    await server_1.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+
+    for _ in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+    funds = sum(
+        [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
+    )
+
+    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
+    )
+    spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(wallet_0.id())
+
+    spend_bundle = spend_bundle_list[0].spend_bundle
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
+
+    for _ in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+    await time_out_assert(15, wallet_0.get_pending_change_balance, 0)
+    hex_did_id = did_wallet.get_my_DID()
+
+    res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hex_did_id))
+    assert isinstance(res, dict)
+    assert res.get("success")
+    nft_wallet_0_id = res["wallet_id"]
+
+    # now create NFT wallet with P2 standard puzzle for inner puzzle
+    res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 0"))
+    assert isinstance(res, dict)
+    assert res.get("success")
+    nft_wallet_p2_puzzle = res["wallet_id"]
+    assert nft_wallet_p2_puzzle != nft_wallet_0_id
+
+    # Create a NFT without DID, this will go the unassigned NFT wallet
+    resp = await api_0.nft_mint_nft(
+        {
+            "wallet_id": nft_wallet_p2_puzzle,
+            "did_id": "",
+            "hash": "0xD4584AD463139FA8C0D9F68F4B59F181",
+            "uris": ["https://url1"],
+        }
+    )
+    assert resp.get("success")
+    sb = resp["spend_bundle"]
+
+    # ensure hints are generated
+    assert compute_memos(sb)
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 9999999999998)
+    await time_out_assert(10, wallet_0.get_confirmed_balance, 9999999999998)
+    # Check DID NFT
+    time_left = 5.0
+    coins_response = {}
+    while time_left > 0:
+        coins_response = await api_0.nft_get_nfts(dict(wallet_id=nft_wallet_p2_puzzle))
+        if coins_response.get("nft_list"):
+            break
+        await asyncio.sleep(0.5)
+        time_left -= 0.5
+    assert coins_response["nft_list"], coins_response
+    assert coins_response.get("success")
+    coins = coins_response["nft_list"]
+    assert len(coins) == 1
+
+    resp = await api_0.nft_set_nft_did(
+        {
+            "wallet_id": nft_wallet_p2_puzzle,
+            "nft_coin_id": coins[0].nft_coin_id.hex(),
+            "did_id": hex_did_id,
+        }
+    )
+    assert resp.get("success")
+    sb = resp["spend_bundle"]
+    # ensure hints are generated
+    assert compute_memos(sb)
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 13999999999998)
+    await time_out_assert(10, wallet_0.get_confirmed_balance, 13999999999998)
+    # Check DID NFT
+    time_left = 5.0
+    while time_left > 0:
+        coins_response = await api_0.nft_get_nfts(dict(wallet_id=nft_wallet_0_id))
+        try:
+            assert isinstance(coins_response, dict)
+            assert coins_response.get("success")
+            coins = coins_response["nft_list"]
+            assert len(coins) == 1
+            coin = coins[0].to_json_dict()
+            assert coin["owner_did"][2:] == hex_did_id
+        except AssertionError:
+            if time_left < 1:
+                raise
+        await asyncio.sleep(0.5)
+        time_left -= 0.5

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from typing import Any
 
 import pytest
@@ -20,9 +19,6 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.wallet_types import WalletType
 from tests.time_out_assert import time_out_assert, time_out_assert_not_none
-
-logging.getLogger("aiosqlite").setLevel(logging.INFO)  # Too much logging on debug level
-logging.getLogger("chia.wallet.wallet_puzzle_store").setLevel(logging.INFO)  # Too much logging on debug level
 
 
 async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:


### PR DESCRIPTION
When user accepts an offer for NFT, they will receive it without any DID set, so we need this function to set DID. 

New RPC api `nft_set_nft_did`