### PR TITLE
reduce round-trips to the sqlite thread by using execute_fetchall()

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -1,6 +1,6 @@
 import logging
 import sqlite3
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any, Iterable
 
 import zstd
 
@@ -16,6 +16,14 @@ from chia.util.ints import uint32
 from chia.util.lru_cache import LRUCache
 
 log = logging.getLogger(__name__)
+
+
+def first_item(c: Iterable[Any]) -> Optional[Any]:
+    i = c.__iter__()
+    try:
+        return i.__next__()
+    except StopIteration:
+        return None
 
 
 class BlockStore:
@@ -244,16 +252,15 @@ class BlockStore:
             return cached
 
         async with self.db_wrapper.read_db() as conn:
-            async with conn.execute(
+            rows = await conn.execute_fetchall(
                 "SELECT challenge_segments from sub_epoch_segments_v3 WHERE ses_block_hash=?",
                 (self.maybe_to_hex(ses_block_hash),),
-            ) as cursor:
-                row = await cursor.fetchone()
-
-        if row is not None:
-            challenge_segments = SubEpochSegments.from_bytes(row[0]).challenge_segments
-            self.ses_challenge_cache.put(ses_block_hash, challenge_segments)
-            return challenge_segments
+            )
+            row = first_item(rows)
+            if row is not None:
+                challenge_segments = SubEpochSegments.from_bytes(row[0]).challenge_segments
+                self.ses_challenge_cache.put(ses_block_hash, challenge_segments)
+                return challenge_segments
         return None
 
     def rollback_cache_block(self, header_hash: bytes32):
@@ -307,11 +314,11 @@ class BlockStore:
         heights_db = tuple(heights)
         formatted_str = f'SELECT block from full_blocks WHERE height in ({"?," * (len(heights_db) - 1)}?)'
         async with self.db_wrapper.read_db() as conn:
-            async with conn.execute(formatted_str, heights_db) as cursor:
-                ret: List[FullBlock] = []
-                for row in await cursor.fetchall():
-                    ret.append(self.maybe_decompress(row[0]))
-                return ret
+            rows = await conn.execute_fetchall(formatted_str, heights_db)
+            ret: List[FullBlock] = []
+            for row in rows:
+                ret.append(self.maybe_decompress(row[0]))
+            return ret
 
     async def get_generator(self, header_hash: bytes32) -> Optional[SerializedProgram]:
 
@@ -384,21 +391,21 @@ class BlockStore:
         all_blocks: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
+                rows = await conn.execute_fetchall(
                     "SELECT header_hash,block_record FROM full_blocks "
                     f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
                     tuple(header_hashes),
-                ) as cursor:
-                    for row in await cursor.fetchall():
-                        header_hash = bytes32(row[0])
-                        all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
+                )
+                for row in rows:
+                    header_hash = bytes32(row[0])
+                    all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
         else:
             formatted_str = f'SELECT block from block_records WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)'
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(formatted_str, tuple([hh.hex() for hh in header_hashes])) as cursor:
-                    for row in await cursor.fetchall():
-                        block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
-                        all_blocks[block_rec.header_hash] = block_rec
+                rows = await conn.execute_fetchall(formatted_str, tuple([hh.hex() for hh in header_hashes]))
+                for row in rows:
+                    block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
+                    all_blocks[block_rec.header_hash] = block_rec
 
         ret: List[BlockRecord] = []
         for hh in header_hashes:
@@ -461,12 +468,12 @@ class BlockStore:
         )
         all_blocks: Dict[bytes32, FullBlock] = {}
         async with self.db_wrapper.read_db() as conn:
-            async with conn.execute(formatted_str, header_hashes_db) as cursor:
-                for row in await cursor.fetchall():
-                    header_hash = bytes32(self.maybe_from_hex(row[0]))
-                    full_block: FullBlock = self.maybe_decompress(row[1])
-                    all_blocks[header_hash] = full_block
-                    self.block_cache.put(header_hash, full_block)
+            rows = await conn.execute_fetchall(formatted_str, header_hashes_db)
+            for row in rows:
+                header_hash = bytes32(self.maybe_from_hex(row[0]))
+                full_block: FullBlock = self.maybe_decompress(row[1])
+                all_blocks[header_hash] = full_block
+                self.block_cache.put(header_hash, full_block)
         ret: List[FullBlock] = []
         for hh in header_hashes:
             if hh not in all_blocks:
