### PR TITLE
add new_transaction() to DBWrapper2

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -113,7 +113,7 @@ class SpendSim:
         self.defaults = defaults
 
         # Load the next data if there is any
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute("CREATE TABLE IF NOT EXISTS block_data(data blob PRIMARY_KEY)")
             cursor = await conn.execute("SELECT * from block_data")
             row = await cursor.fetchone()
@@ -134,7 +134,7 @@ class SpendSim:
             return self
 
     async def close(self) -> None:
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             c = await conn.execute("DELETE FROM block_data")
             await c.close()
             c = await conn.execute(
@@ -159,7 +159,7 @@ class SpendSim:
 
     async def all_non_reward_coins(self) -> List[Coin]:
         coins = set()
-        async with self.mempool_manager.coin_store.db_wrapper.read_db() as conn:
+        async with self.mempool_manager.coin_store.db_wrapper.reader_no_transaction() as conn:
             cursor = await conn.execute(
                 "SELECT * from coin_record WHERE coinbase=0 AND spent=0 ",
             )

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -263,7 +263,7 @@ class Blockchain(BlockchainInterface):
             None,
         )
         # Always add the block to the database
-        async with self.block_store.db_wrapper.write_db():
+        async with self.block_store.db_wrapper.writer():
             try:
                 header_hash: bytes32 = block.header_hash
                 # Perform the DB operations to update the state, and rollback if something goes wrong

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -57,7 +57,7 @@ class BlockHeightMap:
         self.__height_to_hash_filename = blockchain_dir / "height-to-hash"
         self.__ses_filename = blockchain_dir / "sub-epoch-summaries"
 
-        async with self.db.read_db() as conn:
+        async with self.db.reader_no_transaction() as conn:
             if db.db_version == 2:
                 async with conn.execute("SELECT hash FROM current_peak WHERE key = 0") as cursor:
                     peak_row = await cursor.fetchone()
@@ -169,7 +169,7 @@ class BlockHeightMap:
                     "INDEXED BY height WHERE height>=? AND height <?"
                 )
 
-            async with self.db.read_db() as conn:
+            async with self.db.reader_no_transaction() as conn:
                 async with conn.execute(query, (window_end, height)) as cursor:
 
                     # maps block-hash -> (height, prev-hash, sub-epoch-summary)

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -29,7 +29,7 @@ class BlockStore:
         # All full blocks which have been added to the blockchain. Header_hash -> block
         self.db_wrapper = db_wrapper
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
 
             if self.db_wrapper.db_version == 2:
 
@@ -138,14 +138,14 @@ class BlockStore:
 
     async def rollback(self, height: int) -> None:
         if self.db_wrapper.db_version == 2:
-            async with self.db_wrapper.write_db() as conn:
+            async with self.db_wrapper.writer_maybe_transaction() as conn:
                 await conn.execute(
                     "UPDATE OR FAIL full_blocks SET in_main_chain=0 WHERE height>? AND in_main_chain=1", (height,)
                 )
 
     async def set_in_chain(self, header_hashes: List[Tuple[bytes32]]) -> None:
         if self.db_wrapper.db_version == 2:
-            async with self.db_wrapper.write_db() as conn:
+            async with self.db_wrapper.writer_maybe_transaction() as conn:
                 await conn.executemany(
                     "UPDATE OR FAIL full_blocks SET in_main_chain=1 WHERE header_hash=?", header_hashes
                 )
@@ -162,7 +162,7 @@ class BlockStore:
 
         self.block_cache.put(header_hash, block)
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
                 "UPDATE full_blocks SET block=?,is_fully_compactified=? WHERE header_hash=?",
                 (
@@ -183,7 +183,7 @@ class BlockStore:
                 else bytes(block_record.sub_epoch_summary_included)
             )
 
-            async with self.db_wrapper.write_db() as conn:
+            async with self.db_wrapper.writer_maybe_transaction() as conn:
                 await conn.execute(
                     "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
                     (
@@ -199,7 +199,7 @@ class BlockStore:
                 )
 
         else:
-            async with self.db_wrapper.write_db() as conn:
+            async with self.db_wrapper.writer_maybe_transaction() as conn:
                 await conn.execute(
                     "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?)",
                     (
@@ -229,7 +229,7 @@ class BlockStore:
     async def persist_sub_epoch_challenge_segments(
         self, ses_block_hash: bytes32, segments: List[SubEpochChallengeSegment]
     ) -> None:
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
                 "INSERT OR REPLACE INTO sub_epoch_segments_v3 VALUES(?, ?)",
                 (self.maybe_to_hex(ses_block_hash), bytes(SubEpochSegments(segments))),
@@ -243,7 +243,7 @@ class BlockStore:
         if cached is not None:
             return cached
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT challenge_segments from sub_epoch_segments_v3 WHERE ses_block_hash=?",
                 (self.maybe_to_hex(ses_block_hash),),
@@ -270,7 +270,7 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return cached
         log.debug(f"cache miss for block {header_hash.hex()}")
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
             ) as cursor:
@@ -287,7 +287,7 @@ class BlockStore:
             log.debug(f"cache hit for block {header_hash.hex()}")
             return bytes(cached)
         log.debug(f"cache miss for block {header_hash.hex()}")
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT block from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
             ) as cursor:
@@ -306,7 +306,7 @@ class BlockStore:
 
         heights_db = tuple(heights)
         formatted_str = f'SELECT block from full_blocks WHERE height in ({"?," * (len(heights_db) - 1)}?)'
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(formatted_str, heights_db) as cursor:
                 ret: List[FullBlock] = []
                 for row in await cursor.fetchall():
@@ -321,7 +321,7 @@ class BlockStore:
             return cached.transactions_generator
 
         formatted_str = "SELECT block, height from full_blocks WHERE header_hash=?"
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(formatted_str, (self.maybe_to_hex(header_hash),)) as cursor:
                 row = await cursor.fetchone()
                 if row is None:
@@ -353,7 +353,7 @@ class BlockStore:
             f"SELECT block, height from full_blocks "
             f'WHERE in_main_chain=1 AND height in ({"?," * (len(heights_db) - 1)}?)'
         )
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(formatted_str, heights_db) as cursor:
                 async for row in cursor:
                     block_bytes = zstd.decompress(row[0])
