### PR TITLE
use language:system for pre-commit mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,5 +59,5 @@ repos:
     -   id: mypy
         name: mypy
         entry: ./activated.py mypy
-        language: python
+        language: system
         pass_filenames: false


### PR DESCRIPTION
I've been getting the following traceback when running pre-commit even after deleting all the envs.

```pytb
- hook id: mypy
- exit code: 1

Traceback (most recent call last):
  File "./activated.py", line 28, in <module>
    sys.exit(main(*sys.argv[1:]))
  File "./activated.py", line 23, in main
    completed_process = subprocess.run(command)
  File "/home/altendky/.pyenv/versions/3.8.6/lib/python3.8/subprocess.py", line 489, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/home/altendky/.pyenv/versions/3.8.6/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/home/altendky/.pyenv/versions/3.8.6/lib/python3.8/subprocess.py", line 1702, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'activated.sh'
```