### PR TITLE
util: Drop partially implemented BIP39 passphrase support

### DIFF
--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -56,8 +56,7 @@ def add_private_key_seed(mnemonic: str):
     """
 
     try:
-        passphrase = ""
-        sk = Keychain().add_private_key(mnemonic, passphrase)
+        sk = Keychain().add_private_key(mnemonic)
         fingerprint = sk.get_g1().get_fingerprint()
         print(f"Added private key with public key fingerprint {fingerprint}")
 
@@ -203,7 +202,7 @@ def migrate_keys():
                 keychain = Keychain()
                 for sk, seed_bytes in keys_to_migrate:
                     mnemonic = bytes_to_mnemonic(seed_bytes)
-                    keychain.add_private_key(mnemonic, "")
+                    keychain.add_private_key(mnemonic)
                     fingerprint = sk.get_g1().get_fingerprint()
                     print(f"Added private key with public key fingerprint {fingerprint}")
 
@@ -657,7 +656,7 @@ def private_key_from_mnemonic_seed_file(filename: Path) -> PrivateKey:
     """
 
     mnemonic = filename.read_text().rstrip()
-    seed = mnemonic_to_seed(mnemonic, "")
+    seed = mnemonic_to_seed(mnemonic)
     return AugSchemeMPL.key_gen(seed)
 
 

--- a/chia/daemon/keychain_proxy.py
+++ b/chia/daemon/keychain_proxy.py
@@ -169,19 +169,17 @@ class KeychainProxy(DaemonProxy):
                     raise Exception(f"{err}")
                 raise Exception(f"{error}")
 
-    async def add_private_key(self, mnemonic: str, passphrase: str) -> PrivateKey:
+    async def add_private_key(self, mnemonic: str) -> PrivateKey:
         """
         Forwards to Keychain.add_private_key()
         """
         key: PrivateKey
         if self.use_local_keychain():
-            key = self.keychain.add_private_key(mnemonic, passphrase)
+            key = self.keychain.add_private_key(mnemonic)
         else:
-            response, success = await self.get_response_for_request(
-                "add_private_key", {"mnemonic": mnemonic, "passphrase": passphrase}
-            )
+            response, success = await self.get_response_for_request("add_private_key", {"mnemonic": mnemonic})
             if success:
-                seed = mnemonic_to_seed(mnemonic, passphrase)
+                seed = mnemonic_to_seed(mnemonic)
                 key = AugSchemeMPL.key_gen(seed)
             else:
                 error = response["data"].get("error", None)
@@ -254,7 +252,7 @@ class KeychainProxy(DaemonProxy):
                             continue  # We'll skip the incomplete key entry
                         ent = bytes.fromhex(ent_str)
                         mnemonic = bytes_to_mnemonic(ent)
-                        seed = mnemonic_to_seed(mnemonic, passphrase="")
+                        seed = mnemonic_to_seed(mnemonic)
                         key = AugSchemeMPL.key_gen(seed)
                         if bytes(key.get_g1()).hex() == pk:
                             keys.append((key, ent))
@@ -292,7 +290,7 @@ class KeychainProxy(DaemonProxy):
                         raise KeychainMalformedResponse(f"{err}")
                     ent = bytes.fromhex(ent_str)
                     mnemonic = bytes_to_mnemonic(ent)
-                    seed = mnemonic_to_seed(mnemonic, passphrase="")
+                    seed = mnemonic_to_seed(mnemonic)
                     sk = AugSchemeMPL.key_gen(seed)
                     if bytes(sk.get_g1()).hex() == pk:
                         key = sk
@@ -336,7 +334,7 @@ class KeychainProxy(DaemonProxy):
                     raise KeychainMalformedResponse(f"{err}")
                 else:
                     mnemonic = bytes_to_mnemonic(bytes.fromhex(ent))
-                    seed = mnemonic_to_seed(mnemonic, passphrase="")
+                    seed = mnemonic_to_seed(mnemonic)
                     private_key = AugSchemeMPL.key_gen(seed)
                     if bytes(private_key.get_g1()).hex() == pk:
                         key = private_key

--- a/chia/daemon/keychain_server.py
+++ b/chia/daemon/keychain_server.py
@@ -82,16 +82,15 @@ class KeychainServer:
             return {"success": False, "error": KEYCHAIN_ERR_LOCKED}
 
         mnemonic = request.get("mnemonic", None)
