### PR TITLE
cmds: Can't shadow `info` which is `NFTInfo` in the first place

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -347,13 +347,13 @@ async def make_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
             print("--------------")
             print()
             print("OFFERING:")
-            for name, info in printable_dict.items():
-                amount, unit, multiplier = info
+            for name, data in printable_dict.items():
+                amount, unit, multiplier = data
                 if multiplier < 0:
                     print(f"  - {amount} {name} ({int(Decimal(amount) * unit)} mojos)")
             print("REQUESTING:")
-            for name, info in printable_dict.items():
-                amount, unit, multiplier = info
+            for name, data in printable_dict.items():
+                amount, unit, multiplier = data
                 if multiplier > 0:
                     print(f"  - {amount} {name} ({int(Decimal(amount) * unit)} mojos)")
 


### PR DESCRIPTION
`mypy` complains [here](https://github.com/xdustinface/chia-blockchain/blob/7ae530a43088e58c234e1d8757020a1b7f627da0/chia/cmds/wallet_funcs.py#L300) if `NFTInfo.from_json_dict` gets hinted properly like in #11763.