### PR TITLE
remove unused WalletCoinStore.get_unspent_coins_at_height

### DIFF
--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -206,9 +206,8 @@ class WalletCoinStore:
         else:
             all_unspent = set()
             for name, coin_record in self.coin_record_cache.items():
-                if (
-                    coin_record.spent is False
-                    or coin_record.spent_block_height > height >= coin_record.confirmed_block_height
+                if coin_record.confirmed_block_height <= height and (
+                    coin_record.spent is False or coin_record.spent_block_height > height
                 ):
                     all_unspent.add(coin_record)
             return all_unspent

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -191,27 +191,6 @@ class WalletCoinStore:
 
         return None
 
-    async def get_unspent_coins_at_height(self, height: Optional[uint32] = None) -> Set[WalletCoinRecord]:
-        """
-        Returns set of CoinRecords that have not been spent yet. If a height is specified,
-        We can also return coins that were unspent at this height (but maybe spent later).
-        Finally, the coins must be confirmed at the height or less.
-        """
-        if height is None:
-            all_unspent = set()
-            for name, coin_record in self.coin_record_cache.items():
-                if coin_record.spent is False:
-                    all_unspent.add(coin_record)
-            return all_unspent
-        else:
-            all_unspent = set()
-            for name, coin_record in self.coin_record_cache.items():
-                if coin_record.confirmed_block_height <= height and (
-                    coin_record.spent is False or coin_record.spent_block_height > height
-                ):
-                    all_unspent.add(coin_record)
-            return all_unspent
-
     async def get_unspent_coins_for_wallet(self, wallet_id: int) -> Set[WalletCoinRecord]:
         """Returns set of CoinRecords that have not been spent yet for a wallet."""
         if wallet_id in self.unspent_coin_wallet_cache:


### PR DESCRIPTION
a coin where `spent=0` is not necessarily "unspent at height" if `confirmed_block_height` > height. i.e. if it didn't exist yet at the specified height, it should not be included in the returned set.

The function does not appear to be used anywhere, so I removed it.