### PR TITLE
daemon: Implement system metrics logger based on beta config

### DIFF
--- a/chia/util/beta_metrics.py
+++ b/chia/util/beta_metrics.py
@@ -1,0 +1,114 @@
+import asyncio
+import logging
+import platform
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import psutil
+
+from chia.util.config import load_config
+
+log = logging.getLogger("beta")
+
+metrics_log_interval_default = 5
+metrics_log_interval_min = 1
+metrics_log_interval_max = 30
+
+
+def log_static_info() -> None:
+    log.debug(f"architecture: {platform.architecture()}")
+    log.debug(f"processor: {platform.processor()}")
+    log.debug(f"cpu count: {psutil.cpu_count()}")
+    log.debug(f"machine: {platform.machine()}")
+    log.debug(f"platform: {platform.platform()}")
+
+
+def log_cpu_metrics() -> None:
+    log.debug(
+        f"CPU - percent: {psutil.cpu_percent(percpu=True)}, "
+        f"freq: {psutil.cpu_times(percpu=True)}, "
+        f"freq: {psutil.cpu_freq(percpu=True)}, "
+        f"load_avg: {psutil.getloadavg()}"
+    )
+
+
+def log_memory_metrics() -> None:
+    psutil.disk_io_counters(perdisk=False)
+    log.debug(f"MEMORY - virtual memory: {psutil.virtual_memory()}, swap: {psutil.swap_memory()}")
+
+
+def log_disk_metrics(root_path: Path, plot_dirs: List[str]) -> None:
+    # TODO, Could this spam the logs too much for large farms? Maybe don't log usage of plot dirs and
+    #       set perdisk=False rather for psutil.disk_io_counters? Lets try it with the default interval of 15s for now.
+    log.debug(f"DISK partitions: {psutil.disk_partitions()}")
+    for pot_dir in plot_dirs:
+        try:
+            usage = psutil.disk_usage(pot_dir)
+        except FileNotFoundError:
+            usage = "Directory not found"
+        log.debug(f"DISK - usage {pot_dir}: {usage}")
+    log.debug(f"DISK - usage root: {psutil.disk_usage(str(root_path))}")
+    log.debug(f"DISK - io counters: {psutil.disk_io_counters(perdisk=True)}")
+
+
+def log_port_states(config: Dict[str, Any]) -> None:
+    selected_network = config["selected_network"]
+    full_node_port = config["network_overrides"]["config"][selected_network]["default_full_node_port"]
+    test_socket_ipv4 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    port_open_ipv4 = test_socket_ipv4.connect_ex(("127.0.0.1", full_node_port)) == 0
+    log.debug(f"full node port IPv4 [{full_node_port}]: {'open' if port_open_ipv4 else 'closed'}")
+    test_socket_ipv6 = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    port_open_ipv6 = test_socket_ipv6.connect_ex(("::1", full_node_port)) == 0
+    log.debug(f"full node port IPv6 [{full_node_port}]: {'open' if port_open_ipv6 else 'closed'}")
+
+
+def log_network_metrics() -> None:
+    log.debug(f"NETWORK: io counters: {psutil.net_io_counters(pernic=False)}")
+
+
+@dataclass
+class BetaMetricsLogger:
+    root_path: Path
+    task: Optional[asyncio.Task] = None  # type: ignore[type-arg]  # mypy wants Task as generic, that doesn't work
+    stop_task: bool = False
+
+    def start_logging(self) -> None:
+        log.debug("start_logging")
+        log_static_info()
+        if self.task is not None:
+            raise RuntimeError("Already started")
+        self.stop_task = False
+        self.task = asyncio.create_task(self.run())
+
+    async def stop_logging(self) -> None:
+        log.debug("stop_logging")
+        if self.task is None:
+            raise RuntimeError("Not yet started")
+
+        self.stop_task = True
+        await self.task
+        self.task = None
+
+    async def run(self) -> None:
+        config = load_config(self.root_path, "config.yaml")
+        interval = min(max(config["beta"]["metrics_log_interval"], metrics_log_interval_min), metrics_log_interval_max)
+        tick = 0
+        while not self.stop_task:
+            try:
+                tick += 1
+                # Log every interval
+                if tick % interval == 0:
+                    log_cpu_metrics()
+                    log_memory_metrics()
+                    log_network_metrics()
+                # Log after 10 intervals passed
+                if tick % (interval * 10) == 0:
+                    log_disk_metrics(self.root_path, config["harvester"]["plot_directories"])
+                    log_port_states(config)
+            except Exception as e:
+                log.warning(f"BetaMetricsLogger run failed: {e}")
+                await asyncio.sleep(10)
+            await asyncio.sleep(1)
+        log.debug("done")

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ dependencies = [
     "typing-extensions==4.3.0",  # typing backports like Protocol and TypedDict
     "zstd==1.5.0.4",
     "packaging==21.3",
+    "psutil==5.9.1",
 ]
 
 upnp_dependencies = [

--- a/tests/core/cmds/test_beta.py
+++ b/tests/core/cmds/test_beta.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner, Result
 
 from chia.cmds.beta_funcs import default_beta_root_path
 from chia.cmds.chia import cli
+from chia.util.beta_metrics import metrics_log_interval_default, metrics_log_interval_max, metrics_log_interval_min
 from chia.util.config import lock_and_load_config, save_config
 
 
@@ -93,29 +94,34 @@ def generate_example_submission_data(beta_root_path: Path, versions: int, logs: 
                 pass
 
 
-def generate_beta_config(root_path: Path, enabled: bool, beta_path: Path) -> None:
+def generate_beta_config(
+    root_path: Path, enabled: bool, beta_path: Path, interval: int = metrics_log_interval_default
+) -> None:
     with lock_and_load_config(root_path, "config.yaml") as config:
         config["beta"] = {
             "enabled": enabled,
             "path": str(beta_path),
+            "metrics_log_interval": interval,
         }
         save_config(root_path, "config.yaml", config)
 
 
-@pytest.mark.parametrize("option", ["--path", "-p"])
-def test_configure(root_path_populated_with_config: Path, option: str) -> None:
+@pytest.mark.parametrize("interval_option", ["--interval", "-i"])
+@pytest.mark.parametrize("path_option", ["--path", "-p"])
+def test_configure(root_path_populated_with_config: Path, path_option: str, interval_option: str) -> None:
     root_path = root_path_populated_with_config
     beta_path = root_path / "beta"
     beta_path.mkdir()
     generate_beta_config(root_path, True, beta_path)
 
-    result = configure(root_path, option, str(beta_path))
+    result = configure(root_path, path_option, str(beta_path), interval_option, str(metrics_log_interval_max))
     assert result.exit_code == 0
 
     with lock_and_load_config(root_path, "config.yaml") as config:
         assert config["beta"] == {
             "enabled": True,
             "path": str(beta_path),
+            "metrics_log_interval": metrics_log_interval_max,
         }
 
 
@@ -131,20 +137,27 @@ def test_configure_no_beta_config(root_path_populated_with_config: Path) -> None
     assert "beta test mode is not enabled, enable it first with `chia beta enable`" in result.output
 
 
+@pytest.mark.parametrize("accept_existing_interval", [True, False])
 @pytest.mark.parametrize("accept_existing_path", [True, False])
-def test_beta_configure_interactive(root_path_populated_with_config: Path, accept_existing_path: bool) -> None:
+def test_beta_configure_interactive(
+    root_path_populated_with_config: Path, accept_existing_path: bool, accept_existing_interval: bool
+) -> None:
+    assert metrics_log_interval_default != metrics_log_interval_min
     root_path = root_path_populated_with_config
     beta_path = root_path / "beta"
     generate_beta_config(root_path, True, root_path_populated_with_config)
-
-    result = configure_interactive(root_path, f"{'' if accept_existing_path else str(beta_path)}\ny\n")
+    path_input = "\n" if accept_existing_path else str(beta_path) + "\ny\n"
+    interval_input = "\n" if accept_existing_interval else str(metrics_log_interval_min) + "\n"
+    result = configure_interactive(root_path, f"{path_input}{interval_input}")
     assert result.exit_code == 0
     assert "beta config updated" in result.output
 
+    metrics_log_interval = metrics_log_interval_default if accept_existing_interval else metrics_log_interval_min
     with lock_and_load_config(root_path, "config.yaml") as config:
         assert config["beta"] == {
             "enabled": True,
             "path": str(root_path_populated_with_config if accept_existing_path else beta_path),
+            "metrics_log_interval": metrics_log_interval,
         }
 
 
@@ -164,6 +177,7 @@ def test_beta_enable(root_path_populated_with_config: Path, option: str) -> None
         assert config["beta"] == {
             "enabled": True,
             "path": str(beta_path),
+            "metrics_log_interval": metrics_log_interval_default,
         }
 
 
@@ -187,6 +201,7 @@ def test_beta_enable_preconfigured(root_path_populated_with_config: Path, enable
         assert config["beta"] == {
             "enabled": True,
             "path": str(beta_path),
+            "metrics_log_interval": metrics_log_interval_default,
         }
 
 
@@ -208,6 +223,7 @@ def test_beta_enable_interactive(root_path_populated_with_config: Path, accept_d
         assert config["beta"] == {
             "enabled": True,
             "path": str(default_beta_root_path() if accept_default_path else beta_path),
+            "metrics_log_interval": metrics_log_interval_default,
         }
 
 
@@ -240,6 +256,33 @@ def test_beta_invalid_directories(
         assert f"Directory doesn't exist: {str(beta_path)!r}" in result.output
 
 
+@pytest.mark.parametrize("option", ["-i", "--interval"])
+@pytest.mark.parametrize(
+    "interval, valid",
+    [
+        (-1, False),
+        (0, False),
+        (metrics_log_interval_min - 1, False),
+        (metrics_log_interval_min, True),
+        (metrics_log_interval_min + 1, True),
+        (metrics_log_interval_max + 1, False),
+        (metrics_log_interval_max - 1, True),
+        (metrics_log_interval_max, True),
+    ],
+)
+def test_beta_configure_interval(
+    root_path_populated_with_config: Path, interval: int, valid: bool, option: str
+) -> None:
+    root_path = root_path_populated_with_config
+    beta_path = root_path / "beta"
+    beta_path.mkdir()
+    generate_beta_config(root_path, True, root_path_populated_with_config)
+    result = configure(root_path, "--path", str(beta_path), option, str(interval))
+    assert result.exit_code == 0 if valid else 1
+    if not valid:
+        assert f"Must be in the range of {metrics_log_interval_min}s to {metrics_log_interval_max}s." in result.output
+
+
 @pytest.mark.parametrize("enabled", [True, False])
 def test_beta_disable(root_path_populated_with_config: Path, enabled: bool) -> None:
     root_path = root_path_populated_with_config
@@ -266,6 +309,7 @@ def test_beta_disable(root_path_populated_with_config: Path, enabled: bool) -> N
         assert config["beta"] == {
             "enabled": False,
             "path": str(beta_path),
+            "metrics_log_interval": metrics_log_interval_default,
         }
 
 
@@ -310,13 +354,13 @@ def test_prepare_submission(
 
 
 @pytest.mark.parametrize(
-    "enabled, path",
+    "enabled, path, interval",
     [
-        (True, Path("path_1")),
-        (False, Path("path_2")),
+        (True, Path("path_1"), metrics_log_interval_min),
+        (False, Path("path_2"), metrics_log_interval_max),
     ],
 )
-def test_beta_status(root_path_populated_with_config: Path, enabled: bool, path: Path) -> None:
+def test_beta_status(root_path_populated_with_config: Path, enabled: bool, path: Path, interval: int) -> None:
     root_path = root_path_populated_with_config
     generate_beta_config(root_path, enabled, path)
 
@@ -333,3 +377,4 @@ def test_beta_status(root_path_populated_with_config: Path, enabled: bool, path:
     assert result.exit_code == 0
     assert f"enabled: {enabled}" in result.output
     assert f"path: {str(path)}" in result.output
+    assert f"metrics log interval: {str(metrics_log_interval_default)}" in result.output


### PR DESCRIPTION
Adds the class `BetaMetricsLogger` which gets instantiated in the daemon to periodically log some system metrics while in beta test mode.

The metrics logged in here now are a first draft from my side, feel free to provide suggestions about what we should log additionally or maybe remove from the current logs :) 

Based on:
- #12389 