### PR TITLE
try not starting RPC in setup

### DIFF
--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -307,6 +307,7 @@ async def setup_full_system(
                 True,
                 connect_to_daemon=connect_to_daemon,
                 db_version=db_version,
+                start_rpc_server=True,
             )
             for i in range(2)
         ]

--- a/tests/setup_services.py
+++ b/tests/setup_services.py
@@ -79,6 +79,7 @@ async def setup_full_node(
     connect_to_daemon=False,
     db_version=1,
     disable_capabilities: Optional[List[Capability]] = None,
+    start_rpc_server: bool = False,
 ):
     db_path = local_bt.root_path / f"{db_name}"
     if db_path.exists():
@@ -107,7 +108,7 @@ async def setup_full_node(
     service_config["dns_servers"] = []
     service_config["port"] = 0
     service_config["rpc_port"] = 0
-    service_config["start_rpc_server"] = False
+    service_config["start_rpc_server"] = start_rpc_server
     config["simulator"]["auto_farm"] = False  # Disable Auto Farm for tests
     config["simulator"]["use_current_time"] = False  # Disable Real timestamps when running tests
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]

--- a/tests/setup_services.py
+++ b/tests/setup_services.py
@@ -107,6 +107,7 @@ async def setup_full_node(
     service_config["dns_servers"] = []
     service_config["port"] = 0
     service_config["rpc_port"] = 0
+    service_config["start_rpc_server"] = False
     config["simulator"]["auto_farm"] = False  # Disable Auto Farm for tests
     config["simulator"]["use_current_time"] = False  # Disable Real timestamps when running tests
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
@@ -175,6 +176,7 @@ async def setup_wallet_node(
             db_path.unlink()
         service_config["database_path"] = str(db_name)
         service_config["testing"] = True
+        service_config["start_rpc_server"] = False
 
         service_config["introducer_peer"]["host"] = self_hostname
         if introducer_port is not None:
@@ -225,6 +227,7 @@ async def setup_harvester(
         config["harvester"]["selected_network"] = "testnet0"
         config["harvester"]["port"] = 0
         config["harvester"]["rpc_port"] = 0
+        config["harvester"]["start_rpc_server"] = False
         config["harvester"]["farmer_peer"]["host"] = self_hostname
         config["harvester"]["farmer_peer"]["port"] = int(farmer_port)
         config["harvester"]["plot_directories"] = [str(b_tools.plot_dir.resolve())]
@@ -268,6 +271,7 @@ async def setup_farmer(
     service_config["pool_public_keys"] = [bytes(pk).hex() for pk in b_tools.pool_pubkeys]
     service_config["port"] = port
     service_config["rpc_port"] = uint16(0)
+    service_config["start_rpc_server"] = False
     config_pool["xch_target_address"] = encode_puzzle_hash(b_tools.pool_ph, "xch")
 
     if full_node_port:


### PR DESCRIPTION
Trying to fix the RPC port flaky test issue:
https://github.com/Chia-Network/chia-blockchain/runs/7610404145?check_suite_focus=true

There are duplicate RPC servers created, 2 for each service. This removes the duplicate.
Let's see what happens. It's not clear that this will fix the flaky test, but it's better to not start duplicate servers.

EDIT: this does not fix the flaky test, as the test failed again in this PR:
https://github.com/Chia-Network/chia-blockchain/runs/7630283862?check_suite_focus=true