-        passphrase = request.get("passphrase", None)
-        if mnemonic is None or passphrase is None:
+        if mnemonic is None:
             return {
                 "success": False,
                 "error": KEYCHAIN_ERR_MALFORMED_REQUEST,
-                "error_details": {"message": "missing mnemonic and/or passphrase"},
+                "error_details": {"message": "missing mnemonic"},
             }
 
         try:
-            self.get_keychain_for_request(request).add_private_key(mnemonic, passphrase)
+            self.get_keychain_for_request(request).add_private_key(mnemonic)
         except KeyError as e:
             return {
                 "success": False,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -271,9 +271,8 @@ class WalletRpcApi:
 
         # Adding a key from 24 word mnemonic
         mnemonic = request["mnemonic"]
-        passphrase = ""
         try:
-            sk = await self.service.keychain_proxy.add_private_key(" ".join(mnemonic), passphrase)
+            sk = await self.service.keychain_proxy.add_private_key(" ".join(mnemonic))
         except KeyError as e:
             return {
                 "success": False,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -249,11 +249,9 @@ class BlockTools:
             self.farmer_master_sk_entropy = std_hash(b"block_tools farmer key")  # both entropies are only used here
             self.pool_master_sk_entropy = std_hash(b"block_tools pool key")
             self.farmer_master_sk = await keychain_proxy.add_private_key(
-                bytes_to_mnemonic(self.farmer_master_sk_entropy), ""
+                bytes_to_mnemonic(self.farmer_master_sk_entropy)
             )
-            self.pool_master_sk = await keychain_proxy.add_private_key(
-                bytes_to_mnemonic(self.pool_master_sk_entropy), ""
-            )
+            self.pool_master_sk = await keychain_proxy.add_private_key(bytes_to_mnemonic(self.pool_master_sk_entropy))
         else:
             self.farmer_master_sk = await keychain_proxy.get_key_for_fingerprint(fingerprint)
             self.pool_master_sk = await keychain_proxy.get_key_for_fingerprint(fingerprint)

--- a/chia/simulator/simulator_test_tools.py
+++ b/chia/simulator/simulator_test_tools.py
@@ -33,8 +33,7 @@ def mnemonic_fingerprint() -> Tuple[str, int]:
         "memory riot escape high dragon knock food blade"
     )
     # add key to keychain
-    passphrase = ""
-    sk = Keychain().add_private_key(mnemonic, passphrase)
+    sk = Keychain().add_private_key(mnemonic)
     fingerprint = sk.get_g1().get_fingerprint()
     return mnemonic, fingerprint
 

--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -75,7 +75,7 @@ def empty_keyring():
 @pytest.fixture(scope="function")
 def keyring_with_one_key(empty_keyring):
     keychain = empty_keyring
-    keychain.add_private_key(TEST_MNEMONIC_SEED, "")
+    keychain.add_private_key(TEST_MNEMONIC_SEED)
     return keychain
 
 
@@ -355,7 +355,7 @@ class TestKeysCommands:
 
         for i in range(5):
             mnemonic: str = generate_mnemonic()
-            keychain.add_private_key(mnemonic, "")
+            keychain.add_private_key(mnemonic)
 
         assert len(keychain.get_all_private_keys()) == 5
 

--- a/tests/core/util/test_keychain.py
+++ b/tests/core/util/test_keychain.py
@@ -34,12 +34,12 @@ class TestKeychain(unittest.TestCase):
             " ".join(bad_mnemonic),
         )
 
-        kc.add_private_key(mnemonic, "")
+        kc.add_private_key(mnemonic)
         assert kc._get_free_private_key_index() == 1
         assert len(kc.get_all_private_keys()) == 1
 
-        kc.add_private_key(mnemonic_2, "")
-        kc.add_private_key(mnemonic_2, "")  # checks to not add duplicates
+        kc.add_private_key(mnemonic_2)
+        kc.add_private_key(mnemonic_2)  # checks to not add duplicates
         assert kc._get_free_private_key_index() == 2
         assert len(kc.get_all_private_keys()) == 2
 
@@ -51,7 +51,7 @@ class TestKeychain(unittest.TestCase):
 
         assert len(kc.get_all_private_keys()) == 2
 
