### PR TITLE
Remove double bytes32 conversion

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -645,7 +645,7 @@ class Streamable:
             stream_func(getattr(self, field.name), f)
 
     def get_hash(self) -> bytes32:
-        return bytes32(std_hash(bytes(self), skip_bytes_conversion=True))
+        return std_hash(bytes(self), skip_bytes_conversion=True)
 
     @classmethod
     def from_bytes(cls: Any, blob: bytes) -> Any:


### PR DESCRIPTION
std_hash returns a `bytes32` in all cases