### PR TITLE
Add set_nft_did API

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -137,6 +137,7 @@ class WalletRpcApi:
             "/nft_mint_nft": self.nft_mint_nft,
             "/nft_get_nfts": self.nft_get_nfts,
             "/nft_get_by_did": self.nft_get_by_did,
+            "/nft_set_nft_did": self.nft_set_nft_did,
             "/nft_get_wallet_did": self.nft_get_wallet_did,
             "/nft_get_wallets_with_dids": self.nft_get_wallets_with_dids,
             "/nft_get_info": self.nft_get_info,
@@ -1394,6 +1395,20 @@ class WalletRpcApi:
         for nft in nfts:
             nft_info_list.append(nft_puzzles.get_nft_info_from_puzzle(nft))
         return {"wallet_id": wallet_id, "success": True, "nft_list": nft_info_list}
+
+    async def nft_set_nft_did(self, request):
+        try:
+            assert self.service.wallet_state_manager is not None
+            wallet_id = uint32(request["wallet_id"])
+            nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
+            did_id = decode_puzzle_hash(request["did_id"])
+            nft_coin_info = nft_wallet.get_nft_coin_by_id(bytes32.from_hexstr(request["nft_coin_id"]))
+            fee = uint64(request.get("fee", 0))
+            spend_bundle = await nft_wallet.set_nft_did(nft_coin_info, did_id, fee=fee)
+            return {"wallet_id": wallet_id, "success": True, "spend_bundle": spend_bundle}
+        except Exception as e:
+            log.exception(f"Failed to set DID on NFT: {e}")
+            return {"success": False, "error": str(e)}
 
     async def nft_get_by_did(self, request) -> Dict:
         did_id: Optional[bytes32] = None

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1405,7 +1405,9 @@ class WalletRpcApi:
             assert self.service.wallet_state_manager is not None
             wallet_id = uint32(request["wallet_id"])
             nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
-            did_id = decode_puzzle_hash(request["did_id"])
+            did_id: Optional[bytes32] = None
+            if "did_id" in request:
+                did_id = decode_puzzle_hash(request["did_id"])
             nft_coin_info = nft_wallet.get_nft_coin_by_id(bytes32.from_hexstr(request["nft_coin_id"]))
             fee = uint64(request.get("fee", 0))
             spend_bundle = await nft_wallet.set_nft_did(nft_coin_info, did_id, fee=fee)
@@ -1484,7 +1486,7 @@ class WalletRpcApi:
             txs = await nft_wallet.generate_signed_transaction(
                 [nft_coin_info.coin.amount],
                 [puzzle_hash],
-                coins=[nft_coin_info.coin],
+                coins={nft_coin_info.coin},
                 fee=fee,
             )
             spend_bundle: Optional[SpendBundle] = None

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1414,7 +1414,7 @@ class WalletRpcApi:
             return {"wallet_id": wallet_id, "success": True, "spend_bundle": spend_bundle}
         except Exception as e:
             log.exception(f"Failed to set DID on NFT: {e}")
-            return {"success": False, "error": str(e)}
+            return {"success": False, "error": f"Failed to set DID on NFT: {e}"}
 
     async def nft_get_by_did(self, request) -> Dict:
         did_id: Optional[bytes32] = None

--- a/chia/wallet/nft_wallet/nft_puzzles.py
+++ b/chia/wallet/nft_wallet/nft_puzzles.py
@@ -285,7 +285,7 @@ def get_metadata_and_phs(unft: UncurriedNFT, solution: SerializedProgram) -> Tup
 def recurry_nft_puzzle(unft: UncurriedNFT, solution: Program, sp2_puzzle: Program) -> Program:
     log.debug("Generating NFT puzzle with ownership support: %s", disassemble(solution))
     conditions = solution.at("frfr").as_iter()
-    new_did_id = None
+    new_did_id = unft.owner_did
     new_puzhash = None
     for condition in conditions:
         if condition.first().as_int() == -10:

