### PR TITLE
Sleep to allow neworking layer to execute

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -342,6 +342,8 @@ class WalletStateManager:
                     self.log.debug(
                         f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash_unhardened.hex()}"
                     )
+                    # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
+                    # not have await and therefore block). This can prevent networking layer from responding to ping.
                     await asyncio.sleep(0)
                     derivation_paths.append(
                         DerivationRecord(

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -342,6 +342,7 @@ class WalletStateManager:
                     self.log.debug(
                         f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash_unhardened.hex()}"
                     )
+                    await asyncio.sleep(0)
                     derivation_paths.append(
                         DerivationRecord(
                             uint32(index),


### PR DESCRIPTION
To replicate the issue:
Set `initial_num_public_keys` to something that takes > 30 seconds, like 10000.

Then start the wallet. When it's done generating the PHs, do `chia wallet show`. It results in `No keys loaded` issue.


This fixes it.