### PR TITLE
util: Introduce `KeyData` and `_get_pk_and_entropy` -> `_get_key_data`

### DIFF
--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -184,9 +184,9 @@ class KeychainException(Exception):
     pass
 
 
-class KeychainKeyDataMissmatch(KeychainException):
+class KeychainKeyDataMismatch(KeychainException):
     def __init__(self, data_type: str):
-        super().__init__(f"KeyData missmatch for: {data_type}")
+        super().__init__(f"KeyData mismatch for: {data_type}")
 
 
 class KeychainIsLocked(KeychainException):

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -184,7 +184,16 @@ class KeychainException(Exception):
     pass
 
 
+class KeychainKeyDataMissmatch(KeychainException):
+    def __init__(self, data_type: str):
+        super().__init__(f"KeyData missmatch for: {data_type}")
+
+
 class KeychainIsLocked(KeychainException):
+    pass
+
+
+class KeychainSecretsMissing(KeychainException):
     pass
 
 
@@ -235,6 +244,11 @@ class KeychainLockTimeout(KeychainException):
 class KeychainProxyConnectionTimeout(KeychainException):
     def __init__(self) -> None:
         super().__init__("Could not reconnect to keychain service in 30 seconds.")
+
+
+class KeychainUserNotFound(KeychainException):
+    def __init__(self, service: str, user: str) -> None:
+        super().__init__(f"user {user!r} not found for service {service!r}")
 
 
 class KeychainFingerprintError(KeychainException):

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -155,13 +155,14 @@ class KeyDataSecrets(Streamable):
         # This is redundant if `from_*` methods are used but its to make sure there can't be an `KeyDataSecrets`
         # instance with an attribute mismatch for calculated cached values. Should be ok since we don't handle a lot of
         # keys here.
+        mnemonic_str = self.mnemonic_str()
         try:
-            bytes_from_mnemonic(self.mnemonic_str())
+            bytes_from_mnemonic(mnemonic_str)
         except Exception as e:
             raise KeychainKeyDataMismatch("mnemonic") from e
-        if bytes_from_mnemonic(self.mnemonic_str()) != self.entropy:
+        if bytes_from_mnemonic(mnemonic_str) != self.entropy:
             raise KeychainKeyDataMismatch("entropy")
-        if AugSchemeMPL.key_gen(mnemonic_to_seed(self.mnemonic_str())) != self.private_key:
+        if AugSchemeMPL.key_gen(mnemonic_to_seed(mnemonic_str)) != self.private_key:
             raise KeychainKeyDataMismatch("private_key")
 
     @classmethod

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -379,7 +379,7 @@ class Keychain:
         removed = 0
         for index in range(MAX_KEYS + 1):
             try:
-                key_data = self._get_key_data(index)
+                key_data = self._get_key_data(index, include_secrets=False)
                 if key_data.fingerprint == fingerprint:
                     try:
                         self.keyring_wrapper.delete_passphrase(self.service, get_private_key_user(self.user, index))

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -1,17 +1,28 @@
+from __future__ import annotations
 import pkg_resources
 import sys
 import unicodedata
 
 from bitstring import BitArray  # pyright: reportMissingImports=false
 from blspy import AugSchemeMPL, G1Element, PrivateKey  # pyright: reportMissingImports=false
-from chia.util.errors import KeychainNotSet, KeychainFingerprintExists
+from chia.util.errors import (
+    KeychainNotSet,
+    KeychainKeyDataMissmatch,
+    KeychainFingerprintExists,
+    KeychainSecretsMissing,
+    KeychainUserNotFound,
+)
 from chia.util.hash import std_hash
+from chia.util.ints import uint32
 from chia.util.keyring_wrapper import KeyringWrapper
+from chia.util.streamable import streamable, Streamable
+from dataclasses import dataclass
 from hashlib import pbkdf2_hmac
 from pathlib import Path
 from secrets import token_bytes
 from typing import Any, Dict, List, Optional, Tuple
 
