### PR TITLE
remove soft fork logic at height 2300000

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -316,7 +316,6 @@ async def validate_block_body(
                     min(constants.MAX_BLOCK_COST_CLVM, curr.transactions_info.cost),
                     cost_per_byte=constants.COST_PER_BYTE,
                     mempool_mode=False,
-                    height=curr.height,
                 )
                 removals_in_curr, additions_in_curr = tx_removals_and_additions(curr_npc_result.conds)
             else:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -441,7 +441,6 @@ class Blockchain(BlockchainInterface):
                 self.constants.MAX_BLOCK_COST_CLVM,
                 cost_per_byte=self.constants.COST_PER_BYTE,
                 mempool_mode=False,
-                height=block.height,
             )
         tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
         return tx_removals, tx_additions, npc_result
@@ -616,14 +615,13 @@ class Blockchain(BlockchainInterface):
             validate_signatures=validate_signatures,
         )
 
-    async def run_generator(self, unfinished_block: bytes, generator: BlockGenerator, height: uint32) -> NPCResult:
+    async def run_generator(self, unfinished_block: bytes, generator: BlockGenerator) -> NPCResult:
         task = asyncio.get_running_loop().run_in_executor(
             self.pool,
             _run_generator,
             self.constants,
             unfinished_block,
             bytes(generator),
-            height,
         )
         npc_result_bytes = await task
         if npc_result_bytes is None:

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -60,7 +60,6 @@ class ConsensusConstants:
     MAX_GENERATOR_SIZE: uint32
     MAX_GENERATOR_REF_LIST_SIZE: uint32
     POOL_SUB_SLOT_ITERS: uint64
-    SOFT_FORK_HEIGHT: uint32
 
     def replace(self, **changes: object) -> "ConsensusConstants":
         return dataclasses.replace(self, **changes)

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -54,7 +54,6 @@ testnet_kwargs = {
     "MAX_GENERATOR_SIZE": 1000000,
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
-    "SOFT_FORK_HEIGHT": 2300000,
 }
 
 

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -90,7 +90,6 @@ def batch_pre_validate_blocks(
                         min(constants.MAX_BLOCK_COST_CLVM, block.transactions_info.cost),
                         cost_per_byte=constants.COST_PER_BYTE,
                         mempool_mode=False,
-                        height=block.height,
                     )
                     removals, tx_additions = tx_removals_and_additions(npc_result.conds)
                 if npc_result is not None and npc_result.error is not None:
