### PR TITLE
avoid redundant printing of puzzle program in NFT uncurry attempt

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1587,7 +1587,9 @@ class WalletRpcApi:
             # Check if the metadata is updated
             full_puzzle: Program = Program.from_bytes(bytes(coin_spend.puzzle_reveal))
 
-            uncurried_nft: UncurriedNFT = UncurriedNFT.uncurry(full_puzzle)
+            uncurried_nft: Optional[UncurriedNFT] = UncurriedNFT.uncurry(full_puzzle)
+            if uncurried_nft is None:
+                return {"success": False, "error": "The coin is not a NFT."}
             metadata, p2_puzzle_hash = get_metadata_and_phs(uncurried_nft, coin_spend.solution)
             # Note: This is not the actual unspent NFT full puzzle.
             # There is no way to rebuild the full puzzle in a different wallet.

--- a/chia/wallet/nft_wallet/nft_puzzles.py
+++ b/chia/wallet/nft_wallet/nft_puzzles.py
@@ -88,7 +88,8 @@ def get_nft_info_from_puzzle(nft_coin_info: NFTCoinInfo) -> NFTInfo:
     :param nft_coin_info NFTCoinInfo in local database
     :return: NFTInfo
     """
-    uncurried_nft: UncurriedNFT = UncurriedNFT.uncurry(nft_coin_info.full_puzzle)
+    uncurried_nft: Optional[UncurriedNFT] = UncurriedNFT.uncurry(nft_coin_info.full_puzzle)
+    assert uncurried_nft is not None
     data_uris: List[str] = []
 
     for uri in uncurried_nft.data_uris.as_python():  # pylint: disable=E1133

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -167,6 +167,7 @@ class NFTWallet:
         # This method will be called only when the wallet state manager uncurried this coin as a NFT puzzle.
 
         uncurried_nft = UncurriedNFT.uncurry(puzzle)
+        assert uncurried_nft is not None
         self.log.info(
             f"found the info for NFT coin {coin_name} {uncurried_nft.inner_puzzle} {uncurried_nft.singleton_struct}"
         )
@@ -413,12 +414,8 @@ class NFTWallet:
         for spend in spend_bundle.coin_spends:
             pks = {}
             if not puzzle_hashes:
-                try:
-                    uncurried_nft = UncurriedNFT.uncurry(spend.puzzle_reveal.to_program())
-                except ValueError:
-                    # not an NFT
-                    pass
-                else:
+                uncurried_nft = UncurriedNFT.uncurry(spend.puzzle_reveal.to_program())
+                if uncurried_nft is not None:
                     self.log.debug("Found a NFT state layer to sign")
                     puzzle_hashes.append(uncurried_nft.p2_puzzle.get_tree_hash())
             for ph in puzzle_hashes:
@@ -454,6 +451,7 @@ class NFTWallet:
         self, nft_coin_info: NFTCoinInfo, key: str, uri: str, fee: uint64 = uint64(0)
     ) -> Optional[SpendBundle]:
         uncurried_nft = UncurriedNFT.uncurry(nft_coin_info.full_puzzle)
+        assert uncurried_nft is not None
         puzzle_hash = uncurried_nft.p2_puzzle.get_tree_hash()
 
         self.log.info(
@@ -698,6 +696,7 @@ class NFTWallet:
         )
 
         unft = UncurriedNFT.uncurry(nft_coin.full_puzzle)
+        assert unft is not None
         magic_condition = None
         if unft.supports_did:
             if new_owner is None:
@@ -900,6 +899,7 @@ class NFTWallet:
     async def set_nft_did(self, nft_coin_info: NFTCoinInfo, did_id: bytes, fee: uint64 = uint64(0)) -> SpendBundle:
         self.log.debug("Setting NFT DID with parameters: nft=%s did=%s", nft_coin_info, did_id)
         unft = UncurriedNFT.uncurry(nft_coin_info.full_puzzle)
+        assert unft is not None
         nft_id = unft.singleton_launcher_id
         puzzle_hashes_to_sign = [unft.p2_puzzle.get_tree_hash()]
         did_inner_hash = b""

--- a/chia/wallet/nft_wallet/uncurry_nft.py
+++ b/chia/wallet/nft_wallet/uncurry_nft.py
@@ -85,7 +85,7 @@ class UncurriedNFT:
     trade_price_percentage: Optional[uint16]
 
     @classmethod
-    def uncurry(cls: Type[_T_UncurriedNFT], puzzle: Program) -> _T_UncurriedNFT:
+    def uncurry(cls: Type[_T_UncurriedNFT], puzzle: Program) -> Optional[_T_UncurriedNFT]:
         """
         Try to uncurry a NFT puzzle
         :param cls UncurriedNFT class
