### PR TITLE
Wallet dbwrapper 2

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -835,14 +835,11 @@ class WalletRpcApi:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
 
-        async with self.service.wallet_state_manager.lock:
-            async with self.service.wallet_state_manager.tx_store.db_wrapper.lock:
-                await self.service.wallet_state_manager.tx_store.db_wrapper.begin_transaction()
-                await self.service.wallet_state_manager.tx_store.delete_unconfirmed_transactions(wallet_id)
-                if self.service.wallet_state_manager.wallets[wallet_id].type() == WalletType.POOLING_WALLET.value:
-                    self.service.wallet_state_manager.wallets[wallet_id].target_state = None
-                await self.service.wallet_state_manager.tx_store.db_wrapper.commit_transaction()
-                return {}
+        async with self.service.wallet_state_manager.db_wrapper.write_db():
+            await self.service.wallet_state_manager.tx_store.delete_unconfirmed_transactions(wallet_id)
+            if self.service.wallet_state_manager.wallets[wallet_id].type() == WalletType.POOLING_WALLET.value:
+                self.service.wallet_state_manager.wallets[wallet_id].target_state = None
+            return {}
 
     async def select_coins(self, request) -> EndpointResult:
         if await self.service.wallet_state_manager.synced() is False:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -483,6 +483,11 @@ wallet:
   # see description for full_node.db_sync
   db_sync: auto
 
+  # the number of threads used to read from the wallet database
+  # concurrently. There's always only 1 writer, but the number of readers is
+  # configurable
+  db_readers: 2
+
   connect_to_unknown_peers: True
 
   # The minimum height that we care about for our transactions. Set to zero

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -105,7 +105,7 @@ class CATWallet:
             )
             assert self.cat_info.limitations_program_hash != empty_bytes
         except Exception:
-            await wallet_state_manager.user_store.delete_wallet(self.id(), False)
+            await wallet_state_manager.user_store.delete_wallet(self.id())
             raise
         if spend_bundle is None:
             await wallet_state_manager.user_store.delete_wallet(self.id())
@@ -165,7 +165,6 @@ class CATWallet:
         wallet: Wallet,
         limitations_program_hash_hex: str,
         name=None,
-        in_transaction=False,
     ) -> CATWallet:
         self = CATWallet()
         self.cost_of_single_tx = None
@@ -190,14 +189,10 @@ class CATWallet:
         limitations_program_hash = bytes32(hexstr_to_bytes(limitations_program_hash_hex))
         self.cat_info = CATInfo(limitations_program_hash, None)
         info_as_string = bytes(self.cat_info).hex()
-        self.wallet_info = await wallet_state_manager.user_store.create_wallet(
-            name, WalletType.CAT, info_as_string, in_transaction=in_transaction
-        )
+        self.wallet_info = await wallet_state_manager.user_store.create_wallet(name, WalletType.CAT, info_as_string)
 
-        self.lineage_store = await CATLineageStore.create(
-            self.wallet_state_manager.db_wrapper, self.get_asset_id(), in_transaction=in_transaction
-        )
-        await self.wallet_state_manager.add_new_wallet(self, self.id(), in_transaction=in_transaction)
+        self.lineage_store = await CATLineageStore.create(self.wallet_state_manager.db_wrapper, self.get_asset_id())
+        await self.wallet_state_manager.add_new_wallet(self, self.id())
         return self
 
     @classmethod
@@ -207,14 +202,12 @@ class CATWallet:
         wallet: Wallet,
         puzzle_driver: PuzzleInfo,
         name=None,
-        in_transaction=False,
     ) -> CATWallet:
         return await cls.create_wallet_for_cat(
             wallet_state_manager,
             wallet,
             puzzle_driver["tail"].hex(),
             name,
-            in_transaction,
         )
 
     @staticmethod
@@ -240,8 +233,8 @@ class CATWallet:
             self.cat_info = CATInfo(cat_info.limitations_program_hash, cat_info.my_tail)
             self.lineage_store = await CATLineageStore.create(self.wallet_state_manager.db_wrapper, self.get_asset_id())
             for coin_id, lineage in cat_info.lineage_proofs:
-                await self.add_lineage(coin_id, lineage, False)
-            await self.save_info(self.cat_info, False)
+                await self.add_lineage(coin_id, lineage)
+            await self.save_info(self.cat_info)
 
         return self
 
@@ -309,7 +302,7 @@ class CATWallet:
     async def set_name(self, new_name: str):
         new_info = dataclasses.replace(self.wallet_info, name=new_name)
         self.wallet_info = new_info
-        await self.wallet_state_manager.user_store.update_wallet(self.wallet_info, False)
+        await self.wallet_state_manager.user_store.update_wallet(self.wallet_info)
 
     def get_asset_id(self) -> str:
         return bytes(self.cat_info.limitations_program_hash).hex()
@@ -320,8 +313,7 @@ class CATWallet:
             CATInfo(
                 self.cat_info.limitations_program_hash,
                 Program.fromhex(tail_program),
-            ),
-            False,
+            )
         )
 
     async def coin_added(self, coin: Coin, height: uint32):
@@ -330,7 +322,7 @@ class CATWallet:
 
         inner_puzzle = await self.inner_puzzle_for_cat_puzhash(coin.puzzle_hash)
         lineage_proof = LineageProof(coin.parent_coin_info, inner_puzzle.get_tree_hash(), uint64(coin.amount))
-        await self.add_lineage(coin.name(), lineage_proof, True)
+        await self.add_lineage(coin.name(), lineage_proof)
 
         lineage = await self.get_lineage_proof_for_coin(coin)
 
@@ -356,7 +348,6 @@ class CATWallet:
             await self.add_lineage(
                 coin_name,
                 LineageProof(parent_coin.parent_coin_info, inner_puzzle.get_tree_hash(), uint64(parent_coin.amount)),
-                True,
             )
         else:
             # The parent is not a CAT which means we need to scrub all of its children from our DB
@@ -772,26 +763,26 @@ class CATWallet:
 
         return tx_list
 
-    async def add_lineage(self, name: bytes32, lineage: Optional[LineageProof], in_transaction):
+    async def add_lineage(self, name: bytes32, lineage: Optional[LineageProof]):
         """
         Lineage proofs are stored as a list of parent coins and the lineage proof you will need if they are the
         parent of the coin you are trying to spend. 'If I'm your parent, here's the info you need to spend yourself'
         """
         self.log.info(f"Adding parent {name}: {lineage}")
         if lineage is not None:
-            await self.lineage_store.add_lineage_proof(name, lineage, in_transaction)
+            await self.lineage_store.add_lineage_proof(name, lineage)
 
     async def remove_lineage(self, name: bytes32):
         self.log.info(f"Removing parent {name} (probably had a non-CAT parent)")
         await self.lineage_store.remove_lineage_proof(name)
 
-    async def save_info(self, cat_info: CATInfo, in_transaction):
+    async def save_info(self, cat_info: CATInfo):
         self.cat_info = cat_info
         current_info = self.wallet_info
         data_str = bytes(cat_info).hex()
         wallet_info = WalletInfo(current_info.id, current_info.name, current_info.type, data_str)
         self.wallet_info = wallet_info
-        await self.wallet_state_manager.user_store.update_wallet(wallet_info, in_transaction)
+        await self.wallet_state_manager.user_store.update_wallet(wallet_info)
 
     def match_puzzle_info(self, puzzle_driver: PuzzleInfo) -> bool:
         return (

--- a/chia/wallet/cat_wallet/lineage_store.py
+++ b/chia/wallet/cat_wallet/lineage_store.py
@@ -1,10 +1,8 @@
 import logging
 from typing import Dict, Optional
 
-import aiosqlite
-
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.wallet.lineage_proof import LineageProof
 
 log = logging.getLogger(__name__)
@@ -17,74 +15,50 @@ class CATLineageStore:
     WalletInterestedStore to keep track of puzzle hashes which we are interested in.
     """
 
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
     table_name: str
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper, asset_id: str, in_transaction=False):
+    async def create(cls, db_wrapper: DBWrapper2, asset_id: str):
         self = cls()
         self.table_name = f"lineage_proofs_{asset_id}"
         self.db_wrapper = db_wrapper
-        self.db_connection = self.db_wrapper.db
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            await self.db_connection.execute(
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
                 (f"CREATE TABLE IF NOT EXISTS {self.table_name}(" " coin_id text PRIMARY KEY," " lineage blob)")
             )
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
         return self
 
-    async def close(self):
-        await self.db_connection.close()
-
     async def _clear_database(self):
-        cursor = await self.db_connection.execute(f"DELETE FROM {self.table_name}")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(f"DELETE FROM {self.table_name}")
+            await cursor.close()
 
-    async def add_lineage_proof(self, coin_id: bytes32, lineage: LineageProof, in_transaction) -> None:
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+    async def add_lineage_proof(self, coin_id: bytes32, lineage: LineageProof) -> None:
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 f"INSERT OR REPLACE INTO {self.table_name} VALUES(?, ?)",
                 (coin_id.hex(), bytes(lineage)),
             )
-
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
-    async def remove_lineage_proof(self, coin_id: bytes32, in_transaction=True) -> None:
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+    async def remove_lineage_proof(self, coin_id: bytes32) -> None:
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 f"DELETE FROM {self.table_name} WHERE coin_id=?;",
                 (coin_id.hex(),),
             )
-
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
     async def get_lineage_proof(self, coin_id: bytes32) -> Optional[LineageProof]:
 
-        cursor = await self.db_connection.execute(
-            f"SELECT * FROM {self.table_name} WHERE coin_id=?;",
-            (coin_id.hex(),),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                f"SELECT * FROM {self.table_name} WHERE coin_id=?;",
+                (coin_id.hex(),),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             return LineageProof.from_bytes(row[1])
@@ -92,9 +66,10 @@ class CATLineageStore:
         return None
 
     async def get_all_lineage_proofs(self) -> Dict[bytes32, LineageProof]:
-        cursor = await self.db_connection.execute(f"SELECT * FROM {self.table_name}")
-        rows = await cursor.fetchall()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(f"SELECT * FROM {self.table_name}")
+            rows = await cursor.fetchall()
+            await cursor.close()
 
         lineage_dict = {}
 

--- a/chia/wallet/key_val_store.py
+++ b/chia/wallet/key_val_store.py
@@ -1,8 +1,6 @@
 from typing import Any
 
-import aiosqlite
-
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 
 
 class KeyValStore:
@@ -10,67 +8,52 @@ class KeyValStore:
     Multipurpose persistent key-value store
     """
 
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper):
+    async def create(cls, db_wrapper: DBWrapper2):
         self = cls()
         self.db_wrapper = db_wrapper
-        self.db_connection = db_wrapper.db
-        await self.db_connection.execute(
-            "CREATE TABLE IF NOT EXISTS key_val_store(" " key text PRIMARY KEY," " value blob)"
-        )
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute("CREATE TABLE IF NOT EXISTS key_val_store(" " key text PRIMARY KEY," " value blob)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS key_val_name on key_val_store(key)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS key_val_name on key_val_store(key)")
 
-        await self.db_connection.commit()
         return self
 
     async def _clear_database(self):
-        cursor = await self.db_connection.execute("DELETE FROM key_val_store")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute("DELETE FROM key_val_store")
+            await cursor.close()
+            await conn.commit()
 
     async def get_object(self, key: str, object_type: Any) -> Any:
         """
         Return bytes representation of stored object
         """
 
-        cursor = await self.db_connection.execute("SELECT * from key_val_store WHERE key=?", (key,))
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT * from key_val_store WHERE key=?", (key,))
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is None:
             return None
 
         return object_type.from_bytes(row[1])
 