@@ -383,7 +383,7 @@ class BlockStore:
 
         all_blocks: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "SELECT header_hash,block_record FROM full_blocks "
                     f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
@@ -394,7 +394,7 @@ class BlockStore:
                         all_blocks[header_hash] = BlockRecord.from_bytes(row[1])
         else:
             formatted_str = f'SELECT block from block_records WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)'
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(formatted_str, tuple([hh.hex() for hh in header_hashes])) as cursor:
                     for row in await cursor.fetchall():
                         block_rec: BlockRecord = BlockRecord.from_bytes(row[0])
@@ -427,7 +427,7 @@ class BlockStore:
             f'SELECT header_hash, block from full_blocks WHERE header_hash in ({"?," * (len(header_hashes_db) - 1)}?)'
         )
         all_blocks: Dict[bytes32, bytes] = {}
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(formatted_str, header_hashes_db) as cursor:
                 for row in await cursor.fetchall():
                     header_hash = bytes32(self.maybe_from_hex(row[0]))
@@ -460,7 +460,7 @@ class BlockStore:
             f'SELECT header_hash, block from full_blocks WHERE header_hash in ({"?," * (len(header_hashes_db) - 1)}?)'
         )
         all_blocks: Dict[bytes32, FullBlock] = {}
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(formatted_str, header_hashes_db) as cursor:
                 for row in await cursor.fetchall():
                     header_hash = bytes32(self.maybe_from_hex(row[0]))
@@ -478,7 +478,7 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
 
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "SELECT block_record FROM full_blocks WHERE header_hash=?",
                     (header_hash,),
@@ -488,7 +488,7 @@ class BlockStore:
                 return BlockRecord.from_bytes(row[0])
 
         else:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "SELECT block from block_records WHERE header_hash=?",
                     (header_hash.hex(),),
@@ -511,7 +511,7 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
 
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "SELECT header_hash, block_record FROM full_blocks WHERE height >= ? AND height <= ?",
                     (start, stop),
@@ -524,7 +524,7 @@ class BlockStore:
 
             formatted_str = f"SELECT header_hash, block from block_records WHERE height >= {start} and height <= {stop}"
 
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with await conn.execute(formatted_str) as cursor:
                     for row in await cursor.fetchall():
                         header_hash = bytes32(self.maybe_from_hex(row[0]))
@@ -544,7 +544,7 @@ class BlockStore:
 
         maybe_decompress_blob = self.maybe_decompress_blob
         assert self.db_wrapper.db_version == 2
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT block FROM full_blocks WHERE height >= ? AND height <= ? and in_main_chain=1",
                 (start, stop),
@@ -557,19 +557,19 @@ class BlockStore:
     async def get_peak(self) -> Optional[Tuple[bytes32, uint32]]:
 
         if self.db_wrapper.db_version == 2:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute("SELECT hash FROM current_peak WHERE key = 0") as cursor:
                     peak_row = await cursor.fetchone()
             if peak_row is None:
                 return None
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute("SELECT height FROM full_blocks WHERE header_hash=?", (peak_row[0],)) as cursor:
                     peak_height = await cursor.fetchone()
             if peak_height is None:
                 return None
             return bytes32(peak_row[0]), uint32(peak_height[0])
         else:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute("SELECT header_hash, height from block_records WHERE is_peak = 1") as cursor:
                     peak_row = await cursor.fetchone()
             if peak_row is None:
@@ -591,7 +591,7 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         if self.db_wrapper.db_version == 2:
 
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "SELECT header_hash, block_record FROM full_blocks WHERE height >= ?",
                     (peak[1] - blocks_n,),
@@ -602,7 +602,7 @@ class BlockStore:
 
         else:
             formatted_str = f"SELECT header_hash, block  from block_records WHERE height >= {peak[1] - blocks_n}"
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(formatted_str) as cursor:
                     for row in await cursor.fetchall():
                         header_hash = bytes32(self.maybe_from_hex(row[0]))
@@ -616,10 +616,10 @@ class BlockStore:
 
         if self.db_wrapper.db_version == 2:
             # Note: we use the key field as 0 just to ensure all inserts replace the existing row
-            async with self.db_wrapper.write_db() as conn:
+            async with self.db_wrapper.writer_maybe_transaction() as conn:
                 await conn.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, header_hash))
         else:
-            async with self.db_wrapper.write_db() as conn:
+            async with self.db_wrapper.writer_maybe_transaction() as conn:
                 await conn.execute("UPDATE block_records SET is_peak=0 WHERE is_peak=1")
                 await conn.execute(
                     "UPDATE block_records SET is_peak=1 WHERE header_hash=?",
@@ -627,7 +627,7 @@ class BlockStore:
                 )
 
     async def is_fully_compactified(self, header_hash: bytes32) -> Optional[bool]:
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             async with conn.execute(
                 "SELECT is_fully_compactified from full_blocks WHERE header_hash=?", (self.maybe_to_hex(header_hash),)
             ) as cursor:
@@ -639,7 +639,7 @@ class BlockStore:
     async def get_random_not_compactified(self, number: int) -> List[int]:
 
         if self.db_wrapper.db_version == 2:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     f"SELECT height FROM full_blocks WHERE in_main_chain=1 AND is_fully_compactified=0 "
                     f"ORDER BY RANDOM() LIMIT {number}"
