### PR TITLE
on failure to get keys, log and return exception

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -223,7 +223,8 @@ class WalletRpcApi:
         except KeyringIsLocked:
             return {"keyring_is_locked": True}
         except Exception:
-            return {"public_key_fingerprints": []}
+            log.exception("Error while getting keys.  If the issue persists, restart all services.")
+            raise
         else:
             return {"public_key_fingerprints": fingerprints}
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -223,7 +223,10 @@ class WalletRpcApi:
         except KeyringIsLocked:
             return {"keyring_is_locked": True}
         except Exception as e:
-            raise Exception(f"Error while getting keys.  If the issue persists, restart all services.  Original error: {type(e).__name__}: {e}") from e
+            raise Exception(
+                "Error while getting keys.  If the issue persists, restart all services."
+                f"  Original error: {type(e).__name__}: {e}"
+            ) from e
         else:
             return {"public_key_fingerprints": fingerprints}
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -222,9 +222,8 @@ class WalletRpcApi:
             ]
         except KeyringIsLocked:
             return {"keyring_is_locked": True}
-        except Exception:
-            log.exception("Error while getting keys.  If the issue persists, restart all services.")
-            raise
+        except Exception as e:
+            raise Exception(f"Error while getting keys.  If the issue persists, restart all services.  Original error: {type(e).__name__}: {e}") from e
         else:
             return {"public_key_fingerprints": fingerprints}
 


### PR DESCRIPTION
Example CLI response:
```
Exception from 'wallet' {'error': "Error while getting keys.  If the issue persists, restart all services.  Original error: TypeError: 'NoneType' object is not subscriptable", 'success': False}
```

Example log:
```
Jul 17 20:54:19 fullnode chia_wallet[1432335]: 2022-07-17T20:54:19.142 wallet chia.rpc.util              : WARNING  Error while handling message: Traceback (most recent call last):
Jul 17 20:54:19 fullnode chia_wallet[1432335]:   File "/farm/chia-blockchain/chia/rpc/wallet_rpc_api.py", line 221, in get_public_keys
Jul 17 20:54:19 fullnode chia_wallet[1432335]:     sk.get_g1().get_fingerprint() for (sk, seed) in await self.service.keychain_proxy.get_all_private_keys()
Jul 17 20:54:19 fullnode chia_wallet[1432335]:   File "/farm/chia-blockchain/chia/daemon/keychain_proxy.py", line 185, in get_all_private_keys
Jul 17 20:54:19 fullnode chia_wallet[1432335]:     response, success = await self.get_response_for_request("get_all_private_keys", {})
Jul 17 20:54:19 fullnode chia_wallet[1432335]:   File "/farm/chia-blockchain/chia/daemon/keychain_proxy.py", line 93, in get_response_for_request
Jul 17 20:54:19 fullnode chia_wallet[1432335]:     success = response["data"].get("success", False)
Jul 17 20:54:19 fullnode chia_wallet[1432335]: TypeError: 'NoneType' object is not subscriptable
Jul 17 20:54:19 fullnode chia_wallet[1432335]: The above exception was the direct cause of the following exception:
Jul 17 20:54:19 fullnode chia_wallet[1432335]: Traceback (most recent call last):
Jul 17 20:54:19 fullnode chia_wallet[1432335]:   File "/farm/chia-blockchain/chia/rpc/util.py", line 16, in inner
Jul 17 20:54:19 fullnode chia_wallet[1432335]:     res_object = await f(request_data)
Jul 17 20:54:19 fullnode chia_wallet[1432335]:   File "/farm/chia-blockchain/chia/rpc/wallet_rpc_api.py", line 226, in get_public_keys
Jul 17 20:54:19 fullnode chia_wallet[1432335]:     raise Exception(
Jul 17 20:54:19 fullnode chia_wallet[1432335]: Exception: Error while getting keys.  If the issue persists, restart all services.  Original error: TypeError: 'NoneType' object is not subscriptable
```