### PR TITLE
Add RPCs for getting/extending the current derivation path index

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -254,6 +254,45 @@ def delete_unconfirmed_transactions_cmd(wallet_rpc_port: Optional[int], id, fing
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, delete_unconfirmed_transactions))
 
 
+@wallet_cmd.command("get_derivation_index", short_help="Get the last puzzle hash derivation path index")
+@click.option(
+    "-wp",
+    "--wallet-rpc-port",
+    help="Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml",
+    type=int,
+    default=None,
+)
+@click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
+def get_derivation_index_cmd(wallet_rpc_port: Optional[int], fingerprint: int) -> None:
+    extra_params: Dict[str, Any] = {}
+    import asyncio
+    from .wallet_funcs import execute_with_wallet, get_derivation_index
+
+    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, get_derivation_index))
+
+
+@wallet_cmd.command(
+    "update_derivation_index", short_help="Generate additional derived puzzle hashes starting at the provided index"
+)
+@click.option(
+    "-wp",
+    "--wallet-rpc-port",
+    help="Set the port where the Wallet is hosting the RPC interface. See the rpc_port under wallet in config.yaml",
+    type=int,
+    default=None,
+)
+@click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
+@click.option(
+    "-i", "--index", help="Index to set. Must be greater than the current derivation index", type=int, required=True
+)
+def update_derivation_index_cmd(wallet_rpc_port: Optional[int], fingerprint: int, index: int) -> None:
+    extra_params = {"index": index}
+    import asyncio
+    from .wallet_funcs import execute_with_wallet, update_derivation_index
+
+    asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, update_derivation_index))
+
+
 @wallet_cmd.command("add_token", short_help="Add/Rename a CAT to the wallet by its asset ID")
 @click.option(
     "-wp",

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -259,6 +259,19 @@ async def delete_unconfirmed_transactions(args: dict, wallet_client: WalletRpcCl
     print(f"Successfully deleted all unconfirmed transactions for wallet id {wallet_id} on key {fingerprint}")
 
 
+async def get_derivation_index(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
+    res = await wallet_client.get_current_derivation_index()
+    print(f"Last derivation index: {res}")
+
+
+async def update_derivation_index(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
+    index = args["index"]
+    print("Updating derivation index... This may take a while.")
+    res = await wallet_client.extend_derivation_index(index)
+    print(f"Updated derivation index: {res}")
+    print("Your balances may take a while to update.")
+
+
 async def add_token(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     asset_id = args["asset_id"]
     token_name = args["token_name"]

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -57,6 +57,7 @@ from chia.wallet.wallet_node import WalletNode
 
 # Timeout for response from wallet/full node for sending a transaction
 TIMEOUT = 30
+MAX_DERIVATION_INDEX_DELTA = 1000
 
 log = logging.getLogger(__name__)
 
@@ -104,6 +105,8 @@ class WalletRpcApi:
             "/create_signed_transaction": self.create_signed_transaction,
             "/delete_unconfirmed_transactions": self.delete_unconfirmed_transactions,
             "/select_coins": self.select_coins,
+            "/get_current_derivation_index": self.get_current_derivation_index,
+            "/extend_derivation_index": self.extend_derivation_index,
             # CATs and trading
             "/cat_set_name": self.cat_set_name,
             "/cat_asset_id_to_name": self.cat_asset_id_to_name,
@@ -877,6 +880,49 @@ class WalletRpcApi:
             )
 
         return {"coins": [coin.to_json_dict() for coin in selected_coins]}
+
+    async def get_current_derivation_index(self, request) -> Dict[str, Any]:
+        assert self.service.wallet_state_manager is not None
+
+        index: Optional[uint32] = await self.service.wallet_state_manager.puzzle_store.get_last_derivation_path()
+
+        return {"success": True, "index": index}
+
+    async def extend_derivation_index(self, request) -> Dict[str, Any]:
+        assert self.service.wallet_state_manager is not None
+
+        # Require a new max derivation index
+        if "index" not in request:
+            raise ValueError("Derivation index is required")
+
+        # Require that the wallet is fully synced
+        synced = await self.service.wallet_state_manager.synced()
+        if synced is False:
+            raise ValueError("Wallet needs to be fully synced before extending derivation index")
+
+        index = uint32(request["index"])
+        current: Optional[uint32] = await self.service.wallet_state_manager.puzzle_store.get_last_derivation_path()
+
+        # Additional sanity check that the wallet is synced
+        if current is None:
+            raise ValueError("No current derivation record found, unable to extend index")
+
+        # Require that the new index is greater than the current index
+        if index <= current:
+            raise ValueError(f"New derivation index must be greater than current index: {current}")
+
+        if index - current > MAX_DERIVATION_INDEX_DELTA:
+            raise ValueError(
+                "Too many derivations requested. "
+                f"Use a derivation index less than {current + MAX_DERIVATION_INDEX_DELTA + 1}"
+            )
+
+        await self.service.wallet_state_manager.create_more_puzzle_hashes(from_zero=False, up_to_index=index)
+
+        updated: Optional[uint32] = await self.service.wallet_state_manager.puzzle_store.get_last_derivation_path()
+        updated_index = updated if updated is not None else None
+
+        return {"success": True, "index": updated_index}
 
     ##########################################################################################
     # CATs and Trading

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -197,6 +197,12 @@ class WalletRpcClient(RpcClient):
         )
         return None
 
+    async def get_current_derivation_index(self) -> str:
+        return (await self.fetch("get_current_derivation_index", {}))["index"]
+
+    async def extend_derivation_index(self, index: int) -> str:
+        return (await self.fetch("extend_derivation_index", {"index": index}))["index"]
+
     async def get_farmed_amount(self) -> Dict:
         return await self.fetch("get_farmed_amount", {})
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -271,14 +271,18 @@ class WalletStateManager:
         pubkey = private.get_g1()
         return pubkey, private
 
-    async def create_more_puzzle_hashes(self, from_zero: bool = False):
+    async def create_more_puzzle_hashes(
+        self, from_zero: bool = False, in_transaction=False, up_to_index: Optional[uint32] = None
+    ):
         """
         For all wallets in the user store, generates the first few puzzle hashes so
         that we can restore the wallet from only the private keys.
         """
         targets = list(self.wallets.keys())
         self.log.debug("Target wallets to generate puzzle hashes for: %s", repr(targets))
-        unused: Optional[uint32] = await self.puzzle_store.get_unused_derivation_path()
+        unused: Optional[uint32] = (
+            up_to_index if up_to_index is not None else await self.puzzle_store.get_unused_derivation_path()
+        )
         if unused is None:
             # This handles the case where the database has entries but they have all been used
             unused = await self.puzzle_store.get_last_derivation_path()
@@ -287,6 +291,7 @@ class WalletStateManager:
                 # This handles the case where the database is empty
                 unused = uint32(0)
 
+        self.log.debug(f"Requested to generate puzzle hashes to at least index {unused}")
         to_generate = self.config["initial_num_public_keys"]
         new_paths: bool = False
 
@@ -358,6 +363,8 @@ class WalletStateManager:
                 [record.puzzle_hash for record in derivation_paths],
                 [record.wallet_id for record in derivation_paths],
             )
+            if len(derivation_paths) > 0:
+                self.state_changed("new_derivation_index", data_object={"index": derivation_paths[-1].index})
         if unused > 0 and new_paths:
             await self.puzzle_store.set_used_up_to(uint32(unused - 1))
 


### PR DESCRIPTION
This PR adds the RPCs:
`get_current_derivation_index` - Returns `index` referencing the current derivation index (for the XCH wallet, but should apply across all wallets). The value of the returned index may be null if the DB doesn't have a current derivation path.

`extend_derivation_index` - Takes an `index` parameter from the request and generates additional puzzle hashes up to and including that index. If the `index` value is < the current derivation index, no action is taken. Returns `index` in the same manner as `get_current_derivation_index`

Adds a `state_changed` message:
`new_derivation_index` - Posted when the wallet state manager generates new puzzle hashes. The `additional_data` object in the payload will include `index` as above.

CLI options have been added to use the new RPCs:

`chia wallet get_derivation_index`
`chia wallet update_derivation_index -i <new index>`