@@ -479,23 +486,21 @@ class BlockStore:
         if self.db_wrapper.db_version == 2:
 
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
-                    "SELECT block_record FROM full_blocks WHERE header_hash=?",
-                    (header_hash,),
-                ) as cursor:
-                    row = await cursor.fetchone()
-            if row is not None:
-                return BlockRecord.from_bytes(row[0])
+                rows = await conn.execute_fetchall(
+                    "SELECT block_record FROM full_blocks WHERE header_hash=?", (header_hash,)
+                )
+                row = first_item(rows)
+                if row is not None:
+                    return BlockRecord.from_bytes(row[0])
 
         else:
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
-                    "SELECT block from block_records WHERE header_hash=?",
-                    (header_hash.hex(),),
-                ) as cursor:
-                    row = await cursor.fetchone()
-            if row is not None:
-                return BlockRecord.from_bytes(row[0])
+                rows = await conn.execute_fetchall(
+                    "SELECT block from block_records WHERE header_hash=?", (header_hash.hex(),)
+                )
+                row = first_item(rows)
+                if row is not None:
+                    return BlockRecord.from_bytes(row[0])
         return None
 
     async def get_block_records_in_range(
@@ -512,23 +517,22 @@ class BlockStore:
         if self.db_wrapper.db_version == 2:
 
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
-                    "SELECT header_hash, block_record FROM full_blocks WHERE height >= ? AND height <= ?",
-                    (start, stop),
-                ) as cursor:
-                    for row in await cursor.fetchall():
-                        header_hash = bytes32(row[0])
-                        ret[header_hash] = BlockRecord.from_bytes(row[1])
+                rows = await conn.execute_fetchall(
+                    "SELECT header_hash, block_record FROM full_blocks WHERE height >= ? AND height <= ?", (start, stop)
+                )
+                for row in rows:
+                    header_hash = bytes32(row[0])
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         else:
 
             formatted_str = f"SELECT header_hash, block from block_records WHERE height >= {start} and height <= {stop}"
 
             async with self.db_wrapper.read_db() as conn:
-                async with await conn.execute(formatted_str) as cursor:
-                    for row in await cursor.fetchall():
-                        header_hash = bytes32(self.maybe_from_hex(row[0]))
-                        ret[header_hash] = BlockRecord.from_bytes(row[1])
+                rows = await conn.execute_fetchall(formatted_str)
+                for row in rows:
+                    header_hash = bytes32(self.maybe_from_hex(row[0]))
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret
 
@@ -558,22 +562,21 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute("SELECT hash FROM current_peak WHERE key = 0") as cursor:
-                    peak_row = await cursor.fetchone()
-            if peak_row is None:
-                return None
-            async with self.db_wrapper.read_db() as conn:
-                async with conn.execute("SELECT height FROM full_blocks WHERE header_hash=?", (peak_row[0],)) as cursor:
-                    peak_height = await cursor.fetchone()
-            if peak_height is None:
-                return None
-            return bytes32(peak_row[0]), uint32(peak_height[0])
+                rows = await conn.execute_fetchall("SELECT hash FROM current_peak WHERE key = 0")
+                peak_row = first_item(rows)
+                if peak_row is None:
+                    return None
+                rows = await conn.execute_fetchall("SELECT height FROM full_blocks WHERE header_hash=?", (peak_row[0],))
+                peak_height = first_item(rows)
+                if peak_height is None:
+                    return None
+                return bytes32(peak_row[0]), uint32(peak_height[0])
         else:
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute("SELECT header_hash, height from block_records WHERE is_peak = 1") as cursor:
-                    peak_row = await cursor.fetchone()
-            if peak_row is None:
-                return None
+                rows = await conn.execute_fetchall("SELECT header_hash, height from block_records WHERE is_peak = 1")
+                peak_row = first_item(rows)
+                if peak_row is None:
+                    return None
             return bytes32(bytes.fromhex(peak_row[0])), uint32(peak_row[1])
 
     async def get_block_records_close_to_peak(
@@ -592,21 +595,20 @@ class BlockStore:
         if self.db_wrapper.db_version == 2:
 
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
-                    "SELECT header_hash, block_record FROM full_blocks WHERE height >= ?",
-                    (peak[1] - blocks_n,),
-                ) as cursor:
-                    for row in await cursor.fetchall():
-                        header_hash = bytes32(row[0])
-                        ret[header_hash] = BlockRecord.from_bytes(row[1])
+                rows = await conn.execute_fetchall(
+                    "SELECT header_hash, block_record FROM full_blocks WHERE height >= ?", (peak[1] - blocks_n,)
+                )
+                for row in rows:
+                    header_hash = bytes32(row[0])
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         else:
             formatted_str = f"SELECT header_hash, block  from block_records WHERE height >= {peak[1] - blocks_n}"
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(formatted_str) as cursor:
-                    for row in await cursor.fetchall():
-                        header_hash = bytes32(self.maybe_from_hex(row[0]))
-                        ret[header_hash] = BlockRecord.from_bytes(row[1])
+                rows = await conn.execute_fetchall(formatted_str)
+                for row in rows:
+                    header_hash = bytes32(self.maybe_from_hex(row[0]))
+                    ret[header_hash] = BlockRecord.from_bytes(row[1])
 
         return ret, peak[0]
 