-        seed_2 = mnemonic_to_seed(mnemonic, "")
+        seed_2 = mnemonic_to_seed(mnemonic)
         seed_key_2 = AugSchemeMPL.key_gen(seed_2)
         kc.delete_key_by_fingerprint(seed_key_2.get_g1().get_fingerprint())
         assert kc._get_free_private_key_index() == 0
@@ -61,22 +61,17 @@ class TestKeychain(unittest.TestCase):
         assert kc._get_free_private_key_index() == 0
         assert len(kc.get_all_private_keys()) == 0
 
-        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)), "my passphrase")
-        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)), "")
-        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)), "third passphrase")
+        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)))
+        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)))
+        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)))
 
         assert len(kc.get_all_public_keys()) == 3
-        assert len(kc.get_all_private_keys()) == 1
-        assert len(kc.get_all_private_keys(["my passphrase", ""])) == 2
-        assert len(kc.get_all_private_keys(["my passphrase", "", "third passphrase", "another"])) == 3
-        assert len(kc.get_all_private_keys(["my passhrase wrong"])) == 0
 
         assert kc.get_first_private_key() is not None
-        assert kc.get_first_private_key(["bad passphrase"]) is None
         assert kc.get_first_public_key() is not None
 
         kc.delete_all_keys()
-        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)), "my passphrase")
+        kc.add_private_key(bytes_to_mnemonic(token_bytes(32)))
         assert kc.get_first_public_key() is not None
 
     @using_temp_file_keyring()
@@ -85,16 +80,15 @@ class TestKeychain(unittest.TestCase):
         kc.delete_all_keys()
 
         mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-        passphrase = "TREZOR"
-        print("entropy to seed:", mnemonic_to_seed(mnemonic, passphrase).hex())
-        master_sk = kc.add_private_key(mnemonic, passphrase)
-        tv_master_int = 5399117110774477986698372024995405256382522670366369834617409486544348441851
-        tv_child_int = 11812940737387919040225825939013910852517748782307378293770044673328955938106
+        print("entropy to seed:", mnemonic_to_seed(mnemonic).hex())
+        master_sk = kc.add_private_key(mnemonic)
+        tv_master_int = 8075452428075949470768183878078858156044736575259233735633523546099624838313
+        tv_child_int = 18507161868329770878190303689452715596635858303241878571348190917018711023613
         assert master_sk == PrivateKey.from_bytes(tv_master_int.to_bytes(32, "big"))
         child_sk = AugSchemeMPL.derive_child_sk(master_sk, 0)
         assert child_sk == PrivateKey.from_bytes(tv_child_int.to_bytes(32, "big"))
 
-    def test_bip39_test_vectors_trezor(self):
+    def test_bip39_test_vectors(self):
         with open("tests/util/bip39_test_vectors.json") as f:
             all_vectors = json.loads(f.read())
 
@@ -105,7 +99,7 @@ class TestKeychain(unittest.TestCase):
 
             assert bytes_from_mnemonic(mnemonic) == entropy_bytes
             assert bytes_to_mnemonic(entropy_bytes) == mnemonic
-            assert mnemonic_to_seed(mnemonic, "TREZOR") == seed
+            assert mnemonic_to_seed(mnemonic) == seed
 
     def test_utf8_nfkd(self):
         # Test code from trezor:
@@ -118,15 +112,10 @@ class TestKeychain(unittest.TestCase):
         words_nfkc = "P\u0159\xed\u0161ern\u011b \u017elu\u0165ou\u010dk\xfd k\u016f\u0148 \xfap\u011bl \u010f\xe1belsk\xe9 \xf3dy z\xe1ke\u0159n\xfd u\u010de\u0148 b\u011b\u017e\xed pod\xe9l z\xf3ny \xfal\u016f"  # noqa: E501
         words_nfd = "Pr\u030ci\u0301s\u030cerne\u030c z\u030clut\u030couc\u030cky\u0301 ku\u030an\u030c u\u0301pe\u030cl d\u030ca\u0301belske\u0301 o\u0301dy za\u0301ker\u030cny\u0301 uc\u030cen\u030c be\u030cz\u030ci\u0301 pode\u0301l zo\u0301ny u\u0301lu\u030a"  # noqa: E501
 