-    async def set_object(self, key: str, obj: Any, in_transaction=False):
+    async def set_object(self, key: str, obj: Any):
         """
         Adds object to key val store. Obj MUST support __bytes__ and bytes() methods.
         """
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-
-        try:
-            cursor = await self.db_connection.execute(
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 "INSERT OR REPLACE INTO key_val_store VALUES(?, ?)",
                 (key, bytes(obj)),
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
-    async def remove_object(self, key: str, in_transaction=False):
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute("DELETE FROM key_val_store where key=?", (key,))
+    async def remove_object(self, key: str):
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute("DELETE FROM key_val_store where key=?", (key,))
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -61,7 +61,6 @@ class NFTWallet:
         wallet: Wallet,
         did_id: Optional[bytes32] = None,
         name: Optional[str] = None,
-        in_transaction: bool = False,
     ) -> _T_NFTWallet:
         """
         This must be called under the wallet state manager lock
@@ -76,10 +75,7 @@ class NFTWallet:
         self.my_nft_coins = []
         info_as_string = json.dumps(self.nft_wallet_info.to_json_dict())
         wallet_info = await wallet_state_manager.user_store.create_wallet(
-            name,
-            uint32(WalletType.NFT.value),
-            info_as_string,
-            in_transaction=in_transaction,
+            name, uint32(WalletType.NFT.value), info_as_string
         )
 
         if wallet_info is None:
@@ -88,7 +84,7 @@ class NFTWallet:
         self.wallet_id = self.wallet_info.id
         self.log.debug("NFT wallet id: %r and standard wallet id: %r", self.wallet_id, self.standard_wallet.wallet_id)
 
-        await self.wallet_state_manager.add_new_wallet(self, self.wallet_info.id, in_transaction=in_transaction)
+        await self.wallet_state_manager.add_new_wallet(self, self.wallet_info.id)
         self.log.debug("Generated a new NFT wallet: %s", self.__dict__)
         return self
 
@@ -146,10 +142,10 @@ class NFTWallet:
                 return nft_coin
         raise KeyError(f"Couldn't find coin with id: {nft_coin_id}")
 
-    async def add_nft_coin(self, coin: Coin, spent_height: uint32, in_transaction: bool) -> None:
-        await self.coin_added(coin, spent_height, in_transaction=in_transaction)
+    async def add_nft_coin(self, coin: Coin, spent_height: uint32) -> None:
+        await self.coin_added(coin, spent_height)
 
-    async def coin_added(self, coin: Coin, height: uint32, in_transaction: bool) -> None:
+    async def coin_added(self, coin: Coin, height: uint32) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"NFT wallet %s has been notified that {coin} was added", self.wallet_info.name)
         for coin_info in self.my_nft_coins:
@@ -165,9 +161,9 @@ class NFTWallet:
         parent_coin = coin_states[0].coin
         cs = await wallet_node.fetch_puzzle_solution(height, parent_coin)
         assert cs is not None
-        await self.puzzle_solution_received(cs, in_transaction=in_transaction)
+        await self.puzzle_solution_received(cs)
 
-    async def puzzle_solution_received(self, coin_spend: CoinSpend, in_transaction: bool) -> None:
+    async def puzzle_solution_received(self, coin_spend: CoinSpend) -> None:
         self.log.debug("Puzzle solution received to wallet: %s", self.wallet_info)
         coin_name = coin_spend.coin.name()
         puzzle: Program = Program.from_bytes(bytes(coin_spend.puzzle_reveal))
@@ -249,7 +245,6 @@ class NFTWallet:
             child_puzzle,
             LineageProof(parent_coin.parent_coin_info, parent_inner_puzhash, uint64(parent_coin.amount)),
             mint_height,
-            in_transaction=in_transaction,
         )
 
     async def add_coin(
@@ -259,7 +254,6 @@ class NFTWallet:
         puzzle: Program,
         lineage_proof: LineageProof,
         mint_height: uint32,
-        in_transaction: bool,
     ) -> None:
         my_nft_coins = self.my_nft_coins
         for coin_info in my_nft_coins:
@@ -267,19 +261,17 @@ class NFTWallet:
                 my_nft_coins.remove(coin_info)
         new_nft = NFTCoinInfo(nft_id, coin, lineage_proof, puzzle, mint_height)
         my_nft_coins.append(new_nft)
-        await self.wallet_state_manager.nft_store.save_nft(
-            self.id(), self.get_did(), new_nft, in_transaction=in_transaction
-        )
-        await self.wallet_state_manager.add_interested_coin_ids([coin.name()], in_transaction=in_transaction)
+        await self.wallet_state_manager.nft_store.save_nft(self.id(), self.get_did(), new_nft)
+        await self.wallet_state_manager.add_interested_coin_ids([coin.name()])
         self.wallet_state_manager.state_changed("nft_coin_added", self.wallet_info.id)
         return
 
-    async def remove_coin(self, coin: Coin, in_transaction: bool) -> None:
+    async def remove_coin(self, coin: Coin) -> None:
         my_nft_coins = self.my_nft_coins
         for coin_info in my_nft_coins:
             if coin_info.coin == coin:
                 my_nft_coins.remove(coin_info)
-                await self.wallet_state_manager.nft_store.delete_nft(coin_info.nft_id, in_transaction=in_transaction)
+                await self.wallet_state_manager.nft_store.delete_nft(coin_info.nft_id)
         self.wallet_state_manager.state_changed("nft_coin_removed", self.wallet_info.id)
         return
 
@@ -485,9 +477,7 @@ class NFTWallet:
     def get_current_nfts(self) -> List[NFTCoinInfo]:
         return self.my_nft_coins
 
-    async def update_coin_status(
-        self, coin_id: bytes32, pending_transaction: bool, in_transaction: bool = False
-    ) -> None:
+    async def update_coin_status(self, coin_id: bytes32, pending_transaction: bool) -> None:
         my_nft_coins = self.my_nft_coins
         target_nft: Optional[NFTCoinInfo] = None
         for coin_info in my_nft_coins:
@@ -505,17 +495,15 @@ class NFTWallet:
             pending_transaction,
         )
         my_nft_coins.append(new_nft)
-        await self.wallet_state_manager.nft_store.save_nft(
-            self.id(), self.get_did(), new_nft, in_transaction=in_transaction
-        )
+        await self.wallet_state_manager.nft_store.save_nft(self.id(), self.get_did(), new_nft)
 
-    async def save_info(self, nft_info: NFTWalletInfo, in_transaction: bool) -> None:
+    async def save_info(self, nft_info: NFTWalletInfo) -> None:
         self.nft_wallet_info = nft_info
         current_info = self.wallet_info
         data_str = json.dumps(nft_info.to_json_dict())
         wallet_info = WalletInfo(current_info.id, current_info.name, current_info.type, data_str)
         self.wallet_info = wallet_info
-        await self.wallet_state_manager.user_store.update_wallet(wallet_info, in_transaction)
+        await self.wallet_state_manager.user_store.update_wallet(wallet_info)
 
     async def convert_puzzle_hash(self, puzhash: bytes32) -> bytes32:
         return puzhash
@@ -558,7 +546,6 @@ class NFTWallet:
         wallet: Wallet,
         puzzle_driver: PuzzleInfo,
         name=None,
-        in_transaction=False,
     ) -> Any:
         # Off the bat we don't support multiple profile but when we do this will have to change
         for wallet in wallet_state_manager.wallets.values():
@@ -571,7 +558,6 @@ class NFTWallet:
             wallet,
             None,
             name,
-            in_transaction,
         )
 
     async def create_tandem_xch_tx(

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -78,7 +78,7 @@ class GenesisById(LimitationsProgram):
         wallet.lineage_store = await CATLineageStore.create(
             wallet.wallet_state_manager.db_wrapper, tail.get_tree_hash().hex()
         )
-        await wallet.add_lineage(origin_id, LineageProof(), False)
+        await wallet.add_lineage(origin_id, LineageProof())
 
         minted_cat_puzzle_hash: bytes32 = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), cat_inner).get_tree_hash()
 
@@ -108,10 +108,7 @@ class GenesisById(LimitationsProgram):
         signed_eve_spend = await wallet.sign(eve_spend)
 
         if wallet.cat_info.my_tail is None:
-            await wallet.save_info(
-                CATInfo(tail.get_tree_hash(), tail),
-                False,
-            )
+            await wallet.save_info(CATInfo(tail.get_tree_hash(), tail))
 
         return tx_record, SpendBundle.aggregate([tx_record.spend_bundle, signed_eve_spend])
 

--- a/chia/wallet/rl_wallet/rl_wallet.py
+++ b/chia/wallet/rl_wallet/rl_wallet.py
@@ -212,7 +212,7 @@ class RLWallet:
 
         data_str = json.dumps(new_rl_info.to_json_dict())
         new_wallet_info = WalletInfo(self.id(), self.wallet_info.name, self.type(), data_str)
-        await self.wallet_state_manager.user_store.update_wallet(new_wallet_info, False)
+        await self.wallet_state_manager.user_store.update_wallet(new_wallet_info)
         await self.wallet_state_manager.add_new_wallet(self, self.id())
         self.wallet_info = new_wallet_info
         self.rl_info = new_rl_info
@@ -290,7 +290,7 @@ class RLWallet:
 
         data_str = json.dumps(new_rl_info.to_json_dict())
         new_wallet_info = WalletInfo(self.id(), self.wallet_info.name, self.type(), data_str)
-        await self.wallet_state_manager.user_store.update_wallet(new_wallet_info, False)
+        await self.wallet_state_manager.user_store.update_wallet(new_wallet_info)
         await self.wallet_state_manager.add_new_wallet(self, self.id())
         self.wallet_info = new_wallet_info
         self.rl_info = new_rl_info

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -11,7 +11,7 @@ from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
@@ -76,7 +76,7 @@ class TradeManager:
     @staticmethod
     async def create(
         wallet_state_manager: Any,
-        db_wrapper: DBWrapper,
+        db_wrapper: DBWrapper2,
         name: str = None,
     ):
         self = TradeManager()
@@ -160,12 +160,12 @@ class TradeManager:
         # If any of our settlement_payments were spent, this offer was a success!
         if set(our_settlement_ids) & set(coin_state_names):
             height = coin_states[0].spent_height
-            await self.trade_store.set_status(trade.trade_id, TradeStatus.CONFIRMED, True, height)
+            await self.trade_store.set_status(trade.trade_id, TradeStatus.CONFIRMED, height)
             tx_records: List[TransactionRecord] = await self.calculate_tx_records_for_offer(offer, False)
             for tx in tx_records:
                 if TradeStatus(trade.status) == TradeStatus.PENDING_ACCEPT:
                     await self.wallet_state_manager.add_transaction(
-                        dataclasses.replace(tx, confirmed_at_height=height, confirmed=True), in_transaction=True
+                        dataclasses.replace(tx, confirmed_at_height=height, confirmed=True)
                     )
 
             self.log.info(f"Trade with id: {trade.trade_id} confirmed at height: {height}")
@@ -173,10 +173,10 @@ class TradeManager:
             # In any other scenario this trade failed
             await self.wallet_state_manager.delete_trade_transactions(trade.trade_id)
             if trade.status == TradeStatus.PENDING_CANCEL.value:
-                await self.trade_store.set_status(trade.trade_id, TradeStatus.CANCELLED, True)
+                await self.trade_store.set_status(trade.trade_id, TradeStatus.CANCELLED)
                 self.log.info(f"Trade with id: {trade.trade_id} canceled")
             elif trade.status == TradeStatus.PENDING_CONFIRM.value:
-                await self.trade_store.set_status(trade.trade_id, TradeStatus.FAILED, True)
+                await self.trade_store.set_status(trade.trade_id, TradeStatus.FAILED)
                 self.log.warning(f"Trade with id: {trade.trade_id} failed")
 
     async def get_locked_coins(self, wallet_id: int = None) -> Dict[bytes32, WalletCoinRecord]:
@@ -210,7 +210,7 @@ class TradeManager:
         return record
 
     async def cancel_pending_offer(self, trade_id: bytes32):
-        await self.trade_store.set_status(trade_id, TradeStatus.CANCELLED, False)
+        await self.trade_store.set_status(trade_id, TradeStatus.CANCELLED)
         self.wallet_state_manager.state_changed("offer_cancelled")
 
     async def cancel_pending_offer_safely(
@@ -285,12 +285,12 @@ class TradeManager:
         for tx in all_txs:
             await self.wallet_state_manager.add_pending_transaction(tx_record=dataclasses.replace(tx, fee_amount=fee))
 
-        await self.trade_store.set_status(trade_id, TradeStatus.PENDING_CANCEL, False)
+        await self.trade_store.set_status(trade_id, TradeStatus.PENDING_CANCEL)
 
         return all_txs
 
     async def save_trade(self, trade: TradeRecord):
-        await self.trade_store.add_trade_record(trade, False)
+        await self.trade_store.add_trade_record(trade)
         self.wallet_state_manager.state_changed("offer_added")
 
     async def create_offer_for_ids(

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -181,8 +181,8 @@ class Wallet:
         public_key = await self.hack_populate_secret_key_for_puzzle_hash(puzzle_hash)
         return puzzle_for_pk(bytes(public_key))
 
-    async def get_new_puzzle(self, in_transaction: bool = False) -> Program:
-        dr = await self.wallet_state_manager.get_unused_derivation_record(self.id(), in_transaction=in_transaction)
+    async def get_new_puzzle(self) -> Program:
+        dr = await self.wallet_state_manager.get_unused_derivation_record(self.id())
         return puzzle_for_pk(bytes(dr.pubkey))
 
     async def get_puzzle_hash(self, new: bool) -> bytes32:
@@ -196,8 +196,8 @@ class Wallet:
                 return await self.get_new_puzzlehash()
             return record.puzzle_hash
 
-    async def get_new_puzzlehash(self, in_transaction: bool = False) -> bytes32:
-        return (await self.wallet_state_manager.get_unused_derivation_record(self.id(), in_transaction)).puzzle_hash
+    async def get_new_puzzlehash(self) -> bytes32:
+        return (await self.wallet_state_manager.get_unused_derivation_record(self.id())).puzzle_hash
 
     def make_solution(
         self,

--- a/chia/wallet/wallet_action_store.py
+++ b/chia/wallet/wallet_action_store.py
@@ -1,8 +1,6 @@
 from typing import List, Optional
 
-import aiosqlite
-
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_action import WalletAction
@@ -14,86 +12,74 @@ class WalletActionStore:
     Used by CATs, Atomic swaps, Rate Limited, and Authorized payee wallets
     """
 
-    db_connection: aiosqlite.Connection
     cache_size: uint32
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper):
+    async def create(cls, db_wrapper: DBWrapper2):
         self = cls()
         self.db_wrapper = db_wrapper
-        self.db_connection = db_wrapper.db
 
-        await self.db_connection.execute(
-            (
-                "CREATE TABLE IF NOT EXISTS action_queue("
-                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                " name text,"
-                " wallet_id int,"
-                " wallet_type int,"
-                " wallet_callback text,"
-                " done int,"
-                " data text)"
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS action_queue("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    " name text,"
+                    " wallet_id int,"
+                    " wallet_type int,"
+                    " wallet_callback text,"
+                    " done int,"
+                    " data text)"
+                )
             )
-        )
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS action_queue_name on action_queue(name)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS action_queue_name on action_queue(name)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS action_queue_wallet_id on action_queue(wallet_id)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS action_queue_wallet_id on action_queue(wallet_id)")
 
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS action_queue_wallet_type on action_queue(wallet_type)"
-        )
-
-        await self.db_connection.commit()
+            await conn.execute("CREATE INDEX IF NOT EXISTS action_queue_wallet_type on action_queue(wallet_type)")
         return self
 
     async def _clear_database(self):
-        cursor = await self.db_connection.execute("DELETE FROM action_queue")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM action_queue")).close()
 
     async def get_wallet_action(self, id: int) -> Optional[WalletAction]:
         """
         Return a wallet action by id
         """
 
-        cursor = await self.db_connection.execute("SELECT * from action_queue WHERE id=?", (id,))
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT * from action_queue WHERE id=?", (id,))
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is None:
             return None
 
         return WalletAction(row[0], row[1], row[2], WalletType(row[3]), row[4], bool(row[5]), row[6])
 
-    async def create_action(
-        self, name: str, wallet_id: int, type: int, callback: str, done: bool, data: str, in_transaction: bool
-    ):
+    async def create_action(self, name: str, wallet_id: int, type: int, callback: str, done: bool, data: str):
         """
         Creates Wallet Action
         """
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 "INSERT INTO action_queue VALUES(?, ?, ?, ?, ?, ?, ?)",
                 (None, name, wallet_id, type, callback, done, data),
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
     async def get_all_pending_actions(self) -> List[WalletAction]:
         """
         Returns list of all pending action
         """
         result: List[WalletAction] = []
-        cursor = await self.db_connection.execute("SELECT * from action_queue WHERE done=?", (0,))
-        rows = await cursor.fetchall()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT * from action_queue WHERE done=?", (0,))
+            rows = await cursor.fetchall()
+            await cursor.close()
 
         if rows is None:
             return result
