### PR TITLE
Ms.fix coin selection

### DIFF
--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -100,11 +100,11 @@ async def select_coins(
         return coin_set
     else:
         # if smaller_coin_sum == amount and len(smaller_coins) >= max_num_coins.
-        coin = select_smallest_coin_over_target(amount, valid_spendable_coins)
-        if coin is None:
+        potential_large_coin: Optional[Coin] = select_smallest_coin_over_target(amount, valid_spendable_coins)
+        if potential_large_coin is None:
             raise ValueError("Too many coins are required to make this transaction")
-        log.debug(f"Resorted to selecting smallest coin over target due to dust.: {coin}")
-        return {coin}
+        log.debug(f"Resorted to selecting smallest coin over target due to dust.: {potential_large_coin}")
+        return {potential_large_coin}
 
 
 # These algorithms were based off of the algorithms in:

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -85,7 +85,7 @@ async def select_coins(
     elif smaller_coin_sum > amount:
         coin_set: Optional[Set[Coin]] = knapsack_coin_algorithm(smaller_coins, amount, max_coin_amount, max_num_coins)
         log.debug(f"Selected coins from knapsack algorithm: {coin_set}")
-        if coin_set is None or len(coin_set) > max_num_coins:
+        if coin_set is None:
             coin_set = sum_largest_coins(amount, smaller_coins)
             if coin_set is None or len(coin_set) > max_num_coins:
                 greater_coin = select_smallest_coin_over_target(amount, valid_spendable_coins)
@@ -119,7 +119,6 @@ def check_for_exact_match(coin_list: List[Coin], target: uint64) -> Optional[Coi
 # amount of coins smaller than target, followed by a list of all valid spendable coins.
 # Coins must be sorted in descending amount order.
 def select_smallest_coin_over_target(target: uint128, sorted_coin_list: List[Coin]) -> Optional[Coin]:
-    # sorted_coin_list: List[Coin] = list(sorted(coin_list, key=lambda c: c.amount))
     if sorted_coin_list[0].amount < target:
         return None
     for coin in reversed(sorted_coin_list):

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -115,7 +115,7 @@ def check_for_exact_match(coin_list: List[Coin], target: uint64) -> Optional[Coi
 
 # amount of coins smaller than target, followed by a list of all valid spendable coins sorted in descending order.
 def select_smallest_coin_over_target(smaller_coin_amount: int, valid_spendable_coin_list: List[Coin]) -> Coin:
-    if smaller_coin_amount >= len(valid_spendable_coin_list):
+    if smaller_coin_amount >= sum([c.amount for c in valid_spendable_coin_list]):
         raise ValueError("Unable to select coins for this transaction. Try sending a smaller amount")
     if smaller_coin_amount > 0:  # in case we only have bigger coins.
         greater_coins = valid_spendable_coin_list[:-smaller_coin_amount]

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -89,7 +89,7 @@ async def select_coins(
             raise ValueError("Knapsack algorithm failed to find a solution.")
         if len(coin_set) > max_num_coins:
             coin_set = sum_largest_coins(amount, smaller_coins)
-            if coin_set is None:
+            if coin_set is None or len(coin_set) > max_num_coins:
                 greater_coin = select_smallest_coin_over_target(amount, valid_spendable_coins)
                 if greater_coin is None:
                     raise ValueError(

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -420,7 +420,7 @@ class TestCoinSelection:
 
         # Just a sanity check, it's actually much faster than this time
         assert time.time() - start < 10000
-        
+
     @pytest.mark.asyncio
     async def test_coin_selection_min_coin(self, a_hash: bytes32) -> None:
         spendable_amount = uint128(5000000 + 500 + 40050)

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -363,11 +363,11 @@ class TestCoinSelection:
         coin_list: List[Coin] = [
             Coin(a_hash, std_hash(i.to_bytes(4, "big")), uint64((39 - i) * 1000)) for i in range(40)
         ]
-        assert select_smallest_coin_over_target(uint128(100), coin_list).amount == 1000
-        assert select_smallest_coin_over_target(uint128(1000), coin_list).amount == 1000
-        assert select_smallest_coin_over_target(uint128(1001), coin_list).amount == 2000
-        assert select_smallest_coin_over_target(uint128(37000), coin_list).amount == 37000
-        assert select_smallest_coin_over_target(uint128(39000), coin_list).amount == 39000
+        assert select_smallest_coin_over_target(uint128(100), coin_list) == coin_list[39 - 1]
+        assert select_smallest_coin_over_target(uint128(1000), coin_list) == coin_list[39 - 1]
+        assert select_smallest_coin_over_target(uint128(1001), coin_list) == coin_list[39 - 2]
+        assert select_smallest_coin_over_target(uint128(37000), coin_list) == coin_list[39 - 37]
+        assert select_smallest_coin_over_target(uint128(39000), coin_list) == coin_list[39 - 39]
         assert select_smallest_coin_over_target(uint128(39001), coin_list) is None
 
     @pytest.mark.asyncio

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -416,7 +416,7 @@ class TestCoinSelection:
         coin_list: List[Coin] = [
             Coin(a_hash, std_hash(i.to_bytes(4, "big")), uint64((200000 - i) * 1000)) for i in range(200000)
         ]
-        knapsack_coin_algorithm(coin_list, 2000000, 9999999999999999, 500)
+        knapsack_coin_algorithm(coin_list, uint128(2000000), 9999999999999999, 500)
 
         # Just a sanity check, it's actually much faster than this time
         assert time.time() - start < 10000

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -14,6 +14,7 @@ from chia.wallet.coin_selection import (
     knapsack_coin_algorithm,
     select_coins,
     select_smallest_coin_over_target,
+    sum_largest_coins,
 )
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -367,3 +368,10 @@ class TestCoinSelection:
         assert select_smallest_coin_over_target(uint128(37000), coin_list).amount == 37000
         assert select_smallest_coin_over_target(uint128(39000), coin_list).amount == 39000
         assert select_smallest_coin_over_target(uint128(39001), coin_list) is None
+
+    @pytest.mark.asyncio
+    async def test_sum_largest_coins(self, a_hash: bytes32) -> None:
+        coin_list: List[Coin] = [Coin(a_hash, std_hash(i.to_bytes(4, "big")), uint64(i)) for i in range(41)]
+        assert sum_largest_coins(uint128(40), coin_list) == {coin_list[40]}
+        assert sum_largest_coins(uint128(79), coin_list) == {coin_list[40], coin_list[39]}
+        assert sum_largest_coins(uint128(40000), coin_list) is None

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -104,6 +104,7 @@ class TestCoinSelection:
             )
         # make sure coins are not identical.
         for target_amount in [10000, 9999]:
+            print("Target amount: ", target_amount)
             result: Set[Coin] = await select_coins(
                 spendable_amount,
                 DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -132,6 +132,38 @@ class TestCoinSelection:
                 assert coin.amount > 1
             assert len(dusty_result) <= 500
 
+        # test when we have multiple coins under target, and a lot of dust coins.
+        spendable_amount = uint128(25000 + 10000)
+        new_coin_list: List[WalletCoinRecord] = []
+        for i in range(5):
+            new_coin_list.append(
+                WalletCoinRecord(
+                    Coin(a_hash, std_hash(i), uint64(5000)), uint32(1), uint32(1), False, True, WalletType(0), 1
+                )
+            )
+
+        for i in range(10000):
+            new_coin_list.append(
+                WalletCoinRecord(
+                    Coin(a_hash, std_hash(i), uint64(1)), uint32(1), uint32(1), False, True, WalletType(0), 1
+                )
+            )
+        for target_amount in [20000, 15000, 10000, 5000]:  # select the first 100 values
+            print(f"Sending {target_amount}")
+            dusty_below_target: Set[Coin] = await select_coins(
+                spendable_amount,
+                DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                new_coin_list,
+                {},
+                logging.getLogger("test"),
+                uint128(target_amount),
+            )
+            assert dusty_below_target is not None
+            assert sum([coin.amount for coin in dusty_below_target]) >= target_amount
+            for coin in dusty_below_target:
+                assert coin.amount == 5000
+            assert len(dusty_below_target) <= 500
+
     @pytest.mark.asyncio
     async def test_coin_selection_failure(self, a_hash: bytes32) -> None:
         spendable_amount = uint128(10000)


### PR DESCRIPTION
Two bugs :
1. `test_smallest_coin_over_amount` did not work properly when all coins where smaller than the amount.
2. In the cases where knapsack found a solution but it was too large, we fell back to selecting the "largest coin over the amount" as in issue 1, but instead we should be adding up the largest coins that are < the target amount first, because we might not have any large coins.

It also fixes a performance issue with knapsack, where it keeps searching even if we are selecting more coins than we can actually select.
Old performance with 200k coins:  60 seconds. New: 0.78 seconds.

A bunch of tests are added to test all the functionality.