### PR TITLE
remove seen_bundle_hashes

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1230,7 +1230,6 @@ class FullNodeAPI:
     async def send_transaction(self, request: wallet_protocol.SendTransaction, *, test=False) -> Optional[Message]:
         spend_name = request.transaction.name()
         if self.full_node.mempool_manager.get_spendbundle(spend_name) is not None:
-            self.full_node.mempool_manager.remove_seen(spend_name)
             response = wallet_protocol.TransactionAck(spend_name, uint8(MempoolInclusionStatus.SUCCESS), None)
             return make_msg(ProtocolMessageTypes.transaction_ack, response)
 

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -27,7 +27,6 @@ def assert_sb_not_in_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
 def evict_from_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
     mempool_item = node.full_node.mempool_manager.mempool.spends[sb.name()]
     node.full_node.mempool_manager.mempool.remove_from_pool(mempool_item)
-    node.full_node.mempool_manager.remove_seen(sb.name())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
rather than having a cache of recently seen SpendBundles for the mempool, just use the mempool itself to know whether we've seen a spend bundle or not.

It appears we currently keep the `seen` dictionary in sync with what's in the mempool anyway.