### PR TITLE
Fix sql error when only config file is deleted

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -510,9 +510,9 @@ def chia_init(
         db_path_replaced = config["database_path"].replace("CHALLENGE", config["selected_network"])
         db_path = path_from_root(root_path, db_path_replaced)
         db_path.parent.mkdir(parents=True, exist_ok=True)
-
-        with sqlite3.connect(db_path) as connection:
-            set_db_version(connection, 2)
+        if not db_path.exists():
+            with sqlite3.connect(db_path) as connection:
+                set_db_version(connection, 2)
 
     print("")
     print("To see your keys, run 'chia keys show --show-mnemonic-seed'")

--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -510,9 +510,13 @@ def chia_init(
         db_path_replaced = config["database_path"].replace("CHALLENGE", config["selected_network"])
         db_path = path_from_root(root_path, db_path_replaced)
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        if not db_path.exists():
+        try:
+            # create new v2 db file
             with sqlite3.connect(db_path) as connection:
                 set_db_version(connection, 2)
+        except sqlite3.OperationalError:
+            # db already exists, so we're good
+            pass
 
     print("")
     print("To see your keys, run 'chia keys show --show-mnemonic-seed'")


### PR DESCRIPTION
If the config file is deleted and chia init is then ran, it will throw an error because chia init tries to write the db version to an existing database.