### PR TITLE
Increase timeouts to reduce flakiness

### DIFF
--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -94,7 +94,7 @@ class TestPerformance:
             )
             await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), fake_peer)
 
-        await time_out_assert(10, node_height_at_least, True, full_node_1, start_height + 20)
+        await time_out_assert(20, node_height_at_least, True, full_node_1, start_height + 20)
 
         spend_bundles = []
         spend_bundle_ids = []

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -35,7 +35,7 @@ class TestTransactions:
         # funds += calculate_base_farmer_reward(0)
         await asyncio.sleep(2)
         print(await wallet.get_confirmed_balance(), funds)
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
     @pytest.mark.asyncio
     async def test_tx_propagation(self, three_nodes_two_wallets, self_hostname):
@@ -68,7 +68,7 @@ class TestTransactions:
         funds = sum(
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
-        await time_out_assert(10, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
         async def peak_height(fna: FullNodeAPI):
             peak: Optional[BlockRecord] = fna.full_node.blockchain.get_peak()
@@ -77,8 +77,8 @@ class TestTransactions:
             peak_height = peak.height
             return peak_height
 
-        await time_out_assert(10, peak_height, num_blocks, full_node_api_1)
-        await time_out_assert(10, peak_height, num_blocks, full_node_api_2)
+        await time_out_assert(20, peak_height, num_blocks, full_node_api_1)
+        await time_out_assert(20, peak_height, num_blocks, full_node_api_2)
 
         tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, ph1, 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
@@ -117,7 +117,7 @@ class TestTransactions:
             wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance,
             (funds - 10),
         )
-        await time_out_assert(15, wallet_1.wallet_state_manager.main_wallet.get_confirmed_balance, 10)
+        await time_out_assert(20, wallet_1.wallet_state_manager.main_wallet.get_confirmed_balance, 10)
 
     @pytest.mark.asyncio
     async def test_mempool_tx_sync(self, three_nodes_two_wallets, self_hostname):
@@ -150,7 +150,7 @@ class TestTransactions:
         funds = sum(
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
-        await time_out_assert(10, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
         tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, token_bytes(), 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -60,8 +60,8 @@ class TestCATWallet:
             ]
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
 
         async with wallet_node.wallet_state_manager.lock:
             cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -80,9 +80,9 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 100)
-        await time_out_assert(15, cat_wallet.get_spendable_balance, 100)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_spendable_balance, 100)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 100)
 
         # Test migration
         all_lineage = await cat_wallet.lineage_store.get_all_lineage_proofs()
@@ -100,7 +100,7 @@ class TestCATWallet:
 
         height = full_node_api.full_node.blockchain.get_peak_height()
         await full_node_api.reorg_from_index_to_new_index(ReorgProtocol(height - num_blocks - 1, height + 1, 32 * b"1"))
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 0)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 0)
 
     @pytest.mark.asyncio
     async def test_cat_creation_unique_lineage_store(self, self_hostname, two_wallet_nodes):
@@ -125,8 +125,8 @@ class TestCATWallet:
             ]
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
 
         async with wallet_node.wallet_state_manager.lock:
             cat_wallet_1: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -178,7 +178,7 @@ class TestCATWallet:
             ]
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
             cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -193,8 +193,8 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 100)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 100)
 
         assert cat_wallet.cat_info.limitations_program_hash is not None
         asset_id = cat_wallet.get_asset_id()
@@ -216,15 +216,15 @@ class TestCATWallet:
             if tx_record.wallet_id is cat_wallet.id():
                 assert tx_record.to_puzzle_hash == cat_2_hash
 
-        await time_out_assert(15, cat_wallet.get_pending_change_balance, 40)
+        await time_out_assert(20, cat_wallet.get_pending_change_balance, 40)
 
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"\0"))
 
         await time_out_assert(30, wallet.get_confirmed_balance, funds - 101)
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 40)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 40)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 40)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 40)
 
         await time_out_assert(30, cat_wallet_2.get_confirmed_balance, 60)
         await time_out_assert(30, cat_wallet_2.get_unconfirmed_balance, 60)
@@ -239,12 +239,12 @@ class TestCATWallet:
 
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 55)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 55)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 55)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 55)
 
         height = full_node_api.full_node.blockchain.get_peak_height()
         await full_node_api.reorg_from_index_to_new_index(ReorgProtocol(height - 1, height + 1, 32 * b"1"))
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 40)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 40)
 
     @pytest.mark.parametrize(
         "trusted",
@@ -277,7 +277,7 @@ class TestCATWallet:
             ]
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
             cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -335,7 +335,7 @@ class TestCATWallet:
             ]
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
             cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -349,8 +349,8 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 100)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 100)
 
         assert cat_wallet.cat_info.limitations_program_hash is not None
         asset_id = cat_wallet.get_asset_id()
