### PR TITLE
workflow library

### DIFF
--- a/.github/workflows/library-data.yml
+++ b/.github/workflows/library-data.yml
@@ -46,6 +46,24 @@ python:
     cibw-build: 'cp310-*'
     matrix: '3.10'
 
+exclude: &exclude
+  - os:
+      matrix: windows
+    arch:
+      matrix: arm
+  - os:
+      matrix: macos
+    python:
+      matrix: '3.7'
+    arch:
+      matrix: arm
+  - os:
+      matrix: macos
+    python:
+      matrix: '3.8'
+    arch:
+      matrix: arm
+
 matrix:
   os:
     - *os_macos
@@ -59,20 +77,4 @@ matrix:
   arch:
     - *arch_arm
     - *arch_intel
-  exclude:
-    - os:
-        matrix: windows
-      arch:
-        matrix: arm
-    - os:
-        matrix: macos
-      python:
-        matrix: '3.7'
-      arch:
-        matrix: arm
-    - os:
-        matrix: macos
-      python:
-        matrix: '3.8'
-      arch:
-        matrix: arm
+  exclude: *exclude

--- a/.github/workflows/library-data.yml
+++ b/.github/workflows/library-data.yml
@@ -39,6 +39,7 @@ arch:
 
 python:
   c3_7: &python_3_7
+    name: '3.7'
     matrix: '3.7'
     major-dot-minor: '3.7'
     action: '3.7'
@@ -46,6 +47,7 @@ python:
     install_sh: '3.7'
     cibw-build: 'cp37-*'
   c3_8: &python_3_8
+    name: '3.8'
     matrix: '3.8'
     major-dot-minor: '3.8'
     action: '3.8'
@@ -53,6 +55,7 @@ python:
     install_sh: '3.8'
     cibw-build: 'cp38-*'
   c3_9: &python_3_9
+    name: '3.9'
     matrix: '3.9'
     major-dot-minor: '3.9'
     action: '3.9'
@@ -60,6 +63,7 @@ python:
     install_sh: '3.9'
     cibw-build: 'cp39-*'
   c3_10: &python_3_10
+    name: '3.10'
     matrix: '3.10'
     major-dot-minor: '3.10'
     action: '3.10'

--- a/.github/workflows/library-data.yml
+++ b/.github/workflows/library-data.yml
@@ -1,0 +1,84 @@
+os:
+  macos: &os_macos
+    name: macOS
+    matrix: macos
+    runs-on:
+      arm: [macOS, ARM64]
+      intel: [macos-latest]
+    cibw-archs-macos:
+      arm: arm64
+      intel: x86_64
+  linux: &os_linux
+    name: Ubuntu
+    matrix: ubuntu
+    runs-on:
+      arm: [ Linux, ARM64 ]
+      intel: [ ubuntu-latest ]
+  windows: &os_windows
+    name: Windows
+    matrix: windows
+    runs-on:
+      intel: [windows-latest]
+
+matrix:
+  os:
+    - *os_macos
+    - *os_linux
+    - *os_windows
+  python:
+    - major-dot-minor: '3.7'
+      cibw-build: 'cp37-*'
+      matrix: '3.7'
+    - major-dot-minor: '3.8'
+      cibw-build: 'cp38-*'
+      matrix: '3.8'
+    - major-dot-minor: '3.9'
+      cibw-build: 'cp39-*'
+      matrix: '3.9'
+    - major-dot-minor: '3.10'
+      cibw-build: 'cp310-*'
+      matrix: '3.10'
+  arch:
+    - name: ARM
+      matrix: arm
+    - name: Intel
+      matrix: intel
+  exclude:
+    # Only partial entries are required here by GitHub Actions so generally I
+    # only specify the `matrix:` entry.  The super linter complains so for now
+    # all entries are included to avoid that.  Reported at
+    # https://github.com/github/super-linter/issues/3016
+    - os:
+        name: Windows
+        matrix: windows
+        runs-on:
+          intel: [windows-latest]
+      arch:
+        name: ARM
+        matrix: arm
+    - os:
+        name: macOS
+        matrix: macos
+        runs-on:
+          arm: [macOS, ARM64]
+          intel: [macos-latest]
+      python:
+        major-dot-minor: '3.7'
+        cibw-build: 'cp37-*'
+        matrix: '3.7'
+      arch:
+        name: ARM
+        matrix: arm
+    - os:
+        name: macOS
+        matrix: macos
+        runs-on:
+          arm: [macOS, ARM64]
+          intel: [macos-latest]
+      python:
+        major-dot-minor: '3.8'
+        cibw-build: 'cp38-*'
+        matrix: '3.8'
+      arch:
+        name: ARM
+        matrix: arm

