### PR TITLE
avoid responding to an ack

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -207,14 +207,14 @@ class RpcServer:
             "success": "true",
         }
 
-    async def ws_api(self, message: WsRpcMessage) -> Dict[str, object]:
+    async def ws_api(self, message: WsRpcMessage) -> Optional[Dict[str, object]]:
         """
         This function gets called when new message is received via websocket.
         """
 
         command = message["command"]
         if message["ack"]:
-            return {}
+            return None
 
         data: Dict[str, object] = {}
         if "data" in message:


### PR DESCRIPTION
```pytb
Error while handling message: Traceback (most recent call last):
  File "/home/altendky/repos/chia-blockchain/chia/daemon/server.py", line 230, in incoming_connection
    response, sockets_to_use = await self.handle_message(ws, decoded)
  File "/home/altendky/repos/chia-blockchain/chia/daemon/server.py", line 356, in handle_message
    response = await self.register_service(websocket, cast(Dict[str, Any], data))
  File "/home/altendky/repos/chia-blockchain/chia/daemon/server.py", line 1161, in register_service
    service = request["service"]
KeyError: 'service'
```

This was introduced in https://github.com/Chia-Network/chia-blockchain/pull/11928.