### PR TITLE
When extending the derivation index, make sure we don't mark previously

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -917,8 +917,11 @@ class WalletRpcApi:
                 f"Use a derivation index less than {current + MAX_DERIVATION_INDEX_DELTA + 1}"
             )
 
+        # Since we've bumping the derivation index without having found any new puzzles, we want
+        # to preserve the current last used index, so we call create_more_puzzle_hashes with
+        # mark_existing_as_used=False
         await self.service.wallet_state_manager.create_more_puzzle_hashes(
-            from_zero=False, up_to_index=index, num_additional_phs=0
+            from_zero=False, mark_existing_as_used=False, up_to_index=index, num_additional_phs=0
         )
 
         updated: Optional[uint32] = await self.service.wallet_state_manager.puzzle_store.get_last_derivation_path()

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -275,6 +275,7 @@ class WalletStateManager:
         self,
         from_zero: bool = False,
         in_transaction=False,
+        mark_existing_as_used=True,
         up_to_index: Optional[uint32] = None,
         num_additional_phs: Optional[int] = None,
     ):
@@ -372,7 +373,9 @@ class WalletStateManager:
             )
             if len(derivation_paths) > 0:
                 self.state_changed("new_derivation_index", data_object={"index": derivation_paths[-1].index})
-        if unused > 0 and new_paths:
+        # By default, we'll mark previously generated unused puzzle hashes as used if we have new paths
+        if mark_existing_as_used and unused > 0 and new_paths:
+            self.log.info(f"Updating last used derivation index: {unused - 1}")
             await self.puzzle_store.set_used_up_to(uint32(unused - 1))
 
     async def update_wallet_puzzle_hashes(self, wallet_id):


### PR DESCRIPTION
unused indices as used. This helps minimize gaps in the address space.