@@ -649,7 +649,7 @@ class BlockStore:
             # Since orphan blocks do not get compactified, we need to check whether all blocks with a
             # certain height are not compact. And if we do have compact orphan blocks, then all that
             # happens is that the occasional chain block stays uncompact - not ideal, but harmless.
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     f"SELECT height FROM full_blocks GROUP BY height HAVING sum(is_fully_compactified)=0 "
                     f"ORDER BY RANDOM() LIMIT {number}"
@@ -663,13 +663,13 @@ class BlockStore:
     async def count_compactified_blocks(self) -> int:
         if self.db_wrapper.db_version == 2:
             # DB V2 has an index on is_fully_compactified only for blocks in the main chain
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "select count(*) from full_blocks where is_fully_compactified=1 and in_main_chain=1"
                 ) as cursor:
                     row = await cursor.fetchone()
         else:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute("select count(*) from full_blocks where is_fully_compactified=1") as cursor:
                     row = await cursor.fetchone()
 
@@ -681,13 +681,13 @@ class BlockStore:
     async def count_uncompactified_blocks(self) -> int:
         if self.db_wrapper.db_version == 2:
             # DB V2 has an index on is_fully_compactified only for blocks in the main chain
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "select count(*) from full_blocks where is_fully_compactified=0 and in_main_chain=1"
                 ) as cursor:
                     row = await cursor.fetchone()
         else:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute("select count(*) from full_blocks where is_fully_compactified=0") as cursor:
                     row = await cursor.fetchone()
 

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -32,7 +32,7 @@ class CoinStore:
         self.db_wrapper = db_wrapper
         self.coins_added_at_height_cache = LRUCache(capacity=100)
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
 
             if self.db_wrapper.db_version == 2:
 
@@ -81,7 +81,7 @@ class CoinStore:
         return self
 
     async def num_unspent(self) -> int:
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute("SELECT COUNT(*) FROM coin_record WHERE spent_index=0") as cursor:
                 row = await cursor.fetchone()
         if row is not None:
@@ -157,7 +157,7 @@ class CoinStore:
 
     # Checks DB and DiffStores for CoinRecord with coin_name and returns it
     async def get_coin_record(self, coin_name: bytes32) -> Optional[CoinRecord]:
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 "coin_parent, amount, timestamp FROM coin_record WHERE coin_name=?",
@@ -175,7 +175,7 @@ class CoinStore:
 
         coins: List[CoinRecord] = []
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             cursors: List[Cursor] = []
             for names_chunk in chunks(names, SQLITE_MAX_VARIABLE_NUMBER):
                 names_db: Tuple[Any, ...]
@@ -205,7 +205,7 @@ class CoinStore:
         if coins_added is not None:
             return coins_added
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index=?",
@@ -223,7 +223,7 @@ class CoinStore:
         # Special case to avoid querying all unspent coins (spent_index=0)
         if height == 0:
             return []
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 "coin_parent, amount, timestamp FROM coin_record WHERE spent_index=?",
@@ -248,7 +248,7 @@ class CoinStore:
 
         coins = set()
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash WHERE puzzle_hash=? "
@@ -279,7 +279,7 @@ class CoinStore:
         else:
             puzzle_hashes_db = tuple([ph.hex() for ph in puzzle_hashes])
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
@@ -311,7 +311,7 @@ class CoinStore:
         else:
             names_db = tuple([name.hex() for name in names])
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 f"coin_parent, amount, timestamp FROM coin_record INDEXED BY sqlite_autoindex_coin_record_1 "
@@ -349,7 +349,7 @@ class CoinStore:
             return []
 
         coins = set()
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             for puzzles in chunks(puzzle_hashes, SQLITE_MAX_VARIABLE_NUMBER):
                 puzzle_hashes_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
@@ -381,7 +381,7 @@ class CoinStore:
             return []
 
         coins = set()
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             for ids in chunks(parent_ids, SQLITE_MAX_VARIABLE_NUMBER):
                 parent_ids_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
@@ -412,7 +412,7 @@ class CoinStore:
             return []
 
         coins = set()
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             for ids in chunks(coin_ids, SQLITE_MAX_VARIABLE_NUMBER):
                 coin_ids_db: Tuple[Any, ...]
                 if self.db_wrapper.db_version == 2:
@@ -438,7 +438,7 @@ class CoinStore:
 
         coin_changes: Dict[bytes32, CoinRecord] = {}
         # Add coins that are confirmed in the reverted blocks to the list of updated coins.
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             async with conn.execute(
                 "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
@@ -492,7 +492,7 @@ class CoinStore:
                     )
                 )
             if len(values2) > 0:
-                async with self.db_wrapper.write_db() as conn:
+                async with self.db_wrapper.writer_maybe_transaction() as conn:
                     await conn.executemany(
                         "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
                         values2,
@@ -514,7 +514,7 @@ class CoinStore:
                     )
                 )
             if len(values) > 0:
-                async with self.db_wrapper.write_db() as conn:
+                async with self.db_wrapper.writer_maybe_transaction() as conn:
                     await conn.executemany(
                         "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
                         values,
@@ -528,7 +528,7 @@ class CoinStore:
         if len(coin_names) == 0:
             return
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             rows_updated: int = 0
             for coin_names_chunk in chunks(coin_names, SQLITE_MAX_VARIABLE_NUMBER):
                 name_params = ",".join(["?"] * len(coin_names_chunk))

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -205,14 +205,14 @@ class FullNode:
         await (await db_connection.execute("pragma synchronous={}".format(db_sync))).close()
 
         if db_version != 2:
-            async with self.db_wrapper.read_db() as conn:
+            async with self.db_wrapper.reader_no_transaction() as conn:
                 async with conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name='full_blocks'"
                 ) as cur:
                     if len(await cur.fetchall()) == 0:
                         try:
                             # this is a new DB file. Make it v2
