### PR TITLE
Support extend_derivation_index specifying the actual last index value

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -917,7 +917,9 @@ class WalletRpcApi:
                 f"Use a derivation index less than {current + MAX_DERIVATION_INDEX_DELTA + 1}"
             )
 
-        await self.service.wallet_state_manager.create_more_puzzle_hashes(from_zero=False, up_to_index=index)
+        await self.service.wallet_state_manager.create_more_puzzle_hashes(
+            from_zero=False, up_to_index=index, num_additional_phs=0
+        )
 
         updated: Optional[uint32] = await self.service.wallet_state_manager.puzzle_store.get_last_derivation_path()
         updated_index = updated if updated is not None else None

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -272,7 +272,11 @@ class WalletStateManager:
         return pubkey, private
 
     async def create_more_puzzle_hashes(
-        self, from_zero: bool = False, in_transaction=False, up_to_index: Optional[uint32] = None
+        self,
+        from_zero: bool = False,
+        in_transaction=False,
+        up_to_index: Optional[uint32] = None,
+        num_additional_phs: Optional[int] = None,
     ):
         """
         For all wallets in the user store, generates the first few puzzle hashes so
@@ -281,7 +285,7 @@ class WalletStateManager:
         targets = list(self.wallets.keys())
         self.log.debug("Target wallets to generate puzzle hashes for: %s", repr(targets))
         unused: Optional[uint32] = (
-            up_to_index if up_to_index is not None else await self.puzzle_store.get_unused_derivation_path()
+            uint32(up_to_index + 1) if up_to_index is not None else await self.puzzle_store.get_unused_derivation_path()
         )
         if unused is None:
             # This handles the case where the database has entries but they have all been used
@@ -292,7 +296,7 @@ class WalletStateManager:
                 unused = uint32(0)
 
         self.log.debug(f"Requested to generate puzzle hashes to at least index {unused}")
-        to_generate = self.config["initial_num_public_keys"]
+        to_generate = num_additional_phs if num_additional_phs is not None else self.config["initial_num_public_keys"]
         new_paths: bool = False
 
         for wallet_id in targets:
@@ -317,7 +321,7 @@ class WalletStateManager:
             if start_index >= last_index:
                 self.log.debug(f"Nothing to create for for wallet_id: {wallet_id}, index: {start_index}")
             else:
-                creating_msg = f"Creating puzzle hashes from {start_index} to {last_index} for wallet_id: {wallet_id}"
+                creating_msg = f"Creating puzzle hashes from {start_index} to {last_index-1} for wallet_id: {wallet_id}"
                 self.log.info(f"Start: {creating_msg}")
                 for index in range(start_index, last_index):
                     if WalletType(target_wallet.type()) == WalletType.POOLING_WALLET:


### PR DESCRIPTION
Previously, when `extend_derivation_index` was called, the index value was being passed to `create_more_puzzle_hashes`, which would add `initial_num_public_keys` to the index value. This has caused some confusion as the value provided by the user gets bumped up to a larger value than expected.

This change introduces an optional `num_additional_phs` param to `create_more_puzzle_hashes` that overrides the default behavior of adding `initial_num_public_keys` to the last index. `extend_derivation_index` specifies a value of 0 to prevent generating additional puzzle hashes beyond the specified index.

This also makes a small change to account for `range` not including the `last_index`. This was a bit confusing because the logged message made it seem that the range was inclusive.