### PR TITLE
Wallet coin store cache

### DIFF
--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -130,22 +130,20 @@ class WalletCoinStore:
 
     async def get_coin_record(self, coin_name: bytes32) -> Optional[WalletCoinRecord]:
         """Returns CoinRecord with specified coin id."""
-        cursor = await self.db_connection.execute("SELECT * from coin_record WHERE coin_name=?", (coin_name.hex(),))
-        row = await cursor.fetchone()
-        await cursor.close()
+        rows = list(
+            await self.db_connection.execute_fetchall("SELECT * from coin_record WHERE coin_name=?", (coin_name.hex(),))
+        )
 
-        if row is None:
+        if len(rows) == 0:
             return None
-        return self.coin_record_from_row(row)
+        return self.coin_record_from_row(rows[0])
 
     async def get_first_coin_height(self) -> Optional[uint32]:
         """Returns height of first confirmed coin"""
-        cursor = await self.db_connection.execute("SELECT MIN(confirmed_height) FROM coin_record;")
-        row = await cursor.fetchone()
-        await cursor.close()
+        rows = list(await self.db_connection.execute_fetchall("SELECT MIN(confirmed_height) FROM coin_record"))
 
-        if row is not None and row[0] is not None:
-            return uint32(row[0])
+        if len(rows) != 0 and rows[0][0] is not None:
+            return uint32(rows[0][0])
 
         return None
 

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Set
+from typing import List, Optional, Set
 
 import aiosqlite
 import sqlite3