@@ -94,18 +94,21 @@ class UncurriedNFT:
         """
         mod, curried_args = puzzle.uncurry()
         if mod != SINGLETON_TOP_LAYER_MOD:
-            raise ValueError(f"Cannot uncurry NFT puzzle, failed on singleton top layer: Mod {mod}")
+            log.debug("Cannot uncurry NFT puzzle, failed on singleton top layer: Mod %s", mod)
+            return None
         try:
             (singleton_struct, nft_state_layer) = curried_args.as_iter()
             singleton_mod_hash = singleton_struct.first()
             singleton_launcher_id = singleton_struct.rest().first()
             launcher_puzhash = singleton_struct.rest().rest()
         except ValueError as e:
-            raise ValueError(f"Cannot uncurry singleton top layer: Args {curried_args}") from e
+            log.debug("Cannot uncurry singleton top layer: Args %s error: %s", curried_args, e)
+            return None
 
         mod, curried_args = curried_args.rest().first().uncurry()
         if mod != NFT_MOD:
-            raise ValueError(f"Cannot uncurry NFT puzzle, failed on NFT state layer: Mod {mod}")
+            log.debug("Cannot uncurry NFT puzzle, failed on NFT state layer: Mod %s", mod)
+            return None
         try:
             # Set nft parameters
             nft_mod_hash, metadata, metadata_updater_hash, inner_puzzle = curried_args.as_iter()
@@ -159,7 +162,9 @@ class UncurriedNFT:
                 log.debug("Creating a standard NFT puzzle")
                 p2_puzzle = inner_puzzle
         except Exception as e:
-            raise ValueError(f"Cannot uncurry NFT state layer: Args {curried_args}") from e
+            log.debug("Cannot uncurry NFT state layer: Args %s Error: %s", curried_args, e)
+            return None
+
         return cls(
             nft_mod_hash=nft_mod_hash,
             nft_state_layer=nft_state_layer,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -644,12 +644,9 @@ class WalletStateManager:
         # Check if the coin is a NFT
         #                                                        hint
         # First spend where 1 mojo coin -> Singleton launcher -> NFT -> NFT
-        try:
-            uncurried_nft = UncurriedNFT.uncurry(puzzle)
+        uncurried_nft = UncurriedNFT.uncurry(puzzle)
+        if uncurried_nft is not None:
             return await self.handle_nft(coin_spend, uncurried_nft)
-        except Exception:
-            # This is not a NFT coin, skip NFT handling
-            pass
 
         # Check if the coin is a DID
         did_matched, did_curried_args = match_did_puzzle(puzzle)

--- a/tests/wallet/nft_wallet/test_nft_puzzles.py
+++ b/tests/wallet/nft_wallet/test_nft_puzzles.py
@@ -68,6 +68,7 @@ def test_nft_transfer_puzzle_hashes():
     assert nft_info.also().also() is not None
 
     unft = uncurry_nft.UncurriedNFT.uncurry(nft_puz)
+    assert unft is not None
     assert unft.supports_did
 
     # setup transfer
@@ -183,6 +184,7 @@ def test_transfer_puzzle_builder() -> None:
     )
     clvm_puzzle_hash = get_updated_nft_puzzle(clvm_nft_puzzle, solution.at("rrf"))
     unft = uncurry_nft.UncurriedNFT.uncurry(puzzle)
+    assert unft is not None
     assert unft.nft_state_layer == clvm_nft_puzzle
     assert unft.inner_puzzle == ownership_puzzle
     assert unft.p2_puzzle == p2_puzzle


### PR DESCRIPTION
The caller of `UncurriedNft.uncurry()` doesn't care about the exception's message, it just interprets it as the puzzle not being an NFT. Formatting the message, especially ones that contain the whole puzzle program is expensive. Since this is the common path through `uncurry()`, it spends the majority of its time serializing and formatting the puzzle program into a string, which is then discarded.