### PR TITLE
tests: Drop redundant `RpcServer` instances 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,6 +288,12 @@ async def two_nodes_sim_and_wallets():
 
 
 @pytest_asyncio.fixture(scope="function")
+async def two_nodes_sim_and_wallets_services():
+    async for _ in setup_simulators_and_wallets(2, 0, {}, yield_services=True):
+        yield _
+
+
+@pytest_asyncio.fixture(scope="function")
 async def wallet_node_sim_and_wallet():
     async for _ in setup_simulators_and_wallets(1, 1, {}):
         yield _
@@ -305,6 +311,12 @@ async def two_wallet_nodes(request):
     if request and request.param_index > 0:
         params = request.param
     async for _ in setup_simulators_and_wallets(1, 2, {}, **params):
+        yield _
+
+
+@pytest_asyncio.fixture(scope="function")
+async def two_wallet_nodes_services():
+    async for _ in setup_simulators_and_wallets(1, 2, {}, yield_services=True):
         yield _
 
 

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -17,7 +17,6 @@ from chia.plotting.util import add_plot_directory
 from chia.protocols import farmer_protocol
 from chia.protocols.harvester_protocol import Plot
 from chia.rpc.farmer_rpc_api import (
-    FarmerRpcApi,
     FilterItem,
     PaginatedRequestData,
     PlotInfoRequestData,
@@ -25,9 +24,7 @@ from chia.rpc.farmer_rpc_api import (
     plot_matches_filter,
 )
 from chia.rpc.farmer_rpc_client import FarmerRpcClient
-from chia.rpc.harvester_rpc_api import HarvesterRpcApi
 from chia.rpc.harvester_rpc_client import HarvesterRpcClient
-from chia.rpc.rpc_server import start_rpc_server
 from chia.simulator.block_tools import get_plot_dir
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -35,7 +32,7 @@ from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, lock_and_load_config, save_config
 from chia.util.hash import std_hash
-from chia.util.ints import uint8, uint16, uint32, uint64
+from chia.util.ints import uint8, uint32, uint64
 from chia.util.misc import get_list_or_len
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from tests.plot_sync.test_delta import dummy_plot
@@ -58,40 +55,11 @@ async def harvester_farmer_environment(farmer_one_harvester, self_hostname):
     harvesters, farmer_service, bt = farmer_one_harvester
     harvester_service = harvesters[0]
 
-    def stop_node_cb():
-        pass
-
-    config = bt.config
-    hostname = config["self_hostname"]
-    daemon_port = config["daemon_port"]
-
-    farmer_rpc_api = FarmerRpcApi(farmer_service._api.farmer)
-    harvester_rpc_api = HarvesterRpcApi(harvester_service._node)
-
-    rpc_server_farmer = await start_rpc_server(
-        farmer_rpc_api,
-        hostname,
-        daemon_port,
-        uint16(0),
-        stop_node_cb,
-        bt.root_path,
-        config,
-        connect_to_daemon=False,
+    farmer_rpc_cl = await FarmerRpcClient.create(
+        self_hostname, farmer_service.rpc_server.listen_port, farmer_service.root_path, farmer_service.config
     )
-    rpc_server_harvester = await start_rpc_server(
-        harvester_rpc_api,
-        hostname,
-        daemon_port,
-        uint16(0),
-        stop_node_cb,
-        bt.root_path,
-        config,
-        connect_to_daemon=False,
-    )
-
-    farmer_rpc_cl = await FarmerRpcClient.create(self_hostname, rpc_server_farmer.listen_port, bt.root_path, config)
     harvester_rpc_cl = await HarvesterRpcClient.create(
-        self_hostname, rpc_server_harvester.listen_port, bt.root_path, config
+        self_hostname, harvester_service.rpc_server.listen_port, harvester_service.root_path, harvester_service.config
     )
 
     async def have_connections():
@@ -99,31 +67,25 @@ async def harvester_farmer_environment(farmer_one_harvester, self_hostname):
 
     await time_out_assert(15, have_connections, True)
 
-    yield farmer_service, farmer_rpc_api, farmer_rpc_cl, harvester_service, harvester_rpc_api, harvester_rpc_cl, bt
+    yield farmer_service, farmer_rpc_cl, harvester_service, harvester_rpc_cl, bt
 
     farmer_rpc_cl.close()
     harvester_rpc_cl.close()
-    rpc_server_harvester.close()
-    rpc_server_farmer.close()
     await farmer_rpc_cl.await_closed()
     await harvester_rpc_cl.await_closed()
-    await rpc_server_harvester.await_closed()
-    await rpc_server_farmer.await_closed()
 
 
 @pytest.mark.asyncio
 async def test_get_routes(harvester_farmer_environment):
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         _,
     ) = harvester_farmer_environment
-    await validate_get_routes(farmer_rpc_client, farmer_rpc_api)
-    await validate_get_routes(harvester_rpc_client, harvester_rpc_api)
+    await validate_get_routes(farmer_rpc_client, farmer_service.rpc_server.rpc_api)
+    await validate_get_routes(harvester_rpc_client, harvester_service.rpc_server.rpc_api)
 
 
 @pytest.mark.parametrize("endpoint", ["get_harvesters", "get_harvesters_summary"])
@@ -131,10 +93,8 @@ async def test_get_routes(harvester_farmer_environment):
 async def test_farmer_get_harvesters_and_summary(harvester_farmer_environment, endpoint: str):
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         _,
     ) = harvester_farmer_environment