--- a/.github/workflows/library-data.yml
+++ b/.github/workflows/library-data.yml
@@ -5,6 +5,9 @@ os:
     runs-on:
       arm: [macOS, ARM64]
       intel: [macos-latest]
+    emoji: 🍎
+    file_name: macos
+    concurrency_name: macos
     cibw-archs-macos:
       arm: arm64
       intel: x86_64
@@ -14,11 +17,17 @@ os:
     runs-on:
       arm: [ Linux, ARM64 ]
       intel: [ ubuntu-latest ]
+    emoji: 🐧
+    file_name: ubuntu
+    concurrency_name: ubuntu
   windows: &os_windows
     name: Windows
     matrix: windows
     runs-on:
       intel: [windows-latest]
+    emoji: 🪟
+    file_name: windows
+    concurrency_name: windows
 
 arch:
   arm: &arch_arm
@@ -30,51 +39,81 @@ arch:
 
 python:
   c3_7: &python_3_7
-    major-dot-minor: '3.7'
-    cibw-build: 'cp37-*'
     matrix: '3.7'
+    major-dot-minor: '3.7'
+    action: '3.7'
+    apt: '3.7'
+    install_sh: '3.7'
+    cibw-build: 'cp37-*'
   c3_8: &python_3_8
-    major-dot-minor: '3.8'
-    cibw-build: 'cp38-*'
     matrix: '3.8'
+    major-dot-minor: '3.8'
+    action: '3.8'
+    apt: '3.8'
+    install_sh: '3.8'
+    cibw-build: 'cp38-*'
   c3_9: &python_3_9
-    major-dot-minor: '3.9'
-    cibw-build: 'cp39-*'
     matrix: '3.9'
+    major-dot-minor: '3.9'
+    action: '3.9'
+    apt: '3.9'
+    install_sh: '3.9'
+    cibw-build: 'cp39-*'
   c3_10: &python_3_10
-    major-dot-minor: '3.10'
-    cibw-build: 'cp310-*'
     matrix: '3.10'
+    major-dot-minor: '3.10'
+    action: '3.10'
+    apt: '3.10'
+    install_sh: '3.10'
+    cibw-build: 'cp310-*'
 
-exclude: &exclude
-  - os:
+exclude:
+  windows-arm: &exclude_windows-arm
+    os:
       matrix: windows
     arch:
       matrix: arm
-  - os:
+  macos-3-7: &exclude_macos-3-7
+    os:
       matrix: macos
     python:
       matrix: '3.7'
-    arch:
-      matrix: arm
-  - os:
+  macos-3-8: &exclude_macos-3-8
+    os:
       matrix: macos
     python:
       matrix: '3.8'
-    arch:
-      matrix: arm
 
 matrix:
-  os:
-    - *os_macos
-    - *os_linux
-    - *os_windows
-  python:
-    - *python_3_7
-    - *python_3_8
-    - *python_3_9
-    - *python_3_10
-  arch:
-    - *arch_arm
-    - *arch_intel
-  exclude: *exclude
+  all:
+    os:
+      - *os_macos
+      - *os_linux
+      - *os_windows
+    python:
+      - *python_3_7
+      - *python_3_8
+      - *python_3_9
+      - *python_3_10
+    arch:
+      - *arch_arm
+      - *arch_intel
+    exclude:
+      - *exclude_windows-arm
+      - *exclude_macos-3-7
+      - *exclude_macos-3-8
+  intel:
+    os:
+      - *os_macos
+      - *os_linux
+      - *os_windows
+    python:
+      - *python_3_7
+      - *python_3_8
+      - *python_3_9
+      - *python_3_10
+    arch:
+      - *arch_intel
+    exclude:
+      - *exclude_macos-3-7
+      - *exclude_macos-3-8

--- a/.github/workflows/library-data.yml
+++ b/.github/workflows/library-data.yml
@@ -60,41 +60,19 @@ matrix:
     - *arch_arm
     - *arch_intel
   exclude:
