### PR TITLE
Add small coin selection improvements

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -422,7 +422,11 @@ class CATWallet:
         return result
 
     async def select_coins(
-        self, amount: uint64, exclude: Optional[List[Coin]] = None, min_coin_amount: Optional[uint64] = None
+        self,
+        amount: uint64,
+        exclude: Optional[List[Coin]] = None,
+        min_coin_amount: Optional[uint64] = None,
+        max_coin_amount: Optional[uint64] = None,
     ) -> Set[Coin]:
         """
         Returns a set of coins that can be used for generating a new transaction.
@@ -436,10 +440,11 @@ class CATWallet:
         unconfirmed_removals: Dict[bytes32, Coin] = await self.wallet_state_manager.unconfirmed_removals_for_wallet(
             self.id()
         )
-
+        if max_coin_amount is None:
+            max_coin_amount = uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT)
         coins = await select_coins(
             spendable_amount,
-            uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT),
+            max_coin_amount,
             spendable_coins,
             unconfirmed_removals,
             self.log,

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -439,7 +439,7 @@ class CATWallet:
 
         coins = await select_coins(
             spendable_amount,
-            self.wallet_state_manager.constants.MAX_COIN_AMOUNT,
+            uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT),
             spendable_coins,
             unconfirmed_removals,
             self.log,

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -102,7 +102,7 @@ async def select_coins(
                 coin_set = {greater_coin}
         return coin_set
     else:
-        # if smaller_coin_sum == amount and len(smaller_coins) >= max_num_coins, or amount == 0.
+        # if smaller_coin_sum == amount and (len(smaller_coins) >= max_num_coins or amount == 0)
         potential_large_coin: Optional[Coin] = select_smallest_coin_over_target(amount, valid_spendable_coins)
         if potential_large_coin is None:
             raise ValueError("Too many coins are required to make this transaction")

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -44,7 +44,7 @@ async def select_coins(
             continue
         if coin_record.coin in exclude:
             continue
-        if coin_record.coin.amount < min_coin_amount:
+        if coin_record.coin.amount < min_coin_amount or coin_record.coin.amount > max_coin_amount:
             continue
         valid_spendable_coins.append(coin_record.coin)
         sum_spendable_coins += coin_record.coin.amount

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -10,7 +10,7 @@ from chia.wallet.wallet_coin_record import WalletCoinRecord
 
 async def select_coins(
     spendable_amount: uint128,
-    max_coin_amount: int,
+    max_coin_amount: uint64,
     spendable_coins: List[WalletCoinRecord],
     unconfirmed_removals: Dict[bytes32, Coin],
     log: logging.Logger,

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -56,6 +56,11 @@ async def select_coins(
             f"Transaction for {amount} is greater than spendable balance of {sum_spendable_coins}. "
             "There may be other transactions pending or our minimum coin amount is too high."
         )
+    if amount == 0 and sum_spendable_coins == 0:
+        raise ValueError(
+            "No coins available to spend, you can not create a coin with an amount of 0,"
+            " without already having coins."
+        )
 
     # Sort the coins by amount
     valid_spendable_coins.sort(reverse=True, key=lambda r: r.amount)

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -74,7 +74,7 @@ async def select_coins(
         if coin.amount < amount:
             smaller_coin_sum += coin.amount
             smaller_coins.append(coin)
-    if smaller_coin_sum == amount and len(smaller_coins) < max_num_coins:
+    if smaller_coin_sum == amount and len(smaller_coins) < max_num_coins and amount != 0:
         log.debug(f"Selected all smaller coins because they equate to an exact match of the target.: {smaller_coins}")
         return set(smaller_coins)
     elif smaller_coin_sum < amount:
@@ -97,7 +97,7 @@ async def select_coins(
                 coin_set = {greater_coin}
         return coin_set
     else:
-        # if smaller_coin_sum == amount and len(smaller_coins) >= max_num_coins.
+        # if smaller_coin_sum == amount and len(smaller_coins) >= max_num_coins, or amount == 0.
         potential_large_coin: Optional[Coin] = select_smallest_coin_over_target(amount, valid_spendable_coins)
         if potential_large_coin is None:
             raise ValueError("Too many coins are required to make this transaction")

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -297,7 +297,11 @@ class DIDWallet:
         return await self.wallet_state_manager.get_unconfirmed_balance(self.id(), record_list)
 
     async def select_coins(
-        self, amount: uint64, exclude: Optional[List[Coin]] = None, min_coin_amount: Optional[uint64] = None
+        self,
+        amount: uint64,
+        exclude: Optional[List[Coin]] = None,
+        min_coin_amount: Optional[uint64] = None,
+        max_coin_amount: Optional[uint64] = None,
     ) -> Optional[Set[Coin]]:
         """
         Returns a set of coins that can be used for generating a new transaction.
