### PR TITLE
remove wallet transaction store cache

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -841,8 +841,6 @@ class WalletRpcApi:
                 if self.service.wallet_state_manager.wallets[wallet_id].type() == WalletType.POOLING_WALLET.value:
                     self.service.wallet_state_manager.wallets[wallet_id].target_state = None
                 await self.service.wallet_state_manager.tx_store.db_wrapper.commit_transaction()
-                # Update the cache
-                await self.service.wallet_state_manager.tx_store.rebuild_tx_cache()
                 return {}
 
     async def select_coins(self, request) -> Dict[str, object]:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -514,7 +514,6 @@ class WalletNode:
                 tb = traceback.format_exc()
                 self.log.error(f"Exception while perform_atomic_rollback: {e} {tb}")
                 await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                await self.wallet_state_manager.tx_store.rebuild_tx_cache()
                 await self.wallet_state_manager.pool_store.rebuild_cache()
                 raise
             else:
@@ -711,7 +710,6 @@ class WalletNode:
                                 tb = traceback.format_exc()
                                 self.log.error(f"Exception while adding state: {e} {tb}")
                                 await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                                await self.wallet_state_manager.tx_store.rebuild_tx_cache()
                                 await self.wallet_state_manager.pool_store.rebuild_cache()
                             else:
                                 await self.wallet_state_manager.blockchain.clean_block_records()
@@ -747,7 +745,6 @@ class WalletNode:
                         await self.wallet_state_manager.db_wrapper.commit_transaction()
                     except Exception as e:
                         await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                        await self.wallet_state_manager.tx_store.rebuild_tx_cache()
                         await self.wallet_state_manager.pool_store.rebuild_cache()
                         tb = traceback.format_exc()
                         self.log.error(f"Error adding states.. {e} {tb}")

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -30,9 +30,7 @@ class WalletTransactionStore:
 
     db_connection: aiosqlite.Connection
     db_wrapper: DBWrapper
-    tx_record_cache: Dict[bytes32, TransactionRecord]
     tx_submitted: Dict[bytes32, Tuple[int, int]]  # tx_id: [time submitted: count]
-    unconfirmed_for_wallet: Dict[int, Dict[bytes32, TransactionRecord]]
     last_wallet_tx_resend_time: int  # Epoch time in seconds
 
     @classmethod
@@ -87,25 +85,9 @@ class WalletTransactionStore:
         )
 
         await self.db_connection.commit()
-        self.tx_record_cache = {}
         self.tx_submitted = {}
-        self.unconfirmed_for_wallet = {}
         self.last_wallet_tx_resend_time = int(time.time())
-        await self.rebuild_tx_cache()
         return self
-
-    async def rebuild_tx_cache(self):
-        # init cache here
-        all_records = await self.get_all_transactions()
-        self.tx_record_cache = {}
-        self.unconfirmed_for_wallet = {}
-
-        for record in all_records:
-            self.tx_record_cache[record.name] = record
-            if record.wallet_id not in self.unconfirmed_for_wallet:
-                self.unconfirmed_for_wallet[record.wallet_id] = {}
-            if not record.confirmed:
-                self.unconfirmed_for_wallet[record.wallet_id][record.name] = record
 
     async def _clear_database(self):
         cursor = await self.db_connection.execute("DELETE FROM transaction_record")
@@ -116,15 +98,6 @@ class WalletTransactionStore:
         """
         Store TransactionRecord in DB and Cache.
         """
-        self.tx_record_cache[record.name] = record
-        if record.wallet_id not in self.unconfirmed_for_wallet:
-            self.unconfirmed_for_wallet[record.wallet_id] = {}
-        unconfirmed_dict = self.unconfirmed_for_wallet[record.wallet_id]
-        if record.confirmed and record.name in unconfirmed_dict:
-            unconfirmed_dict.pop(record.name)
-        if not record.confirmed:
-            unconfirmed_dict[record.name] = record
-
         if not in_transaction:
             await self.db_wrapper.lock.acquire()
         try:
@@ -148,22 +121,11 @@ class WalletTransactionStore:
             await cursor.close()
             if not in_transaction:
                 await self.db_connection.commit()
-        except BaseException:
-            if not in_transaction:
-                await self.rebuild_tx_cache()
-            raise
         finally:
             if not in_transaction:
                 self.db_wrapper.lock.release()
 
     async def delete_transaction_record(self, tx_id: bytes32) -> None:
-        if tx_id in self.tx_record_cache:
-            tx_record = self.tx_record_cache.pop(tx_id)
-            if tx_record.wallet_id in self.unconfirmed_for_wallet:
-                tx_cache = self.unconfirmed_for_wallet[tx_record.wallet_id]
-                if tx_id in tx_cache:
-                    tx_cache.pop(tx_id)
-
         c = await self.db_connection.execute("DELETE FROM transaction_record WHERE bundle_id=?", (tx_id,))
         await c.close()
 
@@ -277,9 +239,6 @@ class WalletTransactionStore:
         """
         Checks DB and cache for TransactionRecord with id: id and returns it.
         """
-        if tx_id in self.tx_record_cache:
-            return self.tx_record_cache[tx_id]
-
         # NOTE: bundle_id is being stored as bytes, not hex
         cursor = await self.db_connection.execute("SELECT * from transaction_record WHERE bundle_id=?", (tx_id,))
         row = await cursor.fetchone()
@@ -364,10 +323,10 @@ class WalletTransactionStore:
         """
         Returns the list of transaction that have not yet been confirmed.
         """
-        if wallet_id in self.unconfirmed_for_wallet:
-            return list(self.unconfirmed_for_wallet[wallet_id].values())
-        else:
-            return []
+        rows = await self.db_connection.execute_fetchall(
+            "SELECT transaction_record from transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,)
+        )
+        return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transactions_between(
         self, wallet_id: int, start, end, sort_key=None, reverse=False, to_puzzle_hash: Optional[bytes32] = None
@@ -493,12 +452,6 @@ class WalletTransactionStore:
 
     async def rollback_to_block(self, height: int):
         # Delete from storage
-        to_delete = []
-        for tx in self.tx_record_cache.values():
-            if tx.confirmed_at_height > height:
-                to_delete.append(tx)
-        for tx in to_delete:
-            self.tx_record_cache.pop(tx.name)
         self.tx_submitted = {}
         c1 = await self.db_connection.execute("DELETE FROM transaction_record WHERE confirmed_at_height>?", (height,))
         await c1.close()


### PR DESCRIPTION
This is part of an effort to simplify the store-classes in the wallet and transition to `DBWrapper2`.

Currently, the DB transaction handling (the error handling in particular) is quite complex. We store an in-memory copy of the database which is re-created from the DB on certain errors. This patch remove the in-memory copy to just rely on the sqlite database.

There's also a second commit to optimize the aiosqlite interaction a bit.

# benchmarks

main:

```
chia.wallet.wallet_node    : INFO     Successfully subscribed and updated 103906 coin ids
chia.wallet.wallet_node    : INFO     Sync (trusted: True) duration was: 159.03764295578003
```

this patch:

```
chia.wallet.wallet_node    : INFO     Successfully subscribed and updated 103906 coin ids
chia.wallet.wallet_node    : INFO     Sync (trusted: True) duration was: 158.9499671459198
```