### PR TITLE
Fee and cancel fix

### DIFF
--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -816,7 +816,17 @@ class NFTWallet:
             puzzle_announcements_to_assert=puzzle_announcements_bytes,
         )
 
-        if UncurriedNFT.uncurry(nft_coin.full_puzzle).supports_did:
+        uncurried_nft = UncurriedNFT.uncurry(nft_coin.full_puzzle)
+        if uncurried_nft.supports_did:
+            if new_owner is None:
+                # If no new owner was specified and we're sending this to ourselves, let's not reset the DID
+                derivation_record: Optional[
+                    DerivationRecord
+                ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
+                    payments[0].puzzle_hash
+                )
+                if derivation_record is not None:
+                    new_owner = uncurried_nft.owner_did
             magic_condition = Program.to([-10, new_owner, trade_prices_list, new_did_inner_hash])
             # TODO: This line is a hack, make_solution should allow us to pass extra conditions to it
             w_added_magic_condition = Program.to([[], (1, magic_condition.cons(innersol.at("rfr"))), []])

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1369,14 +1369,13 @@ class WalletStateManager:
 
     async def create_wallet_for_puzzle_info(self, puzzle_driver: PuzzleInfo, name=None, in_transaction=False):
         if AssetType(puzzle_driver.type()) in self.asset_to_wallet_map:
-            async with self.lock:
-                await self.asset_to_wallet_map[AssetType(puzzle_driver.type())].create_from_puzzle_info(
-                    self,
-                    self.main_wallet,
-                    puzzle_driver,
-                    name,
-                    in_transaction,
-                )
+            await self.asset_to_wallet_map[AssetType(puzzle_driver.type())].create_from_puzzle_info(
+                self,
+                self.main_wallet,
+                puzzle_driver,
+                name,
+                in_transaction,
+            )
 
     async def add_new_wallet(self, wallet: Any, wallet_id: int, create_puzzle_hashes=True, in_transaction=False):
         self.wallets[uint32(wallet_id)] = wallet

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -24,6 +24,7 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.outer_puzzles import create_asset_id, match_puzzle
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.trading.offer import Offer
+from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.util.compute_memos import compute_memos
 
 # from chia.wallet.util.wallet_types import WalletType
