### PR TITLE
util: Fix passphrase hint

### DIFF
--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -423,6 +423,7 @@ class FileKeyring(FileSystemEventHandler):
             "salt": self.salt.hex(),
             "nonce": nonce.hex(),
             "data": base64.b64encode(encrypted_inner_payload).decode("utf-8"),
+            "passphrase_hint": self.outer_payload_cache.get("passphrase_hint", None),
         }
 
         # Merge in other properties like "passphrase_hint"

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -469,8 +469,4 @@ class FileKeyring(FileSystemEventHandler):
         Store the new passphrase hint in the staging dict (outer_payload_properties_for_next_write) to
         be written-out on the next write to the keyring.
         """
-        assert self.outer_payload_properties_for_next_write is not None
-        if passphrase_hint is not None and len(passphrase_hint) > 0:
-            self.outer_payload_properties_for_next_write["passphrase_hint"] = passphrase_hint
-        elif "passphrase_hint" in self.outer_payload_properties_for_next_write:
-            del self.outer_payload_properties_for_next_write["passphrase_hint"]
+        self.outer_payload_properties_for_next_write["passphrase_hint"] = passphrase_hint

--- a/tests/core/util/test_keyring_wrapper.py
+++ b/tests/core/util/test_keyring_wrapper.py
@@ -427,6 +427,12 @@ class TestKeyringWrapper:
         # Expect: to retrieve the passphrase hint that was just set
         assert KeyringWrapper.get_shared_instance().get_master_passphrase_hint() == "rhymes with bassphrase"
 
+        # When: writing the keyring again
+        KeyringWrapper.get_shared_instance().keyring.write_keyring()
+
+        # Expect: the hint is still set
+        assert KeyringWrapper.get_shared_instance().get_master_passphrase_hint() == "rhymes with bassphrase"
+
     @using_temp_file_keyring()
     def test_passphrase_hint_removal(self):
         """


### PR DESCRIPTION
- [1114a55](https://github.com/Chia-Network/chia-blockchain/pull/12517/commits/1114a55b1b6b358b6c2fae0a77d5a8f3b4fba6e1) Fix for: Currently that the hint gets dropped if the keychain gets re-written after the hint has been set becaue the `passphrase_hint` isn't included in "to write payload" which gets created
https://github.com/Chia-Network/chia-blockchain/blob/11ddc8c27ef1410dcafb1e8d885fc549b6bbc18c/chia/util/file_keyring.py#L421-L426
It works the first time because it there gets injected here, just once: 
https://github.com/Chia-Network/chia-blockchain/blob/11ddc8c27ef1410dcafb1e8d885fc549b6bbc18c/chia/util/file_keyring.py#L428-L430
- [f3eb90e](https://github.com/Chia-Network/chia-blockchain/pull/12517/commits/f3eb90e4b08d48b60cb01f3cd0273b8f4d42b44b) Fix for: "hint removal" also doesn't work currently on main. The related test only worked because there is a write between the removal and the assertion.


See 5182ffde39089d45d042dd56f767ca33d4d55158 which is failing without 1114a55b1b6b358b6c2fae0a77d5a8f3b4fba6e1 and `test_passphrase_hint_removal` fails with 1114a55b1b6b358b6c2fae0a77d5a8f3b4fba6e1 only and passes with f3eb90e4b08d48b60cb01f3cd0273b8f4d42b44b on top.