-                            async with self.db_wrapper.write_db() as w_conn:
+                            async with self.db_wrapper.writer_maybe_transaction() as w_conn:
                                 await set_db_version_async(w_conn, 2)
                                 self.db_wrapper.db_version = 2
                         except sqlite3.OperationalError:
@@ -2248,7 +2248,7 @@ class FullNode:
                 new_block = dataclasses.replace(block, challenge_chain_ip_proof=vdf_proof)
         if new_block is None:
             return False
-        async with self.db_wrapper.write_db():
+        async with self.db_wrapper.writer():
             try:
                 await self.block_store.replace_proof(header_hash, new_block)
                 return True

--- a/chia/full_node/hint_store.py
+++ b/chia/full_node/hint_store.py
@@ -14,7 +14,7 @@ class HintStore:
         self = cls()
         self.db_wrapper = db_wrapper
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             if self.db_wrapper.db_version == 2:
                 await conn.execute("CREATE TABLE IF NOT EXISTS hints(coin_id blob, hint blob, UNIQUE (coin_id, hint))")
             else:
@@ -25,7 +25,7 @@ class HintStore:
         return self
 
     async def get_coin_ids(self, hint: bytes) -> List[bytes32]:
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             cursor = await conn.execute("SELECT coin_id from hints WHERE hint=?", (hint,))
             rows = await cursor.fetchall()
             await cursor.close()