@@ -375,11 +375,11 @@ class TestCATWallet:
         await time_out_assert(30, wallet.get_confirmed_balance, funds - 101)
         await time_out_assert(30, wallet.get_unconfirmed_balance, funds - 101)
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 40)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 40)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 40)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 40)
 
-        await time_out_assert(15, cat_wallet_2.get_confirmed_balance, 60)
-        await time_out_assert(15, cat_wallet_2.get_unconfirmed_balance, 60)
+        await time_out_assert(20, cat_wallet_2.get_confirmed_balance, 60)
+        await time_out_assert(20, cat_wallet_2.get_unconfirmed_balance, 60)
 
         cc2_ph = await cat_wallet_2.get_new_cat_puzzle_hash()
         tx_record = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(10, cc2_ph, 0)
@@ -397,10 +397,10 @@ class TestCATWallet:
             all_txs = await wsm.tx_store.get_all_transactions_for_wallet(id)
             return len(list(filter(lambda tx: tx.amount == 10, all_txs)))
 
-        await time_out_assert(15, query_and_assert_transactions, 0, wsm, id)
-        await time_out_assert(15, wsm.get_confirmed_balance_for_wallet, 60, id)
-        await time_out_assert(15, cat_wallet_2.get_confirmed_balance, 60)
-        await time_out_assert(15, cat_wallet_2.get_unconfirmed_balance, 60)
+        await time_out_assert(20, query_and_assert_transactions, 0, wsm, id)
+        await time_out_assert(20, wsm.get_confirmed_balance_for_wallet, 60, id)
+        await time_out_assert(20, cat_wallet_2.get_confirmed_balance, 60)
+        await time_out_assert(20, cat_wallet_2.get_unconfirmed_balance, 60)
 
     @pytest.mark.parametrize(
         "trusted",
@@ -439,7 +439,7 @@ class TestCATWallet:
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        await time_out_assert(15, wallet_0.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
 
         async with wallet_node_0.wallet_state_manager.lock:
             cat_wallet_0: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -453,8 +453,8 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet_0.get_confirmed_balance, 100)
-        await time_out_assert(15, cat_wallet_0.get_unconfirmed_balance, 100)
+        await time_out_assert(20, cat_wallet_0.get_confirmed_balance, 100)
+        await time_out_assert(20, cat_wallet_0.get_unconfirmed_balance, 100)
 
         assert cat_wallet_0.cat_info.limitations_program_hash is not None
         asset_id = cat_wallet_0.get_asset_id()
@@ -482,8 +482,8 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet_0.get_confirmed_balance, 20)
-        await time_out_assert(15, cat_wallet_0.get_unconfirmed_balance, 20)
+        await time_out_assert(20, cat_wallet_0.get_confirmed_balance, 20)
+        await time_out_assert(20, cat_wallet_0.get_unconfirmed_balance, 20)
 
         await time_out_assert(30, cat_wallet_1.get_confirmed_balance, 60)
         await time_out_assert(30, cat_wallet_1.get_unconfirmed_balance, 60)
@@ -510,8 +510,8 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet_0.get_confirmed_balance, 55)
-        await time_out_assert(15, cat_wallet_0.get_unconfirmed_balance, 55)
+        await time_out_assert(20, cat_wallet_0.get_confirmed_balance, 55)
+        await time_out_assert(20, cat_wallet_0.get_unconfirmed_balance, 55)
 
         await time_out_assert(30, cat_wallet_1.get_confirmed_balance, 45)
         await time_out_assert(30, cat_wallet_1.get_unconfirmed_balance, 45)
@@ -578,7 +578,7 @@ class TestCATWallet:
             ]
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
             cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -592,8 +592,8 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 100000)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 100000)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 100000)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 100000)
 
         assert cat_wallet.cat_info.limitations_program_hash is not None
 
@@ -631,7 +631,7 @@ class TestCATWallet:
                     return False
             return True
 
-        await time_out_assert(15, check_all_there, True)
+        await time_out_assert(20, check_all_there, True)
         await asyncio.sleep(5)
         max_sent_amount = await cat_wallet.get_max_send_amount()
 
@@ -713,7 +713,7 @@ class TestCATWallet:
             ]
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
             cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -727,8 +727,8 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(32 * b"0"))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 100)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 100)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 100)
         assert cat_wallet.cat_info.limitations_program_hash is not None
 
         cat_2_hash = await wallet2.get_new_puzzlehash()
@@ -744,18 +744,18 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 40)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 40)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 40)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 40)
 
         async def check_wallets(node):
             return len(node.wallet_state_manager.wallets.keys())
 
         if autodiscovery:
             # Autodiscovery enabled: test that wallet was created at this point
-            await time_out_assert(10, check_wallets, 2, wallet_node_2)
+            await time_out_assert(20, check_wallets, 2, wallet_node_2)
         else:
             # Autodiscovery disabled: test that no wallet was created
