### PR TITLE
util: Force keyring migration / Deprecate legacy keyring support

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -55,17 +55,24 @@ def monkey_patch_click() -> None:
     "--keys-root-path", default=DEFAULT_KEYS_ROOT_PATH, help="Keyring file root", type=click.Path(), show_default=True
 )
 @click.option("--passphrase-file", type=click.File("r"), help="File or descriptor to read the keyring passphrase from")
+@click.option(
+    "--force-legacy-keyring-migration/--no-force-legacy-keyring-migration",
+    default=True,
+    help="Force legacy keyring migration. Legacy keyring support will be dropped in 1.5.2!",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
     root_path: str,
     keys_root_path: Optional[str] = None,
     passphrase_file: Optional[TextIOWrapper] = None,
+    force_legacy_keyring_migration: bool = True,
 ) -> None:
     from pathlib import Path
 
     ctx.ensure_object(dict)
     ctx.obj["root_path"] = Path(root_path)
+    ctx.obj["force_legacy_keyring_migration"] = force_legacy_keyring_migration
 
     # keys_root_path and passphrase_file will be None if the passphrase options have been
     # scrubbed from the CLI options

--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -8,6 +8,10 @@ from typing import Optional, Tuple
 def keys_cmd(ctx: click.Context):
     """Create, delete, view and use your key pairs"""
     from pathlib import Path
+    from .keys_funcs import migrate_keys
+
+    if ctx.obj["force_legacy_keyring_migration"]:
+        migrate_keys(True)
 
     root_path: Path = ctx.obj["root_path"]
     if not root_path.is_dir():

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -188,7 +188,7 @@ def migrate_keys(forced: bool = False):
     from chia.util.misc import prompt_yes_no
 
     deprecation_message = (
-        "\nLegacy keyring support is deprecated and is getting removed in version 1.5.2, "
+        "\nLegacy keyring support is deprecated and will be removed in version 1.5.2. "
         "you need to migrate your keyring to continue using chia."
     )
 

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -189,7 +189,7 @@ def migrate_keys(forced: bool = False):
 
     deprecation_message = (
         "\nLegacy keyring support is deprecated and will be removed in version 1.5.2. "
-        "you need to migrate your keyring to continue using chia."
+        "You need to migrate your keyring to continue using Chia."
     )
 
     # Check if the keyring needs a full migration (i.e. if it's using the old keyring)

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -183,48 +183,55 @@ def verify(message: str, public_key: str, signature: str):
     print(AugSchemeMPL.verify(public_key, messageBytes, signature))
 
 
-def migrate_keys():
+def migrate_keys(forced: bool = False):
     from chia.util.keyring_wrapper import KeyringWrapper
     from chia.util.misc import prompt_yes_no
 
+    deprecation_message = (
+        "\nLegacy keyring support is deprecated and is getting removed in version 1.5.2, "
+        "you need to migrate your keyring to continue using chia."
+    )
+
     # Check if the keyring needs a full migration (i.e. if it's using the old keyring)
     if Keychain.needs_migration():
+        print(deprecation_message)
         KeyringWrapper.get_shared_instance().migrate_legacy_keyring_interactive()
     else:
         keys_to_migrate, legacy_keyring = Keychain.get_keys_needing_migration()
         if len(keys_to_migrate) > 0 and legacy_keyring is not None:
+            print(deprecation_message)
             print(f"Found {len(keys_to_migrate)} key(s) that need migration:")
             for key, _ in keys_to_migrate:
                 print(f"Fingerprint: {key.get_g1().get_fingerprint()}")
 
             print()
-            response = prompt_yes_no("Migrate these keys?")
-            if response:
-                keychain = Keychain()
-                for sk, seed_bytes in keys_to_migrate:
-                    mnemonic = bytes_to_mnemonic(seed_bytes)
-                    keychain.add_private_key(mnemonic, "")
-                    fingerprint = sk.get_g1().get_fingerprint()
-                    print(f"Added private key with public key fingerprint {fingerprint}")
+            if not prompt_yes_no("Migrate these keys?"):
+                sys.exit("Migration aborted, can't run any chia commands.")
 
-                print(f"Migrated {len(keys_to_migrate)} key(s)")
+            keychain = Keychain()
+            for sk, seed_bytes in keys_to_migrate:
+                mnemonic = bytes_to_mnemonic(seed_bytes)
+                keychain.add_private_key(mnemonic, "")
+                fingerprint = sk.get_g1().get_fingerprint()
+                print(f"Added private key with public key fingerprint {fingerprint}")
 
