### PR TITLE
Fix issue with unsynced local node

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -23,6 +23,8 @@ from chia.protocols.wallet_protocol import (
     RespondToCoinUpdates,
     RespondHeaderBlocks,
     RequestHeaderBlocks,
+    RejectHeaderBlocks,
+    RejectBlockHeaders,
 )
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import hash_coin_ids, Coin
@@ -325,7 +327,7 @@ async def request_header_blocks(
         response = await peer.request_block_headers(RequestBlockHeaders(start_height, end_height, False))
     else:
         response = await peer.request_header_blocks(RequestHeaderBlocks(start_height, end_height))
-    if response is None:
+    if response is None or isinstance(response, RejectBlockHeaders) or isinstance(response, RejectHeaderBlocks):
         return None
     return response.header_blocks
 

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -148,6 +148,10 @@ class WalletNodeAPI:
     async def reject_header_blocks(self, request: wallet_protocol.RejectHeaderBlocks):
         self.log.warning(f"Reject header blocks: {request}")
 
+    @api_request
+    async def reject_block_headers(self, request: wallet_protocol.RejectBlockHeaders):
+        pass
+
     @execute_task
     @peer_required
     @api_request


### PR DESCRIPTION
Situation: Full node is running locally but not synced. Wallet starts up and tries to sync, but full node will reject the requests. Wallet did not handle the rejection properly.

```
2022-06-29T16:03:24.112 wallet chia.wallet.wallet_node    : ERROR    Exception handling NewPeakItem(item_type=<NewPeakQueueTypes.NEW_PEAK_WALLET: 4>, data=(NewPeakWallet(header_hash=<bytes32: f4fea11e996468133196c1294c9e88aca1c0163a5f8dfce49c8a5d8185330e50>, height=1181365, weight=97469186612, fork_point_with_previous_peak=1181365), <chia.server.ws_connection.WSChiaConnection object at 0x1088d5c10>)), 'NoneType' object has no attribute '__annotations__' Traceback (most recent call last):
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/wallet/wallet_node.py", line 421, in _process_new_subscriptions
    await self.new_peak_wallet(request, peer)
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/wallet/wallet_node.py", line 948, in new_peak_wallet
    if await self.check_for_synced_trusted_peer(header_block, request_time):
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/wallet/wallet_node.py", line 861, in check_for_synced_trusted_peer
    if self.is_trusted(peer) and await self.is_peer_synced(peer, header_block, request_time):
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/wallet/wallet_node.py", line 788, in is_peer_synced
    last_tx: Optional[HeaderBlock] = await fetch_last_tx_from_peer(header_block.height, peer)
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/wallet/util/wallet_sync_utils.py", line 44, in fetch_last_tx_from_peer
    response: Optional[List[HeaderBlock]] = await request_header_blocks(
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/wallet/util/wallet_sync_utils.py", line 325, in request_header_blocks
    response = await peer.request_block_headers(RequestBlockHeaders(start_height, end_height, False))
  File "/Users/arvid/Documents/dev/chia-blockchain/chia/server/ws_connection.py", line 328, in invoke
    req_annotations = ret_attr.__annotations__
AttributeError: 'NoneType' object has no attribute '__annotations__'
```