-            await time_out_assert(10, check_wallets, 1, wallet_node_2)
+            await time_out_assert(20, check_wallets, 1, wallet_node_2)
 
         # Then we update the wallet's default CATs
         wallet_node_2.wallet_state_manager.default_cats = {
@@ -779,11 +779,11 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 30)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 30)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 30)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 30)
 
         # Now we check that another wallet WAS created, even if autodiscovery was disabled
-        await time_out_assert(10, check_wallets, 2, wallet_node_2)
+        await time_out_assert(20, check_wallets, 2, wallet_node_2)
         cat_wallet_2 = wallet_node_2.wallet_state_manager.wallets[2]
 
         # Previous balance + balance that triggered creation in case of disabled autodiscovery
@@ -802,5 +802,5 @@ class TestCATWallet:
         for i in range(1, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
 
-        await time_out_assert(15, cat_wallet.get_confirmed_balance, 35)
-        await time_out_assert(15, cat_wallet.get_unconfirmed_balance, 35)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, 35)
+        await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 35)

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -99,8 +99,8 @@ async def test_nft_wallet_creation_automatically(two_wallet_nodes: Any, trusted:
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
 
@@ -195,8 +195,8 @@ async def test_nft_wallet_creation_and_transfer(two_wallet_nodes: Any, trusted: 
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
 
@@ -214,8 +214,8 @@ async def test_nft_wallet_creation_and_transfer(two_wallet_nodes: Any, trusted: 
         ]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 2000000000000)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 2000000000000)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 2000000000000)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 2000000000000)
     sb = await nft_wallet_0.generate_new_nft(metadata)
     assert sb
     # ensure hints are generated
@@ -225,7 +225,7 @@ async def test_nft_wallet_creation_and_transfer(two_wallet_nodes: Any, trusted: 
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
 
-    await time_out_assert(10, len, 1, nft_wallet_0.my_nft_coins)
+    await time_out_assert(20, len, 1, nft_wallet_0.my_nft_coins)
     metadata = Program.to(
         [
             ("u", ["https://www.test.net/logo.svg"]),
@@ -233,8 +233,8 @@ async def test_nft_wallet_creation_and_transfer(two_wallet_nodes: Any, trusted: 
         ]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 4000000000000 - 1)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 4000000000000 - 1)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 4000000000000 - 1)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 4000000000000 - 1)
     sb = await nft_wallet_0.generate_new_nft(metadata)
     assert sb
     # ensure hints are generated
@@ -327,9 +327,9 @@ async def test_nft_wallet_rpc_creation_and_list(two_wallet_nodes: Any, trusted: 
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
-    await time_out_assert(10, wallet_node_0.wallet_state_manager.synced, True)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_node_0.wallet_state_manager.synced, True)
     api_0 = WalletRpcApi(wallet_node_0)
     nft_wallet_0 = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(nft_wallet_0, dict)
@@ -423,12 +423,12 @@ async def test_nft_wallet_rpc_update_metadata(two_wallet_nodes: Any, trusted: An
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
 
     api_0 = WalletRpcApi(wallet_node_0)
-    await time_out_assert(10, wallet_node_0.wallet_state_manager.synced, True)
-    await time_out_assert(10, wallet_node_1.wallet_state_manager.synced, True)
+    await time_out_assert(20, wallet_node_0.wallet_state_manager.synced, True)
+    await time_out_assert(20, wallet_node_1.wallet_state_manager.synced, True)
     nft_wallet_0 = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(nft_wallet_0, dict)
     assert nft_wallet_0.get("success")
@@ -577,8 +577,8 @@ async def test_nft_with_did_wallet_creation(two_wallet_nodes: Any, trusted: Any)
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
         wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
     )
@@ -608,8 +608,8 @@ async def test_nft_with_did_wallet_creation(two_wallet_nodes: Any, trusted: Any)
 
     res = await api_0.nft_get_by_did({"did_id": hmr_did_id})
     assert nft_wallet_0_id == res["wallet_id"]
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 3999999999999)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 3999999999999)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 3999999999999)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 3999999999999)
 
     res = await api_0.nft_get_wallets_with_dids({})
     assert res.get("success")
@@ -650,8 +650,8 @@ async def test_nft_with_did_wallet_creation(two_wallet_nodes: Any, trusted: Any)
 
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 5999999999999 - 1)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 5999999999999 - 1)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 5999999999999 - 1)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 5999999999999 - 1)
     # Create a NFT without DID, this will go the unassigned NFT wallet
     resp = await api_0.nft_mint_nft(
         {
@@ -669,8 +669,8 @@ async def test_nft_with_did_wallet_creation(two_wallet_nodes: Any, trusted: Any)
     await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
 
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 7999999999998 - 1)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 7999999999998 - 1)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 7999999999998 - 1)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 7999999999998 - 1)
     # Check DID NFT
     coins_response = await wait_rpc_state_condition(
         5, api_0.nft_get_nfts, [dict(wallet_id=nft_wallet_0_id)], lambda x: x["nft_list"]
@@ -740,8 +740,8 @@ async def test_nft_rpc_mint(two_wallet_nodes: Any, trusted: Any) -> None:
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
         wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
     )
