### PR TITLE
Remove unused ping/pong code

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -260,6 +260,7 @@ class RpcServer:
         await ws.send_str(payload)
 
         while True:
+            # ClientWebSocketReponse::receive() internally handles PING, PONG, and CLOSE messages
             msg = await ws.receive()
             if msg.type == WSMsgType.TEXT:
                 message = msg.data.strip()
@@ -267,16 +268,8 @@ class RpcServer:
                 await self.safe_handle(ws, message)
             elif msg.type == WSMsgType.BINARY:
                 log.debug("Received binary data")
-            elif msg.type == WSMsgType.PING:
-                log.debug("Ping received")
-                await ws.pong()
-            elif msg.type == WSMsgType.PONG:
-                log.debug("Pong received")
             else:
-                if msg.type == WSMsgType.CLOSE:
-                    log.debug("Closing RPC websocket")
-                    await ws.close()
-                elif msg.type == WSMsgType.ERROR:
+                if msg.type == WSMsgType.ERROR:
                     log.error("Error during receive %s" % ws.exception())
                 elif msg.type == WSMsgType.CLOSED:
                     pass

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -52,19 +52,14 @@ class TestDaemon:
 
         async def reader(ws, queue):
             while True:
+                # ClientWebSocketReponse::receive() internally handles PING, PONG, and CLOSE messages
                 msg = await ws.receive()
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     message = msg.data.strip()
                     message = json.loads(message)
                     await queue.put(message)
-                elif msg.type == aiohttp.WSMsgType.PING:
-                    await ws.pong()
-                elif msg.type == aiohttp.WSMsgType.PONG:
-                    continue
                 else:
-                    if msg.type == aiohttp.WSMsgType.CLOSE:
-                        await ws.close()
-                    elif msg.type == aiohttp.WSMsgType.ERROR:
+                    if msg.type == aiohttp.WSMsgType.ERROR:
                         await ws.close()
                     elif msg.type == aiohttp.WSMsgType.CLOSED:
                         pass


### PR DESCRIPTION
The ClientWebSocketResponse::receive() call internally eats PING, PONG, and CLOSE, so those msgs are never seen by callers

(I checked both the aiohttp code in client_ws.py - but this is also in the documentation: "The coroutine implicitly handles PING, PONG and CLOSE without returning the message.

It process ping-pong game and performs closing handshake internally." (https://docs.aiohttp.org/en/stable/client_reference.html)
