### PR TITLE
optimize ph generation (~65% faster)

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -7,7 +7,7 @@ import traceback
 from secrets import token_bytes
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from blspy import AugSchemeMPL, G2Element
+from blspy import AugSchemeMPL, G2Element, G1Element
 
 from chia.consensus.cost_calculator import NPCResult
 from chia.full_node.bundle_tools import simple_solution_generator
@@ -370,8 +370,8 @@ class CATWallet:
     async def get_new_puzzlehash(self) -> bytes32:
         return await self.standard_wallet.get_new_puzzlehash()
 
-    def puzzle_for_pk(self, pubkey) -> Program:
-        inner_puzzle = self.standard_wallet.puzzle_for_pk(bytes(pubkey))
+    def puzzle_for_pk(self, pubkey: G1Element) -> Program:
+        inner_puzzle = self.standard_wallet.puzzle_for_pk(pubkey)
         cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, self.cat_info.limitations_program_hash, inner_puzzle)
         return cat_puzzle
 
@@ -488,7 +488,7 @@ class CATWallet:
         ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(cat_hash)
         if record is None:
             raise RuntimeError(f"Missing Derivation Record for CAT puzzle_hash {cat_hash}")
-        inner_puzzle: Program = self.standard_wallet.puzzle_for_pk(bytes(record.pubkey))
+        inner_puzzle: Program = self.standard_wallet.puzzle_for_pk(record.pubkey)
         return inner_puzzle
 
     async def convert_puzzle_hash(self, puzzle_hash: bytes32) -> bytes32:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -412,7 +412,7 @@ class DIDWallet:
         # full_puz = did_wallet_puzzles.create_fullpuz(innerpuz, origin.name())
         # All additions in this block here:
 
-        new_pubkey = bytes((await self.wallet_state_manager.get_unused_derivation_record(self.wallet_info.id)).pubkey)
+        new_pubkey = (await self.wallet_state_manager.get_unused_derivation_record(self.wallet_info.id)).pubkey
         new_puzhash = puzzle_for_pk(new_pubkey).get_tree_hash()
         parent_info = None
         assert did_info.origin_coin is not None
@@ -448,7 +448,7 @@ class DIDWallet:
                     did_info.current_inner,
                     child_coin,
                     new_did_inner_puzhash,
-                    new_pubkey,
+                    bytes(new_pubkey),
                     False,
                     did_info.metadata,
                 )

--- a/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -73,8 +73,6 @@ DEFAULT_HIDDEN_PUZZLE_HASH = DEFAULT_HIDDEN_PUZZLE.get_tree_hash()  # this puzzl
 
 MOD = load_clvm("p2_delegated_puzzle_or_hidden_puzzle.clvm")
 
-SYNTHETIC_MOD = load_clvm("calculate_synthetic_public_key.clvm")
-
 PublicKeyProgram = Union[bytes, Program]
 
 GROUP_ORDER = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001

