### PR TITLE
Wallet execute fetchall

### DIFF
--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from typing import AsyncIterator, Dict, Optional
+import sqlite3
+from typing import Any, AsyncIterator, Dict, Iterable, Optional
 
 import aiosqlite
 
@@ -36,6 +37,15 @@ class DBWrapper:
 
     async def commit_transaction(self) -> None:
         await self.db.commit()
+
+
+async def execute_fetchone(
+    c: aiosqlite.Connection, sql: str, parameters: Iterable[Any] = None
+) -> Optional[sqlite3.Row]:
+    rows = await c.execute_fetchall(sql, parameters)
+    for row in rows:
+        return row
+    return None
 
 
 class DBWrapper2:

--- a/chia/wallet/wallet_nft_store.py
+++ b/chia/wallet/wallet_nft_store.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Type, TypeVar
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.nft_wallet.nft_info import DEFAULT_STATUS, IN_TRANSACTION_STATUS, NFTCoinInfo
@@ -49,7 +49,7 @@ class WalletNftStore:
 
     async def delete_nft(self, nft_id: bytes32) -> None:
         async with self.db_wrapper.write_db() as conn:
-            await (await conn.execute(f"DELETE FROM users_nfts where nft_id='{nft_id.hex()}'")).close()
+            await (await conn.execute("DELETE FROM users_nfts where nft_id=?", (nft_id.hex(),))).close()
 
     async def save_nft(self, wallet_id: uint32, did_id: Optional[bytes32], nft_coin_info: NFTCoinInfo) -> None:
         async with self.db_wrapper.write_db() as conn:
@@ -83,32 +83,27 @@ class WalletNftStore:
             sql += f" where did_id='{did_id.hex()}' and wallet_id={wallet_id}"
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(sql)
-            rows = await cursor.fetchall()
-            await cursor.close()
-        result = []
+            rows = await conn.execute_fetchall(sql)
 
