### PR TITLE
Increment macOS Intel installer build timeout to 55

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: MacOS Intel Installer
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 55
     strategy:
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
There are plenty of runs in the high 30s and even low 40s lately.