### PR TITLE
Fix misleading argument name

### DIFF
--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -71,7 +71,7 @@ class BlockchainInterface:
         return None
 
     async def persist_sub_epoch_challenge_segments(
-        self, sub_epoch_summary_height: bytes32, segments: List[SubEpochChallengeSegment]
+        self, sub_epoch_summary_hash: bytes32, segments: List[SubEpochChallengeSegment]
     ) -> None:
         pass
 


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/pull/9793 modified `persist_sub_epoch_challenge_segments` and `get_sub_epoch_challenge_segments` to take a hash instead of a height but only updated one of the argument names. This pr updates the argument name of `persist_sub_epoch_challenge_segments` so it reflects the actual behavior and is consistent with `get_sub_epoch_challenge_segments`.