@@ -366,7 +365,6 @@ def _run_generator(
     constants: ConsensusConstants,
     unfinished_block_bytes: bytes,
     block_generator_bytes: bytes,
-    height: uint32,
 ) -> Optional[bytes]:
     """
     Runs the CLVM generator from bytes inputs. This is meant to be called under a ProcessPoolExecutor, in order to
@@ -382,7 +380,6 @@ def _run_generator(
             min(constants.MAX_BLOCK_COST_CLVM, unfinished_block.transactions_info.cost),
             cost_per_byte=constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=height,
         )
         return bytes(npc_result)
     except ValidationError as e:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1741,8 +1741,7 @@ class FullNode:
             if block_bytes is None:
                 block_bytes = bytes(block)
 
-            height = uint32(0) if prev_b is None else uint32(prev_b.height + 1)
-            npc_result = await self.blockchain.run_generator(block_bytes, block_generator, height)
+            npc_result = await self.blockchain.run_generator(block_bytes, block_generator)
             pre_validation_time = time.time() - pre_validation_start
 
             # blockchain.run_generator throws on errors, so npc_result is

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -2,7 +2,6 @@ import logging
 from typing import Dict, Optional
 from chia_rs import MEMPOOL_MODE, COND_CANON_INTS, NO_NEG_DIV
 
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.cost_calculator import NPCResult
 from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.full_node.generator import create_generator_args, setup_generator_args
@@ -25,7 +24,7 @@ def unwrap(x: Optional[uint32]) -> uint32:
 
 
 def get_name_puzzle_conditions(
-    generator: BlockGenerator, max_cost: int, *, cost_per_byte: int, mempool_mode: bool, height: Optional[uint32] = None
+    generator: BlockGenerator, max_cost: int, *, cost_per_byte: int, mempool_mode: bool
 ) -> NPCResult:
     block_program, block_program_args = setup_generator_args(generator)
     size_cost = len(bytes(generator.program)) * cost_per_byte
@@ -33,23 +32,17 @@ def get_name_puzzle_conditions(
     if max_cost < 0:
         return NPCResult(uint16(Err.INVALID_BLOCK_COST.value), None, uint64(0))
 
-    # in mempool mode, the height doesn't matter, because it's always strict.
-    # But otherwise, height must be specified to know which rules to apply
-    assert mempool_mode or height is not None
-
     # mempool mode also has these rules apply
     assert (MEMPOOL_MODE & COND_CANON_INTS) != 0
     assert (MEMPOOL_MODE & NO_NEG_DIV) != 0
 
     if mempool_mode:
         flags = MEMPOOL_MODE
-    elif unwrap(height) >= DEFAULT_CONSTANTS.SOFT_FORK_HEIGHT:
+    else:
         # conditions must use integers in canonical encoding (i.e. no redundant
         # leading zeros)
         # the division operator may not be used with negative operands
         flags = COND_CANON_INTS | NO_NEG_DIV
-    else:
-        flags = 0
 
     try:
         err, result = GENERATOR_MOD.run_as_generator(max_cost, flags, block_program, block_program_args)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -242,7 +242,7 @@ class TestBlockHeaderValidation:
         assert empty_blockchain.get_peak().height == len(blocks) - 1
 
     @pytest.mark.asyncio
-    async def test_unfinished_blocks(self, empty_blockchain, softfork_height, bt):
+    async def test_unfinished_blocks(self, empty_blockchain, bt):
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(3)
         for block in blocks[:-1]:
@@ -263,7 +263,7 @@ class TestBlockHeaderValidation:
         if unf.transactions_generator is not None:
             block_generator: BlockGenerator = await blockchain.get_block_generator(unf)
             block_bytes = bytes(unf)
-            npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
+            npc_result = await blockchain.run_generator(block_bytes, block_generator)
 
         validate_res = await blockchain.validate_unfinished_block(unf, npc_result, False)
         err = validate_res.error
@@ -287,7 +287,7 @@ class TestBlockHeaderValidation:
         if unf.transactions_generator is not None:
             block_generator: BlockGenerator = await blockchain.get_block_generator(unf)
             block_bytes = bytes(unf)
-            npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
+            npc_result = await blockchain.run_generator(block_bytes, block_generator)
         validate_res = await blockchain.validate_unfinished_block(unf, npc_result, False)
         assert validate_res.error is None
 
@@ -332,7 +332,7 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == num_blocks - 1
 
     @pytest.mark.asyncio
-    async def test_unf_block_overflow(self, empty_blockchain, softfork_height, bt):
+    async def test_unf_block_overflow(self, empty_blockchain, bt):
         blockchain = empty_blockchain
 
         blocks = []
@@ -366,7 +366,7 @@ class TestBlockHeaderValidation:
                 if block.transactions_generator is not None:
                     block_generator: BlockGenerator = await blockchain.get_block_generator(unf)
                     block_bytes = bytes(unf)
-                    npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
+                    npc_result = await blockchain.run_generator(block_bytes, block_generator)
                 validate_res = await blockchain.validate_unfinished_block(
                     unf, npc_result, skip_overflow_ss_validation=True
                 )
@@ -2261,7 +2261,7 @@ class TestBodyValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_cost_exceeds_max(self, empty_blockchain, softfork_height, bt):
+    async def test_cost_exceeds_max(self, empty_blockchain, bt):
         # 7
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2295,7 +2295,6 @@ class TestBodyValidation:
             b.constants.MAX_BLOCK_COST_CLVM * 1000,
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=softfork_height,
         )
         err = (await b.receive_block(blocks[-1], PreValidationResult(None, uint64(1), npc_result, True)))[1]
         assert err in [Err.BLOCK_COST_EXCEEDS_MAX]
@@ -2312,7 +2311,7 @@ class TestBodyValidation:
         pass
 
     @pytest.mark.asyncio
-    async def test_invalid_cost_in_block(self, empty_blockchain, softfork_height, bt):
+    async def test_invalid_cost_in_block(self, empty_blockchain, bt):
         # 9
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2356,7 +2355,6 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=softfork_height,
         )
         result, err, _ = await b.receive_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))
         assert err == Err.INVALID_BLOCK_COST
@@ -2381,7 +2379,6 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=softfork_height,
         )
         result, err, _ = await b.receive_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))
         assert err == Err.INVALID_BLOCK_COST
@@ -2406,7 +2403,6 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=softfork_height,
         )
 
         result, err, _ = await b.receive_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -265,7 +265,7 @@ class TestBlockchainTransactions:
                 await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_spend_reorg_coin(self, two_nodes, softfork_height):
+    async def test_validate_blockchain_spend_reorg_coin(self, two_nodes):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -306,7 +306,6 @@ class TestBlockchainTransactions:
             new_blocks[-1],
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
-            height=softfork_height,
         )[1]:
             if coin.puzzle_hash == receiver_1_puzzlehash:
                 coin_2 = coin
@@ -330,7 +329,6 @@ class TestBlockchainTransactions:
             new_blocks[-1],
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
-            height=softfork_height,
         )[1]:
             if coin.puzzle_hash == receiver_2_puzzlehash:
                 coin_3 = coin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,11 +93,6 @@ def db_version(request):
     return request.param
 
 
-@pytest.fixture(scope="function", params=[1000000, 2300000])
-def softfork_height(request):
-    return request.param
-
-
 saved_blocks_version = "rc5"
 
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -50,7 +50,7 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 
 class TestCoinStoreWithBlocks:
     @pytest.mark.asyncio
-    async def test_basic_coin_store(self, db_version, softfork_height, bt):
+    async def test_basic_coin_store(self, db_version, bt):
         wallet_a = WALLET_A
         reward_ph = wallet_a.get_new_puzzlehash()
 
@@ -99,7 +99,6 @@ class TestCoinStoreWithBlocks:
                             bt.constants.MAX_BLOCK_COST_CLVM,
                             cost_per_byte=bt.constants.COST_PER_BYTE,
                             mempool_mode=False,
-                            height=softfork_height,
                         )
                         tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
                     else:

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -24,7 +24,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.types.mempool_item import MempoolItem
 from chia.util.condition_tools import conditions_for_solution, pkm_pairs
 from chia.util.errors import Err
-from chia.util.ints import uint64, uint32
+from chia.util.ints import uint64
 from chia.util.hash import std_hash
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.api_decorators import api_request, peer_required, bytes_required
@@ -1856,7 +1856,6 @@ def generator_condition_tester(
     mempool_mode: bool = False,
     quote: bool = True,
     max_cost: int = MAX_BLOCK_COST_CLVM,
-    height: uint32,
 ) -> NPCResult:
     prg = f"(q ((0x0101010101010101010101010101010101010101010101010101010101010101 {'(q ' if quote else ''} {conditions} {')' if quote else ''} 123 (() (q . ())))))"  # noqa
     print(f"program: {prg}")
@@ -1864,47 +1863,45 @@ def generator_condition_tester(
     generator = BlockGenerator(program, [], [])
     print(f"len: {len(bytes(program))}")
     npc_result: NPCResult = get_name_puzzle_conditions(
-        generator, max_cost, cost_per_byte=COST_PER_BYTE, mempool_mode=mempool_mode, height=height
+        generator, max_cost, cost_per_byte=COST_PER_BYTE, mempool_mode=mempool_mode
     )
     return npc_result
 
 
 class TestGeneratorConditions:
-    def test_invalid_condition_args_terminator(self, softfork_height):
+    def test_invalid_condition_args_terminator(self):
 
         # note how the condition argument list isn't correctly terminated with a
         # NIL atom. This is allowed, and all arguments beyond the ones we look
         # at are ignored, including the termination of the list
-        npc_result = generator_condition_tester("(80 50 . 1)", height=softfork_height)
+        npc_result = generator_condition_tester("(80 50 . 1)")
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
         assert npc_result.conds.spends[0].seconds_relative == 50
 
     @pytest.mark.parametrize(
-        "mempool,height,operand,expected",
+        "mempool,operand,expected",
         [
-            (True, 0, -1, Err.GENERATOR_RUNTIME_ERROR.value),
-            (False, 1000000, -1, None),
-            (False, 2300000, -1, Err.GENERATOR_RUNTIME_ERROR.value),
-            (True, 0, 1, None),
-            (False, 1000000, 1, None),
-            (False, 2300000, 1, None),
+            (True, -1, Err.GENERATOR_RUNTIME_ERROR.value),
+            (False, -1, Err.GENERATOR_RUNTIME_ERROR.value),
+            (True, 1, None),
+            (False, 1, None),
         ],
     )
-    def test_div(self, mempool, height: uint32, operand, expected):
+    def test_div(self, mempool, operand, expected):
 
         # op_div is disallowed on negative numbers in the mempool, and after the
         # softfork
         npc_result = generator_condition_tester(
-            f"(c (c (q . 80) (c (/ (q . 50) (q . {operand})) ())) ())", quote=False, mempool_mode=mempool, height=height
+            f"(c (c (q . 80) (c (/ (q . 50) (q . {operand})) ())) ())", quote=False, mempool_mode=mempool
         )
         assert npc_result.error == expected
 
-    def test_invalid_condition_list_terminator(self, softfork_height):
+    def test_invalid_condition_list_terminator(self):
 
         # note how the list of conditions isn't correctly terminated with a
         # NIL atom. This is a failure
-        npc_result = generator_condition_tester("(80 50) . 3", height=softfork_height)
+        npc_result = generator_condition_tester("(80 50) . 3")
         assert npc_result.error in [Err.INVALID_CONDITION.value, Err.GENERATOR_RUNTIME_ERROR.value]
 
     @pytest.mark.parametrize(
@@ -1916,12 +1913,10 @@ class TestGeneratorConditions:
             ConditionOpcode.ASSERT_SECONDS_RELATIVE,
         ],
     )
-    def test_duplicate_height_time_conditions(self, opcode, softfork_height):
+    def test_duplicate_height_time_conditions(self, opcode):
         # even though the generator outputs multiple conditions, we only
         # need to return the highest one (i.e. most strict)
-        npc_result = generator_condition_tester(
-            " ".join([f"({opcode.value[0]} {i})" for i in range(50, 101)]), height=softfork_height
-        )
+        npc_result = generator_condition_tester(" ".join([f"({opcode.value[0]} {i})" for i in range(50, 101)]))
         print(npc_result)
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
@@ -1943,11 +1938,11 @@ class TestGeneratorConditions:
             ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT,
         ],
     )
-    def test_just_announcement(self, opcode, softfork_height):
+    def test_just_announcement(self, opcode):
         message = "a" * 1024
         # announcements are validated on the Rust side and never returned
         # back. They are either satisified or cause an immediate failure
-        npc_result = generator_condition_tester(f'({opcode.value[0]} "{message}") ' * 50, height=softfork_height)
+        npc_result = generator_condition_tester(f'({opcode.value[0]} "{message}") ' * 50)
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
         # create-announcements and assert-announcements are dropped once
@@ -1960,36 +1955,36 @@ class TestGeneratorConditions:
             ConditionOpcode.ASSERT_PUZZLE_ANNOUNCEMENT,
         ],
     )
-    def test_assert_announcement_fail(self, opcode, softfork_height):
+    def test_assert_announcement_fail(self, opcode):
         message = "a" * 1024
         # announcements are validated on the Rust side and never returned
         # back. They ar either satisified or cause an immediate failure
         # in this test we just assert announcements, we never make them, so
         # these should fail
-        npc_result = generator_condition_tester(f'({opcode.value[0]} "{message}") ', height=softfork_height)
+        npc_result = generator_condition_tester(f'({opcode.value[0]} "{message}") ')
         print(npc_result)
         assert npc_result.error == Err.ASSERT_ANNOUNCE_CONSUMED_FAILED.value
 
-    def test_multiple_reserve_fee(self, softfork_height):
+    def test_multiple_reserve_fee(self):
         # RESERVE_FEE
         cond = 52
         # even though the generator outputs 3 conditions, we only need to return one copy
         # with all the fees accumulated
-        npc_result = generator_condition_tester(f"({cond} 100) " * 3, height=softfork_height)
+        npc_result = generator_condition_tester(f"({cond} 100) " * 3)
         assert npc_result.error is None
         assert npc_result.conds.reserve_fee == 300
         assert len(npc_result.conds.spends) == 1
 
-    def test_duplicate_outputs(self, softfork_height):
+    def test_duplicate_outputs(self):
         # CREATE_COIN
         # creating multiple coins with the same properties (same parent, same
         # target puzzle hash and same amount) is not allowed. That's a consensus
         # failure.
         puzzle_hash = "abababababababababababababababab"
-        npc_result = generator_condition_tester(f'(51 "{puzzle_hash}" 10) ' * 2, height=softfork_height)
+        npc_result = generator_condition_tester(f'(51 "{puzzle_hash}" 10) ' * 2)
         assert npc_result.error == Err.DUPLICATE_OUTPUT.value
 
-    def test_create_coin_cost(self, softfork_height):
+    def test_create_coin_cost(self):
         # CREATE_COIN
         puzzle_hash = "abababababababababababababababab"
 
@@ -1997,7 +1992,6 @@ class TestGeneratorConditions:
         npc_result = generator_condition_tester(
             f'(51 "{puzzle_hash}" 10) ',
             max_cost=20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value,
-            height=softfork_height,
         )
         assert npc_result.error is None
         assert npc_result.cost == 20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value
@@ -2008,11 +2002,10 @@ class TestGeneratorConditions:
         npc_result = generator_condition_tester(
             f'(51 "{puzzle_hash}" 10) ',
             max_cost=20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value - 1,
-            height=softfork_height,
         )
         assert npc_result.error in [Err.BLOCK_COST_EXCEEDS_MAX.value, Err.INVALID_BLOCK_COST.value]
 
-    def test_agg_sig_cost(self, softfork_height):
+    def test_agg_sig_cost(self):
         # AGG_SIG_ME
         pubkey = "abababababababababababababababababababababababab"
 
@@ -2020,7 +2013,6 @@ class TestGeneratorConditions:
         npc_result = generator_condition_tester(
             f'(49 "{pubkey}" "foobar") ',
             max_cost=20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value,
-            height=softfork_height,
         )
         assert npc_result.error is None
         assert npc_result.cost == 20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value
@@ -2030,11 +2022,10 @@ class TestGeneratorConditions:
         npc_result = generator_condition_tester(
             f'(49 "{pubkey}" "foobar") ',
             max_cost=20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value - 1,
-            height=softfork_height,
         )
         assert npc_result.error in [Err.BLOCK_COST_EXCEEDS_MAX.value, Err.INVALID_BLOCK_COST.value]
 
-    def test_create_coin_different_parent(self, softfork_height):
+    def test_create_coin_different_parent(self):
 
         # if the coins we create have different parents, they are never
         # considered duplicate, even when they have the same puzzle hash and
@@ -2047,60 +2038,49 @@ class TestGeneratorConditions:
         )
         generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
-            generator, MAX_BLOCK_COST_CLVM, cost_per_byte=COST_PER_BYTE, mempool_mode=False, height=softfork_height
+            generator, MAX_BLOCK_COST_CLVM, cost_per_byte=COST_PER_BYTE, mempool_mode=False
         )
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 2
         for s in npc_result.conds.spends:
             assert s.create_coin == [(puzzle_hash.encode("ascii"), 10, None)]
 
-    def test_create_coin_different_puzzhash(self, softfork_height):
+    def test_create_coin_different_puzzhash(self):
         # CREATE_COIN
         # coins with different puzzle hashes are not considered duplicate
         puzzle_hash_1 = "abababababababababababababababab"
         puzzle_hash_2 = "cbcbcbcbcbcbcbcbcbcbcbcbcbcbcbcb"
-        npc_result = generator_condition_tester(
-            f'(51 "{puzzle_hash_1}" 5) (51 "{puzzle_hash_2}" 5)', height=softfork_height
-        )
+        npc_result = generator_condition_tester(f'(51 "{puzzle_hash_1}" 5) (51 "{puzzle_hash_2}" 5)')
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
         assert (puzzle_hash_1.encode("ascii"), 5, None) in npc_result.conds.spends[0].create_coin
         assert (puzzle_hash_2.encode("ascii"), 5, None) in npc_result.conds.spends[0].create_coin
 
-    def test_create_coin_different_amounts(self, softfork_height):
+    def test_create_coin_different_amounts(self):
         # CREATE_COIN
         # coins with different amounts are not considered duplicate
         puzzle_hash = "abababababababababababababababab"
-        npc_result = generator_condition_tester(
-            f'(51 "{puzzle_hash}" 5) (51 "{puzzle_hash}" 4)', height=softfork_height
-        )
+        npc_result = generator_condition_tester(f'(51 "{puzzle_hash}" 5) (51 "{puzzle_hash}" 4)')
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
         coins = npc_result.conds.spends[0].create_coin
         assert (puzzle_hash.encode("ascii"), 5, None) in coins
         assert (puzzle_hash.encode("ascii"), 4, None) in coins
 
-    def test_create_coin_with_hint(self, softfork_height):
+    def test_create_coin_with_hint(self):
         # CREATE_COIN
         puzzle_hash_1 = "abababababababababababababababab"
         hint = "12341234123412341234213421341234"
-        npc_result = generator_condition_tester(f'(51 "{puzzle_hash_1}" 5 ("{hint}"))', height=softfork_height)
+        npc_result = generator_condition_tester(f'(51 "{puzzle_hash_1}" 5 ("{hint}"))')
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
         coins = npc_result.conds.spends[0].create_coin
         assert coins == [(puzzle_hash_1.encode("ascii"), 5, hint.encode("ascii"))]
 
-    @pytest.mark.parametrize(
-        "mempool,height",
-        [
-            (True, None),
-            (False, 1000000),
-            (False, 2300000),
-        ],
-    )
-    def test_unknown_condition(self, mempool: bool, height: uint32):
+    @pytest.mark.parametrize("mempool", [True, False, False])
+    def test_unknown_condition(self, mempool: bool):
         for c in ['(2 100 "foo" "bar")', "(100)", "(4 1) (2 2) (3 3)", '("foobar")']:
-            npc_result = generator_condition_tester(c, mempool_mode=mempool, height=height)
+            npc_result = generator_condition_tester(c, mempool_mode=mempool)
             print(npc_result)
             if mempool:
                 assert npc_result.error == Err.INVALID_CONDITION.value
@@ -2235,25 +2215,13 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_ladder(self, request, opcode, softfork_height):
+    def test_duplicate_large_integer_ladder(self, request, opcode):
         condition = SINGLE_ARG_INT_LADDER_COND.format(opcode=opcode.value[0], num=28, filler="0x00")
 
         with assert_runtime(seconds=0.7, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
-        if softfork_height >= 2300000:
-            assert npc_result.error == error_for_condition(opcode)
-        else:
-            assert npc_result.error is None
-            assert len(npc_result.conds.spends) == 1
-            if opcode == ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE:
-                assert npc_result.conds.height_absolute == 28
-            elif opcode == ConditionOpcode.ASSERT_HEIGHT_RELATIVE:
-                assert npc_result.conds.spends[0].height_relative == 28
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_ABSOLUTE:
-                assert npc_result.conds.seconds_absolute == 28
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_RELATIVE:
-                assert npc_result.conds.spends[0].seconds_relative == 28
+        assert npc_result.error == error_for_condition(opcode)
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2265,26 +2233,13 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer(self, request, opcode, softfork_height):
+    def test_duplicate_large_integer(self, request, opcode):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
         with assert_runtime(seconds=1.1, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
-        if softfork_height >= 2300000:
-            assert npc_result.error == error_for_condition(opcode)
-        else:
-            assert npc_result.error is None
-            assert len(npc_result.conds.spends) == 1
-
-            if opcode == ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE:
-                assert npc_result.conds.height_absolute == 100
-            elif opcode == ConditionOpcode.ASSERT_HEIGHT_RELATIVE:
-                assert npc_result.conds.spends[0].height_relative == 100
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_ABSOLUTE:
-                assert npc_result.conds.seconds_absolute == 100
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_RELATIVE:
-                assert npc_result.conds.spends[0].seconds_relative == 100
+        assert npc_result.error == error_for_condition(opcode)
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2296,26 +2251,13 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_substr(self, request, opcode, softfork_height):
+    def test_duplicate_large_integer_substr(self, request, opcode):
         condition = SINGLE_ARG_INT_SUBSTR_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
         with assert_runtime(seconds=1.1, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
-        if softfork_height >= 2300000:
-            assert npc_result.error == error_for_condition(opcode)
-        else:
-            assert npc_result.error is None
-            assert len(npc_result.conds.spends) == 1
-
-            if opcode == ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE:
-                assert npc_result.conds.height_absolute == 100
-            elif opcode == ConditionOpcode.ASSERT_HEIGHT_RELATIVE:
-                assert npc_result.conds.spends[0].height_relative == 100
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_ABSOLUTE:
-                assert npc_result.conds.seconds_absolute == 100
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_RELATIVE:
-                assert npc_result.conds.spends[0].seconds_relative == 100
+        assert npc_result.error == error_for_condition(opcode)
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2327,28 +2269,15 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_substr_tail(self, request, opcode, softfork_height):
+    def test_duplicate_large_integer_substr_tail(self, request, opcode):
         condition = SINGLE_ARG_INT_SUBSTR_TAIL_COND.format(
             opcode=opcode.value[0], num=280, val="0xffffffff", filler="0x00"
         )
 
         with assert_runtime(seconds=0.3, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
-        if softfork_height >= 2300000:
-            assert npc_result.error == error_for_condition(opcode)
-        else:
-            assert npc_result.error is None
-            assert len(npc_result.conds.spends) == 1
-
-            if opcode == ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE:
-                assert npc_result.conds.height_absolute == 0xFFFFFFFF
-            elif opcode == ConditionOpcode.ASSERT_HEIGHT_RELATIVE:
-                assert npc_result.conds.spends[0].height_relative == 0xFFFFFFFF
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_ABSOLUTE:
-                assert npc_result.conds.seconds_absolute == 0xFFFFFFFF
-            elif opcode == ConditionOpcode.ASSERT_SECONDS_RELATIVE:
-                assert npc_result.conds.spends[0].seconds_relative == 0xFFFFFFFF
+        assert npc_result.error == error_for_condition(opcode)
 
     @pytest.mark.parametrize(
         "opcode",
@@ -2360,37 +2289,32 @@ class TestMaliciousGenerators:
         ],
     )
     @pytest.mark.benchmark
-    def test_duplicate_large_integer_negative(self, request, opcode, softfork_height):
+    def test_duplicate_large_integer_negative(self, request, opcode):
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0xff")
 
         with assert_runtime(seconds=1, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
 
     @pytest.mark.benchmark
-    def test_duplicate_reserve_fee(self, request, softfork_height):
+    def test_duplicate_reserve_fee(self, request):
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=280000, val=100, filler="0x00")
 
         with assert_runtime(seconds=1, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
-        if softfork_height >= 2300000:
-            assert npc_result.error == error_for_condition(opcode)
-        else:
-            assert npc_result.error is None
-            assert len(npc_result.conds.spends) == 1
-            assert npc_result.conds.reserve_fee == 100 * 280000
+        assert npc_result.error == error_for_condition(opcode)
 
     @pytest.mark.benchmark
-    def test_duplicate_reserve_fee_negative(self, request: pytest.FixtureRequest, softfork_height):
+    def test_duplicate_reserve_fee_negative(self, request: pytest.FixtureRequest):
         opcode = ConditionOpcode.RESERVE_FEE
         condition = SINGLE_ARG_INT_COND.format(opcode=opcode.value[0], num=200000, val=100, filler="0xff")
 
         with assert_runtime(seconds=0.8, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
         # RESERVE_FEE conditions fail unconditionally if they have a negative
         # amount
@@ -2401,11 +2325,11 @@ class TestMaliciousGenerators:
         "opcode", [ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT]
     )
     @pytest.mark.benchmark
-    def test_duplicate_coin_announces(self, request, opcode, softfork_height):
+    def test_duplicate_coin_announces(self, request, opcode):
         condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
 
         with assert_runtime(seconds=7, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1
@@ -2413,7 +2337,7 @@ class TestMaliciousGenerators:
         # TODO: optimize clvm to make this run in < 1 second
 
     @pytest.mark.benchmark
-    def test_create_coin_duplicates(self, request: pytest.FixtureRequest, softfork_height):
+    def test_create_coin_duplicates(self, request: pytest.FixtureRequest):
         # CREATE_COIN
         # this program will emit 6000 identical CREATE_COIN conditions. However,
         # we'll just end up looking at two of them, and fail at the first
@@ -2421,13 +2345,13 @@ class TestMaliciousGenerators:
         condition = CREATE_COIN.format(num=600000)
 
         with assert_runtime(seconds=0.8, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
         assert npc_result.error == Err.DUPLICATE_OUTPUT.value
         assert npc_result.conds is None
 
     @pytest.mark.benchmark
-    def test_many_create_coin(self, request, softfork_height):
+    def test_many_create_coin(self, request):
         # CREATE_COIN
         # this program will emit many CREATE_COIN conditions, all with different
         # amounts.
@@ -2435,7 +2359,7 @@ class TestMaliciousGenerators:
         condition = CREATE_UNIQUE_COINS.format(num=6094)
 
         with assert_runtime(seconds=0.3, label=request.node.name):
-            npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)
+            npc_result = generator_condition_tester(condition, quote=False)
 
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 1

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -48,7 +48,7 @@ def large_block_generator(size):
 
 class TestCostCalculation:
     @pytest.mark.asyncio
-    async def test_basics(self, softfork_height, bt):
+    async def test_basics(self, bt):
         wallet_tool = bt.get_pool_wallet_tool()
         ph = wallet_tool.get_new_puzzlehash()
         num_blocks = 3
@@ -74,7 +74,6 @@ class TestCostCalculation:
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=softfork_height,
         )
 
         assert npc_result.error is None
@@ -107,7 +106,7 @@ class TestCostCalculation:
         )
 
     @pytest.mark.asyncio
-    async def test_mempool_mode(self, softfork_height, bt):
+    async def test_mempool_mode(self, bt):
         wallet_tool = bt.get_pool_wallet_tool()
         ph = wallet_tool.get_new_puzzlehash()
 
@@ -146,7 +145,6 @@ class TestCostCalculation:
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
             mempool_mode=True,
-            height=softfork_height,
         )
         assert npc_result.error is not None
         npc_result = get_name_puzzle_conditions(
@@ -154,7 +152,6 @@ class TestCostCalculation:
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=softfork_height,
         )
         assert npc_result.error is None
 
@@ -165,7 +162,7 @@ class TestCostCalculation:
         assert error is None
 
     @pytest.mark.asyncio
-    async def test_clvm_mempool_mode(self, softfork_height):
+    async def test_clvm_mempool_mode(self):
         block = Program.from_bytes(bytes(SMALL_BLOCK_GENERATOR.program))
         disassembly = binutils.disassemble(block)
         # this is a valid generator program except the first clvm
@@ -186,13 +183,12 @@ class TestCostCalculation:
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
             mempool_mode=False,
-            height=softfork_height,
         )
         assert npc_result.error is None
 
     @pytest.mark.asyncio
     @pytest.mark.benchmark
-    async def test_tx_generator_speed(self, request, softfork_height):
+    async def test_tx_generator_speed(self, request):
         LARGE_BLOCK_COIN_CONSUMED_COUNT = 687
         generator_bytes = large_block_generator(LARGE_BLOCK_COIN_CONSUMED_COUNT)
         program = SerializedProgram.from_bytes(generator_bytes)
@@ -204,14 +200,13 @@ class TestCostCalculation:
                 test_constants.MAX_BLOCK_COST_CLVM,
                 cost_per_byte=test_constants.COST_PER_BYTE,
                 mempool_mode=False,
-                height=softfork_height,
             )
 
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == LARGE_BLOCK_COIN_CONSUMED_COUNT
 
     @pytest.mark.asyncio
-    async def test_clvm_max_cost(self, softfork_height):
+    async def test_clvm_max_cost(self):
 
         block = Program.from_bytes(bytes(SMALL_BLOCK_GENERATOR.program))
         disassembly = binutils.disassemble(block)
@@ -231,7 +226,6 @@ class TestCostCalculation:
             10000000,
             cost_per_byte=0,
             mempool_mode=False,
-            height=softfork_height,
         )
 
         assert npc_result.error is not None
@@ -239,9 +233,7 @@ class TestCostCalculation:
 
         # raise the max cost to make sure this passes
         # ensure we pass if the program does not exceeds the cost
-        npc_result = get_name_puzzle_conditions(
-            generator, 23000000, cost_per_byte=0, mempool_mode=False, height=softfork_height
-        )
+        npc_result = get_name_puzzle_conditions(generator, 23000000, cost_per_byte=0, mempool_mode=False)
 
         assert npc_result.error is None
         assert npc_result.cost > 10000000

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -92,16 +92,14 @@ class TestROM:
         assert cost == EXPECTED_ABBREVIATED_COST
         assert r.as_bin().hex() == EXPECTED_OUTPUT
 
-    def test_get_name_puzzle_conditions(self, softfork_height):
+    def test_get_name_puzzle_conditions(self):
         # this tests that extra block or coin data doesn't confuse `get_name_puzzle_conditions`
 
         gen = block_generator()
         cost, r = run_generator_unsafe(gen, max_cost=MAX_COST)
         print(r)
 
-        npc_result = get_name_puzzle_conditions(
-            gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, mempool_mode=False, height=softfork_height
-        )
+        npc_result = get_name_puzzle_conditions(gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, mempool_mode=False)
         assert npc_result.error is None
         assert npc_result.cost == EXPECTED_COST + ConditionCost.CREATE_COIN.value + (
             len(bytes(gen.program)) * COST_PER_BYTE

--- a/tests/util/generator_tools_testing.py
+++ b/tests/util/generator_tools_testing.py
@@ -6,11 +6,10 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.generator_types import BlockGenerator
 from chia.util.generator_tools import tx_removals_and_additions
-from chia.util.ints import uint32
 
 
 def run_and_get_removals_and_additions(
-    block: FullBlock, max_cost: int, *, cost_per_byte: int, height: uint32, mempool_mode=False
+    block: FullBlock, max_cost: int, *, cost_per_byte: int, mempool_mode=False
 ) -> Tuple[List[bytes32], List[Coin]]:
     removals: List[bytes32] = []
     additions: List[Coin] = []
@@ -25,7 +24,6 @@ def run_and_get_removals_and_additions(
             max_cost,
             cost_per_byte=cost_per_byte,
             mempool_mode=mempool_mode,
-            height=height,
         )
         assert npc_result.error is None
         rem, add = tx_removals_and_additions(npc_result.conds)

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -41,7 +41,6 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import click
-from chia_rs import COND_CANON_INTS, NO_NEG_DIV
 from clvm.casts import int_from_bytes
 
 from chia.consensus.constants import ConsensusConstants
@@ -96,20 +95,10 @@ def npc_to_dict(npc: NPC):
     }
 
 
-def run_generator(
-    block_generator: BlockGenerator, constants: ConsensusConstants, max_cost: int, height: uint32
-) -> List[CAT]:
-
-    if height >= DEFAULT_CONSTANTS.SOFT_FORK_HEIGHT:
-        # conditions must use integers in canonical encoding (i.e. no redundant
-        # leading zeros)
-        # the division operator may not be used with negative operands
-        flags = COND_CANON_INTS | NO_NEG_DIV
-    else:
-        flags = 0
+def run_generator(block_generator: BlockGenerator, constants: ConsensusConstants, max_cost: int) -> List[CAT]:
 
     args = create_generator_args(block_generator.generator_refs).first()
-    _, block_result = block_generator.program.run_with_cost(max_cost, flags, args)
+    _, block_result = block_generator.program.run_with_cost(max_cost, 0, args)
 
     coin_spends = block_result.first()
 
@@ -188,13 +177,12 @@ def run_generator_with_args(
     generator_args: List[SerializedProgram],
     constants: ConsensusConstants,
     cost: uint64,
-    height: uint32,
 ) -> List[CAT]:
     if not generator_program_hex:
         return []
     generator_program = SerializedProgram.fromhex(generator_program_hex)
     block_generator = BlockGenerator(generator_program, generator_args, [])
-    return run_generator(block_generator, constants, min(constants.MAX_BLOCK_COST_CLVM, cost), height)
+    return run_generator(block_generator, constants, min(constants.MAX_BLOCK_COST_CLVM, cost))
 
 
 @click.command()
@@ -208,12 +196,11 @@ def run_json_block(full_block, parent: Path, constants: ConsensusConstants) -> L
     ref_list = full_block["block"]["transactions_generator_ref_list"]
     tx_info: dict = full_block["block"]["transactions_info"]
     generator_program_hex: str = full_block["block"]["transactions_generator"]
-    height = full_block["block"]["reward_chain_block"]["height"]
     cat_list: List[CAT] = []
     if tx_info and generator_program_hex:
         cost = tx_info["cost"]
         args = ref_list_to_args(ref_list, parent)
-        cat_list = run_generator_with_args(generator_program_hex, args, constants, cost, height)
+        cat_list = run_generator_with_args(generator_program_hex, args, constants, cost)
 
     return cat_list
 

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -66,6 +66,24 @@ class FakeServer:
     def set_received_message_callback(self, callback: Callable):
         pass
 
+    async def get_peer_info(self) -> Optional[PeerInfo]:
+        return None
+
+    def get_full_node_outgoing_connections(self) -> List[ws.WSChiaConnection]:
+        return []
+
+    def is_duplicate_or_self_connection(self, target_node: PeerInfo) -> bool:
+        return False
+
+    async def start_client(
+        self,
+        target_node: PeerInfo,
+        on_connect: Callable = None,
+        auth: bool = False,
+        is_feeler: bool = False,
+    ) -> bool:
+        return False
+
 
 class FakePeer:
     def get_peer_logging(self) -> PeerInfo:
@@ -73,6 +91,9 @@ class FakePeer:
 
     def __init__(self):
         self.peer_node_id = bytes([0] * 32)
+
+    async def get_peer_info(self) -> Optional[PeerInfo]:
+        return None
 
 
 async def run_sync_test(


### PR DESCRIPTION
The whole chain can be validated with the post-soft-fork rules. Remove testing of pre-soft-fork rules.

This includes:

* removing the consensus constant `SOFT_FORK_HEIGHT`
* removing the `height` parameter from `run_generator()` and `get_name_puzzle_conditions()`, as it no longer depends on the block height (along with a whole bunch of passing around block height)
* simplify logic in `get_name_puzzle_conditions()` to always pass in the stricter flags (`COND_CANON_INTS` and `NO_NEG_DIV`)
* removing the `softfork_height` test fixture, which removes a bunch of test runs

There were also a few new member functions I had to add to the mocked peer and server objects in `test_full_sync.py` to make it pass.