### PR TITLE
Simplify service start configuration loading

### DIFF
--- a/chia/seeder/start_crawler.py
+++ b/chia/seeder/start_crawler.py
@@ -23,32 +23,32 @@ log = logging.getLogger(__name__)
 def service_kwargs_for_full_node_crawler(
     root_path: pathlib.Path, full_config: Dict, consensus_constants: ConsensusConstants
 ) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
     crawler = Crawler(
-        config,
+        service_config,
         root_path=root_path,
         consensus_constants=consensus_constants,
     )
     api = CrawlerAPI(crawler)
 
-    network_id = config["selected_network"]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
         node=api.crawler,
         peer_api=api,
         node_type=NodeType.FULL_NODE,
-        advertised_port=config["port"],
+        advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
         upnp_ports=[],
-        server_listen_ports=[config["port"]],
+        server_listen_ports=[service_config["port"]],
         on_connect_callback=crawler.on_connect,
         network_id=network_id,
     )
 
-    if config.get("crawler", {}).get("start_rpc_server", True):
-        kwargs["rpc_info"] = (CrawlerRpcApi, config.get("crawler", {}).get("rpc_port", 8561))
+    if service_config.get("crawler", {}).get("start_rpc_server", True):
+        kwargs["rpc_info"] = (CrawlerRpcApi, service_config.get("crawler", {}).get("rpc_port", 8561))
 
     return kwargs
 
