### PR TITLE
pre-commit: Reorder hooks by runtime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,28 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [click~=7.1]
+-   repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    -   id: black
+        additional_dependencies: ['click<8.1']
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+        exclude: ".*?(.hex|.clvm|.clib)"
+    -   id: trailing-whitespace
+    -   id: check-merge-conflict
+    -   id: check-ast
+    -   id: debug-statements
+-   repo: local
+    hooks:
+    -   id: mypy
+        name: mypy
+        entry: ./activated.py mypy
+        language: system
+        pass_filenames: false
 # The following, commented hook is the usual way to add isort. However, it doesn't work in some environments.
 # See https://github.com/PyCQA/isort/issues/1874#issuecomment-1002212936
 # -----------------------------------------------------
@@ -35,29 +57,7 @@ repos:
         args: ['--filter-files']
         minimum_pre_commit_version: '2.9.2'
         additional_dependencies: [isort==5.10.1]
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
-    hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-        exclude: ".*?(.hex|.clvm|.clib)"
-    -   id: trailing-whitespace
-    -   id: check-merge-conflict
-    -   id: check-ast
-    -   id: debug-statements
--   repo: https://github.com/psf/black
-    rev: 21.12b0
-    hooks:
-    -   id: black
-        additional_dependencies: ['click<8.1']
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8
--   repo: local
-    hooks:
-    -   id: mypy
-        name: mypy
-        entry: ./activated.py mypy
-        language: system
-        pass_filenames: false


### PR DESCRIPTION
Moving `black` and `mypy` up a bit, run `flake8` as last. New order:

```
Validate SQL statements
__init__.py files
black
Check Yaml
Fix End of Files
Trim Trailing Whitespace
Check for merge conflicts
Check python ast
Debug Statements (Python)
mypy
isort
flake8
```