### PR TITLE
Added nft_get_wallets_with_dids RPC to simplify the discovery

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1406,7 +1406,7 @@ class WalletRpcApi:
         did_wallets_by_did_id: Dict[bytes32, uint32] = {
             wallet.did_info.origin_coin.name(): wallet.id()
             for wallet in all_wallets
-            if isinstance(wallet, DIDWallet) and wallet.did_info.origin_coin is not None
+            if wallet.type() == uint8(WalletType.DISTRIBUTED_ID) and wallet.did_info.origin_coin is not None
         }
         did_nft_wallets: List[Dict] = []
         for wallet in all_wallets:

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -599,6 +599,13 @@ async def test_nft_with_did_wallet_creation(two_wallet_nodes: Any, trusted: Any)
     assert nft_wallet_0_id == res["wallet_id"]
     await time_out_assert(10, wallet_0.get_unconfirmed_balance, 5999999999999)
     await time_out_assert(10, wallet_0.get_confirmed_balance, 5999999999999)
+
+    res = await api_0.nft_get_wallets_with_dids({})
+    assert res.get("success")
+    assert res.get("nft_wallets") == [
+        {"wallet_id": nft_wallet_0_id, "did_id": hex_did_id, "did_wallet_id": did_wallet.id()}
+    ]
+
     # Create a NFT with DID
     nft_ph: bytes32 = await wallet_0.get_new_puzzlehash()
     resp = await api_0.nft_mint_nft(


### PR DESCRIPTION
 of NFT wallets that have an associated DID, and identifying the DID wallet.

It's challenging pulling together a list of DID wallets that have NFTs associated with them. Without this, the GUI needs to invoke several RPCs:

wallets = `get_wallets`
all_dids = for each DID wallet in wallets => `did_get_did`
nft_wallets_with_dids = for each did in all_dids => `nft_get_by_did`
map did wallets to nft_wallets_with_dids

Tested manually using the CLI as well as using the included test code.