### PR TITLE
Add symlinks to the UI RPM to mirror the .deb UI and the CLI installers

### DIFF
--- a/build_scripts/assets/rpm/postinst.sh
+++ b/build_scripts/assets/rpm/postinst.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Post install script for the UI .rpm to place symlinks in places to allow the CLI to work similarly in both versions
+
+set -e
+
+ln -s /usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon/chia /usr/bin/chia || true
+ln -s /usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon /opt/chia || true

--- a/build_scripts/assets/rpm/prerm.sh
+++ b/build_scripts/assets/rpm/prerm.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Pre remove script for the UI .rpm to clean up the symlinks from the installer
+
+set -e
+
+unlink /usr/bin/chia || true
+unlink /opt/chia || true

--- a/build_scripts/build_linux_rpm.sh
+++ b/build_scripts/build_linux_rpm.sh
@@ -124,9 +124,10 @@ if [ "$REDHAT_PLATFORM" = "x86_64" ]; then
 	# shellcheck disable=SC2086
 	sed -i "s#throw new Error('Please upgrade to RPM 4.13.*#console.warn('You are using RPM < 4.13')\n      return { requires: [ 'gtk3', 'libnotify', 'nss', 'libXScrnSaver', 'libXtst', 'xdg-utils', 'at-spi2-core', 'libdrm', 'mesa-libgbm', 'libxcb' ] }#g" $GLOBAL_NPM_ROOT/electron-installer-redhat/src/dependencies.js
 
-  electron-installer-redhat --src dist/$DIR_NAME/ --dest final_installer/ \
-  --arch "$REDHAT_PLATFORM" --options.version $CHIA_INSTALLER_VERSION \
-  --license ../LICENSE --options.bin chia-blockchain --options.name chia-blockchain
+  electron-installer-redhat --src dist/$DIR_NAME/ \
+  --arch "$REDHAT_PLATFORM" \
+  --options.version $CHIA_INSTALLER_VERSION \
+  --config rpm-options.json
   LAST_EXIT_CODE=$?
   if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 	  echo >&2 "electron-installer-redhat failed!"

--- a/build_scripts/rpm-options.json
+++ b/build_scripts/rpm-options.json
@@ -1,0 +1,10 @@
+{
+  "dest": "final_installer/",
+  "bin": "chia-blockchain",
+  "name": "chia-blockchain",
+  "license": "../LICENSE",
+  "scripts": {
+    "post": "assets/rpm/postinst.sh",
+    "preun": "assets/rpm/prerm.sh"
+  }
+}


### PR DESCRIPTION
The paths being symlinked are the default paths in the CLI installers. The symlinks were previously added to the .deb CLI, so this is just bringing the UI rpm up to speed with the changes for consistency.

`/usr/bin/chia` -> `/usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon/chia`
`/opt/chia` -> `/usr/lib/chia-blockchain/resources/app.asar.unpacked/daemon`

.deb PR with the same changes was #11258