-        passphrase_nfkd = "Neuve\u030cr\u030citelne\u030c bezpec\u030cne\u0301 hesli\u0301c\u030cko"
-        passphrase_nfc = "Neuv\u011b\u0159iteln\u011b bezpe\u010dn\xe9 hesl\xed\u010dko"
-        passphrase_nfkc = "Neuv\u011b\u0159iteln\u011b bezpe\u010dn\xe9 hesl\xed\u010dko"
-        passphrase_nfd = "Neuve\u030cr\u030citelne\u030c bezpec\u030cne\u0301 hesli\u0301c\u030cko"
-
-        seed_nfkd = mnemonic_to_seed(words_nfkd, passphrase_nfkd)
-        seed_nfc = mnemonic_to_seed(words_nfc, passphrase_nfc)
-        seed_nfkc = mnemonic_to_seed(words_nfkc, passphrase_nfkc)
-        seed_nfd = mnemonic_to_seed(words_nfd, passphrase_nfd)
+        seed_nfkd = mnemonic_to_seed(words_nfkd)
+        seed_nfc = mnemonic_to_seed(words_nfc)
+        seed_nfkc = mnemonic_to_seed(words_nfkc)
+        seed_nfd = mnemonic_to_seed(words_nfd)
 
         assert seed_nfkd == seed_nfc
         assert seed_nfkd == seed_nfkc

--- a/tests/farmer_harvester/test_farmer_harvester.py
+++ b/tests/farmer_harvester/test_farmer_harvester.py
@@ -24,7 +24,7 @@ async def test_start_with_empty_keychain(farmer_one_harvester_not_started):
     await asyncio.sleep(5)
     assert not farmer.started
     # Add a key to the keychain, this should lead to the start task passing `setup_keys` and set `Farmer.initialized`
-    bt.local_keychain.add_private_key(generate_mnemonic(), "")
+    bt.local_keychain.add_private_key(generate_mnemonic())
     await time_out_assert(5, farmer_is_started, True, farmer)
     # Stop it and wait for `Farmer.initialized` to become reset
     farmer_service.stop()
@@ -82,7 +82,7 @@ async def test_harvester_handshake(farmer_one_harvester_not_started):
     await farmer_service.start()
     await time_out_assert(5, handshake_task_active, True)
     assert not await handshake_done()
-    bt.local_keychain.add_private_key(generate_mnemonic(), "")
+    bt.local_keychain.add_private_key(generate_mnemonic())
     await time_out_assert(5, farmer_is_started, True, farmer)
     await time_out_assert(5, handshake_task_active, False)
     await time_out_assert(5, handshake_done, True)