@@ -38,7 +38,7 @@ class HintStore:
         if len(coin_hint_list) == 0:
             return None
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             if self.db_wrapper.db_version == 2:
                 cursor = await conn.executemany(
                     "INSERT OR IGNORE INTO hints VALUES(?, ?)",
@@ -52,7 +52,7 @@ class HintStore:
             await cursor.close()
 
     async def count_hints(self) -> int:
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute("select count(*) from hints") as cursor:
                 row = await cursor.fetchone()
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -850,7 +850,7 @@ class WalletRpcApi:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
 
-        async with self.service.wallet_state_manager.db_wrapper.write_db():
+        async with self.service.wallet_state_manager.db_wrapper.writer():
             await self.service.wallet_state_manager.tx_store.delete_unconfirmed_transactions(wallet_id)
             if self.service.wallet_state_manager.wallets[wallet_id].type() == WalletType.POOLING_WALLET.value:
                 self.service.wallet_state_manager.wallets[wallet_id].target_state = None

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -87,41 +87,73 @@ class DBWrapper2:
         return name
 
     @contextlib.asynccontextmanager
-    async def write_db(self) -> AsyncIterator[aiosqlite.Connection]:
+    async def _savepoint_ctx(self) -> AsyncIterator[None]:
+        name = self._next_savepoint()
+        await self._write_connection.execute(f"SAVEPOINT {name}")
+        try:
+            yield
+        except:  # noqa E722
+            await self._write_connection.execute(f"ROLLBACK TO {name}")
+            raise
+        finally:
+            # rollback to a savepoint doesn't cancel the transaction, it
+            # just rolls back the state. We need to cancel it regardless
+            await self._write_connection.execute(f"RELEASE {name}")
+
+    @contextlib.asynccontextmanager
+    async def writer(self) -> AsyncIterator[aiosqlite.Connection]:
+        """
+        Initiates a new, possibly nested, transaction. If this task is already
+        in a transaction, none of the changes made as part of this transaction
+        will become visible to others until that top level transaction commits.
+        If this transaction fails (by exiting the context manager with an
+        exception) this transaction will be rolled back, but the next outer
+        transaction is not necessarily cancelled. It would also need to exit
+        with an exception to be cancelled.
+        The sqlite features this relies on are SAVEPOINT, ROLLBACK TO and RELEASE.
+        """
         task = asyncio.current_task()
         assert task is not None
         if self._current_writer == task:
             # we allow nesting writers within the same task
-
-            name = self._next_savepoint()
-            await self._write_connection.execute(f"SAVEPOINT {name}")
-            try:
+            async with self._savepoint_ctx():
                 yield self._write_connection
-            except:  # noqa E722
-                await self._write_connection.execute(f"ROLLBACK TO {name}")
-                raise
-            finally:
-                # rollback to a savepoint doesn't cancel the transaction, it
-                # just rolls back the state. We need to cancel it regardless
-                await self._write_connection.execute(f"RELEASE {name}")
             return
 
         async with self._lock:
-
-            name = self._next_savepoint()
-            await self._write_connection.execute(f"SAVEPOINT {name}")
-            try:
+            async with self._savepoint_ctx():
                 self._current_writer = task
-                yield self._write_connection
-            except:  # noqa E722
-                await self._write_connection.execute(f"ROLLBACK TO {name}")
-                raise
-            finally:
-                self._current_writer = None
-                await self._write_connection.execute(f"RELEASE {name}")
+                try:
+                    yield self._write_connection
+                finally:
+                    self._current_writer = None
 
     @contextlib.asynccontextmanager
-    async def read_db(self) -> AsyncIterator[aiosqlite.Connection]:
+    async def writer_maybe_transaction(self) -> AsyncIterator[aiosqlite.Connection]:
+        """
+        Initiates a write to the database. If this task is already in a write
+        transaction with the DB, this is a no-op. Any changes made to the
+        database will be rolled up into the transaction we're already in. If the
+        current task is not already in a transaction, one will be created and
+        committed (or rolled back in the case of an exception).
+        """
+        task = asyncio.current_task()
+        assert task is not None
+        if self._current_writer == task:
+            # just use the existing transaction
+            yield self._write_connection
+            return
+
+        async with self._lock:
+            async with self._savepoint_ctx():
+                self._current_writer = task
+                try:
+                    yield self._write_connection
+                finally:
+                    self._current_writer = None
+
+    @contextlib.asynccontextmanager
+    async def reader_no_transaction(self) -> AsyncIterator[aiosqlite.Connection]:
         # there should have been read connections added
         assert self._num_read_connections > 0
 

--- a/chia/wallet/wallet_action_store.py
+++ b/chia/wallet/wallet_action_store.py
@@ -20,7 +20,7 @@ class WalletActionStore:
         self = cls()
         self.db_wrapper = db_wrapper
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
                 (
                     "CREATE TABLE IF NOT EXISTS action_queue("
@@ -46,7 +46,7 @@ class WalletActionStore:
         Return a wallet action by id
         """
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             cursor = await conn.execute("SELECT * from action_queue WHERE id=?", (id,))
             row = await cursor.fetchone()
             await cursor.close()
@@ -60,7 +60,7 @@ class WalletActionStore:
         """
         Creates Wallet Action
         """
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             cursor = await conn.execute(
                 "INSERT INTO action_queue VALUES(?, ?, ?, ?, ?, ?, ?)",
                 (None, name, wallet_id, type, callback, done, data),
@@ -72,7 +72,7 @@ class WalletActionStore:
         Returns list of all pending action
         """
         result: List[WalletAction] = []
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             cursor = await conn.execute("SELECT * from action_queue WHERE done=?", (0,))
             rows = await cursor.fetchall()
             await cursor.close()
@@ -91,7 +91,7 @@ class WalletActionStore:
         Return a wallet action by id
         """
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             cursor = await conn.execute("SELECT * from action_queue WHERE id=?", (id,))
             row = await cursor.fetchone()
             await cursor.close()

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -23,7 +23,7 @@ class WalletCoinStore:
 
         self.db_wrapper = wrapper
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
                 (
                     "CREATE TABLE IF NOT EXISTS coin_record("
@@ -59,7 +59,7 @@ class WalletCoinStore:
             return []
 
         as_hexes = [cn.hex() for cn in coin_names]
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 f'SELECT * from coin_record WHERE coin_name in ({"?," * (len(as_hexes) - 1)}?)', tuple(as_hexes)
             )
@@ -71,7 +71,7 @@ class WalletCoinStore:
         if name is None:
             name = record.name()
         assert record.spent == (record.spent_block_height != 0)
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute_insert(
                 "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
@@ -90,7 +90,7 @@ class WalletCoinStore:
 
     # Sometimes we realize that a coin is actually not interesting to us so we need to delete it
     async def delete_coin_record(self, coin_name: bytes32) -> None:
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (await conn.execute("DELETE FROM coin_record WHERE coin_name=?", (coin_name.hex(),))).close()
 
     # Update coin_record to be spent in DB
@@ -120,7 +120,7 @@ class WalletCoinStore:
 
     async def get_coin_record(self, coin_name: bytes32) -> Optional[WalletCoinRecord]:
         """Returns CoinRecord with specified coin id."""
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = list(await conn.execute_fetchall("SELECT * from coin_record WHERE coin_name=?", (coin_name.hex(),)))
 
         if len(rows) == 0:
@@ -129,7 +129,7 @@ class WalletCoinStore:
 
     async def get_first_coin_height(self) -> Optional[uint32]:
         """Returns height of first confirmed coin"""
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = list(await conn.execute_fetchall("SELECT MIN(confirmed_height) FROM coin_record"))
 
         if len(rows) != 0 and rows[0][0] is not None:
@@ -139,7 +139,7 @@ class WalletCoinStore:
 
     async def get_unspent_coins_for_wallet(self, wallet_id: int) -> Set[WalletCoinRecord]:
         """Returns set of CoinRecords that have not been spent yet for a wallet."""
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 "SELECT * FROM coin_record WHERE wallet_id=? AND spent_height=0", (wallet_id,)
             )
@@ -147,7 +147,7 @@ class WalletCoinStore:
 
     async def get_coins_to_check(self, check_height) -> Set[WalletCoinRecord]:
         """Returns set of all CoinRecords."""
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 "SELECT * from coin_record where spent_height=0 or spent_height>? or confirmed_height>?",
                 (
@@ -161,7 +161,7 @@ class WalletCoinStore:
     # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them
     async def get_coin_records_by_puzzle_hash(self, puzzle_hash: bytes32) -> List[WalletCoinRecord]:
         """Returns a list of all coin records with the given puzzle hash"""
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall("SELECT * from coin_record WHERE puzzle_hash=?", (puzzle_hash.hex(),))
 
         return [self.coin_record_from_row(row) for row in rows]
@@ -169,7 +169,7 @@ class WalletCoinStore:
     # Checks DB and DiffStores for CoinRecords with parent_coin_info and returns them
     async def get_coin_records_by_parent_id(self, parent_coin_info: bytes32) -> List[WalletCoinRecord]:
         """Returns a list of all coin records with the given parent id"""
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 "SELECT * from coin_record WHERE coin_parent=?", (parent_coin_info.hex(),)
             )
@@ -182,7 +182,7 @@ class WalletCoinStore:
         All coins spent after this point are set to unspent. Can be -1 (rollback all)
         """
 
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (await conn.execute("DELETE FROM coin_record WHERE confirmed_height>?", (height,))).close()
             await (
                 await conn.execute(

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -500,7 +500,7 @@ class WalletNode:
     async def perform_atomic_rollback(self, fork_height: int, cache: Optional[PeerRequestCache] = None):
         self.log.info(f"perform_atomic_rollback to {fork_height}")
         # this is to start a write transaction
-        async with self.wallet_state_manager.db_wrapper.write_db():
+        async with self.wallet_state_manager.db_wrapper.writer():
             try:
                 removed_wallet_ids = await self.wallet_state_manager.reorg_rollback(fork_height)
                 await self.wallet_state_manager.blockchain.set_finished_sync_up_to(fork_height, in_rollback=True)
@@ -684,8 +684,7 @@ class WalletNode:
                         if await self.validate_received_state_from_peer(inner_state, peer, cache, fork_height)
                     ]
                     if len(valid_states) > 0:
-                        # this is to start a write transaction
-                        async with self.wallet_state_manager.db_wrapper.write_db():
+                        async with self.wallet_state_manager.db_wrapper.writer():
                             self.log.info(
                                 f"new coin state received ({inner_idx_start}-"
                                 f"{inner_idx_start + len(inner_states) - 1}/ {len(items)})"
@@ -729,8 +728,7 @@ class WalletNode:
                 await asyncio.gather(*all_tasks)
                 return False
             if trusted:
-                # this is to start a write transaction
-                async with self.wallet_state_manager.db_wrapper.write_db():
+                async with self.wallet_state_manager.db_wrapper.writer():
                     try:
                         self.log.info(f"new coin state received ({idx}-" f"{idx + len(states) - 1}/ {len(items)})")
                         await self.wallet_state_manager.new_coin_state(states, peer, fork_height)

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -35,7 +35,7 @@ class WalletTransactionStore:
         self = cls()
 
         self.db_wrapper = db_wrapper
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
                 (
                     "CREATE TABLE IF NOT EXISTS transaction_record("
@@ -83,7 +83,7 @@ class WalletTransactionStore:
         """
         Store TransactionRecord in DB and Cache.
         """
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute_insert(
                 "INSERT OR REPLACE INTO transaction_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
@@ -103,7 +103,7 @@ class WalletTransactionStore:
             )
 
     async def delete_transaction_record(self, tx_id: bytes32) -> None:
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (await conn.execute("DELETE FROM transaction_record WHERE bundle_id=?", (tx_id,))).close()
 
     async def set_confirmed(self, tx_id: bytes32, height: uint32):
@@ -166,7 +166,7 @@ class WalletTransactionStore:
         """
         Checks DB and cache for TransactionRecord with id: id and returns it.
         """
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             # NOTE: bundle_id is being stored as bytes, not hex
             rows = list(await conn.execute_fetchall("SELECT * from transaction_record WHERE bundle_id=?", (tx_id,)))
         if len(rows) > 0:
@@ -182,7 +182,7 @@ class WalletTransactionStore:
         Returns the list of transactions that have not been received by full node yet.
         """
         current_time = int(time.time())
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 "SELECT * from transaction_record WHERE confirmed=0",
             )
@@ -215,7 +215,7 @@ class WalletTransactionStore:
         """
         Returns the list of all farming rewards.
         """
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             fee_int = TransactionType.FEE_REWARD.value
             pool_int = TransactionType.COINBASE_REWARD.value
             rows = await conn.execute_fetchall(
@@ -227,7 +227,7 @@ class WalletTransactionStore:
         """
         Returns the list of all transaction that have not yet been confirmed.
         """
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall("SELECT * from transaction_record WHERE confirmed=0")
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
@@ -235,7 +235,7 @@ class WalletTransactionStore:
         """
         Returns the list of transaction that have not yet been confirmed.
         """
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 "SELECT transaction_record from transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,)
             )
@@ -264,7 +264,7 @@ class WalletTransactionStore:
         else:
             query_str = SortKey[sort_key].ascending()
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 f"SELECT * FROM transaction_record WHERE wallet_id=?{puzz_hash_where}"
                 f" {query_str}, rowid"
@@ -275,7 +275,7 @@ class WalletTransactionStore:
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transaction_count_for_wallet(self, wallet_id) -> int:
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = list(
                 await conn.execute_fetchall("SELECT COUNT(*) FROM transaction_record where wallet_id=?", (wallet_id,))
             )
@@ -285,7 +285,7 @@ class WalletTransactionStore:
         """
         Returns all stored transactions.
         """
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             if type is None:
                 rows = await conn.execute_fetchall("SELECT * FROM transaction_record WHERE wallet_id=?", (wallet_id,))
             else:
@@ -302,32 +302,32 @@ class WalletTransactionStore:
         """
         Returns all stored transactions.
         """
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall("SELECT * from transaction_record")
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transaction_above(self, height: int) -> List[TransactionRecord]:
         # Can be -1 (get all tx)
 
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 "SELECT * from transaction_record WHERE confirmed_at_height>?", (height,)
             )
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def get_transactions_by_trade_id(self, trade_id: bytes32) -> List[TransactionRecord]:
-        async with self.db_wrapper.read_db() as conn:
+        async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall("SELECT * from transaction_record WHERE trade_id=?", (trade_id,))
         return [TransactionRecord.from_bytes(row[0]) for row in rows]
 
     async def rollback_to_block(self, height: int):
         # Delete from storage
         self.tx_submitted = {}
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (await conn.execute("DELETE FROM transaction_record WHERE confirmed_at_height>?", (height,))).close()
 
     async def delete_unconfirmed_transactions(self, wallet_id: int):
-        async with self.db_wrapper.write_db() as conn:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (
                 await conn.execute("DELETE FROM transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,))
             ).close()

--- a/tests/blockchain/blockchain_test_utils.py
+++ b/tests/blockchain/blockchain_test_utils.py
@@ -15,7 +15,7 @@ async def check_block_store_invariant(bc: Blockchain):
 
     in_chain = set()
     max_height = -1
-    async with db_wrapper.write_db() as conn:
+    async with db_wrapper.writer_maybe_transaction() as conn:
         async with conn.execute("SELECT height, in_main_chain FROM full_blocks") as cursor:
             rows = await cursor.fetchall()
             for row in rows:

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -120,7 +120,7 @@ class TestBlockStore:
                 # make sure all block heights are unique
                 assert len(set(ret)) == count
 
-            async with db_wrapper.read_db() as conn:
+            async with db_wrapper.reader_no_transaction() as conn:
                 for block in blocks:
                     async with conn.execute(
                         "SELECT in_main_chain FROM full_blocks WHERE header_hash=?", (block.header_hash,)
@@ -132,7 +132,7 @@ class TestBlockStore:
             await block_store.rollback(5)
 
             count = 0
-            async with db_wrapper.read_db() as conn:
+            async with db_wrapper.reader_no_transaction() as conn:
                 for block in blocks:
                     async with conn.execute(
                         "SELECT in_main_chain FROM full_blocks WHERE header_hash=? ORDER BY height",

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -170,7 +170,7 @@ class TestCoinStoreWithBlocks:
                 if block.is_transaction_block():
                     removals: List[bytes32] = []
                     additions: List[Coin] = []
-                    async with db_wrapper.write_db():
+                    async with db_wrapper.writer():
                         if block.is_transaction_block():
                             assert block.foliage_transaction_block is not None
                             await coin_store.new_block(

--- a/tests/core/full_node/stores/test_hint_store.py
+++ b/tests/core/full_node/stores/test_hint_store.py
@@ -92,7 +92,7 @@ class TestHintStore:
             coins_for_hint_0 = await hint_store.get_coin_ids(hint_0)
             assert coin_id_0 in coins_for_hint_0
 
-            async with db_wrapper.read_db() as conn:
+            async with db_wrapper.reader_no_transaction() as conn:
                 cursor = await conn.execute("SELECT COUNT(*) FROM hints")
                 rows = await cursor.fetchall()
 

--- a/tests/core/full_node/test_block_height_map.py
+++ b/tests/core/full_node/test_block_height_map.py
@@ -29,7 +29,7 @@ async def new_block(
     is_peak: bool,
     ses: Optional[SubEpochSummary],
 ):
-    async with db.write_db() as conn:
+    async with db.writer_maybe_transaction() as conn:
         if db.db_version == 2:
             cursor = await conn.execute(
                 "INSERT INTO full_blocks VALUES(?, ?, ?, ?)",
@@ -62,7 +62,7 @@ async def new_block(
 
 async def setup_db(db: DBWrapper2):
 
-    async with db.write_db() as conn:
+    async with db.writer_maybe_transaction() as conn:
         if db.db_version == 2:
             await conn.execute(
                 "CREATE TABLE IF NOT EXISTS full_blocks("
@@ -171,7 +171,7 @@ class TestBlockHeightMap:
             # in the DB since we keep loading until we find a match of both hash
             # and sub epoch summary. In this test we have a sub epoch summary
             # every 20 blocks, so we generate the 30 last blocks only
-            async with db_wrapper.write_db() as conn:
+            async with db_wrapper.writer_maybe_transaction() as conn:
                 if db_version == 2:
                     await conn.execute("DROP TABLE full_blocks")
                 else:

--- a/tests/core/test_db_validation.py
+++ b/tests/core/test_db_validation.py
@@ -133,7 +133,7 @@ async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
     try:
         await db_wrapper.add_connection(await aiosqlite.connect(db_file))
 
-        async with db_wrapper.write_db() as conn:
+        async with db_wrapper.writer_maybe_transaction() as conn:
             # this is done by chia init normally
             await conn.execute("CREATE TABLE database_version(version int)")
             await conn.execute("INSERT INTO database_version VALUES (2)")

--- a/tests/core/util/test_db_wrapper.py
+++ b/tests/core/util/test_db_wrapper.py
@@ -10,7 +10,7 @@ from tests.util.db_connection import DBConnection
 
 
 async def increment_counter(db_wrapper: DBWrapper2) -> None:
-    async with db_wrapper.write_db() as connection:
+    async with db_wrapper.writer_maybe_transaction() as connection:
         async with connection.execute("SELECT value FROM counter") as cursor:
             row = await cursor.fetchone()
 
@@ -24,7 +24,7 @@ async def increment_counter(db_wrapper: DBWrapper2) -> None:
 
 
 async def sum_counter(db_wrapper: DBWrapper2, output: List[int]) -> None:
-    async with db_wrapper.read_db() as connection:
+    async with db_wrapper.reader_no_transaction() as connection:
         async with connection.execute("SELECT value FROM counter") as cursor:
             row = await cursor.fetchone()
 
@@ -37,7 +37,7 @@ async def sum_counter(db_wrapper: DBWrapper2, output: List[int]) -> None:
 
 
 async def setup_table(db: DBWrapper2) -> None:
-    async with db.write_db() as conn:
+    async with db.writer_maybe_transaction() as conn:
         await conn.execute("CREATE TABLE counter(value INTEGER NOT NULL)")
         await conn.execute("INSERT INTO counter(value) VALUES(0)")
 
@@ -62,7 +62,7 @@ async def test_concurrent_writers(acquire_outside: bool) -> None:
 
         async with contextlib.AsyncExitStack() as exit_stack:
             if acquire_outside:
-                await exit_stack.enter_async_context(db_wrapper.write_db())
+                await exit_stack.enter_async_context(db_wrapper.writer_maybe_transaction())
 
             tasks = []
             for index in range(concurrent_task_count):
@@ -71,7 +71,7 @@ async def test_concurrent_writers(acquire_outside: bool) -> None:
 
         await asyncio.wait_for(asyncio.gather(*tasks), timeout=None)
 
-        async with db_wrapper.read_db() as connection:
+        async with db_wrapper.reader_no_transaction() as connection:
             async with connection.execute("SELECT value FROM counter") as cursor:
                 row = await cursor.fetchone()
 
@@ -85,14 +85,14 @@ async def test_concurrent_writers(acquire_outside: bool) -> None:
 async def test_writers_nests() -> None:
     async with DBConnection(2) as db_wrapper:
         await setup_table(db_wrapper)
-        async with db_wrapper.write_db() as conn1:
+        async with db_wrapper.writer_maybe_transaction() as conn1:
             async with conn1.execute("SELECT value FROM counter") as cursor:
                 value = await get_value(cursor)
-            async with db_wrapper.write_db() as conn2:
+            async with db_wrapper.writer_maybe_transaction() as conn2:
                 assert conn1 == conn2
                 value += 1
                 await conn2.execute("UPDATE counter SET value = :value", {"value": value})
-                async with db_wrapper.write_db() as conn3:
+                async with db_wrapper.writer_maybe_transaction() as conn3:
                     assert conn1 == conn3
                     async with conn3.execute("SELECT value FROM counter") as cursor:
                         value = await get_value(cursor)
@@ -105,12 +105,12 @@ async def test_partial_failure() -> None:
     values = []
     async with DBConnection(2) as db_wrapper:
         await setup_table(db_wrapper)
-        async with db_wrapper.write_db() as conn1:
+        async with db_wrapper.writer() as conn1:
             await conn1.execute("UPDATE counter SET value = 42")
             async with conn1.execute("SELECT value FROM counter") as cursor:
                 values.append(await get_value(cursor))
             try:
-                async with db_wrapper.write_db() as conn2:
+                async with db_wrapper.writer() as conn2:
                     await conn2.execute("UPDATE counter SET value = 1337")
                     async with conn1.execute("SELECT value FROM counter") as cursor:
                         values.append(await get_value(cursor))
@@ -132,10 +132,10 @@ async def test_readers_nests() -> None:
     async with DBConnection(2) as db_wrapper:
         await setup_table(db_wrapper)
 
-        async with db_wrapper.read_db() as conn1:
-            async with db_wrapper.read_db() as conn2:
+        async with db_wrapper.reader_no_transaction() as conn1:
+            async with db_wrapper.reader_no_transaction() as conn2:
                 assert conn1 == conn2
-                async with db_wrapper.read_db() as conn3:
+                async with db_wrapper.reader_no_transaction() as conn3:
                     assert conn1 == conn3
                     async with conn3.execute("SELECT value FROM counter") as cursor:
                         value = await get_value(cursor)
@@ -148,10 +148,10 @@ async def test_readers_nests_writer() -> None:
     async with DBConnection(2) as db_wrapper:
         await setup_table(db_wrapper)
 
-        async with db_wrapper.write_db() as conn1:
-            async with db_wrapper.read_db() as conn2:
+        async with db_wrapper.writer_maybe_transaction() as conn1:
+            async with db_wrapper.reader_no_transaction() as conn2:
                 assert conn1 == conn2
-                async with db_wrapper.write_db() as conn3:
+                async with db_wrapper.writer_maybe_transaction() as conn3:
                     assert conn1 == conn3
                     async with conn3.execute("SELECT value FROM counter") as cursor:
                         value = await get_value(cursor)
@@ -169,14 +169,14 @@ async def test_concurrent_readers(acquire_outside: bool) -> None:
     async with DBConnection(2) as db_wrapper:
         await setup_table(db_wrapper)
 
-        async with db_wrapper.write_db() as connection:
+        async with db_wrapper.writer_maybe_transaction() as connection:
             await connection.execute("UPDATE counter SET value = 1")
 
         concurrent_task_count = 200
 
         async with contextlib.AsyncExitStack() as exit_stack:
             if acquire_outside:
-                await exit_stack.enter_async_context(db_wrapper.read_db())
+                await exit_stack.enter_async_context(db_wrapper.reader_no_transaction())
 
             tasks = []
             values: List[int] = []
@@ -199,14 +199,14 @@ async def test_mixed_readers_writers(acquire_outside: bool) -> None:
     async with DBConnection(2) as db_wrapper:
         await setup_table(db_wrapper)
 
-        async with db_wrapper.write_db() as connection:
+        async with db_wrapper.writer_maybe_transaction() as connection:
             await connection.execute("UPDATE counter SET value = 1")
 
         concurrent_task_count = 200
 
         async with contextlib.AsyncExitStack() as exit_stack:
             if acquire_outside:
-                await exit_stack.enter_async_context(db_wrapper.read_db())
+                await exit_stack.enter_async_context(db_wrapper.reader_no_transaction())
 
             tasks = []
             values: List[int] = []

--- a/tests/pools/test_wallet_pool_store.py
+++ b/tests/pools/test_wallet_pool_store.py
@@ -37,7 +37,7 @@ class TestWalletPoolStore:
             store = await WalletPoolStore.create(db_wrapper)
 
             try:
-                async with db_wrapper.write_db():
+                async with db_wrapper.writer():
                     coin_0 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
                     coin_0_alt = Coin(token_bytes(32), token_bytes(32), uint64(12312))
                     solution_0: CoinSpend = make_child_solution(None, coin_0)


### PR DESCRIPTION
which creates a nested transaction, and make `write_db()` just add writes to the existing transaction.

This improves performance, getting it back in line with pre-DBWrapper2. The full node performance is not particularly affected by this, but the wallet is.

This PR https://github.com/Chia-Network/chia-blockchain/pull/12234 makes wallet sync take 22% longer by switching to DBWrapper2. With this patch, that performance penalty goes away.

I suspect the main cost of the nested transactions are the round-trips to the sqlite thread, and not the actual DB operations themselves. But aiosqlite does not have an API that supports pipelining commands to its thread.