### PR TITLE
cmds: `NFTInfo.royalty_puzzle_hash` is `Optional` but not `None` here

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -313,6 +313,7 @@ async def make_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
                                 },
                             }
                             if info.supports_did:
+                                assert info.royalty_puzzle_hash is not None
                                 driver_dict[id]["also"]["also"] = {
                                     "type": "ownership",
                                     "owner": "()",


### PR DESCRIPTION
`mypy` complains [here](https://github.com/xdustinface/chia-blockchain/blob/dc805f1e6314a34201ac9270c65660373b86a5bc/chia/cmds/wallet_funcs.py#L323) if `NFTInfo.from_json_dict` gets hinted properly like in #11763.

It should be fine to just assert this here, see https://github.com/Chia-Network/chia-blockchain/pull/12004#discussion_r907604272 