@@ -185,10 +145,8 @@ async def test_farmer_get_harvesters_and_summary(harvester_farmer_environment, e
 async def test_farmer_signage_point_endpoints(harvester_farmer_environment):
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         _,
     ) = harvester_farmer_environment
@@ -213,10 +171,8 @@ async def test_farmer_signage_point_endpoints(harvester_farmer_environment):
 async def test_farmer_reward_target_endpoints(harvester_farmer_environment):
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         bt,
     ) = harvester_farmer_environment
@@ -275,10 +231,8 @@ async def test_farmer_reward_target_endpoints(harvester_farmer_environment):
 async def test_farmer_get_pool_state(harvester_farmer_environment, self_hostname):
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         _,
     ) = harvester_farmer_environment
@@ -338,10 +292,8 @@ async def test_farmer_get_pool_state(harvester_farmer_environment, self_hostname
 async def test_farmer_get_pool_state_plot_count(harvester_farmer_environment, self_hostname: str) -> None:
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         _,
     ) = harvester_farmer_environment
@@ -454,10 +406,8 @@ async def test_farmer_get_harvester_plots_endpoints(
 ) -> None:
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         _,
     ) = harvester_farmer_environment
@@ -557,10 +507,8 @@ async def test_farmer_get_harvester_plots_endpoints(
 async def test_harvester_add_plot_directory(harvester_farmer_environment) -> None:
     (
         farmer_service,
-        farmer_rpc_api,
         farmer_rpc_client,
         harvester_service,
-        harvester_rpc_api,
         harvester_rpc_client,
         _,
     ) = harvester_farmer_environment

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -7,16 +7,14 @@ from blspy import AugSchemeMPL
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.signage_point import SignagePoint
 from chia.protocols import full_node_protocol
-from chia.rpc.full_node_rpc_api import FullNodeRpcApi
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
-from chia.rpc.rpc_server import start_rpc_server
 from chia.server.outbound_message import NodeType
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.hash import std_hash
-from chia.util.ints import uint8, uint16
+from chia.util.ints import uint8
 from chia.simulator.block_tools import get_signage_point
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.connection_utils import connect_and_get_peer
@@ -28,37 +26,22 @@ from chia.simulator.wallet_tools import WalletTool
 
 class TestRpc:
     @pytest.mark.asyncio
-    async def test1(self, two_nodes_sim_and_wallets, self_hostname):
+    async def test1(self, two_nodes_sim_and_wallets_services, self_hostname):
         num_blocks = 5
-        nodes, _, bt = two_nodes_sim_and_wallets
-        full_node_api_1, full_node_api_2 = nodes
-        server_1 = full_node_api_1.full_node.server
+        nodes, _, bt = two_nodes_sim_and_wallets_services
+        full_node_service_1, full_node_service_2 = nodes
+        full_node_api_1 = full_node_service_1._api
+        full_node_api_2 = full_node_service_2._api
         server_2 = full_node_api_2.full_node.server
 
-        def stop_node_cb():
-            full_node_api_1._close()
-            server_1.close_all()
-
-        full_node_rpc_api = FullNodeRpcApi(full_node_api_1.full_node)
-
-        config = bt.config
-        hostname = config["self_hostname"]
-        daemon_port = config["daemon_port"]
-
-        rpc_server = await start_rpc_server(
-            full_node_rpc_api,
-            hostname,
-            daemon_port,
-            uint16(0),
-            stop_node_cb,
-            bt.root_path,
-            config,
-            connect_to_daemon=False,
-        )
-
         try:
-            client = await FullNodeRpcClient.create(self_hostname, rpc_server.listen_port, bt.root_path, config)
-            await validate_get_routes(client, full_node_rpc_api)
+            client = await FullNodeRpcClient.create(
+                self_hostname,
+                full_node_service_1.rpc_server.listen_port,
+                full_node_service_1.root_path,
+                full_node_service_1.config,
+            )
+            await validate_get_routes(client, full_node_service_1.rpc_server.rpc_api)
             state = await client.get_blockchain_state()
             assert state["peak"] is None
             assert not state["sync"]["sync_mode"]
@@ -284,42 +267,29 @@ class TestRpc:
         finally:
             # Checks that the RPC manages to stop the node
             client.close()
-            rpc_server.close()
             await client.await_closed()
-            await rpc_server.await_closed()
 
     @pytest.mark.asyncio
-    async def test_signage_points(self, two_nodes_sim_and_wallets, empty_blockchain):
-        nodes, _, bt = two_nodes_sim_and_wallets
-        full_node_api_1, full_node_api_2 = nodes
+    async def test_signage_points(self, two_nodes_sim_and_wallets_services, empty_blockchain):
+        nodes, _, bt = two_nodes_sim_and_wallets_services
+        full_node_service_1, full_node_service_2 = nodes
+        full_node_api_1 = full_node_service_1._api
+        full_node_api_2 = full_node_service_2._api
         server_1 = full_node_api_1.full_node.server
         server_2 = full_node_api_2.full_node.server
 
         config = bt.config
         self_hostname = config["self_hostname"]
-        daemon_port = config["daemon_port"]
 
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
-        def stop_node_cb():
-            full_node_api_1._close()
-            server_1.close_all()
-
-        full_node_rpc_api = FullNodeRpcApi(full_node_api_1.full_node)
-
-        rpc_server = await start_rpc_server(
-            full_node_rpc_api,
-            self_hostname,
-            daemon_port,
-            uint16(0),
-            stop_node_cb,
-            bt.root_path,
-            config,
-            connect_to_daemon=False,
-        )
-
         try:
-            client = await FullNodeRpcClient.create(self_hostname, rpc_server.listen_port, bt.root_path, config)
+            client = await FullNodeRpcClient.create(
+                self_hostname,
+                full_node_service_1.rpc_server.listen_port,
+                full_node_service_1.root_path,
+                full_node_service_1.config,
+            )
 
             # Only provide one
             res = await client.get_recent_signage_point_or_eos(None, None)
@@ -429,6 +399,4 @@ class TestRpc:
         finally:
             # Checks that the RPC manages to stop the node
             client.close()
-            rpc_server.close()
             await client.await_closed()
-            await rpc_server.await_closed()

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -16,8 +16,6 @@ from chia.pools.pool_puzzles import SINGLETON_LAUNCHER_HASH
 from chia.pools.pool_wallet_info import PoolSingletonState, PoolWalletInfo
 from chia.protocols import full_node_protocol
 from chia.protocols.full_node_protocol import RespondBlock
-from chia.rpc.rpc_server import start_rpc_server
-from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -88,71 +86,48 @@ async def one_wallet_node_and_rpc(
     self_hostname,
 ) -> AsyncGenerator[Tuple[WalletRpcClient, Any, FullNodeAPI, BlockTools], None]:
     rmtree(get_pool_plot_dir(), ignore_errors=True)
-    async for nodes in setup_simulators_and_wallets(1, 1, {}):
+    async for nodes in setup_simulators_and_wallets(1, 1, {}, yield_services=True):
         full_nodes, wallets, bt = nodes
-        full_node_api = full_nodes[0]
-        wallet_node_0, wallet_server_0 = wallets[0]
-
+        full_node_api = full_nodes[0]._api
+        wallet_service = wallets[0]
+        wallet_node_0 = wallet_service._node
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         our_ph = await wallet_0.get_new_puzzlehash()
         await farm_blocks(full_node_api, our_ph, PREFARMED_BLOCKS)
 
-        api_user = WalletRpcApi(wallet_node_0)
-        config = bt.config
-        daemon_port = config["daemon_port"]
-
-        rpc_server = await start_rpc_server(
-            api_user,
-            self_hostname,
-            daemon_port,
-            uint16(0),
-            lambda: None,
-            bt.root_path,
-            config,
-            connect_to_daemon=False,
+        client = await WalletRpcClient.create(
+            self_hostname, wallet_service.rpc_server.listen_port, wallet_service.root_path, wallet_service.config
         )
-        client = await WalletRpcClient.create(self_hostname, rpc_server.listen_port, bt.root_path, config)
 
         yield client, wallet_node_0, full_node_api, bt
 
         client.close()
-        rpc_server.close()
         await client.await_closed()
-        await rpc_server.await_closed()
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup(two_wallet_nodes, self_hostname):
+async def setup(two_wallet_nodes_services, self_hostname):
     rmtree(get_pool_plot_dir(), ignore_errors=True)
-    full_nodes, wallets, bt = two_wallet_nodes
-    wallet_node_0, wallet_server_0 = wallets[0]
-    wallet_node_1, wallet_server_1 = wallets[1]
+    full_nodes, wallets, bt = two_wallet_nodes_services
+    full_node_apis = [full_node_service._api for full_node_service in full_nodes]
+    wallet_service_0 = wallets[0]
+    wallet_service_1 = wallets[1]
+    wallet_node_0 = wallet_service_0._node
+    wallet_node_1 = wallet_service_1._node
     our_ph_record = await wallet_node_0.wallet_state_manager.get_unused_derivation_record(1, hardened=True)
     pool_ph_record = await wallet_node_1.wallet_state_manager.get_unused_derivation_record(1, hardened=True)
     our_ph = our_ph_record.puzzle_hash
     pool_ph = pool_ph_record.puzzle_hash
-    api_user = WalletRpcApi(wallet_node_0)
-    config = bt.config
-    daemon_port = config["daemon_port"]
 
-    rpc_server = await start_rpc_server(
-        api_user,
-        self_hostname,
-        daemon_port,
-        uint16(0),
-        lambda x: None,
-        bt.root_path,
-        config,
-        connect_to_daemon=False,
+    client = await WalletRpcClient.create(
+        self_hostname, wallet_service_0.rpc_server.listen_port, wallet_service_0.root_path, wallet_service_0.config
     )
-    client = await WalletRpcClient.create(self_hostname, rpc_server.listen_port, bt.root_path, config)
 
     return (
-        full_nodes,
+        full_node_apis,
         [wallet_node_0, wallet_node_1],
         [our_ph, pool_ph],
         client,  # wallet rpc client
-        rpc_server,
     )
 
 
@@ -810,7 +785,7 @@ class TestPoolWalletRpc:
         trusted, fee = trusted_and_fee
         num_blocks = 4  # Num blocks to farm at a time
         total_blocks = 0  # Total blocks farmed so far
-        full_nodes, wallet_nodes, receive_address, client, rpc_server = setup
+        full_nodes, wallet_nodes, receive_address, client = setup
         wallets = [wallet_n.wallet_state_manager.main_wallet for wallet_n in wallet_nodes]
         wallet_node_0 = wallet_nodes[0]
         our_ph = receive_address[0]
@@ -923,16 +898,14 @@ class TestPoolWalletRpc:
 
         finally:
             client.close()
-            rpc_server.close()
             await client.await_closed()
-            await rpc_server.await_closed()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted_and_fee", [(True, FEE_AMOUNT), (False, 0)])
     async def test_leave_pool(self, setup, trusted_and_fee, self_hostname):
         """This tests self-pooling -> pooling -> escaping -> self pooling"""
         trusted, fee = trusted_and_fee
-        full_nodes, wallet_nodes, receive_address, client, rpc_server = setup
+        full_nodes, wallet_nodes, receive_address, client = setup
         our_ph = receive_address[0]
         wallets = [wallet_n.wallet_state_manager.main_wallet for wallet_n in wallet_nodes]
         pool_ph = receive_address[1]
@@ -1059,16 +1032,14 @@ class TestPoolWalletRpc:
 
         finally:
             client.close()
-            rpc_server.close()
             await client.await_closed()
-            await rpc_server.await_closed()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted_and_fee", [(True, FEE_AMOUNT), (False, 0)])
     async def test_change_pools(self, setup, trusted_and_fee, self_hostname):
         """This tests Pool A -> escaping -> Pool B"""
         trusted, fee = trusted_and_fee
-        full_nodes, wallet_nodes, receive_address, client, rpc_server = setup
+        full_nodes, wallet_nodes, receive_address, client = setup
         our_ph = receive_address[0]
         pool_a_ph = receive_address[1]
         wallets = [wallet_n.wallet_state_manager.main_wallet for wallet_n in wallet_nodes]
@@ -1161,16 +1132,14 @@ class TestPoolWalletRpc:
 
         finally:
             client.close()
-            rpc_server.close()
             await client.await_closed()
-            await rpc_server.await_closed()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("trusted_and_fee", [(True, FEE_AMOUNT), (False, 0)])
     async def test_change_pools_reorg(self, setup, trusted_and_fee, self_hostname):
         """This tests Pool A -> escaping -> reorg -> escaping -> Pool B"""
         trusted, fee = trusted_and_fee
-        full_nodes, wallet_nodes, receive_address, client, rpc_server = setup
+        full_nodes, wallet_nodes, receive_address, client = setup
         our_ph = receive_address[0]
         pool_a_ph = receive_address[1]
         wallets = [wallet_n.wallet_state_manager.main_wallet for wallet_n in wallet_nodes]
@@ -1289,6 +1258,4 @@ class TestPoolWalletRpc:
 
         finally:
             client.close()
-            rpc_server.close()
             await client.await_closed()
-            await rpc_server.await_closed()

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import AsyncIterator, Dict, List, Tuple, Optional
+from typing import AsyncIterator, Dict, List, Tuple, Optional, Union
 from pathlib import Path
 
 from chia.consensus.constants import ConsensusConstants
@@ -160,9 +160,10 @@ async def setup_simulators_and_wallets(
     db_version=1,
     config_overrides: Optional[Dict] = None,
     disable_capabilities: Optional[List[Capability]] = None,
+    yield_services: bool = False,
 ):
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
-        simulators: List[FullNodeAPI] = []
+        simulators: List[Union[FullNodeAPI, Service]] = []
         wallets = []
         node_iters = []
         bt_tools: List[BlockTools] = []
@@ -182,6 +183,7 @@ async def setup_simulators_and_wallets(
                 simulator=True,
                 db_version=db_version,
                 disable_capabilities=disable_capabilities,
+                yield_service=yield_services,
             )
             simulators.append(await sim.__anext__())
             node_iters.append(sim)
@@ -205,6 +207,7 @@ async def setup_simulators_and_wallets(
                 key_seed=seed,
                 starting_height=starting_height,
                 initial_num_public_keys=initial_num_public_keys,
+                yield_service=yield_services,
             )
             wallets.append(await wlt.__anext__())
             node_iters.append(wlt)

--- a/tests/setup_services.py
+++ b/tests/setup_services.py
@@ -79,6 +79,7 @@ async def setup_full_node(
     connect_to_daemon=False,
     db_version=1,
     disable_capabilities: Optional[List[Capability]] = None,
+    yield_service: bool = False,
 ):
     db_path = local_bt.root_path / f"{db_name}"
     if db_path.exists():
@@ -131,7 +132,11 @@ async def setup_full_node(
         )
     await service.start()
 
-    yield service._api
+    # TODO, just always yield the service only and adjust all other places
+    if yield_service:
+        yield service
+    else:
+        yield service._api
 
     service.stop()
     await service.wait_closed()
@@ -150,6 +155,7 @@ async def setup_wallet_node(
     key_seed=None,
     starting_height=None,
     initial_num_public_keys=5,
+    yield_service: bool = False,
 ):
     with TempKeyring(populate=True) as keychain:
         config = local_bt.config
@@ -200,7 +206,11 @@ async def setup_wallet_node(
 
         await service.start()
 
-        yield service._node, service._node.server
+        # TODO, just always yield the service only and adjust all other places
+        if yield_service:
+            yield service
+        else:
+            yield service._node, service._node.server
 
         service.stop()
         await service.wait_closed()


### PR DESCRIPTION
Just use the ones started by the actual `Service`.

This is an alternative to #12744 

Based on: 
- #12768 