@@ -760,8 +760,8 @@ async def test_nft_rpc_mint(two_wallet_nodes: Any, trusted: Any) -> None:
     assert res.get("success")
     nft_wallet_0_id = res["wallet_id"]
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 5999999999999)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 5999999999999)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 5999999999999)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 5999999999999)
     # Create a NFT with DID
     royalty_address = ph1
     data_hash_param = "0xD4584AD463139FA8C0D9F68F4B59F185"
@@ -797,8 +797,8 @@ async def test_nft_rpc_mint(two_wallet_nodes: Any, trusted: Any) -> None:
 
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 9999999999998)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 9999999999998)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 9999999999998)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 9999999999998)
     coins_response = await wait_rpc_state_condition(
         5, api_0.nft_get_nfts, [dict(wallet_id=nft_wallet_0_id)], lambda x: x["nft_list"]
     )
@@ -858,8 +858,8 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     funds = sum(
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
     )
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
         wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
     )
@@ -896,8 +896,8 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     coins_response = await wait_rpc_state_condition(
         5, api_0.nft_get_nfts, [dict(wallet_id=nft_wallet_0_id)], lambda x: x["nft_list"]
     )
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 5999999999898)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 5999999999898)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 5999999999898)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 5999999999898)
     coins = coins_response["nft_list"]
     assert len(coins) == 1
     assert coins[0].owner_did.hex() == hex_did_id
@@ -925,10 +925,10 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     await wait_rpc_state_condition(
         5, api_0.nft_get_nfts, [dict(wallet_id=nft_wallet_0_id)], lambda x: not x["nft_list"]
     )
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 5999999999798)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 5999999999798)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 5999999999798)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 5999999999798)
     # wait for all wallets to be created
-    await time_out_assert(10, len, 3, wallet_1.wallet_state_manager.wallets)
+    await time_out_assert(20, len, 3, wallet_1.wallet_state_manager.wallets)
     did_wallet_1 = wallet_1.wallet_state_manager.wallets[3]
     assert len(wallet_node_0.wallet_state_manager.wallets[nft_wallet_0_id].my_nft_coins) == 0
     # Check if the NFT owner DID is reset
@@ -953,8 +953,8 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     coins_response = await wait_rpc_state_condition(
         5, api_1.nft_get_by_did, [dict(did_id=hmr_did_id)], lambda x: x.get("wallet_id", 0) > 0
     )
-    await time_out_assert(10, wallet_1.get_unconfirmed_balance, 10000000000100)
-    await time_out_assert(10, wallet_1.get_confirmed_balance, 10000000000100)
+    await time_out_assert(20, wallet_1.get_unconfirmed_balance, 10000000000100)
+    await time_out_assert(20, wallet_1.get_confirmed_balance, 10000000000100)
     nft_wallet_1_id = coins_response.get("wallet_id")
     assert nft_wallet_1_id
     # Check NFT DID is set now
@@ -1008,8 +1008,8 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
         wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
     )
@@ -1029,7 +1029,7 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
     assert res.get("success")
     nft_wallet_0_id = res["wallet_id"]
 
-    await time_out_assert(5, did_wallet.get_confirmed_balance, 1)
+    await time_out_assert(20, did_wallet.get_confirmed_balance, 1)
 
     # Create a NFT with DID
     resp = await api_0.nft_mint_nft(
@@ -1078,8 +1078,8 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
     # check that new URI was added
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, 11999999999898)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, 11999999999898)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, 11999999999898)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, 11999999999898)
     coins_response = await wait_rpc_state_condition(
         5,
         api_0.nft_get_info,
@@ -1134,8 +1134,8 @@ async def test_nft_set_did(two_wallet_nodes: Any, trusted: Any) -> None:
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
         wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
     )
@@ -1154,7 +1154,7 @@ async def test_nft_set_did(two_wallet_nodes: Any, trusted: Any) -> None:
     assert res.get("success")
     nft_wallet_0_id = res["wallet_id"]
 
-    await time_out_assert(5, did_wallet.get_confirmed_balance, 1)
+    await time_out_assert(20, did_wallet.get_confirmed_balance, 1)
 
     # Create a NFT with DID
     resp = await api_0.nft_mint_nft(
@@ -1189,7 +1189,7 @@ async def test_nft_set_did(two_wallet_nodes: Any, trusted: Any) -> None:
     await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
 
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await time_out_assert(5, did_wallet1.get_spendable_balance, 1)
+    await time_out_assert(20, did_wallet1.get_spendable_balance, 1)
     resp = await api_0.nft_set_nft_did(
         dict(wallet_id=nft_wallet_0_id, did_id=hmr_did_id, nft_coin_id=nft_coin_id.hex())
     )
@@ -1300,8 +1300,8 @@ async def test_set_nft_status(two_wallet_nodes: Any, trusted: Any) -> None:
         [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks - 1)]
     )
 
