### PR TITLE
Pool store cache

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -514,7 +514,6 @@ class WalletNode:
                 tb = traceback.format_exc()
                 self.log.error(f"Exception while perform_atomic_rollback: {e} {tb}")
                 await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                await self.wallet_state_manager.pool_store.rebuild_cache()
                 raise
             else:
                 await self.wallet_state_manager.blockchain.clean_block_records()
@@ -710,7 +709,6 @@ class WalletNode:
                                 tb = traceback.format_exc()
                                 self.log.error(f"Exception while adding state: {e} {tb}")
                                 await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                                await self.wallet_state_manager.pool_store.rebuild_cache()
                             else:
                                 await self.wallet_state_manager.blockchain.clean_block_records()
 
@@ -745,7 +743,6 @@ class WalletNode:
                         await self.wallet_state_manager.db_wrapper.commit_transaction()
                     except Exception as e:
                         await self.wallet_state_manager.db_wrapper.rollback_transaction()
-                        await self.wallet_state_manager.pool_store.rebuild_cache()
                         tb = traceback.format_exc()
                         self.log.error(f"Error adding states.. {e} {tb}")
                         return False


### PR DESCRIPTION
this patch removes the in-memory copy of the pool transition DB. there's a bit of extra DB lookups in order to assign transition indices correctly (which is a monotonically increasing index of all transitions).

Pool transitions do not happen frequently, so this is not expected to have material performance impact (but lowers memory footprint).

The objective is to simplify the class to nor require a `rebuild_cache()` function which makes it easier to transition to using `DBWrapper2`.