--- a/chia/wallet/nft_wallet/nft_puzzles.py
+++ b/chia/wallet/nft_wallet/nft_puzzles.py
@@ -226,7 +226,7 @@ def create_ownership_layer_puzzle(
 
 def create_ownership_layer_transfer_solution(
     new_did: bytes,
-    new_did_inner_hash: bytes32,
+    new_did_inner_hash: bytes,
     trade_prices_list: List[List[int]],
     new_puzhash: bytes32,
 ) -> Program:
@@ -256,7 +256,7 @@ def create_ownership_layer_transfer_solution(
     return solution
 
 
-def get_metadata_and_phs(unft: UncurriedNFT, puzzle: Program, solution: SerializedProgram) -> Tuple[Program, bytes32]:
+def get_metadata_and_phs(unft: UncurriedNFT, solution: SerializedProgram) -> Tuple[Program, bytes32]:
     conditions = unft.p2_puzzle.run(unft.get_innermost_solution(solution.to_program()))
     metadata = unft.metadata
     puzhash_for_derivation: Optional[bytes32] = None
@@ -298,3 +298,13 @@ def recurry_nft_puzzle(unft: UncurriedNFT, solution: Program, sp2_puzzle: Progra
     assert unft.transfer_program
     inner_puzzle = construct_ownership_layer(new_did_id, unft.transfer_program, sp2_puzzle)
     return inner_puzzle
+
+
+def get_new_owner_did(solution: Program) -> Optional[bytes32]:
+    conditions = solution.at("rrfffrfr").as_iter()
+    new_did_id = None
+    for condition in conditions:
+        if condition.first().as_int() == -10:
+            # this is the change owner magic condition
+            new_did_id = condition.at("rf").atom
+    return new_did_id

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -571,7 +571,6 @@ class NFTWallet:
             condition_list = [
                 [51, puzzle_hash, coin.amount, [puzzle_hash]],
                 [-24, NFT_METADATA_UPDATER, (key, uri)],
-                [-10, [], [], []],
             ]
             inner_solution = Program.to([[solution_for_conditions(condition_list)]])
         else:
@@ -706,6 +705,7 @@ class NFTWallet:
         memos: Optional[List[List[bytes]]] = None,
         coin_announcements_to_consume: Optional[Set[Announcement]] = None,
         puzzle_announcements_to_consume: Optional[Set[Announcement]] = None,
+        ignore_max_send_amount: bool = False,
         new_owner: Optional[bytes] = None,
         new_did_inner_hash: Optional[bytes] = None,
         trade_prices_list: Optional[Program] = None,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -26,6 +26,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.full_block import FullBlock
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
+from chia.util.bech32m import encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import process_config_start_method
 from chia.util.db_synchronous import db_synchronous_on
@@ -37,6 +38,7 @@ from chia.wallet.cat_wallet.cat_utils import construct_cat_puzzle, match_cat_puz
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
+from chia.wallet.did_wallet.did_info import DID_HRP
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import DID_INNERPUZ_MOD, create_fullpuz, match_did_puzzle
 from chia.wallet.key_val_store import KeyValStore

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -26,7 +26,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.full_block import FullBlock
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.util.bech32m import encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import process_config_start_method
 from chia.util.db_synchronous import db_synchronous_on
@@ -43,7 +42,7 @@ from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import DID_INNERPUZ_MOD, create_fullpuz, match_did_puzzle
 from chia.wallet.key_val_store import KeyValStore
 from chia.wallet.nft_wallet.nft_info import NFTWalletInfo
-from chia.wallet.nft_wallet.nft_puzzles import get_metadata_and_phs
+from chia.wallet.nft_wallet.nft_puzzles import get_metadata_and_phs, get_new_owner_did
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
 from chia.wallet.outer_puzzles import AssetType
@@ -722,7 +721,16 @@ class WalletStateManager:
         """
         wallet_id = None
         wallet_type = None
-        did_id = uncurried_nft.owner_did
+        did_id = None
+        if uncurried_nft.supports_did:
+            # Try to get the latest owner DID
+            did_id = get_new_owner_did(coin_spend.solution.to_program())
+        if did_id is None:
+            # No DID owner update, use the original DID
+            did_id = uncurried_nft.owner_did
+        if did_id == b"":
+            # Owner DID is updated to None
+            did_id = None
         self.log.debug("Handling NFT: %s， DID: %s", coin_spend, did_id)
         for wallet_info in await self.get_all_wallet_info_entries(wallet_type=WalletType.NFT):
             nft_wallet_info: NFTWalletInfo = NFTWalletInfo.from_json_dict(json.loads(wallet_info.data))
@@ -751,7 +759,6 @@ class WalletStateManager:
                     )
                     metadata, p2_puzzle_hash = get_metadata_and_phs(
                         uncurried_nft,
-                        Program.from_bytes(bytes(coin_spend.puzzle_reveal)),
                         coin_spend.solution,
                     )
                     derivation_record: Optional[

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -851,6 +851,7 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
     wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
     api_0 = WalletRpcApi(wallet_node_0)
+    api_1 = WalletRpcApi(wallet_node_1)
     ph = await wallet_0.get_new_puzzlehash()
     ph1 = await wallet_1.get_new_puzzlehash()
 
@@ -960,8 +961,15 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     else:
         raise AssertionError("NFT not transferred")
 
-    nft_wallet_1 = wallet_1.wallet_state_manager.wallets[2]
-    await time_out_assert(15, len, 1, nft_wallet_1.nft_wallet_info.my_nft_coins)
+    resp = await api_1.nft_get_by_did(dict(did_id=hmr_did_id))
+    assert resp.get("success")
+    nft_wallet_id_1 = resp.get("wallet_id")
+    coins_response = await api_1.nft_get_nfts(dict(wallet_id=nft_wallet_id_1))
+    assert coins_response.get("success")
+    assert len(coins_response.get("nft_list")) == 1
+    assert coins_response.get("nft_list")[0].owner_did is None
+
+
 
 
 @pytest.mark.parametrize(
@@ -1093,3 +1101,121 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
                 raise
         await asyncio.sleep(0.5)
         time_left -= 0.5
+
+@pytest.mark.parametrize(
+    "trusted",
+    [True, False],
+)
+@pytest.mark.asyncio
+async def test_nft_set_did(two_wallet_nodes: Any, trusted: Any) -> None:
+    num_blocks = 5
+    full_nodes, wallets = two_wallet_nodes
+    full_node_api: FullNodeSimulator = full_nodes[0]
+    full_node_server = full_node_api.server
+    wallet_node_0, server_0 = wallets[0]
+    wallet_node_1, server_1 = wallets[1]
+    wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
+    api_0 = WalletRpcApi(wallet_node_0)
+    ph = await wallet_0.get_new_puzzlehash()
+
+    if trusted:
+        wallet_node_0.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+        wallet_node_1.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+    else:
+        wallet_node_0.config["trusted_peers"] = {}
+        wallet_node_1.config["trusted_peers"] = {}
+
+    await server_0.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+    await server_1.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+
+    for _ in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+    funds = sum(
+        [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
+    )
+
+    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
+    )
+    spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(wallet_0.id())
+
+    spend_bundle = spend_bundle_list[0].spend_bundle
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
+
+    for _ in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+    await time_out_assert(15, wallet_0.get_pending_change_balance, 0)
+    hex_did_id = did_wallet.get_my_DID()
+    hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), DID_HRP)
+
+    res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
+    assert isinstance(res, dict)
+    assert res.get("success")
+    nft_wallet_0_id = res["wallet_id"]
+
+    await time_out_assert(5, did_wallet.get_confirmed_balance, 1)
+
+    # Create a NFT with DID
+    resp = await api_0.nft_mint_nft(
+        {
+            "wallet_id": nft_wallet_0_id,
+            "hash": "0xD4584AD463139FA8C0D9F68F4B59F185",
+            "uris": ["https://www.chia.net/img/branding/chia-logo.svg"],
+            "mu": ["https://www.chia.net/img/branding/chia-logo.svg"],
+        }
+    )
+    assert resp.get("success")
+    sb = resp["spend_bundle"]
+
+    # ensure hints are generated
+    assert compute_memos(sb)
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+    # Check DID NFT
+    time_left = 5.0
+    coins_response = {}
+    while time_left > 0:
+        coins_response = await api_0.nft_get_nfts(dict(wallet_id=nft_wallet_0_id))
+        if coins_response.get("nft_list"):
+            break
+        await asyncio.sleep(0.5)
+        time_left -= 0.5
+    assert coins_response["nft_list"], isinstance(coins_response, dict)
+    assert coins_response.get("success")
+    coins = coins_response["nft_list"]
+    assert len(coins) == 1
+    assert coins[0].owner_did is None
+    nft_coin_id = coins[0].nft_coin_id
+    # Set DID
+    resp = await api_0.nft_set_nft_did(dict(wallet_id=nft_wallet_0_id, did_id=hmr_did_id, nft_coin_id=nft_coin_id.hex()))
+    assert resp.get("success")
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+    time_left = 5.0
+    coins_response = {}
+    while time_left > 0:
+        coins_response = await api_0.nft_get_by_did(dict(did_id=hmr_did_id))
+        if coins_response.get("wallet_id"):
+            break
+        await asyncio.sleep(0.5)
+        time_left -= 0.5
+    nft_wallet_1_id = coins_response.get("wallet_id")
+    print(coins_response)
+    # Check NFT DID
+    resp =  await api_0.nft_get_nfts(dict(wallet_id=nft_wallet_1_id))
+    assert resp.get("success")
+    coins = coins_response["nft_list"]
+    assert len(coins) == 1
+    assert coins[0].owner_did == hmr_did_id

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1001,7 +1001,13 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     nft_wallet_1_id = coins_response.get("wallet_id")
     assert nft_wallet_1_id
     # Check NFT DID
-    resp = await api_1.nft_get_nfts(dict(wallet_id=nft_wallet_1_id))
+    time_left = 15.0
+    while time_left > 0:
+        resp = await api_1.nft_get_nfts(dict(wallet_id=nft_wallet_1_id))
+        if coins_response.get("nft_list"):
+            break
+        await asyncio.sleep(0.5)
+        time_left -= 0.5
     assert resp.get("success")
     coins = resp["nft_list"]
     assert len(coins) == 1
@@ -1116,7 +1122,7 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
     # check that new URI was added
-    time_left = 5.0
+    time_left = 10.0
     while time_left > 0:
         coins_response = await api_0.nft_get_nfts(dict(wallet_id=nft_wallet_0_id))
         try:


### PR DESCRIPTION
Add:
Set DID for a NFT

Fix:
Wrong DID is used to determine the ownership in the wallet_state_manager
Cannot mint unassigned NFT
Update metadata reset the DID mistakenly

Unit Tests:
Set DID after a transfer
Set DID after mint an unassigned NFT (None -> DID1)
Change DID (DID1 -> DID2)
Reset DID to None (DID2 -> None)