@@ -17,10 +17,6 @@ class WalletCoinStore:
     """
 
     db_connection: aiosqlite.Connection
-    # coin_record_cache keeps ALL coin records in memory. [record_name: record]
-    coin_record_cache: Dict[bytes32, WalletCoinRecord]
-    # unspent_coin_wallet_cache keeps ALL unspent coin records for wallet in memory [wallet_id: [record_name: record]]
-    unspent_coin_wallet_cache: Dict[int, Dict[bytes32, WalletCoinRecord]]
     db_wrapper: DBWrapper
 
     @classmethod
@@ -61,9 +57,6 @@ class WalletCoinStore:
         await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
 
         await self.db_connection.commit()
-        self.coin_record_cache = {}
-        self.unspent_coin_wallet_cache = {}
-        await self.rebuild_wallet_cache()
         return self
 
     async def _clear_database(self):
@@ -71,49 +64,23 @@ class WalletCoinStore:
         await cursor.close()
         await self.db_connection.commit()
 
-    async def rebuild_wallet_cache(self):
-        # First update all coins that were reorged, then re-add coin_records
-        all_coins = await self.get_all_coins()
-        self.unspent_coin_wallet_cache = {}
-        self.coin_record_cache = {}
-        for coin_record in all_coins:
-            name = coin_record.name()
-            self.coin_record_cache[name] = coin_record
-            if coin_record.spent is False:
-                if coin_record.wallet_id not in self.unspent_coin_wallet_cache:
-                    self.unspent_coin_wallet_cache[coin_record.wallet_id] = {}
-                self.unspent_coin_wallet_cache[coin_record.wallet_id][name] = coin_record
-
     async def get_multiple_coin_records(self, coin_names: List[bytes32]) -> List[WalletCoinRecord]:
         """Return WalletCoinRecord(s) that have a coin name in the specified list"""
-        if set(coin_names).issubset(set(self.coin_record_cache.keys())):
-            return list(filter(lambda cr: cr.coin.name() in coin_names, self.coin_record_cache.values()))
-        else:
-            as_hexes = [cn.hex() for cn in coin_names]
-            cursor = await self.db_connection.execute(
-                f'SELECT * from coin_record WHERE coin_name in ({"?," * (len(as_hexes) - 1)}?)', tuple(as_hexes)
-            )
-            rows = await cursor.fetchall()
-            await cursor.close()
+        if len(coin_names) == 0:
+            return []
 
-            return [self.coin_record_from_row(row) for row in rows]
+        as_hexes = [cn.hex() for cn in coin_names]
+        rows = await self.db_connection.execute_fetchall(
+            f'SELECT * from coin_record WHERE coin_name in ({"?," * (len(as_hexes) - 1)}?)', tuple(as_hexes)
+        )
+
+        return [self.coin_record_from_row(row) for row in rows]
 
     # Store CoinRecord in DB and ram cache
     async def add_coin_record(self, record: WalletCoinRecord, name: Optional[bytes32] = None) -> None:
-        # update wallet cache
         if name is None:
             name = record.name()
-        self.coin_record_cache[name] = record
-        if record.wallet_id in self.unspent_coin_wallet_cache:
-            if record.spent and name in self.unspent_coin_wallet_cache[record.wallet_id]:
-                self.unspent_coin_wallet_cache[record.wallet_id].pop(name)
-            if not record.spent:
-                self.unspent_coin_wallet_cache[record.wallet_id][name] = record
-        else:
-            if not record.spent:
-                self.unspent_coin_wallet_cache[record.wallet_id] = {}
-                self.unspent_coin_wallet_cache[record.wallet_id][name] = record
-
+        assert record.spent == (record.spent_block_height != 0)
         cursor = await self.db_connection.execute(
             "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
@@ -133,13 +100,6 @@ class WalletCoinStore:
 
     # Sometimes we realize that a coin is actually not interesting to us so we need to delete it
     async def delete_coin_record(self, coin_name: bytes32) -> None:
-        if coin_name in self.coin_record_cache:
-            coin_record = self.coin_record_cache.pop(coin_name)
-            if coin_record.wallet_id in self.unspent_coin_wallet_cache:
-                coin_cache = self.unspent_coin_wallet_cache[coin_record.wallet_id]
-                if coin_name in coin_cache:
-                    coin_cache.pop(coin_record.coin.name())
-
         c = await self.db_connection.execute("DELETE FROM coin_record WHERE coin_name=?", (coin_name.hex(),))
         await c.close()
 
@@ -170,8 +130,6 @@ class WalletCoinStore:
 
     async def get_coin_record(self, coin_name: bytes32) -> Optional[WalletCoinRecord]:
         """Returns CoinRecord with specified coin id."""
-        if coin_name in self.coin_record_cache:
-            return self.coin_record_cache[coin_name]
         cursor = await self.db_connection.execute("SELECT * from coin_record WHERE coin_name=?", (coin_name.hex(),))
         row = await cursor.fetchone()
         await cursor.close()
@@ -193,51 +151,38 @@ class WalletCoinStore:
 
     async def get_unspent_coins_for_wallet(self, wallet_id: int) -> Set[WalletCoinRecord]:
         """Returns set of CoinRecords that have not been spent yet for a wallet."""
-        if wallet_id in self.unspent_coin_wallet_cache:
-            wallet_coins: Dict[bytes32, WalletCoinRecord] = self.unspent_coin_wallet_cache[wallet_id]
-            return set(wallet_coins.values())
-        else:
-            return set()
-
-    async def get_all_coins(self) -> Set[WalletCoinRecord]:
-        """Returns set of all CoinRecords."""
-        cursor = await self.db_connection.execute("SELECT * from coin_record")
-        rows = await cursor.fetchall()
-        await cursor.close()
-
+        rows = await self.db_connection.execute_fetchall(
+            "SELECT * FROM coin_record WHERE wallet_id=? AND spent_height=0", (wallet_id,)
+        )
         return set(self.coin_record_from_row(row) for row in rows)
 
     async def get_coins_to_check(self, check_height) -> Set[WalletCoinRecord]:
         """Returns set of all CoinRecords."""
-        cursor = await self.db_connection.execute(
+        rows = await self.db_connection.execute_fetchall(
             "SELECT * from coin_record where spent_height=0 or spent_height>? or confirmed_height>?",
             (
                 check_height,
                 check_height,
             ),
         )
-        rows = await cursor.fetchall()
-        await cursor.close()
 
         return set(self.coin_record_from_row(row) for row in rows)
 
     # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them
     async def get_coin_records_by_puzzle_hash(self, puzzle_hash: bytes32) -> List[WalletCoinRecord]:
         """Returns a list of all coin records with the given puzzle hash"""
-        cursor = await self.db_connection.execute("SELECT * from coin_record WHERE puzzle_hash=?", (puzzle_hash.hex(),))
-        rows = await cursor.fetchall()
-        await cursor.close()
+        rows = await self.db_connection.execute_fetchall(
+            "SELECT * from coin_record WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+        )
 
         return [self.coin_record_from_row(row) for row in rows]
 
     # Checks DB and DiffStores for CoinRecords with parent_coin_info and returns them
     async def get_coin_records_by_parent_id(self, parent_coin_info: bytes32) -> List[WalletCoinRecord]:
         """Returns a list of all coin records with the given parent id"""
-        cursor = await self.db_connection.execute(
+        rows = await self.db_connection.execute_fetchall(
             "SELECT * from coin_record WHERE coin_parent=?", (parent_coin_info.hex(),)
         )
-        rows = await cursor.fetchall()
-        await cursor.close()
 
         return [self.coin_record_from_row(row) for row in rows]
 
@@ -246,31 +191,6 @@ class WalletCoinStore:
         Rolls back the blockchain to block_index. All coins confirmed after this point are removed.
         All coins spent after this point are set to unspent. Can be -1 (rollback all)
         """