-    # Only partial entries are required here by GitHub Actions so generally I
-    # only specify the `matrix:` entry.  The super linter complains so for now
-    # all entries are included to avoid that.  Reported at
-    # https://github.com/github/super-linter/issues/3016
     - os:
-        name: Windows
         matrix: windows
-        runs-on:
-          intel: [windows-latest]
       arch:
-        name: ARM
         matrix: arm
     - os:
-        name: macOS
         matrix: macos
-        runs-on:
-          arm: [macOS, ARM64]
-          intel: [macos-latest]
       python:
-        major-dot-minor: '3.7'
-        cibw-build: 'cp37-*'
         matrix: '3.7'
       arch:
-        name: ARM
         matrix: arm
     - os:
-        name: macOS
         matrix: macos
-        runs-on:
-          arm: [macOS, ARM64]
-          intel: [macos-latest]
       python:
-        major-dot-minor: '3.8'
-        cibw-build: 'cp38-*'
         matrix: '3.8'
       arch:
-        name: ARM
         matrix: arm

--- a/.github/workflows/library-data.yml
+++ b/.github/workflows/library-data.yml
@@ -20,29 +20,45 @@ os:
     runs-on:
       intel: [windows-latest]
 
+arch:
+  arm: &arch_arm
+    name: ARM
+    matrix: arm
+  intel: &arch_intel
+    name: Intel
+    matrix: intel
+
+python:
+  c3_7: &python_3_7
+    major-dot-minor: '3.7'
+    cibw-build: 'cp37-*'
+    matrix: '3.7'
+  c3_8: &python_3_8
+    major-dot-minor: '3.8'
+    cibw-build: 'cp38-*'
+    matrix: '3.8'
+  c3_9: &python_3_9
+    major-dot-minor: '3.9'
+    cibw-build: 'cp39-*'
+    matrix: '3.9'
+  c3_10: &python_3_10
+    major-dot-minor: '3.10'
+    cibw-build: 'cp310-*'
+    matrix: '3.10'
+
 matrix:
   os:
     - *os_macos
     - *os_linux
     - *os_windows
   python:
-    - major-dot-minor: '3.7'
-      cibw-build: 'cp37-*'
-      matrix: '3.7'
-    - major-dot-minor: '3.8'
-      cibw-build: 'cp38-*'
-      matrix: '3.8'
-    - major-dot-minor: '3.9'
-      cibw-build: 'cp39-*'
-      matrix: '3.9'
-    - major-dot-minor: '3.10'
-      cibw-build: 'cp310-*'
-      matrix: '3.10'
+    - *python_3_7
+    - *python_3_8
+    - *python_3_9
+    - *python_3_10
   arch:
-    - name: ARM
-      matrix: arm
-    - name: Intel
-      matrix: intel
+    - *arch_arm
+    - *arch_intel
   exclude:
     # Only partial entries are required here by GitHub Actions so generally I
     # only specify the `matrix:` entry.  The super linter complains so for now

--- a/.github/workflows/library.py
+++ b/.github/workflows/library.py
@@ -1,0 +1,18 @@
+import json
+import pathlib
+import sys
+
+import yaml
+
+here = pathlib.Path(__file__).parent
+
+
+def main() -> int:
+    with here.joinpath("library-data.yml").open() as file:
+        loaded = yaml.safe_load(file)
+    print(json.dumps(loaded, indent=4))
+
+    return 0
+
+
+sys.exit(main())

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -1,9 +1,4 @@
-name: test
-
-# This reusable workflow structure was chosen for the sole purpose of working around
-# the 256 job per matrix limit.  The initial total test job count was 290.  This
-# approach shifts the 256 limit to be per OS rather than overall.  A simpler single
-# regular workflow with matrixing against the OS would be preferred.
+name: library
 
 on:
   workflow_call:

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -1,0 +1,37 @@
+name: test
+
+# This reusable workflow structure was chosen for the sole purpose of working around
+# the 256 job per matrix limit.  The initial total test job count was 290.  This
+# approach shifts the 256 limit to be per OS rather than overall.  A simpler single
+# regular workflow with matrixing against the OS would be preferred.
+
+on:
+  workflow_call:
+
+jobs:
+  configure:
+    name: Set library output
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Python environment
+        uses: chia-network/actions/setup-python@main
+        with:
+          python-version: '3.9'
+
+      - name: Install PyYAML
+        run: |
+          pip install pyyaml
+
+      - name: Generate matrix configuration
+        id: library
+        run: |
+          python lib.py > library.json
+          cat library.json
+          echo ::set-output name=library::$(cat library.json)
+
+    outputs:
+      library: ${{ steps.library.outputs.library }}

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Generate matrix configuration
         id: library
         run: |
