### PR TITLE
not optional - `WalletNode.wallet_state_manager`, `.server`, `.keychain_proxy`

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -181,7 +181,6 @@ class WalletRpcApi:
                 await peers_close_task
 
     async def _convert_tx_puzzle_hash(self, tx: TransactionRecord) -> TransactionRecord:
-        assert self.service.wallet_state_manager is not None
         return dataclasses.replace(
             tx,
             to_puzzle_hash=(
@@ -215,7 +214,6 @@ class WalletRpcApi:
 
     async def get_public_keys(self, request: Dict):
         try:
-            assert self.service.keychain_proxy is not None  # An offering to the mypy gods
             fingerprints = [
                 sk.get_g1().get_fingerprint() for (sk, seed) in await self.service.keychain_proxy.get_all_private_keys()
             ]
@@ -228,7 +226,6 @@ class WalletRpcApi:
 
     async def _get_private_key(self, fingerprint) -> Tuple[Optional[PrivateKey], Optional[bytes]]:
         try:
-            assert self.service.keychain_proxy is not None  # An offering to the mypy gods
             all_keys = await self.service.keychain_proxy.get_all_private_keys()
             for sk, seed in all_keys:
                 if sk.get_g1().get_fingerprint() == fingerprint:
@@ -371,7 +368,6 @@ class WalletRpcApi:
     async def delete_all_keys(self, request: Dict):
         await self._stop_wallet()
         try:
-            assert self.service.keychain_proxy is not None  # An offering to the mypy gods
             await self.service.keychain_proxy.delete_all_keys()
         except Exception as e:
             log.error(f"Failed to delete all keys: {e}")
@@ -386,24 +382,20 @@ class WalletRpcApi:
     ##########################################################################################
 
     async def get_sync_status(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
         syncing = self.service.wallet_state_manager.sync_mode
         synced = await self.service.wallet_state_manager.synced()
         return {"synced": synced, "syncing": syncing, "genesis_initialized": True}
 
     async def get_height_info(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
         height = await self.service.wallet_state_manager.blockchain.get_finished_sync_up_to()
         return {"height": height}
 
     async def get_network_info(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
         network_name = self.service.config["selected_network"]
         address_prefix = self.service.config["network_overrides"]["config"][network_name]["address_prefix"]
         return {"network_name": network_name, "network_prefix": address_prefix}
 
     async def push_tx(self, request: Dict):
-        assert self.service.server is not None
         nodes = self.service.server.get_full_node_connections()
         if len(nodes) == 0:
             raise ValueError("Wallet is not currently connected to any full node peers")
@@ -423,7 +415,6 @@ class WalletRpcApi:
     ##########################################################################################
 
     async def get_wallets(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
         include_data: bool = request.get("include_data", True)
         wallet_type: Optional[WalletType] = None
         if "type" in request:
@@ -438,7 +429,6 @@ class WalletRpcApi:
         return {"wallets": wallets}
 
     async def create_new_wallet(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
         wallet_state_manager = self.service.wallet_state_manager
 
         if await self.service.wallet_state_manager.synced() is False:
@@ -655,7 +645,6 @@ class WalletRpcApi:
     ##########################################################################################
 
     async def get_wallet_balance(self, request: Dict) -> Dict:
-        assert self.service.wallet_state_manager is not None
         wallet_id = uint32(int(request["wallet_id"]))
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
 
@@ -708,7 +697,6 @@ class WalletRpcApi:
         return {"wallet_balance": wallet_balance}
 
     async def get_transaction(self, request: Dict) -> Dict:
-        assert self.service.wallet_state_manager is not None
         transaction_id: bytes32 = bytes32(hexstr_to_bytes(request["transaction_id"]))
         tr: Optional[TransactionRecord] = await self.service.wallet_state_manager.get_transaction(transaction_id)
         if tr is None:
@@ -720,8 +708,6 @@ class WalletRpcApi:
         }
 
     async def get_transactions(self, request: Dict) -> Dict:
-        assert self.service.wallet_state_manager is not None
-
         wallet_id = int(request["wallet_id"])
 
         start = request.get("start", 0)
@@ -746,8 +732,6 @@ class WalletRpcApi:
         }
 
     async def get_transaction_count(self, request: Dict) -> Dict:
-        assert self.service.wallet_state_manager is not None
-
         wallet_id = int(request["wallet_id"])
         count = await self.service.wallet_state_manager.tx_store.get_transaction_count_for_wallet(wallet_id)
         return {
@@ -765,8 +749,6 @@ class WalletRpcApi:
         """
         Returns a new address
         """
-        assert self.service.wallet_state_manager is not None
-
         if request["new_address"] is True:
             create_new = True
         else:
@@ -790,8 +772,6 @@ class WalletRpcApi:
         }
 
     async def send_transaction(self, request):
-        assert self.service.wallet_state_manager is not None
-
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before sending transactions")
 
@@ -830,8 +810,6 @@ class WalletRpcApi:
         }
 
     async def send_transaction_multi(self, request) -> Dict:
-        assert self.service.wallet_state_manager is not None
-
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before sending transactions")
 
@@ -865,8 +843,6 @@ class WalletRpcApi:
                 return {}
 
     async def select_coins(self, request) -> Dict[str, List[Dict]]:
-        assert self.service.wallet_state_manager is not None
-
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before selecting coins")
 
@@ -887,14 +863,12 @@ class WalletRpcApi:
         return {"cat_list": list(DEFAULT_CATS.values())}
 
     async def cat_set_name(self, request):
-        assert self.service.wallet_state_manager is not None
         wallet_id = int(request["wallet_id"])
         wallet: CATWallet = self.service.wallet_state_manager.wallets[wallet_id]
         await wallet.set_name(str(request["name"]))
         return {"wallet_id": wallet_id}
 
     async def cat_get_name(self, request):
-        assert self.service.wallet_state_manager is not None
         wallet_id = int(request["wallet_id"])
         wallet: CATWallet = self.service.wallet_state_manager.wallets[wallet_id]
         name: str = await wallet.get_name()
@@ -906,13 +880,10 @@ class WalletRpcApi:
         :param request: RPC request
         :return: A list of unacknowledged CATs
         """
-        assert self.service.wallet_state_manager is not None
         cats = await self.service.wallet_state_manager.interested_store.get_unacknowledged_tokens()
         return {"stray_cats": cats}
 
     async def cat_spend(self, request):
-        assert self.service.wallet_state_manager is not None
-
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
         wallet_id = int(request["wallet_id"])
@@ -943,14 +914,12 @@ class WalletRpcApi:
         }
 
     async def cat_get_asset_id(self, request):
-        assert self.service.wallet_state_manager is not None
         wallet_id = int(request["wallet_id"])
         wallet: CATWallet = self.service.wallet_state_manager.wallets[wallet_id]
         asset_id: str = wallet.get_asset_id()
         return {"asset_id": asset_id, "wallet_id": wallet_id}
 
     async def cat_asset_id_to_name(self, request):
-        assert self.service.wallet_state_manager is not None
         wallet = await self.service.wallet_state_manager.get_wallet_for_asset_id(request["asset_id"])
         if wallet is None:
             if request["asset_id"] in DEFAULT_CATS:
@@ -961,7 +930,8 @@ class WalletRpcApi:
             return {"wallet_id": wallet.id(), "name": (await wallet.get_name())}
 
     async def create_offer_for_ids(self, request):
-        assert self.service.wallet_state_manager is not None
+        # TODO: Maybe needed for early failout?  accessing will fail if None.
+        self.service.wallet_state_manager
 
         offer: Dict[str, int] = request["offer"]
         fee: uint64 = uint64(request.get("fee", 0))
@@ -1006,7 +976,9 @@ class WalletRpcApi:
         raise ValueError(error)
 
     async def get_offer_summary(self, request):
-        assert self.service.wallet_state_manager is not None
+        # TODO: Maybe needed for early failout?  accessing will fail if None.
+        # TODO: what was this needed for to begin with?
+        self.service.wallet_state_manager
         offer_hex: str = request["offer"]
         offer = Offer.from_bech32(offer_hex)
         offered, requested, infos = offer.summary()
@@ -1014,14 +986,12 @@ class WalletRpcApi:
         return {"summary": {"offered": offered, "requested": requested, "fees": offer.bundle.fees(), "infos": infos}}
 
     async def check_offer_validity(self, request):
-        assert self.service.wallet_state_manager is not None
         offer_hex: str = request["offer"]
         offer = Offer.from_bech32(offer_hex)
 
         return {"valid": (await self.service.wallet_state_manager.trade_manager.check_offer_validity(offer))}
 
     async def take_offer(self, request):
-        assert self.service.wallet_state_manager is not None
         offer_hex: str = request["offer"]
         offer = Offer.from_bech32(offer_hex)
         fee: uint64 = uint64(request.get("fee", 0))
@@ -1037,8 +1007,6 @@ class WalletRpcApi:
         return {"trade_record": trade_record.to_json_dict_convenience()}
 
     async def get_offer(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
-
         trade_mgr = self.service.wallet_state_manager.trade_manager
 
         trade_id = bytes32.from_hexstr(request["trade_id"])
@@ -1052,8 +1020,6 @@ class WalletRpcApi:
         return {"trade_record": trade_record.to_json_dict_convenience(), "offer": offer_value}
 
     async def get_all_offers(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
-
         trade_mgr = self.service.wallet_state_manager.trade_manager
 
         start: int = request.get("start", 0)
@@ -1085,8 +1051,6 @@ class WalletRpcApi:
         return {"trade_records": result, "offers": offer_values}
 
     async def get_offers_count(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
-
         trade_mgr = self.service.wallet_state_manager.trade_manager
 
         (total, my_offers_count, taken_offers_count) = await trade_mgr.trade_store.get_trades_count()
@@ -1094,8 +1058,6 @@ class WalletRpcApi:
         return {"total": total, "my_offers_count": my_offers_count, "taken_offers_count": taken_offers_count}
 
     async def cancel_offer(self, request: Dict):
-        assert self.service.wallet_state_manager is not None
-
         wsm = self.service.wallet_state_manager
         secure = request["secure"]
         trade_id = bytes32.from_hexstr(request["trade_id"])
@@ -1113,7 +1075,6 @@ class WalletRpcApi:
     ##########################################################################################
 
     async def did_set_wallet_name(self, request):
-        assert self.service.wallet_state_manager is not None
         wallet_id = int(request["wallet_id"])
         wallet: DIDWallet = self.service.wallet_state_manager.wallets[wallet_id]
         if wallet.type() == WalletType.DISTRIBUTED_ID:
@@ -1123,7 +1084,6 @@ class WalletRpcApi:
             return {"success": False, "error": f"Wallet id {wallet_id} is not a DID wallet"}
 
     async def did_get_wallet_name(self, request):
-        assert self.service.wallet_state_manager is not None
         wallet_id = int(request["wallet_id"])
         wallet: DIDWallet = self.service.wallet_state_manager.wallets[wallet_id]
         name: str = await wallet.get_name()
@@ -1303,7 +1263,6 @@ class WalletRpcApi:
         return {"wallet_id": wallet_id, "success": True, "backup_data": did_wallet.create_backup()}
 
     async def did_transfer_did(self, request):
-        assert self.service.wallet_state_manager is not None
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
         wallet_id = int(request["wallet_id"])
@@ -1385,7 +1344,6 @@ class WalletRpcApi:
 
     async def nft_get_nfts(self, request) -> Dict:
         wallet_id = uint32(request["wallet_id"])
-        assert self.service.wallet_state_manager is not None
         nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
         nfts = nft_wallet.get_current_nfts()
         nft_info_list = []
@@ -1395,7 +1353,6 @@ class WalletRpcApi:
 
     async def nft_set_nft_did(self, request):
         try:
-            assert self.service.wallet_state_manager is not None
             wallet_id = uint32(request["wallet_id"])
             nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
             did_id: Optional[bytes32] = None
@@ -1413,7 +1370,6 @@ class WalletRpcApi:
         did_id: Optional[bytes32] = None
         if "did_id" in request:
             did_id = decode_puzzle_hash(request["did_id"])
-        assert self.service.wallet_state_manager is not None
         for wallet in self.service.wallet_state_manager.wallets.values():
             if isinstance(wallet, NFTWallet) and wallet.get_did() == did_id:
                 return {"wallet_id": wallet.wallet_id, "success": True}
@@ -1421,7 +1377,6 @@ class WalletRpcApi:
 
     async def nft_get_wallet_did(self, request) -> Dict:
         wallet_id = uint32(request["wallet_id"])
-        assert self.service.wallet_state_manager is not None
         nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
         if nft_wallet is not None:
             if nft_wallet.type() != WalletType.NFT.value:
@@ -1434,7 +1389,6 @@ class WalletRpcApi:
         return {"success": False, "error": f"Wallet {wallet_id} not found"}
 
     async def nft_get_wallets_with_dids(self, request) -> Dict:
-        assert self.service.wallet_state_manager is not None
         all_wallets = self.service.wallet_state_manager.wallets.values()
         did_wallets_by_did_id: Dict[bytes32, uint32] = {
             wallet.did_info.origin_coin.name(): wallet.id()
@@ -1460,7 +1414,6 @@ class WalletRpcApi:
         return {"success": True, "nft_wallets": did_nft_wallets}
 
     async def nft_transfer_nft(self, request):
-        assert self.service.wallet_state_manager is not None
         wallet_id = uint32(request["wallet_id"])
         address = request["target_address"]
         if isinstance(address, str):
@@ -1493,7 +1446,6 @@ class WalletRpcApi:
             return {"success": False, "error": str(e)}
 
     async def nft_get_info(self, request: Dict) -> Optional[Dict]:
-        assert self.service.wallet_state_manager is not None
         if "coin_id" not in request:
             return {"success": False, "error": "Coin ID is required."}
         coin_id = request["coin_id"]
@@ -1589,7 +1541,6 @@ class WalletRpcApi:
             return {"success": True, "nft_info": nft_info}
 
     async def nft_add_uri(self, request) -> Dict:
-        assert self.service.wallet_state_manager is not None
         wallet_id = uint32(request["wallet_id"])
         # Note metadata updater can only add one uri for one field per spend.
         # If you want to add multiple uris for one field, you need to spend multiple times.
@@ -1615,8 +1566,6 @@ class WalletRpcApi:
     ##########################################################################################
 
     async def rl_set_user_info(self, request):
-        assert self.service.wallet_state_manager is not None
-
         wallet_id = uint32(int(request["wallet_id"]))
         rl_user = self.service.wallet_state_manager.wallets[wallet_id]
         origin = request["origin"]
@@ -1632,8 +1581,6 @@ class WalletRpcApi:
         return {}
 
     async def send_clawback_transaction(self, request):
-        assert self.service.wallet_state_manager is not None
-
         wallet_id = int(request["wallet_id"])
         wallet: RLWallet = self.service.wallet_state_manager.wallets[wallet_id]
 
@@ -1689,7 +1636,8 @@ class WalletRpcApi:
         }
 
     async def create_signed_transaction(self, request, hold_lock=True) -> Dict:
-        assert self.service.wallet_state_manager is not None
+        # TODO: Maybe needed for early failout?  accessing will fail if None.
+        self.service.wallet_state_manager
         if "additions" not in request or len(request["additions"]) < 1:
             raise ValueError("Specify additions list")
 
@@ -1786,8 +1734,6 @@ class WalletRpcApi:
     # Pool Wallet
     ##########################################################################################
     async def pw_join_pool(self, request) -> Dict:
-        if self.service.wallet_state_manager is None:
-            return {"success": False, "error": "not_initialized"}
         fee = uint64(request.get("fee", 0))
         wallet_id = uint32(request["wallet_id"])
         wallet: PoolWallet = self.service.wallet_state_manager.wallets[wallet_id]
@@ -1816,8 +1762,6 @@ class WalletRpcApi:
             return {"total_fee": total_fee, "transaction": tx, "fee_transaction": fee_tx}
 
     async def pw_self_pool(self, request) -> Dict:
-        if self.service.wallet_state_manager is None:
-            return {"success": False, "error": "not_initialized"}
         # Leaving a pool requires two state transitions.
         # First we transition to PoolSingletonState.LEAVING_POOL
         # Then we transition to FARMING_TO_POOL or SELF_POOLING
@@ -1836,8 +1780,6 @@ class WalletRpcApi:
 
     async def pw_absorb_rewards(self, request) -> Dict:
         """Perform a sweep of the p2_singleton rewards controlled by the pool wallet singleton"""
-        if self.service.wallet_state_manager is None:
-            return {"success": False, "error": "not_initialized"}
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before collecting rewards")
         fee = uint64(request.get("fee", 0))
@@ -1854,8 +1796,6 @@ class WalletRpcApi:
 
     async def pw_status(self, request) -> Dict:
         """Return the complete state of the Pool wallet with id `request["wallet_id"]`"""
-        if self.service.wallet_state_manager is None:
-            return {"success": False, "error": "not_initialized"}
         wallet_id = uint32(request["wallet_id"])
         wallet: PoolWallet = self.service.wallet_state_manager.wallets[wallet_id]
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -930,9 +930,6 @@ class WalletRpcApi:
             return {"wallet_id": wallet.id(), "name": (await wallet.get_name())}
 
     async def create_offer_for_ids(self, request):
-        # TODO: Maybe needed for early failout?  accessing will fail if None.
-        self.service.wallet_state_manager
-
         offer: Dict[str, int] = request["offer"]
         fee: uint64 = uint64(request.get("fee", 0))
         validate_only: bool = request.get("validate_only", False)
@@ -976,9 +973,6 @@ class WalletRpcApi:
         raise ValueError(error)
 
     async def get_offer_summary(self, request):
-        # TODO: Maybe needed for early failout?  accessing will fail if None.
-        # TODO: what was this needed for to begin with?
-        self.service.wallet_state_manager
         offer_hex: str = request["offer"]
         offer = Offer.from_bech32(offer_hex)
         offered, requested, infos = offer.summary()
@@ -1636,8 +1630,6 @@ class WalletRpcApi:
         }
 
     async def create_signed_transaction(self, request, hold_lock=True) -> Dict:
-        # TODO: Maybe needed for early failout?  accessing will fail if None.
-        self.service.wallet_state_manager
         if "additions" not in request or len(request["additions"]) < 1:
             raise ValueError("Specify additions list")
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -87,14 +87,14 @@ class WalletNode:
     # Sync data
     proof_hashes: List = dataclasses.field(default_factory=list)
     state_changed_callback: Optional[Callable] = None
-    wallet_state_manager: Optional[WalletStateManager] = None
-    server: Optional[ChiaServer] = None
+    _wallet_state_manager: Optional[WalletStateManager] = None
+    _server: Optional[ChiaServer] = None
     wsm_close_task: Optional[asyncio.Task] = None
     sync_task: Optional[asyncio.Task] = None
     logged_in_fingerprint: Optional[int] = None
     peer_task: Optional[asyncio.Task] = None
     logged_in: bool = False
-    keychain_proxy: Optional[KeychainProxy] = None
+    _keychain_proxy: Optional[KeychainProxy] = None
     height_to_time: Dict[uint32, uint64] = dataclasses.field(default_factory=dict)
     # Peers that we have long synced to
     synced_peers: Set[bytes32] = dataclasses.field(default_factory=set)
@@ -120,15 +120,42 @@ class WalletNode:
     _primary_peer_sync_task: Optional[asyncio.Task] = None
     _secondary_peer_sync_task: Optional[asyncio.Task] = None
 
+    @property
+    def keychain_proxy(self) -> KeychainProxy:
+        # This is a stop gap until the class usage is refactored such the values of
+        # integral attributes are known at creation of the instance.
+        if self._keychain_proxy is None:
+            raise RuntimeError("keychain proxy not assigned")
+
+        return self._keychain_proxy
+
+    @property
+    def wallet_state_manager(self) -> WalletStateManager:
+        # This is a stop gap until the class usage is refactored such the values of
+        # integral attributes are known at creation of the instance.
+        if self._wallet_state_manager is None:
+            raise RuntimeError("wallet state manager not assigned")
+
+        return self._wallet_state_manager
+
+    @property
+    def server(self) -> ChiaServer:
+        # This is a stop gap until the class usage is refactored such the values of
+        # integral attributes are known at creation of the instance.
+        if self._server is None:
+            raise RuntimeError("server not assigned")
+
+        return self._server
+
     async def ensure_keychain_proxy(self) -> KeychainProxy:
-        if self.keychain_proxy is None:
+        if self._keychain_proxy is None:
             if self.local_keychain:
-                self.keychain_proxy = wrap_local_keychain(self.local_keychain, log=self.log)
+                self._keychain_proxy = wrap_local_keychain(self.local_keychain, log=self.log)
             else:
-                self.keychain_proxy = await connect_to_keychain_and_validate(self.root_path, self.log)
-                if not self.keychain_proxy:
+                self._keychain_proxy = await connect_to_keychain_and_validate(self.root_path, self.log)
+                if not self._keychain_proxy:
                     raise KeychainProxyConnectionFailure("Failed to connect to keychain service")
-        return self.keychain_proxy
+        return self._keychain_proxy
 
     def get_cache_for_peer(self, peer) -> PeerRequestCache:
         if peer.peer_node_id not in self.untrusted_caches:
@@ -184,8 +211,7 @@ class WalletNode:
                 self.log.info(f"Copying wallet db from {standalone_path} to {path}")
                 path.write_bytes(standalone_path.read_bytes())
 
-        assert self.server is not None
-        self.wallet_state_manager = await WalletStateManager.create(
+        self._wallet_state_manager = await WalletStateManager.create(
             private_key,
             self.config,
             path,
@@ -195,7 +221,7 @@ class WalletNode:
             self,
         )
 
-        assert self.wallet_state_manager is not None
+        assert self._wallet_state_manager is not None
 
         self.config["starting_height"] = 0
 
@@ -241,16 +267,16 @@ class WalletNode:
     async def _await_closed(self, shutting_down: bool = True):
         self.log.info("self._await_closed")
 
-        if self.server is not None:
+        if self._server is not None:
             await self.server.close_all_connections()
         if self.wallet_peers is not None:
             await self.wallet_peers.ensure_is_closed()
-        if self.wallet_state_manager is not None:
+        if self._wallet_state_manager is not None:
             await self.wallet_state_manager._await_closed()
-            self.wallet_state_manager = None
-        if shutting_down and self.keychain_proxy is not None:
-            proxy = self.keychain_proxy
-            self.keychain_proxy = None
+            self._wallet_state_manager = None
+        if shutting_down and self._keychain_proxy is not None:
+            proxy = self._keychain_proxy
+            self._keychain_proxy = None
             await proxy.close()
             await asyncio.sleep(0.5)  # https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
         self.logged_in = False
@@ -259,17 +285,17 @@ class WalletNode:
     def _set_state_changed_callback(self, callback: Callable):
         self.state_changed_callback = callback
 
-        if self.wallet_state_manager is not None:
+        if self._wallet_state_manager is not None:
             self.wallet_state_manager.set_callback(self.state_changed_callback)
             self.wallet_state_manager.set_pending_callback(self._pending_tx_handler)
 
     def _pending_tx_handler(self):
-        if self.wallet_state_manager is None:
+        if self._wallet_state_manager is None:
             return None
         asyncio.create_task(self._resend_queue())
 
     async def _action_messages(self) -> List[Message]:
-        if self.wallet_state_manager is None:
+        if self._wallet_state_manager is None:
             return []
         actions: List[WalletAction] = await self.wallet_state_manager.action_store.get_all_pending_actions()
         result: List[Message] = []
@@ -288,11 +314,11 @@ class WalletNode:
         return result
 
     async def _resend_queue(self):
-        if self._shut_down or self.server is None or self.wallet_state_manager is None:
+        if self._shut_down or self._server is None or self._wallet_state_manager is None:
             return None
 
         for msg, sent_peers in await self._messages_to_resend():
-            if self._shut_down or self.server is None or self.wallet_state_manager is None:
+            if self._shut_down or self._server is None or self._wallet_state_manager is None:
                 return None
             full_nodes = self.server.get_full_node_connections()
             for peer in full_nodes:
@@ -302,12 +328,12 @@ class WalletNode:
                 await peer.send_message(msg)
 
         for msg in await self._action_messages():
-            if self._shut_down or self.server is None or self.wallet_state_manager is None:
+            if self._shut_down or self._server is None or self._wallet_state_manager is None:
                 return None
             await self.server.send_to_all([msg], NodeType.FULL_NODE)
 
     async def _messages_to_resend(self) -> List[Tuple[Message, Set[bytes32]]]:
-        if self.wallet_state_manager is None or self._shut_down:
+        if self._wallet_state_manager is None or self._shut_down:
             return []
         messages: List[Tuple[Message, Set[bytes32]]] = []
 
@@ -390,7 +416,7 @@ class WalletNode:
                     await peer.close(9999)
 
     def set_server(self, server: ChiaServer):
-        self.server = server
+        self._server = server
         self.initialize_wallet_peers()
 
     def initialize_wallet_peers(self):
@@ -433,7 +459,7 @@ class WalletNode:
             self.node_peaks.pop(peer.peer_node_id)
 
     async def on_connect(self, peer: WSChiaConnection):
-        if self.wallet_state_manager is None:
+        if self._wallet_state_manager is None:
             return None
 
         if Version(peer.protocol_version) < Version("0.0.33"):
@@ -459,7 +485,6 @@ class WalletNode:
             await self.wallet_peers.on_connect(peer)
 
     async def perform_atomic_rollback(self, fork_height: int, cache: Optional[PeerRequestCache] = None):
-        assert self.wallet_state_manager is not None
         self.log.info(f"perform_atomic_rollback to {fork_height}")
         async with self.wallet_state_manager.db_wrapper.lock:
             try:
@@ -514,7 +539,6 @@ class WalletNode:
 
         trusted: bool = self.is_trusted(full_node)
         self.log.info(f"Starting sync trusted: {trusted} to peer {full_node.peer_host}")
-        assert self.wallet_state_manager is not None
         start_time = time.time()
 
         if rollback:
@@ -600,7 +624,7 @@ class WalletNode:
         # Adds the state to the wallet state manager. If the peer is trusted, we do not validate. If the peer is
         # untrusted we do, but we might not add the state, since we need to receive the new_peak message as well.
 
-        if self.wallet_state_manager is None:
+        if self._wallet_state_manager is None:
             return False
         trusted = self.is_trusted(peer)
         # Validate states in parallel, apply serial
@@ -632,7 +656,7 @@ class WalletNode:
         items = sorted(items_input, key=last_change_height_cs)
 
         async def receive_and_validate(inner_states: List[CoinState], inner_idx_start: int, cs_heights: List[uint32]):
-            assert self.wallet_state_manager is not None
+            assert self._wallet_state_manager is not None
             try:
                 assert self.validation_semaphore is not None
                 async with self.validation_semaphore:
@@ -652,7 +676,7 @@ class WalletNode:
                                 f"new coin state received ({inner_idx_start}-"
                                 f"{inner_idx_start + len(inner_states) - 1}/ {len(items)})"
                             )
-                            if self.wallet_state_manager is None:
+                            if self._wallet_state_manager is None:
                                 return
                             try:
                                 await self.wallet_state_manager.db_wrapper.begin_transaction()
@@ -691,7 +715,7 @@ class WalletNode:
         # Untrusted has a smaller batch size since validation has to happen which takes a while
         chunk_size: int = 900 if trusted else 20
         for states in chunks(items, chunk_size):
-            if self.server is None:
+            if self._server is None:
                 self.log.error("No server")
                 await asyncio.gather(*all_tasks)
                 return False
@@ -731,14 +755,13 @@ class WalletNode:
                 all_tasks.append(asyncio.create_task(receive_and_validate(states, idx, concurrent_tasks_cs_heights)))
             idx += len(states)
 
-        still_connected = self.server is not None and peer.peer_node_id in self.server.all_connections
+        still_connected = self._server is not None and peer.peer_node_id in self.server.all_connections
         await asyncio.gather(*all_tasks)
         await self.update_ui()
-        return still_connected and self.server is not None and peer.peer_node_id in self.server.all_connections
+        return still_connected and self._server is not None and peer.peer_node_id in self.server.all_connections
 
     async def get_coins_with_puzzle_hash(self, puzzle_hash) -> List[CoinState]:
-        assert self.wallet_state_manager is not None
-        assert self.server is not None
+        assert self._wallet_state_manager is not None
         all_nodes = self.server.connection_by_type[NodeType.FULL_NODE]
         if len(all_nodes.keys()) == 0:
             raise ValueError("Not connected to the full node")
@@ -764,7 +787,6 @@ class WalletNode:
         return latest_timestamp
 
     def is_trusted(self, peer) -> bool:
-        assert self.server is not None
         return self.server.is_trusted_peer(peer, self.config["trusted_peers"])
 
     def add_state_to_race_cache(self, header_hash: bytes32, height: uint32, coin_state: CoinState) -> None:
@@ -786,8 +808,6 @@ class WalletNode:
         # that is of interest to this wallet. It is not guaranteed to come for every height. This message is guaranteed
         # to come before the corresponding new_peak for each height. We handle this differently for trusted and
         # untrusted peers. For trusted, we always process the state, and we process reorgs as well.
-        assert self.wallet_state_manager is not None
-        assert self.server is not None
         for coin in request.items:
             self.log.info(f"request coin: {coin.coin.name()}{coin}")
 
@@ -801,7 +821,7 @@ class WalletNode:
             )
 
     def get_full_node_peer(self) -> Optional[WSChiaConnection]:
-        if self.server is None:
+        if self._server is None:
             return None
 
         nodes = self.server.get_full_node_connections()
@@ -811,7 +831,7 @@ class WalletNode:
             return None
 
     async def disconnect_and_stop_wpeers(self) -> None:
-        if self.server is None:
+        if self._server is None:
             return
 
         # Close connection of non-trusted peers
@@ -825,7 +845,7 @@ class WalletNode:
             self.wallet_peers = None
 
     async def check_for_synced_trusted_peer(self, header_block: HeaderBlock, request_time: uint64) -> bool:
-        if self.server is None:
+        if self._server is None:
             return False
         for peer in self.server.get_full_node_connections():
             if self.is_trusted(peer) and await self.is_peer_synced(peer, header_block, request_time):
@@ -857,10 +877,10 @@ class WalletNode:
         return last_tx_block.foliage_transaction_block.timestamp
 
     async def new_peak_wallet(self, new_peak: wallet_protocol.NewPeakWallet, peer: WSChiaConnection):
-        if self.wallet_state_manager is None:
+        if self._wallet_state_manager is None:
             # When logging out of wallet
             return
-        assert self.server is not None
+        assert self._server is not None
         request_time = uint64(int(time.time()))
         trusted: bool = self.is_trusted(peer)
         peak_hb: Optional[HeaderBlock] = await self.wallet_state_manager.blockchain.get_peak_block()
@@ -1048,7 +1068,6 @@ class WalletNode:
             await self.wallet_state_manager.new_peak(new_peak)
 
     async def wallet_short_sync_backtrack(self, header_block: HeaderBlock, peer: WSChiaConnection) -> int:
-        assert self.wallet_state_manager is not None
         peak: Optional[HeaderBlock] = await self.wallet_state_manager.blockchain.get_peak_block()
 
         top = header_block
@@ -1096,7 +1115,6 @@ class WalletNode:
     async def fetch_and_validate_the_weight_proof(
         self, peer: WSChiaConnection, peak: HeaderBlock
     ) -> Tuple[bool, Optional[WeightProof], List[SubEpochSummary], List[BlockRecord]]:
-        assert self.wallet_state_manager is not None
         assert self.wallet_state_manager.weight_proof_handler is not None
 
         weight_request = RequestProofOfWeight(peak.height, peak.header_hash)
@@ -1135,7 +1153,6 @@ class WalletNode:
         return valid, weight_proof, summaries, block_records
 
     async def get_puzzle_hashes_to_subscribe(self) -> List[bytes32]:
-        assert self.wallet_state_manager is not None
         all_puzzle_hashes = list(await self.wallet_state_manager.puzzle_store.get_all_puzzle_hashes())
         # Get all phs from interested store
         interested_puzzle_hashes = [
@@ -1145,7 +1162,6 @@ class WalletNode:
         return all_puzzle_hashes
 
     async def get_coin_ids_to_subscribe(self, min_height: int) -> List[bytes32]:
-        assert self.wallet_state_manager is not None
         all_coins: Set[WalletCoinRecord] = await self.wallet_state_manager.coin_store.get_coins_to_check(min_height)
         all_coin_names: Set[bytes32] = {coin_record.name() for coin_record in all_coins}
         removed_dict = await self.wallet_state_manager.trade_manager.get_coins_of_interest()
@@ -1164,8 +1180,6 @@ class WalletNode:
         Returns all state that is valid and included in the blockchain proved by the weight proof. If return_old_states
         is False, only new states that are not in the coin_store are returned.
         """
-        assert self.wallet_state_manager is not None
-
         # Only use the cache if we are talking about states before the fork point. If we are evaluating something
         # in a reorg, we cannot use the cache, since we don't know if it's actually in the new chain after the reorg.
         if await can_use_peer_request_cache(coin_state, peer_request_cache, fork_height):
@@ -1301,8 +1315,7 @@ class WalletNode:
     async def validate_block_inclusion(
         self, block: HeaderBlock, peer: WSChiaConnection, peer_request_cache: PeerRequestCache
     ) -> bool:
-        assert self.wallet_state_manager is not None
-        assert self.server is not None
+        assert self._server is not None
         if self.wallet_state_manager.blockchain.contains_height(block.height):
             stored_hash = self.wallet_state_manager.blockchain.height_to_hash(block.height)
             stored_record = self.wallet_state_manager.blockchain.try_block_record(stored_hash)
@@ -1462,7 +1475,6 @@ class WalletNode:
     async def get_coin_state(
         self, coin_names: List[bytes32], fork_height: Optional[uint32] = None, peer: Optional[WSChiaConnection] = None
     ) -> List[CoinState]:
-        assert self.server is not None
         all_nodes = self.server.connection_by_type[NodeType.FULL_NODE]
         if len(all_nodes.keys()) == 0:
             raise ValueError("Not connected to the full node")

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -761,7 +761,6 @@ class WalletNode:
         return still_connected and self._server is not None and peer.peer_node_id in self.server.all_connections
 
     async def get_coins_with_puzzle_hash(self, puzzle_hash) -> List[CoinState]:
-        assert self._wallet_state_manager is not None
         all_nodes = self.server.connection_by_type[NodeType.FULL_NODE]
         if len(all_nodes.keys()) == 0:
             raise ValueError("Not connected to the full node")
@@ -880,7 +879,6 @@ class WalletNode:
         if self._wallet_state_manager is None:
             # When logging out of wallet
             return
-        assert self._server is not None
         request_time = uint64(int(time.time()))
         trusted: bool = self.is_trusted(peer)
         peak_hb: Optional[HeaderBlock] = await self.wallet_state_manager.blockchain.get_peak_block()
@@ -1315,7 +1313,6 @@ class WalletNode:
     async def validate_block_inclusion(
         self, block: HeaderBlock, peer: WSChiaConnection, peer_request_cache: PeerRequestCache
     ) -> bool:
-        assert self._server is not None
         if self.wallet_state_manager.blockchain.contains_height(block.height):
             stored_hash = self.wallet_state_manager.blockchain.height_to_hash(block.height)
             stored_record = self.wallet_state_manager.blockchain.try_block_record(stored_hash)

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -79,8 +79,13 @@ class WalletNodeAPI:
         assert peer.peer_node_id is not None
         name = peer.peer_node_id.hex()
         status = MempoolInclusionStatus(ack.status)
-        if self.wallet_node.wallet_state_manager is None:
-            return None
+        try:
+            wallet_state_manager = self.wallet_node.wallet_state_manager
+        except ValueError as e:
+            if "not assigned" in str(e):
+                return None
+            raise
+
         if status == MempoolInclusionStatus.SUCCESS:
             self.wallet_node.log.info(f"SpendBundle has been received and accepted to mempool by the FullNode. {ack}")
         elif status == MempoolInclusionStatus.PENDING:
@@ -92,9 +97,9 @@ class WalletNodeAPI:
                 return
             self.wallet_node.log.warning(f"SpendBundle has been rejected by the FullNode. {ack}")
         if ack.error is not None:
-            await self.wallet_node.wallet_state_manager.remove_from_queue(ack.txid, name, status, Err[ack.error])
+            await wallet_state_manager.remove_from_queue(ack.txid, name, status, Err[ack.error])
         else:
-            await self.wallet_node.wallet_state_manager.remove_from_queue(ack.txid, name, status, None)
+            await wallet_state_manager.remove_from_queue(ack.txid, name, status, None)
 
     @peer_required
     @api_request
@@ -120,9 +125,12 @@ class WalletNodeAPI:
 
     @api_request
     async def respond_puzzle_solution(self, request: wallet_protocol.RespondPuzzleSolution):
-        if self.wallet_node.wallet_state_manager is None:
-            return None
-        await self.wallet_node.wallet_state_manager.puzzle_solution_received(request)
+        try:
+            await self.wallet_node.wallet_state_manager.puzzle_solution_received(request)
+        except ValueError as e:
+            if "not assigned" in str(e):
+                return None
+            raise
 
     @api_request
     async def reject_puzzle_solution(self, request: wallet_protocol.RejectPuzzleSolution):

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -81,7 +81,7 @@ class WalletNodeAPI:
         status = MempoolInclusionStatus(ack.status)
         try:
             wallet_state_manager = self.wallet_node.wallet_state_manager
-        except ValueError as e:
+        except RuntimeError as e:
             if "not assigned" in str(e):
                 return None
             raise
@@ -127,7 +127,7 @@ class WalletNodeAPI:
     async def respond_puzzle_solution(self, request: wallet_protocol.RespondPuzzleSolution):
         try:
             await self.wallet_node.wallet_state_manager.puzzle_solution_received(request)
-        except ValueError as e:
+        except RuntimeError as e:
             if "not assigned" in str(e):
                 return None
             raise

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -22,7 +22,6 @@ def wallet_height_at_least(wallet_node, h):
 
 
 async def wallet_balance_at_least(wallet_node: WalletNode, balance):
-    assert wallet_node.wallet_state_manager is not None
     b = await wallet_node.wallet_state_manager.get_confirmed_balance_for_wallet(1)
     if b >= balance:
         return True

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -81,7 +81,6 @@ class TemporaryPoolPlot:
 
 
 async def wallet_is_synced(wallet_node: WalletNode, full_node_api) -> bool:
-    assert wallet_node.wallet_state_manager is not None
     wallet_height = await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()
     full_node_height = full_node_api.full_node.blockchain.get_peak_height()
     return wallet_height == full_node_height

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -607,7 +607,6 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     await farm_transaction(full_node_api, wallet_node, spend_bundle)
 
     # Test unacknowledged CAT
-    assert wallet_node.wallet_state_manager is not None
     await wallet_node.wallet_state_manager.interested_store.add_unacknowledged_token(
         asset_id, "Unknown", uint32(10000), bytes32(b"\00" * 32)
     )
@@ -814,8 +813,6 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     for _ in range(3):
         await farm_transaction_block(full_node_api, wallet_1_node)
 
-    assert wallet_2_node.wallet_state_manager is not None
-
     did_wallets = list(
         filter(
             lambda w: (w.type == WalletType.DISTRIBUTED_ID),
@@ -857,8 +854,6 @@ async def test_nft_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     for _ in range(3):
         await farm_transaction_block(full_node_api, wallet_1_node)
 
-    assert wallet_1_node.wallet_state_manager is not None
-
     nft_wallet: NFTWallet = wallet_1_node.wallet_state_manager.wallets[nft_wallet_id]
     # Test with the hex version of nft_id
     nft_id = nft_wallet.get_current_nfts()[0].coin.name().hex()
@@ -875,8 +870,6 @@ async def test_nft_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
 
     for _ in range(3):
         await farm_transaction_block(full_node_api, wallet_1_node)
-
-    assert wallet_2_node.wallet_state_manager is not None
 
     nft_wallet_id_1 = (
         await wallet_2_node.wallet_state_manager.get_all_wallet_info_entries(wallet_type=WalletType.NFT)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -43,7 +43,6 @@ class TestWalletSimulator:
         server_1: ChiaServer = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]
 
-        assert wallet_node.wallet_state_manager is not None
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
         if trusted:
@@ -65,7 +64,6 @@ class TestWalletSimulator:
         )
 
         async def check_tx_are_pool_farm_rewards() -> bool:
-            assert wallet_node.wallet_state_manager is not None
             wsm: WalletStateManager = wallet_node.wallet_state_manager
             all_txs = await wsm.get_all_transactions(1)
             expected_count = (num_blocks + 1) * 2
@@ -105,9 +103,7 @@ class TestWalletSimulator:
         full_node_api = full_nodes[0]
         server_1 = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         wallet_node_2, server_3 = wallets[1]
-        assert wallet_node_2.wallet_state_manager is not None
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
         if trusted:
@@ -169,7 +165,6 @@ class TestWalletSimulator:
         full_node_api = full_nodes[0]
         fn_server = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
         if trusted:
@@ -215,7 +210,6 @@ class TestWalletSimulator:
         full_nodes, wallets = three_sim_two_wallets
 
         wallet_0, wallet_server_0 = wallets[0]
-        assert wallet_0.wallet_state_manager is not None
 
         full_node_api_0 = full_nodes[0]
         full_node_api_1 = full_nodes[1]
@@ -294,9 +288,7 @@ class TestWalletSimulator:
         server_0 = full_node_0.server
 
         wallet_node_0, wallet_0_server = wallets[0]
-        assert wallet_node_0.wallet_state_manager is not None
         wallet_node_1, wallet_1_server = wallets[1]
-        assert wallet_node_1.wallet_state_manager is not None
 
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
@@ -420,9 +412,7 @@ class TestWalletSimulator:
         full_node_1 = full_nodes[0]
 
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         wallet_node_2, server_3 = wallets[1]
-        assert wallet_node_2.wallet_state_manager is not None
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
@@ -497,7 +487,6 @@ class TestWalletSimulator:
         full_node_1 = full_nodes[0]
 
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         wallet_node_2, server_3 = wallets[1]
 
         wallet = wallet_node.wallet_state_manager.main_wallet
@@ -602,9 +591,7 @@ class TestWalletSimulator:
         full_node_1 = full_nodes[0]
 
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         wallet_node_2, server_3 = wallets[1]
-        assert wallet_node_2.wallet_state_manager is not None
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
@@ -698,9 +685,7 @@ class TestWalletSimulator:
         fn_server = full_node_api.full_node.server
 
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         wallet_node_2, server_3 = wallets[1]
-        assert wallet_node_2.wallet_state_manager is not None
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         wallet_2 = wallet_node_2.wallet_state_manager.main_wallet
@@ -805,7 +790,6 @@ class TestWalletSimulator:
         full_node_api = full_nodes[0]
         server_1: ChiaServer = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         if trusted:
             wallet_node.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
         else:
@@ -856,9 +840,7 @@ class TestWalletSimulator:
         server_1 = full_node_api.full_node.server
 
         wallet_node, server_2 = wallets[0]
-        assert wallet_node.wallet_state_manager is not None
         wallet_node_2, server_3 = wallets[1]
-        assert wallet_node_2.wallet_state_manager is not None
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -43,7 +43,6 @@ async def test_wallet_tx_retry(
     wallet_node_1: WalletNode = wallets[0][0]
     wallet_node_1.config["tx_resend_timeout_secs"] = 5
     wallet_server_1 = wallets[0][1]
-    assert wallet_node_1.wallet_state_manager is not None
     wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
     reward_ph = await wallet_1.get_new_puzzlehash()
 
@@ -77,7 +76,6 @@ async def test_wallet_tx_retry(
     await time_out_assert(wait_secs, wallet_is_synced, True, wallet_node_1, full_node_1)
 
     async def check_transaction_in_mempool_or_confirmed(transaction: TransactionRecord) -> bool:
-        assert wallet_node_1.wallet_state_manager is not None
         txn = await wallet_node_1.wallet_state_manager.get_transaction(transaction.name)
         assert txn is not None
         sb = txn.spend_bundle


### PR DESCRIPTION
This makes the attributes accessible via properties that raise if the attribute is `None` instead of making every single call site decide and code how to handle `None`ness.  This is a stop gap until the class and it's creation are refactored to simply have the attributes be known prior to creating the instance.

Draft for:
- [x] Check exception types between raise sites and catch sites