@@ -56,9 +56,9 @@ def service_kwargs_for_full_node_crawler(
 def main():
     # TODO: refactor to avoid the double load
     full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = config
-    overrides = config["network_overrides"]["constants"][config["selected_network"]]
+    service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = service_config
+    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
     kwargs = service_kwargs_for_full_node_crawler(DEFAULT_ROOT_PATH, full_config, updated_constants)
     return run_service(**kwargs)

--- a/chia/seeder/start_crawler.py
+++ b/chia/seeder/start_crawler.py
@@ -10,7 +10,7 @@ from chia.seeder.crawler import Crawler
 from chia.seeder.crawler_api import CrawlerAPI
 from chia.server.outbound_message import NodeType
 from chia.server.start_service import run_service
-from chia.util.config import load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 
 # See: https://bugs.python.org/issue29288
@@ -21,8 +21,10 @@ log = logging.getLogger(__name__)
 
 
 def service_kwargs_for_full_node_crawler(
-    root_path: pathlib.Path, config: Dict, consensus_constants: ConsensusConstants
+    root_path: pathlib.Path, full_config: Dict, consensus_constants: ConsensusConstants
 ) -> Dict:
+    config = full_config[SERVICE_NAME]
+
     crawler = Crawler(
         config,
         root_path=root_path,
@@ -33,6 +35,7 @@ def service_kwargs_for_full_node_crawler(
     network_id = config["selected_network"]
     kwargs = dict(
         root_path=root_path,
+        config=full_config,
         node=api.crawler,
         peer_api=api,
         node_type=NodeType.FULL_NODE,
@@ -51,10 +54,13 @@ def service_kwargs_for_full_node_crawler(
 
 
 def main():
+    # TODO: refactor to avoid the double load
+    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", "seeder")
+    full_config[SERVICE_NAME] = config
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
-    kwargs = service_kwargs_for_full_node_crawler(DEFAULT_ROOT_PATH, config, updated_constants)
+    kwargs = service_kwargs_for_full_node_crawler(DEFAULT_ROOT_PATH, full_config, updated_constants)
     return run_service(**kwargs)
 
 

--- a/chia/seeder/start_crawler.py
+++ b/chia/seeder/start_crawler.py
@@ -21,9 +21,9 @@ log = logging.getLogger(__name__)
 
 
 def service_kwargs_for_full_node_crawler(
-    root_path: pathlib.Path, full_config: Dict, consensus_constants: ConsensusConstants
+    root_path: pathlib.Path, config: Dict, consensus_constants: ConsensusConstants
 ) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+    service_config = config[SERVICE_NAME]
 
     crawler = Crawler(
         service_config,
@@ -35,7 +35,7 @@ def service_kwargs_for_full_node_crawler(
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         node=api.crawler,
         peer_api=api,
         node_type=NodeType.FULL_NODE,
@@ -55,12 +55,12 @@ def service_kwargs_for_full_node_crawler(
 
 def main():
     # TODO: refactor to avoid the double load
-    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = service_config
+    config[SERVICE_NAME] = service_config
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
-    kwargs = service_kwargs_for_full_node_crawler(DEFAULT_ROOT_PATH, full_config, updated_constants)
+    kwargs = service_kwargs_for_full_node_crawler(DEFAULT_ROOT_PATH, config, updated_constants)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -21,12 +21,12 @@ SERVICE_NAME = "farmer"
 
 def service_kwargs_for_farmer(
     root_path: pathlib.Path,
-    full_config: Dict,
+    config: Dict,
     config_pool: Dict,
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+    service_config = config[SERVICE_NAME]
 
     connect_peers = []
     fnp = service_config.get("full_node_peer")
@@ -43,7 +43,7 @@ def service_kwargs_for_farmer(
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         node=farmer,
         peer_api=peer_api,
         node_type=NodeType.FARMER,
@@ -62,12 +62,12 @@ def service_kwargs_for_farmer(
 
 def main() -> None:
     # TODO: refactor to avoid the double load
-    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = service_config
+    config[SERVICE_NAME] = service_config
     config_pool = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", "pool")
-    full_config["pool"] = config_pool
-    kwargs = service_kwargs_for_farmer(DEFAULT_ROOT_PATH, full_config, config_pool, DEFAULT_CONSTANTS)
+    config["pool"] = config_pool
+    kwargs = service_kwargs_for_farmer(DEFAULT_ROOT_PATH, config, config_pool, DEFAULT_CONSTANTS)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -26,7 +26,7 @@ def service_kwargs_for_farmer(
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
-    config = full_config
+    config = full_config[SERVICE_NAME]
 
     connect_peers = []
     fnp = config.get("full_node_peer")

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -9,7 +9,7 @@ from chia.rpc.farmer_rpc_api import FarmerRpcApi
 from chia.server.outbound_message import NodeType
 from chia.server.start_service import run_service
 from chia.types.peer_info import PeerInfo
-from chia.util.config import load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.keychain import Keychain
 
@@ -21,11 +21,12 @@ SERVICE_NAME = "farmer"
 
 def service_kwargs_for_farmer(
     root_path: pathlib.Path,
-    config: Dict,
+    full_config: Dict,
     config_pool: Dict,
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
+    config = full_config
 
     connect_peers = []
     fnp = config.get("full_node_peer")
@@ -40,6 +41,7 @@ def service_kwargs_for_farmer(
     network_id = config["selected_network"]
     kwargs = dict(
         root_path=root_path,
+        config=full_config,
         node=farmer,
         peer_api=peer_api,
         node_type=NodeType.FARMER,
@@ -57,9 +59,13 @@ def service_kwargs_for_farmer(
 
 
 def main() -> None:
+    # TODO: refactor to avoid the double load
+    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = config
     config_pool = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", "pool")
-    kwargs = service_kwargs_for_farmer(DEFAULT_ROOT_PATH, config, config_pool, DEFAULT_CONSTANTS)
+    full_config["pool"] = config_pool
+    kwargs = service_kwargs_for_farmer(DEFAULT_ROOT_PATH, full_config, config_pool, DEFAULT_CONSTANTS)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -26,43 +26,45 @@ def service_kwargs_for_farmer(
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
     connect_peers = []
-    fnp = config.get("full_node_peer")
+    fnp = service_config.get("full_node_peer")
     if fnp is not None:
         connect_peers.append(PeerInfo(fnp["host"], fnp["port"]))
 
-    overrides = config["network_overrides"]["constants"][config["selected_network"]]
+    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
 
-    farmer = Farmer(root_path, config, config_pool, consensus_constants=updated_constants, local_keychain=keychain)
+    farmer = Farmer(
+        root_path, service_config, config_pool, consensus_constants=updated_constants, local_keychain=keychain
+    )
     peer_api = FarmerAPI(farmer)
-    network_id = config["selected_network"]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
         node=farmer,
         peer_api=peer_api,
         node_type=NodeType.FARMER,
-        advertised_port=config["port"],
+        advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
-        server_listen_ports=[config["port"]],
+        server_listen_ports=[service_config["port"]],
         connect_peers=connect_peers,
         auth_connect_peers=False,
         on_connect_callback=farmer.on_connect,
         network_id=network_id,
     )
-    if config["start_rpc_server"]:
-        kwargs["rpc_info"] = (FarmerRpcApi, config["rpc_port"])
+    if service_config["start_rpc_server"]:
+        kwargs["rpc_info"] = (FarmerRpcApi, service_config["rpc_port"])
     return kwargs
 
 
 def main() -> None:
     # TODO: refactor to avoid the double load
     full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = config
+    service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = service_config
     config_pool = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", "pool")
     full_config["pool"] = config_pool
     kwargs = service_kwargs_for_farmer(DEFAULT_ROOT_PATH, full_config, config_pool, DEFAULT_CONSTANTS)

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -21,9 +21,9 @@ log = logging.getLogger(__name__)
 
 
 def service_kwargs_for_full_node(
-    root_path: pathlib.Path, full_config: Dict, consensus_constants: ConsensusConstants
+    root_path: pathlib.Path, config: Dict, consensus_constants: ConsensusConstants
 ) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+    service_config = config[SERVICE_NAME]
 
     full_node = FullNode(
         service_config,
@@ -38,7 +38,7 @@ def service_kwargs_for_full_node(
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         node=api.full_node,
         peer_api=api,
         node_type=NodeType.FULL_NODE,
@@ -56,12 +56,12 @@ def service_kwargs_for_full_node(
 
 def main() -> None:
     # TODO: refactor to avoid the double load
-    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = service_config
+    config[SERVICE_NAME] = service_config
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
-    kwargs = service_kwargs_for_full_node(DEFAULT_ROOT_PATH, full_config, updated_constants)
+    kwargs = service_kwargs_for_full_node(DEFAULT_ROOT_PATH, config, updated_constants)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -23,43 +23,43 @@ log = logging.getLogger(__name__)
 def service_kwargs_for_full_node(
     root_path: pathlib.Path, full_config: Dict, consensus_constants: ConsensusConstants
 ) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
     full_node = FullNode(
-        config,
+        service_config,
         root_path=root_path,
         consensus_constants=consensus_constants,
     )
     api = FullNodeAPI(full_node)
 
     upnp_list = []
-    if config["enable_upnp"]:
-        upnp_list = [config["port"]]
-    network_id = config["selected_network"]
+    if service_config["enable_upnp"]:
+        upnp_list = [service_config["port"]]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
         node=api.full_node,
         peer_api=api,
         node_type=NodeType.FULL_NODE,
-        advertised_port=config["port"],
+        advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
         upnp_ports=upnp_list,
-        server_listen_ports=[config["port"]],
+        server_listen_ports=[service_config["port"]],
         on_connect_callback=full_node.on_connect,
         network_id=network_id,
     )
-    if config["start_rpc_server"]:
-        kwargs["rpc_info"] = (FullNodeRpcApi, config["rpc_port"])
+    if service_config["start_rpc_server"]:
+        kwargs["rpc_info"] = (FullNodeRpcApi, service_config["rpc_port"])
     return kwargs
 
 
 def main() -> None:
     # TODO: refactor to avoid the double load
     full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = config
-    overrides = config["network_overrides"]["constants"][config["selected_network"]]
+    service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = service_config
+    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
     kwargs = service_kwargs_for_full_node(DEFAULT_ROOT_PATH, full_config, updated_constants)
     return run_service(**kwargs)

--- a/chia/server/start_harvester.py
+++ b/chia/server/start_harvester.py
@@ -20,10 +20,10 @@ SERVICE_NAME = "harvester"
 
 def service_kwargs_for_harvester(
     root_path: pathlib.Path,
-    full_config: Dict,
+    config: Dict,
     consensus_constants: ConsensusConstants,
 ) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+    service_config = config[SERVICE_NAME]
 
     connect_peers = [PeerInfo(service_config["farmer_peer"]["host"], service_config["farmer_peer"]["port"])]
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
@@ -34,7 +34,7 @@ def service_kwargs_for_harvester(
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         node=harvester,
         peer_api=peer_api,
         node_type=NodeType.HARVESTER,
@@ -52,10 +52,10 @@ def service_kwargs_for_harvester(
 
 def main() -> None:
     # TODO: refactor to avoid the double load
-    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = service_config
-    kwargs = service_kwargs_for_harvester(DEFAULT_ROOT_PATH, full_config, DEFAULT_CONSTANTS)
+    config[SERVICE_NAME] = service_config
+    kwargs = service_kwargs_for_harvester(DEFAULT_ROOT_PATH, config, DEFAULT_CONSTANTS)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_harvester.py
+++ b/chia/server/start_harvester.py
@@ -23,38 +23,38 @@ def service_kwargs_for_harvester(
     full_config: Dict,
     consensus_constants: ConsensusConstants,
 ) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
-    connect_peers = [PeerInfo(config["farmer_peer"]["host"], config["farmer_peer"]["port"])]
-    overrides = config["network_overrides"]["constants"][config["selected_network"]]
+    connect_peers = [PeerInfo(service_config["farmer_peer"]["host"], service_config["farmer_peer"]["port"])]
+    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
 
-    harvester = Harvester(root_path, config, updated_constants)
+    harvester = Harvester(root_path, service_config, updated_constants)
     peer_api = HarvesterAPI(harvester)
-    network_id = config["selected_network"]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
         node=harvester,
         peer_api=peer_api,
         node_type=NodeType.HARVESTER,
-        advertised_port=config["port"],
+        advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
-        server_listen_ports=[config["port"]],
+        server_listen_ports=[service_config["port"]],
         connect_peers=connect_peers,
         auth_connect_peers=True,
         network_id=network_id,
     )
-    if config["start_rpc_server"]:
-        kwargs["rpc_info"] = (HarvesterRpcApi, config["rpc_port"])
+    if service_config["start_rpc_server"]:
+        kwargs["rpc_info"] = (HarvesterRpcApi, service_config["rpc_port"])
     return kwargs
 
 
 def main() -> None:
     # TODO: refactor to avoid the double load
     full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = config
+    service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = service_config
     kwargs = service_kwargs_for_harvester(DEFAULT_ROOT_PATH, full_config, DEFAULT_CONSTANTS)
     return run_service(**kwargs)
 

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -18,20 +18,20 @@ def service_kwargs_for_introducer(
     root_path: pathlib.Path,
     full_config: Dict,
 ) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
-    introducer = Introducer(config["max_peers_to_send"], config["recent_peer_threshold"])
+    introducer = Introducer(service_config["max_peers_to_send"], service_config["recent_peer_threshold"])
     node__api = IntroducerAPI(introducer)
-    network_id = config["selected_network"]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
         node=introducer,
         peer_api=node__api,
         node_type=NodeType.INTRODUCER,
-        advertised_port=config["port"],
+        advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
-        server_listen_ports=[config["port"]],
+        server_listen_ports=[service_config["port"]],
         network_id=network_id,
     )
     return kwargs
@@ -40,8 +40,8 @@ def service_kwargs_for_introducer(
 def main() -> None:
     # TODO: refactor to avoid the double load
     full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = config
+    service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = service_config
     kwargs = service_kwargs_for_introducer(DEFAULT_ROOT_PATH, full_config)
     return run_service(**kwargs)
 

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -16,16 +16,16 @@ SERVICE_NAME = "introducer"
 
 def service_kwargs_for_introducer(
     root_path: pathlib.Path,
-    full_config: Dict,
+    config: Dict,
 ) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+    service_config = config[SERVICE_NAME]
 
     introducer = Introducer(service_config["max_peers_to_send"], service_config["recent_peer_threshold"])
     node__api = IntroducerAPI(introducer)
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         node=introducer,
         peer_api=node__api,
         node_type=NodeType.INTRODUCER,
@@ -39,10 +39,10 @@ def service_kwargs_for_introducer(
 
 def main() -> None:
     # TODO: refactor to avoid the double load
-    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = service_config
-    kwargs = service_kwargs_for_introducer(DEFAULT_ROOT_PATH, full_config)
+    config[SERVICE_NAME] = service_config
+    kwargs = service_kwargs_for_introducer(DEFAULT_ROOT_PATH, config)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -5,7 +5,7 @@ from chia.introducer.introducer import Introducer
 from chia.introducer.introducer_api import IntroducerAPI
 from chia.server.outbound_message import NodeType
 from chia.server.start_service import run_service
-from chia.util.config import load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 
 # See: https://bugs.python.org/issue29288
@@ -16,8 +16,10 @@ SERVICE_NAME = "introducer"
 
 def service_kwargs_for_introducer(
     root_path: pathlib.Path,
-    config: Dict,
+    full_config: Dict,
 ) -> Dict:
+    config = full_config["SERVICE_NAME"]
+
     introducer = Introducer(config["max_peers_to_send"], config["recent_peer_threshold"])
     node__api = IntroducerAPI(introducer)
     network_id = config["selected_network"]
@@ -35,8 +37,11 @@ def service_kwargs_for_introducer(
 
 
 def main() -> None:
+    # TODO: refactor to avoid the double load
+    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    kwargs = service_kwargs_for_introducer(DEFAULT_ROOT_PATH, config)
+    full_config[SERVICE_NAME] = config
+    kwargs = service_kwargs_for_introducer(DEFAULT_ROOT_PATH, full_config)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -25,6 +25,7 @@ def service_kwargs_for_introducer(
     network_id = config["selected_network"]
     kwargs = dict(
         root_path=root_path,
+        config=full_config,
         node=introducer,
         peer_api=node__api,
         node_type=NodeType.INTRODUCER,

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -18,7 +18,7 @@ def service_kwargs_for_introducer(
     root_path: pathlib.Path,
     full_config: Dict,
 ) -> Dict:
-    config = full_config["SERVICE_NAME"]
+    config = full_config[SERVICE_NAME]
 
     introducer = Introducer(config["max_peers_to_send"], config["recent_peer_threshold"])
     node__api = IntroducerAPI(introducer)

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -5,7 +5,7 @@ import logging
 import logging.config
 import signal
 from sys import platform
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from chia.daemon.server import singleton, service_launch_lock_path
 from chia.server.ssl_context import chia_ssl_ca_paths, private_ssl_ca_paths
@@ -22,7 +22,6 @@ from chia.server.server import ChiaServer
 from chia.server.upnp import UPnP
 from chia.types.peer_info import PeerInfo
 from chia.util.chia_logging import initialize_logging
-from chia.util.config import load_config, load_config_cli
 from chia.util.setproctitle import setproctitle
 from chia.util.ints import uint16
 
@@ -45,19 +44,19 @@ class Service:
         service_name: str,
         network_id: str,
         *,
+        config: Dict[str, Any],
         upnp_ports: List[int] = [],
         server_listen_ports: List[int] = [],
         connect_peers: List[PeerInfo] = [],
         auth_connect_peers: bool = True,
         on_connect_callback: Optional[Callable] = None,
         rpc_info: Optional[Tuple[type, int]] = None,
-        parse_cli_args=True,
         connect_to_daemon=True,
         max_request_body_size: Optional[int] = None,
         override_capabilities: Optional[List[Tuple[uint16, str]]] = None,
     ) -> None:
         self.root_path = root_path
-        self.config = load_config(root_path, "config.yaml")
+        self.config = config
         ping_interval = self.config.get("ping_interval")
         self.self_hostname = self.config.get("self_hostname")
         self.daemon_port = self.config.get("daemon_port")
@@ -72,10 +71,7 @@ class Service:
 
         self._log = logging.getLogger(service_name)
 
-        if parse_cli_args:
-            self.service_config = load_config_cli(root_path, "config.yaml", service_name)
-        else:
-            self.service_config = load_config(root_path, "config.yaml", service_name)
+        self.service_config = self.config[service_name]
 
         self._rpc_info = rpc_info
         private_ca_crt, private_ca_key = private_ssl_ca_paths(root_path, self.config)

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -27,31 +27,31 @@ def service_kwargs_for_timelord(
     full_config: Dict,
     constants: ConsensusConstants,
 ) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
-    connect_peers = [PeerInfo(config["full_node_peer"]["host"], config["full_node_peer"]["port"])]
-    overrides = config["network_overrides"]["constants"][config["selected_network"]]
+    connect_peers = [PeerInfo(service_config["full_node_peer"]["host"], service_config["full_node_peer"]["port"])]
+    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = constants.replace_str_to_bytes(**overrides)
 
-    node = Timelord(root_path, config, updated_constants)
+    node = Timelord(root_path, service_config, updated_constants)
     peer_api = TimelordAPI(node)
-    network_id = config["selected_network"]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
         peer_api=peer_api,
         node=node,
         node_type=NodeType.TIMELORD,
-        advertised_port=config["port"],
+        advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
-        server_listen_ports=[config["port"]],
+        server_listen_ports=[service_config["port"]],
         connect_peers=connect_peers,
         auth_connect_peers=False,
         network_id=network_id,
     )
 
-    if config.get("start_rpc_server", True):
-        kwargs["rpc_info"] = (TimelordRpcApi, config.get("rpc_port", 8557))
+    if service_config.get("start_rpc_server", True):
+        kwargs["rpc_info"] = (TimelordRpcApi, service_config.get("rpc_port", 8557))
 
     return kwargs
 
@@ -59,8 +59,8 @@ def service_kwargs_for_timelord(
 def main() -> None:
     # TODO: refactor to avoid the double load
     full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = config
+    service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = service_config
     kwargs = service_kwargs_for_timelord(DEFAULT_ROOT_PATH, full_config, DEFAULT_CONSTANTS)
     return run_service(**kwargs)
 

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -38,6 +38,7 @@ def service_kwargs_for_timelord(
     network_id = config["selected_network"]
     kwargs = dict(
         root_path=root_path,
+        config=full_config,
         peer_api=peer_api,
         node=node,
         node_type=NodeType.TIMELORD,

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -10,7 +10,7 @@ from chia.server.start_service import run_service
 from chia.timelord.timelord import Timelord
 from chia.timelord.timelord_api import TimelordAPI
 from chia.types.peer_info import PeerInfo
-from chia.util.config import load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 
 # See: https://bugs.python.org/issue29288
@@ -24,9 +24,10 @@ log = logging.getLogger(__name__)
 
 def service_kwargs_for_timelord(
     root_path: pathlib.Path,
-    config: Dict,
+    full_config: Dict,
     constants: ConsensusConstants,
 ) -> Dict:
+    config = full_config[SERVICE_NAME]
 
     connect_peers = [PeerInfo(config["full_node_peer"]["host"], config["full_node_peer"]["port"])]
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
@@ -55,8 +56,11 @@ def service_kwargs_for_timelord(
 
 
 def main() -> None:
+    # TODO: refactor to avoid the double load
+    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    kwargs = service_kwargs_for_timelord(DEFAULT_ROOT_PATH, config, DEFAULT_CONSTANTS)
+    full_config[SERVICE_NAME] = config
+    kwargs = service_kwargs_for_timelord(DEFAULT_ROOT_PATH, full_config, DEFAULT_CONSTANTS)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -24,10 +24,10 @@ log = logging.getLogger(__name__)
 
 def service_kwargs_for_timelord(
     root_path: pathlib.Path,
-    full_config: Dict,
+    config: Dict,
     constants: ConsensusConstants,
 ) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+    service_config = config[SERVICE_NAME]
 
     connect_peers = [PeerInfo(service_config["full_node_peer"]["host"], service_config["full_node_peer"]["port"])]
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
@@ -38,7 +38,7 @@ def service_kwargs_for_timelord(
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         peer_api=peer_api,
         node=node,
         node_type=NodeType.TIMELORD,
@@ -58,10 +58,10 @@ def service_kwargs_for_timelord(
 
 def main() -> None:
     # TODO: refactor to avoid the double load
-    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = service_config
-    kwargs = service_kwargs_for_timelord(DEFAULT_ROOT_PATH, full_config, DEFAULT_CONSTANTS)
+    config[SERVICE_NAME] = service_config
+    kwargs = service_kwargs_for_timelord(DEFAULT_ROOT_PATH, config, DEFAULT_CONSTANTS)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -23,17 +23,17 @@ SERVICE_NAME = "wallet"
 
 def service_kwargs_for_wallet(
     root_path: pathlib.Path,
-    full_config: Dict,
+    config: Dict,
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+    service_config = config[SERVICE_NAME]
 
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
     # add local node to trusted peers if old config
     if "trusted_peers" not in service_config:
-        full_node_config = full_config["full_node"]
+        full_node_config = config["full_node"]
         trusted_peer = full_node_config["ssl"]["public_crt"]
         service_config["trusted_peers"] = {}
         service_config["trusted_peers"]["local_node"] = trusted_peer
@@ -57,7 +57,7 @@ def service_kwargs_for_wallet(
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         node=node,
         peer_api=peer_api,
         node_type=NodeType.WALLET,
@@ -82,9 +82,9 @@ def service_kwargs_for_wallet(
 
 def main() -> None:
     # TODO: refactor to avoid the double load
-    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = service_config
+    config[SERVICE_NAME] = service_config
 
     # This is simulator
     local_test = service_config["testing"]
@@ -97,7 +97,7 @@ def main() -> None:
         service_config["selected_network"] = "testnet0"
     else:
         constants = DEFAULT_CONSTANTS
-    kwargs = service_kwargs_for_wallet(DEFAULT_ROOT_PATH, full_config, constants)
+    kwargs = service_kwargs_for_wallet(DEFAULT_ROOT_PATH, config, constants)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -78,7 +78,11 @@ def service_kwargs_for_wallet(
 
 
 def main() -> None:
+    # TODO: refactor to avoid the double load
+    full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = config
+
     # This is simulator
     local_test = config["testing"]
     if local_test is True:
@@ -90,7 +94,7 @@ def main() -> None:
         config["selected_network"] = "testnet0"
     else:
         constants = DEFAULT_CONSTANTS
-    kwargs = service_kwargs_for_wallet(DEFAULT_ROOT_PATH, config, constants)
+    kwargs = service_kwargs_for_wallet(DEFAULT_ROOT_PATH, full_config, constants)
     return run_service(**kwargs)
 
 

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -27,13 +27,13 @@ def service_kwargs_for_wallet(
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
-    config = full_config
+    config = full_config[SERVICE_NAME]
 
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
     # add local node to trusted peers if old config
     if "trusted_peers" not in config:
-        full_node_config = load_config(DEFAULT_ROOT_PATH, "config.yaml", "full_node")
+        full_node_config = full_config["full_node"]
         trusted_peer = full_node_config["ssl"]["public_crt"]
         config["trusted_peers"] = {}
         config["trusted_peers"]["local_node"] = trusted_peer

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -27,26 +27,26 @@ def service_kwargs_for_wallet(
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
-    overrides = config["network_overrides"]["constants"][config["selected_network"]]
+    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
     # add local node to trusted peers if old config
-    if "trusted_peers" not in config:
+    if "trusted_peers" not in service_config:
         full_node_config = full_config["full_node"]
         trusted_peer = full_node_config["ssl"]["public_crt"]
-        config["trusted_peers"] = {}
-        config["trusted_peers"]["local_node"] = trusted_peer
-    if "short_sync_blocks_behind_threshold" not in config:
-        config["short_sync_blocks_behind_threshold"] = 20
+        service_config["trusted_peers"] = {}
+        service_config["trusted_peers"]["local_node"] = trusted_peer
+    if "short_sync_blocks_behind_threshold" not in service_config:
+        service_config["short_sync_blocks_behind_threshold"] = 20
     node = WalletNode(
-        config,
+        service_config,
         root_path,
         constants=updated_constants,
         local_keychain=keychain,
     )
     peer_api = WalletNodeAPI(node)
-    fnp = config.get("full_node_peer")
+    fnp = service_config.get("full_node_peer")
 
     if fnp:
         connect_peers = [PeerInfo(fnp["host"], fnp["port"])]
@@ -54,7 +54,7 @@ def service_kwargs_for_wallet(
     else:
         connect_peers = []
         node.full_node_peer = None
-    network_id = config["selected_network"]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
@@ -67,15 +67,15 @@ def service_kwargs_for_wallet(
         auth_connect_peers=False,
         network_id=network_id,
     )
-    port = config.get("port")
+    port = service_config.get("port")
     if port is not None:
         kwargs.update(
-            advertised_port=config["port"],
-            server_listen_ports=[config["port"]],
+            advertised_port=service_config["port"],
+            server_listen_ports=[service_config["port"]],
         )
-    rpc_port = config.get("rpc_port")
+    rpc_port = service_config.get("rpc_port")
     if rpc_port is not None:
-        kwargs["rpc_info"] = (WalletRpcApi, config["rpc_port"])
+        kwargs["rpc_info"] = (WalletRpcApi, service_config["rpc_port"])
 
     return kwargs
 
@@ -83,18 +83,18 @@ def service_kwargs_for_wallet(
 def main() -> None:
     # TODO: refactor to avoid the double load
     full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-    config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-    full_config[SERVICE_NAME] = config
+    service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+    full_config[SERVICE_NAME] = service_config
 
     # This is simulator
-    local_test = config["testing"]
+    local_test = service_config["testing"]
     if local_test is True:
         from tests.block_tools import test_constants
 
         constants = test_constants
-        current = config["database_path"]
-        config["database_path"] = f"{current}_simulation"
-        config["selected_network"] = "testnet0"
+        current = service_config["database_path"]
+        service_config["database_path"] = f"{current}_simulation"
+        service_config["selected_network"] = "testnet0"
     else:
         constants = DEFAULT_CONSTANTS
     kwargs = service_kwargs_for_wallet(DEFAULT_ROOT_PATH, full_config, constants)

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -23,10 +23,12 @@ SERVICE_NAME = "wallet"
 
 def service_kwargs_for_wallet(
     root_path: pathlib.Path,
-    config: Dict,
+    full_config: Dict,
     consensus_constants: ConsensusConstants,
     keychain: Optional[Keychain] = None,
 ) -> Dict:
+    config = full_config
+
     overrides = config["network_overrides"]["constants"][config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
     # add local node to trusted peers if old config
@@ -55,6 +57,7 @@ def service_kwargs_for_wallet(
     network_id = config["selected_network"]
     kwargs = dict(
         root_path=root_path,
+        config=full_config,
         node=node,
         peer_api=peer_api,
         node_type=NodeType.WALLET,

--- a/chia/simulator/start_simulator.py
+++ b/chia/simulator/start_simulator.py
@@ -38,6 +38,7 @@ def service_kwargs_for_full_node_simulator(root_path: Path, full_config: Dict, b
     network_id = config["selected_network"]
     kwargs = dict(
         root_path=root_path,
+        config=full_config,
         node=node,
         peer_api=peer_api,
         node_type=NodeType.FULL_NODE,

--- a/chia/simulator/start_simulator.py
+++ b/chia/simulator/start_simulator.py
@@ -21,8 +21,8 @@ from chia.simulator.full_node_simulator import FullNodeSimulator
 SERVICE_NAME = "full_node"
 
 
-def service_kwargs_for_full_node_simulator(root_path: Path, full_config: Dict, bt: BlockTools) -> Dict:
-    service_config = full_config[SERVICE_NAME]
+def service_kwargs_for_full_node_simulator(root_path: Path, config: Dict, bt: BlockTools) -> Dict:
+    service_config = config[SERVICE_NAME]
 
     path_from_root(root_path, service_config["database_path"]).parent.mkdir(parents=True, exist_ok=True)
     constants = bt.constants
@@ -38,7 +38,7 @@ def service_kwargs_for_full_node_simulator(root_path: Path, full_config: Dict, b
     network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
-        config=full_config,
+        config=config,
         node=node,
         peer_api=peer_api,
         node_type=NodeType.FULL_NODE,
@@ -61,9 +61,9 @@ def main() -> None:
             keychain = None
             sys.argv.remove("-D")  # Remove -D to avoid conflicting with load_config_cli's argparse usage
         # TODO: refactor to avoid the double load
-        full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+        config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
         service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-        full_config[SERVICE_NAME] = service_config
+        config[SERVICE_NAME] = service_config
         service_config["database_path"] = service_config["simulator_database_path"]
         service_config["peers_file_path"] = service_config["simulator_peers_file_path"]
         service_config["introducer_peer"]["host"] = "127.0.0.1"
@@ -72,7 +72,7 @@ def main() -> None:
         service_config["simulation"] = True
         kwargs = service_kwargs_for_full_node_simulator(
             DEFAULT_ROOT_PATH,
-            full_config,
+            config,
             create_block_tools(test_constants, root_path=DEFAULT_ROOT_PATH, keychain=keychain),
         )
         return run_service(**kwargs)

--- a/chia/simulator/start_simulator.py
+++ b/chia/simulator/start_simulator.py
@@ -22,31 +22,31 @@ SERVICE_NAME = "full_node"
 
 
 def service_kwargs_for_full_node_simulator(root_path: Path, full_config: Dict, bt: BlockTools) -> Dict:
-    config = full_config[SERVICE_NAME]
+    service_config = full_config[SERVICE_NAME]
 
-    path_from_root(root_path, config["database_path"]).parent.mkdir(parents=True, exist_ok=True)
+    path_from_root(root_path, service_config["database_path"]).parent.mkdir(parents=True, exist_ok=True)
     constants = bt.constants
 
     node = FullNode(
-        config,
+        service_config,
         root_path=root_path,
         consensus_constants=constants,
         name=SERVICE_NAME,
     )
 
     peer_api = FullNodeSimulator(node, bt)
-    network_id = config["selected_network"]
+    network_id = service_config["selected_network"]
     kwargs = dict(
         root_path=root_path,
         config=full_config,
         node=node,
         peer_api=peer_api,
         node_type=NodeType.FULL_NODE,
-        advertised_port=config["port"],
+        advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
-        server_listen_ports=[config["port"]],
+        server_listen_ports=[service_config["port"]],
         on_connect_callback=node.on_connect,
-        rpc_info=(SimulatorFullNodeRpcApi, config["rpc_port"]),
+        rpc_info=(SimulatorFullNodeRpcApi, service_config["rpc_port"]),
         network_id=network_id,
     )
     return kwargs
@@ -62,14 +62,14 @@ def main() -> None:
             sys.argv.remove("-D")  # Remove -D to avoid conflicting with load_config_cli's argparse usage
         # TODO: refactor to avoid the double load
         full_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-        config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
-        full_config[SERVICE_NAME] = config
-        config["database_path"] = config["simulator_database_path"]
-        config["peers_file_path"] = config["simulator_peers_file_path"]
-        config["introducer_peer"]["host"] = "127.0.0.1"
-        config["introducer_peer"]["port"] = 58555
-        config["selected_network"] = "testnet0"
-        config["simulation"] = True
+        service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
+        full_config[SERVICE_NAME] = service_config
+        service_config["database_path"] = service_config["simulator_database_path"]
+        service_config["peers_file_path"] = service_config["simulator_peers_file_path"]
+        service_config["introducer_peer"]["host"] = "127.0.0.1"
+        service_config["introducer_peer"]["port"] = 58555
+        service_config["selected_network"] = "testnet0"
+        service_config["simulation"] = True
         kwargs = service_kwargs_for_full_node_simulator(
             DEFAULT_ROOT_PATH,
             full_config,

--- a/tests/setup_services.py
+++ b/tests/setup_services.py
@@ -93,8 +93,8 @@ async def setup_full_node(
 
     if connect_to_daemon:
         assert local_bt.config["daemon_port"] is not None
-    full_config = local_bt.config
-    service_config = full_config["full_node"]
+    config = local_bt.config
+    service_config = config["full_node"]
     service_config["database_path"] = db_name
     service_config["send_uncompact_interval"] = send_uncompact_interval
     service_config["target_uncompact_proofs"] = 30
@@ -112,9 +112,9 @@ async def setup_full_node(
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
     if simulator:
-        kwargs = service_kwargs_for_full_node_simulator(local_bt.root_path, full_config, local_bt)
+        kwargs = service_kwargs_for_full_node_simulator(local_bt.root_path, config, local_bt)
     else:
-        kwargs = service_kwargs_for_full_node(local_bt.root_path, full_config, updated_constants)
+        kwargs = service_kwargs_for_full_node(local_bt.root_path, config, updated_constants)
 
     kwargs.update(
         connect_to_daemon=connect_to_daemon,
@@ -147,8 +147,8 @@ async def setup_wallet_node(
     initial_num_public_keys=5,
 ):
     with TempKeyring(populate=True) as keychain:
-        full_config = local_bt.config
-        service_config = full_config["wallet"]
+        config = local_bt.config
+        service_config = config["wallet"]
         service_config["port"] = 0
         service_config["rpc_port"] = 0
         if starting_height is not None:
@@ -185,7 +185,7 @@ async def setup_wallet_node(
         else:
             del service_config["full_node_peer"]
 
-        kwargs = service_kwargs_for_wallet(local_bt.root_path, full_config, consensus_constants, keychain)
+        kwargs = service_kwargs_for_wallet(local_bt.root_path, config, consensus_constants, keychain)
         kwargs.update(
             connect_to_daemon=False,
         )
@@ -342,8 +342,8 @@ async def setup_timelord(
     b_tools: BlockTools,
     vdf_port: uint16 = uint16(0),
 ):
-    full_config = b_tools.config
-    service_config = full_config["timelord"]
+    config = b_tools.config
+    service_config = config["timelord"]
     service_config["full_node_peer"]["port"] = full_node_port
     service_config["bluebox_mode"] = sanitizer
     service_config["fast_algorithm"] = False
@@ -351,7 +351,7 @@ async def setup_timelord(
     service_config["start_rpc_server"] = True
     service_config["rpc_port"] = uint16(0)
 
-    kwargs = service_kwargs_for_timelord(b_tools.root_path, full_config, consensus_constants)
+    kwargs = service_kwargs_for_timelord(b_tools.root_path, config, consensus_constants)
     kwargs.update(
         connect_to_daemon=False,
     )

--- a/tests/setup_services.py
+++ b/tests/setup_services.py
@@ -94,22 +94,22 @@ async def setup_full_node(
     if connect_to_daemon:
         assert local_bt.config["daemon_port"] is not None
     full_config = local_bt.config
-    config = full_config["full_node"]
-    config["database_path"] = db_name
-    config["send_uncompact_interval"] = send_uncompact_interval
-    config["target_uncompact_proofs"] = 30
-    config["peer_connect_interval"] = 50
-    config["sanitize_weight_proof_only"] = sanitize_weight_proof_only
+    service_config = full_config["full_node"]
+    service_config["database_path"] = db_name
+    service_config["send_uncompact_interval"] = send_uncompact_interval
+    service_config["target_uncompact_proofs"] = 30
+    service_config["peer_connect_interval"] = 50
+    service_config["sanitize_weight_proof_only"] = sanitize_weight_proof_only
     if introducer_port is not None:
-        config["introducer_peer"]["host"] = self_hostname
-        config["introducer_peer"]["port"] = introducer_port
+        service_config["introducer_peer"]["host"] = self_hostname
+        service_config["introducer_peer"]["port"] = introducer_port
     else:
-        config["introducer_peer"] = None
-    config["dns_servers"] = []
-    config["port"] = 0
-    config["rpc_port"] = 0
+        service_config["introducer_peer"] = None
+    service_config["dns_servers"] = []
+    service_config["port"] = 0
+    service_config["rpc_port"] = 0
 
-    overrides = config["network_overrides"]["constants"][config["selected_network"]]
+    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
     if simulator:
         kwargs = service_kwargs_for_full_node_simulator(local_bt.root_path, full_config, local_bt)
@@ -148,12 +148,12 @@ async def setup_wallet_node(
 ):
     with TempKeyring(populate=True) as keychain:
         full_config = local_bt.config
-        config = full_config["wallet"]
-        config["port"] = 0
-        config["rpc_port"] = 0
+        service_config = full_config["wallet"]
+        service_config["port"] = 0
+        service_config["rpc_port"] = 0
         if starting_height is not None:
-            config["starting_height"] = starting_height
-        config["initial_num_public_keys"] = initial_num_public_keys
+            service_config["starting_height"] = starting_height
+        service_config["initial_num_public_keys"] = initial_num_public_keys
 
         entropy = token_bytes(32)
         if key_seed is None:
@@ -168,22 +168,22 @@ async def setup_wallet_node(
 
         if db_path.exists():
             db_path.unlink()
-        config["database_path"] = str(db_name)
-        config["testing"] = True
+        service_config["database_path"] = str(db_name)
+        service_config["testing"] = True
 
-        config["introducer_peer"]["host"] = self_hostname
+        service_config["introducer_peer"]["host"] = self_hostname
         if introducer_port is not None:
-            config["introducer_peer"]["port"] = introducer_port
-            config["peer_connect_interval"] = 10
+            service_config["introducer_peer"]["port"] = introducer_port
+            service_config["peer_connect_interval"] = 10
         else:
-            config["introducer_peer"] = None
+            service_config["introducer_peer"] = None
 
         if full_node_port is not None:
-            config["full_node_peer"] = {}
-            config["full_node_peer"]["host"] = self_hostname
-            config["full_node_peer"]["port"] = full_node_port
+            service_config["full_node_peer"] = {}
+            service_config["full_node_peer"]["host"] = self_hostname
+            service_config["full_node_peer"]["port"] = full_node_port
         else:
-            del config["full_node_peer"]
+            del service_config["full_node_peer"]
 
         kwargs = service_kwargs_for_wallet(local_bt.root_path, full_config, consensus_constants, keychain)
         kwargs.update(
@@ -255,20 +255,20 @@ async def setup_farmer(
         root_config["selected_network"] = "testnet0"
         root_config["farmer"]["selected_network"] = "testnet0"
         save_config(root_path, "config.yaml", root_config)
-    config = root_config["farmer"]
+    service_config = root_config["farmer"]
     config_pool = root_config["pool"]
 
-    config["xch_target_address"] = encode_puzzle_hash(b_tools.farmer_ph, "xch")
-    config["pool_public_keys"] = [bytes(pk).hex() for pk in b_tools.pool_pubkeys]
-    config["port"] = port
-    config["rpc_port"] = uint16(0)
+    service_config["xch_target_address"] = encode_puzzle_hash(b_tools.farmer_ph, "xch")
+    service_config["pool_public_keys"] = [bytes(pk).hex() for pk in b_tools.pool_pubkeys]
+    service_config["port"] = port
+    service_config["rpc_port"] = uint16(0)
     config_pool["xch_target_address"] = encode_puzzle_hash(b_tools.pool_ph, "xch")
 
     if full_node_port:
-        config["full_node_peer"]["host"] = self_hostname
-        config["full_node_peer"]["port"] = full_node_port
+        service_config["full_node_peer"]["host"] = self_hostname
+        service_config["full_node_peer"]["port"] = full_node_port
     else:
-        del config["full_node_peer"]
+        del service_config["full_node_peer"]
 
     kwargs = service_kwargs_for_farmer(root_path, root_config, config_pool, consensus_constants, b_tools.local_keychain)
     kwargs.update(
@@ -343,13 +343,13 @@ async def setup_timelord(
     vdf_port: uint16 = uint16(0),
 ):
     full_config = b_tools.config
-    config = full_config["timelord"]
-    config["full_node_peer"]["port"] = full_node_port
-    config["bluebox_mode"] = sanitizer
-    config["fast_algorithm"] = False
-    config["vdf_server"]["port"] = vdf_port
-    config["start_rpc_server"] = True
-    config["rpc_port"] = uint16(0)
+    service_config = full_config["timelord"]
+    service_config["full_node_peer"]["port"] = full_node_port
+    service_config["bluebox_mode"] = sanitizer
+    service_config["fast_algorithm"] = False
+    service_config["vdf_server"]["port"] = vdf_port
+    service_config["start_rpc_server"] = True
+    service_config["rpc_port"] = uint16(0)
 
     kwargs = service_kwargs_for_timelord(b_tools.root_path, full_config, consensus_constants)
     kwargs.update(


### PR DESCRIPTION
Draft for:
- [x] Use `config`/`service_config` naming instead of `full_config`/`config`.  Leaving as is until 'the end' since I think the diff is easier to read.
- [x] Local testing
  - [x] Launched each service directly via their entry point file on my test system and observed it seeming to launch without failure.  Did not 'use' the services here.
  - [x] Launched each service directly via my systemd setup on my actual node and observed the whole system seeming to work as expected.