-          python library.py > library.json
+          python .github/workflows/library.py > library.json
           cat library.json
           echo ::set-output name=library::$(cat library.json)
 

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Generate matrix configuration
         id: library
         run: |
-          python lib.py > library.json
+          python library.py > library.json
           cat library.json
           echo ::set-output name=library::$(cat library.json)
 

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -7,9 +7,13 @@ name: test
 
 on:
   workflow_call:
+    outputs:
+      library:
+        description: "The library in JSON form."
+        value: ${{ jobs.library.outputs.library }}
 
 jobs:
-  configure:
+  library:
     name: Set library output
     runs-on: ubuntu-latest
 
@@ -26,7 +30,7 @@ jobs:
         run: |
           pip install pyyaml
 
-      - name: Generate matrix configuration
+      - name: Generate library output
         id: library
         run: |
           python .github/workflows/library.py > library.json

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.library.outputs.library)["matrix"] }}
+      matrix: ${{ fromJson(needs.library.outputs.library).matrix }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,9 +18,9 @@ jobs:
     uses: ./.github/workflows/library.yml
 
   pre-commit:
-    name: pre-commit
+    name: pre-commit ${{ matrix.os.name }}
     needs: library
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runs-on }}
     strategy:
       fail_fast: false
       matrix: ${{ fromJson(needs.library.outputs.library)["matrix"] }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
     needs: library
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
-      fail_fast: false
+      fail-fast: false
       matrix: ${{ fromJson(needs.library.outputs.library)["matrix"] }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,7 +20,7 @@ jobs:
   pre-commit:
     name: pre-commit ${{ matrix.os.name }}
     needs: library
-    runs-on: ${{ matrix.os.runs-on }}
+    runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.library.outputs.library).matrix }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,7 +23,15 @@ jobs:
     runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.library.outputs.library).matrix }}
