### PR TITLE
websockets - remove extra break preventing all sockets from being attempted

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -243,7 +243,6 @@ class WebSocketServer:
                             self.log.error(f"Unexpected exception trying to send to websocket: {e} {tb}")
                             self.remove_connection(socket)
                             await socket.close()
-                            break
             else:
                 service_name = "Unknown"
                 if ws in self.remote_address_map:


### PR DESCRIPTION
This was added with the recent websocket refactor. Was not present in this commit prior to the refactor https://github.com/Chia-Network/chia-blockchain/blob/a691d3c4b2aad546b8d9058b6a3882416edaee9b/chia/daemon/server.py#L236). 

It is preventing other sockets (when `sockets_to_use` is > 1) from getting data when earlier ones raise an exception. Running this branch stopped the issue I was seeing with missing websocket responses.