@@ -109,9 +95,10 @@ class WalletActionStore:
         Return a wallet action by id
         """
 
-        cursor = await self.db_connection.execute("SELECT * from action_queue WHERE id=?", (id,))
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT * from action_queue WHERE id=?", (id,))
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is None:
             return None

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -184,11 +184,10 @@ class WalletBlockchain(BlockchainInterface):
             return self._peak
         return await self._basic_store.get_object("PEAK_BLOCK", HeaderBlock)
 
-    async def set_finished_sync_up_to(self, height: int, in_transaction=False, in_rollback=False):
+    async def set_finished_sync_up_to(self, height: int, *, in_rollback=False):
         if (in_rollback and height >= 0) or (height > await self.get_finished_sync_up_to()):
-            await self._basic_store.set_object("FINISHED_SYNC_UP_TO", uint32(height), in_transaction)
-            if not in_transaction:
-                await self.clean_block_records()
+            await self._basic_store.set_object("FINISHED_SYNC_UP_TO", uint32(height))
+            await self.clean_block_records()
 
     async def get_finished_sync_up_to(self):
         h: Optional[uint32] = await self._basic_store.get_object("FINISHED_SYNC_UP_TO", uint32)

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -1,11 +1,10 @@
 from typing import List, Optional, Set
 
-import aiosqlite
 import sqlite3
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -16,53 +15,47 @@ class WalletCoinStore:
     This object handles CoinRecords in DB used by wallet.
     """
 
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper):
+    async def create(cls, wrapper: DBWrapper2):
         self = cls()
 
-        self.db_connection = wrapper.db
         self.db_wrapper = wrapper
-        await self.db_connection.execute(
-            (
-                "CREATE TABLE IF NOT EXISTS coin_record("
-                "coin_name text PRIMARY KEY,"
-                " confirmed_height bigint,"
-                " spent_height bigint,"
-                " spent int,"
-                " coinbase int,"
-                " puzzle_hash text,"
-                " coin_parent text,"
-                " amount blob,"
-                " wallet_type int,"
-                " wallet_id int)"
+
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS coin_record("
+                    "coin_name text PRIMARY KEY,"
+                    " confirmed_height bigint,"
+                    " spent_height bigint,"
+                    " spent int,"
+                    " coinbase int,"
+                    " puzzle_hash text,"
+                    " coin_parent text,"
+                    " amount blob,"
+                    " wallet_type int,"
+                    " wallet_id int)"
+                )
             )
-        )
 
-        # Useful for reorg lookups
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS coin_confirmed_height on coin_record(confirmed_height)"
-        )
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS coin_spent_height on coin_record(spent_height)")
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS coin_spent on coin_record(spent)")
+            # Useful for reorg lookups
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_confirmed_height on coin_record(confirmed_height)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_spent_height on coin_record(spent_height)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_spent on coin_record(spent)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS coin_puzzlehash on coin_record(puzzle_hash)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_puzzlehash on coin_record(puzzle_hash)")
 
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS coin_record_wallet_type on coin_record(wallet_type)"
-        )
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_record_wallet_type on coin_record(wallet_type)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
 
-        await self.db_connection.commit()
         return self
 
     async def _clear_database(self):
-        cursor = await self.db_connection.execute("DELETE FROM coin_record")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM coin_record")).close()
 
     async def get_multiple_coin_records(self, coin_names: List[bytes32]) -> List[WalletCoinRecord]:
         """Return WalletCoinRecord(s) that have a coin name in the specified list"""
@@ -70,9 +63,10 @@ class WalletCoinStore:
             return []
 
         as_hexes = [cn.hex() for cn in coin_names]
-        rows = await self.db_connection.execute_fetchall(
-            f'SELECT * from coin_record WHERE coin_name in ({"?," * (len(as_hexes) - 1)}?)', tuple(as_hexes)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                f'SELECT * from coin_record WHERE coin_name in ({"?," * (len(as_hexes) - 1)}?)', tuple(as_hexes)
+            )
 
         return [self.coin_record_from_row(row) for row in rows]
 
@@ -81,27 +75,27 @@ class WalletCoinStore:
         if name is None:
             name = record.name()
         assert record.spent == (record.spent_block_height != 0)
-        cursor = await self.db_connection.execute(
-            "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                name.hex(),
-                record.confirmed_block_height,
-                record.spent_block_height,
-                int(record.spent),
-                int(record.coinbase),
-                str(record.coin.puzzle_hash.hex()),
-                str(record.coin.parent_coin_info.hex()),
-                bytes(uint64(record.coin.amount)),
-                record.wallet_type,
-                record.wallet_id,
-            ),
-        )
-        await cursor.close()
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute_insert(
+                "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    name.hex(),
+                    record.confirmed_block_height,
+                    record.spent_block_height,
+                    int(record.spent),
+                    int(record.coinbase),
+                    str(record.coin.puzzle_hash.hex()),
+                    str(record.coin.parent_coin_info.hex()),
+                    bytes(uint64(record.coin.amount)),
+                    record.wallet_type,
+                    record.wallet_id,
+                ),
+            )
 
     # Sometimes we realize that a coin is actually not interesting to us so we need to delete it
     async def delete_coin_record(self, coin_name: bytes32) -> None:
-        c = await self.db_connection.execute("DELETE FROM coin_record WHERE coin_name=?", (coin_name.hex(),))
-        await c.close()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM coin_record WHERE coin_name=?", (coin_name.hex(),))).close()
 
     # Update coin_record to be spent in DB
     async def set_spent(self, coin_name: bytes32, height: uint32) -> WalletCoinRecord:
@@ -130,9 +124,8 @@ class WalletCoinStore:
 
     async def get_coin_record(self, coin_name: bytes32) -> Optional[WalletCoinRecord]:
         """Returns CoinRecord with specified coin id."""
-        rows = list(
-            await self.db_connection.execute_fetchall("SELECT * from coin_record WHERE coin_name=?", (coin_name.hex(),))
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = list(await conn.execute_fetchall("SELECT * from coin_record WHERE coin_name=?", (coin_name.hex(),)))
 
         if len(rows) == 0:
             return None
@@ -140,7 +133,8 @@ class WalletCoinStore:
 
     async def get_first_coin_height(self) -> Optional[uint32]:
         """Returns height of first confirmed coin"""
-        rows = list(await self.db_connection.execute_fetchall("SELECT MIN(confirmed_height) FROM coin_record"))
+        async with self.db_wrapper.read_db() as conn:
+            rows = list(await conn.execute_fetchall("SELECT MIN(confirmed_height) FROM coin_record"))
 
         if len(rows) != 0 and rows[0][0] is not None:
             return uint32(rows[0][0])
@@ -149,38 +143,40 @@ class WalletCoinStore:
 
     async def get_unspent_coins_for_wallet(self, wallet_id: int) -> Set[WalletCoinRecord]:
         """Returns set of CoinRecords that have not been spent yet for a wallet."""
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * FROM coin_record WHERE wallet_id=? AND spent_height=0", (wallet_id,)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                "SELECT * FROM coin_record WHERE wallet_id=? AND spent_height=0", (wallet_id,)
+            )
         return set(self.coin_record_from_row(row) for row in rows)
 
     async def get_coins_to_check(self, check_height) -> Set[WalletCoinRecord]:
         """Returns set of all CoinRecords."""
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * from coin_record where spent_height=0 or spent_height>? or confirmed_height>?",
-            (
-                check_height,
-                check_height,
-            ),
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                "SELECT * from coin_record where spent_height=0 or spent_height>? or confirmed_height>?",
+                (
+                    check_height,
+                    check_height,
+                ),
+            )
 
         return set(self.coin_record_from_row(row) for row in rows)
 
     # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them
     async def get_coin_records_by_puzzle_hash(self, puzzle_hash: bytes32) -> List[WalletCoinRecord]:
         """Returns a list of all coin records with the given puzzle hash"""
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * from coin_record WHERE puzzle_hash=?", (puzzle_hash.hex(),)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall("SELECT * from coin_record WHERE puzzle_hash=?", (puzzle_hash.hex(),))
 
         return [self.coin_record_from_row(row) for row in rows]
 
     # Checks DB and DiffStores for CoinRecords with parent_coin_info and returns them
     async def get_coin_records_by_parent_id(self, parent_coin_info: bytes32) -> List[WalletCoinRecord]:
         """Returns a list of all coin records with the given parent id"""
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * from coin_record WHERE coin_parent=?", (parent_coin_info.hex(),)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                "SELECT * from coin_record WHERE coin_parent=?", (parent_coin_info.hex(),)
+            )
 
         return [self.coin_record_from_row(row) for row in rows]
 
@@ -190,10 +186,11 @@ class WalletCoinStore:
         All coins spent after this point are set to unspent. Can be -1 (rollback all)
         """
 
-        c1 = await self.db_connection.execute("DELETE FROM coin_record WHERE confirmed_height>?", (height,))
-        await c1.close()
-        c2 = await self.db_connection.execute(
-            "UPDATE coin_record SET spent_height = 0, spent = 0 WHERE spent_height>?",
-            (height,),
-        )
-        await c2.close()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM coin_record WHERE confirmed_height>?", (height,))).close()
+            await (
+                await conn.execute(
+                    "UPDATE coin_record SET spent_height = 0, spent = 0 WHERE spent_height>?",
+                    (height,),
+                )
+            ).close()

--- a/chia/wallet/wallet_interested_store.py
+++ b/chia/wallet/wallet_interested_store.py
@@ -1,9 +1,7 @@
 from typing import List, Tuple, Optional
 
-import aiosqlite
-
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32
 
 
@@ -12,99 +10,77 @@ class WalletInterestedStore:
     Stores coin ids that we are interested in receiving
     """
 
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper):
+    async def create(cls, wrapper: DBWrapper2):
         self = cls()
-
-        self.db_connection = wrapper.db
         self.db_wrapper = wrapper
 
-        await self.db_connection.execute("CREATE TABLE IF NOT EXISTS interested_coins(coin_name text PRIMARY KEY)")
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute("CREATE TABLE IF NOT EXISTS interested_coins(coin_name text PRIMARY KEY)")
 
-        await self.db_connection.execute(
-            "CREATE TABLE IF NOT EXISTS interested_puzzle_hashes(puzzle_hash text PRIMARY KEY, wallet_id integer)"
-        )
+            await conn.execute(
+                "CREATE TABLE IF NOT EXISTS interested_puzzle_hashes(puzzle_hash text PRIMARY KEY, wallet_id integer)"
+            )
 
-        # Table for unknown CATs
-        fields = "asset_id text PRIMARY KEY, name text, first_seen_height integer, sender_puzzle_hash text"
-        await self.db_connection.execute(f"CREATE TABLE IF NOT EXISTS unacknowledged_asset_tokens({fields})")
+            # Table for unknown CATs
+            fields = "asset_id text PRIMARY KEY, name text, first_seen_height integer, sender_puzzle_hash text"
+            await conn.execute(f"CREATE TABLE IF NOT EXISTS unacknowledged_asset_tokens({fields})")
 
-        await self.db_connection.commit()
         return self
 
     async def _clear_database(self):
-        cursor = await self.db_connection.execute("DELETE FROM interested_puzzle_hashes")
-        await cursor.close()
-        cursor = await self.db_connection.execute("DELETE FROM interested_coins")
-        await cursor.close()
-        cursor = await self.db_connection.execute("DELETE FROM unacknowledged_asset_tokens")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute("DELETE FROM interested_puzzle_hashes")
+            await cursor.close()
+            cursor = await conn.execute("DELETE FROM interested_coins")
+            await cursor.close()
+            cursor = await conn.execute("DELETE FROM unacknowledged_asset_tokens")
+            await cursor.close()
 
     async def get_interested_coin_ids(self) -> List[bytes32]:
-        cursor = await self.db_connection.execute("SELECT coin_name FROM interested_coins")
-        rows_hex = await cursor.fetchall()
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute("SELECT coin_name FROM interested_coins")
+            rows_hex = await cursor.fetchall()
         return [bytes32(bytes.fromhex(row[0])) for row in rows_hex]
 
-    async def add_interested_coin_id(self, coin_id: bytes32, in_transaction: bool = False) -> None:
+    async def add_interested_coin_id(self, coin_id: bytes32) -> None:
 
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
-                "INSERT OR REPLACE INTO interested_coins VALUES (?)", (coin_id.hex(),)
-            )
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute("INSERT OR REPLACE INTO interested_coins VALUES (?)", (coin_id.hex(),))
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
     async def get_interested_puzzle_hashes(self) -> List[Tuple[bytes32, int]]:
-        cursor = await self.db_connection.execute("SELECT puzzle_hash, wallet_id FROM interested_puzzle_hashes")
-        rows_hex = await cursor.fetchall()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT puzzle_hash, wallet_id FROM interested_puzzle_hashes")
+            rows_hex = await cursor.fetchall()
         return [(bytes32(bytes.fromhex(row[0])), row[1]) for row in rows_hex]
 
     async def get_interested_puzzle_hash_wallet_id(self, puzzle_hash: bytes32) -> Optional[int]:
-        cursor = await self.db_connection.execute(
-            "SELECT wallet_id FROM interested_puzzle_hashes WHERE puzzle_hash=?", (puzzle_hash.hex(),)
-        )
-        row = await cursor.fetchone()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT wallet_id FROM interested_puzzle_hashes WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+            )
+            row = await cursor.fetchone()
         if row is None:
             return None
         return row[0]
 
-    async def add_interested_puzzle_hash(
-        self, puzzle_hash: bytes32, wallet_id: int, in_transaction: bool = False
-    ) -> None:
+    async def add_interested_puzzle_hash(self, puzzle_hash: bytes32, wallet_id: int) -> None:
 
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 "INSERT OR REPLACE INTO interested_puzzle_hashes VALUES (?, ?)", (puzzle_hash.hex(), wallet_id)
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
-    async def remove_interested_puzzle_hash(self, puzzle_hash: bytes32, in_transaction: bool = False) -> None:
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+    async def remove_interested_puzzle_hash(self, puzzle_hash: bytes32) -> None:
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 "DELETE FROM interested_puzzle_hashes WHERE puzzle_hash=?", (puzzle_hash.hex(),)
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
     async def add_unacknowledged_token(
         self,
@@ -112,7 +88,6 @@ class WalletInterestedStore:
         name: str,
         first_seen_height: Optional[uint32],
         sender_puzzle_hash: bytes32,
-        in_transaction: bool = True,
     ) -> None:
         """
         Add an unacknowledged CAT to the database. It will only be inserted once at the first time.
@@ -120,13 +95,10 @@ class WalletInterestedStore:
         :param name: Name of the CAT, for now it will be unknown until we integrate the CAT name service
         :param first_seen_height: The block height of the wallet received this CAT in the first time
         :param sender_puzzle_hash: The puzzle hash of the sender
-        :param in_transaction: In transaction or not
         :return: None
         """
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 "INSERT OR IGNORE INTO unacknowledged_asset_tokens VALUES (?, ?, ?, ?)",
                 (
                     asset_id.hex(),
@@ -136,20 +108,17 @@ class WalletInterestedStore:
                 ),
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
     async def get_unacknowledged_tokens(self) -> List:
         """
         Get a list of all unacknowledged CATs
         :return: A json style list of unacknowledged CATs
         """