+      matrix:
+        os:
+        - ${{ fromJson(needs.library.outputs.library).os.macos }}
+        - ${{ fromJson(needs.library.outputs.library).os.linux }}
+        - ${{ fromJson(needs.library.outputs.library).os.windows }}
+        python:
+        - ${{ fromJson(needs.library.outputs.library).python.c3_9 }}
+        arch:
+        - ${{ fromJson(needs.library.outputs.library).arch.intel }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,9 +14,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  library:
+    uses: ./.github/workflows/library.yml
+
   pre-commit:
     name: pre-commit
+    needs: library
     runs-on: ubuntu-latest
+    strategy:
+      fail_fast: false
+      matrix: ${{ fromJson(needs.library.outputs.library)["matrix"] }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        configuration: ${{ fromJson(inputs.configuration) }}
+        configuration: ${{ fromJson(needs.configure.outputs.configuration) }}
         os:
           - emoji: ${{ inputs.emoji }}
             matrix: ${{ inputs.matrix }}

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -8,25 +8,31 @@ name: test
 on:
   workflow_call:
     inputs:
-      emoji:
+      os:
         required: true
         type: string
-      matrix:
-        required: true
-        type: string
-      name:
-        required: true
-        type: string
-      file_name:
-        required: true
-        type: string
-      concurrency_name:
-        required: true
-        type: string
-      configuration:
-        required: true
-        type: string
-      runs-on:
+#      emoji:
+#        required: true
+#        type: string
+#      matrix:
+#        required: true
+#        type: string
+#      name:
+#        required: true
+#        type: string
+#      file_name:
+#        required: true
+#        type: string
+#      concurrency_name:
+#        required: true
+#        type: string
+#      configuration:
+#        required: true
+#        type: string
+#      runs-on:
+#        required: true
+#        type: string
+      library:
         required: true
         type: string
 
@@ -45,46 +51,12 @@ jobs:
       fail-fast: false
       matrix:
         configuration: ${{ fromJson(inputs.configuration) }}
-        os:
-          - emoji: ${{ inputs.emoji }}
-            matrix: ${{ inputs.matrix }}
-            name: ${{ inputs.name }}
-            file_name: ${{ inputs.file_name }}
-            runs-on: ${{ inputs.runs-on }}
-        python:
-          - name: '3.7'
-            file_name: '3.7'
-            action: '3.7'
-            apt: '3.7'
-            install_sh: '3.7'
-            matrix: '3.7'
-          - name: '3.8'
-            file_name: '3.8'
-            action: '3.8'
-            apt: '3.8'
-            install_sh: '3.8'
-            matrix: '3.8'
-          - name: '3.9'
-            file_name: '3.9'
-            action: '3.9'
-            apt: '3.9'
-            install_sh: '3.9'
-            matrix: '3.9'
-          - name: '3.10'
-            file_name: '3.10'
-            action: '3.10'
-            apt: '3.10'
-            install_sh: '3.10'
-            matrix: '3.10'
+        os: ${{ fromJSON(inputs.os) }}
+        python: ${{ fromJSON(inputs.library).matrix.intel.python
+        arch: ${{ fromJSON(inputs.library).matrix.intel.arch
         exclude:
-          - os:
-              matrix: macos
-            python:
-              matrix: '3.7'
-          - os:
-              matrix: macos
-            python:
-              matrix: '3.8'
+          - ${{ fromJSON(inputs.library).matrix.intel.exclude[0]
+          - ${{ fromJSON(inputs.library).matrix.intel.exclude[1]
           - os:
               matrix: windows
             configuration:

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -11,27 +11,6 @@ on:
       os:
         required: true
         type: string
-#      emoji:
-#        required: true
-#        type: string
-#      matrix:
-#        required: true
-#        type: string
-#      name:
-#        required: true
-#        type: string
-#      file_name:
-#        required: true
-#        type: string
-#      concurrency_name:
-#        required: true
-#        type: string
-#      configuration:
-#        required: true
-#        type: string
-#      runs-on:
-#        required: true
-#        type: string
       library:
         required: true
         type: string

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   test:
     name: ${{ matrix.os.emoji }} ${{ matrix.configuration.name }} - ${{ matrix.python.name }}
-    runs-on: ${{ matrix.os.runs-on }}
+    runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}
     timeout-minutes: ${{ matrix.configuration.job_timeout }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -11,6 +11,9 @@ on:
       os:
         required: true
         type: string
+      configuration:
+        required: true
+        type: string
       library:
         required: true
         type: string

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -33,7 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         configuration: ${{ fromJson(inputs.configuration) }}
-        os: ${{ fromJSON(inputs.os) }}
+        os:
+          - ${{ fromJSON(inputs.os) }}
         python: ${{ fromJSON(inputs.library).matrix.intel.python }}
         arch: ${{ fromJSON(inputs.library).matrix.intel.arch }}
         exclude:

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -31,11 +31,11 @@ jobs:
       matrix:
         configuration: ${{ fromJson(inputs.configuration) }}
         os: ${{ fromJSON(inputs.os) }}
-        python: ${{ fromJSON(inputs.library).matrix.intel.python
-        arch: ${{ fromJSON(inputs.library).matrix.intel.arch
+        python: ${{ fromJSON(inputs.library).matrix.intel.python }}
+        arch: ${{ fromJSON(inputs.library).matrix.intel.arch }}
         exclude:
-          - ${{ fromJSON(inputs.library).matrix.intel.exclude[0]
-          - ${{ fromJSON(inputs.library).matrix.intel.exclude[1]
+          - ${{ fromJSON(inputs.library).matrix.intel.exclude[0] }}
+          - ${{ fromJSON(inputs.library).matrix.intel.exclude[1] }}
           - os:
               matrix: windows
             configuration:

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   # SHA is added to the end if on `main` to let all main workflows run
-  group: ${{ github.ref }}-${{ github.workflow }}-${{ inputs.concurrency_name }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ fromJSON(inputs.os).concurrency_name }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        configuration: ${{ fromJson(needs.configure.outputs.configuration) }}
+        configuration: ${{ fromJson(inputs.configuration) }}
         os:
           - emoji: ${{ inputs.emoji }}
             matrix: ${{ inputs.matrix }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - configure
       - library
     with:
-      os: ${{ fromJSON(needs.library.outputs.library).os.macos }}
+      os: ${{ toJSON(fromJSON(needs.library.outputs.library).os.macos) }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}
   ubuntu:
@@ -60,7 +60,7 @@ jobs:
       - configure
       - library
     with:
-      os: ${{ fromJSON(needs.library.outputs.library).os.linux }}
+      os: ${{ toJSON(fromJSON(needs.library.outputs.library).os.linux) }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}
   windows:
@@ -69,6 +69,6 @@ jobs:
       - configure
       - library
     with:
-      os: ${{ fromJSON(needs.library.outputs.library).os.windows }}
+      os: ${{ toJSON(fromJSON(needs.library.outputs.library).os.windows) }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,20 +46,20 @@ jobs:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
-      os: ${{ needs.library.outputs.library }}.os.macos
+      os: ${{ fromJSON(needs.library.outputs.library).os.macos }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}
   ubuntu:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
-      os: ${{ needs.library.outputs.library }}.os.linux
+      os: ${{ fromJSON(needs.library.outputs.library).os.linux }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}
   windows:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
-      os: ${{ needs.library.outputs.library }}.os.windows
+      os: ${{ fromJSON(needs.library.outputs.library).os.windows }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,32 +46,17 @@ jobs:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
-      emoji: 🍎
-      matrix: macos
-      name: macOS
-      file_name: macos
-      concurrency_name: macos
+      os: ${{ needs.library.outputs.library }}.os.macos
       configuration: ${{ needs.configure.outputs.configuration }}
-      runs-on: macos-latest
   ubuntu:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
-      emoji: 🐧
-      matrix: ubuntu
-      name: Ubuntu
-      file_name: ubuntu
-      concurrency_name: ubuntu
+      os: ${{ needs.library.outputs.library }}.os.linux
       configuration: ${{ needs.configure.outputs.configuration }}
-      runs-on: ubuntu-latest
   windows:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
-      emoji: 🪟
-      matrix: windows
-      name: Windows
-      file_name: windows
-      concurrency_name: windows
-      configuration: ${{ needs.configure.outputs.configuration }}
+      os: ${{ needs.library.outputs.library }}.os.windows
       runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,21 +47,27 @@ jobs:
 
   macos:
     uses: ./.github/workflows/test-single.yml
-    needs: configure
+    needs:
+      - configure
+      - library
     with:
       os: ${{ fromJSON(needs.library.outputs.library).os.macos }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}
   ubuntu:
     uses: ./.github/workflows/test-single.yml
-    needs: configure
+    needs:
+      - configure
+      - library
     with:
       os: ${{ fromJSON(needs.library.outputs.library).os.linux }}
       configuration: ${{ needs.configure.outputs.configuration }}
       library: ${{ needs.library.outputs.library }}
   windows:
     uses: ./.github/workflows/test-single.yml
-    needs: configure
+    needs:
+      - configure
+      - library
     with:
       os: ${{ fromJSON(needs.library.outputs.library).os.windows }}
       configuration: ${{ needs.configure.outputs.configuration }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,15 +48,18 @@ jobs:
     with:
       os: ${{ needs.library.outputs.library }}.os.macos
       configuration: ${{ needs.configure.outputs.configuration }}
+      library: ${{ needs.library.outputs.library }}
   ubuntu:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
       os: ${{ needs.library.outputs.library }}.os.linux
       configuration: ${{ needs.configure.outputs.configuration }}
+      library: ${{ needs.library.outputs.library }}
   windows:
     uses: ./.github/workflows/test-single.yml
     needs: configure
     with:
       os: ${{ needs.library.outputs.library }}.os.windows
-      runs-on: windows-latest
+      configuration: ${{ needs.configure.outputs.configuration }}
+      library: ${{ needs.library.outputs.library }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  library:
+    uses: ./.github/workflows/library.yml
+
   configure:
     name: Configure matrix
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is an exploration of a...  a not beautiful way to share workflow definition pieces among several workflows without having to copy paste all of the common bits nor keep them up to date.  Actions are great, but they can't be used to define your matrices as far as I know.  The basic design is to store the common bits in a non-workflow YAML file.  This file can leverage pyyaml supported features like anchors etc to further enable reuse without repetition.  The library data file is loaded in a pre-run workflow whose sole purpose is to provide the data as a workflow output serialized to JSON.  This allows other jobs and matrices to depend on this pre-job to get copies of the data, parse it from the JSON, and use pieces as needed.  Note that the library reusable workflow could exist in the actions repository for example to be shared not only among workflows in the blockchain repository but among all of our repositories.

Draft for:
- [ ] Being more than just an exploration
- [ ] Presumably the library would be in another repository such as the actions repository
- [ ] Consideration of how to version this so updates are easily deployed without just breaking everything that uses it regularly