### PR TITLE
Removing `logging.basicConfig()` from `ChiaServer.__init__()`

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -118,7 +118,6 @@ class ChiaServer:
         name: str = None,
     ):
         # Keeps track of all connections to and from this node.
-        logging.basicConfig(level=logging.DEBUG)
         self.all_connections: Dict[bytes32, WSChiaConnection] = {}
         self.tasks: Set[asyncio.Task] = set()
 


### PR DESCRIPTION
https://docs.python.org/3.10/library/logging.html#logging.basicConfig
> This function does nothing if the root logger already has handlers configured, unless the keyword argument force is set to True.

Previously this was being run before our logging config but https://github.com/Chia-Network/chia-blockchain/pull/12172 reordered this to come first.  A fix will be made to relocate the logging config prior to the `ChiaServer` instantiation but this shouldn't be called regardless.