--- a/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -89,7 +89,7 @@ def calculate_synthetic_offset(public_key: G1Element, hidden_puzzle_hash: bytes3
 
 def calculate_synthetic_public_key(public_key: G1Element, hidden_puzzle_hash: bytes32) -> G1Element:
     r = SYNTHETIC_MOD.run([bytes(public_key), hidden_puzzle_hash])
-    return G1Element.from_bytes(r.as_atom())
+    return G1Element.from_bytes_unchecked(r.as_atom())
 
 
 def calculate_synthetic_secret_key(secret_key: PrivateKey, hidden_puzzle_hash: bytes32) -> PrivateKey:

--- a/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -88,8 +88,10 @@ def calculate_synthetic_offset(public_key: G1Element, hidden_puzzle_hash: bytes3
 
 
 def calculate_synthetic_public_key(public_key: G1Element, hidden_puzzle_hash: bytes32) -> G1Element:
-    r = SYNTHETIC_MOD.run([bytes(public_key), hidden_puzzle_hash])
-    return G1Element.from_bytes_unchecked(r.as_atom())
+    synthetic_offset: PrivateKey = PrivateKey.from_bytes(
+        calculate_synthetic_offset(public_key, hidden_puzzle_hash).to_bytes(32, "big")
+    )
+    return public_key + synthetic_offset.get_g1()
 
 
 def calculate_synthetic_secret_key(secret_key: PrivateKey, hidden_puzzle_hash: bytes32) -> PrivateKey:

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -147,7 +147,7 @@ class Wallet:
 
         return uint64(addition_amount)
 
-    def puzzle_for_pk(self, pubkey: bytes) -> Program:
+    def puzzle_for_pk(self, pubkey: G1Element) -> Program:
         return puzzle_for_pk(pubkey)
 
     async def convert_puzzle_hash(self, puzzle_hash: bytes32) -> bytes32:
@@ -179,11 +179,11 @@ class Wallet:
 
     async def puzzle_for_puzzle_hash(self, puzzle_hash: bytes32) -> Program:
         public_key = await self.hack_populate_secret_key_for_puzzle_hash(puzzle_hash)
-        return puzzle_for_pk(bytes(public_key))
+        return puzzle_for_pk(public_key)
 
     async def get_new_puzzle(self) -> Program:
         dr = await self.wallet_state_manager.get_unused_derivation_record(self.id())
-        return puzzle_for_pk(bytes(dr.pubkey))
+        return puzzle_for_pk(dr.pubkey)
 
     async def get_puzzle_hash(self, new: bool) -> bytes32:
         if new:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -664,7 +664,7 @@ class WalletStateManager:
         if derivation_record is None:
             self.log.info(f"Received state for the coin that doesn't belong to us {coin_state}")
         else:
-            our_inner_puzzle: Program = self.main_wallet.puzzle_for_pk(bytes(derivation_record.pubkey))
+            our_inner_puzzle: Program = self.main_wallet.puzzle_for_pk(derivation_record.pubkey)
             asset_id: bytes32 = bytes32(bytes(tail_hash)[1:])
             cat_puzzle = construct_cat_puzzle(CAT_MOD, asset_id, our_inner_puzzle, CAT_MOD_HASH)
             if cat_puzzle.get_tree_hash() != coin_state.coin.puzzle_hash:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -41,7 +41,14 @@ from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_utils import construct_cat_puzzle, match_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.derivation_record import DerivationRecord
-from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
+from chia.wallet.derive_keys import (
+    master_sk_to_wallet_sk,
+    master_sk_to_wallet_sk_unhardened,
+    master_sk_to_wallet_sk_intermediate,
+    _derive_path,
+    master_sk_to_wallet_sk_unhardened_intermediate,
+    _derive_path_unhardened,
+)
 from chia.wallet.did_wallet.did_info import DID_HRP
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import DID_INNERPUZ_MOD, create_fullpuz, match_did_puzzle
@@ -314,12 +321,14 @@ class WalletStateManager:
             else:
                 creating_msg = f"Creating puzzle hashes from {start_index} to {last_index} for wallet_id: {wallet_id}"
                 self.log.info(f"Start: {creating_msg}")
+                intermediate_sk = master_sk_to_wallet_sk_intermediate(self.private_key)
+                intermediate_sk_un = master_sk_to_wallet_sk_unhardened_intermediate(self.private_key)
                 for index in range(start_index, last_index):
                     if WalletType(target_wallet.type()) == WalletType.POOLING_WALLET:
                         continue
 
                     # Hardened
-                    pubkey: G1Element = self.get_public_key(uint32(index))
+                    pubkey: G1Element = _derive_path(intermediate_sk, [index]).get_g1()
                     puzzle: Program = target_wallet.puzzle_for_pk(bytes(pubkey))
                     if puzzle is None:
                         self.log.error(f"Unable to create puzzles with wallet {target_wallet}")
@@ -333,7 +342,7 @@ class WalletStateManager:
                         )
                     )
                     # Unhardened
-                    pubkey_unhardened: G1Element = self.get_public_key_unhardened(uint32(index))
+                    pubkey_unhardened: G1Element = _derive_path_unhardened(intermediate_sk_un, [index]).get_g1()
                     puzzle_unhardened: Program = target_wallet.puzzle_for_pk(bytes(pubkey_unhardened))
                     if puzzle_unhardened is None:
                         self.log.error(f"Unable to create puzzles with wallet {target_wallet}")

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -329,7 +329,7 @@ class WalletStateManager:
 
                     # Hardened
                     pubkey: G1Element = _derive_path(intermediate_sk, [index]).get_g1()
