### PR TITLE
cmds: Move config loading into start/stop/passphrase commands

### DIFF
--- a/chia/cmds/passphrase.py
+++ b/chia/cmds/passphrase.py
@@ -4,6 +4,8 @@ import sys
 from io import TextIOWrapper
 from typing import Optional
 
+from chia.util.config import load_config
+
 
 @click.group("passphrase", short_help="Manage your keyring passphrase")
 def passphrase_cmd():
@@ -65,7 +67,9 @@ def set_cmd(
 
     if success:
         # Attempt to update the daemon's passphrase cache
-        sys.exit(asyncio.run(async_update_daemon_passphrase_cache_if_running(ctx.obj["root_path"])))
+        root_path = ctx.obj["root_path"]
+        config = load_config(root_path, "config.yaml")
+        sys.exit(asyncio.run(async_update_daemon_passphrase_cache_if_running(root_path, config)))
 
 
 @passphrase_cmd.command(
@@ -91,7 +95,9 @@ def remove_cmd(ctx: click.Context, current_passphrase_file: Optional[TextIOWrapp
 
     if remove_passphrase(current_passphrase):
         # Attempt to update the daemon's passphrase cache
-        sys.exit(asyncio.run(async_update_daemon_passphrase_cache_if_running(ctx.obj["root_path"])))
+        root_path = ctx.obj["root_path"]
+        config = load_config(root_path, "config.yaml")
+        sys.exit(asyncio.run(async_update_daemon_passphrase_cache_if_running(root_path, config)))
 
 
 @passphrase_cmd.group("hint", short_help="Manage the optional keyring passphrase hint")

--- a/chia/cmds/start.py
+++ b/chia/cmds/start.py
@@ -1,5 +1,6 @@
 import click
 
+from chia.util.config import load_config
 from chia.util.service_groups import all_groups
 
 
@@ -11,4 +12,6 @@ def start_cmd(ctx: click.Context, restart: bool, group: str) -> None:
     import asyncio
     from .start_funcs import async_start
 
-    asyncio.run(async_start(ctx.obj["root_path"], group, restart))
+    root_path = ctx.obj["root_path"]
+    config = load_config(root_path, "config.yaml")
+    asyncio.run(async_start(root_path, config, group, restart))

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from chia.cmds.passphrase_funcs import get_current_passphrase
 from chia.daemon.client import DaemonProxy, connect_to_daemon_and_validate
@@ -21,8 +21,8 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     return process
 
 
-async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProxy]:
-    connection = await connect_to_daemon_and_validate(root_path)
+async def create_start_daemon_connection(root_path: Path, config: Dict[str, Any]) -> Optional[DaemonProxy]:
+    connection = await connect_to_daemon_and_validate(root_path, config)
     if connection is None:
         print("Starting daemon")
         # launch a daemon
@@ -32,7 +32,7 @@ async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProx
             process.stdout.readline()
         await asyncio.sleep(1)
         # it prints "daemon: listening"
-        connection = await connect_to_daemon_and_validate(root_path)
+        connection = await connect_to_daemon_and_validate(root_path, config)
     if connection:
         passphrase = None
         if await connection.is_keyring_locked():
@@ -49,9 +49,9 @@ async def create_start_daemon_connection(root_path: Path) -> Optional[DaemonProx
     return None
 
 
-async def async_start(root_path: Path, group: str, restart: bool) -> None:
+async def async_start(root_path: Path, config: Dict[str, Any], group: str, restart: bool) -> None:
     try:
-        daemon = await create_start_daemon_connection(root_path)
+        daemon = await create_start_daemon_connection(root_path, config)
     except KeyringMaxUnlockAttempts:
         print("Failed to unlock keyring")
         return None

--- a/chia/cmds/stop.py
+++ b/chia/cmds/stop.py
@@ -1,15 +1,17 @@
 import sys
 from pathlib import Path
+from typing import Any, Dict
 
 import click
 
+from chia.util.config import load_config
 from chia.util.service_groups import all_groups, services_for_groups
 
 
-async def async_stop(root_path: Path, group: str, stop_daemon: bool) -> int:
+async def async_stop(root_path: Path, config: Dict[str, Any], group: str, stop_daemon: bool) -> int:
     from chia.daemon.client import connect_to_daemon_and_validate
 
-    daemon = await connect_to_daemon_and_validate(root_path)
+    daemon = await connect_to_daemon_and_validate(root_path, config)
     if daemon is None:
         print("Couldn't connect to chia daemon")
         return 1
@@ -46,4 +48,6 @@ async def async_stop(root_path: Path, group: str, stop_daemon: bool) -> int:
 def stop_cmd(ctx: click.Context, daemon: bool, group: str) -> None:
     import asyncio
 
-    sys.exit(asyncio.run(async_stop(ctx.obj["root_path"], group, daemon)))
+    root_path = ctx.obj["root_path"]
+    config = load_config(root_path, "config.yaml")
+    sys.exit(asyncio.run(async_stop(root_path, config, group, daemon)))

--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
-from chia.util.config import load_config
 from chia.util.json_util import dict_to_json_str
 from chia.util.ws_message import WsRpcMessage, create_payload_dict
 
@@ -162,7 +161,9 @@ async def connect_to_daemon(
     return client
 
 
-async def connect_to_daemon_and_validate(root_path: Path, quiet: bool = False) -> Optional[DaemonProxy]:
+async def connect_to_daemon_and_validate(
+    root_path: Path, config: Dict[str, Any], quiet: bool = False
+) -> Optional[DaemonProxy]:
     """
     Connect to the local daemon and do a ping to ensure that something is really
     there and running.
@@ -170,15 +171,14 @@ async def connect_to_daemon_and_validate(root_path: Path, quiet: bool = False) -
     from chia.server.server import ssl_context_for_client
 
     try:
-        net_config = load_config(root_path, "config.yaml")
-        daemon_max_message_size = net_config.get("daemon_max_message_size", 50 * 1000 * 1000)
-        crt_path = root_path / net_config["daemon_ssl"]["private_crt"]
-        key_path = root_path / net_config["daemon_ssl"]["private_key"]
-        ca_crt_path = root_path / net_config["private_ssl_ca"]["crt"]
-        ca_key_path = root_path / net_config["private_ssl_ca"]["key"]
+        daemon_max_message_size = config.get("daemon_max_message_size", 50 * 1000 * 1000)
+        crt_path = root_path / config["daemon_ssl"]["private_crt"]
+        key_path = root_path / config["daemon_ssl"]["private_key"]
+        ca_crt_path = root_path / config["private_ssl_ca"]["crt"]
+        ca_key_path = root_path / config["private_ssl_ca"]["key"]
         ssl_context = ssl_context_for_client(ca_crt_path, ca_key_path, crt_path, key_path)
         connection = await connect_to_daemon(
-            net_config["self_hostname"], net_config["daemon_port"], daemon_max_message_size, ssl_context
+            config["self_hostname"], config["daemon_port"], daemon_max_message_size, ssl_context
         )
         r = await connection.ping()
 
@@ -192,7 +192,7 @@ async def connect_to_daemon_and_validate(root_path: Path, quiet: bool = False) -
 
 
 @asynccontextmanager
-async def acquire_connection_to_daemon(root_path: Path, quiet: bool = False):
+async def acquire_connection_to_daemon(root_path: Path, config: Dict[str, Any], quiet: bool = False):
     """
     Asynchronous context manager which attempts to create a connection to the daemon.
     The connection object (DaemonProxy) is yielded to the caller. After the caller's
@@ -202,7 +202,7 @@ async def acquire_connection_to_daemon(root_path: Path, quiet: bool = False):
 
     daemon: Optional[DaemonProxy] = None
     try:
-        daemon = await connect_to_daemon_and_validate(root_path, quiet=quiet)
+        daemon = await connect_to_daemon_and_validate(root_path, config, quiet=quiet)
         yield daemon  # <----
     except Exception as e:
         print(f"Exception occurred while communicating with the daemon: {e}")


### PR DESCRIPTION
I want to access the config in start/stop to print a warning if the `beta` section is in the config. The alternative to this PR would be to double load the config in start/stop, i think avoid loading twice makes sense but if there are objections about all this passing the config around let me know.