### PR TITLE
fix a few instances of coin name logging

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -274,7 +274,7 @@ class PoolWallet:
         if spent_coin_name != new_state.coin.name():
             history: List[Tuple[uint32, CoinSpend]] = await self.get_spend_history()
             if new_state.coin.name() in [sp.coin.name() for _, sp in history]:
-                self.log.info(f"Already have state transition: {new_state.coin.name()}")
+                self.log.info(f"Already have state transition: {new_state.coin.name().hex()}")
             else:
                 self.log.warning(
                     f"Failed to apply state transition. tip: {tip_coin} new_state: {new_state} height {block_height}"

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -343,7 +343,7 @@ class CATWallet:
         args = match_cat_puzzle(*puzzle.uncurry())
         if args is not None:
             mod_hash, genesis_coin_checker_hash, inner_puzzle = args
-            self.log.info(f"parent: {coin_name} inner_puzzle for parent is {inner_puzzle}")
+            self.log.info(f"parent: {coin_name.hex()} inner_puzzle for parent is {inner_puzzle}")
 
             await self.add_lineage(
                 coin_name,
@@ -782,7 +782,7 @@ class CATWallet:
         Lineage proofs are stored as a list of parent coins and the lineage proof you will need if they are the
         parent of the coin you are trying to spend. 'If I'm your parent, here's the info you need to spend yourself'
         """
-        self.log.info(f"Adding parent {name}: {lineage}")
+        self.log.info(f"Adding parent {name.hex()}: {lineage}")
         if lineage is not None:
             await self.lineage_store.add_lineage_proof(name, lineage)
 


### PR DESCRIPTION
that would print binary-escaped strings instead of hex.

These are regressions from when I moved `Coin` to rust. `Coin.name()` now returns `bytes` instead of `bytes32`. One difference is that `bytes32` prints as hex by default, whereas `bytes` doesn't.