### PR TITLE
Change client connection errors from info to error

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -477,7 +477,8 @@ class ChiaServer:
                 asyncio.create_task(connection.close())
             return True
         except client_exceptions.ClientConnectorError as e:
-            self.log.info(f"{e}")
+            log_function = self.log.error if self.log.name in [ 'harvester_server', 'farmer_server' ] else self.log.info
+            log_function(f"{e}")
         except ProtocolError as e:
             if connection is not None:
                 await connection.close(self.invalid_protocol_ban_seconds, WSCloseCode.PROTOCOL_ERROR, e.code)


### PR DESCRIPTION
Resubmitting PR #10929. Log farmer and harvester connection failures are errors instead of informational.

Connection errors from harvester and farmer should be logged as errors instead of info, so problems with farming are easier to identify as they are hidden by the default log level INFO.