### PR TITLE
optimize simple_solution_generator()

### DIFF
--- a/chia/full_node/bundle_tools.py
+++ b/chia/full_node/bundle_tools.py
@@ -1,9 +1,6 @@
 import re
 from typing import Optional, Tuple, List, Union
 
-from clvm import SExp
-from clvm_tools import binutils
-
 from chia.full_node.generator import create_compressed_generator
 from chia.types.blockchain_format.program import SerializedProgram, Program
 from chia.types.coin_spend import CoinSpend
@@ -11,15 +8,34 @@ from chia.types.generator_types import BlockGenerator, CompressorArg
 from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint32, uint64
+from clvm.casts import int_to_bytes
+
+
+def _serialize_amount(val: int) -> bytes:
+    assert val >= 0
+    assert val < 2 ** 64
+    atom = int_to_bytes(val)
+    size = len(atom)
+    assert size <= 9
+
+    if size == 0:
+        return b"\x80"
+    if size == 1 and atom[0] <= 0x7F:
+        return atom
+    size_blob = bytes([0x80 | size])
+    return size_blob + atom
 
 
 def spend_bundle_to_serialized_coin_spend_entry_list(bundle: SpendBundle) -> bytes:
     r = b""
+    # ( ( parent-coin-id puzzle-reveal amount solution ) ... )
     for coin_spend in bundle.coin_spends:
         r += b"\xff"
-        r += b"\xff" + SExp.to(coin_spend.coin.parent_coin_info).as_bin()
+        # A0 is the length-prefix for the parent coin ID (which is always 32
+        # bytes long)
+        r += b"\xff\xa0" + coin_spend.coin.parent_coin_info
         r += b"\xff" + bytes(coin_spend.puzzle_reveal)
-        r += b"\xff" + SExp.to(coin_spend.coin.amount).as_bin()
+        r += b"\xff" + _serialize_amount(coin_spend.coin.amount)
         r += b"\xff" + bytes(coin_spend.solution)
         r += b"\x80"
     r += b"\x80"
@@ -31,11 +47,10 @@ def simple_solution_generator(bundle: SpendBundle) -> BlockGenerator:
     Simply quotes the solutions we know.
     """
     cse_list = spend_bundle_to_serialized_coin_spend_entry_list(bundle)
-    block_program = b"\xff"
-
-    block_program += SExp.to(binutils.assemble("#q")).as_bin()
-
-    block_program += b"\xff" + cse_list + b"\x80"
+    # this is the serialized form of the lisp structure below. The "q" operator
+    # is has opcode 1.
+    # (q . ( cse_list ))
+    block_program = b"\xff\x01\xff" + cse_list + b"\x80"
 
     return BlockGenerator(SerializedProgram.from_bytes(block_program), [], [])
 


### PR DESCRIPTION
this is a somewhat expensive part of adding a transaction to the mempool. With the planned raise of the mempool size this is an attempt to mitigate load- and performance issues caused by higher pressure on the mempool.

The benchmark shows a small improvement on wall-clock time, but it's CPU time in the main process that's the more precious resource. We already limit validation to 2 threads.

CPU usage:

| CPU usage | before | after | after / before |
| --- | --- | --- | --- |
| mempool_manager.add_spendbundle() | 13.58% | 6.12% | 0.45 |

main:
```
add_spendbundle time: 2.1495s
2.15ms per add_spendbundle() call
```

this patch:
```
add_spendbundle time: 2.0407s
2.04ms per add_spendbundle() call
```

# profiles

main:

![mempool-add-mt](https://user-images.githubusercontent.com/661450/183031243-5a01751a-13ab-4ffb-afd5-1915b770de16.png)

this patch:

![mempool-add-mt](https://user-images.githubusercontent.com/661450/183031096-cfd63a34-2c6e-4ed9-b83b-daa719956d5c.png)

