### PR TITLE
minor fixes

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -469,10 +469,10 @@ class MempoolManager:
 
         new_item = MempoolItem(new_spend, uint64(fees), npc_result, cost, spend_name, additions, removals, program)
         self.mempool.add_to_pool(new_item)
-        now = time.time()
+        duration = time.time() - start_time
         log.log(
-            logging.DEBUG,
-            f"add_spendbundle {spend_name} took {now - start_time:0.2f} seconds. "
+            logging.DEBUG if duration < 2 else logging.WARNING,
+            f"add_spendbundle {spend_name} took {duration:0.2f} seconds. "
             f"Cost: {cost} ({round(100.0 * cost/self.constants.MAX_BLOCK_COST_CLVM, 3)}% of max block cost)",
         )
 

--- a/chia/util/generator_tools.py
+++ b/chia/util/generator_tools.py
@@ -45,7 +45,7 @@ def additions_for_npc(npc_result: NPCResult) -> List[Coin]:
         return []
     for spend in npc_result.conds.spends:
         for puzzle_hash, amount, _ in spend.create_coin:
-            coin = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
+            coin = Coin(spend.coin_id, puzzle_hash, amount)
             additions.append(coin)
 
     return additions

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -886,7 +886,7 @@ class WalletStateManager:
         used_up_to = -1
         ph_to_index_cache: LRUCache = LRUCache(100)
 
-        for coin_state_idx, coin_state in enumerate(coin_states):
+        for coin_state in coin_states:
             coin_name: bytes32 = coin_state.coin.name()
             wallet_info: Optional[Tuple[uint32, WalletType]] = await self.get_wallet_id_for_puzzle_hash(
                 coin_state.coin.puzzle_hash


### PR DESCRIPTION
remove a redundant enumerate()
remove redundant bytes32 copies
print a warning when inserting a mempool item takes a long time