### PR TITLE
WIP spam filter

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -541,3 +541,8 @@ wallet:
 
   # Interval to resend unconfirmed transactions, even if previously accepted into Mempool
   tx_resend_timeout_secs: 1800
+
+  # After n received unspent transactions, the spam filter will be enabled, which will filter out received
+  # coins with very small value. Any standard TX under xch_spam_amount is filtered
+  spam_filter_after_n_txs: 200
+  xch_spam_amount: 10000000

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -487,8 +487,6 @@ wallet:
 
   # The minimum height that we care about for our transactions. Set to zero
   # If we are restoring from private key and don't know the height.
-  starting_height: 0
-  start_height_buffer: 100  # Wallet will stop fly sync at starting_height - buffer
   num_sync_batches: 50
   initial_num_public_keys: 100
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -485,9 +485,6 @@ wallet:
 
   connect_to_unknown_peers: True
 
-  # The minimum height that we care about for our transactions. Set to zero
-  # If we are restoring from private key and don't know the height.
-  num_sync_batches: 50
   initial_num_public_keys: 100
 
   dns_servers:

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -220,6 +220,12 @@ class WalletCoinStore:
         else:
             return set()
 
+    def get_all_unspent_coins(self) -> Set[WalletCoinRecord]:
+        all_unspent: Set[WalletCoinRecord] = set()
+        for _, wallet_coins in self.unspent_coin_wallet_cache.items():
+            all_unspent.update(wallet_coins.values())
+        return all_unspent
+
     async def get_all_coins(self) -> Set[WalletCoinRecord]:
         """Returns set of all CoinRecords."""
         cursor = await self.db_connection.execute("SELECT * from coin_record")

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -225,8 +225,6 @@ class WalletNode:
 
         assert self.wallet_state_manager is not None
 
-        self.config["starting_height"] = 0
-
         if self.wallet_peers is None:
             self.initialize_wallet_peers()
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -657,7 +657,12 @@ class WalletNode:
         concurrent_tasks_cs_heights: List[uint32] = []
 
         # Ensure the list is sorted
-        items = sorted(items_input, key=last_change_height_cs)
+
+        items_input_2 = list(sorted(items_input, key=last_change_height_cs))
+        self.log.info(f"Filtering spam, total items: {len(items_input_2)}")
+        items = [item for item in items_input_2 if (await self.wallet_state_manager.is_not_standard_spam(item))]
+        # items = list(filter(self.wallet_state_manager.is_not_standard_spam, items))
+        self.log.info(f"Filtered spam. Total left: {len(items)}")
 
         async def receive_and_validate(inner_states: List[CoinState], inner_idx_start: int, cs_heights: List[uint32]):
             assert self.wallet_state_manager is not None

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -656,10 +656,8 @@ class WalletNode:
 
         # Ensure the list is sorted
 
-        items_input_2 = list(sorted(items_input, key=last_change_height_cs))
-        self.log.info(f"Filtering spam, total items: {len(items_input_2)}")
-        items = [item for item in items_input_2 if (await self.wallet_state_manager.is_not_standard_spam(item))]
-        # items = list(filter(self.wallet_state_manager.is_not_standard_spam, items))
+        self.log.info(f"Filtering spam, total items: {len(items_input)}")
+        items = await self.wallet_state_manager.filter_spam(list(sorted(items_input, key=last_change_height_cs)))
         self.log.info(f"Filtered spam. Total left: {len(items)}")
 
         async def receive_and_validate(inner_states: List[CoinState], inner_idx_start: int, cs_heights: List[uint32]):

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -585,18 +585,41 @@ class WalletStateManager:
 
         return None, None
 
-    async def is_not_standard_spam(self, coin_state: CoinState) -> bool:
-        return True
+    async def filter_spam(self, new_coin_state: List[CoinState]) -> List[CoinState]:
+        all_unspent: Set[WalletCoinRecord] = self.coin_store.get_all_unspent_coins()
+        spam_filter_after_n_txs = self.config.get("spam_filter_after_n_txs", 200)
+        xch_spam_amount = self.config.get("xch_spam_amount", 10000000)
+        small_unspent_count = len([r for r in all_unspent if r.coin.amount < xch_spam_amount])
+
+        # if small_unspent_count > spam_filter_after_n_txs:
+        filtered_cs: List[CoinState] = []
+        is_standard_wallet_phs: Set[bytes32] = set()
+
+        for cs in new_coin_state:
+            # Only apply filter to new coins being sent to our wallet, that are very small
+            if (
+                cs.created_height is not None
+                and cs.spent_height is None
+                and cs.coin.amount < xch_spam_amount
+                and (cs.coin.puzzle_hash in is_standard_wallet_phs or await self.is_standard_wallet_tx(cs))
+            ):
+                is_standard_wallet_phs.add(cs.coin.puzzle_hash)
+                if small_unspent_count < spam_filter_after_n_txs:
+                    self.log.info(f"Not filteed 1 {small_unspent_count}")
+                    filtered_cs.append(cs)
+                small_unspent_count += 1
+            else:
+                self.log.info(f"Not filteed 2 {small_unspent_count}")
+                filtered_cs.append(cs)
+        return filtered_cs
+
+    async def is_standard_wallet_tx(self, coin_state: CoinState) -> bool:
         wallet_info: Optional[Tuple[uint32, WalletType]] = await self.get_wallet_id_for_puzzle_hash(
             coin_state.coin.puzzle_hash
         )
