### PR TITLE
Allow Identification of CAT1 coins in offers.

### DIFF
--- a/chia/wallet/cat_wallet/cat_outer_puzzle.py
+++ b/chia/wallet/cat_wallet/cat_outer_puzzle.py
@@ -11,6 +11,7 @@ from chia.wallet.cat_wallet.cat_utils import (
     SpendableCAT,
     construct_cat_puzzle,
     match_cat_puzzle,
+    match_cat1_puzzle,
     unsigned_spend_bundle_for_spendable_cats,
 )
 from chia.wallet.lineage_proof import LineageProof
@@ -112,3 +113,42 @@ class CATOuterPuzzle:
             )
         bundle = unsigned_spend_bundle_for_spendable_cats(CAT_MOD, spendable_cats)
         return next(cs.solution.to_program() for cs in bundle.coin_spends if cs.coin == target_coin)
+
+
+@dataclass(frozen=True)
+class CAT1OuterPuzzle:
+    """
+    This driver is here to allow devs to get limited data from CAT1 coins.
+    It also allows the trade_manager to identify EOL Cat1 coins.
+    """
+
+    _match: Any
+    _asset_id: Any
+    _construct: Any
+    _solve: Any
+    _get_inner_puzzle: Any
+    _get_inner_solution: Any
+
+    def match(self, puzzle: Program) -> Optional[PuzzleInfo]:
+        matched, curried_args = match_cat1_puzzle(puzzle)
+        if matched:
+            raise ValueError("Cat1 is no longer supported")
+        else:
+            return None
+
+    def get_inner_puzzle(self, *args: Any) -> Optional[Program]:
+        return None
+
+    def get_inner_solution(self, *args: Any) -> Optional[Program]:
+        return None
+
+    def asset_id(self, constructor: PuzzleInfo) -> Optional[bytes32]:
+        return bytes32(constructor["tail"])
+
+    def construct(self, *args: Any) -> Program:
+        program: Program = Program.to(None)
+        return program
+
+    def solve(self, *args: Any) -> Program:
+        program: Program = Program.to(None)
+        return program

--- a/chia/wallet/cat_wallet/cat_outer_puzzle.py
+++ b/chia/wallet/cat_wallet/cat_outer_puzzle.py
@@ -132,7 +132,7 @@ class CAT1OuterPuzzle:
     def match(self, puzzle: Program) -> Optional[PuzzleInfo]:
         matched, curried_args = match_cat1_puzzle(puzzle)
         if matched:
-            raise ValueError("Cat1 is no longer supported")
+            raise ValueError("CAT1 is no longer supported!")
         else:
             return None
 

--- a/chia/wallet/cat_wallet/cat_utils.py
+++ b/chia/wallet/cat_wallet/cat_utils.py
@@ -41,6 +41,17 @@ def match_cat_puzzle(puzzle: Program) -> Tuple[bool, Iterator[Program]]:
         return False, iter(())
 
 
+def match_cat1_puzzle(puzzle: Program) -> Tuple[bool, Iterator[Program]]:
+    """
+    Given a puzzle test if it's a CAT1 and, if it is, return the curried arguments.
+    """
+    mod, curried_args = puzzle.uncurry()
+    if mod.get_tree_hash() == bytes32.from_hexstr("72dec062874cd4d3aab892a0906688a1ae412b0109982e1797a170add88bdcdc"):
+        return True, curried_args.as_iter()
+    else:
+        return False, iter(())
+
+
 def get_innerpuzzle_from_puzzle(puzzle: Program) -> Program:
     mod, curried_args = puzzle.uncurry()
     if mod == CAT_MOD:

--- a/chia/wallet/outer_puzzles.py
+++ b/chia/wallet/outer_puzzles.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional
 
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.wallet.cat_wallet.cat_outer_puzzle import CATOuterPuzzle
+from chia.wallet.cat_wallet.cat_outer_puzzle import CATOuterPuzzle, CAT1OuterPuzzle
 from chia.wallet.nft_wallet.metadata_outer_puzzle import MetadataOuterPuzzle
 from chia.wallet.nft_wallet.ownership_outer_puzzle import OwnershipOuterPuzzle
 from chia.wallet.nft_wallet.singleton_outer_puzzle import SingletonOuterPuzzle
@@ -36,6 +36,7 @@ class AssetType(Enum):
     METADATA = "metadata"
     OWNERSHIP = "ownership"
     ROYALTY_TRANSFER_PROGRAM = "royalty transfer program"
+    CAT1 = "EOL CAT1"
 
 
 def match_puzzle(puzzle: Program) -> Optional[PuzzleInfo]:
@@ -76,4 +77,5 @@ driver_lookup: Dict[AssetType, Any] = {
     AssetType.METADATA: MetadataOuterPuzzle(*function_args),
     AssetType.OWNERSHIP: OwnershipOuterPuzzle(*function_args),
     AssetType.ROYALTY_TRANSFER_PROGRAM: TransferProgramPuzzle(*function_args),
+    AssetType.CAT1: CAT1OuterPuzzle(*function_args),
 }


### PR DESCRIPTION
- [x] 1.5 gets merged into main

This adds a function to identify cat1 coins, and a shell driver that throws a value error making the offer invalid 