@@ -627,53 +629,49 @@ class BlockStore:
                 )
 
     async def is_fully_compactified(self, header_hash: bytes32) -> Optional[bool]:
-        async with self.db_wrapper.write_db() as conn:
-            async with conn.execute(
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
                 "SELECT is_fully_compactified from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
-            ) as cursor:
-                row = await cursor.fetchone()
-        if row is None:
-            return None
-        return bool(row[0])
+            )
+            row = first_item(rows)
+            if row is None:
+                return None
+            return bool(row[0])
 
     async def get_random_not_compactified(self, number: int) -> List[int]:
 
         if self.db_wrapper.db_version == 2:
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
+                rows = await conn.execute_fetchall(
                     f"SELECT height FROM full_blocks WHERE in_main_chain=1 AND is_fully_compactified=0 "
                     f"ORDER BY RANDOM() LIMIT {number}"
-                ) as cursor:
-                    rows = await cursor.fetchall()
+                )
+                return [int(row[0]) for row in rows]
         else:
             # Since orphan blocks do not get compactified, we need to check whether all blocks with a
             # certain height are not compact. And if we do have compact orphan blocks, then all that
             # happens is that the occasional chain block stays uncompact - not ideal, but harmless.
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
+                rows = await conn.execute_fetchall(
                     f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 "
                     f"ORDER BY RANDOM() LIMIT {number}"
-                ) as cursor:
-                    rows = await cursor.fetchall()
-
-        heights = [int(row[0]) for row in rows]
-
-        return heights
+                )
+                return [int(row[0]) for row in rows]
 
     async def count_compactified_blocks(self) -> int:
         if self.db_wrapper.db_version == 2:
             # DB V2 has an index on is_fully_compactified only for blocks in the main chain
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute(
+                rows = await conn.execute_fetchall(
                     "select count(*) from full_blocks where is_fully_compactified=1 and in_main_chain=1"
-                ) as cursor:
-                    row = await cursor.fetchone()
+                )
+                row = first_item(rows)
+                assert row is not None
         else:
             async with self.db_wrapper.read_db() as conn:
-                async with conn.execute("select count(*) from full_blocks where is_fully_compactified=1") as cursor:
-                    row = await cursor.fetchone()
-
-        assert row is not None
+                rows = await conn.execute_fetchall("select count(*) from full_blocks where is_fully_compactified=1")
+                row = first_item(rows)
+                assert rows is not None
 
         [count] = row
         return int(count)


### PR DESCRIPTION
instead of issuing `execute()` and `fetchall()` as separate calls into aiosqlite, combine them into a single round-trip to the DB thread by `execute_fetchall()`.

It's unclear whether this give a speed-up in practice (at least on M1 + SSD). My measurements are likely within the noise. I suspect it might be more relevant on something like a Raspberry PI, but I'm not in a position to test that right now.

So for now, the only benefit would be slight increased clarity of intention of the code.

| test | before | after | after / before |
| --- | --- | --- | --- |
| sync empty blocks | 13.25s | 13.04s | 0.984 |
| sync full blocks | 102.24s | 102.83s | 1.0058 |
| keep-up empty blocks | 81.02s | 80.83s | 0.9977 |