-        cursor = await self.db_connection.execute(
-            "SELECT asset_id, name, first_seen_height, sender_puzzle_hash FROM unacknowledged_asset_tokens"
-        )
-        cats = await cursor.fetchall()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT asset_id, name, first_seen_height, sender_puzzle_hash FROM unacknowledged_asset_tokens"
+            )
+            cats = await cursor.fetchall()
         return [
             {"asset_id": cat[0], "name": cat[1], "first_seen_height": cat[2], "sender_puzzle_hash": cat[3]}
             for cat in cats

--- a/chia/wallet/wallet_nft_store.py
+++ b/chia/wallet/wallet_nft_store.py
@@ -1,12 +1,10 @@
 import json
 from typing import List, Optional, Type, TypeVar
 
-import aiosqlite
-
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.nft_wallet.nft_info import DEFAULT_STATUS, IN_TRANSACTION_STATUS, NFTCoinInfo
@@ -19,57 +17,43 @@ class WalletNftStore:
     WalletNftStore keeps track of all user created NFTs and necessary smart-contract data
     """
 
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls: Type[_T_WalletNftStore], db_wrapper: DBWrapper) -> _T_WalletNftStore:
+    async def create(cls: Type[_T_WalletNftStore], db_wrapper: DBWrapper2) -> _T_WalletNftStore:
         self = cls()
         self.db_wrapper = db_wrapper
-        self.db_connection = db_wrapper.db
-        await self.db_connection.execute(
-            (
-                "CREATE TABLE IF NOT EXISTS users_nfts("
-                " nft_id text PRIMARY KEY,"
-                " nft_coin_id text,"
-                " wallet_id int,"
-                " did_id text,"
-                " coin text,"
-                " lineage_proof text,"
-                " mint_height bigint,"
-                " status text,"
-                " full_puzzle blob)"
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS users_nfts("
+                    " nft_id text PRIMARY KEY,"
+                    " nft_coin_id text,"
+                    " wallet_id int,"
+                    " did_id text,"
+                    " coin text,"
+                    " lineage_proof text,"
+                    " mint_height bigint,"
+                    " status text,"
+                    " full_puzzle blob)"
+                )
             )
-        )
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS nft_coin_id on users_nfts(nft_coin_id)")
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS nft_wallet_id on users_nfts(wallet_id)")
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS nft_did_id on users_nfts(did_id)")
-        await self.db_connection.commit()
+            await conn.execute("CREATE INDEX IF NOT EXISTS nft_coin_id on users_nfts(nft_coin_id)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS nft_wallet_id on users_nfts(wallet_id)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS nft_did_id on users_nfts(did_id)")
         return self
 
     async def _clear_database(self) -> None:
-        cursor = await self.db_connection.execute("DELETE FROM users_nfts")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM users_nfts")).close()
 
-    async def delete_nft(self, nft_id: bytes32, in_transaction: bool = False) -> None:
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(f"DELETE FROM users_nfts where nft_id='{nft_id.hex()}'")
-            await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
+    async def delete_nft(self, nft_id: bytes32) -> None:
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute(f"DELETE FROM users_nfts where nft_id='{nft_id.hex()}'")).close()
 
-    async def save_nft(
-        self, wallet_id: uint32, did_id: Optional[bytes32], nft_coin_info: NFTCoinInfo, in_transaction: bool = False
-    ) -> None:
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+    async def save_nft(self, wallet_id: uint32, did_id: Optional[bytes32], nft_coin_info: NFTCoinInfo) -> None:
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 "INSERT or REPLACE INTO users_nfts VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     nft_coin_info.nft_id.hex(),
@@ -86,10 +70,6 @@ class WalletNftStore:
                 ),
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
     async def get_nft_list(
         self, wallet_id: Optional[uint32] = None, did_id: Optional[bytes32] = None
@@ -101,9 +81,11 @@ class WalletNftStore:
             sql += f" where did_id='{did_id.hex()}'"
         if wallet_id is not None and did_id is not None:
             sql += f" where did_id='{did_id.hex()}' and wallet_id={wallet_id}"
-        cursor = await self.db_connection.execute(sql)
-        rows = await cursor.fetchall()
-        await cursor.close()
+
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(sql)
+            rows = await cursor.fetchall()
+            await cursor.close()
         result = []
 
         for row in rows:
@@ -120,12 +102,13 @@ class WalletNftStore:
         return result
 
     async def get_nft_by_id(self, nft_id: bytes32) -> Optional[NFTCoinInfo]:
-        cursor = await self.db_connection.execute(
-            "SELECT nft_id, coin, lineage_proof, mint_height, status, full_puzzle from users_nfts WHERE nft_id=?",
-            (nft_id.hex(),),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT nft_id, coin, lineage_proof, mint_height, status, full_puzzle from users_nfts WHERE nft_id=?",
+                (nft_id.hex(),),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is None:
             return None
@@ -138,6 +121,3 @@ class WalletNftStore:
             uint32(row[3]),
             row[4] == IN_TRANSACTION_STATUS,
         )
-
-    async def close(self) -> None:
-        await self.db_connection.close()

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -517,6 +517,11 @@ class WalletNode:
                 for wallet_id in removed_wallet_ids:
                     self.wallet_state_manager.wallets.pop(wallet_id)
 
+        # this has to be called *after* the transaction commits, otherwise it
+        # won't see the changes (since we spawn a new task to handle potential
+        # resends)
+        self._pending_tx_handler()
+
     async def long_sync(
         self,
         target_height: uint32,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -802,7 +802,7 @@ class WalletNode:
         # to come before the corresponding new_peak for each height. We handle this differently for trusted and
         # untrusted peers. For trusted, we always process the state, and we process reorgs as well.
         for coin in request.items:
-            self.log.info(f"request coin: {coin.coin.name()}{coin}")
+            self.log.info(f"request coin: {coin.coin.name().hex()}{coin}")
 
         async with self.wallet_state_manager.lock:
             await self.receive_state_from_peer(

--- a/chia/wallet/wallet_pool_store.py
+++ b/chia/wallet/wallet_pool_store.py
@@ -1,49 +1,43 @@
 import logging
 from typing import List, Tuple
 
-import aiosqlite
-
 from chia.types.coin_spend import CoinSpend
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32
 
 log = logging.getLogger(__name__)
 
 
 class WalletPoolStore:
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper):
+    async def create(cls, wrapper: DBWrapper2):
         self = cls()
-
-        self.db_connection = wrapper.db
         self.db_wrapper = wrapper
 
-        await self.db_connection.execute(
-            "CREATE TABLE IF NOT EXISTS pool_state_transitions("
-            " transition_index integer,"
-            " wallet_id integer,"
-            " height bigint,"
-            " coin_spend blob,"
-            " PRIMARY KEY(transition_index, wallet_id))"
-        )
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
+                "CREATE TABLE IF NOT EXISTS pool_state_transitions("
+                " transition_index integer,"
+                " wallet_id integer,"
+                " height bigint,"
+                " coin_spend blob,"
+                " PRIMARY KEY(transition_index, wallet_id))"
+            )
 
-        await self.db_connection.commit()
         return self
 
     async def _clear_database(self):
-        cursor = await self.db_connection.execute("DELETE FROM interested_coins")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute("DELETE FROM interested_coins")
+            await cursor.close()
 
     async def add_spend(
         self,
         wallet_id: int,
         spend: CoinSpend,
         height: uint32,
-        in_transaction=False,
     ) -> None:
         """
         Appends (or replaces) entries in the DB. The new list must be at least as long as the existing list, and the
@@ -51,12 +45,10 @@ class WalletPoolStore:
         until db_wrapper.commit() is called. However it is written to the cache, so it can be fetched with
         get_all_state_transitions.
         """
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
+        async with self.db_wrapper.write_db() as conn:
             # find the most recent transition in wallet_id
             rows = list(
-                await self.db_connection.execute_fetchall(
+                await conn.execute_fetchall(
                     "SELECT transition_index, height, coin_spend "
                     "FROM pool_state_transitions "
                     "WHERE wallet_id=? "
@@ -70,7 +62,7 @@ class WalletPoolStore:
                 transition_index = 0
             else:
                 existing = list(
-                    await self.db_connection.execute_fetchall(
+                    await conn.execute_fetchall(
                         "SELECT COUNT(*) "
                         "FROM pool_state_transitions "
                         "WHERE wallet_id=? AND height=? AND coin_spend=?",
@@ -89,7 +81,7 @@ class WalletPoolStore:
                     raise ValueError("New spend does not extend")
                 transition_index = row[0]
 
-            cursor = await self.db_connection.execute(
+            cursor = await conn.execute(
                 "INSERT OR IGNORE INTO pool_state_transitions VALUES (?, ?, ?, ?)",
                 (
                     transition_index + 1,
@@ -99,37 +91,28 @@ class WalletPoolStore:
                 ),
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
 
     async def get_spends_for_wallet(self, wallet_id: int) -> List[Tuple[uint32, CoinSpend]]:
         """
         Retrieves all entries for a wallet ID.
         """
 
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT height, coin_spend FROM pool_state_transitions WHERE wallet_id=? ORDER BY transition_index",
-            (wallet_id,),
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                "SELECT height, coin_spend FROM pool_state_transitions WHERE wallet_id=? ORDER BY transition_index",
+                (wallet_id,),
+            )
         return [(uint32(row[0]), CoinSpend.from_bytes(row[1])) for row in rows]
 
-    async def rollback(self, height: int, wallet_id_arg: int, in_transaction: bool) -> None:
+    async def rollback(self, height: int, wallet_id_arg: int) -> None:
         """
         Rollback removes all entries which have entry_height > height passed in. Note that this is not committed to the
         DB until db_wrapper.commit() is called. However it is written to the cache, so it can be fetched with
         get_all_state_transitions.
         """
 
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
+        async with self.db_wrapper.write_db() as conn:
+            cursor = await conn.execute(
                 "DELETE FROM pool_state_transitions WHERE height>? AND wallet_id=?", (height, wallet_id_arg)
             )
             await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -2,11 +2,10 @@ import asyncio
 import logging
 from typing import List, Optional, Set, Tuple
 
-import aiosqlite
 from blspy import G1Element
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32
 from chia.util.lru_cache import LRUCache
 from chia.wallet.derivation_record import DerivationRecord
@@ -22,56 +21,49 @@ class WalletPuzzleStore:
     WalletInterestedStore to keep track of puzzle hashes which we are interested in.
     """
 
-    db_connection: aiosqlite.Connection
     lock: asyncio.Lock
     cache_size: uint32
     all_puzzle_hashes: Set[bytes32]
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper, cache_size: uint32 = uint32(600000)):
+    async def create(cls, db_wrapper: DBWrapper2, cache_size: uint32 = uint32(600000)):
         self = cls()
 
         self.cache_size = cache_size
 
         self.db_wrapper = db_wrapper
-        self.db_connection = self.db_wrapper.db
-        await self.db_connection.execute(
-            (
-                "CREATE TABLE IF NOT EXISTS derivation_paths("
-                "derivation_index int,"
-                " pubkey text,"
-                " puzzle_hash text PRIMARY KEY,"
-                " wallet_type int,"
-                " wallet_id int,"
-                " used tinyint,"
-                " hardened tinyint)"
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS derivation_paths("
+                    "derivation_index int,"
+                    " pubkey text,"
+                    " puzzle_hash text PRIMARY KEY,"
+                    " wallet_type int,"
+                    " wallet_id int,"
+                    " used tinyint,"
+                    " hardened tinyint)"
+                )
             )
-        )
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS derivation_index_index on derivation_paths(derivation_index)"
-        )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS derivation_index_index on derivation_paths(derivation_index)"
+            )
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS ph on derivation_paths(puzzle_hash)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS ph on derivation_paths(puzzle_hash)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS pubkey on derivation_paths(pubkey)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS pubkey on derivation_paths(pubkey)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS wallet_type on derivation_paths(wallet_type)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS wallet_type on derivation_paths(wallet_type)")
 
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS derivation_paths_wallet_id on derivation_paths(wallet_id)"
-        )
+            await conn.execute("CREATE INDEX IF NOT EXISTS derivation_paths_wallet_id on derivation_paths(wallet_id)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS used on derivation_paths(wallet_type)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS used on derivation_paths(wallet_type)")
 
-        await self.db_connection.commit()
         # Lock
         self.lock = asyncio.Lock()  # external
         await self._init_cache()
         return self
-
-    async def close(self):
-        await self.db_connection.close()
 
     async def _init_cache(self):
         self.all_puzzle_hashes = await self.get_all_puzzle_hashes()
@@ -79,49 +71,42 @@ class WalletPuzzleStore:
         self.wallet_info_for_ph_cache = LRUCache(100)
 
     async def _clear_database(self):
-        cursor = await self.db_connection.execute("DELETE FROM derivation_paths")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM derivation_paths")).close()
 