-    await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(res, dict)
     assert res.get("success")

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -72,11 +72,13 @@ class WalletRpcTestEnvironment:
 
 async def farm_transaction_block(full_node_api: FullNodeSimulator, wallet_node: WalletNode):
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
-    await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+    await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
 
 
 async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: WalletNode, spend_bundle: SpendBundle):
-    await time_out_assert(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle, spend_bundle.name())
+    await time_out_assert(
+        20, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle, spend_bundle.name()
+    )
     await farm_transaction_block(full_node_api, wallet_node)
     assert full_node_api.full_node.mempool_manager.get_spendbundle(spend_bundle.name()) is None
 
@@ -97,9 +99,9 @@ async def generate_funds(full_node_api: FullNodeSimulator, wallet_bundle: Wallet
 
     expected_confirmed = initial_balances["confirmed_wallet_balance"] + generated_funds
     expected_unconfirmed = initial_balances["unconfirmed_wallet_balance"] + generated_funds
-    await time_out_assert(10, get_confirmed_balance, expected_confirmed, wallet_bundle.rpc_client, wallet_id)
-    await time_out_assert(10, get_unconfirmed_balance, expected_unconfirmed, wallet_bundle.rpc_client, wallet_id)
-    await time_out_assert(10, wallet_bundle.rpc_client.get_synced)
+    await time_out_assert(20, get_confirmed_balance, expected_confirmed, wallet_bundle.rpc_client, wallet_id)
+    await time_out_assert(20, get_unconfirmed_balance, expected_unconfirmed, wallet_bundle.rpc_client, wallet_id)
+    await time_out_assert(20, wallet_bundle.rpc_client.get_synced)
 
     return generated_funds
 
@@ -272,8 +274,8 @@ async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment
     spend_bundle = tx.spend_bundle
     assert spend_bundle is not None
 
-    await time_out_assert(5, tx_in_mempool, True, client, transaction_id)
-    await time_out_assert(5, get_unconfirmed_balance, generated_funds - tx_amount, client, 1)
+    await time_out_assert(20, tx_in_mempool, True, client, transaction_id)
+    await time_out_assert(20, get_unconfirmed_balance, generated_funds - tx_amount, client, 1)
 
     await farm_transaction(full_node_api, wallet_node, spend_bundle)
 
@@ -284,7 +286,7 @@ async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment
     assert [b"this is a basic tx"] in tx_confirmed.get_memos().values()
     assert list(tx_confirmed.get_memos().keys())[0] in [a.name() for a in spend_bundle.additions()]
 
-    await time_out_assert(5, get_confirmed_balance, generated_funds - tx_amount, client, 1)
+    await time_out_assert(20, get_confirmed_balance, generated_funds - tx_amount, client, 1)
 
 
 @pytest.mark.parametrize(
@@ -336,7 +338,7 @@ async def test_create_signed_transaction(
     push_res = await full_node_rpc.push_tx(spend_bundle)
     assert push_res["success"]
     await farm_transaction(full_node_api, wallet_1_node, spend_bundle)
-    await time_out_assert(5, get_confirmed_balance, generated_funds - amount_total, wallet_1_rpc, 1)
+    await time_out_assert(20, get_confirmed_balance, generated_funds - amount_total, wallet_1_rpc, 1)
 
     # Validate the memos
     for output in outputs:
@@ -477,7 +479,7 @@ async def test_send_transaction_multi(wallet_rpc_environment: WalletRpcTestEnvir
 
     await farm_transaction(full_node_api, wallet_node, spend_bundle)
 
-    await time_out_assert(5, get_confirmed_balance, generated_funds - amount_outputs - amount_fee, client, 1)
+    await time_out_assert(20, get_confirmed_balance, generated_funds - amount_outputs - amount_fee, client, 1)
 
     # Checks that the memo can be retrieved
     tx_confirmed = await client.get_transaction("1", send_tx_res.name)
@@ -538,7 +540,7 @@ async def test_get_transactions(wallet_rpc_environment: WalletRpcTestEnvironment
     ph_by_addr = await wallet.get_new_puzzlehash()
     await client.send_transaction("1", uint64(1), encode_puzzle_hash(ph_by_addr, "txch"))
     await client.farm_block(encode_puzzle_hash(ph_by_addr, "txch"))
-    await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+    await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
     tx_for_address = await client.get_transactions("1", to_address=encode_puzzle_hash(ph_by_addr, "txch"))
     assert len(tx_for_address) == 1
     assert tx_for_address[0].to_puzzle_hash == ph_by_addr
@@ -610,7 +612,7 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     await farm_transaction_block(full_node_api, wallet_node)
     await farm_transaction_block(full_node_api, wallet_node)
 
-    await time_out_assert(10, get_confirmed_balance, 20, client, cat_0_id)
+    await time_out_assert(20, get_confirmed_balance, 20, client, cat_0_id)
     bal_0 = await client.get_wallet_balance(cat_0_id)
     assert bal_0["pending_coin_removal_count"] == 0
     assert bal_0["unspent_coin_count"] == 1
@@ -647,8 +649,8 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     cats = await client.get_stray_cats()
     assert len(cats) == 1
 
-    await time_out_assert(10, get_confirmed_balance, 16, client, cat_0_id)
-    await time_out_assert(10, get_confirmed_balance, 4, client_2, cat_1_id)
+    await time_out_assert(20, get_confirmed_balance, 16, client, cat_0_id)
+    await time_out_assert(20, get_confirmed_balance, 4, client_2, cat_1_id)
 
     # Test CAT coin selection
     selected_coins = await client.select_coins(amount=1, wallet_id=cat_0_id)
@@ -675,7 +677,7 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     await farm_transaction_block(full_node_api, wallet_node)
     await farm_transaction_block(full_node_api, wallet_node)
     await farm_transaction_block(full_node_api, wallet_node)
-    await time_out_assert(10, get_confirmed_balance, 20, wallet_1_rpc, cat_wallet_id)
+    await time_out_assert(20, get_confirmed_balance, 20, wallet_1_rpc, cat_wallet_id)
 
     # Creates a wallet for the same CAT on wallet_2 and send 4 CAT from wallet_1 to it
     await wallet_2_rpc.create_wallet_for_existing_cat(cat_asset_id)
@@ -684,7 +686,7 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     spend_bundle = tx_res.spend_bundle
     assert spend_bundle is not None
     await farm_transaction(full_node_api, wallet_node, spend_bundle)
-    await time_out_assert(10, get_confirmed_balance, 4, wallet_2_rpc, cat_wallet_id)
+    await time_out_assert(20, get_confirmed_balance, 4, wallet_2_rpc, cat_wallet_id)
 
     # Create an offer of 5 chia for one CAT
     offer, trade_record = await wallet_1_rpc.create_offer_for_ids(
@@ -956,7 +958,7 @@ async def test_key_and_address_endpoints(wallet_rpc_environment: WalletRpcTestEn
 
     created_tx = await client.send_transaction("1", tx_amount, addr)
 
-    await time_out_assert(5, tx_in_mempool, True, client, created_tx.name)
+    await time_out_assert(20, tx_in_mempool, True, client, created_tx.name)
     assert len(await wallet.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(1)) == 1
     await client.delete_unconfirmed_transactions("1")
     assert len(await wallet.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(1)) == 0
@@ -1081,9 +1083,9 @@ async def test_select_coins_rpc(wallet_rpc_environment: WalletRpcTestEnvironment
             if coin.amount == uint64(300):
                 coin_300 = [coin]
 
-        await time_out_assert(5, tx_in_mempool, True, client, tx.name)
+        await time_out_assert(20, tx_in_mempool, True, client, tx.name)
         await farm_transaction(full_node_api, wallet_node, spend_bundle)
-        await time_out_assert(5, get_confirmed_balance, funds, client, 1)
+        await time_out_assert(20, get_confirmed_balance, funds, client, 1)
 
     # test min coin amount
     min_coins: List[Coin] = await client_2.select_coins(amount=1000, wallet_id=1, min_coin_amount=uint64(1001))

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -171,7 +171,7 @@ class TestSimpleSyncProtocol:
             for cr in await full_node_api.full_node.coin_store.get_coin_records_by_puzzle_hash(False, puzzle_hash)
         )
 
-        await time_out_assert(15, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
         assert funds == fn_amount
 
         msg_1 = wallet_protocol.RegisterForPhUpdates([puzzle_hash], 0)
@@ -180,7 +180,7 @@ class TestSimpleSyncProtocol:
         data_response_1: RespondToPhUpdates = RespondToCoinUpdates.from_bytes(msg_response_1.data)
         assert len(data_response_1.coin_states) == 2 * num_blocks  # 2 per height farmer / pool reward
 
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
         tx_record = await wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
         assert len(tx_record.spend_bundle.removals()) == 1
         spent_coin = tx_record.spend_bundle.removals()[0]
@@ -198,7 +198,7 @@ class TestSimpleSyncProtocol:
         # Let's make sure the wallet can handle a non ephemeral launcher
         from chia.wallet.puzzles.singleton_top_layer import SINGLETON_LAUNCHER_HASH
 
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
         tx_record = await wallet.generate_signed_transaction(uint64(10), SINGLETON_LAUNCHER_HASH, uint64(0))
         await wallet.push_transaction(tx_record)
 
@@ -209,7 +209,7 @@ class TestSimpleSyncProtocol:
         for i in range(0, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(SINGLETON_LAUNCHER_HASH))
 
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
 
         # Send a transaction to make sure the wallet is still running
         tx_record = await wallet.generate_signed_transaction(uint64(10), junk_ph, uint64(0))
@@ -261,7 +261,7 @@ class TestSimpleSyncProtocol:
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        await time_out_assert(15, standard_wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, standard_wallet.get_confirmed_balance, funds)
 
         my_coins: List[CoinRecord] = await full_node_api.full_node.coin_store.get_coin_records_by_puzzle_hash(
             True, puzzle_hash
@@ -301,7 +301,7 @@ class TestSimpleSyncProtocol:
         assert notified_coins == coins
 
         # Test getting notification for coin that is about to be created
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
         tx_record = await standard_wallet.generate_signed_transaction(uint64(10), puzzle_hash, uint64(0))
 
         tx_record.spend_bundle.additions()
@@ -378,7 +378,7 @@ class TestSimpleSyncProtocol:
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(zero_ph))
 
         expected_height = uint32(long_blocks + 2 * num_blocks + 1)
-        await time_out_assert(15, full_node_api.full_node.blockchain.get_peak_height, expected_height)
+        await time_out_assert(20, full_node_api.full_node.blockchain.get_peak_height, expected_height)
 
         coin_records = await full_node_api.full_node.coin_store.get_coin_records_by_puzzle_hash(True, puzzle_hash)
         assert len(coin_records) > 0
@@ -450,7 +450,7 @@ class TestSimpleSyncProtocol:
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(zero_ph))
 
         expected_height = uint32(long_blocks + 2 * num_blocks + 1)
-        await time_out_assert(15, full_node_api.full_node.blockchain.get_peak_height, expected_height)
+        await time_out_assert(20, full_node_api.full_node.blockchain.get_peak_height, expected_height)
 
         coin_records = await full_node_api.full_node.coin_store.get_coin_records_by_puzzle_hash(True, puzzle_hash)
         assert len(coin_records) > 0
@@ -523,7 +523,7 @@ class TestSimpleSyncProtocol:
                 ConditionWithArgs(ConditionOpcode.CREATE_COIN, [hint_puzzle_hash, amount_bin, hint])
             ]
         }
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
         tx: SpendBundle = wt.generate_signed_transaction(
             10,
             wt.get_new_puzzlehash(),
@@ -532,7 +532,7 @@ class TestSimpleSyncProtocol:
         )
         await full_node_api.respond_transaction(RespondTransaction(tx), fake_wallet_peer)
 
-        await time_out_assert(15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx.name())
+        await time_out_assert(20, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx.name())
 
         for i in range(0, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -606,7 +606,7 @@ class TestSimpleSyncProtocol:
                 ConditionWithArgs(ConditionOpcode.CREATE_COIN, [hint_puzzle_hash, amount_bin, hint])
             ]
         }
-        await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
         tx: SpendBundle = wt.generate_signed_transaction(
             10,
             wt.get_new_puzzlehash(),
@@ -615,7 +615,7 @@ class TestSimpleSyncProtocol:
         )
         await full_node_api.respond_transaction(RespondTransaction(tx), fake_wallet_peer)
 
-        await time_out_assert(15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx.name())
+        await time_out_assert(20, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx.name())
 
         # Create more blocks than recent "short_sync_blocks_behind_threshold" so that node enters batch
         for i in range(0, 100):

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -360,8 +360,8 @@ class TestWalletSync:
 
         for wallet_node, wallet_server in wallets:
             wallet = wallet_node.wallet_state_manager.main_wallet
-            await time_out_assert(5, wallet.get_confirmed_balance, funds)
-            await time_out_assert(5, get_tx_count, 2 * (num_blocks - 1), wallet_node.wallet_state_manager, 1)
+            await time_out_assert(20, wallet.get_confirmed_balance, funds)
+            await time_out_assert(20, get_tx_count, 2 * (num_blocks - 1), wallet_node.wallet_state_manager, 1)
 
         # Reorg blocks that carry reward
         num_blocks = 30
@@ -372,8 +372,8 @@ class TestWalletSync:
 
         for wallet_node, wallet_server in wallets:
             wallet = wallet_node.wallet_state_manager.main_wallet
-            await time_out_assert(5, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
-            await time_out_assert(5, wallet.get_confirmed_balance, 0)
+            await time_out_assert(20, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
+            await time_out_assert(20, wallet.get_confirmed_balance, 0)
 
     @pytest.mark.asyncio
     async def test_wallet_reorg_get_coinbase(self, two_wallet_nodes, default_400_blocks, self_hostname):
@@ -406,7 +406,7 @@ class TestWalletSync:
             return len(txs)
 
         for wallet_node, wallet_server in wallets:
-            await time_out_assert(10, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
+            await time_out_assert(30, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
             await time_out_assert(30, wallet_is_synced, True, wallet_node, full_node_api)
 
         num_blocks_reorg_1 = 40

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -87,7 +87,7 @@ class TestWalletSimulator:
             return True
 
         await time_out_assert(20, check_tx_are_pool_farm_rewards, True)
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
     @pytest.mark.parametrize(
         "trusted",
@@ -124,8 +124,8 @@ class TestWalletSimulator:
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds)
 
         tx = await wallet.generate_signed_transaction(
             uint64(10),
@@ -134,9 +134,9 @@ class TestWalletSimulator:
         )
         await wallet.push_transaction(tx)
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds - 10)
-        await time_out_assert(10, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds - 10)
+        await time_out_assert(20, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)
 
         for i in range(0, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -148,8 +148,8 @@ class TestWalletSimulator:
             ]
         )
 
-        await time_out_assert(10, wallet.get_confirmed_balance, new_funds - 10)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, new_funds - 10)
+        await time_out_assert(20, wallet.get_confirmed_balance, new_funds - 10)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, new_funds - 10)
 
     @pytest.mark.parametrize(
         "trusted",
@@ -195,7 +195,7 @@ class TestWalletSimulator:
             ]
         )
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
     @pytest.mark.parametrize(
         "trusted",
@@ -252,7 +252,7 @@ class TestWalletSimulator:
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        await time_out_assert(10, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
         tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
             uint64(10), bytes32(32 * b"0"), uint64(0)
@@ -437,8 +437,8 @@ class TestWalletSimulator:
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds)
 
         assert await wallet.get_confirmed_balance() == funds
         assert await wallet.get_unconfirmed_balance() == funds
@@ -470,8 +470,8 @@ class TestWalletSimulator:
             ]
         )
 
-        await time_out_assert(10, wallet.get_confirmed_balance, new_funds - tx_amount - tx_fee)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, new_funds - tx_amount - tx_fee)
+        await time_out_assert(20, wallet.get_confirmed_balance, new_funds - tx_amount - tx_fee)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, new_funds - tx_amount - tx_fee)
 
     @pytest.mark.parametrize(
         "trusted",
@@ -616,8 +616,8 @@ class TestWalletSimulator:
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds)
 
         assert await wallet.get_confirmed_balance() == funds
         assert await wallet.get_unconfirmed_balance() == funds
