### PR TITLE
Remove fasteners dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ dependencies = [
     "colorlog==6.6.0",  # Adds color to logs
     "concurrent-log-handler==0.9.19",  # Concurrently log and rotate logs
     "cryptography==36.0.2",  # Python cryptography library for TLS - keyring conflict
-    "fasteners==0.17.3",  # For interprocess file locking, expected to be replaced by filelock
     "filelock==3.7.1",  # For reading and writing config multiprocess and multithread safely  (non-reentrant locks)
     "keyring==23.6.0",  # Store keys in MacOS Keychain, Windows Credential Locker
     "keyrings.cryptfile==1.3.4",  # Secure storage for keys on Linux (Will be replaced)


### PR DESCRIPTION
We have filelock dependency so we don't need fasteners.

Draft for: Failing test in ubuntu.