--- a/tests/setup_services.py
+++ b/tests/setup_services.py
@@ -163,7 +163,7 @@ async def setup_wallet_node(
         entropy = token_bytes(32)
         if key_seed is None:
             key_seed = entropy
-        keychain.add_private_key(bytes_to_mnemonic(key_seed), "")
+        keychain.add_private_key(bytes_to_mnemonic(key_seed))
         first_pk = keychain.get_first_public_key()
         assert first_pk is not None
         db_path_key_suffix = str(first_pk.get_fingerprint())

--- a/tests/util/bip39_test_vectors.json
+++ b/tests/util/bip39_test_vectors.json
@@ -3,146 +3,122 @@
         [
             "00000000000000000000000000000000",
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-            "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
-            "xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF"
+            "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4"
         ],
         [
             "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
             "legal winner thank year wave sausage worth useful legal winner thank yellow",
-            "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
-            "xprv9s21ZrQH143K2gA81bYFHqU68xz1cX2APaSq5tt6MFSLeXnCKV1RVUJt9FWNTbrrryem4ZckN8k4Ls1H6nwdvDTvnV7zEXs2HgPezuVccsq"
+            "878386efb78845b3355bd15ea4d39ef97d179cb712b77d5c12b6be415fffeffe5f377ba02bf3f8544ab800b955e51fbff09828f682052a20faa6addbbddfb096"
         ],
         [
             "80808080808080808080808080808080",
             "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
-            "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
-            "xprv9s21ZrQH143K2shfP28KM3nr5Ap1SXjz8gc2rAqqMEynmjt6o1qboCDpxckqXavCwdnYds6yBHZGKHv7ef2eTXy461PXUjBFQg6PrwY4Gzq"
+            "77d6be9708c8218738934f84bbbb78a2e048ca007746cb764f0673e4b1812d176bbb173e1a291f31cf633f1d0bad7d3cf071c30e98cd0688b5bcce65ecaceb36"
         ],
         [
             "ffffffffffffffffffffffffffffffff",
             "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
-            "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
-            "xprv9s21ZrQH143K2V4oox4M8Zmhi2Fjx5XK4Lf7GKRvPSgydU3mjZuKGCTg7UPiBUD7ydVPvSLtg9hjp7MQTYsW67rZHAXeccqYqrsx8LcXnyd"
+            "b6a6d8921942dd9806607ebc2750416b289adea669198769f2e15ed926c3aa92bf88ece232317b4ea463e84b0fcd3b53577812ee449ccc448eb45e6f544e25b6"
         ],
         [
             "000000000000000000000000000000000000000000000000",
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
-            "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
-            "xprv9s21ZrQH143K3mEDrypcZ2usWqFgzKB6jBBx9B6GfC7fu26X6hPRzVjzkqkPvDqp6g5eypdk6cyhGnBngbjeHTe4LsuLG1cCmKJka5SMkmU"
+            "4975bb3d1faf5308c86a30893ee903a976296609db223fd717e227da5a813a34dc1428b71c84a787fc51f3b9f9dc28e9459f48c08bd9578e9d1b170f2d7ea506"
         ],
         [
             "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
             "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
-            "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
-            "xprv9s21ZrQH143K3Lv9MZLj16np5GzLe7tDKQfVusBni7toqJGcnKRtHSxUwbKUyUWiwpK55g1DUSsw76TF1T93VT4gz4wt5RM23pkaQLnvBh7"
+            "b059400ce0f55498a5527667e77048bb482ff6daa16c37b4b9e8af70c85b3f4df588004f19812a1a027c9a51e5e94259a560268e91cd10e206451a129826e740"
         ],
         [
             "808080808080808080808080808080808080808080808080",
             "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
-            "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
-            "xprv9s21ZrQH143K3VPCbxbUtpkh9pRG371UCLDz3BjceqP1jz7XZsQ5EnNkYAEkfeZp62cDNj13ZTEVG1TEro9sZ9grfRmcYWLBhCocViKEJae"
+            "04d5f77103510c41d610f7f5fb3f0badc77c377090815cee808ea5d2f264fdfabf7c7ded4be6d4c6d7cdb021ba4c777b0b7e57ca8aa6de15aeb9905dba674d66"
         ],
         [
             "ffffffffffffffffffffffffffffffffffffffffffffffff",
             "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
-            "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
-            "xprv9s21ZrQH143K36Ao5jHRVhFGDbLP6FCx8BEEmpru77ef3bmA928BxsqvVM27WnvvyfWywiFN8K6yToqMaGYfzS6Db1EHAXT5TuyCLBXUfdm"
+            "d2911131a6dda23ac4441d1b66e2113ec6324354523acfa20899a2dcb3087849264e91f8ec5d75355f0f617be15369ffa13c3d18c8156b97cd2618ac693f759f"
         ],
         [
             "0000000000000000000000000000000000000000000000000000000000000000",
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
-            "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
-            "xprv9s21ZrQH143K32qBagUJAMU2LsHg3ka7jqMcV98Y7gVeVyNStwYS3U7yVVoDZ4btbRNf4h6ibWpY22iRmXq35qgLs79f312g2kj5539ebPM"
+            "408b285c123836004f4b8842c89324c1f01382450c0d439af345ba7fc49acf705489c6fc77dbd4e3dc1dd8cc6bc9f043db8ada1e243c4a0eafb290d399480840"
         ],
         [
             "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
             "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
-            "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
-            "xprv9s21ZrQH143K3Y1sd2XVu9wtqxJRvybCfAetjUrMMco6r3v9qZTBeXiBZkS8JxWbcGJZyio8TrZtm6pkbzG8SYt1sxwNLh3Wx7to5pgiVFU"
+            "761914478ebf6fe16185749372e91549361af22b386de46322cf8b1ba7e92e80c4af05196f742be1e63aab603899842ddadf4e7248d8e43870a4b6ff9bf16324"
         ],
         [
             "8080808080808080808080808080808080808080808080808080808080808080",
             "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
-            "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
-            "xprv9s21ZrQH143K3CSnQNYC3MqAAqHwxeTLhDbhF43A4ss4ciWNmCY9zQGvAKUSqVUf2vPHBTSE1rB2pg4avopqSiLVzXEU8KziNnVPauTqLRo"
+            "848bbe19cad445e46f35fd3d1a89463583ac2b60b5eb4cfcf955731775a5d9e17a81a71613fed83f1ae27b408478fdec2bbc75b5161d1937aa7cdf4ad686ef5f"
         ],
         [
             "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
             "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
-            "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
-            "xprv9s21ZrQH143K2WFF16X85T2QCpndrGwx6GueB72Zf3AHwHJaknRXNF37ZmDrtHrrLSHvbuRejXcnYxoZKvRquTPyp2JiNG3XcjQyzSEgqCB"
+            "e28a37058c7f5112ec9e16a3437cf363a2572d70b6ceb3b6965447623d620f14d06bb321a26b33ec15fcd84a3b5ddfd5520e230c924c87aaa0d559749e044fef"
         ],
         [
             "9e885d952ad362caeb4efe34a8e91bd2",
             "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
-            "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
-            "xprv9s21ZrQH143K2oZ9stBYpoaZ2ktHj7jLz7iMqpgg1En8kKFTXJHsjxry1JbKH19YrDTicVwKPehFKTbmaxgVEc5TpHdS1aYhB2s9aFJBeJH"
+            "e2f88a043776c828063d4c3c97173944d32cf847a925b6e40b0b8bd0b4bead3ba734bdda5250d4698b310a71c9934e1a48e562315ce22bf85f89459df0e73a6c"
         ],
         [
             "6610b25967cdcca9d59875f5cb50b0ea75433311869e930b",
             "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
-            "628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac",
-            "xprv9s21ZrQH143K3uT8eQowUjsxrmsA9YUuQQK1RLqFufzybxD6DH6gPY7NjJ5G3EPHjsWDrs9iivSbmvjc9DQJbJGatfa9pv4MZ3wjr8qWPAK"
+            "31736b4f31612ece84404c74a5d3b938a092480eb89c11b81491f1a3657eb2fe50024610fbe814df55913a87ef741020fcf076a75a29aea0aba638126ba4c8bb"
         ],
         [
             "68a79eaca2324873eacc50cb9c6eca8cc68ea5d936f98787c60c7ebc74e6ce7c",
             "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
-            "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
-            "xprv9s21ZrQH143K2XTAhys3pMNcGn261Fi5Ta2Pw8PwaVPhg3D8DWkzWQwjTJfskj8ofb81i9NP2cUNKxwjueJHHMQAnxtivTA75uUFqPFeWzk"
+            "17e4b5661796eeff8904550f8572289317ece7c1cc1316469f8f4c986c1ffd7b9f4c3aeac3e1713ffc21fa33707d09d57a2ece358d72111ef7c7658e7b33f2d5"
         ],
         [
             "c0ba5a8e914111210f2bd131f3d5e08d",
             "scheme spot photo card baby mountain device kick cradle pact join borrow",
-            "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
-            "xprv9s21ZrQH143K3FperxDp8vFsFycKCRcJGAFmcV7umQmcnMZaLtZRt13QJDsoS5F6oYT6BB4sS6zmTmyQAEkJKxJ7yByDNtRe5asP2jFGhT6"
+            "00e1e39a39e23735adab690d0ffbefda6cacc063b4a5fcc605de060bd370adc54c94370d966b9a3fae5ed16bd58a02224cbefca4146a083951b70be2a2ce3dcc"
         ],
         [
             "6d9be1ee6ebd27a258115aad99b7317b9c8d28b6d76431c3",
             "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
-            "fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d",
-            "xprv9s21ZrQH143K3R1SfVZZLtVbXEB9ryVxmVtVMsMwmEyEvgXN6Q84LKkLRmf4ST6QrLeBm3jQsb9gx1uo23TS7vo3vAkZGZz71uuLCcywUkt"
+            "e893fc34fa2a78ceaaea78c246b69257ad283fa538d88f3c4520beb618a2062b8ec4920ed1793fff6ad443523ed18c03da433004d0a1e9497e194621607bc9e2"
         ],
         [
             "9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863",
             "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
-            "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
-            "xprv9s21ZrQH143K2WNnKmssvZYM96VAr47iHUQUTUyUXH3sAGNjhJANddnhw3i3y3pBbRAVk5M5qUGFr4rHbEWwXgX4qrvrceifCYQJbbFDems"
+            "3e066d7dee2dbf8fcd3fe240a3975658ca118a8f6f4ca81cf99104944604b05a5090a79d99e545704b914ca0397fedb82fd00fd6a72098703709c891a065ee49"
         ],
         [
             "23db8160a31d3e0dca3688ed941adbf3",
             "cat swing flag economy stadium alone churn speed unique patch report train",
-            "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
-            "xprv9s21ZrQH143K4G28omGMogEoYgDQuigBo8AFHAGDaJdqQ99QKMQ5J6fYTMfANTJy6xBmhvsNZ1CJzRZ64PWbnTFUn6CDV2FxoMDLXdk95DQ"
+            "7ea73b3a398f8a71f7dde589d972b0358d3fa8b9e91317ecc544e42752b1bb251a1926b1f4c69eec0a80c0396aa0f7df29f7d73411d3106eba539f3d584fcdf8"
         ],
         [
             "8197a4a47f0425faeaa69deebc05ca29c0a5b5cc76ceacc0",
             "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
-            "4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02",
-            "xprv9s21ZrQH143K3wtsvY8L2aZyxkiWULZH4vyQE5XkHTXkmx8gHo6RUEfH3Jyr6NwkJhvano7Xb2o6UqFKWHVo5scE31SGDCAUsgVhiUuUDyh"
+            "d0ca8861283a7124515e825b7a06de8e0ad0dd5ac7888013efe6e3c300d4745bbd2c729f3355d769d23718579e7b735999a8f0b38e22b5bff45c9085af449056"
         ],
         [
             "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
             "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
-            "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
-            "xprv9s21ZrQH143K3rEfqSM4QZRVmiMuSWY9wugscmaCjYja3SbUD3KPEB1a7QXJoajyR2T1SiXU7rFVRXMV9XdYVSZe7JoUXdP4SRHTxsT1nzm"
+            "fc795be0c3f18c50dddb34e72179dc597d64055497ecc1e69e2e56a5409651bc139aae8070d4df0ea14d8d2a518a9a00bb1cc6e92e053fe34051f6821df9164c"
         ],
         [
             "f30f8c1da665478f49b001d94c5fc452",
             "vessel ladder alter error federal sibling chat ability sun glass valve picture",
-            "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
-            "xprv9s21ZrQH143K2QWV9Wn8Vvs6jbqfF1YbTCdURQW9dLFKDovpKaKrqS3SEWsXCu6ZNky9PSAENg6c9AQYHcg4PjopRGGKmdD313ZHszymnps"
+            "e2d7f9a462875c1325f44f321392edc8eaafebf1547c89d72d10b41b4ee23af3fb0ab010f39f5cbea3b3aa671161b58262b6a508bcbe2d34ee272a942534d45f"
         ],
         [
             "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
             "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
-            "7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88",
-            "xprv9s21ZrQH143K4aERa2bq7559eMCCEs2QmmqVjUuzfy5eAeDX4mqZffkYwpzGQRE2YEEeLVRoH4CSHxianrFaVnMN2RYaPUZJhJx8S5j6puX"
+            "a555426999448df9022c3afc2ed0e4aebff3a0ac37d8a395f81412e14994efc960ed168d39a80478e0467a3d5cfc134fef2767c1d3a27f18e3afeb11bfc8e6ad"
         ],
         [
             "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
             "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
-            "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
-            "xprv9s21ZrQH143K39rnQJknpH1WEPFJrzmAqqasiDcVrNuk926oizzJDDQkdiTvNPr2FYDYzWgiMiC63YmfPAa2oPyNB23r2g7d1yiK6WpqaQS"
+            "b873212f885ccffbf4692afcb84bc2e55886de2dfa07d90f5c3c239abc31c0a6ce047e30fd8bf6a281e71389aa82d73df74c7bbfb3b06b4639a5cee775cccd3c"
         ]
     ]
 }