@@ -660,8 +660,8 @@ class TestWalletSimulator:
         )
         await wallet.push_transaction(stolen_tx)
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds - stolen_cs.coin.amount)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds - stolen_cs.coin.amount)
 
         for i in range(0, num_blocks):
             await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(32 * b"0")))
@@ -720,14 +720,14 @@ class TestWalletSimulator:
         assert tx.spend_bundle is not None
         await wallet.push_transaction(tx)
         await full_node_api.full_node.respond_transaction(tx.spend_bundle, tx.name)
-        await time_out_assert(10, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
         for i in range(0, 2):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(32 * b"0")))
-        await time_out_assert(10, wallet_2.get_confirmed_balance, 1000)
+        await time_out_assert(20, wallet_2.get_confirmed_balance, 1000)
         funds -= 1000
 
-        await time_out_assert(10, wallet_node.wallet_state_manager.blockchain.get_peak_height, 7)
+        await time_out_assert(20, wallet_node.wallet_state_manager.blockchain.get_peak_height, 7)
         peak = full_node_api.full_node.blockchain.get_peak()
         assert peak is not None
         peak_height = peak.height
@@ -754,7 +754,7 @@ class TestWalletSimulator:
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(32 * b"0")))
 
         # By this point, the transaction should be confirmed
