### PR TITLE
Fix attribute error on `FullNode.simulator_transaction_callback`

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -161,6 +161,7 @@ class FullNode:
         self.peer_sub_counter: Dict[bytes32, int] = {}  # Peer ID: int (subscription count)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._transaction_queue_task = None
+        self.simulator_transaction_callback = None
 
     def _set_state_changed_callback(self, callback: Callable):
         self.state_changed_callback = callback

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2116,7 +2116,7 @@ class FullNode:
                     await self.server.send_to_all_except([msg], NodeType.FULL_NODE, peer.peer_node_id)
                 self.not_dropped_tx += 1
                 if self.simulator_transaction_callback is not None:  # callback
-                    await self.simulator_transaction_callback(spend_name)
+                    await self.simulator_transaction_callback(spend_name)  # pylint: disable=E1102
             else:
                 self.mempool_manager.remove_seen(spend_name)
                 self.log.debug(


### PR DESCRIPTION
Introduced in https://github.com/Chia-Network/chia-blockchain/pull/12072/files#diff-a84a0802b416c9c5a5fdc6d2293c4c7971ca0b1519f246ede123e304a56e540a.

```
Jul 17 17:52:45 fullnode chia_full_node[1175517]: 2022-07-17T17:52:45.239 full_node chia.full_node.full_node: ERROR    Error in _handle_one_transaction, closing: Traceback (most recent call last):
Jul 17 17:52:45 fullnode chia_full_node[1175517]:   File "/farm/chia-blockchain/chia/full_node/full_node.py", line 318, in _handle_one_transaction
Jul 17 17:52:45 fullnode chia_full_node[1175517]:     inc_status, err = await self.respond_transaction(entry.transaction, entry.spend_name, peer, entry.test)
Jul 17 17:52:45 fullnode chia_full_node[1175517]:   File "/farm/chia-blockchain/chia/full_node/full_node.py", line 2117, in respond_transaction
Jul 17 17:52:45 fullnode chia_full_node[1175517]:     if self.simulator_transaction_callback is not None:  # callback
Jul 17 17:52:45 fullnode chia_full_node[1175517]: AttributeError: 'FullNode' object has no attribute 'simulator_transaction_callback'
```

I'm not sure the `FullNode` should reference the simulator at all, but in so much as it does it should define all the used attributes in `.__init__()`.