### PR TITLE
Go to untrusted peers for coin state if trusted isn't synced

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1450,13 +1450,14 @@ class WalletNode:
         if len(all_nodes.keys()) == 0:
             raise ValueError("Not connected to the full node")
         # Use supplied if provided, prioritize trusted otherwise
+        synced_peers = [node for node in all_nodes.values() if node.peer_node_id in self.synced_peers]
         if peer is None:
-            for node in list(all_nodes.values()):
+            for node in synced_peers:
                 if self.is_trusted(node):
                     peer = node
                     break
             if peer is None:
-                peer = list(all_nodes.values())[0]
+                peer = synced_peers[0]
 
         assert peer is not None
         msg = wallet_protocol.RegisterForCoinUpdates(coin_names, uint32(0))


### PR DESCRIPTION
Currently, if you have a trusted node, but it is not synced, then `get_coin_state` still tries to go to the local node rather than its synced untrusted peers.  This small fix should change that behavior.