-        # Delete from storage
-        delete_queue: List[WalletCoinRecord] = []
-        for coin_name, coin_record in self.coin_record_cache.items():
-            if coin_record.spent_block_height > height:
-                new_record = WalletCoinRecord(
-                    coin_record.coin,
-                    coin_record.confirmed_block_height,
-                    uint32(0),
-                    False,
-                    coin_record.coinbase,
-                    coin_record.wallet_type,
-                    coin_record.wallet_id,
-                )
-                self.coin_record_cache[coin_record.coin.name()] = new_record
-                if coin_record.wallet_id in self.unspent_coin_wallet_cache:
-                    self.unspent_coin_wallet_cache[coin_record.wallet_id][coin_record.coin.name()] = new_record
-            if coin_record.confirmed_block_height > height:
-                delete_queue.append(coin_record)
-
-        for coin_record in delete_queue:
-            self.coin_record_cache.pop(coin_record.coin.name())
-            if coin_record.wallet_id in self.unspent_coin_wallet_cache:
-                coin_cache = self.unspent_coin_wallet_cache[coin_record.wallet_id]
-                if coin_record.coin.name() in coin_cache:
-                    coin_cache.pop(coin_record.coin.name())
 
         c1 = await self.db_connection.execute("DELETE FROM coin_record WHERE confirmed_height>?", (height,))
         await c1.close()

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -514,7 +514,6 @@ class WalletNode:
                 tb = traceback.format_exc()
                 self.log.error(f"Exception while perform_atomic_rollback: {e} {tb}")
                 await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                await self.wallet_state_manager.coin_store.rebuild_wallet_cache()
                 await self.wallet_state_manager.tx_store.rebuild_tx_cache()
                 await self.wallet_state_manager.pool_store.rebuild_cache()
                 raise
@@ -712,7 +711,6 @@ class WalletNode:
                                 tb = traceback.format_exc()
                                 self.log.error(f"Exception while adding state: {e} {tb}")
                                 await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                                await self.wallet_state_manager.coin_store.rebuild_wallet_cache()
                                 await self.wallet_state_manager.tx_store.rebuild_tx_cache()
                                 await self.wallet_state_manager.pool_store.rebuild_cache()
                             else:
@@ -749,7 +747,6 @@ class WalletNode:
                         await self.wallet_state_manager.db_wrapper.commit_transaction()
                     except Exception as e:
                         await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                        await self.wallet_state_manager.coin_store.rebuild_wallet_cache()
                         await self.wallet_state_manager.tx_store.rebuild_tx_cache()
                         await self.wallet_state_manager.pool_store.rebuild_cache()
                         tb = traceback.format_exc()

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -40,7 +40,7 @@ record_4 = WalletCoinRecord(
 record_5 = WalletCoinRecord(
     coin_5,
     uint32(5),
-    uint32(15),
+    uint32(0),
     False,
     False,
     WalletType.STANDARD_WALLET,
@@ -58,7 +58,7 @@ record_6 = WalletCoinRecord(
 record_7 = WalletCoinRecord(
     coin_7,
     uint32(5),
-    uint32(15),
+    uint32(0),
     False,
     False,
     WalletType.POOLING_WALLET,
@@ -125,10 +125,10 @@ async def test_get_unspent_coins_for_wallet() -> None:
 
         assert await store.get_unspent_coins_for_wallet(1) == set()
 
-        await store.add_coin_record(record_4)  # this is spent
-        await store.add_coin_record(record_5)
-        await store.add_coin_record(record_6)  # this is spent
-        await store.add_coin_record(record_7)
+        await store.add_coin_record(record_4)  # this is spent and wallet 0
+        await store.add_coin_record(record_5)  # wallet 1
+        await store.add_coin_record(record_6)  # this is spent and wallet 2
+        await store.add_coin_record(record_7)  # wallet 2
 
         assert await store.get_unspent_coins_for_wallet(1) == set([record_5])
         assert await store.get_unspent_coins_for_wallet(2) == set([record_7])


### PR DESCRIPTION
This patch removes the `coin_record_cache` and `unspent_coin_wallet_cache` fields from `WalletCoinStore`. Keeping all coins ever received and spent in memory does not scale.

Removing this cache offers some substantial simplifications to the `WalletCoinStore` class. In particular, being able to remove the `rebuild_wallet_cache()` function simplifies a future transition to using `DBWrapper2` in the wallet (which is a goal this patch serves to move towards).

The other benefit of this patch is that it results in using a lot less memory (for large, long-lived or dusted wallets).

The downside, of course, is that we'll have to hit the DB a lot more often instead. Since the DB also has a RAM cache, the main additional cost appears to be in constructing python objects, parsing serialized objects and the aiosqlite thread rount-trip.

To mitigate this, there's a second commit that optimizes some of the aiosqlite interactions, by saving round-trips.

# benchmarks

To benchmark, I synced the toilet wallet on testnet:

`main`:

```
chia.wallet.wallet_node    : INFO     Successfully subscribed and updated 103906 coin ids
chia.wallet.wallet_node    : INFO     Sync (trusted: True) duration was: 174.8691442012787
```

this patch:

```
chia.wallet.wallet_node    : INFO     Successfully subscribed and updated 103906 coin ids
chia.wallet.wallet_node    : INFO     Sync (trusted: True) duration was: 159.03764295578003
```

The benchmark looks better than it is in reality. `main` would probably be sped up by the aiosqlite optimization as well, but I did not run that test. I think it's fair to say that the magnitude of the slow-down caused by removing the cache is small relative to the optimization opportunities in the database interaction.

# profiles

the wallet sync has two phases. The first subscribes to all coins and puzzle hashes, the second phase receives, parses and ingests all updates.

## main

phase 1:
![main-phase1](https://user-images.githubusercontent.com/661450/176465256-344b6864-fdfd-41f8-a487-ab7b8e02ef91.png)

phase 2:
![main-phase2](https://user-images.githubusercontent.com/661450/176465304-e3db1e23-c2b0-493b-ae89-aed97c21cae0.png)

## this patch

phase 1:
![patched-phase1](https://user-images.githubusercontent.com/661450/176465381-369a3e99-5fb6-4739-bb65-bacfaff1fad9.png)

phase 2:
![patched-phase2](https://user-images.githubusercontent.com/661450/176465428-b38ab85e-9164-4d79-ab66-38ac860402d1.png)

As these profiles show, Phase 2 in particular, has a lot more DB interactions show up with this patch. I expect a fair amount of that to be shaved off in optimizations to streaming in the future.