### PR TITLE
Return before fetching weight proof if secondary sync task is running

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -966,7 +966,7 @@ class WalletNode:
                     syncing = True
                     self.wallet_state_manager.set_sync_mode(True)
 
-                if syncing and not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
+                if not syncing and not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
                     self.log.info("Will not do secondary sync, there is already another sync task running.")
                     return
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -965,6 +965,11 @@ class WalletNode:
                 if far_behind or len(self.synced_peers) == 0:
                     syncing = True
                     self.wallet_state_manager.set_sync_mode(True)
+
+                if syncing and not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
+                    self.log.info("Will not do secondary sync, there is already another sync task running.")
+                    return
+
                 try:
                     (
                         valid_weight_proof,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -966,7 +966,7 @@ class WalletNode:
                     syncing = True
                     self.wallet_state_manager.set_sync_mode(True)
 
-                if not syncing and not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
+                if not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
                     self.log.info("Will not do secondary sync, there is already another sync task running.")
                     return
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -966,7 +966,9 @@ class WalletNode:
                     syncing = True
                     self.wallet_state_manager.set_sync_mode(True)
 
-                if not syncing and not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
+                if not syncing and not (
+                    self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()
+                ):
                     self.log.info("Will not do secondary sync, there is already another sync task running.")
                     return
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -966,7 +966,7 @@ class WalletNode:
                     syncing = True
                     self.wallet_state_manager.set_sync_mode(True)
 
-                if not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
+                if not syncing and not (self._secondary_peer_sync_task is None or self._secondary_peer_sync_task.done()):
                     self.log.info("Will not do secondary sync, there is already another sync task running.")
                     return
 


### PR DESCRIPTION
I noticed that we often download multiple weight proofs from peers with which we are currently performing a secondary sync. You can verify this with `cat ~/.chia/mainnet/log/debug.log | grep 'request_proof_of_weight to peer'` and looking at the timestamps. This seems like a waste of resources as we will return early a [few lines later](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/wallet/wallet_node.py#L1008) without handling the new peak message.

This pr adds a check to see if we are currently performing a secondary sync before fetching and validating the weight proof. From what I can tell, sync behavior should remain unchanged, apart from skipping the [call](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/wallet/wallet_node.py#L990) to `wallet_state_manager.blockchain.new_weight_proof`, which seems safe to me.