### PR TITLE
separate trusted and non-trusted wallet sync to simplify them a bit

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -880,11 +880,13 @@ class WalletStateManager:
         used_up_to = -1
         ph_to_index_cache: LRUCache = LRUCache(100)
 
-        for coin_state_idx, coin_state in enumerate(coin_states):
+        for coin_state in coin_states:
             coin_name: bytes32 = coin_state.coin.name()
             wallet_info: Optional[Tuple[uint32, WalletType]] = await self.get_wallet_id_for_puzzle_hash(
                 coin_state.coin.puzzle_hash
             )
+
+            # TODO: it would be nice to get rid of this lookup
             local_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(coin_name)
             self.log.debug("%s: %s", coin_name, coin_state)
 


### PR DESCRIPTION
and don't chunk coin states in trusted sync.