-                print("Verifying migration results...", end="")
-                if Keychain.verify_keys_present(keys_to_migrate):
-                    print(" Verified")
-                    print()
-                    response = prompt_yes_no("Remove key(s) from old keyring?")
-                    if response:
-                        legacy_keyring.delete_keys(keys_to_migrate)
-                        print(f"Removed {len(keys_to_migrate)} key(s) from old keyring")
-                    print("Migration complete")
-                else:
-                    print(" Failed")
-                    sys.exit(1)
-        else:
+            print(f"Migrated {len(keys_to_migrate)} key(s)")
+
+            print("Verifying migration results...", end="")
+            if Keychain.verify_keys_present(keys_to_migrate):
+                print(" Verified")
+                print()
+                response = prompt_yes_no("Remove key(s) from old keyring?")
+                if response:
+                    legacy_keyring.delete_keys(keys_to_migrate)
+                    print(f"Removed {len(keys_to_migrate)} key(s) from old keyring")
+                print("Migration complete")
+            else:
+                print(" Failed")
+                sys.exit(1)
+            sys.exit(0)
+        elif not forced:
             print("No keys need migration")
-
-        Keychain.mark_migration_checked_for_current_version()
 
 
 def _clear_line_part(n: int):

--- a/chia/cmds/passphrase.py
+++ b/chia/cmds/passphrase.py
@@ -8,8 +8,12 @@ from chia.util.config import load_config
 
 
 @click.group("passphrase", short_help="Manage your keyring passphrase")
