### PR TITLE
Tx submission idempotance, and prioritize wallet

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2062,6 +2062,9 @@ class FullNode:
         if not test and not (await self.synced()):
             return MempoolInclusionStatus.FAILED, Err.NO_TRANSACTIONS_WHILE_SYNCING
 
+        if self.mempool_manager.get_spendbundle(spend_name) is not None:
+            self.mempool_manager.remove_seen(spend_name)
+            return MempoolInclusionStatus.SUCCESS, None
         if self.mempool_manager.seen(spend_name):
             return MempoolInclusionStatus.FAILED, Err.ALREADY_INCLUDING_TRANSACTION
         self.mempool_manager.add_and_maybe_pop_seen(spend_name)
@@ -2083,7 +2086,7 @@ class FullNode:
             async with self._blockchain_lock_low_priority:
                 if self.mempool_manager.get_spendbundle(spend_name) is not None:
                     self.mempool_manager.remove_seen(spend_name)
-                    return MempoolInclusionStatus.FAILED, Err.ALREADY_INCLUDING_TRANSACTION
+                    return MempoolInclusionStatus.SUCCESS, None
                 cost, status, error = await self.mempool_manager.add_spendbundle(transaction, cost_result, spend_name)
             if status == MempoolInclusionStatus.SUCCESS:
                 self.log.debug(

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -251,7 +251,7 @@ class FullNodeAPI:
             return None
         # Higher fee means priority is a smaller number, which means it will be handled earlier
         await self.full_node.transaction_queue.put(
-            (0, TransactionQueueEntry(tx.transaction, tx_bytes, spend_name, peer, test))
+            (1, TransactionQueueEntry(tx.transaction, tx_bytes, spend_name, peer, test))
         )
         return None
 
@@ -1229,6 +1229,11 @@ class FullNodeAPI:
     @api_request
     async def send_transaction(self, request: wallet_protocol.SendTransaction, *, test=False) -> Optional[Message]:
         spend_name = request.transaction.name()
+        if self.full_node.mempool_manager.get_spendbundle(spend_name) is not None:
+            self.full_node.mempool_manager.remove_seen(spend_name)
+            response = wallet_protocol.TransactionAck(spend_name, uint8(MempoolInclusionStatus.SUCCESS), None)
+            return make_msg(ProtocolMessageTypes.transaction_ack, response)
+
         await self.full_node.transaction_queue.put(
             (0, TransactionQueueEntry(request.transaction, None, spend_name, None, test))
         )
@@ -1258,8 +1263,7 @@ class FullNodeAPI:
                     )
                 else:
                     response = wallet_protocol.TransactionAck(spend_name, uint8(status.value), error_name)
-        msg = make_msg(ProtocolMessageTypes.transaction_ack, response)
-        return msg
+        return make_msg(ProtocolMessageTypes.transaction_ack, response)
 
     @api_request
     async def request_puzzle_solution(self, request: wallet_protocol.RequestPuzzleSolution) -> Optional[Message]:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -249,7 +249,7 @@ class FullNodeAPI:
         if self.full_node.transaction_queue.full():
             self.full_node.dropped_tx.add(spend_name)
             return None
-        # Higher fee means priority is a smaller number, which means it will be handled earlier
+        # TODO: Use fee in priority calculation, to prioritize high fee TXs
         await self.full_node.transaction_queue.put(
             (1, TransactionQueueEntry(tx.transaction, tx_bytes, spend_name, peer, test))
         )


### PR DESCRIPTION
1. We check for inclusion in mempool before adding to the queue. even if queue is full, `send_transaction` will return success if it's in mempool. Also return SUCCESS from full_node.respond_transaction in case it gets into the mempool while we are waiting in the queue.
2. Increase the priority of wallet transactions vs full node broadcasted transactions, so we don't have to wait in line as a wallet user. We do this by increasing the full node transactions priority to 1 (wallet is 0). Lower numbers go first.