-        await time_out_assert(15, wallet.get_confirmed_balance, funds - 1000)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds - 1000)
 
         unconfirmed = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(int(wallet.id()))
         assert len(unconfirmed) == 0
@@ -866,8 +866,8 @@ class TestWalletSimulator:
             ]
         )
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds)
 
         AMOUNT_TO_SEND = 4000000000000
         coins = await wallet.select_coins(uint64(AMOUNT_TO_SEND))
@@ -885,15 +885,15 @@ class TestWalletSimulator:
         assert paid_coin.parent_coin_info == coin_list[2].name()
         await wallet.push_transaction(tx)
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds - AMOUNT_TO_SEND)
-        await time_out_assert(10, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds - AMOUNT_TO_SEND)
+        await time_out_assert(20, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle, tx.name)
 
         for i in range(0, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32([0] * 32)))
 
-        await time_out_assert(10, wallet.get_confirmed_balance, funds - AMOUNT_TO_SEND)
-        await time_out_assert(10, wallet.get_unconfirmed_balance, funds - AMOUNT_TO_SEND)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds - AMOUNT_TO_SEND)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds - AMOUNT_TO_SEND)
 
 
 def test_get_wallet_db_path_v2_r1() -> None:


### PR DESCRIPTION
The runners sometimes struggle with the concurrent tests, and this leads to flakiness with untrusted wallet sync not finishing fast enough. Increasing the timeouts can reduce failures.