### PR TITLE
Add `change_data` to `_state_changed` since the later calls expect it

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -85,7 +85,7 @@ class RpcServer:
                 tb = traceback.format_exc()
                 log.warning(f"Sending data failed. Exception {tb}.")
 
-    def state_changed(self, change: str, change_data: Dict[str, Any] = None) -> None:
+    def state_changed(self, change: str, change_data: Optional[Dict[str, Any]] = None) -> None:
         if self.websocket is None or self.websocket.closed:
             return None
         asyncio.create_task(self._state_changed(change, change_data))

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -85,7 +85,7 @@ class RpcServer:
                 tb = traceback.format_exc()
                 log.warning(f"Sending data failed. Exception {tb}.")
 
-    def state_changed(self, change: str, change_data: Dict[str, Any]) -> None:
+    def state_changed(self, change: str, change_data: Dict[str, Any] = None) -> None:
         if self.websocket is None or self.websocket.closed:
             return None
         asyncio.create_task(self._state_changed(change, change_data))

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -326,7 +326,7 @@ class Crawler:
     def set_server(self, server: ChiaServer):
         self.server = server
 
-    def _state_changed(self, change: str, change_data: Dict[str, Any] = None):
+    def _state_changed(self, change: str, change_data: Optional[Dict[str, Any]] = None):
         if self.state_changed_callback is not None:
             self.state_changed_callback(change, change_data)
 

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -326,9 +326,9 @@ class Crawler:
     def set_server(self, server: ChiaServer):
         self.server = server
 
-    def _state_changed(self, change: str):
+    def _state_changed(self, change: str, change_data: Dict[str, Any] = None):
         if self.state_changed_callback is not None:
-            self.state_changed_callback(change)
+            self.state_changed_callback(change, change_data)
 
     async def new_peak(self, request: full_node_protocol.NewPeak, peer: ws.WSChiaConnection):
         try:


### PR DESCRIPTION
Fixes
```
2022-07-13T16:00:16.167 full_node chia.seeder.crawler     : ERROR    Exception: state_changed() missing 1 required positional argument: 'change_data'. Traceback: Traceback (most recent call last):
  File "/home/ubuntu/chia-blockchain/chia/seeder/crawler.py", line 166, in crawl
    self._state_changed("loaded_initial_peers")
  File "/home/ubuntu/chia-blockchain/chia/seeder/crawler.py", line 331, in _state_changed
    self.state_changed_callback(change)
TypeError: state_changed() missing 1 required positional argument: 'change_data'
```

Was broken by https://github.com/Chia-Network/chia-blockchain/commit/04c822b2c367af77e2cfe24bfc97f739f575e664 with the addition of specific args without defaults for the `change_data` param