+from typing_extensions import final
 
 CURRENT_KEY_VERSION = "1.8"
 DEFAULT_USER = f"user-chia-{CURRENT_KEY_VERSION}"  # e.g. user-chia-1.8
@@ -132,6 +143,104 @@ def get_private_key_user(user: str, index: int) -> str:
     return f"wallet-{user}-{index}"
 
 
+@final
+@streamable
+@dataclass(frozen=True)
+class KeyDataSecrets(Streamable):
+    mnemonic: List[str]
+    entropy: bytes
+    private_key: PrivateKey
+
+    def __post_init__(self) -> None:
+        # This is redundant if `from_*` methods are used but its to make sure there can't be an `KeyDataSecrets`
+        # instance with an attribute missmatch for calculated cached values. Should be ok since we don't handle a lot of
+        # keys here.
+        try:
+            bytes_from_mnemonic(self.mnemonic_str())
+        except Exception as e:
+            raise KeychainKeyDataMissmatch("mnemonic") from e
+        if bytes_from_mnemonic(self.mnemonic_str()) != self.entropy:
+            raise KeychainKeyDataMissmatch("entropy")
+        if AugSchemeMPL.key_gen(mnemonic_to_seed(self.mnemonic_str())) != self.private_key:
+            raise KeychainKeyDataMissmatch("private_key")
+
+    @classmethod
+    def from_mnemonic(cls, mnemonic: str) -> KeyDataSecrets:
+        return cls(
+            mnemonic=mnemonic.split(),
+            entropy=bytes_from_mnemonic(mnemonic),
+            private_key=AugSchemeMPL.key_gen(mnemonic_to_seed(mnemonic)),
+        )
+
+    @classmethod
+    def from_entropy(cls, entropy: bytes) -> KeyDataSecrets:
+        return cls.from_mnemonic(bytes_to_mnemonic(entropy))
+
+    @classmethod
+    def generate(cls) -> KeyDataSecrets:
+        return cls.from_mnemonic(generate_mnemonic())
+
+    def mnemonic_str(self) -> str:
+        return " ".join(self.mnemonic)
+
+
+@final
+@streamable
+@dataclass(frozen=True)
+class KeyData(Streamable):
+    fingerprint: uint32
+    public_key: G1Element
+    secrets: Optional[KeyDataSecrets]
+
+    def __post_init__(self) -> None:
+        # This is redundant if `from_*` methods are used but its to make sure there can't be an `KeyData` instance with
+        # an attribute missmatch for calculated cached values. Should be ok since we don't handle a lot of keys here.
+        if self.secrets is not None and self.public_key != self.private_key.get_g1():
+            raise KeychainKeyDataMissmatch("public_key")
+        if self.public_key.get_fingerprint() != self.fingerprint:
+            raise KeychainKeyDataMissmatch("fingerprint")
+
+    @classmethod
+    def from_mnemonic(cls, mnemonic: str) -> KeyData:
+        private_key = AugSchemeMPL.key_gen(mnemonic_to_seed(mnemonic))
+        return cls(
+            fingerprint=private_key.get_g1().get_fingerprint(),
+            public_key=private_key.get_g1(),
+            secrets=KeyDataSecrets.from_mnemonic(mnemonic),
+        )
+
+    @classmethod
+    def from_entropy(cls, entropy: bytes) -> KeyData:
+        return cls.from_mnemonic(bytes_to_mnemonic(entropy))
+
+    @classmethod
+    def generate(cls) -> KeyData:
+        return cls.from_mnemonic(generate_mnemonic())
+
+    @property
+    def mnemonic(self) -> List[str]:
+        if self.secrets is None:
+            raise KeychainSecretsMissing()
+        return self.secrets.mnemonic
+
+    def mnemonic_str(self) -> str:
+        if self.secrets is None:
+            raise KeychainSecretsMissing()
+        return self.secrets.mnemonic_str()
+
+    @property
+    def entropy(self) -> bytes:
+        if self.secrets is None:
+            raise KeychainSecretsMissing()
+        return self.secrets.entropy
+
+    @property
+    def private_key(self) -> PrivateKey:
+        if self.secrets is None:
+            raise KeychainSecretsMissing()
+        return self.secrets.private_key
+
+
 class Keychain:
     """
     The keychain stores two types of keys: private keys, which are PrivateKeys from blspy,
@@ -156,19 +265,24 @@ class Keychain:
 
         self.keyring_wrapper = keyring_wrapper
 
-    def _get_pk_and_entropy(self, user: str) -> Optional[Tuple[G1Element, bytes]]:
+    def _get_key_data(self, index: int, include_secrets: bool = True) -> KeyData:
         """