-def passphrase_cmd():
-    pass
+@click.pass_context
+def passphrase_cmd(ctx: click.Context):
+    from .keys_funcs import migrate_keys
+
+    if ctx.obj["force_legacy_keyring_migration"]:
+        migrate_keys(True)
 
 
 @passphrase_cmd.command(

--- a/chia/cmds/start.py
+++ b/chia/cmds/start.py
@@ -11,6 +11,10 @@ from chia.util.service_groups import all_groups
 def start_cmd(ctx: click.Context, restart: bool, group: str) -> None:
     import asyncio
     from .start_funcs import async_start
+    from .keys_funcs import migrate_keys
+
+    if ctx.obj["force_legacy_keyring_migration"]:
+        migrate_keys(True)
 
     root_path = ctx.obj["root_path"]
     config = load_config(root_path, "config.yaml")

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -9,8 +9,12 @@ from chia.wallet.util.wallet_types import WalletType
 
 
 @click.group("wallet", short_help="Manage your wallet")
-def wallet_cmd() -> None:
-    pass
+@click.pass_context
+def wallet_cmd(ctx: click.Context) -> None:
+    from .keys_funcs import migrate_keys
+
+    if ctx.obj["force_legacy_keyring_migration"]:
+        migrate_keys(True)
 
 
 @wallet_cmd.command("get_transaction", short_help="Get a transaction")

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -400,18 +400,6 @@ class WebSocketServer:
             if Keychain.master_passphrase_is_valid(key, force_reload=True):
                 Keychain.set_cached_master_passphrase(key)
                 success = True
-
-                # Attempt to silently migrate legacy keys if necessary. Non-fatal if this fails.
-                try:
-                    if not Keychain.migration_checked_for_current_version():
-                        self.log.info("Will attempt to migrate legacy keys...")
-                        Keychain.migrate_legacy_keys_silently()
-                        self.log.info("Migration of legacy keys complete.")
-                    else:
-                        self.log.debug("Skipping legacy key migration (previously attempted).")
-                except Exception:
-                    self.log.exception("Failed to migrate keys silently. Run `chia keys migrate` manually.")
-
                 # Inform the GUI of keyring status changes
                 self.keyring_status_changed(await self.keyring_status(), "wallet_ui")
             else:

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -468,44 +468,6 @@ class Keychain:
         return KeyringWrapper.get_shared_instance().using_legacy_keyring()
 
     @staticmethod
-    def migration_checked_for_current_version() -> bool:
-        """
-        Returns a bool indicating whether the current client version has checked the legacy keyring
-        for keys needing migration.
-        """
-
-        def compare_versions(version1: str, version2: str) -> int:
-            # Making the assumption that versions will be of the form: x[x].y[y].z[z]
-            # We limit the number of components to 3, with each component being up to 2 digits long
-            ver1: List[int] = [int(n[:2]) for n in version1.split(".")[:3]]
-            ver2: List[int] = [int(n[:2]) for n in version2.split(".")[:3]]
-            if ver1 > ver2:
-                return 1
-            elif ver1 < ver2:
-                return -1
-            else:
-                return 0
-
-        migration_version_file: Path = KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
-        if migration_version_file.exists():
-            current_version_str = pkg_resources.get_distribution("chia-blockchain").version
-            with migration_version_file.open("r") as f:
-                last_migration_version_str = f.read().strip()
-            return compare_versions(current_version_str, last_migration_version_str) <= 0
-
-        return False
-
-    @staticmethod
-    def mark_migration_checked_for_current_version():
-        """
-        Marks the current client version as having checked the legacy keyring for keys needing migration.
-        """
-        migration_version_file: Path = KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
-        current_version_str = pkg_resources.get_distribution("chia-blockchain").version
-        with migration_version_file.open("w") as f:
-            f.write(current_version_str)
-
-    @staticmethod
     def handle_migration_completed():
         """
         When migration completes outside of the current process, we rely on a notification to inform
@@ -563,27 +525,6 @@ class Keychain:
         set_sks = {str(x[0]) for x in all_sks}
         keys_present = set_sks.issuperset(set(map(lambda x: str(x[0]), keys_to_verify)))
         return keys_present
-
-    @staticmethod
-    def migrate_legacy_keys_silently():
-        """
-        Migrates keys silently, without prompting the user. Requires that keyring.yaml already exists.
-        Does not attempt to delete migrated keys from their old location.
-        """
-        if Keychain.needs_migration():
-            raise RuntimeError("Full keyring migration is required. Cannot run silently.")
-
-        keys_to_migrate, _ = Keychain.get_keys_needing_migration()
-        if len(keys_to_migrate) > 0:
-            keychain = Keychain()
-            for _, seed_bytes in keys_to_migrate:
-                mnemonic = bytes_to_mnemonic(seed_bytes)
-                keychain.add_private_key(mnemonic, "")
-
-            if not Keychain.verify_keys_present(keys_to_migrate):
-                raise RuntimeError("Failed to migrate keys. Legacy keyring left intact.")
-
-        Keychain.mark_migration_checked_for_current_version()
 
     @staticmethod
     def passphrase_is_optional() -> bool:

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -353,7 +353,7 @@ class KeyringWrapper:
         master_passphrase, _ = self.get_cached_master_passphrase()
         if master_passphrase == DEFAULT_PASSPHRASE_IF_NO_MASTER_PASSPHRASE:
             print(
-                "\nYour existing keys need to be migrated to a new keyring that is optionally secured by a master "
+                "\nYour existing keys will be migrated to a new keyring that is optionally secured by a master "
                 "passphrase."
             )
             print(
@@ -418,8 +418,6 @@ class KeyringWrapper:
         for (user, passphrase) in user_passphrase_pairs:
             self.keyring.set_password(service, user, passphrase)
 
-        Keychain.mark_migration_checked_for_current_version()
-
         return KeyringWrapper.MigrationResults(
             original_private_keys, self.legacy_keyring, service, [user for (user, _) in user_passphrase_pairs]
         )
@@ -473,7 +471,7 @@ class KeyringWrapper:
         elif legacy_keyring_type is WinKeyring:
             keyring_name = "Windows Credential Manager"
 
-        prompt = "Remove keys from old keyring"
+        prompt = "Remove keys from old keyring (recommended)"
         if len(keyring_name) > 0:
             prompt += f" ({keyring_name})?"
         else:
@@ -502,11 +500,9 @@ class KeyringWrapper:
         """
         from chia.cmds.passphrase_funcs import async_update_daemon_migration_completed_if_running
 
-        # Make sure the user is ready to begin migration.
-        response = self.confirm_migration()
-        if not response:
-            print("Skipping migration. Unable to proceed")
-            exit(0)
+        # Let the user know about the migration.
+        if not self.confirm_migration():
+            exit("Migration aborted, can't run any chia commands.")
 
         try:
             results = self.migrate_legacy_keys()
@@ -528,6 +524,7 @@ class KeyringWrapper:
 
         # Notify the daemon (if running) that migration has completed
         asyncio.run(async_update_daemon_migration_completed_if_running())
+        exit(0)
 
     # Keyring interface
 

--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -1,5 +1,4 @@
 import os
-import pkg_resources
 import pytest
 import re
 
@@ -135,7 +134,16 @@ class TestKeysCommands:
         # Generate a new key
         runner = CliRunner()
         result: Result = runner.invoke(
-            cli, ["--root-path", os.fspath(tmp_path), "--keys-root-path", os.fspath(keys_root_path), "keys", "generate"]
+            cli,
+            [
+                "--no-force-legacy-keyring-migration",
+                "--root-path",
+                os.fspath(tmp_path),
+                "--keys-root-path",
+                os.fspath(keys_root_path),
+                "keys",
+                "generate",
+            ],
         )
 
         assert result.exit_code == 0
@@ -171,7 +179,16 @@ class TestKeysCommands:
         # Generate the first key
         runner = CliRunner()
         generate_result: Result = runner.invoke(
-            cli, ["--root-path", os.fspath(tmp_path), "--keys-root-path", os.fspath(keys_root_path), "keys", "generate"]
+            cli,
+            [
+                "--no-force-legacy-keyring-migration",
+                "--root-path",
+                os.fspath(tmp_path),
+                "--keys-root-path",
+                os.fspath(keys_root_path),
+                "keys",
+                "generate",
+            ],
         )
 
         assert generate_result.exit_code == 0
@@ -189,7 +206,16 @@ class TestKeysCommands:
         # Generate the second key
         runner = CliRunner()
         result: Result = runner.invoke(
-            cli, ["--root-path", os.fspath(tmp_path), "--keys-root-path", os.fspath(keys_root_path), "keys", "generate"]
+            cli,
+            [
+                "--no-force-legacy-keyring-migration",
+                "--root-path",
+                os.fspath(tmp_path),
+                "--keys-root-path",
+                os.fspath(keys_root_path),
+                "keys",
+                "generate",
+            ],
         )
 
         assert result.exit_code == 0
@@ -251,7 +277,15 @@ class TestKeysCommands:
         runner = CliRunner()
         result: Result = runner.invoke(
             cli,
-            ["--root-path", os.fspath(tmp_path), "--keys-root-path", os.fspath(keys_root_path), "keys", "add"],
+            [
+                "--no-force-legacy-keyring-migration",
+                "--root-path",
+                os.fspath(tmp_path),
+                "--keys-root-path",
+                os.fspath(keys_root_path),
+                "keys",
+                "add",
+            ],
             input=f"{TEST_MNEMONIC_SEED}\n",
         )
 
@@ -278,6 +312,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -312,6 +347,7 @@ class TestKeysCommands:
         add_result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -330,6 +366,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -522,6 +559,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -580,6 +618,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -628,6 +667,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -717,6 +757,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -767,6 +808,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -825,6 +867,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -885,6 +928,7 @@ class TestKeysCommands:
         result: Result = runner.invoke(
             cli,
             [
+                "--no-force-legacy-keyring-migration",
                 "--root-path",
                 os.fspath(tmp_path),
                 "--keys-root-path",
@@ -1008,12 +1052,6 @@ class TestKeysCommands:
         assert len(Keychain().get_all_public_keys()) == 3  # new keyring has 3 keys
         assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 0  # legacy keys removed
 
-        current_version_str = pkg_resources.get_distribution("chia-blockchain").version
-        last_migration_version_str = (
-            KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
-        ).read_text()
-        assert last_migration_version_str == current_version_str  # last migration version set
-
     def test_migration_incremental(self, tmp_path, keyring_with_one_key, monkeypatch):
         KeyringWrapper.set_keys_root_path(tmp_path)
         KeyringWrapper.cleanup_shared_instance()
@@ -1059,107 +1097,3 @@ class TestKeysCommands:
         assert type(KeyringWrapper.get_shared_instance().keyring) is FileKeyring  # new keyring set
         assert len(Keychain().get_all_public_keys()) == 4  # new keyring has 4 keys
         assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 0  # legacy keys removed
-
-        current_version_str = pkg_resources.get_distribution("chia-blockchain").version
-        last_migration_version_str = (
-            KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
-        ).read_text()
-        assert last_migration_version_str == current_version_str  # last migration version set
-
-    def test_migration_silent(self, tmp_path, keyring_with_one_key, monkeypatch):
-        KeyringWrapper.set_keys_root_path(tmp_path)
-        KeyringWrapper.cleanup_shared_instance()
-
-        keychain = keyring_with_one_key
-        legacy_keyring = DummyLegacyKeyring()
-
-        def mock_get_legacy_keyring_instance() -> Optional[LegacyKeyring]:
-            nonlocal legacy_keyring
-            return legacy_keyring
-
-        from chia.util import keyring_wrapper
-
-        monkeypatch.setattr(keyring_wrapper, "get_legacy_keyring_instance", mock_get_legacy_keyring_instance)
-
-        assert len(keychain.get_all_private_keys()) == 1
-        assert len(Keychain().get_all_private_keys()) == 1
-        assert keychain.keyring_wrapper.legacy_keyring is None
-        assert legacy_keyring is not None
-        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 3
-
-        keys_needing_migration, legacy_migration_keychain = Keychain.get_keys_needing_migration()
-        assert len(keys_needing_migration) == 3
-        assert legacy_migration_keychain is not None
-
-        Keychain.migrate_legacy_keys_silently()
-
-        assert type(KeyringWrapper.get_shared_instance().keyring) is FileKeyring  # new keyring set
-        assert len(Keychain().get_all_public_keys()) == 4  # new keyring has 4 keys
-        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 3  # legacy keys still intact
-
-    def test_migration_silent_keys_already_present(self, tmp_path, keyring_with_one_key, monkeypatch):
-        KeyringWrapper.set_keys_root_path(tmp_path)
-        KeyringWrapper.cleanup_shared_instance()
-
-        keychain = keyring_with_one_key
-        pkent_str = keychain.keyring_wrapper.get_passphrase(DEFAULT_SERVICE, f"wallet-{DEFAULT_USER}-0")
-        legacy_keyring = DummyLegacyKeyring(populate=False)
-        legacy_keyring.set_password(DEFAULT_SERVICE, f"wallet-{DEFAULT_USER}-0", pkent_str)
-
-        def mock_get_legacy_keyring_instance() -> Optional[LegacyKeyring]:
-            nonlocal legacy_keyring
-            return legacy_keyring
-
-        from chia.util import keyring_wrapper
-
-        monkeypatch.setattr(keyring_wrapper, "get_legacy_keyring_instance", mock_get_legacy_keyring_instance)
-
-        assert len(keychain.get_all_private_keys()) == 1
-        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 1
-
-        keys_needing_migration, legacy_migration_keychain = Keychain.get_keys_needing_migration()
-        assert len(keys_needing_migration) == 0
-        assert legacy_migration_keychain is not None
-
-        Keychain.migrate_legacy_keys_silently()
-
-        assert type(KeyringWrapper.get_shared_instance().keyring) is FileKeyring  # new keyring set
-        assert len(Keychain().get_all_public_keys()) == 1  # keyring has 1 key
-        assert len(legacy_keyring.service_dict[DEFAULT_SERVICE]) == 1  # legacy keys still intact
-
-    def test_migration_checked(self, tmp_path, monkeypatch):
-        KeyringWrapper.set_keys_root_path(tmp_path)
-        KeyringWrapper.cleanup_shared_instance()
-
-        assert Keychain.migration_checked_for_current_version() is False
-
-        dist_version = ""
-
-        class DummyDistribution:
-            def __init__(self, version):
-                self.version = version
-
-        def mock_get_distribution_version(_) -> DummyDistribution:
-            nonlocal dist_version
-            return DummyDistribution(dist_version)
-
-        monkeypatch.setattr(pkg_resources, "get_distribution", mock_get_distribution_version)
-
-        dist_version = "1.2.11.dev123"
-        assert pkg_resources.get_distribution("chia-blockchain").version == "1.2.11.dev123"
-
-        Keychain.mark_migration_checked_for_current_version()
-
-        last_migration_version_str = (
-            KeyringWrapper.get_shared_instance().keys_root_path / ".last_legacy_migration"
-        ).read_text()
-        assert last_migration_version_str == "1.2.11.dev123"  # last migration version set
-
-        assert Keychain.migration_checked_for_current_version() is True
-
-        dist_version = "1.2.11.dev345"
-        assert Keychain.migration_checked_for_current_version() is True  # We don't check the build number
-        dist_version = "1.2.10.dev111"
-        assert Keychain.migration_checked_for_current_version() is True  # Checked version > current version
-        dist_version = "1.3.0.dev100"
-        assert Keychain.migration_checked_for_current_version() is False  # Checked version < current version


### PR DESCRIPTION
After this PR the users will be forced to migrate their keyring if they didn't yet. This will only happen on CLI level if the user runs any of the following commands: `chia keys`, `chia passphrase`, `chia wallet`, `chia start`. The message they will see then is:

```
Legacy keyring support is deprecated and gets removed in version 1.5.2, you need to migrate your keyring
to continue using chia.

Your existing keys will be migrated to a new keyring that is optionally secured by a master passphrase.
Would you like to set a master passphrase now? Use 'chia passphrase set' to change the passphrase.
```

Aborting the migration will result in the CLI exiting with:

```
Migration aborted, can't continue running any chia command.
```

I tested all of this for both migration paths (full migration required and partially migration required).