-    async def add_derivation_paths(self, records: List[DerivationRecord], in_transaction=False) -> None:
+    async def add_derivation_paths(self, records: List[DerivationRecord]) -> None:
         """
         Insert many derivation paths into the database.
         """
         if len(records) == 0:
             return
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            sql_records = []
-            for record in records:
-                log.debug("Adding derivation record: %s", record)
-                self.all_puzzle_hashes.add(record.puzzle_hash)
-                if record.hardened:
-                    hardened = 1
-                else:
-                    hardened = 0
-                sql_records.append(
-                    (
-                        record.index,
-                        bytes(record.pubkey).hex(),
-                        record.puzzle_hash.hex(),
-                        record.wallet_type,
-                        record.wallet_id,
-                        0,
-                        hardened,
-                    ),
-                )
-
-            cursor = await self.db_connection.executemany(
-                "INSERT OR REPLACE INTO derivation_paths VALUES(?, ?, ?, ?, ?, ?, ?)",
-                sql_records,
+        sql_records = []
+        for record in records:
+            log.debug("Adding derivation record: %s", record)
+            self.all_puzzle_hashes.add(record.puzzle_hash)
+            if record.hardened:
+                hardened = 1
+            else:
+                hardened = 0
+            sql_records.append(
+                (
+                    record.index,
+                    bytes(record.pubkey).hex(),
+                    record.puzzle_hash.hex(),
+                    record.wallet_type,
+                    record.wallet_id,
+                    0,
+                    hardened,
+                ),
             )
 
-            await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
+        async with self.db_wrapper.write_db() as conn:
+            await (
+                await conn.executemany(
+                    "INSERT OR REPLACE INTO derivation_paths VALUES(?, ?, ?, ?, ?, ?, ?)",
+                    sql_records,
+                )
+            ).close()
 
     async def get_derivation_record(
         self, index: uint32, wallet_id: uint32, hardened: bool
@@ -133,13 +118,14 @@ class WalletPuzzleStore:
             hard = 1
         else:
             hard = 0
-        cursor = await self.db_connection.execute(
-            "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used FROM derivation_paths "
-            "WHERE derivation_index=? AND wallet_id=? AND hardened=?",
-            (index, wallet_id, hard),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used FROM derivation_paths "
+                "WHERE derivation_index=? AND wallet_id=? AND hardened=?",
+                (index, wallet_id, hard),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             return DerivationRecord(
@@ -157,13 +143,14 @@ class WalletPuzzleStore:
         """
         Returns the derivation record by index and wallet id.
         """
-        cursor = await self.db_connection.execute(
-            "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, hardened FROM derivation_paths "
-            "WHERE puzzle_hash=?",
-            (puzzle_hash.hex(),),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, hardened FROM derivation_paths "
+                "WHERE puzzle_hash=?",
+                (puzzle_hash.hex(),),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             return DerivationRecord(
@@ -177,34 +164,30 @@ class WalletPuzzleStore:
 
         return None
 
-    async def set_used_up_to(self, index: uint32, in_transaction=False) -> None:
+    async def set_used_up_to(self, index: uint32) -> None:
         """
         Sets a derivation path to used so we don't use it again.
         """
 
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            cursor = await self.db_connection.execute(
-                "UPDATE derivation_paths SET used=1 WHERE derivation_index<=?",
-                (index,),
-            )
-            await cursor.close()
-        finally:
-            if not in_transaction:
-                await self.db_connection.commit()
-                self.db_wrapper.lock.release()
+        async with self.db_wrapper.write_db() as conn:
+            await (
+                await conn.execute(
+                    "UPDATE derivation_paths SET used=1 WHERE derivation_index<=?",
+                    (index,),
+                )
+            ).close()
 
     async def puzzle_hash_exists(self, puzzle_hash: bytes32) -> bool:
         """
         Checks if passed puzzle_hash is present in the db.
         """
 
-        cursor = await self.db_connection.execute(
-            "SELECT puzzle_hash FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT puzzle_hash FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         return row is not None
 
@@ -237,11 +220,12 @@ class WalletPuzzleStore:
         Returns None if not present.
         """
 
-        cursor = await self.db_connection.execute(
-            "SELECT derivation_index FROM derivation_paths WHERE pubkey=?", (bytes(pubkey).hex(),)
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT derivation_index FROM derivation_paths WHERE pubkey=?", (bytes(pubkey).hex(),)
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None:
             return uint32(row[0])
@@ -254,14 +238,15 @@ class WalletPuzzleStore:
         Returns None if not present.
         """
 
-        cursor = await self.db_connection.execute(
-            "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used, hardened "
-            "FROM derivation_paths "
-            "WHERE pubkey=?",
-            (bytes(pubkey).hex(),),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used, hardened "
+                "FROM derivation_paths "
+                "WHERE pubkey=?",
+                (bytes(pubkey).hex(),),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None:
             return self.row_to_record(row)
@@ -273,11 +258,12 @@ class WalletPuzzleStore:
         Returns the derivation path for the puzzle_hash.
         Returns None if not present.
         """
-        cursor = await self.db_connection.execute(
-            "SELECT derivation_index FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT derivation_index FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None:
             return uint32(row[0])
@@ -289,14 +275,15 @@ class WalletPuzzleStore:
         Returns the derivation path for the puzzle_hash.
         Returns None if not present.
         """
-        cursor = await self.db_connection.execute(
-            "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used, hardened "
-            "FROM derivation_paths "
-            "WHERE puzzle_hash=?",
-            (puzzle_hash.hex(),),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used, hardened "
+                "FROM derivation_paths "
+                "WHERE puzzle_hash=?",
+                (puzzle_hash.hex(),),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             return self.row_to_record(row)
@@ -308,15 +295,16 @@ class WalletPuzzleStore:
         Returns the derivation path for the puzzle_hash.
         Returns None if not present.
         """
-        cursor = await self.db_connection.execute(
-            "SELECT derivation_index FROM derivation_paths WHERE puzzle_hash=? AND wallet_id=?;",
-            (
-                puzzle_hash.hex(),
-                wallet_id,
-            ),
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT derivation_index FROM derivation_paths WHERE puzzle_hash=? AND wallet_id=?;",
+                (
+                    puzzle_hash.hex(),
+                    wallet_id,
+                ),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None:
             return uint32(row[0])
@@ -331,11 +319,13 @@ class WalletPuzzleStore:
         cached = self.wallet_info_for_ph_cache.get(puzzle_hash)
         if cached is not None:
             return cached
-        cursor = await self.db_connection.execute(
-            "SELECT wallet_type, wallet_id FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT wallet_type, wallet_id FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None:
             self.wallet_info_for_ph_cache.put(puzzle_hash, (row[1], WalletType(row[0])))
@@ -348,9 +338,10 @@ class WalletPuzzleStore:
         Return a set containing all puzzle_hashes we generated.
         """
 
-        cursor = await self.db_connection.execute("SELECT puzzle_hash FROM derivation_paths")
-        rows = await cursor.fetchall()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT puzzle_hash FROM derivation_paths")
+            rows = await cursor.fetchall()
+            await cursor.close()
         result: Set[bytes32] = set()
 
         for row in rows:
@@ -363,9 +354,10 @@ class WalletPuzzleStore:
         Returns the last derivation path by derivation_index.
         """
 
-        cursor = await self.db_connection.execute("SELECT MAX(derivation_index) FROM derivation_paths;")
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute("SELECT MAX(derivation_index) FROM derivation_paths;")
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             return uint32(row[0])
@@ -377,11 +369,12 @@ class WalletPuzzleStore:
         Returns the last derivation path by derivation_index.
         """
 
-        cursor = await self.db_connection.execute(
-            f"SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id={wallet_id};"
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                f"SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id={wallet_id};"
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             return uint32(row[0])
@@ -393,11 +386,14 @@ class WalletPuzzleStore:
         Returns the current derivation record by derivation_index.
         """
 
-        cursor = await self.db_connection.execute(
-            f"SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id={wallet_id} AND used=1 AND hardened=0;"
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT MAX(derivation_index) "
+                "FROM derivation_paths "
+                f"WHERE wallet_id={wallet_id} AND used=1 AND hardened=0;"
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             index = uint32(row[0])
@@ -409,11 +405,12 @@ class WalletPuzzleStore:
         """
         Returns the first unused derivation path by derivation_index.
         """
-        cursor = await self.db_connection.execute(
-            "SELECT MIN(derivation_index) FROM derivation_paths WHERE used=0 AND hardened=0;"
-        )
-        row = await cursor.fetchone()
-        await cursor.close()
+        async with self.db_wrapper.read_db() as conn:
+            cursor = await conn.execute(
+                "SELECT MIN(derivation_index) FROM derivation_paths WHERE used=0 AND hardened=0;"
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
 
         if row is not None and row[0] is not None:
             return uint32(row[0])

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1379,7 +1379,6 @@ class WalletStateManager:
                 TransactionType.INCOMING_TRADE,
             ]:
                 await self.tx_store.tx_reorged(record)
-        self.tx_pending_changed()
 
         # Removes wallets that were created from a blockchain transaction which got reorged.
         remove_ids = []

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -32,7 +32,7 @@ from chia.util.bech32m import encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import process_config_start_method
 from chia.util.db_synchronous import db_synchronous_on
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.errors import Err
 from chia.util.path import path_from_root
 from chia.util.ints import uint8, uint32, uint64, uint128
@@ -104,8 +104,7 @@ class WalletStateManager:
     pending_tx_callback: Optional[Callable]
     puzzle_hash_created_callbacks: Dict = defaultdict(lambda *x: None)
     db_path: Path
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
 
     main_wallet: Wallet
     wallets: Dict[uint32, Any]
@@ -147,25 +146,36 @@ class WalletStateManager:
         self.log = logging.getLogger(name if name else __name__)
         self.lock = asyncio.Lock()
         self.log.debug(f"Starting in db path: {db_path}")
-        self.db_connection = await aiosqlite.connect(db_path)
-        await self.db_connection.execute("pragma journal_mode=wal")
+        db_connection = await aiosqlite.connect(db_path)
+        await (await db_connection.execute("pragma journal_mode=wal")).close()
 
-        await self.db_connection.execute(
-            "pragma synchronous={}".format(db_synchronous_on(self.config.get("db_sync", "auto"), db_path))
-        )
+        await (
+            await db_connection.execute(
+                "pragma synchronous={}".format(db_synchronous_on(self.config.get("db_sync", "auto"), db_path))
+            )
+        ).close()
+
+        sql_log_path = path_from_root(self.root_path, "log/wallet_sql.log")
+
+        def sql_trace_callback(req: str) -> None:
+            timestamp = datetime.now().strftime("%H:%M:%S.%f")
+            with open(sql_log_path, "a") as log:
+                log.write(timestamp + " " + req + "\n")
 
         if self.config.get("log_sqlite_cmds", False):
-            sql_log_path = path_from_root(self.root_path, "log/wallet_sql.log")
             self.log.info(f"logging SQL commands to {sql_log_path}")
 
-            def sql_trace_callback(req: str):
-                timestamp = datetime.now().strftime("%H:%M:%S.%f")
-                with open(sql_log_path, "a") as log:
-                    log.write(timestamp + " " + req + "\n")
+            await db_connection.set_trace_callback(sql_trace_callback)
 
-            await self.db_connection.set_trace_callback(sql_trace_callback)
+        self.db_wrapper = DBWrapper2(db_connection)
 
-        self.db_wrapper = DBWrapper(self.db_connection)
+        # add reader threads for the DB
+        for i in range(self.config.get("db_readers", 4)):
+            c = await aiosqlite.connect(db_path)
+            if self.config.get("log_sqlite_cmds", False):
+                await c.set_trace_callback(sql_trace_callback)
+            await self.db_wrapper.add_connection(c)
+
         self.coin_store = await WalletCoinStore.create(self.db_wrapper)
         self.tx_store = await WalletTransactionStore.create(self.db_wrapper)
         self.puzzle_store = await WalletPuzzleStore.create(self.db_wrapper)
@@ -261,7 +271,7 @@ class WalletStateManager:
         pubkey = private.get_g1()
         return pubkey, private
 
-    async def create_more_puzzle_hashes(self, from_zero: bool = False, in_transaction=False):
+    async def create_more_puzzle_hashes(self, from_zero: bool = False):
         """
         For all wallets in the user store, generates the first few puzzle hashes so
         that we can restore the wallet from only the private keys.
@@ -343,16 +353,15 @@ class WalletStateManager:
                         )
                     )
                 self.log.info(f"Done: {creating_msg}")
-            await self.puzzle_store.add_derivation_paths(derivation_paths, in_transaction)
+            await self.puzzle_store.add_derivation_paths(derivation_paths)
             await self.add_interested_puzzle_hashes(
                 [record.puzzle_hash for record in derivation_paths],
                 [record.wallet_id for record in derivation_paths],
-                in_transaction,
             )
         if unused > 0 and new_paths:
-            await self.puzzle_store.set_used_up_to(uint32(unused - 1), in_transaction)
+            await self.puzzle_store.set_used_up_to(uint32(unused - 1))
 
-    async def update_wallet_puzzle_hashes(self, wallet_id, in_transaction=False):
+    async def update_wallet_puzzle_hashes(self, wallet_id):
         derivation_paths: List[DerivationRecord] = []
         target_wallet = self.wallets[wallet_id]
         last: Optional[uint32] = await self.puzzle_store.get_last_derivation_path_for_wallet(wallet_id)
@@ -379,11 +388,9 @@ class WalletStateManager:
                     False,
                 )
             )
-        await self.puzzle_store.add_derivation_paths(derivation_paths, in_transaction=in_transaction)
+        await self.puzzle_store.add_derivation_paths(derivation_paths)
 
-    async def get_unused_derivation_record(
-        self, wallet_id: uint32, in_transaction=False, hardened=False
-    ) -> DerivationRecord:
+    async def get_unused_derivation_record(self, wallet_id: uint32, *, hardened=False) -> DerivationRecord:
         """
         Creates a puzzle hash for the given wallet, and then makes more puzzle hashes
         for every wallet to ensure we always have more in the database. Never reusue the
@@ -406,10 +413,10 @@ class WalletStateManager:
             assert record is not None
 
             # Set this key to used so we never use it again
-            await self.puzzle_store.set_used_up_to(record.index, in_transaction=in_transaction)
+            await self.puzzle_store.set_used_up_to(record.index)
 
             # Create more puzzle hashes / keys
-            await self.create_more_puzzle_hashes(in_transaction=in_transaction)
+            await self.create_more_puzzle_hashes()
             return record
 
     async def get_current_derivation_record_for_wallet(self, wallet_id: uint32) -> Optional[DerivationRecord]:
@@ -656,9 +663,7 @@ class WalletStateManager:
             if bytes(tail_hash).hex()[2:] in self.default_cats or self.config.get(
                 "automatically_add_unknown_cats", False
             ):
-                cat_wallet = await CATWallet.create_wallet_for_cat(
-                    self, self.main_wallet, bytes(tail_hash).hex()[2:], in_transaction=True
-                )
+                cat_wallet = await CATWallet.create_wallet_for_cat(self, self.main_wallet, bytes(tail_hash).hex()[2:])
                 wallet_id = cat_wallet.id()
                 wallet_type = WalletType(cat_wallet.type())
                 self.state_changed("wallet_created")
@@ -807,7 +812,7 @@ class WalletStateManager:
                     old_did_id,
                 )
                 nft_wallet: NFTWallet = self.wallets[wallet_info.id]
-                await nft_wallet.remove_coin(coin_spend.coin, in_transaction=True)
+                await nft_wallet.remove_coin(coin_spend.coin)
             if nft_wallet_info.did_id == new_did_id:
                 self.log.info(
                     "Adding new NFT, NFT_ID:%s, DID_ID:%s",
@@ -825,7 +830,7 @@ class WalletStateManager:
                 new_did_id,
             )
             new_nft_wallet: NFTWallet = await NFTWallet.create_new_nft_wallet(
-                self, self.main_wallet, did_id=new_did_id, name="NFT Wallet", in_transaction=True
+                self, self.main_wallet, did_id=new_did_id, name="NFT Wallet"
             )
             wallet_id = uint32(new_nft_wallet.wallet_id)
             wallet_type = WalletType.NFT
@@ -889,7 +894,7 @@ class WalletStateManager:
             if derivation_index is not None:
                 ph_to_index_cache.put(coin_state.coin.puzzle_hash, derivation_index)
                 if derivation_index > used_up_to:
-                    await self.puzzle_store.set_used_up_to(derivation_index, True)
+                    await self.puzzle_store.set_used_up_to(derivation_index)
                     used_up_to = max(used_up_to, derivation_index)
 
             if coin_state.created_height is None:
@@ -967,7 +972,7 @@ class WalletStateManager:
                             name=bytes32(token_bytes()),
                             memos=[],
                         )
-                        await self.tx_store.add_transaction_record(tx_record, True)
+                        await self.tx_store.add_transaction_record(tx_record)
 
                     children = await self.wallet_node.fetch_children(coin_name, fork_height, peer)
                     assert children is not None
@@ -1022,7 +1027,7 @@ class WalletStateManager:
                                 memos=[],
                             )
 
-                            await self.tx_store.add_transaction_record(tx_record, True)
+                            await self.tx_store.add_transaction_record(tx_record)
                 else:
                     await self.coin_store.set_spent(coin_name, coin_state.spent_height)
                     rem_tx_records: List[TransactionRecord] = []
@@ -1063,7 +1068,7 @@ class WalletStateManager:
                                 record.wallet_type,
                             )
                             await self.coin_store.set_spent(curr_coin_state.coin.name(), curr_coin_state.spent_height)
-                            await self.add_interested_coin_ids([new_singleton_coin.name()], True)
+                            await self.add_interested_coin_ids([new_singleton_coin.name()])
                             new_coin_state: List[CoinState] = await self.wallet_node.get_coin_state(
                                 [new_singleton_coin.name()], fork_height, peer
                             )
@@ -1073,7 +1078,7 @@ class WalletStateManager:
                 elif record.wallet_type == WalletType.NFT:
                     if coin_state.spent_height is not None:
                         nft_wallet = self.wallets[uint32(record.wallet_id)]
-                        await nft_wallet.remove_coin(coin_state.coin, in_transaction=True)
+                        await nft_wallet.remove_coin(coin_state.coin)
 
                 # Check if a child is a singleton launcher
                 if children is None:
@@ -1110,7 +1115,6 @@ class WalletStateManager:
                         child.coin.name(),
                         [launcher_spend],
                         child.spent_height,
-                        in_transaction=True,
                         name="pool_wallet",
                     )
                     launcher_spend_additions = launcher_spend.additions()
@@ -1119,7 +1123,7 @@ class WalletStateManager:
                     await self.coin_added(
                         coin_added, coin_state.spent_height, [], pool_wallet.id(), WalletType(pool_wallet.type())
                     )
-                    await self.add_interested_coin_ids([coin_added.name()], True)
+                    await self.add_interested_coin_ids([coin_added.name()])
 
             else:
                 raise RuntimeError("All cases already handled")  # Logic error, all cases handled
@@ -1247,7 +1251,7 @@ class WalletStateManager:
                 name=coin_name,
                 memos=[],
             )
-            await self.tx_store.add_transaction_record(tx_record, True)
+            await self.tx_store.add_transaction_record(tx_record)
         else:
             records: List[TransactionRecord] = []
             for record in all_unconfirmed_transaction_records:
@@ -1280,7 +1284,7 @@ class WalletStateManager:
                     memos=[],
                 )
                 if coin.amount > 0:
-                    await self.tx_store.add_transaction_record(tx_record, True)
+                    await self.tx_store.add_transaction_record(tx_record)
 
         coin_record_1: WalletCoinRecord = WalletCoinRecord(
             coin, height, uint32(0), False, farm_reward, wallet_type, wallet_id
@@ -1292,9 +1296,9 @@ class WalletStateManager:
             await wallet.coin_added(coin, height)
 
         if wallet_type == WalletType.NFT:
-            await self.wallets[wallet_id].add_nft_coin(coin, height, in_transaction=True)
+            await self.wallets[wallet_id].add_nft_coin(coin, height)
 
-        await self.create_more_puzzle_hashes(in_transaction=True)
+        await self.create_more_puzzle_hashes()
         return coin_record_1
 
     async def add_pending_transaction(self, tx_record: TransactionRecord):
@@ -1302,20 +1306,20 @@ class WalletStateManager:
         Called from wallet before new transaction is sent to the full_node
         """
         # Wallet node will use this queue to retry sending this transaction until full nodes receives it
-        await self.tx_store.add_transaction_record(tx_record, False)
+        await self.tx_store.add_transaction_record(tx_record)
         all_coins_names = []
         all_coins_names.extend([coin.name() for coin in tx_record.additions])
         all_coins_names.extend([coin.name() for coin in tx_record.removals])
 
-        await self.add_interested_coin_ids(all_coins_names, False)
+        await self.add_interested_coin_ids(all_coins_names)
         self.tx_pending_changed()
         self.state_changed("pending_transaction", tx_record.wallet_id)
 
-    async def add_transaction(self, tx_record: TransactionRecord, in_transaction=False):
+    async def add_transaction(self, tx_record: TransactionRecord):
         """
         Called from wallet to add transaction that is not being set to full_node
         """
-        await self.tx_store.add_transaction_record(tx_record, in_transaction)
+        await self.tx_store.add_transaction_record(tx_record)
         self.state_changed("pending_transaction", tx_record.wallet_id)
 
     async def remove_from_queue(
@@ -1374,23 +1378,23 @@ class WalletStateManager:
                 TransactionType.OUTGOING_TRADE,
                 TransactionType.INCOMING_TRADE,
             ]:
-                await self.tx_store.tx_reorged(record, in_transaction=True)
+                await self.tx_store.tx_reorged(record)
         self.tx_pending_changed()
 
         # Removes wallets that were created from a blockchain transaction which got reorged.
         remove_ids = []
         for wallet_id, wallet in self.wallets.items():
             if wallet.type() == WalletType.POOLING_WALLET.value:
-                remove: bool = await wallet.rewind(height, in_transaction=True)
+                remove: bool = await wallet.rewind(height)
                 if remove:
                     remove_ids.append(wallet_id)
         for wallet_id in remove_ids:
-            await self.user_store.delete_wallet(wallet_id, in_transaction=True)
+            await self.user_store.delete_wallet(wallet_id)
 
         return remove_ids
 
     async def _await_closed(self) -> None:
-        await self.db_connection.close()
+        await self.db_wrapper.close()
         if self.weight_proof_handler is not None:
             self.weight_proof_handler.cancel_weight_proof_tasks()
 
@@ -1428,20 +1432,19 @@ class WalletStateManager:
                     return wallet
         return None
 
-    async def create_wallet_for_puzzle_info(self, puzzle_driver: PuzzleInfo, name=None, in_transaction=False):
+    async def create_wallet_for_puzzle_info(self, puzzle_driver: PuzzleInfo, name=None):
         if AssetType(puzzle_driver.type()) in self.asset_to_wallet_map:
             await self.asset_to_wallet_map[AssetType(puzzle_driver.type())].create_from_puzzle_info(
                 self,
                 self.main_wallet,
                 puzzle_driver,
                 name,
-                in_transaction,
             )
 
-    async def add_new_wallet(self, wallet: Any, wallet_id: int, create_puzzle_hashes=True, in_transaction=False):
+    async def add_new_wallet(self, wallet: Any, wallet_id: int, create_puzzle_hashes=True):
         self.wallets[uint32(wallet_id)] = wallet
         if create_puzzle_hashes:
-            await self.create_more_puzzle_hashes(in_transaction=in_transaction)
+            await self.create_more_puzzle_hashes()
         self.state_changed("wallet_created")
 
     async def get_spendable_coins_for_wallet(self, wallet_id: int, records=None) -> Set[WalletCoinRecord]:
@@ -1470,10 +1473,8 @@ class WalletStateManager:
 
         return filtered
 
-    async def create_action(
-        self, name: str, wallet_id: int, wallet_type: int, callback: str, done: bool, data: str, in_transaction: bool
-    ):
-        await self.action_store.create_action(name, wallet_id, wallet_type, callback, done, data, in_transaction)
+    async def create_action(self, name: str, wallet_id: int, wallet_type: int, callback: str, done: bool, data: str):
+        await self.action_store.create_action(name, wallet_id, wallet_type, callback, done, data)
         self.tx_pending_changed()
 
     async def generator_received(self, height: uint32, header_hash: uint32, program: Program):
@@ -1521,17 +1522,15 @@ class WalletStateManager:
         if self.wallet_node.last_wallet_tx_resend_time < current_time - self.wallet_node.wallet_tx_resend_timeout_secs:
             self.tx_pending_changed()
 
-    async def add_interested_puzzle_hashes(
-        self, puzzle_hashes: List[bytes32], wallet_ids: List[int], in_transaction: bool = False
-    ) -> None:
+    async def add_interested_puzzle_hashes(self, puzzle_hashes: List[bytes32], wallet_ids: List[int]) -> None:
         for puzzle_hash, wallet_id in zip(puzzle_hashes, wallet_ids):
-            await self.interested_store.add_interested_puzzle_hash(puzzle_hash, wallet_id, in_transaction)
+            await self.interested_store.add_interested_puzzle_hash(puzzle_hash, wallet_id)
         if len(puzzle_hashes) > 0:
             await self.wallet_node.new_peak_queue.subscribe_to_puzzle_hashes(puzzle_hashes)
 
-    async def add_interested_coin_ids(self, coin_ids: List[bytes32], in_transaction: bool = False) -> None:
+    async def add_interested_coin_ids(self, coin_ids: List[bytes32]) -> None:
         for coin_id in coin_ids:
-            await self.interested_store.add_interested_coin_id(coin_id, in_transaction)
+            await self.interested_store.add_interested_coin_id(coin_id)
         if len(coin_ids) > 0:
             await self.wallet_node.new_peak_queue.subscribe_to_coin_ids(coin_ids)
 

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -2,11 +2,9 @@ import dataclasses
 import time
 from typing import Dict, List, Optional, Tuple
 
-import aiosqlite
-
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.util.db_wrapper import DBWrapper
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32
 from chia.wallet.transaction_record import TransactionRecord
@@ -28,80 +26,69 @@ class WalletTransactionStore:
     WalletTransactionStore stores transaction history for the wallet.
     """
 
-    db_connection: aiosqlite.Connection
-    db_wrapper: DBWrapper
+    db_wrapper: DBWrapper2
     tx_submitted: Dict[bytes32, Tuple[int, int]]  # tx_id: [time submitted: count]
     last_wallet_tx_resend_time: int  # Epoch time in seconds
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper):
+    async def create(cls, db_wrapper: DBWrapper2):
         self = cls()
 
         self.db_wrapper = db_wrapper
-        self.db_connection = self.db_wrapper.db
-        await self.db_connection.execute(
-            (
-                "CREATE TABLE IF NOT EXISTS transaction_record("
-                " transaction_record blob,"
-                " bundle_id text PRIMARY KEY,"  # NOTE: bundle_id is being stored as bytes, not hex
-                " confirmed_at_height bigint,"
-                " created_at_time bigint,"
-                " to_puzzle_hash text,"
-                " amount blob,"
-                " fee_amount blob,"
-                " confirmed int,"
-                " sent int,"
-                " wallet_id bigint,"
-                " trade_id text,"
-                " type int)"
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS transaction_record("
+                    " transaction_record blob,"
+                    " bundle_id text PRIMARY KEY,"  # NOTE: bundle_id is being stored as bytes, not hex
+                    " confirmed_at_height bigint,"
+                    " created_at_time bigint,"
+                    " to_puzzle_hash text,"
+                    " amount blob,"
+                    " fee_amount blob,"
+                    " confirmed int,"
+                    " sent int,"
+                    " wallet_id bigint,"
+                    " trade_id text,"
+                    " type int)"
+                )
             )
-        )
 
-        # Useful for reorg lookups
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS tx_confirmed_index on transaction_record(confirmed_at_height)"
-        )
+            # Useful for reorg lookups
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS tx_confirmed_index on transaction_record(confirmed_at_height)"
+            )
 
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS tx_created_index on transaction_record(created_at_time)"
-        )
+            await conn.execute("CREATE INDEX IF NOT EXISTS tx_created_index on transaction_record(created_at_time)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS tx_confirmed on transaction_record(confirmed)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS tx_confirmed on transaction_record(confirmed)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS tx_sent on transaction_record(sent)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS tx_sent on transaction_record(sent)")
 
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS tx_created_time on transaction_record(created_at_time)"
-        )
+            await conn.execute("CREATE INDEX IF NOT EXISTS tx_created_time on transaction_record(created_at_time)")
 
-        await self.db_connection.execute("CREATE INDEX IF NOT EXISTS tx_type on transaction_record(type)")
+            await conn.execute("CREATE INDEX IF NOT EXISTS tx_type on transaction_record(type)")
 
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS tx_to_puzzle_hash on transaction_record(to_puzzle_hash)"
-        )
+            await conn.execute("CREATE INDEX IF NOT EXISTS tx_to_puzzle_hash on transaction_record(to_puzzle_hash)")
 
-        await self.db_connection.execute(
-            "CREATE INDEX IF NOT EXISTS transaction_record_wallet_id on transaction_record(wallet_id)"
-        )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS transaction_record_wallet_id on transaction_record(wallet_id)"
+            )
 
-        await self.db_connection.commit()
         self.tx_submitted = {}
         self.last_wallet_tx_resend_time = int(time.time())
         return self
 
     async def _clear_database(self):
-        cursor = await self.db_connection.execute("DELETE FROM transaction_record")
-        await cursor.close()
-        await self.db_connection.commit()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM transaction_record")).close()
 
-    async def add_transaction_record(self, record: TransactionRecord, in_transaction: bool) -> None:
+    async def add_transaction_record(self, record: TransactionRecord) -> None:
         """
         Store TransactionRecord in DB and Cache.
         """
-        if not in_transaction:
-            await self.db_wrapper.lock.acquire()
-        try:
-            await self.db_connection.execute_insert(
+        async with self.db_wrapper.write_db() as conn:
+            await conn.execute_insert(
                 "INSERT OR REPLACE INTO transaction_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     bytes(record),
@@ -118,15 +105,10 @@ class WalletTransactionStore:
                     record.type,
                 ),
             )
-            if not in_transaction:
-                await self.db_connection.commit()
-        finally:
-            if not in_transaction:
-                self.db_wrapper.lock.release()
 
     async def delete_transaction_record(self, tx_id: bytes32) -> None:
-        c = await self.db_connection.execute("DELETE FROM transaction_record WHERE bundle_id=?", (tx_id,))
-        await c.close()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM transaction_record WHERE bundle_id=?", (tx_id,))).close()
 
     async def set_confirmed(self, tx_id: bytes32, height: uint32):
         """
@@ -155,7 +137,7 @@ class WalletTransactionStore:
             name=current.name,
             memos=current.memos,
         )
-        await self.add_transaction_record(tx, True)
+        await self.add_transaction_record(tx)
 
     async def increment_sent(
         self,
@@ -207,10 +189,10 @@ class WalletTransactionStore:
             memos=current.memos,
         )
 
-        await self.add_transaction_record(tx, False)
+        await self.add_transaction_record(tx)
         return True
 
-    async def tx_reorged(self, record: TransactionRecord, in_transaction: bool) -> None:
+    async def tx_reorged(self, record: TransactionRecord):
         """
         Updates transaction sent count to 0 and resets confirmation data
         """
@@ -232,16 +214,15 @@ class WalletTransactionStore:
             name=record.name,
             memos=record.memos,
         )
-        await self.add_transaction_record(tx, in_transaction=in_transaction)
+        await self.add_transaction_record(tx)
 
     async def get_transaction_record(self, tx_id: bytes32) -> Optional[TransactionRecord]:
         """
         Checks DB and cache for TransactionRecord with id: id and returns it.
         """
-        # NOTE: bundle_id is being stored as bytes, not hex
-        rows = list(
-            await self.db_connection.execute_fetchall("SELECT * from transaction_record WHERE bundle_id=?", (tx_id,))
-        )
+        async with self.db_wrapper.read_db() as conn:
+            # NOTE: bundle_id is being stored as bytes, not hex
+            rows = list(await conn.execute_fetchall("SELECT * from transaction_record WHERE bundle_id=?", (tx_id,)))
         if len(rows) > 0:
             return TransactionRecord.from_bytes(rows[0][0])
         return None
@@ -255,9 +236,10 @@ class WalletTransactionStore:
         Returns the list of transactions that have not been received by full node yet.
         """
         current_time = int(time.time())
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * from transaction_record WHERE confirmed=0",
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                "SELECT * from transaction_record WHERE confirmed=0",
+            )
         records = []
 
         for row in rows:
@@ -265,7 +247,7 @@ class WalletTransactionStore:
             if include_accepted_txs:
                 # Reset the "sent" state for peers that have replied about this transaction. Retain errors.
                 record = dataclasses.replace(record, sent=1, sent_to=filter_ok_mempool_status(record.sent_to))
-                await self.add_transaction_record(record, False)
+                await self.add_transaction_record(record)
                 self.tx_submitted[record.name] = current_time, 1
                 records.append(record)
             elif record.name in self.tx_submitted:
@@ -287,28 +269,30 @@ class WalletTransactionStore:
         """
         Returns the list of all farming rewards.
         """
-        fee_int = TransactionType.FEE_REWARD.value
-        pool_int = TransactionType.COINBASE_REWARD.value
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * from transaction_record WHERE confirmed=1 and (type=? or type=?)", (fee_int, pool_int)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            fee_int = TransactionType.FEE_REWARD.value
+            pool_int = TransactionType.COINBASE_REWARD.value
+            rows = await conn.execute_fetchall(
+                "SELECT * from transaction_record WHERE confirmed=1 and (type=? or type=?)", (fee_int, pool_int)
+            )
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_all_unconfirmed(self) -> List[TransactionRecord]:
         """
         Returns the list of all transaction that have not yet been confirmed.
         """
-
-        rows = await self.db_connection.execute_fetchall("SELECT * from transaction_record WHERE confirmed=0")
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall("SELECT * from transaction_record WHERE confirmed=0")
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_unconfirmed_for_wallet(self, wallet_id: int) -> List[TransactionRecord]:
         """
         Returns the list of transaction that have not yet been confirmed.
         """
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT transaction_record from transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                "SELECT transaction_record from transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,)
+            )
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transactions_between(
@@ -334,70 +318,70 @@ class WalletTransactionStore:
         else:
             query_str = SortKey[sort_key].ascending()
 
-        rows = await self.db_connection.execute_fetchall(
-            f"SELECT * from transaction_record WHERE wallet_id=?{puzz_hash_where}"
-            f" {query_str}, rowid"
-            f" LIMIT {start}, {limit}",
-            (wallet_id,),
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                f"SELECT * FROM transaction_record WHERE wallet_id=?{puzz_hash_where}"
+                f" {query_str}, rowid"
+                f" LIMIT {start}, {limit}",
+                (wallet_id,),
+            )
 
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transaction_count_for_wallet(self, wallet_id) -> int:
-        rows = list(
-            await self.db_connection.execute_fetchall(
-                "SELECT COUNT(*) FROM transaction_record where wallet_id=?", (wallet_id,)
+        async with self.db_wrapper.read_db() as conn:
+            rows = list(
+                await conn.execute_fetchall("SELECT COUNT(*) FROM transaction_record where wallet_id=?", (wallet_id,))
             )
-        )
         return 0 if len(rows) == 0 else rows[0][0]
 
     async def get_all_transactions_for_wallet(self, wallet_id: int, type: int = None) -> List[TransactionRecord]:
         """
         Returns all stored transactions.
         """
-        if type is None:
-            rows = await self.db_connection.execute_fetchall(
-                "SELECT * FROM transaction_record WHERE wallet_id=?", (wallet_id,)
-            )
-        else:
-            rows = await self.db_connection.execute_fetchall(
-                "SELECT * FROM transaction_record WHERE wallet_id=? AND type=?",
-                (
-                    wallet_id,
-                    type,
-                ),
-            )
+        async with self.db_wrapper.read_db() as conn:
+            if type is None:
+                rows = await conn.execute_fetchall("SELECT * FROM transaction_record WHERE wallet_id=?", (wallet_id,))
+            else:
+                rows = await conn.execute_fetchall(
+                    "SELECT * FROM transaction_record WHERE wallet_id=? AND type=?",
+                    (
+                        wallet_id,
+                        type,
+                    ),
+                )
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_all_transactions(self) -> List[TransactionRecord]:
         """
         Returns all stored transactions.
         """
-        rows = await self.db_connection.execute_fetchall("SELECT * from transaction_record")
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall("SELECT * from transaction_record")
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transaction_above(self, height: int) -> List[TransactionRecord]:
         # Can be -1 (get all tx)
 
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * from transaction_record WHERE confirmed_at_height>?", (height,)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall(
+                "SELECT * from transaction_record WHERE confirmed_at_height>?", (height,)
+            )
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transactions_by_trade_id(self, trade_id: bytes32) -> List[TransactionRecord]:
-        rows = await self.db_connection.execute_fetchall(
-            "SELECT * from transaction_record WHERE trade_id=?", (trade_id,)
-        )
+        async with self.db_wrapper.read_db() as conn:
+            rows = await conn.execute_fetchall("SELECT * from transaction_record WHERE trade_id=?", (trade_id,))
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def rollback_to_block(self, height: int):
         # Delete from storage
         self.tx_submitted = {}
-        c1 = await self.db_connection.execute("DELETE FROM transaction_record WHERE confirmed_at_height>?", (height,))
-        await c1.close()
+        async with self.db_wrapper.write_db() as conn:
+            await (await conn.execute("DELETE FROM transaction_record WHERE confirmed_at_height>?", (height,))).close()
 
     async def delete_unconfirmed_transactions(self, wallet_id: int):
-        cursor = await self.db_connection.execute(
-            "DELETE FROM transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,)
-        )
-        await cursor.close()
+        async with self.db_wrapper.write_db() as conn:
+            await (
+                await conn.execute("DELETE FROM transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,))
+            ).close()

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -130,8 +130,8 @@ async def setup(two_wallet_nodes, bt, self_hostname):
     full_nodes, wallets = two_wallet_nodes
     wallet_node_0, wallet_server_0 = wallets[0]
     wallet_node_1, wallet_server_1 = wallets[1]
-    our_ph_record = await wallet_node_0.wallet_state_manager.get_unused_derivation_record(1, False, True)
-    pool_ph_record = await wallet_node_1.wallet_state_manager.get_unused_derivation_record(1, False, True)
+    our_ph_record = await wallet_node_0.wallet_state_manager.get_unused_derivation_record(1, hardened=True)
+    pool_ph_record = await wallet_node_1.wallet_state_manager.get_unused_derivation_record(1, hardened=True)
     our_ph = our_ph_record.puzzle_hash
     pool_ph = pool_ph_record.puzzle_hash
     api_user = WalletRpcApi(wallet_node_0)

--- a/tests/pools/test_pool_wallet.py
+++ b/tests/pools/test_pool_wallet.py
@@ -15,7 +15,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 class MockStandardWallet:
     canned_puzzlehash: bytes32
 
-    async def get_new_puzzlehash(self, in_transaction: bool = False) -> bytes32:
+    async def get_new_puzzlehash(self) -> bytes32:
         return self.canned_puzzlehash
 
 

--- a/tests/pools/test_wallet_pool_store.py
+++ b/tests/pools/test_wallet_pool_store.py
@@ -1,8 +1,6 @@
-from pathlib import Path
 from secrets import token_bytes
 from typing import Optional
 
-import aiosqlite
 import pytest
 from clvm_tools import binutils
 
@@ -10,10 +8,10 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
-from chia.util.db_wrapper import DBWrapper
 from chia.util.ints import uint64
 
 from chia.wallet.wallet_pool_store import WalletPoolStore
+from tests.util.db_connection import DBConnection
 
 
 def make_child_solution(coin_spend: CoinSpend, new_coin: Optional[Coin] = None) -> CoinSpend:
@@ -35,51 +33,49 @@ def make_child_solution(coin_spend: CoinSpend, new_coin: Optional[Coin] = None) 
 class TestWalletPoolStore:
     @pytest.mark.asyncio
     async def test_store(self):
-        db_filename = Path("wallet_pool_store_test.db")
+        async with DBConnection(1) as db_wrapper:
+            store = await WalletPoolStore.create(db_wrapper)
 
-        if db_filename.exists():
-            db_filename.unlink()
+            try:
+                async with db_wrapper.write_db():
+                    coin_0 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
+                    coin_0_alt = Coin(token_bytes(32), token_bytes(32), uint64(12312))
+                    solution_0: CoinSpend = make_child_solution(None, coin_0)
+                    solution_0_alt: CoinSpend = make_child_solution(None, coin_0_alt)
+                    solution_1: CoinSpend = make_child_solution(solution_0)
 
-        db_connection = await aiosqlite.connect(db_filename)
-        db_wrapper = DBWrapper(db_connection)
-        store = await WalletPoolStore.create(db_wrapper)
-        try:
-            await db_wrapper.begin_transaction()
-            coin_0 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
-            coin_0_alt = Coin(token_bytes(32), token_bytes(32), uint64(12312))
-            solution_0: CoinSpend = make_child_solution(None, coin_0)
-            solution_0_alt: CoinSpend = make_child_solution(None, coin_0_alt)
-            solution_1: CoinSpend = make_child_solution(solution_0)
+                    assert await store.get_spends_for_wallet(0) == []
+                    assert await store.get_spends_for_wallet(1) == []
 
-            assert await store.get_spends_for_wallet(0) == []
+                    await store.add_spend(1, solution_1, 100)
+                    assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
+
+                    # Idempotent
+                    await store.add_spend(1, solution_1, 100)
+                    assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
+
+                    with pytest.raises(ValueError):
+                        await store.add_spend(1, solution_1, 101)
+
+                    # Rebuild cache, no longer present
+                    raise RuntimeError("abandon transaction")
+            except Exception:
+                pass
+
             assert await store.get_spends_for_wallet(1) == []
 
-            await store.add_spend(1, solution_1, 100, True)
-            assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
-
-            # Idempotent
-            await store.add_spend(1, solution_1, 100, True)
-            assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
-
-            with pytest.raises(ValueError):
-                await store.add_spend(1, solution_1, 101, True)
-
-            # Rebuild cache, no longer present
-            await db_wrapper.rollback_transaction()
-            assert await store.get_spends_for_wallet(1) == []
-
-            await store.add_spend(1, solution_1, 100, False)
+            await store.add_spend(1, solution_1, 100)
             assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
 
             solution_1_alt: CoinSpend = make_child_solution(solution_0_alt)
 
             with pytest.raises(ValueError):
-                await store.add_spend(1, solution_1_alt, 100, False)
+                await store.add_spend(1, solution_1_alt, 100)
 
             assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
 
             solution_2: CoinSpend = make_child_solution(solution_1)
-            await store.add_spend(1, solution_2, 100, False)
+            await store.add_spend(1, solution_2, 100)
             solution_3: CoinSpend = make_child_solution(solution_2)
             await store.add_spend(1, solution_3, 100)
             solution_4: CoinSpend = make_child_solution(solution_3)
@@ -88,14 +84,14 @@ class TestWalletPoolStore:
                 await store.add_spend(1, solution_4, 99)
 
             await store.add_spend(1, solution_4, 101)
-            await store.rollback(101, 1, False)
+            await store.rollback(101, 1)
             assert await store.get_spends_for_wallet(1) == [
                 (100, solution_1),
                 (100, solution_2),
                 (100, solution_3),
                 (101, solution_4),
             ]
-            await store.rollback(100, 1, False)
+            await store.rollback(100, 1)
             assert await store.get_spends_for_wallet(1) == [
                 (100, solution_1),
                 (100, solution_2),
@@ -107,9 +103,5 @@ class TestWalletPoolStore:
             await store.add_spend(1, solution_4, 105)
             solution_5: CoinSpend = make_child_solution(solution_4)
             await store.add_spend(1, solution_5, 105)
-            await store.rollback(99, 1, False)
+            await store.rollback(99, 1)
             assert await store.get_spends_for_wallet(1) == []
-
-        finally:
-            await db_connection.close()
-            db_filename.unlink()

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -678,7 +678,11 @@ class TestDIDWallet:
         await time_out_assert(15, wallet.get_confirmed_balance, 7999999997899)
         await time_out_assert(15, wallet.get_unconfirmed_balance, 7999999997899)
         # Check if the DID wallet is created in the wallet2
-        await time_out_assert(30, len, 2, wallet_node_2.wallet_state_manager.wallets)
+
+        async def num_wallets() -> int:
+            return len(await wallet_node_2.wallet_state_manager.get_all_wallet_info_entries())
+
+        await time_out_assert(30, num_wallets, 2)
         # Get the new DID wallet
         did_wallets = list(
             filter(

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -138,7 +138,11 @@ async def test_nft_wallet_creation_automatically(two_wallet_nodes: Any, trusted:
     )
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
-    await time_out_assert(15, len, 2, wallet_node_1.wallet_state_manager.wallets)
+
+    async def num_wallets() -> int:
+        return len(await wallet_node_1.wallet_state_manager.get_all_wallet_info_entries())
+
+    await time_out_assert(15, num_wallets, 2)
     # Get the new NFT wallet
     nft_wallets = await wallet_node_1.wallet_state_manager.get_all_wallet_info_entries(WalletType.NFT)
     assert len(nft_wallets) == 1

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -813,6 +813,11 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     for _ in range(3):
         await farm_transaction_block(full_node_api, wallet_1_node)
 
+    async def num_wallets() -> int:
+        return len(await wallet_2_node.wallet_state_manager.get_all_wallet_info_entries())
+
+    await time_out_assert(30, num_wallets, 2)
+
     did_wallets = list(
         filter(
             lambda w: (w.type == WalletType.DECENTRALIZED_ID),

--- a/tests/wallet/test_nft_store.py
+++ b/tests/wallet/test_nft_store.py
@@ -1,30 +1,20 @@
-from pathlib import Path
-
-import aiosqlite
 import pytest
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper
 from chia.util.ints import uint32, uint64
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.nft_wallet.nft_info import NFTCoinInfo
 from chia.wallet.wallet_nft_store import WalletNftStore
+from tests.util.db_connection import DBConnection
 
 
 class TestNftStore:
     @pytest.mark.asyncio
     async def test_nft_store(self) -> None:
-        db_filename = Path("nft_store_test.db")
-
-        if db_filename.exists():
-            db_filename.unlink()
-
-        con = await aiosqlite.connect(db_filename)
-        wrapper = DBWrapper(con)
-        db = await WalletNftStore.create(wrapper)
-        try:
+        async with DBConnection(1) as wrapper:
+            db = await WalletNftStore.create(wrapper)
             a_bytes32 = bytes32.fromhex("09287c75377c63fd6a3a4d6658abed03e9a521e0436b1f83cdf4af99341ce8f1")
             puzzle = Program.to(["A Test puzzle"])
             nft = NFTCoinInfo(
@@ -45,14 +35,3 @@ class TestNftStore:
             # Test delete
             await db.delete_nft(a_bytes32)
             assert await db.get_nft_by_id(a_bytes32) is None
-
-        except Exception as e:
-            print(e, type(e))
-            await db._clear_database()
-            await db.close()
-            db_filename.unlink()
-            raise e
-
-        await db._clear_database()
-        await db.close()
-        db_filename.unlink()

--- a/tests/wallet/test_puzzle_store.py
+++ b/tests/wallet/test_puzzle_store.py
@@ -1,29 +1,22 @@
-from pathlib import Path
 from secrets import token_bytes
 
-import aiosqlite
 import pytest
 from blspy import AugSchemeMPL
 
-from chia.util.db_wrapper import DBWrapper
 from chia.util.ints import uint32
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_puzzle_store import WalletPuzzleStore
+from tests.util.db_connection import DBConnection
 
 
 class TestPuzzleStore:
     @pytest.mark.asyncio
     async def test_puzzle_store(self):
-        db_filename = Path("puzzle_store_test.db")
 
-        if db_filename.exists():
-            db_filename.unlink()
+        async with DBConnection(1) as wrapper:
 
-        con = await aiosqlite.connect(db_filename)
-        wrapper = DBWrapper(con)
-        db = await WalletPuzzleStore.create(wrapper)
-        try:
+            db = await WalletPuzzleStore.create(wrapper)
             derivation_recs = []
             # wallet_types = [t for t in WalletType]
             [t for t in WalletType]
@@ -88,14 +81,3 @@ class TestPuzzleStore:
             await db.set_used_up_to(249)
 
             assert await db.get_unused_derivation_path() == 250
-
-        except Exception as e:
-            print(e, type(e))
-            await db._clear_database()
-            await db.close()
-            db_filename.unlink()
-            raise e
-
-        await db._clear_database()
-        await db.close()
-        db_filename.unlink()

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -1,18 +1,15 @@
 import dataclasses
-from pathlib import Path
-
-import aiosqlite
 import pytest
 
 from chia.consensus.blockchain import ReceiveBlockResult
 from chia.protocols import full_node_protocol
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.weight_proof import WeightProof
-from chia.util.db_wrapper import DBWrapper
 from chia.util.generator_tools import get_block_header
 from chia.wallet.key_val_store import KeyValStore
 from chia.wallet.wallet_blockchain import WalletBlockchain
 from tests.setup_nodes import test_constants
+from tests.util.db_connection import DBConnection
 
 
 class TestWalletBlockchain:
@@ -43,18 +40,11 @@ class TestWalletBlockchain:
         weight_proof_short: WeightProof = full_node_protocol.RespondProofOfWeight.from_bytes(res_2.data).wp
         weight_proof_long: WeightProof = full_node_protocol.RespondProofOfWeight.from_bytes(res_3.data).wp
 
-        db_filename = Path("wallet_blockchain_store_test.db")
-
-        if db_filename.exists():
-            db_filename.unlink()
-
-        db_connection = await aiosqlite.connect(db_filename)
-        db_wrapper = DBWrapper(db_connection)
-        store = await KeyValStore.create(db_wrapper)
-        chain = await WalletBlockchain.create(
-            store, test_constants, wallet_node.wallet_state_manager.weight_proof_handler
-        )
-        try:
+        async with DBConnection(1) as db_wrapper:
+            store = await KeyValStore.create(db_wrapper)
+            chain = await WalletBlockchain.create(
+                store, test_constants, wallet_node.wallet_state_manager.weight_proof_handler
+            )
             assert (await chain.get_peak_block()) is None
             assert chain.get_peak_height() == 0
             assert chain.get_latest_timestamp() == 0
@@ -100,6 +90,3 @@ class TestWalletBlockchain:
                 assert chain.get_peak_height() == block.height
 
             assert chain.get_peak_height() == 999
-        finally:
-            await db_connection.close()
-            db_filename.unlink()

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -7,7 +7,7 @@ from chia.util.ints import uint32, uint64
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_coin_store import WalletCoinStore
-from tests.util.db_connection import DBConnection1
+from tests.util.db_connection import DBConnection
 
 coin_1 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
 coin_2 = Coin(coin_1.parent_coin_info, token_bytes(32), uint64(12311))
@@ -68,7 +68,7 @@ record_7 = WalletCoinRecord(
 
 @pytest.mark.asyncio
 async def test_add_replace_get() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         assert await store.get_coin_record(coin_1.name()) is None
@@ -82,7 +82,7 @@ async def test_add_replace_get() -> None:
 
 @pytest.mark.asyncio
 async def test_persistance() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
         await store.add_coin_record(record_1)
 
@@ -92,7 +92,7 @@ async def test_persistance() -> None:
 
 @pytest.mark.asyncio
 async def test_set_spent() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
         await store.add_coin_record(record_1)
 
@@ -104,7 +104,7 @@ async def test_set_spent() -> None:
 
 @pytest.mark.asyncio
 async def test_get_records_by_puzzle_hash() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         await store.add_coin_record(record_4)
@@ -120,7 +120,7 @@ async def test_get_records_by_puzzle_hash() -> None:
 
 @pytest.mark.asyncio
 async def test_get_unspent_coins_for_wallet() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         assert await store.get_unspent_coins_for_wallet(1) == set()
@@ -155,7 +155,7 @@ async def test_get_unspent_coins_for_wallet() -> None:
 
 @pytest.mark.asyncio
 async def test_get_records_by_parent_id() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         await store.add_coin_record(record_1)
@@ -177,7 +177,7 @@ async def test_get_records_by_parent_id() -> None:
 
 @pytest.mark.asyncio
 async def test_get_multiple_coin_records() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         await store.add_coin_record(record_1)
@@ -216,7 +216,7 @@ async def test_get_multiple_coin_records() -> None:
 
 @pytest.mark.asyncio
 async def test_delete_coin_record() -> None:
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         await store.add_coin_record(record_1)
@@ -272,7 +272,7 @@ async def test_get_coins_to_check() -> None:
     r6 = record(coin_6, confirmed=6, spent=1)
     r7 = record(coin_7, confirmed=7, spent=2)
 
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         await store.add_coin_record(r1)
@@ -312,7 +312,7 @@ async def test_get_first_coin_height() -> None:
     r4 = record(coin_4, confirmed=4, spent=6)
     r5 = record(coin_5, confirmed=5, spent=7)
 
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         assert await store.get_first_coin_height() is None
@@ -338,7 +338,7 @@ async def test_rollback_to_block() -> None:
     r4 = record(coin_4, confirmed=4, spent=6)
     r5 = record(coin_5, confirmed=5, spent=7)
 
-    async with DBConnection1() as db_wrapper:
+    async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
 
         await store.add_coin_record(r1)

--- a/tests/wallet/test_wallet_interested_store.py
+++ b/tests/wallet/test_wallet_interested_store.py
@@ -1,27 +1,18 @@
-from pathlib import Path
 from secrets import token_bytes
-import aiosqlite
 import pytest
 
 from chia.types.blockchain_format.coin import Coin
-from chia.util.db_wrapper import DBWrapper
 from chia.util.ints import uint64
 
 from chia.wallet.wallet_interested_store import WalletInterestedStore
+from tests.util.db_connection import DBConnection
 
 
 class TestWalletInterestedStore:
     @pytest.mark.asyncio
     async def test_store(self):
-        db_filename = Path("wallet_interested_store_test.db")
-
-        if db_filename.exists():
-            db_filename.unlink()
-
-        db_connection = await aiosqlite.connect(db_filename)
-        db_wrapper = DBWrapper(db_connection)
-        store = await WalletInterestedStore.create(db_wrapper)
-        try:
+        async with DBConnection(1) as db_wrapper:
+            store = await WalletInterestedStore.create(db_wrapper)
             coin_1 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
             coin_2 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
             assert (await store.get_interested_coin_ids()) == []
@@ -46,7 +37,3 @@ class TestWalletInterestedStore:
             await store.remove_interested_puzzle_hash(puzzle_hash)
             assert (await store.get_interested_puzzle_hash_wallet_id(puzzle_hash)) is None
             assert len(await store.get_interested_puzzle_hashes()) == 0
-
-        finally:
-            await db_connection.close()
-            db_filename.unlink()

--- a/tests/wallet/test_wallet_key_val_store.py
+++ b/tests/wallet/test_wallet_key_val_store.py
@@ -1,25 +1,16 @@
-from pathlib import Path
-import aiosqlite
 import pytest
 
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
-from chia.util.db_wrapper import DBWrapper
 from chia.wallet.key_val_store import KeyValStore
+from tests.util.db_connection import DBConnection
 
 
 class TestWalletKeyValStore:
     @pytest.mark.asyncio
     async def test_store(self, bt):
-        db_filename = Path("wallet_kv_store_test.db")
-
-        if db_filename.exists():
-            db_filename.unlink()
-
-        db_connection = await aiosqlite.connect(db_filename)
-        db_wrapper = DBWrapper(db_connection)
-        store = await KeyValStore.create(db_wrapper)
-        try:
+        async with DBConnection(1) as db_wrapper:
+            store = await KeyValStore.create(db_wrapper)
             blocks = bt.get_consecutive_blocks(20)
             block: FullBlock = blocks[0]
             block_2: FullBlock = blocks[1]
@@ -44,7 +35,3 @@ class TestWalletKeyValStore:
             await store.set_object("a", block_2)
             with pytest.raises(Exception):
                 await store.get_object("a", HeaderBlock)
-
-        finally:
-            await db_connection.close()
-            db_filename.unlink()

--- a/tests/wallet/test_wallet_user_store.py
+++ b/tests/wallet/test_wallet_user_store.py
@@ -1,24 +1,14 @@
-from pathlib import Path
-
-import aiosqlite
 import pytest
 
-from chia.util.db_wrapper import DBWrapper
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_user_store import WalletUserStore
+from tests.util.db_connection import DBConnection
 
 
 @pytest.mark.asyncio
 async def test_store():
-    db_filename = Path("wallet_user_store_test.db")
-
-    if db_filename.exists():
-        db_filename.unlink()
-
-    db_connection = await aiosqlite.connect(db_filename)
-    db_wrapper = DBWrapper(db_connection)
-    store = await WalletUserStore.create(db_wrapper)
-    try:
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletUserStore.create(db_wrapper)
         await store.init_wallet()
         wallet = None
         for i in range(1, 5):
@@ -28,7 +18,7 @@ async def test_store():
         assert wallet.id == 5
 
         for i in range(2, 6):
-            await store.delete_wallet(i, in_transaction=False)
+            await store.delete_wallet(i)
 
         assert (await store.get_last_wallet()).id == 1
         wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
@@ -39,7 +29,3 @@ async def test_store():
         assert (await store.get_wallet_by_id(7)) is None
         assert (await store.get_wallet_by_id(6)) == wallet
         assert await store.get_last_wallet() == wallet
-
-    finally:
-        await db_connection.close()
-        db_filename.unlink()


### PR DESCRIPTION
This switches the wallet from using `DBWrapper` to `DBWrapper2`. The main benefits are:

* `DBWrapper2` uses nested transactions and the outer-most always commits. There is no longer any need for functions to be told (and pass on) whether they are in a transaction or not, every level just starts a new one, that may be nested. For this reason, all `in_transaction` parameters have been removed.
* `DBWrapper2` supports concurrent readers, but still serializes all writes over a single `Connection` object. This can improve latency for read-only tasks. It also required some minor changes to tests and the `wallet_node` to properly synchronize tasks that read with tasks that write in some cases.
* `DBWrapper2` has a context manager-based API, which means transactions will always either committed or aborted (on exceptions). There's no longer any manual committing and rolling-back necessary. This simplifies a number of functions that previously had to explicitly handle exceptions.