### PR TITLE
streamable: Expand `Field` and introduce `Streamable._streamable_fields`

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -80,8 +80,7 @@ def create_fields(cls: Type[object]) -> StreamableFields:
     hints = get_type_hints(cls)
     fields = []
     for field in dataclasses.fields(cls):
-        hint = hints.get(field.name, None)
-        assert hint is not None
+        hint = hints[field.name]
         fields.append(
             Field(
                 name=field.name,


### PR DESCRIPTION
257d53c74aed9652153b8693bf802632985c4972 adds all functions we currently cache in the `*_FUNCTIONS_FOR_STREAMABLE_CLASS` globals into `streamable.Field` and fcc2caf4f13b0a5dcc32622cecaa5606879649c9 makes the fields related to each class members of the class and drops the global `FIELDS_FOR_STREAMABLE_CLASS`.


Based on:
- #11853 
- #11730 
- #11763 