-        Returns the keychain contents for a specific 'user' (key index). The contents
-        include an G1Element and the entropy required to generate the private key.
-        Note that generating the actual private key also requires the passphrase.
+        Returns the parsed keychain contents for a specific 'user' (key index). The content
+        is represented by the class `KeyData`.
         """
+        user = get_private_key_user(self.user, index)
         read_str = self.keyring_wrapper.get_passphrase(self.service, user)
         if read_str is None or len(read_str) == 0:
-            return None
+            raise KeychainUserNotFound(self.service, user)
         str_bytes = bytes.fromhex(read_str)
-        return (
-            G1Element.from_bytes(str_bytes[: G1Element.SIZE]),
-            str_bytes[G1Element.SIZE :],  # flake8: noqa
+
+        public_key = G1Element.from_bytes(str_bytes[: G1Element.SIZE])
+        entropy = str_bytes[G1Element.SIZE : G1Element.SIZE + 32]
+
+        return KeyData(
+            fingerprint=public_key.get_fingerprint(),
+            public_key=public_key,
+            secrets=KeyDataSecrets.from_entropy(entropy) if include_secrets else None,
         )
 
     def _get_free_private_key_index(self) -> int:
@@ -177,11 +291,11 @@ class Keychain:
         """
         index = 0
         while True:
-            pk = get_private_key_user(self.user, index)
-            pkent = self._get_pk_and_entropy(pk)
-            if pkent is None:
+            try:
+                self._get_key_data(index)
+                index += 1
+            except KeychainUserNotFound:
                 return index
-            index += 1
 
     def add_private_key(self, mnemonic: str) -> PrivateKey:
         """
@@ -210,36 +324,25 @@ class Keychain:
         """
         Returns the first key in the keychain that has one of the passed in passphrases.
         """
-        index = 0
-        pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
-        while index <= MAX_KEYS:
-            if pkent is not None:
-                pk, ent = pkent
-                mnemonic = bytes_to_mnemonic(ent)
-                seed = mnemonic_to_seed(mnemonic)
-                key = AugSchemeMPL.key_gen(seed)
-                if key.get_g1() == pk:
-                    return (key, ent)
-            index += 1
-            pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
+        for index in range(MAX_KEYS + 1):
+            try:
+                key_data = self._get_key_data(index)
+                return key_data.private_key, key_data.entropy
+            except KeychainUserNotFound:
+                pass
         return None
 
     def get_private_key_by_fingerprint(self, fingerprint: int) -> Optional[Tuple[PrivateKey, bytes]]:
         """
         Return first private key which have the given public key fingerprint.
         """
-        index = 0
-        pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
-        while index <= MAX_KEYS:
-            if pkent is not None:
-                pk, ent = pkent
-                mnemonic = bytes_to_mnemonic(ent)
-                seed = mnemonic_to_seed(mnemonic)
-                key = AugSchemeMPL.key_gen(seed)
-                if pk.get_fingerprint() == fingerprint:
-                    return (key, ent)
-            index += 1
-            pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
+        for index in range(MAX_KEYS + 1):
+            try:
+                key_data = self._get_key_data(index)
+                if key_data.fingerprint == fingerprint:
+                    return key_data.private_key, key_data.entropy
+            except KeychainUserNotFound:
+                pass
         return None
 
     def get_all_private_keys(self) -> List[Tuple[PrivateKey, bytes]]:
@@ -248,19 +351,12 @@ class Keychain:
         A tuple of key, and entropy bytes (i.e. mnemonic) is returned for each key.
         """
         all_keys: List[Tuple[PrivateKey, bytes]] = []