-        for row in rows:
-            result.append(
-                NFTCoinInfo(
-                    bytes32.from_hexstr(row[0]),
-                    Coin.from_json_dict(json.loads(row[1])),
-                    None if row[2] is None else LineageProof.from_json_dict(json.loads(row[2])),
-                    Program.from_bytes(row[5]),
-                    uint32(row[3]),
-                    row[4] == IN_TRANSACTION_STATUS,
-                )
+        return [
+            NFTCoinInfo(
+                bytes32.from_hexstr(row[0]),
+                Coin.from_json_dict(json.loads(row[1])),
+                None if row[2] is None else LineageProof.from_json_dict(json.loads(row[2])),
+                Program.from_bytes(row[5]),
+                uint32(row[3]),
+                row[4] == IN_TRANSACTION_STATUS,
             )
-        return result
+            for row in rows
+        ]
 
     async def get_nft_by_id(self, nft_id: bytes32) -> Optional[NFTCoinInfo]:
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
+            row = await execute_fetchone(
+                conn,
                 "SELECT nft_id, coin, lineage_proof, mint_height, status, full_puzzle from users_nfts WHERE nft_id=?",
                 (nft_id.hex(),),
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is None:
             return None

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Set, Tuple
 from blspy import G1Element
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32
 from chia.util.lru_cache import LRUCache
 from chia.wallet.derivation_record import DerivationRecord
@@ -119,13 +119,12 @@ class WalletPuzzleStore:
         else:
             hard = 0
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
+            row = await execute_fetchone(
+                conn,
                 "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used FROM derivation_paths "
                 "WHERE derivation_index=? AND wallet_id=? AND hardened=?",
                 (index, wallet_id, hard),
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None and row[0] is not None:
             return DerivationRecord(
@@ -144,13 +143,12 @@ class WalletPuzzleStore:
         Returns the derivation record by index and wallet id.
         """
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
+            row = await execute_fetchone(
+                conn,
                 "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, hardened FROM derivation_paths "
                 "WHERE puzzle_hash=?",
                 (puzzle_hash.hex(),),
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None and row[0] is not None:
             return DerivationRecord(
@@ -183,11 +181,9 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
-                "SELECT puzzle_hash FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+            row = await execute_fetchone(
+                conn, "SELECT puzzle_hash FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         return row is not None
 
@@ -221,11 +217,9 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
-                "SELECT derivation_index FROM derivation_paths WHERE pubkey=?", (bytes(pubkey).hex(),)
+            row = await execute_fetchone(
+                conn, "SELECT derivation_index FROM derivation_paths WHERE pubkey=?", (bytes(pubkey).hex(),)
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None:
             return uint32(row[0])
@@ -239,19 +233,15 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
+            row = await execute_fetchone(
+                conn,
                 "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used, hardened "
                 "FROM derivation_paths "
                 "WHERE pubkey=?",
                 (bytes(pubkey).hex(),),
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
-        if row is not None:
-            return self.row_to_record(row)
-
-        return None
+        return None if row is None else self.row_to_record(row)
 
     async def index_for_puzzle_hash(self, puzzle_hash: bytes32) -> Optional[uint32]:
         """
@@ -259,16 +249,10 @@ class WalletPuzzleStore:
         Returns None if not present.
         """
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
-                "SELECT derivation_index FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+            row = await execute_fetchone(
+                conn, "SELECT derivation_index FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
             )
-            row = await cursor.fetchone()
-            await cursor.close()
-
-        if row is not None:
-            return uint32(row[0])
-
-        return None
+        return None if row is None else uint32(row[0])
 
     async def record_for_puzzle_hash(self, puzzle_hash: bytes32) -> Optional[DerivationRecord]:
         """
@@ -276,14 +260,13 @@ class WalletPuzzleStore:
         Returns None if not present.
         """
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
+            row = await execute_fetchone(
+                conn,
                 "SELECT derivation_index, pubkey, puzzle_hash, wallet_type, wallet_id, used, hardened "
                 "FROM derivation_paths "
                 "WHERE puzzle_hash=?",
                 (puzzle_hash.hex(),),
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None and row[0] is not None:
             return self.row_to_record(row)
@@ -296,15 +279,14 @@ class WalletPuzzleStore:
         Returns None if not present.
         """
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
+            row = await execute_fetchone(
+                conn,
                 "SELECT derivation_index FROM derivation_paths WHERE puzzle_hash=? AND wallet_id=?;",
                 (
                     puzzle_hash.hex(),
                     wallet_id,
                 ),
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None:
             return uint32(row[0])
@@ -321,11 +303,9 @@ class WalletPuzzleStore:
             return cached
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
-                "SELECT wallet_type, wallet_id FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
+            row = await execute_fetchone(
+                conn, "SELECT wallet_type, wallet_id FROM derivation_paths WHERE puzzle_hash=?", (puzzle_hash.hex(),)
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None:
             self.wallet_info_for_ph_cache.put(puzzle_hash, (row[1], WalletType(row[0])))
@@ -339,15 +319,8 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute("SELECT puzzle_hash FROM derivation_paths")
-            rows = await cursor.fetchall()
-            await cursor.close()
-        result: Set[bytes32] = set()
-
-        for row in rows:
-            result.add(bytes32(bytes.fromhex(row[0])))
-
-        return result
+            rows = await conn.execute_fetchall("SELECT puzzle_hash FROM derivation_paths")
+            return set(bytes32.fromhex(row[0]) for row in rows)
 
     async def get_last_derivation_path(self) -> Optional[uint32]:
         """
@@ -355,14 +328,8 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute("SELECT MAX(derivation_index) FROM derivation_paths;")
-            row = await cursor.fetchone()
-            await cursor.close()
-
-        if row is not None and row[0] is not None:
-            return uint32(row[0])
-
-        return None
+            row = await execute_fetchone(conn, "SELECT MAX(derivation_index) FROM derivation_paths")
+            return None if row is None or row[0] is None else uint32(row[0])
 
     async def get_last_derivation_path_for_wallet(self, wallet_id: int) -> Optional[uint32]:
         """
@@ -370,16 +337,10 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
-                f"SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id={wallet_id};"
+            row = await execute_fetchone(
+                conn, "SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id=?", (wallet_id,)
             )
-            row = await cursor.fetchone()
-            await cursor.close()
-
-        if row is not None and row[0] is not None:
-            return uint32(row[0])
-
-        return None
+            return None if row is None or row[0] is None else uint32(row[0])
 
     async def get_current_derivation_record_for_wallet(self, wallet_id: uint32) -> Optional[DerivationRecord]:
         """
@@ -387,13 +348,11 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
-                "SELECT MAX(derivation_index) "
-                "FROM derivation_paths "
-                f"WHERE wallet_id={wallet_id} AND used=1 AND hardened=0;"
+            row = await execute_fetchone(
+                conn,
+                "SELECT MAX(derivation_index) FROM derivation_paths WHERE wallet_id=? AND used=1 AND hardened=0",
+                (wallet_id,),
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None and row[0] is not None:
             index = uint32(row[0])
@@ -406,11 +365,9 @@ class WalletPuzzleStore:
         Returns the first unused derivation path by derivation_index.
         """
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute(
-                "SELECT MIN(derivation_index) FROM derivation_paths WHERE used=0 AND hardened=0;"
+            row = await execute_fetchone(
+                conn, "SELECT MIN(derivation_index) FROM derivation_paths WHERE used=0 AND hardened=0;"
             )
-            row = await cursor.fetchone()
-            await cursor.close()
 
         if row is not None and row[0] is not None:
             return uint32(row[0])

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_info import WalletInfo
@@ -70,7 +70,7 @@ class WalletUserStore:
 
     async def delete_wallet(self, id: int):
         async with self.db_wrapper.write_db() as conn:
-            await (await conn.execute(f"DELETE FROM users_wallets where id={id}")).close()
+            await (await conn.execute("DELETE FROM users_wallets where id=?", (id,))).close()
 
     async def update_wallet(self, wallet_info: WalletInfo):
         async with self.db_wrapper.write_db() as conn:
@@ -87,14 +87,9 @@ class WalletUserStore:
 
     async def get_last_wallet(self) -> Optional[WalletInfo]:
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute("SELECT MAX(id) FROM users_wallets;")
-            row = await cursor.fetchone()
-            await cursor.close()
+            row = await execute_fetchone(conn, "SELECT MAX(id) FROM users_wallets")
 
-        if row is None:
-            return None
-
-        return await self.get_wallet_by_id(row[0])
+        return None if row is None else await self.get_wallet_by_id(row[0])
 
     async def get_all_wallet_info_entries(self, wallet_type: Optional[WalletType] = None) -> List[WalletInfo]:
         """
@@ -102,18 +97,12 @@ class WalletUserStore:
         """
         async with self.db_wrapper.read_db() as conn:
             if wallet_type is None:
-                cursor = await conn.execute("SELECT * from users_wallets")
+                rows = await conn.execute_fetchall("SELECT * from users_wallets")
             else:
-                cursor = await conn.execute("SELECT * from users_wallets WHERE wallet_type=?", (wallet_type.value,))
-
-            rows = await cursor.fetchall()
-            await cursor.close()
-        result = []
-
-        for row in rows:
-            result.append(WalletInfo(row[0], row[1], row[2], row[3]))
-
-        return result
+                rows = await conn.execute_fetchall(
+                    "SELECT * from users_wallets WHERE wallet_type=?", (wallet_type.value,)
+                )
+            return [WalletInfo(row[0], row[1], row[2], row[3]) for row in rows]
 
     async def get_wallet_by_id(self, id: int) -> Optional[WalletInfo]:
         """
@@ -121,11 +110,6 @@ class WalletUserStore:
         """
 
         async with self.db_wrapper.read_db() as conn:
-            cursor = await conn.execute("SELECT * from users_wallets WHERE id=?", (id,))
-            row = await cursor.fetchone()
-            await cursor.close()
+            row = await execute_fetchone(conn, "SELECT * from users_wallets WHERE id=?", (id,))
 
-        if row is None:
-            return None
-
-        return WalletInfo(row[0], row[1], row[2], row[3])
+        return None if row is None else WalletInfo(row[0], row[1], row[2], row[3])


### PR DESCRIPTION
this saves round-trips to the DB thread, saves some line of code and provides a small speedup compared to `main`.
Another part of this patch is to avoid building sql queries via string manipulation, and uses arguments instead.

sqlite will cache compiled queries, so the fewer query strings we use, the better the cache performs.

main:
```
INFO     Successfully subscribed and updated 103906 coin ids
INFO     Sync (trusted: True) duration was: 196.18760204315186
```

this patch:
```
INFO     Successfully subscribed and updated 103906 coin ids
INFO     Sync (trusted: True) duration was: 180.83409690856934
```