### PR TITLE
Adding Chia-Network/required-reviewers as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@Chia-Network/required-reviewers


### PR DESCRIPTION
This just adds the @Chia-Network/required-reviewers user group as codeowners for the entire contents of the repo, which will allow me to set a branch protection rule to require PR approval from CODEOWNERS before merging