### PR TITLE
Small fix for DID recovery

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1224,7 +1224,7 @@ class WalletRpcApi:
         wallet: DIDWallet = self.service.wallet_state_manager.wallets[wallet_id]
         if len(request["attest_data"]) < wallet.did_info.num_of_backup_ids_needed:
             return {"success": False, "reason": "insufficient messages"}
-
+        spend_bundle = None
         async with self.service.wallet_state_manager.lock:
             (
                 info_list,
@@ -1243,14 +1243,17 @@ class WalletRpcApi:
                 assert wallet.did_info.temp_puzhash is not None
                 puzhash = wallet.did_info.temp_puzhash
 
-            success = await wallet.recovery_spend(
+            spend_bundle = await wallet.recovery_spend(
                 wallet.did_info.temp_coin,
                 puzhash,
                 info_list,
                 pubkey,
                 message_spend_bundle,
             )
-        return {"success": success}
+        if spend_bundle:
+            return {"success": True, "spend_bundle": spend_bundle}
+        else:
+            return {"success": False}
 
     async def did_get_pubkey(self, request):
         wallet_id = uint32(request["wallet_id"])

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -345,6 +345,7 @@ class DIDWallet:
     # This will be used in the recovery case where we don't have the parent info already
     async def coin_added(self, coin: Coin, _: uint32):
         """Notification from wallet state manager that wallet has been received."""
+
         self.log.info(f"DID wallet has been notified that coin was added: {coin.name()}:{coin}")
         inner_puzzle = await self.inner_puzzle_for_did_puzzle(coin.puzzle_hash)
         if self.did_info.temp_coin is not None:
@@ -428,6 +429,13 @@ class DIDWallet:
         parent_info = None
         assert did_info.origin_coin is not None
         assert did_info.current_inner is not None
+        new_did_inner_puzhash = did_wallet_puzzles.get_inner_puzhash_by_p2(
+            new_puzhash,
+            did_info.backup_ids,
+            did_info.num_of_backup_ids_needed,
+            did_info.origin_coin.name(),
+            did_wallet_puzzles.metadata_to_program(json.loads(self.did_info.metadata)),
+        )
         node = self.wallet_state_manager.wallet_node.get_full_node_peer()
         children = await self.wallet_state_manager.wallet_node.fetch_children(node, did_info.origin_coin.name())
         while True:
@@ -452,7 +460,7 @@ class DIDWallet:
                     self.did_info.parent_info,
                     did_info.current_inner,
                     coin,
-                    new_puzhash,
+                    new_did_inner_puzhash,
                     new_pubkey,
                     False,
                     did_info.metadata,

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1089,14 +1089,12 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
     await time_out_assert(10, wallet_0.get_confirmed_balance, 11999999999898)
     coins_response = await wait_rpc_state_condition(
         5,
-        api_0.nft_get_nfts,
-        [dict(wallet_id=nft_wallet_0_id)],
-        lambda x: x["nft_list"] and len(x["nft_list"][0].metadata_uris) == 1,
+        api_0.nft_get_info,
+        [dict(wallet_id=nft_wallet_0_id, coin_id=nft_coin_id.hex(), latest=True)],
+        lambda x: x["nft_info"],
     )
 
-    coins = coins_response["nft_list"]
-    assert len(coins) == 1
-    coin = coins[0].to_json_dict()
+    coin = coins_response["nft_info"].to_json_dict()
     assert coin["mint_height"] > 0
     uris = coin["data_uris"]
     assert len(uris) == 1


### PR DESCRIPTION
The temp_puzhash need to be set as the DID puzzle hash, not the P2 puzzle hash. Using the wrong puzzle hash to recover will send the DID to a blackhole address.