@@ -908,3 +909,146 @@ async def test_nft_offer_request_nft_for_cat(two_wallet_nodes: Any, trusted: Any
     await time_out_assert(10, wallet_taker.get_confirmed_balance, expected_taker_balance)
     await time_out_assert(10, cat_wallet_maker.get_confirmed_balance, expected_maker_cat_balance)
     await time_out_assert(10, cat_wallet_taker.get_confirmed_balance, expected_taker_cat_balance)
+
+
+@pytest.mark.parametrize(
+    "trusted",
+    [True],
+)
+@pytest.mark.asyncio
+# @pytest.mark.skip
+async def test_nft_offer_sell_cancel(two_wallet_nodes: Any, trusted: Any) -> None:
+    num_blocks = 5
+    full_nodes, wallets = two_wallet_nodes
+    full_node_api: FullNodeSimulator = full_nodes[0]
+    full_node_server = full_node_api.server
+    wallet_node_maker, server_0 = wallets[0]
+    wallet_node_taker, server_1 = wallets[1]
+    wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
+    wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
+
+    ph_maker = await wallet_maker.get_new_puzzlehash()
+    ph_taker = await wallet_taker.get_new_puzzlehash()
+    ph_token = bytes32(token_bytes())
+
+    if trusted:
+        wallet_node_maker.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+        wallet_node_taker.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+    else:
+        wallet_node_maker.config["trusted_peers"] = {}
+        wallet_node_taker.config["trusted_peers"] = {}
+
+    await server_0.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+    await server_1.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+
+    for _ in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_maker))
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_taker))
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
+
+    funds = sum(
+        [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
+    )
+
+    await time_out_assert(10, wallet_maker.get_unconfirmed_balance, funds)
+    await time_out_assert(10, wallet_maker.get_confirmed_balance, funds)
+    await time_out_assert(10, wallet_taker.get_unconfirmed_balance, funds)
+    await time_out_assert(10, wallet_taker.get_confirmed_balance, funds)
+
+    did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+    )
+    spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
+        wallet_maker.id()
+    )
+
+    spend_bundle = spend_bundle_list[0].spend_bundle
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
+
+    for _ in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
+
+    await time_out_assert(15, wallet_maker.get_pending_change_balance, 0)
+    await time_out_assert(10, wallet_maker.get_unconfirmed_balance, funds - 1)
+    await time_out_assert(10, wallet_maker.get_confirmed_balance, funds - 1)
+
+    hex_did_id = did_wallet_maker.get_my_DID()
+    did_id = bytes32.fromhex(hex_did_id)
+    target_puzhash = ph_maker
+    royalty_puzhash = ph_maker
+    royalty_basis_pts = uint16(200)
+
+    nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
+        wallet_node_maker.wallet_state_manager, wallet_maker, name="NFT WALLET DID 1", did_id=did_id
+    )
+    metadata = Program.to(
+        [
+            ("u", ["https://www.chia.net/img/branding/chia-logo.svg"]),
+            ("h", "0xD4584AD463139FA8C0D9F68F4B59F185"),
+        ]
+    )
+
+    sb = await nft_wallet_maker.generate_new_nft(
+        metadata,
+        target_puzhash,
+        royalty_puzhash,
+        royalty_basis_pts,
+        did_id,
+    )
+    assert sb
+    # ensure hints are generated
+    assert compute_memos(sb)
+    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
+
+    await time_out_assert(10, len, 1, nft_wallet_maker.my_nft_coins)
+
+    # TAKER SETUP -  NO DID
+    nft_wallet_taker = await NFTWallet.create_new_nft_wallet(
+        wallet_node_taker.wallet_state_manager, wallet_taker, name="NFT WALLET TAKER"
+    )
+
+    # maker create offer: NFT for xch
+    trade_manager_maker = wallet_maker.wallet_state_manager.trade_manager
+    trade_manager_taker = wallet_taker.wallet_state_manager.trade_manager
+
+    coins_maker = nft_wallet_maker.my_nft_coins
+    assert len(coins_maker) == 1
+    coins_taker = nft_wallet_taker.my_nft_coins
+    assert len(coins_taker) == 0
+
+    nft_to_offer = coins_maker[0]
+    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_to_offer_asset_id: bytes32 = create_asset_id(nft_to_offer_info)  # type: ignore
+    xch_requested = 1000
+    maker_fee = uint64(433)
+
+    offer_did_nft_for_xch = {nft_to_offer_asset_id: -1, wallet_maker.id(): xch_requested}
+
+    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+        offer_did_nft_for_xch, {}, fee=maker_fee
+    )
+
+    FEE = uint64(2000000000000)
+    txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=FEE)
+
+    async def get_trade_and_status(trade_manager, trade) -> TradeStatus:
+        trade_rec = await trade_manager.get_trade_by_id(trade.trade_id)
+        return TradeStatus(trade_rec.status)
+
+    await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
+    for tx in txs:
+        if tx.spend_bundle is not None:
+            breakpoint()
+            await time_out_assert(15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx.spend_bundle.name())
+
+    for i in range(1, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(token_bytes()))
+
+    await time_out_assert(15, get_trade_and_status, TradeStatus.CANCELLED, trade_manager_maker, trade_make)


### PR DESCRIPTION
Previously, when using fees, we were double signing the fee transaction in the NFT's generate signed transaction method.  This PR fixes that.

Additionally, I added a heuristic to generate_signed_transaction: when sending a DID enabled NFT, if the recipient is also us, do _not_ reset the DID to empty.  This makes it so that cancelling an NFT for an offer just works in the trade manager and is also probably useful for things like metadata updates as well.