### PR TITLE
Remove flake8 from superlinter workflow

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -64,7 +64,7 @@ jobs:
           DEFAULT_BRANCH: main
           LINTER_RULES_PATH: .
           MARKDOWN_CONFIG_FILE: .markdown-lint.yml
-          PYTHON_FLAKE8_CONFIG_FILE: .flake8
+#           PYTHON_FLAKE8_CONFIG_FILE: .flake8
           PYTHON_ISORT_CONFIG_FILE: .isort.cfg
           PYTHON_PYLINT_CONFIG_FILE: pylintrc
           VALIDATE_BASH: true
@@ -77,7 +77,7 @@ jobs:
           VALIDATE_MD: true
           VALIDATE_POWERSHELL: true
           VALIDATE_PYTHON_PYLINT: true
-          VALIDATE_PYTHON_FLAKE8: true
+#           VALIDATE_PYTHON_FLAKE8: true
 #          VALIDATE_PYTHON_ISORT: true
           VALIDATE_SHELL_SHFMT: true
           VALIDATE_TYPESCRIPT_ES: true


### PR DESCRIPTION
flake8 is already run in CI both via pre-commit and directly.

https://github.com/Chia-Network/chia-blockchain/runs/6804466966?check_suite_focus=true
https://github.com/Chia-Network/chia-blockchain/runs/6804466948?check_suite_focus=true