-                    puzzle: Program = target_wallet.puzzle_for_pk(bytes(pubkey))
+                    puzzle: Program = target_wallet.puzzle_for_pk(pubkey)
                     if puzzle is None:
                         self.log.error(f"Unable to create puzzles with wallet {target_wallet}")
                         break
@@ -343,7 +343,7 @@ class WalletStateManager:
                     )
                     # Unhardened
                     pubkey_unhardened: G1Element = _derive_path_unhardened(intermediate_sk_un, [index]).get_g1()
-                    puzzle_unhardened: Program = target_wallet.puzzle_for_pk(bytes(pubkey_unhardened))
+                    puzzle_unhardened: Program = target_wallet.puzzle_for_pk(pubkey_unhardened)
                     if puzzle_unhardened is None:
                         self.log.error(f"Unable to create puzzles with wallet {target_wallet}")
                         break

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -384,7 +384,7 @@ class WalletStateManager:
         for index in range(unused, last):
             # Since DID are not released yet we can assume they are only using unhardened keys derivation
             pubkey: G1Element = self.get_public_key_unhardened(uint32(index))
-            puzzle: Program = target_wallet.puzzle_for_pk(bytes(pubkey))
+            puzzle: Program = target_wallet.puzzle_for_pk(pubkey)
             puzzlehash: bytes32 = puzzle.get_tree_hash()
             self.log.info(f"Generating public key at index {index} puzzle hash {puzzlehash.hex()}")
             derivation_paths.append(
@@ -718,7 +718,7 @@ class WalletStateManager:
         if derivation_record is None:
             self.log.info(f"Received state for the coin that doesn't belong to us {coin_state}")
         else:
-            our_inner_puzzle: Program = self.main_wallet.puzzle_for_pk(bytes(derivation_record.pubkey))
+            our_inner_puzzle: Program = self.main_wallet.puzzle_for_pk(derivation_record.pubkey)
 
             launch_id: bytes32 = bytes32(bytes(singleton_struct.rest().first())[1:])
             self.log.info(f"Found DID, launch_id {launch_id}.")

--- a/tests/clvm/test_puzzles.py
+++ b/tests/clvm/test_puzzles.py
@@ -191,10 +191,10 @@ class TestPuzzles(TestCase):
         hidden_public_key = public_key_for_index(10, key_lookup)
 
         puzzle = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_public_key_and_hidden_puzzle(
-            hidden_public_key, hidden_puzzle
+            G1Element.from_bytes_unchecked(hidden_public_key), hidden_puzzle
         )
         solution = p2_delegated_puzzle_or_hidden_puzzle.solution_for_hidden_puzzle(
-            hidden_public_key, hidden_puzzle, Program.to(0)
+            G1Element.from_bytes_unchecked(hidden_public_key), hidden_puzzle, Program.to(0)
         )
 
         do_test_spend(puzzle, solution, payments, key_lookup)
@@ -205,9 +205,10 @@ class TestPuzzles(TestCase):
 
         hidden_puzzle = p2_conditions.puzzle_for_conditions(conditions)
         hidden_public_key = public_key_for_index(hidden_pub_key_index, key_lookup)
+        hidden_pub_key_point = G1Element.from_bytes(hidden_public_key)
 
         puzzle = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_public_key_and_hidden_puzzle(
-            hidden_public_key, hidden_puzzle
+            hidden_pub_key_point, hidden_puzzle
         )
         payable_payments, payable_conditions = default_payments_and_conditions(5, key_lookup)
 
@@ -215,7 +216,7 @@ class TestPuzzles(TestCase):
         delegated_solution = []
 
         synthetic_public_key = p2_delegated_puzzle_or_hidden_puzzle.calculate_synthetic_public_key(
-            hidden_public_key, hidden_puzzle.get_tree_hash()
+            G1Element.from_bytes(hidden_public_key), hidden_puzzle.get_tree_hash()
         )
 
         solution = p2_delegated_puzzle_or_hidden_puzzle.solution_for_delegated_puzzle(
@@ -224,10 +225,9 @@ class TestPuzzles(TestCase):
 
         hidden_puzzle_hash = hidden_puzzle.get_tree_hash()
         synthetic_offset = p2_delegated_puzzle_or_hidden_puzzle.calculate_synthetic_offset(
-            hidden_public_key, hidden_puzzle_hash
+            hidden_pub_key_point, hidden_puzzle_hash
         )
 
-        hidden_pub_key_point = G1Element.from_bytes(hidden_public_key)
         assert synthetic_public_key == int_to_public_key(synthetic_offset) + hidden_pub_key_point
 
         secret_exponent = key_lookup.get(hidden_public_key)

--- a/tests/clvm/test_singletons.py
+++ b/tests/clvm/test_singletons.py
@@ -87,7 +87,7 @@ class TestSingleton:
             # START TESTS
             # Generate starting info
             key_lookup = KeyTool()
-            pk: G1Element = public_key_for_index(1, key_lookup)
+            pk: G1Element = G1Element.from_bytes(public_key_for_index(1, key_lookup))
             starting_puzzle: Program = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(pk)  # noqa
 
             if version == 0:

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -2,6 +2,7 @@ import logging
 import pathlib
 
 import pytest
+from blspy import G1Element
 from clvm_tools import binutils
 
 from chia.consensus.condition_costs import ConditionCost
@@ -131,7 +132,7 @@ class TestCostCalculation:
         pk = bytes.fromhex(
             "88bc9360319e7c54ab42e19e974288a2d7a817976f7633f4b43f36ce72074e59c4ab8ddac362202f3e366f0aebbb6280"
         )
-        puzzle = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(pk)
+        puzzle = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(G1Element.from_bytes(pk))
         disassembly = binutils.disassemble(puzzle)
         program = SerializedProgram.from_bytes(
             binutils.assemble(

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -253,7 +253,9 @@ class TestCostCalculation:
         public_key = bytes.fromhex(
             "af949b78fa6a957602c3593a3d6cb7711e08720415dad83" "1ab18adacaa9b27ec3dda508ee32e24bc811c0abc5781ae21"
         )
-        puzzle_program = SerializedProgram.from_bytes(p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(public_key))
+        puzzle_program = SerializedProgram.from_bytes(
+            p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(G1Element.from_bytes(public_key))
+        )
         conditions = binutils.assemble(
             "((51 0x699eca24f2b6f4b25b16f7a418d0dc4fc5fce3b9145aecdda184158927738e3e 10)"
             " (51 0x847bb2385534070c39a39cc5dfdc7b35e2db472dc0ab10ab4dec157a2178adbf 0x00cbba106df6))"

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -802,7 +802,7 @@ class TestWalletSimulator:
         puzzle_hashes = []
         for i in range(211):
             pubkey = master_sk_to_wallet_sk(wallet_node.wallet_state_manager.private_key, uint32(i)).get_g1()
-            puzzle: Program = wallet.puzzle_for_pk(bytes(pubkey))
+            puzzle: Program = wallet.puzzle_for_pk(pubkey)
             puzzle_hash: bytes32 = puzzle.get_tree_hash()
             puzzle_hashes.append(puzzle_hash)
 

--- a/tests/wallet_tools.py
+++ b/tests/wallet_tools.py
@@ -58,7 +58,7 @@ class WalletTool:
                 return master_sk_to_wallet_sk(self.private_key, uint32(child))
         raise ValueError(f"Do not have the keys for puzzle hash {puzzle_hash}")
 
-    def puzzle_for_pk(self, pubkey: bytes) -> Program:
+    def puzzle_for_pk(self, pubkey: G1Element) -> Program:
         return puzzle_for_pk(pubkey)
 
     def get_new_puzzle(self) -> Program:

--- a/tests/wallet_tools.py
+++ b/tests/wallet_tools.py
@@ -54,7 +54,7 @@ class WalletTool:
             return sk
         for child in range(self.next_address):
             pubkey = master_sk_to_wallet_sk(self.private_key, uint32(child)).get_g1()
-            if puzzle_hash == puzzle_for_pk(bytes(pubkey)).get_tree_hash():
+            if puzzle_hash == puzzle_for_pk(pubkey).get_tree_hash():
                 return master_sk_to_wallet_sk(self.private_key, uint32(child))
         raise ValueError(f"Do not have the keys for puzzle hash {puzzle_hash}")
 


### PR DESCRIPTION
Time for generation 1000 puzzle hashes:
before:  9-10 seconds
after: 3-3.5 seconds

These timings are for XCH puzzles. For CAT or other wallets, the improvements might be less than 65%.

This required fixing some call sites where we passed in bytes. It was working because we double called bytes.
This is a low risk change.