--- a/tests/wallet/test_wallet_node.py
+++ b/tests/wallet/test_wallet_node.py
@@ -17,7 +17,7 @@ async def test_get_private_key(root_path_populated_with_config: Path, get_temp_k
     keychain: Keychain = get_temp_keyring
     config: Dict[str, Any] = load_config(root_path, "config.yaml", "wallet")
     node: WalletNode = WalletNode(config, root_path, test_constants, keychain)
-    sk: PrivateKey = keychain.add_private_key(generate_mnemonic(), "")
+    sk: PrivateKey = keychain.add_private_key(generate_mnemonic())
     fingerprint: int = sk.get_g1().get_fingerprint()
 
     key = await node.get_private_key(fingerprint)
@@ -32,12 +32,12 @@ async def test_get_private_key_default_key(root_path_populated_with_config: Path
     keychain: Keychain = get_temp_keyring
     config: Dict[str, Any] = load_config(root_path, "config.yaml", "wallet")
     node: WalletNode = WalletNode(config, root_path, test_constants, keychain)
-    sk: PrivateKey = keychain.add_private_key(generate_mnemonic(), "")
+    sk: PrivateKey = keychain.add_private_key(generate_mnemonic())
     fingerprint: int = sk.get_g1().get_fingerprint()
 
     # Add a couple more keys
-    keychain.add_private_key(generate_mnemonic(), "")
-    keychain.add_private_key(generate_mnemonic(), "")
+    keychain.add_private_key(generate_mnemonic())
+    keychain.add_private_key(generate_mnemonic())
 
     # When no fingerprint is provided, we should get the default (first) key
     key = await node.get_private_key(None)
@@ -70,7 +70,7 @@ async def test_get_private_key_missing_key_use_default(
     keychain: Keychain = get_temp_keyring
     config: Dict[str, Any] = load_config(root_path, "config.yaml", "wallet")
     node: WalletNode = WalletNode(config, root_path, test_constants, keychain)
-    sk: PrivateKey = keychain.add_private_key(generate_mnemonic(), "")
+    sk: PrivateKey = keychain.add_private_key(generate_mnemonic())
     fingerprint: int = sk.get_g1().get_fingerprint()
 
     # Stupid sanity check that the fingerprint we're going to use isn't actually in the keychain
@@ -88,7 +88,7 @@ def test_log_in(root_path_populated_with_config: Path, get_temp_keyring: Keychai
     keychain: Keychain = get_temp_keyring
     config: Dict[str, Any] = load_config(root_path, "config.yaml", "wallet")
     node: WalletNode = WalletNode(config, root_path, test_constants)
-    sk: PrivateKey = keychain.add_private_key(generate_mnemonic(), "")
+    sk: PrivateKey = keychain.add_private_key(generate_mnemonic())
     fingerprint: int = sk.get_g1().get_fingerprint()
 
     node.log_in(sk)
@@ -114,7 +114,7 @@ def test_log_in_failure_to_write_last_used_fingerprint(
         keychain: Keychain = get_temp_keyring
         config: Dict[str, Any] = load_config(root_path, "config.yaml", "wallet")
         node: WalletNode = WalletNode(config, root_path, test_constants)
-        sk: PrivateKey = keychain.add_private_key(generate_mnemonic(), "")
+        sk: PrivateKey = keychain.add_private_key(generate_mnemonic())
         fingerprint: int = sk.get_g1().get_fingerprint()
 
         # Expect log_in to succeed, even though we can't write the last used fingerprint
@@ -131,7 +131,7 @@ def test_log_out(root_path_populated_with_config: Path, get_temp_keyring: Keycha
     keychain: Keychain = get_temp_keyring
     config: Dict[str, Any] = load_config(root_path, "config.yaml", "wallet")
     node: WalletNode = WalletNode(config, root_path, test_constants)
-    sk: PrivateKey = keychain.add_private_key(generate_mnemonic(), "")
+    sk: PrivateKey = keychain.add_private_key(generate_mnemonic())
     fingerprint: int = sk.get_g1().get_fingerprint()
 
     node.log_in(sk)


### PR DESCRIPTION
It's not fully implemented + we already encrypt the keyring with a separate mechanism.

Right now it's possible to add keys with a BIP39 passphrase via the daemon API but there is no way to use them since we only use the default password (no password, `""`) for decryption so i assume its safe to entirely delete this from the code and (also from the daemon API which breaks compatibility but i think its fine in this case since most likely no one uses/used it).


Note: This adjusts the seeds in the BIP39 test vector file to contain the seed without a passphrase, i.e. without `TREZOR`.
