### PR TITLE
Add /subscriptions RPC and add data_layer to chia rpc

### DIFF
--- a/chia/cmds/rpc.py
+++ b/chia/cmds/rpc.py
@@ -10,7 +10,7 @@ from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint16
 
-services: List[str] = ["crawler", "farmer", "full_node", "harvester", "timelord", "wallet"]
+services: List[str] = ["crawler", "farmer", "full_node", "harvester", "timelord", "wallet", "data_layer"]
 
 
 async def call_endpoint(service: str, endpoint: str, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:

--- a/chia/rpc/data_layer_rpc_api.py
+++ b/chia/rpc/data_layer_rpc_api.py
@@ -66,6 +66,7 @@ class DataLayerRpcApi:
             "/insert": self.insert,
             "/subscribe": self.subscribe,
             "/unsubscribe": self.unsubscribe,
+            "/subscriptions": self.subscriptions,
             "/get_kv_diff": self.get_kv_diff,
             "/get_root_history": self.get_root_history,
             "/add_missing_files": self.add_missing_files,
@@ -82,7 +83,7 @@ class DataLayerRpcApi:
         if self.service is None:
             raise Exception("Data layer not created")
         singleton_records = await self.service.get_owned_stores()
-        return {"launcher_ids": [singleton.launcher_id.hex() for singleton in singleton_records]}
+        return {"store_ids": [singleton.launcher_id.hex() for singleton in singleton_records]}
 
     async def get_value(self, request: Dict[str, Any]) -> Dict[str, Any]:
         store_id = bytes32.from_hexstr(request["id"])
@@ -227,6 +228,15 @@ class DataLayerRpcApi:
         store_id_bytes = bytes32.from_hexstr(store_id)
         await self.service.unsubscribe(store_id_bytes)
         return {}
+
+    async def subscriptions(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        List current subscriptions
+        """
+        if self.service is None:
+            raise Exception("Data layer not created")
+        subscriptions: List[Subscription] = await self.service.get_subscriptions()
+        return {"store_ids": [sub.tree_id.hex() for sub in subscriptions]}
 
     async def add_missing_files(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -706,11 +706,10 @@ async def test_subscriptions(one_wallet_node_and_rpc: nodes_with_port, bt: Block
 
         # test subscriptions
         response = await data_rpc_api.subscriptions(request={})
-        assert response["store_ids"][0] == launcher_id.hex()
+        assert launcher_id.hex() in response.get("store_ids", [])
 
         # test unsubscribe
         response = await data_rpc_api.unsubscribe(request={"id": launcher_id.hex()})
 
         response = await data_rpc_api.subscriptions(request={})
-        # should return empty list
-        assert not response["store_ids"]
+        assert launcher_id.hex() not in response.get("store_ids", [])

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -671,3 +671,46 @@ async def test_get_owned_stores(one_wallet_node_and_rpc: nodes_with_port, bt: Bl
         store_ids = sorted(bytes32.from_hexstr(id) for id in response["store_ids"])
 
         assert store_ids == sorted(expected_store_ids)
+
+
+@pytest.mark.asyncio
+async def test_subscriptions(one_wallet_node_and_rpc: nodes_with_port, bt: BlockTools) -> None:
+    wallet_node, full_node_api, wallet_rpc_port = one_wallet_node_and_rpc
+    num_blocks = 4
+    assert wallet_node.server is not None
+    await wallet_node.server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
+    assert wallet_node.wallet_state_manager is not None
+    ph = await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash()
+    for i in range(0, num_blocks):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+        await asyncio.sleep(0.5)
+    funds = sum(
+        [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
+    )
+    await time_out_assert(15, wallet_node.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
+
+    async for data_layer in init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt):
+        data_rpc_api = DataLayerRpcApi(data_layer)
+
+        res = await data_rpc_api.create_data_store({})
+        assert res is not None
+        launcher_id = bytes32.from_hexstr(res["id"])
+
+        for i in range(0, num_blocks):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+            await asyncio.sleep(0.5)
+
+        # This tests subscribe/unsubscribe to your own singletons, which isn't quite
+        # the same thing as using a different wallet, but makes the tests much simpler
+        response = await data_rpc_api.subscribe(request={"id": launcher_id.hex(), "urls": ["http://127:0:0:1/8000"]})
+
+        # test subscriptions
+        response = await data_rpc_api.subscriptions(request={})
+        assert response["store_ids"][0] == launcher_id.hex()
+
+        # test unsubscribe
+        response = await data_rpc_api.unsubscribe(request={"id": launcher_id.hex()})
+
+        response = await data_rpc_api.subscriptions(request={})
+        # should return empty list
+        assert not response["store_ids"]

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -655,19 +655,19 @@ async def test_get_owned_stores(one_wallet_node_and_rpc: nodes_with_port, bt: Bl
     async for data_layer in init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt):
         data_rpc_api = DataLayerRpcApi(data_layer)
 
-        expected_launcher_ids = []
+        expected_store_ids = []
 
         for _ in range(3):
             res = await data_rpc_api.create_data_store({})
             assert res is not None
             launcher_id = bytes32.from_hexstr(res["id"])
-            expected_launcher_ids.append(launcher_id)
+            expected_store_ids.append(launcher_id)
 
         for i in range(0, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
             await asyncio.sleep(0.5)
 
         response = await data_rpc_api.get_owned_stores(request={})
-        launcher_ids = sorted(bytes32.from_hexstr(id) for id in response["launcher_ids"])
+        store_ids = sorted(bytes32.from_hexstr(id) for id in response["store_ids"])
 
-        assert launcher_ids == sorted(expected_launcher_ids)
+        assert store_ids == sorted(expected_store_ids)

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -703,6 +703,7 @@ async def test_subscriptions(one_wallet_node_and_rpc: nodes_with_port, bt: Block
         # This tests subscribe/unsubscribe to your own singletons, which isn't quite
         # the same thing as using a different wallet, but makes the tests much simpler
         response = await data_rpc_api.subscribe(request={"id": launcher_id.hex(), "urls": ["http://127:0:0:1/8000"]})
+        assert response is not None
 
         # test subscriptions
         response = await data_rpc_api.subscriptions(request={})
@@ -710,6 +711,7 @@ async def test_subscriptions(one_wallet_node_and_rpc: nodes_with_port, bt: Block
 
         # test unsubscribe
         response = await data_rpc_api.unsubscribe(request={"id": launcher_id.hex()})
+        assert response is not None
 
         response = await data_rpc_api.subscriptions(request={})
         assert launcher_id.hex() not in response.get("store_ids", [])


### PR DESCRIPTION
Added `/subscriptions` RPC call to data_layer
Added data_layer as included server for `chia rpc`
Changed return from `get_owned_stores` to return `store_ids` instead of `launcher_ids`

Can now use the following CLI commands to get your own stores and your subscriptions

`chia rpc data_layer get_owned_stores`
`chia rpc data_layer subscriptions`