@@ -320,10 +324,11 @@ class DIDWallet:
         unconfirmed_removals: Dict[bytes32, Coin] = await self.wallet_state_manager.unconfirmed_removals_for_wallet(
             self.wallet_info.id
         )
-
+        if max_coin_amount is None:
+            max_coin_amount = uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT)
         coins = await select_coins(
             spendable_amount,
-            uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT),
+            max_coin_amount,
             spendable_coins,
             unconfirmed_removals,
             self.log,

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -323,7 +323,7 @@ class DIDWallet:
 
         coins = await select_coins(
             spendable_amount,
-            self.wallet_state_manager.constants.MAX_COIN_AMOUNT,
+            uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT),
             spendable_coins,
             unconfirmed_removals,
             self.log,

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -247,7 +247,11 @@ class Wallet:
         return Program.to(python_program)
 
     async def select_coins(
-        self, amount: uint64, exclude: Optional[List[Coin]] = None, min_coin_amount: Optional[uint64] = None
+        self,
+        amount: uint64,
+        exclude: Optional[List[Coin]] = None,
+        min_coin_amount: Optional[uint64] = None,
+        max_coin_amount: Optional[uint64] = None,
     ) -> Set[Coin]:
         """
         Returns a set of coins that can be used for generating a new transaction.
@@ -263,10 +267,11 @@ class Wallet:
         unconfirmed_removals: Dict[bytes32, Coin] = await self.wallet_state_manager.unconfirmed_removals_for_wallet(
             self.id()
         )
-
+        if max_coin_amount is None:
+            max_coin_amount = uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT)
         coins = await select_coins(
             spendable_amount,
-            uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT),
+            max_coin_amount,
             spendable_coins,
             unconfirmed_removals,
             self.log,

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -266,7 +266,7 @@ class Wallet:
 
         coins = await select_coins(
             spendable_amount,
-            self.wallet_state_manager.constants.MAX_COIN_AMOUNT,
+            uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT),
             spendable_coins,
             unconfirmed_removals,
             self.log,

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -502,3 +502,26 @@ class TestCoinSelection:
                 amount=target_amount,
                 exclude=exclude_all_coins,
             )
+
+    @pytest.mark.asyncio
+    async def test_coin_selection_with_zero_amount(self, a_hash: bytes32) -> None:
+        coin_amounts = [3, 6, 20, 40, 80, 150, 160, 203, 202, 201, 320]
+        coin_list: List[WalletCoinRecord] = [
+            WalletCoinRecord(Coin(a_hash, a_hash, uint64(a)), uint32(1), uint32(1), False, True, WalletType(0), 1)
+            for a in coin_amounts
+        ]
+        spendable_amount = uint128(sum(coin_amounts))
+
+        # validate that a zero amount is handled correctly
+        target_amount = uint128(0)
+        zero_amount_result: Set[Coin] = await select_coins(
+            spendable_amount,
+            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            coin_list,
+            {},
+            logging.getLogger("test"),
+            target_amount,
+        )
+        assert zero_amount_result is not None
+        assert sum([coin.amount for coin in zero_amount_result]) >= target_amount
+        assert len(zero_amount_result) == 1

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -81,7 +81,7 @@ class TestCoinSelection:
         for target_amount in coin_amounts[:100]:  # select the first 100 values
             result: Set[Coin] = await select_coins(
                 spendable_amount,
-                DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                 coin_list,
                 {},
                 logging.getLogger("test"),
@@ -110,7 +110,7 @@ class TestCoinSelection:
             print("Target amount: ", target_amount)
             result: Set[Coin] = await select_coins(
                 spendable_amount,
-                DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                 coin_list,
                 {},
                 logging.getLogger("test"),
@@ -130,7 +130,7 @@ class TestCoinSelection:
         for target_amount in [50000, 25000, 15000, 10000, 9000, 3000]:  # select the first 100 values
             dusty_result: Set[Coin] = await select_coins(
                 spendable_amount,
-                DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                 coin_list,
                 {},
                 logging.getLogger("test"),
@@ -161,7 +161,7 @@ class TestCoinSelection:
         for target_amount in [20000, 15000, 10000, 5000]:  # select the first 100 values
             dusty_below_target: Set[Coin] = await select_coins(
                 spendable_amount,
-                DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                 new_coin_list,
                 {},
                 logging.getLogger("test"),
@@ -192,7 +192,7 @@ class TestCoinSelection:
         for target_amount in [50000, 10001, 10000, 9999]:
             dusty_below_target: Set[Coin] = await select_coins(
                 spendable_amount,
-                DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                 new_coin_list,
                 {},
                 logging.getLogger("test"),
@@ -218,7 +218,7 @@ class TestCoinSelection:
             for target_amount in [10000, 9999]:
                 await select_coins(
                     spendable_amount,
-                    DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                    uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                     coin_list,
                     {},
                     logging.getLogger("test"),
@@ -229,7 +229,7 @@ class TestCoinSelection:
             for target_amount in [10001, 20000]:
                 await select_coins(
                     spendable_amount,
-                    DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                    uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                     coin_list,
                     {},
                     logging.getLogger("test"),
@@ -249,7 +249,7 @@ class TestCoinSelection:
         target_amount = uint128(40)
         exact_match_result: Set[Coin] = await select_coins(
             spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             coin_list,
             {},
             logging.getLogger("test"),
@@ -263,7 +263,7 @@ class TestCoinSelection:
         target_amount = uint128(153)
         match_2: Set[Coin] = await select_coins(
             spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             coin_list,
             {},
             logging.getLogger("test"),
@@ -276,7 +276,7 @@ class TestCoinSelection:
         target_amount = uint128(541)
         match_3: Set[Coin] = await select_coins(
             spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             coin_list,
             {},
             logging.getLogger("test"),
@@ -290,7 +290,7 @@ class TestCoinSelection:
         target_amount = spendable_amount
         match_all: Set[Coin] = await select_coins(
             spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             coin_list,
             {},
             logging.getLogger("test"),
@@ -310,7 +310,7 @@ class TestCoinSelection:
         target_amount = uint128(625)
         smallest_result: Set[Coin] = await select_coins(
             greater_spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             greater_coin_list,
             {},
             logging.getLogger("test"),
@@ -328,7 +328,7 @@ class TestCoinSelection:
         target_amount = uint128(50000)
         single_greater_result: Set[Coin] = await select_coins(
             single_greater_spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             single_greater_coin_list,
             {},
             logging.getLogger("test"),
@@ -348,7 +348,7 @@ class TestCoinSelection:
         target_amount = uint128(70000)
         multiple_greater_result: Set[Coin] = await select_coins(
             multiple_greater_spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             multiple_greater_coin_list,
             {},
             logging.getLogger("test"),
@@ -378,7 +378,7 @@ class TestCoinSelection:
         target_amount = spendable_amount - 1
         result: Set[Coin] = await select_coins(
             spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             coin_list,
             {},
             logging.getLogger("test"),
@@ -444,7 +444,7 @@ class TestCoinSelection:
             for min_coin_amount in [10, 100, 200, 300, 1000]:
                 result: Set[Coin] = await select_coins(
                     spendable_amount,
-                    DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                    uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                     coin_list,
                     {},
                     logging.getLogger("test"),
@@ -477,7 +477,7 @@ class TestCoinSelection:
         # test that excluded coins are not included in the result
         selected_coins: Set[Coin] = await select_coins(
             spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             spendable_wallet_coin_records,
             {},
             logging.getLogger("test"),
@@ -495,7 +495,7 @@ class TestCoinSelection:
         with pytest.raises(ValueError):
             await select_coins(
                 spendable_amount,
-                DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+                uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
                 spendable_wallet_coin_records,
                 {},
                 logging.getLogger("test"),
@@ -516,7 +516,7 @@ class TestCoinSelection:
         target_amount = uint128(0)
         zero_amount_result: Set[Coin] = await select_coins(
             spendable_amount,
-            DEFAULT_CONSTANTS.MAX_COIN_AMOUNT,
+            uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
             coin_list,
             {},
             logging.getLogger("test"),

--- a/tests/wallet/test_coin_selection.py
+++ b/tests/wallet/test_coin_selection.py
@@ -525,3 +525,13 @@ class TestCoinSelection:
         assert zero_amount_result is not None
         assert sum([coin.amount for coin in zero_amount_result]) >= target_amount
         assert len(zero_amount_result) == 1
+        # make sure that a failure is properly raised if we don't have any coins.
+        with pytest.raises(ValueError):
+            await select_coins(
+                uint128(0),
+                uint64(DEFAULT_CONSTANTS.MAX_COIN_AMOUNT),
+                [],
+                {},
+                logging.getLogger("test"),
+                target_amount,
+            )


### PR DESCRIPTION
- Add support for a target of 0
- Change type of max_coin_amount to uint64
- Validate if coins are below max_coin_amount for future RPC use.

I would go commit by commit for easier reviewing.  