### PR TITLE
pre-commit: Fix a venv activation issue on linux

### DIFF
--- a/activated.py
+++ b/activated.py
@@ -18,7 +18,7 @@ def main(*args: str) -> int:
         command = ["powershell", os.fspath(here.joinpath(script)), *args]
     else:
         script = "activated.sh"
-        command = [os.fspath(here.joinpath(script)), *args]
+        command = ["sh", os.fspath(here.joinpath(script)), *args]
 
     completed_process = subprocess.run(command)
 

--- a/activated.sh
+++ b/activated.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -o errexit
 

--- a/activated.sh
+++ b/activated.sh
@@ -4,6 +4,6 @@ set -o errexit
 
 SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "$0")"; pwd)
 # shellcheck disable=SC1091
-source "${SCRIPT_DIRECTORY}/venv/bin/activate"
+. "${SCRIPT_DIRECTORY}/venv/bin/activate"
 
 "$@"


### PR DESCRIPTION
I ended up with the same issue as in https://github.com/Chia-Network/chia-blockchain/pull/12235 and using `.` instead of `source` (Which is supposed to be the same?) fixed it.