### PR TITLE
Add check to verify wallet is tracking DL in batch_update

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -115,7 +115,7 @@ class DataLayer:
 
         # check before any DL changes that this singleton is currently owned by this wallet
         singleton_records: List[SingletonRecord] = await self.get_owned_stores()
-        if not [singleton for singleton in singleton_records if tree_id == singleton.launcher_id]:
+        if not any(tree_id == singleton.launcher_id for singleton in singleton_records):
             raise ValueError(f"Singleton with launcher ID {tree_id} is not owned by DL Wallet")
 
         t1 = time.monotonic()

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -112,6 +112,12 @@ class DataLayer:
         changelist: List[Dict[str, Any]],
         fee: uint64,
     ) -> TransactionRecord:
+
+        # check before any DL changes that this singleton is currently owned by this wallet
+        singleton_record = await self.wallet_rpc.dl_latest_singleton(tree_id, True)
+        if singleton_record is None:
+            raise ValueError(f"Singleton with launcher ID {tree_id} is not tracked by DL Wallet")
+
         t1 = time.monotonic()
         await self.data_store.insert_batch(tree_id, changelist, lock=True)
         t2 = time.monotonic()

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -114,9 +114,9 @@ class DataLayer:
     ) -> TransactionRecord:
 
         # check before any DL changes that this singleton is currently owned by this wallet
-        singleton_record = await self.wallet_rpc.dl_latest_singleton(tree_id, True)
-        if singleton_record is None:
-            raise ValueError(f"Singleton with launcher ID {tree_id} is not tracked by DL Wallet")
+        singleton_records: List[SingletonRecord] = await self.get_owned_stores()
+        if not [singleton for singleton in singleton_records if tree_id == singleton.launcher_id]:
+            raise ValueError(f"Singleton with launcher ID {tree_id} is not owned by DL Wallet")
 
         t1 = time.monotonic()
         await self.data_store.insert_batch(tree_id, changelist, lock=True)


### PR DESCRIPTION
Add check to make sure the wallet is tracking the DL in batch_update.

The wallet can still throw various exceptions that we should catch and rollback update - but this likely catches most of the common errors before we actually update the DL tree.