-
-        index = 0
-        pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
-        while index <= MAX_KEYS:
-            if pkent is not None:
-                pk, ent = pkent
-                mnemonic = bytes_to_mnemonic(ent)
-                seed = mnemonic_to_seed(mnemonic)
-                key = AugSchemeMPL.key_gen(seed)
-                if key.get_g1() == pk:
-                    all_keys.append((key, ent))
-            index += 1
-            pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
+        for index in range(MAX_KEYS + 1):
+            try:
+                key_data = self._get_key_data(index)
+                all_keys.append((key_data.private_key, key_data.entropy))
+            except KeychainUserNotFound:
+                pass
         return all_keys
 
     def get_all_public_keys(self) -> List[G1Element]:
@@ -282,15 +378,16 @@ class Keychain:
         """
         removed = 0
         for index in range(MAX_KEYS + 1):
-            pkent = self._get_pk_and_entropy(get_private_key_user(self.user, index))
-            if pkent is not None:
-                pk, ent = pkent
-                if pk.get_fingerprint() == fingerprint:
+            try:
+                key_data = self._get_key_data(index)
+                if key_data.fingerprint == fingerprint:
                     try:
                         self.keyring_wrapper.delete_passphrase(self.service, get_private_key_user(self.user, index))
                         removed += 1
                     except Exception:
                         pass
+            except KeychainUserNotFound:
+                pass
         return removed
 
     def delete_keys(self, keys_to_delete: List[Tuple[PrivateKey, bytes]]):

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -7,7 +7,7 @@ from bitstring import BitArray  # pyright: reportMissingImports=false
 from blspy import AugSchemeMPL, G1Element, PrivateKey  # pyright: reportMissingImports=false
 from chia.util.errors import (
     KeychainNotSet,
-    KeychainKeyDataMissmatch,
+    KeychainKeyDataMismatch,
     KeychainFingerprintExists,
     KeychainSecretsMissing,
     KeychainUserNotFound,
@@ -153,16 +153,16 @@ class KeyDataSecrets(Streamable):
 
     def __post_init__(self) -> None:
         # This is redundant if `from_*` methods are used but its to make sure there can't be an `KeyDataSecrets`
-        # instance with an attribute missmatch for calculated cached values. Should be ok since we don't handle a lot of
+        # instance with an attribute mismatch for calculated cached values. Should be ok since we don't handle a lot of
         # keys here.
         try:
             bytes_from_mnemonic(self.mnemonic_str())
         except Exception as e:
-            raise KeychainKeyDataMissmatch("mnemonic") from e
+            raise KeychainKeyDataMismatch("mnemonic") from e
         if bytes_from_mnemonic(self.mnemonic_str()) != self.entropy:
-            raise KeychainKeyDataMissmatch("entropy")
+            raise KeychainKeyDataMismatch("entropy")
         if AugSchemeMPL.key_gen(mnemonic_to_seed(self.mnemonic_str())) != self.private_key:
-            raise KeychainKeyDataMissmatch("private_key")
+            raise KeychainKeyDataMismatch("private_key")
 
     @classmethod
     def from_mnemonic(cls, mnemonic: str) -> KeyDataSecrets:
@@ -194,11 +194,11 @@ class KeyData(Streamable):
 
     def __post_init__(self) -> None:
         # This is redundant if `from_*` methods are used but its to make sure there can't be an `KeyData` instance with
-        # an attribute missmatch for calculated cached values. Should be ok since we don't handle a lot of keys here.
+        # an attribute mismatch for calculated cached values. Should be ok since we don't handle a lot of keys here.
         if self.secrets is not None and self.public_key != self.private_key.get_g1():
-            raise KeychainKeyDataMissmatch("public_key")
+            raise KeychainKeyDataMismatch("public_key")
         if self.public_key.get_fingerprint() != self.fingerprint:
-            raise KeychainKeyDataMissmatch("fingerprint")
+            raise KeychainKeyDataMismatch("fingerprint")
 
     @classmethod
     def from_mnemonic(cls, mnemonic: str) -> KeyData:

--- a/tests/core/util/test_keychain.py
+++ b/tests/core/util/test_keychain.py
@@ -1,18 +1,33 @@
 import json
 import unittest
 from secrets import token_bytes
+from typing import Callable, List, Optional, Tuple
 
 import pytest
-from blspy import AugSchemeMPL, PrivateKey
+from blspy import AugSchemeMPL, G1Element, PrivateKey
 
 from tests.util.keyring import using_temp_file_keyring
-from chia.util.errors import KeychainFingerprintExists
+from chia.util.errors import KeychainFingerprintExists, KeychainKeyDataMissmatch, KeychainSecretsMissing
+from chia.util.ints import uint32
 from chia.util.keychain import (
     Keychain,
+    KeyData,
+    KeyDataSecrets,
     bytes_from_mnemonic,
     bytes_to_mnemonic,
     generate_mnemonic,
     mnemonic_to_seed,
+)
+
+mnemonic = (
+    "rapid this oven common drive ribbon bulb urban uncover napkin kitten usage enforce uncle unveil scene "
+    "apart wire mystery torch peanut august flee fantasy"
+)
+entropy = bytes.fromhex("b1fc1a7717343572077f7aecb25ded77c4a3d93b9e040a5f8649f2aa1e1e5632")
+private_key = PrivateKey.from_bytes(bytes.fromhex("6c6bb4cc3dae03b8d0b327dd6765834464a883f7ca7df134970842055efe8afc"))
+fingerprint = uint32(1310648153)
+public_key = G1Element.from_bytes(
+    bytes.fromhex("b5acf3599bc5fa5da1c00f6cc3d5bcf1560def67778b7f50a8c373a83f78761505b6250ab776e38a292e26628009aec4")
 )
 
 
@@ -131,3 +146,83 @@ class TestKeychain(unittest.TestCase):
         assert seed_nfkd == seed_nfc
         assert seed_nfkd == seed_nfkc
         assert seed_nfkd == seed_nfd
+
+
+def test_key_data_secrets_generate() -> None:
+    secrets = KeyDataSecrets.generate()
+    assert secrets.private_key == AugSchemeMPL.key_gen(mnemonic_to_seed(secrets.mnemonic_str()))
+    assert secrets.entropy == bytes_from_mnemonic(secrets.mnemonic_str())
+
+
+@pytest.mark.parametrize(
+    "input_data, from_method", [(mnemonic, KeyDataSecrets.from_mnemonic), (entropy, KeyDataSecrets.from_entropy)]
+)
+def test_key_data_secrets_creation(input_data: object, from_method: Callable[..., KeyDataSecrets]) -> None:
+    secrets = from_method(input_data)
+    assert secrets.mnemonic == mnemonic.split()
+    assert secrets.mnemonic_str() == mnemonic
+    assert secrets.entropy == entropy
+    assert secrets.private_key == private_key
+
+
+def test_key_data_generate() -> None:
+    key_data = KeyData.generate()
+    assert key_data.private_key == AugSchemeMPL.key_gen(mnemonic_to_seed(key_data.mnemonic_str()))
+    assert key_data.entropy == bytes_from_mnemonic(key_data.mnemonic_str())
+    assert key_data.public_key == key_data.private_key.get_g1()
+    assert key_data.fingerprint == key_data.private_key.get_g1().get_fingerprint()
+
+
+@pytest.mark.parametrize(
+    "input_data, from_method", [(mnemonic, KeyData.from_mnemonic), (entropy, KeyData.from_entropy)]
+)
+def test_key_data_creation(input_data: object, from_method: Callable[..., KeyData]) -> None:
+    key_data = from_method(input_data)
+    assert key_data.fingerprint == fingerprint
+    assert key_data.public_key == public_key
+    assert key_data.mnemonic == mnemonic.split()
+    assert key_data.mnemonic_str() == mnemonic
+    assert key_data.entropy == entropy
+    assert key_data.private_key == private_key
+
+
+def test_key_data_without_secrets() -> None:
+    key_data = KeyData(fingerprint, public_key, None)
+    assert key_data.secrets is None
+
+    with pytest.raises(KeychainSecretsMissing):
+        print(key_data.mnemonic)
+
+    with pytest.raises(KeychainSecretsMissing):
+        print(key_data.mnemonic_str())
+
+    with pytest.raises(KeychainSecretsMissing):
+        print(key_data.entropy)
+
+    with pytest.raises(KeychainSecretsMissing):
+        print(key_data.private_key)
+
+
+@pytest.mark.parametrize(
+    "input_data, data_type",
+    [
+        ((mnemonic.split()[:-1], entropy, private_key), "mnemonic"),
+        ((mnemonic.split(), KeyDataSecrets.generate().entropy, private_key), "entropy"),
+        ((mnemonic.split(), entropy, KeyDataSecrets.generate().private_key), "private_key"),
+    ],
+)
+def test_key_data_secrets_post_init(input_data: Tuple[List[str], bytes, PrivateKey], data_type: str) -> None:
+    with pytest.raises(KeychainKeyDataMissmatch, match=data_type):
+        KeyDataSecrets(*input_data)
+
+
+@pytest.mark.parametrize(
+    "input_data, data_type",
+    [
+        ((fingerprint, G1Element(), KeyDataSecrets(mnemonic.split(), entropy, private_key)), "public_key"),
+        ((fingerprint, G1Element(), None), "fingerprint"),
+    ],
+)
+def test_key_data_post_init(input_data: Tuple[uint32, G1Element, Optional[KeyDataSecrets]], data_type: str) -> None:
+    with pytest.raises(KeychainKeyDataMissmatch, match=data_type):
+        KeyData(*input_data)

--- a/tests/core/util/test_keychain.py
+++ b/tests/core/util/test_keychain.py
@@ -7,7 +7,7 @@ import pytest
 from blspy import AugSchemeMPL, G1Element, PrivateKey
 
 from tests.util.keyring import using_temp_file_keyring
-from chia.util.errors import KeychainFingerprintExists, KeychainKeyDataMissmatch, KeychainSecretsMissing
+from chia.util.errors import KeychainFingerprintExists, KeychainKeyDataMismatch, KeychainSecretsMissing
 from chia.util.ints import uint32
 from chia.util.keychain import (
     Keychain,
@@ -212,7 +212,7 @@ def test_key_data_without_secrets() -> None:
     ],
 )
 def test_key_data_secrets_post_init(input_data: Tuple[List[str], bytes, PrivateKey], data_type: str) -> None:
-    with pytest.raises(KeychainKeyDataMissmatch, match=data_type):
+    with pytest.raises(KeychainKeyDataMismatch, match=data_type):
         KeyDataSecrets(*input_data)
 
 
@@ -224,5 +224,5 @@ def test_key_data_secrets_post_init(input_data: Tuple[List[str], bytes, PrivateK
     ],
 )
 def test_key_data_post_init(input_data: Tuple[uint32, G1Element, Optional[KeyDataSecrets]], data_type: str) -> None:
-    with pytest.raises(KeychainKeyDataMissmatch, match=data_type):
+    with pytest.raises(KeychainKeyDataMismatch, match=data_type):
         KeyData(*input_data)


### PR DESCRIPTION
Introduces the dataclass `KeyData` to cache all related key data calculated by the mnemonic in one structure. Preparation for key names + enables some simplifications.

Based on: 
- #12748 
- #12747 
- #12750
- #12751 