### PR TITLE
`chia wallet show` output now displays the DID ID for NFT/DID wallets

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -539,6 +539,7 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
                 balances["unconfirmed_wallet_balance"], scale, address_prefix
             )
             spendable_balance: str = print_balance(balances["spendable_balance"], scale, address_prefix)
+            my_did: Optional[str] = None
             print()
             print(f"{summary['name']}:")
             print(f"{indent}{'-Total Balance:'.ljust(23)} {total_balance}")
@@ -551,7 +552,7 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
                 print(f"{indent}{'-DID ID:'.ljust(23)} {my_did}")
             elif typ == WalletType.NFT:
                 get_did_response = await wallet_client.get_nft_wallet_did(wallet_id)
-                my_did: Optional[str] = get_did_response["did_id"]
+                my_did = get_did_response["did_id"]
                 if my_did is not None and len(my_did) > 0:
                     print(f"{indent}{'-DID ID:'.ljust(23)} {my_did}")
             elif len(asset_id) > 0:

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -545,7 +545,16 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
             print(f"{indent}{'-Pending Total Balance:'.ljust(23)} " f"{unconfirmed_wallet_balance}")
             print(f"{indent}{'-Spendable:'.ljust(23)} {spendable_balance}")
             print(f"{indent}{'-Type:'.ljust(23)} {typ.name}")
-            if len(asset_id) > 0:
+            if typ == WalletType.DISTRIBUTED_ID:
+                get_did_response = await wallet_client.get_did_id(wallet_id)
+                my_did = get_did_response["my_did"]
+                print(f"{indent}{'-DID ID:'.ljust(23)} {my_did}")
+            elif typ == WalletType.NFT:
+                get_did_response = await wallet_client.get_nft_wallet_did(wallet_id)
+                my_did: Optional[str] = get_did_response["did_id"]
+                if my_did is not None and len(my_did) > 0:
+                    print(f"{indent}{'-DID ID:'.ljust(23)} {my_did}")
+            elif len(asset_id) > 0:
                 print(f"{indent}{'-Asset ID:'.ljust(23)} {asset_id}")
             print(f"{indent}{'-Wallet ID:'.ljust(23)} {wallet_id}")
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1411,7 +1411,7 @@ class WalletRpcApi:
         nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
         if nft_wallet is not None:
             if type(nft_wallet) != NFTWallet:
-               return {"success": False, "error": f"Wallet {wallet_id} is not an NFT wallet"}
+                return {"success": False, "error": f"Wallet {wallet_id} is not an NFT wallet"}
             did_bytes: Optional[bytes32] = nft_wallet.get_did()
             did_id = ""
             if did_bytes is not None:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1410,7 +1410,7 @@ class WalletRpcApi:
         assert self.service.wallet_state_manager is not None
         nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
         if nft_wallet is not None:
-            if type(nft_wallet) != NFTWallet:
+            if nft_wallet.type() != WalletType.NFT.value:
                 return {"success": False, "error": f"Wallet {wallet_id} is not an NFT wallet"}
             did_bytes: Optional[bytes32] = nft_wallet.get_did()
             did_id = ""

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1439,7 +1439,6 @@ class WalletRpcApi:
                         did_nft_wallets.append(
                             {
                                 "wallet_id": wallet.id(),
-                                # "did_id": nft_wallet_did.hex(),
                                 "did_id": encode_puzzle_hash(nft_wallet_did, DID_HRP),
                                 "did_wallet_id": did_wallet_id,
                             }

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -655,3 +655,8 @@ class WalletRpcClient(RpcClient):
         request: Dict[str, Any] = {"wallet_id": wallet_id, "did_id": did_id, "nft_coin_id": nft_coin_id, "fee": fee}
         response = await self.fetch("nft_set_nft_did", request)
         return response
+
+    async def get_nft_wallet_did(self, wallet_id):
+        request: Dict[str, Any] = {"wallet_id": wallet_id}
+        response = await self.fetch("nft_get_wallet_did", request)
+        return response

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -612,8 +612,12 @@ async def test_nft_with_did_wallet_creation(two_wallet_nodes: Any, trusted: Any)
     res = await api_0.nft_get_wallets_with_dids({})
     assert res.get("success")
     assert res.get("nft_wallets") == [
-        {"wallet_id": nft_wallet_0_id, "did_id": hex_did_id, "did_wallet_id": did_wallet.id()}
+        {"wallet_id": nft_wallet_0_id, "did_id": hmr_did_id, "did_wallet_id": did_wallet.id()}
     ]
+
+    res = await api_0.nft_get_wallet_did({"wallet_id": nft_wallet_0_id})
+    assert res.get("success")
+    assert res.get("did_id") == hmr_did_id
 
     # Create a NFT with DID
     nft_ph: bytes32 = await wallet_0.get_new_puzzlehash()

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -16,6 +16,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint16, uint32, uint64
+from chia.wallet.did_wallet.did_info import DID_HRP
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.util.compute_memos import compute_memos
@@ -883,8 +884,9 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
     await time_out_assert(15, wallet_0.get_pending_change_balance, 0)
     hex_did_id = did_wallet.get_my_DID()
+    hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), DID_HRP)
 
-    res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hex_did_id))
+    res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id))
     assert isinstance(res, dict)
     assert res.get("success")
     nft_wallet_0_id = res["wallet_id"]
@@ -1008,8 +1010,9 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
     await time_out_assert(15, wallet_0.get_pending_change_balance, 0)
     hex_did_id = did_wallet.get_my_DID()
+    hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), DID_HRP)
 
-    res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hex_did_id))
+    res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id))
     assert isinstance(res, dict)
     assert res.get("success")
     nft_wallet_0_id = res["wallet_id"]


### PR DESCRIPTION
Added `nft_get_wallet_did` RPC to get the DID ID for an NFT wallet
Bech32m encode the DID ID output from `nft_get_wallets_with_dids` RPC