### PR TITLE
keychain: Drop `supports_keyring_passphrase`

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -22,7 +22,6 @@ from chia.util.keychain import (
     Keychain,
     KeyringCurrentPassphraseIsInvalid,
     set_keys_root_path,
-    supports_keyring_passphrase,
 )
 from chia.util.ssl_check import check_ssl
 from typing import Optional
@@ -95,13 +94,6 @@ def cli(
     check_ssl(Path(root_path))
 
 
-if not supports_keyring_passphrase():
-    from chia.cmds.passphrase_funcs import remove_passphrase_options_from_cmd
-
-    # TODO: Remove once keyring passphrase management is rolled out to all platforms
-    remove_passphrase_options_from_cmd(cli)
-
-
 @cli.command("version", short_help="Show chia version")
 def version_cmd() -> None:
     print(__version__)
@@ -140,9 +132,7 @@ cli.add_command(netspace_cmd)
 cli.add_command(farm_cmd)
 cli.add_command(plotters_cmd)
 cli.add_command(db_cmd)
-
-if supports_keyring_passphrase():
-    cli.add_command(passphrase_cmd)
+cli.add_command(passphrase_cmd)
 
 
 def main() -> None:

--- a/chia/cmds/init.py
+++ b/chia/cmds/init.py
@@ -1,5 +1,4 @@
 import click
-from chia.util.keychain import supports_keyring_passphrase
 
 
 @click.command("init", short_help="Create or migrate the configuration")
@@ -51,13 +50,6 @@ def init_cmd(ctx: click.Context, create_certs: str, fix_ssl_permissions: bool, t
         testnet,
         v1_db,
     )
-
-
-if not supports_keyring_passphrase():
-    from chia.cmds.passphrase_funcs import remove_passphrase_options_from_cmd
-
-    # TODO: Remove once keyring passphrase management is rolled out to all platforms
-    remove_passphrase_options_from_cmd(init_cmd)
 
 
 if __name__ == "__main__":

--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -14,8 +14,6 @@ from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-# Click drops leading dashes, and converts remaining dashes to underscores. e.g. --set-passphrase -> 'set_passphrase'
-PASSPHRASE_CLI_OPTION_NAMES = ["keys_root_path", "set_passphrase", "passphrase_file", "current_passphrase_file"]
 
 SAVE_MASTER_PASSPHRASE_WARNING = (
     colorama.Fore.YELLOW

--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -27,17 +27,6 @@ SAVE_MASTER_PASSPHRASE_WARNING = (
 )
 
 
-def remove_passphrase_options_from_cmd(cmd) -> None:
-    """
-    Filters-out passphrase options from a given Click command object
-    """
-    # TODO: Click doesn't seem to have a great way of adding/removing params using an
-    # existing command, and using the decorator-supported construction of options doesn't
-    # allow for conditionally including options. Once keyring passphrase management is
-    # rolled out to all platforms this can be removed.
-    cmd.params = [param for param in cmd.params if param.name not in PASSPHRASE_CLI_OPTION_NAMES]
-
-
 def verify_passphrase_meets_requirements(
     new_passphrase: str, confirmation_passphrase: str
 ) -> Tuple[bool, Optional[str]]:

--- a/chia/daemon/keychain_proxy.py
+++ b/chia/daemon/keychain_proxy.py
@@ -17,7 +17,6 @@ from chia.util.keychain import (
     KeyringIsLocked,
     bytes_to_mnemonic,
     mnemonic_to_seed,
-    supports_keyring_passphrase,
 )
 from chia.util.ws_message import WsRpcMessage
 from pathlib import Path
@@ -60,8 +59,6 @@ class KeychainProxy(DaemonProxy):
         self.log = log
         if local_keychain:
             self.keychain = local_keychain
-        elif not supports_keyring_passphrase():
-            self.keychain = Keychain()  # Proxy locally, don't use RPC
         else:
             self.keychain = None  # type: ignore
         self.keychain_user = user

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -31,7 +31,6 @@ from chia.util.keychain import (
     KeyringCurrentPassphraseIsInvalid,
     KeyringRequiresMigration,
     passphrase_requirements,
-    supports_keyring_passphrase,
     supports_os_passphrase_storage,
 )
 from chia.util.service_groups import validate_service
@@ -320,7 +319,7 @@ class WebSocketServer:
         if len(data) == 0 and command in commands_with_data:
             response = {"success": False, "error": f'{command} requires "data"'}
         # Keychain commands should be handled by KeychainServer
-        elif command in keychain_commands and supports_keyring_passphrase():
+        elif command in keychain_commands:
             response = await self.keychain_server.handle_command(command, data)
         elif command == "ping":
             response = await ping()
@@ -373,7 +372,6 @@ class WebSocketServer:
         return response
 
     async def keyring_status(self) -> Dict[str, Any]:
-        passphrase_support_enabled: bool = supports_keyring_passphrase()
         can_save_passphrase: bool = supports_os_passphrase_storage()
         user_passphrase_is_set: bool = Keychain.has_master_passphrase() and not using_default_passphrase()
         locked: bool = Keychain.is_keyring_locked()
@@ -385,7 +383,6 @@ class WebSocketServer:
         response: Dict[str, Any] = {
             "success": True,
             "is_keyring_locked": locked,
-            "passphrase_support_enabled": passphrase_support_enabled,
             "can_save_passphrase": can_save_passphrase,
             "user_passphrase_is_set": user_passphrase_is_set,
             "needs_migration": needs_migration,

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -1,5 +1,4 @@
 import colorama
-import os
 import pkg_resources
 import sys
 import unicodedata
@@ -47,11 +46,6 @@ class KeyringNotSet(Exception):
     pass
 
 
-def supports_keyring_passphrase() -> bool:
-    # Support can be disabled by setting CHIA_PASSPHRASE_SUPPORT to 0/false
-    return os.environ.get("CHIA_PASSPHRASE_SUPPORT", "true").lower() in ["1", "true"]
-
-
 def supports_os_passphrase_storage() -> bool:
     return sys.platform in ["darwin", "win32", "cygwin"]
 
@@ -60,9 +54,6 @@ def passphrase_requirements() -> Dict[str, Any]:
     """
     Returns a dictionary specifying current passphrase requirements
     """
-    if not supports_keyring_passphrase:
-        return {}
-
     return {"is_optional": True, "min_length": MIN_PASSPHRASE_LEN}  # lgtm [py/clear-text-logging-sensitive-data]
 
 

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -1,5 +1,4 @@
 import asyncio
-import keyring as keyring_main
 
 from blspy import PrivateKey  # pyright: reportMissingImports=false
 from chia.util.default_root import DEFAULT_KEYS_ROOT_PATH
@@ -135,25 +134,10 @@ class KeyringWrapper:
         # Initialize the cached_passphrase
         self.cached_passphrase = self._get_initial_cached_passphrase()
 
-    def _configure_backend(self) -> Union[LegacyKeyring, FileKeyring]:
-        from chia.util.keychain import supports_keyring_passphrase
-
-        keyring: Union[LegacyKeyring, FileKeyring]
-
+    def _configure_backend(self) -> FileKeyring:
         if self.keyring:
             raise Exception("KeyringWrapper has already been instantiated")
-
-        if supports_keyring_passphrase():
-            keyring = FileKeyring.create(keys_root_path=self.keys_root_path)
-        else:
-            legacy_keyring: Optional[LegacyKeyring] = get_legacy_keyring_instance()
-            if legacy_keyring is None:
-                legacy_keyring = keyring_main
-            else:
-                keyring_main.set_keyring(legacy_keyring)
-            keyring = legacy_keyring
-
-        return keyring
+        return FileKeyring.create(keys_root_path=self.keys_root_path)
 
     def _configure_legacy_backend(self) -> LegacyKeyring:
         # If keyring.yaml isn't found or is empty, check if we're using

--- a/tests/util/keyring.py
+++ b/tests/util/keyring.py
@@ -132,12 +132,6 @@ class TempKeyring:
         existing_keyring_dir = Path(existing_keyring_path).parent if existing_keyring_path else None
         temp_dir = existing_keyring_dir or tempfile.mkdtemp(prefix="test_keyring_wrapper")
 
-        mock_supports_keyring_passphrase_patch = patch("chia.util.keychain.supports_keyring_passphrase")
-        mock_supports_keyring_passphrase = mock_supports_keyring_passphrase_patch.start()
-
-        # Patch supports_keyring_passphrase() to return True
-        mock_supports_keyring_passphrase.return_value = True
-
         mock_supports_os_passphrase_storage_patch = patch("chia.util.keychain.supports_os_passphrase_storage")
         mock_supports_os_passphrase_storage = mock_supports_os_passphrase_storage_patch.start()
 
@@ -172,7 +166,6 @@ class TempKeyring:
         keychain._temp_dir = temp_dir  # type: ignore
 
         # Stash the patches in the keychain instance
-        keychain._mock_supports_keyring_passphrase_patch = mock_supports_keyring_passphrase_patch  # type: ignore
         keychain._mock_supports_os_passphrase_storage_patch = mock_supports_os_passphrase_storage_patch  # type: ignore
         keychain._mock_configure_backend_patch = mock_configure_backend_patch  # type: ignore
         keychain._mock_configure_legacy_backend_patch = mock_configure_legacy_backend_patch  # type: ignore
@@ -204,7 +197,6 @@ class TempKeyring:
             self.keychain.keyring_wrapper.keyring.cleanup_keyring_file_watcher()
             shutil.rmtree(self.keychain._temp_dir)
 
-        self.keychain._mock_supports_keyring_passphrase_patch.stop()
         self.keychain._mock_supports_os_passphrase_storage_patch.stop()
         self.keychain._mock_configure_backend_patch.stop()
         if self.keychain._mock_configure_legacy_backend_patch is not None:


### PR DESCRIPTION
Drops the not longer needed option to disable the passphrase feature via the env variable `CHIA_PASSPHRASE_SUPPORT`. 