### PR TITLE
optimize get_coins_to_check()

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -65,7 +65,6 @@ from chia.wallet.util.wallet_sync_utils import (
     subscribe_to_phs,
 )
 from chia.wallet.wallet_action import WalletAction
-from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_state_manager import WalletStateManager
 from chia.wallet.wallet_weight_proof_handler import get_wp_fork_point
 
@@ -1228,8 +1227,7 @@ class WalletNode:
         return all_puzzle_hashes
 
     async def get_coin_ids_to_subscribe(self, min_height: int) -> List[bytes32]:
-        all_coins: Set[WalletCoinRecord] = await self.wallet_state_manager.coin_store.get_coins_to_check(min_height)
-        all_coin_names: Set[bytes32] = {coin_record.name() for coin_record in all_coins}
+        all_coin_names: Set[bytes32] = await self.wallet_state_manager.coin_store.get_coin_names_to_check(min_height)
         removed_dict = await self.wallet_state_manager.trade_manager.get_coins_of_interest()
         all_coin_names.update(removed_dict.keys())
         all_coin_names.update(await self.wallet_state_manager.interested_store.get_interested_coin_ids())

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -264,7 +264,7 @@ def record(c: Coin, *, confirmed: int, spent: int) -> WalletCoinRecord:
 
 
 @pytest.mark.asyncio
-async def test_get_coins_to_check() -> None:
+async def test_get_coin_names_to_check() -> None:
 
     r1 = record(coin_1, confirmed=1, spent=0)
     r2 = record(coin_2, confirmed=2, spent=4)
@@ -288,22 +288,22 @@ async def test_get_coins_to_check() -> None:
 
         for i in range(10):
 
-            coins = await store.get_coins_to_check(i)
+            coins = await store.get_coin_names_to_check(i)
 
             # r1 is unspent and should always be included, regardless of height
-            assert r1 in coins
+            assert r1.coin.name() in coins
             # r2 was spent at height 4
-            assert (r2 in coins) == (i < 4)
+            assert (r2.coin.name() in coins) == (i < 4)
             # r3 was spent at height 5
-            assert (r3 in coins) == (i < 5)
+            assert (r3.coin.name() in coins) == (i < 5)
             # r4 was spent at height 6
-            assert (r4 in coins) == (i < 6)
+            assert (r4.coin.name() in coins) == (i < 6)
             # r5 was spent at height 7
-            assert (r5 in coins) == (i < 7)
+            assert (r5.coin.name() in coins) == (i < 7)
             # r6 was confirmed at height 6
-            assert (r6 in coins) == (i < 6)
+            assert (r6.coin.name() in coins) == (i < 6)
             # r7 was confirmed at height 7
-            assert (r7 in coins) == (i < 7)
+            assert (r7.coin.name() in coins) == (i < 7)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
by returning the coin_names directly, rather than allocating full WalletCoinRecords and then compute the names