-        # self.log.warning(
-        #     f"Wallet info 1: {wallet_info} {WalletType.STANDARD_WALLET} {wallet_info is not None} {wallet_info[1] == WalletType.STANDARD_WALLET} {coin_state.coin.amount < 1000000}"
-        # )
         if wallet_info is not None and wallet_info[1] == WalletType.STANDARD_WALLET:
-            if coin_state.coin.amount < 1000000:
-                return False
-        return True
+            return True
+        return False
 
     async def handle_cat(
         self,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -585,6 +585,19 @@ class WalletStateManager:
 
         return None, None
 
+    async def is_not_standard_spam(self, coin_state: CoinState) -> bool:
+        return True
+        wallet_info: Optional[Tuple[uint32, WalletType]] = await self.get_wallet_id_for_puzzle_hash(
+            coin_state.coin.puzzle_hash
+        )
+        # self.log.warning(
+        #     f"Wallet info 1: {wallet_info} {WalletType.STANDARD_WALLET} {wallet_info is not None} {wallet_info[1] == WalletType.STANDARD_WALLET} {coin_state.coin.amount < 1000000}"
+        # )
+        if wallet_info is not None and wallet_info[1] == WalletType.STANDARD_WALLET:
+            if coin_state.coin.amount < 1000000:
+                return False
+        return True
+
     async def handle_cat(
         self,
         curried_args: Iterator[Program],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -378,12 +378,6 @@ async def wallet_nodes_perf(bt):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_node_starting_height(self_hostname):
-    async for _ in setup_node_and_wallet(test_constants, self_hostname, starting_height=100):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
 async def wallet_nodes_mainnet(bt, db_version):
     async_gen = setup_simulators_and_wallets(2, 1, {"NETWORK_TYPE": 0}, db_version=db_version)
     nodes, wallets = await async_gen.__anext__()

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -113,7 +113,6 @@ async def setup_n_nodes(consensus_constants: ConsensusConstants, n: int, db_vers
 async def setup_node_and_wallet(
     consensus_constants: ConsensusConstants,
     self_hostname: str,
-    starting_height=None,
     key_seed=None,
     db_version=1,
     disable_capabilities=None,
@@ -135,7 +134,6 @@ async def setup_node_and_wallet(
                 consensus_constants,
                 btools,
                 None,
-                starting_height=starting_height,
                 key_seed=key_seed,
             ),
         ]
@@ -153,7 +151,6 @@ async def setup_simulators_and_wallets(
     wallet_count: int,
     dic: Dict,
     *,
-    starting_height=None,
     key_seed=None,
     initial_num_public_keys=5,
     db_version=1,
@@ -197,7 +194,6 @@ async def setup_simulators_and_wallets(
                 bt_tools,
                 None,
                 key_seed=seed,
-                starting_height=starting_height,
                 initial_num_public_keys=initial_num_public_keys,
             )
             wallets.append(await wlt.__anext__())

--- a/tests/setup_services.py
+++ b/tests/setup_services.py
@@ -144,15 +144,12 @@ async def setup_wallet_node(
     full_node_port=None,
     introducer_port=None,
     key_seed=None,
-    starting_height=None,
     initial_num_public_keys=5,
 ):
     with TempKeyring(populate=True) as keychain:
         config = local_bt.config["wallet"]
         config["port"] = 0
         config["rpc_port"] = 0
-        if starting_height is not None:
-            config["starting_height"] = starting_height
         config["initial_num_public_keys"] = initial_num_public_keys
 
         entropy = token_bytes(32)


### PR DESCRIPTION
* Removes a few unused config values
* Adds two new config values for filtering XCH spam. This enables syncing much much faster for anyone that has dust in their wallet. All the TXs are still downloaded, but some are filtered out and not processed

- [ ] tests for coin store
- [ ] tests for spam filter
- [ ] decide defaults