### PR TITLE
Additional data for `get_wallet_balance` and `get_wallets` endpoints

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -667,9 +667,12 @@ class WalletRpcApi:
                     "max_send_amount": 0,
                     "unspent_coin_count": 0,
                     "pending_coin_removal_count": 0,
+                    "wallet_type": wallet.type(),
                 }
                 if self.service.logged_in_fingerprint is not None:
                     wallet_balance["fingerprint"] = self.service.logged_in_fingerprint
+                if wallet.type() == WalletType.CAT:
+                    wallet_balance["asset_id"] = wallet.get_asset_id()
         else:
             async with self.service.wallet_state_manager.lock:
                 unspent_records = await self.service.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(
@@ -693,9 +696,12 @@ class WalletRpcApi:
                     "max_send_amount": max_send_amount,
                     "unspent_coin_count": len(unspent_records),
                     "pending_coin_removal_count": len(unconfirmed_removals),
+                    "wallet_type": wallet.type(),
                 }
                 if self.service.logged_in_fingerprint is not None:
                     wallet_balance["fingerprint"] = self.service.logged_in_fingerprint
+                if wallet.type() == WalletType.CAT:
+                    wallet_balance["asset_id"] = wallet.get_asset_id()
                 self.balance_cache[wallet_id] = wallet_balance
 
         return {"wallet_balance": wallet_balance}

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -429,7 +429,7 @@ class WalletRpcApi:
             for wallet in wallets:
                 result.append(WalletInfo(wallet.id, wallet.name, wallet.type, ""))
             wallets = result
-        response: Dict[str, Any] = {"wallets": wallets}
+        response: EndpointResult = {"wallets": wallets}
         if self.service.logged_in_fingerprint is not None:
             response["fingerprint"] = self.service.logged_in_fingerprint
         return response

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -429,7 +429,10 @@ class WalletRpcApi:
             for wallet in wallets:
                 result.append(WalletInfo(wallet.id, wallet.name, wallet.type, ""))
             wallets = result
-        return {"wallets": wallets}
+        response = {"wallets": wallets}
+        if self.service.logged_in_fingerprint is not None:
+            response["fingerprint"] = self.service.logged_in_fingerprint
+        return response
 
     async def create_new_wallet(self, request: Dict) -> EndpointResult:
         wallet_state_manager = self.service.wallet_state_manager

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -429,7 +429,7 @@ class WalletRpcApi:
             for wallet in wallets:
                 result.append(WalletInfo(wallet.id, wallet.name, wallet.type, ""))
             wallets = result
-        response = {"wallets": wallets}
+        response: Dict[str, Any] = {"wallets": wallets}
         if self.service.logged_in_fingerprint is not None:
             response["fingerprint"] = self.service.logged_in_fingerprint
         return response


### PR DESCRIPTION
Additions to `get_wallet_balance` endpoint:
* `wallet_type`
* `asset_id` (if a CAT wallet)

Additions to `get_wallets` endpoint:
* `fingerprint` - since all the wallets listed are specific to the currently keys