### PR TITLE
NFT transfer/minting commands now validate the specified addresses

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -24,7 +24,7 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.transaction_record import TransactionRecord
-from chia.wallet.util.address_type import AddressType, ensure_valid_address
+from chia.wallet.util.address_type import ensure_valid_address
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -781,16 +781,16 @@ async def create_nft_wallet(args: Dict, wallet_client: WalletRpcClient, fingerpr
 
 async def mint_nft(args: Dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["wallet_id"]
-    valid_address_types = {AddressType.current_network_address_type()}
+    config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     royalty_address = (
         None
         if not args["royalty_address"]
-        else ensure_valid_address(args["royalty_address"], allowed_types=valid_address_types)
+        else ensure_valid_address(args["royalty_address"], allowed_types={AddressType.XCH}, config=config)
     )
     target_address = (
         None
         if not args["target_address"]
-        else ensure_valid_address(args["target_address"], allowed_types=valid_address_types)
+        else ensure_valid_address(args["target_address"], allowed_types={AddressType.XCH}, config=config)
     )
     no_did_ownership = args["no_did_ownership"]
     hash = args["hash"]
@@ -872,9 +872,8 @@ async def transfer_nft(args: Dict, wallet_client: WalletRpcClient, fingerprint: 
     try:
         wallet_id = args["wallet_id"]
         nft_coin_id = args["nft_coin_id"]
-        target_address = ensure_valid_address(
-            args["target_address"], allowed_types={AddressType.current_network_address_type()}
-        )
+        config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
+        target_address = ensure_valid_address(args["target_address"], allowed_types={AddressType.XCH}, config=config)
         fee: int = int(Decimal(args["fee"]) * units["chia"])
         response = await wallet_client.transfer_nft(wallet_id, nft_coin_id, target_address, fee)
         spend_bundle = response["spend_bundle"]

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -882,11 +882,11 @@ async def transfer_nft(args: Dict, wallet_client: WalletRpcClient, fingerprint: 
         print(f"Failed to transfer NFT: {e}")
 
 
-def print_nft_info(nft: NFTInfo) -> None:
+def print_nft_info(nft: NFTInfo, *, config: Dict[str, Any]) -> None:
     indent: str = "   "
-    owner_did = None if nft.owner_did is None else encode_puzzle_hash(nft.owner_did, AddressType.DID.hrp())
+    owner_did = None if nft.owner_did is None else encode_puzzle_hash(nft.owner_did, AddressType.DID.hrp(config))
     print()
-    print(f"{'NFT identifier:'.ljust(26)} {encode_puzzle_hash(nft.launcher_id, AddressType.NFT.hrp())}")
+    print(f"{'NFT identifier:'.ljust(26)} {encode_puzzle_hash(nft.launcher_id, AddressType.NFT.hrp(config))}")
     print(f"{'Launcher coin ID:'.ljust(26)} {nft.launcher_id}")
     print(f"{'Launcher puzhash:'.ljust(26)} {nft.launcher_puzhash}")
     print(f"{'Current NFT coin ID:'.ljust(26)} {nft.nft_coin_id}")
@@ -920,12 +920,13 @@ def print_nft_info(nft: NFTInfo) -> None:
 async def list_nfts(args: Dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["wallet_id"]
     try:
+        config = load_config(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
         response = await wallet_client.list_nfts(wallet_id)
         nft_list = response["nft_list"]
         if len(nft_list) > 0:
             for n in nft_list:
                 nft = NFTInfo.from_json_dict(n)
-                print_nft_info(nft)
+                print_nft_info(nft, config=config)
         else:
             print(f"No NFTs found for wallet with id {wallet_id} on key {fingerprint}")
     except Exception as e:
@@ -948,8 +949,9 @@ async def set_nft_did(args: Dict, wallet_client: WalletRpcClient, fingerprint: i
 async def get_nft_info(args: Dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     nft_coin_id = args["nft_coin_id"]
     try:
+        config = load_config(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
         response = await wallet_client.get_nft_info(nft_coin_id)
         nft_info = NFTInfo.from_json_dict(response["nft_info"])
-        print_nft_info(nft_info)
+        print_nft_info(nft_info, config=config)
     except Exception as e:
         print(f"Failed to get NFT info: {e}")

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -277,7 +277,9 @@ def override_config(config: Dict[str, Any], config_overrides: Optional[Dict[str,
     return new_config
 
 
-def selected_network_address_prefix(in_config: Optional[Dict[str, Any]] = None) -> str:
-    config = in_config if in_config is not None else load_config(DEFAULT_ROOT_PATH, "config.yaml")
+def selected_network_address_prefix(
+    in_config: Optional[Dict[str, Any]] = None, root_path: Optional[Path] = DEFAULT_ROOT_PATH
+) -> str:
+    config = in_config if in_config is not None else load_config(root_path, "config.yaml")
     address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
     return address_prefix

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -16,6 +16,8 @@ import yaml
 from filelock import FileLock
 from typing_extensions import Literal
 
+from chia.util.default_root import DEFAULT_ROOT_PATH
+
 PEER_DB_PATH_KEY_DEPRECATED = "peer_db_path"  # replaced by "peers_file_path"
 WALLET_PEERS_PATH_KEY_DEPRECATED = "wallet_peers_path"  # replaced by "wallet_peers_file_path"
 
@@ -273,3 +275,9 @@ def override_config(config: Dict[str, Any], config_overrides: Optional[Dict[str,
     for k, v in config_overrides.items():
         add_property(new_config, k, v)
     return new_config
+
+
+def selected_network_address_prefix(in_config: Optional[Dict[str, Any]] = None) -> str:
+    config = in_config if in_config is not None else load_config(DEFAULT_ROOT_PATH, "config.yaml")
+    address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
+    return address_prefix

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -16,8 +16,6 @@ import yaml
 from filelock import FileLock
 from typing_extensions import Literal
 
-from chia.util.default_root import DEFAULT_ROOT_PATH
-
 PEER_DB_PATH_KEY_DEPRECATED = "peer_db_path"  # replaced by "peers_file_path"
 WALLET_PEERS_PATH_KEY_DEPRECATED = "wallet_peers_path"  # replaced by "wallet_peers_file_path"
 
@@ -277,9 +275,6 @@ def override_config(config: Dict[str, Any], config_overrides: Optional[Dict[str,
     return new_config
 
 
-def selected_network_address_prefix(
-    in_config: Optional[Dict[str, Any]] = None, root_path: Path = DEFAULT_ROOT_PATH
-) -> str:
-    config = in_config if in_config is not None else load_config(root_path, "config.yaml")
+def selected_network_address_prefix(config: Dict[str, Any]) -> str:
     address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
     return address_prefix

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -278,7 +278,7 @@ def override_config(config: Dict[str, Any], config_overrides: Optional[Dict[str,
 
 
 def selected_network_address_prefix(
-    in_config: Optional[Dict[str, Any]] = None, root_path: Optional[Path] = DEFAULT_ROOT_PATH
+    in_config: Optional[Dict[str, Any]] = None, root_path: Path = DEFAULT_ROOT_PATH
 ) -> str:
     config = in_config if in_config is not None else load_config(root_path, "config.yaml")
     address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]

--- a/chia/wallet/util/address_type.py
+++ b/chia/wallet/util/address_type.py
@@ -50,16 +50,16 @@ def default_allowed_types_if_none(f: Callable[..., Any]) -> Callable[..., Any]:
 
 
 @default_allowed_types_if_none  # sets allowed_types to xch|txch if not specified
-def is_valid_address(address: str, allowed_types: Set["AddressType"]) -> bool:
+def is_valid_address(address: str, *, allowed_types: Set["AddressType"]) -> bool:
     try:
-        ensure_valid_address(address, allowed_types)
+        ensure_valid_address(address, allowed_types=allowed_types)
         return True
     except ValueError:
         return False
 
 
 @default_allowed_types_if_none  # sets allowed_types to xch|txch if not specified
-def ensure_valid_address(address: str, allowed_types: Set["AddressType"]) -> str:
+def ensure_valid_address(address: str, *, allowed_types: Set["AddressType"]) -> str:
     hrp, data = bech32_decode(address)
     if not data:
         raise ValueError(f"Invalid address: {address}")

--- a/chia/wallet/util/address_type.py
+++ b/chia/wallet/util/address_type.py
@@ -1,33 +1,56 @@
-from enum import Enum, auto
-from typing import Set
+from enum import Enum
+from functools import wraps
+from typing import Any, Callable, Optional, Set, Type, TypeVar
 
 from chia.util.bech32m import bech32_decode
 from chia.util.config import selected_network_address_prefix
 
+_T_CurrentNetworkAddressPrefix = TypeVar("_T_CurrentNetworkAddressPrefix", bound="CurrentNetworkAddressPrefix")
+
+
+# Singleton representing the current network address prefix. Can be updated in case the config changes.
+# Since AddressType is an Enum, it's not possible to have a class attribute within AddressType that is
+# mutable. To support the case where the selected network address prefix changes, we use this class
+# to store that prefix.
+class CurrentNetworkAddressPrefix:
+    current: str = selected_network_address_prefix()
+
+    @classmethod
+    def update(cls: Type[_T_CurrentNetworkAddressPrefix], value: str) -> None:
+        cls.current = value
+
 
 class AddressType(Enum):
-    # def _generate_next_value_(name, start, count, last_values):
-    # if name == "DEFAULT":
-    #     print("_generate_next_value called for DEFAULT")
-    #     return selected_network_address_prefix()
-    # return name
-
-    # DEFAULT = auto()
     XCH = "xch"
     TXCH = "txch"
     NFT = "nft"
     DID = "did:chia:"
 
-    @classmethod
-    def default_prefix(cls):
-        # Loads the config, so use where appropriate
-        return cls(selected_network_address_prefix())
-
-    def hrp(self):
+    def hrp(self) -> str:
         return self.value
 
+    # Update the selected network address prefix in the singleton.
+    # This should be called if the config changes.
+    @classmethod
+    def update_current_network_address_prefix(cls, new_prefix: Optional[str] = None) -> None:
+        CurrentNetworkAddressPrefix.update(new_prefix or selected_network_address_prefix())
 
-def is_valid_address(address: str, allowed_types: Set["AddressType"] = {AddressType.DEFAULT}) -> bool:
+
+# Manipulates kwargs if `allowed_types`` is not specified, setting it to a set consisting
+# of the selected network address prefix (xch|txch)
+def default_allowed_types_if_none(f: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if "allowed_types" not in kwargs:
+            # Add the selected network address prefix (xch|txch) to the list of allowed prefixes
+            kwargs["allowed_types"] = {AddressType(CurrentNetworkAddressPrefix.current)}
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+@default_allowed_types_if_none  # sets allowed_types to xch|txch if not specified
+def is_valid_address(address: str, allowed_types: Set["AddressType"]) -> bool:
     try:
         ensure_valid_address(address, allowed_types)
         return True
@@ -35,13 +58,14 @@ def is_valid_address(address: str, allowed_types: Set["AddressType"] = {AddressT
         return False
 
 
-def ensure_valid_address(address: str, allowed_types: Set["AddressType"] = {AddressType.DEFAULT}) -> str:
+@default_allowed_types_if_none  # sets allowed_types to xch|txch if not specified
+def ensure_valid_address(address: str, allowed_types: Set["AddressType"]) -> str:
     hrp, data = bech32_decode(address)
     if not data:
         raise ValueError(f"Invalid address: {address}")
     if AddressType(hrp) not in allowed_types:
         raise ValueError(
             f"Invalid address: {address}. "
-            f"Valid addresses must contain one of the following prefixes: {[t.value for t in allowed_types]}"
+            f"Expected an address with one of the following prefixes: {[t.value for t in allowed_types]}"
         )
     return address

--- a/chia/wallet/util/address_type.py
+++ b/chia/wallet/util/address_type.py
@@ -1,0 +1,47 @@
+from enum import Enum, auto
+from typing import Set
+
+from chia.util.bech32m import bech32_decode
+from chia.util.config import selected_network_address_prefix
+
+
+class AddressType(Enum):
+    # def _generate_next_value_(name, start, count, last_values):
+    # if name == "DEFAULT":
+    #     print("_generate_next_value called for DEFAULT")
+    #     return selected_network_address_prefix()
+    # return name
+
+    # DEFAULT = auto()
+    XCH = "xch"
+    TXCH = "txch"
+    NFT = "nft"
+    DID = "did:chia:"
+
+    @classmethod
+    def default_prefix(cls):
+        # Loads the config, so use where appropriate
+        return cls(selected_network_address_prefix())
+
+    def hrp(self):
+        return self.value
+
+
+def is_valid_address(address: str, allowed_types: Set["AddressType"] = {AddressType.DEFAULT}) -> bool:
+    try:
+        ensure_valid_address(address, allowed_types)
+        return True
+    except ValueError:
+        return False
+
+
+def ensure_valid_address(address: str, allowed_types: Set["AddressType"] = {AddressType.DEFAULT}) -> str:
+    hrp, data = bech32_decode(address)
+    if not data:
+        raise ValueError(f"Invalid address: {address}")
+    if AddressType(hrp) not in allowed_types:
+        raise ValueError(
+            f"Invalid address: {address}. "
+            f"Valid addresses must contain one of the following prefixes: {[t.value for t in allowed_types]}"
+        )
+    return address

--- a/chia/wallet/util/address_type.py
+++ b/chia/wallet/util/address_type.py
@@ -1,21 +1,19 @@
 from enum import Enum
-from pathlib import Path
-from typing import Any, Dict, Optional, Set, Type, TypeVar
+from typing import Any, Dict, Optional, Set
 
 from chia.util.bech32m import bech32_decode, convertbits
 from chia.util.config import selected_network_address_prefix
-from chia.util.default_root import DEFAULT_ROOT_PATH
-
-_T_AddressType = TypeVar("_T_AddressType", bound="AddressType")
 
 
 class AddressType(Enum):
     XCH = "xch"
-    TXCH = "txch"
     NFT = "nft"
     DID = "did:chia:"
 
-    def hrp(self) -> str:
+    def hrp(self, config: Optional[Dict[str, Any]] = None) -> str:
+        if self == AddressType.XCH and config is not None:
+            # Special case to map XCH to the current network's address prefix
+            return selected_network_address_prefix(config)
         return self.value
 
     def expected_decoded_length(self) -> int:
@@ -23,37 +21,35 @@ class AddressType(Enum):
         # their length, this will need to be updated.
         return 32
 
-    @classmethod
-    def current_network_address_type(
-        cls: Type[_T_AddressType],
-        config: Optional[Dict[str, Any]] = None,
-        root_path: Path = DEFAULT_ROOT_PATH,
-    ) -> _T_AddressType:
-        return cls(selected_network_address_prefix(config, root_path))
 
-
-def is_valid_address(address: str, allowed_types: Set[AddressType]) -> bool:
+def is_valid_address(address: str, allowed_types: Set[AddressType], config: Optional[Dict[str, Any]] = None) -> bool:
     try:
-        ensure_valid_address(address, allowed_types=allowed_types)
+        ensure_valid_address(address, allowed_types=allowed_types, config=config)
         return True
     except ValueError:
         return False
 
 
-def ensure_valid_address(address: str, *, allowed_types: Set[AddressType]) -> str:
+def ensure_valid_address(
+    address: str, *, allowed_types: Set[AddressType], config: Optional[Dict[str, Any]] = None
+) -> str:
     hrp, b32data = bech32_decode(address)
     if not b32data or not hrp:
         raise ValueError(f"Invalid address: {address}")
-    address_type = AddressType(hrp)
+    # Match by prefix (hrp) and return the corresponding address type
+    address_type = next(
+        (addr_type for (addr_type, addr_hrp) in ((a, a.hrp(config)) for a in allowed_types) if addr_hrp == hrp),
+        None,
+    )
+    if address_type is None:
+        raise ValueError(
+            f"Invalid address: {address}. "
+            f"Expected an address with one of the following prefixes: {[t.hrp(config) for t in allowed_types]}"
+        )
     decoded_data = convertbits(b32data, 5, 8, False)
     if len(decoded_data) != address_type.expected_decoded_length():
         raise ValueError(
             f"Invalid address: {address}. "
             f"Expected {address_type.expected_decoded_length()} bytes, got {len(decoded_data)}"
-        )
-    if address_type not in allowed_types:
-        raise ValueError(
-            f"Invalid address: {address}. "
-            f"Expected an address with one of the following prefixes: {[t.value for t in allowed_types]}"
         )
     return address

--- a/chia/wallet/util/address_type.py
+++ b/chia/wallet/util/address_type.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Set
 
 from chia.util.bech32m import bech32_decode, convertbits
 from chia.util.config import selected_network_address_prefix
@@ -10,8 +10,8 @@ class AddressType(Enum):
     NFT = "nft"
     DID = "did:chia:"
 
-    def hrp(self, config: Optional[Dict[str, Any]] = None) -> str:
-        if self == AddressType.XCH and config is not None:
+    def hrp(self, config: Dict[str, Any]) -> str:
+        if self == AddressType.XCH:
             # Special case to map XCH to the current network's address prefix
             return selected_network_address_prefix(config)
         return self.value
@@ -22,7 +22,7 @@ class AddressType(Enum):
         return 32
 
 
-def is_valid_address(address: str, allowed_types: Set[AddressType], config: Optional[Dict[str, Any]] = None) -> bool:
+def is_valid_address(address: str, allowed_types: Set[AddressType], config: Dict[str, Any]) -> bool:
     try:
         ensure_valid_address(address, allowed_types=allowed_types, config=config)
         return True
@@ -30,9 +30,7 @@ def is_valid_address(address: str, allowed_types: Set[AddressType], config: Opti
         return False
 
 
-def ensure_valid_address(
-    address: str, *, allowed_types: Set[AddressType], config: Optional[Dict[str, Any]] = None
-) -> str:
+def ensure_valid_address(address: str, *, allowed_types: Set[AddressType], config: Dict[str, Any]) -> str:
     hrp, b32data = bech32_decode(address)
     if not b32data or not hrp:
         raise ValueError(f"Invalid address: {address}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,9 @@ import pytest
 import pytest_asyncio
 import tempfile
 
-from typing import AsyncIterator, List, Tuple
+from tests.setup_nodes import setup_node_and_wallet, setup_n_nodes, setup_two_nodes
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Tuple
 from chia.server.start_service import Service
 
 # Set spawn after stdlib imports, but before other imports
@@ -16,6 +18,7 @@ from chia.protocols import full_node_protocol
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
+from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
 from chia.util.ints import uint16
 from tests.core.node_height import node_height_at_least
 from tests.pools.test_pool_rpc import wallet_is_synced
@@ -608,3 +611,27 @@ async def setup_sim():
     sim_client = SimClient(sim)
     await sim.farm_block()
     return sim, sim_client
+
+
+@pytest.fixture(scope="function")
+def root_path_populated_with_config(tmpdir) -> Path:
+    """
+    Create a temp directory and populate it with a default config.yaml.
+    Returns the root path containing the config.
+    """
+    root_path: Path = Path(tmpdir)
+    create_default_chia_config(root_path)
+    return Path(root_path)
+
+
+@pytest.fixture(scope="function")
+def root_path_and_config_with_address_prefix(
+    root_path_populated_with_config: Path, prefix: str
+) -> Tuple[Path, Dict[str, Any]]:
+    updated_config: Dict[str, Any] = {}
+    with lock_and_load_config(root_path_populated_with_config, "config.yaml") as config:
+        if prefix is not None:
+            config["network_overrides"]["config"][config["selected_network"]]["address_prefix"] = prefix
+            save_config(root_path_populated_with_config, "config.yaml", config)
+        updated_config = config
+    return root_path_populated_with_config, updated_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -635,9 +635,9 @@ def root_path_populated_with_config(tmp_chia_root) -> Path:
 
 
 @pytest.fixture(scope="function")
-def config_with_address_prefix(root_path_populated_with_config: Path, prefix: str) -> Iterator[Dict[str, Any]]:
+def config_with_address_prefix(root_path_populated_with_config: Path, prefix: str) -> Dict[str, Any]:
     updated_config: Dict[str, Any] = {}
     with lock_and_load_config(root_path_populated_with_config, "config.yaml") as config:
         if prefix is not None:
             config["network_overrides"]["config"][config["selected_network"]]["address_prefix"] = prefix
-        yield config
+    return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import tempfile
 
 from tests.setup_nodes import setup_node_and_wallet, setup_n_nodes, setup_two_nodes
 from pathlib import Path
-from typing import Any, AsyncIterator, Dict, List, Tuple
+from typing import Any, AsyncIterator, Dict, Iterator, List, Tuple
 from chia.server.start_service import Service
 
 # Set spawn after stdlib imports, but before other imports
@@ -18,7 +18,7 @@ from chia.protocols import full_node_protocol
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
-from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
+from chia.util.config import create_default_chia_config, lock_and_load_config
 from chia.util.ints import uint16
 from tests.core.node_height import node_height_at_least
 from tests.pools.test_pool_rpc import wallet_is_synced
@@ -635,13 +635,9 @@ def root_path_populated_with_config(tmp_chia_root) -> Path:
 
 
 @pytest.fixture(scope="function")
-def root_path_and_config_with_address_prefix(
-    root_path_populated_with_config: Path, prefix: str
-) -> Tuple[Path, Dict[str, Any]]:
+def config_with_address_prefix(root_path_populated_with_config: Path, prefix: str) -> Iterator[Dict[str, Any]]:
     updated_config: Dict[str, Any] = {}
     with lock_and_load_config(root_path_populated_with_config, "config.yaml") as config:
         if prefix is not None:
             config["network_overrides"]["config"][config["selected_network"]]["address_prefix"] = prefix
-            save_config(root_path_populated_with_config, "config.yaml", config)
-        updated_config = config
-    return root_path_populated_with_config, updated_config
+        yield config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -614,14 +614,24 @@ async def setup_sim():
 
 
 @pytest.fixture(scope="function")
-def root_path_populated_with_config(tmpdir) -> Path:
+def tmp_chia_root(tmp_path):
     """
-    Create a temp directory and populate it with a default config.yaml.
-    Returns the root path containing the config.
+    Create a temp directory and populate it with an empty chia_root directory.
     """
-    root_path: Path = Path(tmpdir)
+    path: Path = tmp_path / "chia_root"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture(scope="function")
+def root_path_populated_with_config(tmp_chia_root) -> Path:
+    """
+    Create a temp chia_root directory and populate it with a default config.yaml.
+    Returns the chia_root path.
+    """
+    root_path: Path = tmp_chia_root
     create_default_chia_config(root_path)
-    return Path(root_path)
+    return root_path
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import tempfile
 
 from tests.setup_nodes import setup_node_and_wallet, setup_n_nodes, setup_two_nodes
 from pathlib import Path
-from typing import Any, AsyncIterator, Dict, Iterator, List, Tuple
+from typing import Any, AsyncIterator, Dict, List, Tuple
 from chia.server.start_service import Service
 
 # Set spawn after stdlib imports, but before other imports

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -311,8 +311,8 @@ class TestConfig:
         """
         Temp config.yaml created using a default config. address_prefix is defaulted to "xch"
         """
-        root_path = root_path_and_config_with_address_prefix[0]
-        prefix = selected_network_address_prefix(root_path=root_path)
+        config = root_path_and_config_with_address_prefix[1]
+        prefix = selected_network_address_prefix(config)
         assert prefix == "xch"
 
     @pytest.mark.parametrize("prefix", ["txch"])
@@ -322,8 +322,8 @@ class TestConfig:
         """
         Temp config.yaml created using a modified config. address_prefix is set to "txch"
         """
-        root_path = root_path_and_config_with_address_prefix[0]
-        prefix = selected_network_address_prefix(root_path=root_path)
+        config = root_path_and_config_with_address_prefix[1]
+        prefix = selected_network_address_prefix(config)
         assert prefix == "txch"
 
     def test_selected_network_address_prefix_config_dict(self, default_config_dict: Dict[str, Any]) -> None:

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -142,17 +142,6 @@ def run_reader_and_writer_tasks(root_path: Path, default_config: Dict):
 
 
 @pytest.fixture(scope="function")
-def root_path_populated_with_config(tmpdir) -> Path:
-    """
-    Create a temp directory and populate it with a default config.yaml.
-    Returns the root path containing the config.
-    """
-    root_path: Path = Path(tmpdir)
-    create_default_chia_config(root_path)
-    return Path(root_path)
-
-
-@pytest.fixture(scope="function")
 def default_config_dict() -> Dict:
     """
     Returns a dictionary containing the default config.yaml contents
@@ -160,19 +149,6 @@ def default_config_dict() -> Dict:
     content: str = initial_config_file("config.yaml")
     config: Dict = yaml.safe_load(content)
     return config
-
-
-@pytest.fixture(scope="function")
-def root_path_and_config_with_address_prefix(
-    root_path_populated_with_config: Path, prefix: str
-) -> Tuple[Path, Dict[str, Any]]:
-    updated_config: Dict[str, Any] = {}
-    with lock_and_load_config(root_path_populated_with_config, "config.yaml") as config:
-        if prefix is not None:
-            config["network_overrides"]["config"][config["selected_network"]]["address_prefix"] = prefix
-            save_config(root_path_populated_with_config, "config.yaml", config)
-        updated_config = config
-    return root_path_populated_with_config, updated_config
 
 
 class TestConfig:

--- a/tests/core/util/test_config.py
+++ b/tests/core/util/test_config.py
@@ -22,7 +22,7 @@ from multiprocessing import Pool, Queue, TimeoutError
 from pathlib import Path
 from threading import Thread
 from time import sleep
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 
 # Commented-out lines are preserved to aid in debugging the multiprocessing tests
@@ -305,24 +305,20 @@ class TestConfig:
             await asyncio.gather(*all_tasks)
 
     @pytest.mark.parametrize("prefix", [None])
-    def test_selected_network_address_prefix_default_config(
-        self, root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
-    ) -> None:
+    def test_selected_network_address_prefix_default_config(self, config_with_address_prefix: Dict[str, Any]) -> None:
         """
         Temp config.yaml created using a default config. address_prefix is defaulted to "xch"
         """
-        config = root_path_and_config_with_address_prefix[1]
+        config = config_with_address_prefix
         prefix = selected_network_address_prefix(config)
         assert prefix == "xch"
 
     @pytest.mark.parametrize("prefix", ["txch"])
-    def test_selected_network_address_prefix_testnet_config(
-        self, root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
-    ) -> None:
+    def test_selected_network_address_prefix_testnet_config(self, config_with_address_prefix: Dict[str, Any]) -> None:
         """
         Temp config.yaml created using a modified config. address_prefix is set to "txch"
         """
-        config = root_path_and_config_with_address_prefix[1]
+        config = config_with_address_prefix
         prefix = selected_network_address_prefix(config)
         assert prefix == "txch"
 

--- a/tests/wallet/test_address_type.py
+++ b/tests/wallet/test_address_type.py
@@ -1,0 +1,157 @@
+from typing import Any
+import pytest
+
+from chia.wallet.util.address_type import (
+    AddressType,
+    CurrentNetworkAddressPrefix,
+    is_valid_address,
+    ensure_valid_address,
+)
+
+
+@pytest.fixture(scope="function")
+def override_selected_network_address_prefix(monkeypatch: Any, prefix: str):
+    with monkeypatch.context() as m:
+        m.setattr("chia.wallet.util.address_type.CurrentNetworkAddressPrefix.current", prefix)
+        assert CurrentNetworkAddressPrefix.current == prefix
+        yield
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_is_valid_address_mainnet(override_selected_network_address_prefix):
+    valid = is_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd")
+    assert valid is True
+
+
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_is_valid_address_testnet(override_selected_network_address_prefix):
+    valid = is_valid_address("txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7")
+    assert valid is True
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_is_valid_address_mainnet_explicit(override_selected_network_address_prefix):
+    valid = is_valid_address(
+        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}
+    )
+    assert valid is True
+
+
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_is_valid_address_testnet_explicit(override_selected_network_address_prefix):
+    valid = is_valid_address(
+        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
+    )
+    assert valid is True
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_is_valid_address_mainnet_explicit_txch_address(override_selected_network_address_prefix):
+    valid = is_valid_address(
+        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
+    )
+    assert valid is True
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_is_valid_address_mainnet_bad_address(override_selected_network_address_prefix):
+    valid = is_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx")
+    assert valid is False
+
+
+def test_is_valid_address_nft():
+    valid = is_valid_address(
+        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}
+    )
+    assert valid is True
+
+
+def test_is_valid_address_nft_bad_address():
+    valid = is_valid_address(
+        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx", allowed_types={AddressType.NFT}
+    )
+    assert valid is False
+
+
+def test_is_valid_address_did():
+    valid = is_valid_address(
+        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7", allowed_types={AddressType.DID}
+    )
+    assert valid is True
+
+
+def test_is_valid_address_did_bad_address():
+    valid = is_valid_address(
+        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx", allowed_types={AddressType.DID}
+    )
+    assert valid is False
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_ensure_valid_address_mainnet(override_selected_network_address_prefix):
+    address = ensure_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd")
+    assert address == "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd"
+
+
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_ensure_valid_address_testnet(override_selected_network_address_prefix):
+    address = ensure_valid_address("txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7")
+    assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_ensure_valid_address_mainnet_explicit(override_selected_network_address_prefix):
+    address = ensure_valid_address(
+        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}
+    )
+    assert address == "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd"
+
+
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_ensure_valid_address_testnet_explicit(override_selected_network_address_prefix):
+    address = ensure_valid_address(
+        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
+    )
+    assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_ensure_valid_address_mainnet_explicit_txch_address(override_selected_network_address_prefix):
+    address = ensure_valid_address(
+        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
+    )
+    assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
+
+
+@pytest.mark.parametrize("prefix", ["xch"])
+def test_ensure_valid_address_mainnet_bad_address(override_selected_network_address_prefix):
+    with pytest.raises(ValueError):
+        ensure_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx")
+
+
+def test_ensure_valid_address_nft():
+    address = ensure_valid_address(
+        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}
+    )
+    assert address == "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773"
+
+
+def test_ensure_valid_address_nft_bad_address():
+    with pytest.raises(ValueError):
+        ensure_valid_address(
+            "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx", allowed_types={AddressType.NFT}
+        )
+
+
+def test_ensure_valid_address_did():
+    address = ensure_valid_address(
+        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7", allowed_types={AddressType.DID}
+    )
+    assert address == "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7"
+
+
+def test_ensure_valid_address_did_bad_address():
+    with pytest.raises(ValueError):
+        ensure_valid_address(
+            "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx", allowed_types={AddressType.DID}
+        )

--- a/tests/wallet/test_address_type.py
+++ b/tests/wallet/test_address_type.py
@@ -1,156 +1,119 @@
-from typing import Any
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
 import pytest
 
-from chia.wallet.util.address_type import (
-    AddressType,
-    CurrentNetworkAddressPrefix,
-    is_valid_address,
-    ensure_valid_address,
-)
+from chia.wallet.util.address_type import AddressType, ensure_valid_address, is_valid_address
 
 
-@pytest.fixture(scope="function")
-def override_selected_network_address_prefix(monkeypatch: Any, prefix: str):
-    with monkeypatch.context() as m:
-        m.setattr("chia.wallet.util.address_type.CurrentNetworkAddressPrefix.current", prefix)
-        assert CurrentNetworkAddressPrefix.current == prefix
-        yield
-
-
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_is_valid_address_mainnet(override_selected_network_address_prefix):
-    valid = is_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd")
-    assert valid is True
+@pytest.mark.parametrize("prefix", [None])
+def test_current_network_address_type_default_config(
+    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
+) -> None:
+    root_path = root_path_and_config_with_address_prefix[0]
+    assert AddressType.current_network_address_type(root_path=root_path).value == "xch"
 
 
 @pytest.mark.parametrize("prefix", ["txch"])
-def test_is_valid_address_testnet(override_selected_network_address_prefix):
-    valid = is_valid_address("txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7")
-    assert valid is True
+def test_current_network_address_type_testnet_config(
+    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
+) -> None:
+    config = root_path_and_config_with_address_prefix[1]
+    assert AddressType.current_network_address_type(config=config).value == "txch"
 
 
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_is_valid_address_mainnet_explicit(override_selected_network_address_prefix):
+def test_is_valid_address_xch() -> None:
     valid = is_valid_address(
         "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}
     )
     assert valid is True
 
 
-@pytest.mark.parametrize("prefix", ["txch"])
-def test_is_valid_address_testnet_explicit(override_selected_network_address_prefix):
+def test_is_valid_address_txch() -> None:
     valid = is_valid_address(
         "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
     )
     assert valid is True
 
 
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_is_valid_address_mainnet_explicit_txch_address(override_selected_network_address_prefix):
+def test_is_valid_address_xch_bad_address() -> None:
     valid = is_valid_address(
-        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
+        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx", allowed_types={AddressType.XCH}
     )
-    assert valid is True
-
-
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_is_valid_address_mainnet_bad_address(override_selected_network_address_prefix):
-    valid = is_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx")
     assert valid is False
 
 
-def test_is_valid_address_nft():
+def test_is_valid_address_nft() -> None:
     valid = is_valid_address(
         "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}
     )
     assert valid is True
 
 
-def test_is_valid_address_nft_bad_address():
+def test_is_valid_address_nft_bad_address() -> None:
     valid = is_valid_address(
         "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx", allowed_types={AddressType.NFT}
     )
     assert valid is False
 
 
-def test_is_valid_address_did():
+def test_is_valid_address_did() -> None:
     valid = is_valid_address(
         "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7", allowed_types={AddressType.DID}
     )
     assert valid is True
 
 
-def test_is_valid_address_did_bad_address():
+def test_is_valid_address_did_bad_address() -> None:
     valid = is_valid_address(
         "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx", allowed_types={AddressType.DID}
     )
     assert valid is False
 
 
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_ensure_valid_address_mainnet(override_selected_network_address_prefix):
-    address = ensure_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd")
-    assert address == "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd"
-
-
-@pytest.mark.parametrize("prefix", ["txch"])
-def test_ensure_valid_address_testnet(override_selected_network_address_prefix):
-    address = ensure_valid_address("txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7")
-    assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
-
-
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_ensure_valid_address_mainnet_explicit(override_selected_network_address_prefix):
+def test_ensure_valid_address_xch() -> None:
     address = ensure_valid_address(
         "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}
     )
     assert address == "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd"
 
 
-@pytest.mark.parametrize("prefix", ["txch"])
-def test_ensure_valid_address_testnet_explicit(override_selected_network_address_prefix):
+def test_ensure_valid_address_txch() -> None:
     address = ensure_valid_address(
         "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
     )
     assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
 
 
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_ensure_valid_address_mainnet_explicit_txch_address(override_selected_network_address_prefix):
-    address = ensure_valid_address(
-        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
-    )
-    assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
-
-
-@pytest.mark.parametrize("prefix", ["xch"])
-def test_ensure_valid_address_mainnet_bad_address(override_selected_network_address_prefix):
+def test_ensure_valid_address_xch_bad_address() -> None:
     with pytest.raises(ValueError):
-        ensure_valid_address("xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx")
+        ensure_valid_address(
+            "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx", allowed_types={AddressType.XCH}
+        )
 
 
-def test_ensure_valid_address_nft():
+def test_ensure_valid_address_nft() -> None:
     address = ensure_valid_address(
         "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}
     )
     assert address == "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773"
 
 
-def test_ensure_valid_address_nft_bad_address():
+def test_ensure_valid_address_nft_bad_address() -> None:
     with pytest.raises(ValueError):
         ensure_valid_address(
             "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx", allowed_types={AddressType.NFT}
         )
 
 
-def test_ensure_valid_address_did():
+def test_ensure_valid_address_did() -> None:
     address = ensure_valid_address(
         "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7", allowed_types={AddressType.DID}
     )
     assert address == "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7"
 
 
-def test_ensure_valid_address_did_bad_address():
+def test_ensure_valid_address_did_bad_address() -> None:
     with pytest.raises(ValueError):
         ensure_valid_address(
             "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx", allowed_types={AddressType.DID}

--- a/tests/wallet/test_address_type.py
+++ b/tests/wallet/test_address_type.py
@@ -7,33 +7,61 @@ from chia.wallet.util.address_type import AddressType, ensure_valid_address, is_
 
 
 @pytest.mark.parametrize("prefix", [None])
-def test_current_network_address_type_default_config(
-    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
-) -> None:
-    root_path = root_path_and_config_with_address_prefix[0]
-    assert AddressType.current_network_address_type(root_path=root_path).value == "xch"
+def test_xch_hrp_for_default_config(root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]) -> None:
+    config = root_path_and_config_with_address_prefix[1]
+    assert AddressType.XCH.hrp(config) == "xch"
 
 
 @pytest.mark.parametrize("prefix", ["txch"])
-def test_current_network_address_type_testnet_config(
+def test_txch_hrp_for_testnet_config(root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]) -> None:
+    config = root_path_and_config_with_address_prefix[1]
+    assert AddressType.XCH.hrp(config) == "txch"
+
+
+def test_hrps_no_config() -> None:
+    assert AddressType.XCH.hrp() == "xch"
+    assert AddressType.NFT.hrp() == "nft"
+    assert AddressType.DID.hrp() == "did:chia:"
+
+
+@pytest.mark.parametrize("prefix", [None])
+def test_is_valid_address_xch_with_config(
     root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
 ) -> None:
     config = root_path_and_config_with_address_prefix[1]
-    assert AddressType.current_network_address_type(config=config).value == "txch"
+    valid = is_valid_address(
+        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}, config=config
+    )
+    assert valid is True
 
 
-def test_is_valid_address_xch() -> None:
+def test_is_valid_address_xch_no_config() -> None:
     valid = is_valid_address(
         "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}
     )
     assert valid is True
 
 
-def test_is_valid_address_txch() -> None:
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_is_valid_address_txch_with_config(
+    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
+) -> None:
+    config = root_path_and_config_with_address_prefix[1]
+    # TXCH address validation requires a config
     valid = is_valid_address(
-        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
+        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7",
+        allowed_types={AddressType.XCH},
+        config=config,
     )
     assert valid is True
+
+
+def test_is_valid_address_txch_no_config() -> None:
+    # TXCH address validation requires a config, so valid should be False
+    valid = is_valid_address(
+        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.XCH}
+    )
+    assert valid is False
 
 
 def test_is_valid_address_xch_bad_address() -> None:
@@ -43,7 +71,29 @@ def test_is_valid_address_xch_bad_address() -> None:
     assert valid is False
 
 
-def test_is_valid_address_nft() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_is_valid_address_nft_with_config(
+    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
+) -> None:
+    config = root_path_and_config_with_address_prefix[1]
+    valid = is_valid_address(
+        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}, config=config
+    )
+    assert valid is True
+
+
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_is_valid_address_nft_with_testnet_config(
+    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
+) -> None:
+    config = root_path_and_config_with_address_prefix[1]
+    valid = is_valid_address(
+        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}, config=config
+    )
+    assert valid is True
+
+
+def test_is_valid_address_nft_no_config() -> None:
     valid = is_valid_address(
         "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}
     )
@@ -78,9 +128,13 @@ def test_ensure_valid_address_xch() -> None:
     assert address == "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd"
 
 
-def test_ensure_valid_address_txch() -> None:
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_ensure_valid_address_txch(root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]) -> None:
+    config = root_path_and_config_with_address_prefix[1]
     address = ensure_valid_address(
-        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.TXCH}
+        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7",
+        allowed_types={AddressType.XCH},
+        config=config,
     )
     assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
 

--- a/tests/wallet/test_address_type.py
+++ b/tests/wallet/test_address_type.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 import pytest
 
@@ -7,46 +6,29 @@ from chia.wallet.util.address_type import AddressType, ensure_valid_address, is_
 
 
 @pytest.mark.parametrize("prefix", [None])
-def test_xch_hrp_for_default_config(root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]) -> None:
-    config = root_path_and_config_with_address_prefix[1]
+def test_xch_hrp_for_default_config(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     assert AddressType.XCH.hrp(config) == "xch"
 
 
 @pytest.mark.parametrize("prefix", ["txch"])
-def test_txch_hrp_for_testnet_config(root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]) -> None:
-    config = root_path_and_config_with_address_prefix[1]
+def test_txch_hrp_for_testnet(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     assert AddressType.XCH.hrp(config) == "txch"
 
 
-def test_hrps_no_config() -> None:
-    assert AddressType.XCH.hrp() == "xch"
-    assert AddressType.NFT.hrp() == "nft"
-    assert AddressType.DID.hrp() == "did:chia:"
-
-
 @pytest.mark.parametrize("prefix", [None])
-def test_is_valid_address_xch_with_config(
-    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
-) -> None:
-    config = root_path_and_config_with_address_prefix[1]
+def test_is_valid_address_xch(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     valid = is_valid_address(
         "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}, config=config
     )
     assert valid is True
 
 
-def test_is_valid_address_xch_no_config() -> None:
-    valid = is_valid_address(
-        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}
-    )
-    assert valid is True
-
-
 @pytest.mark.parametrize("prefix", ["txch"])
-def test_is_valid_address_txch_with_config(
-    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
-) -> None:
-    config = root_path_and_config_with_address_prefix[1]
+def test_is_valid_address_txch(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     # TXCH address validation requires a config
     valid = is_valid_address(
         "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7",
@@ -56,26 +38,18 @@ def test_is_valid_address_txch_with_config(
     assert valid is True
 
 
-def test_is_valid_address_txch_no_config() -> None:
-    # TXCH address validation requires a config, so valid should be False
+@pytest.mark.parametrize("prefix", [None])
+def test_is_valid_address_xch_bad_address(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     valid = is_valid_address(
-        "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7", allowed_types={AddressType.XCH}
-    )
-    assert valid is False
-
-
-def test_is_valid_address_xch_bad_address() -> None:
-    valid = is_valid_address(
-        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx", allowed_types={AddressType.XCH}
+        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx", allowed_types={AddressType.XCH}, config=config
     )
     assert valid is False
 
 
 @pytest.mark.parametrize("prefix", [None])
-def test_is_valid_address_nft_with_config(
-    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
-) -> None:
-    config = root_path_and_config_with_address_prefix[1]
+def test_is_valid_address_nft(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     valid = is_valid_address(
         "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}, config=config
     )
@@ -83,54 +57,68 @@ def test_is_valid_address_nft_with_config(
 
 
 @pytest.mark.parametrize("prefix", ["txch"])
-def test_is_valid_address_nft_with_testnet_config(
-    root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]
-) -> None:
-    config = root_path_and_config_with_address_prefix[1]
+def test_is_valid_address_nft_with_testnet(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     valid = is_valid_address(
         "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}, config=config
     )
     assert valid is True
 
 
-def test_is_valid_address_nft_no_config() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_is_valid_address_nft_bad_address(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     valid = is_valid_address(
-        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}
-    )
-    assert valid is True
-
-
-def test_is_valid_address_nft_bad_address() -> None:
-    valid = is_valid_address(
-        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx", allowed_types={AddressType.NFT}
+        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx", allowed_types={AddressType.NFT}, config=config
     )
     assert valid is False
 
 
-def test_is_valid_address_did() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_is_valid_address_did(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     valid = is_valid_address(
-        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7", allowed_types={AddressType.DID}
+        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7",
+        allowed_types={AddressType.DID},
+        config=config,
     )
     assert valid is True
 
 
-def test_is_valid_address_did_bad_address() -> None:
+@pytest.mark.parametrize("prefix", ["txch"])
+def test_is_valid_address_did_with_testnet(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     valid = is_valid_address(
-        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx", allowed_types={AddressType.DID}
+        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7",
+        allowed_types={AddressType.DID},
+        config=config,
+    )
+    assert valid is True
+
+
+@pytest.mark.parametrize("prefix", [None])
+def test_is_valid_address_did_bad_address(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
+    valid = is_valid_address(
+        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx",
+        allowed_types={AddressType.DID},
+        config=config,
     )
     assert valid is False
 
 
-def test_ensure_valid_address_xch() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_ensure_valid_address_xch(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     address = ensure_valid_address(
-        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}
+        "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd", allowed_types={AddressType.XCH}, config=config
     )
     assert address == "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8taffd"
 
 
 @pytest.mark.parametrize("prefix", ["txch"])
-def test_ensure_valid_address_txch(root_path_and_config_with_address_prefix: Tuple[Path, Dict[str, Any]]) -> None:
-    config = root_path_and_config_with_address_prefix[1]
+def test_ensure_valid_address_txch(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     address = ensure_valid_address(
         "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7",
         allowed_types={AddressType.XCH},
@@ -139,41 +127,61 @@ def test_ensure_valid_address_txch(root_path_and_config_with_address_prefix: Tup
     assert address == "txch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs2v6lg7"
 
 
-def test_ensure_valid_address_xch_bad_address() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_ensure_valid_address_xch_bad_address(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     with pytest.raises(ValueError):
         ensure_valid_address(
-            "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx", allowed_types={AddressType.XCH}
+            "xch1mnr0ygu7lvmk3nfgzmncfk39fwu0dv933yrcv97nd6pmrt7fzmhs8xxxxx",
+            allowed_types={AddressType.XCH},
+            config=config,
         )
 
 
-def test_ensure_valid_address_nft() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_ensure_valid_address_nft(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     address = ensure_valid_address(
-        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}
+        "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773", allowed_types={AddressType.NFT}, config=config
     )
     assert address == "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtza773"
 
 
-def test_ensure_valid_address_nft_bad_address() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_ensure_valid_address_nft_bad_address(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     with pytest.raises(ValueError):
         ensure_valid_address(
-            "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx", allowed_types={AddressType.NFT}
+            "nft1mx2nkvml2eekjtqwdmxvmf3js8g083hpszzhkhtwvhcss8efqzhqtxxxxx",
+            allowed_types={AddressType.NFT},
+            config=config,
         )
 
 
-def test_ensure_valid_address_did() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_ensure_valid_address_did(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     address = ensure_valid_address(
-        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7", allowed_types={AddressType.DID}
+        "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7",
+        allowed_types={AddressType.DID},
+        config=config,
     )
     assert address == "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsr9gsr7"
 
 
-def test_ensure_valid_address_did_bad_address() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_ensure_valid_address_did_bad_address(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     with pytest.raises(ValueError):
         ensure_valid_address(
-            "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx", allowed_types={AddressType.DID}
+            "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx",
+            allowed_types={AddressType.DID},
+            config=config,
         )
 
 
-def test_ensure_valid_address_bad_length() -> None:
+@pytest.mark.parametrize("prefix", [None])
+def test_ensure_valid_address_bad_length(config_with_address_prefix: Dict[str, Any]) -> None:
+    config = config_with_address_prefix
     with pytest.raises(ValueError):
-        ensure_valid_address("xch1qqqqqqqqqqqqqqqqwygzk5", allowed_types={AddressType.XCH})
+        ensure_valid_address("xch1qqqqqqqqqqqqqqqqwygzk5", allowed_types={AddressType.XCH}, config=config)

--- a/tests/wallet/test_address_type.py
+++ b/tests/wallet/test_address_type.py
@@ -118,3 +118,8 @@ def test_ensure_valid_address_did_bad_address() -> None:
         ensure_valid_address(
             "did:chia:14jxdtqcyp3gk8ka0678eq8mmtnktgpmp2vuqq3vtsl2e5qr7fyrsrxxxxx", allowed_types={AddressType.DID}
         )
+
+
+def test_ensure_valid_address_bad_length() -> None:
+    with pytest.raises(ValueError):
+        ensure_valid_address("xch1qqqqqqqqqqqqqqqqwygzk5", allowed_types={AddressType.XCH})


### PR DESCRIPTION
Some users have been sending NFTs to invalid addresses, such as DID or NFT identifiers. This change adds CLI-side address validation for the NFT transfer and mint commands.

An AddressType enum is introduced with this change which aims to perform bech32m validation of the supplied address, as well as enforcing that the address prefix is of the expected type.

`is_valid_address()` and `ensure_valid_address()` can be called with an `allowed_types` set of `AddressType` enum values. `AddressType.current_network_address_type()` can be called to return the `AddressType` for the config's selected network.

`is_valid_address()` and `ensure_valid_address()` perform the same validation but differ in their return types and exception handling.

Tests included.