### PR TITLE
make web socket timeout a warning without a traceback

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -262,9 +262,7 @@ class WSChiaConnection:
                     await self._send_message(msg)
         except asyncio.CancelledError:
             pass
-        except BrokenPipeError as e:
-            self.log.warning(f"{e} {self.peer_host}")
-        except ConnectionResetError as e:
+        except (BrokenPipeError, ConnectionResetError, TimeoutError) as e:
             self.log.warning(f"{e} {self.peer_host}")
         except Exception as e:
             error_stack = traceback.format_exc()


### PR DESCRIPTION
The following seems a bit loud for a websocket timeout.

```
Aug 07 10:40:18 fullnode chia_full_node[2092772]: 2022-08-07T10:40:18.083 full_node full_node_server        : ERROR    Exception: [Errno 110] Connection timed out with 117.91.173.109
Aug 07 10:40:18 fullnode chia_full_node[2092772]: 2022-08-07T10:40:18.084 full_node full_node_server        : ERROR    Exception Stack: Traceback (most recent call last):
Aug 07 10:40:18 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/server/ws_connection.py", line 262, in outbound_handler
Aug 07 10:40:18 fullnode chia_full_node[2092772]:     await self._send_message(msg)
Aug 07 10:40:18 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/server/ws_connection.py", line 416, in _send_message
Aug 07 10:40:18 fullnode chia_full_node[2092772]:     await self.ws.send_bytes(encoded)
Aug 07 10:40:18 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/web_ws.py", line 315, in send_bytes
Aug 07 10:40:18 fullnode chia_full_node[2092772]:     await self._writer.send(data, binary=True, compress=compress)
Aug 07 10:40:18 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/http_websocket.py", line 688, in send
Aug 07 10:40:18 fullnode chia_full_node[2092772]:     await self._send_frame(message, WSMsgType.BINARY, compress)
Aug 07 10:40:18 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/http_websocket.py", line 659, in _send_frame
Aug 07 10:40:18 fullnode chia_full_node[2092772]:     await self.protocol._drain_helper()
Aug 07 10:40:18 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/base_protocol.py", line 87, in _drain_helper
Aug 07 10:40:18 fullnode chia_full_node[2092772]:     await asyncio.shield(waiter)
Aug 07 10:40:18 fullnode chia_full_node[2092772]:   File "/usr/lib/python3.8/asyncio/selector_events.py", line 848, in _read_ready__data_received
Aug 07 10:40:18 fullnode chia_full_node[2092772]:     data = self._sock.recv(self.max_size)
Aug 07 10:40:18 fullnode chia_full_node[2092772]: TimeoutError: [Errno 110] Connection timed out
Aug 07 10:40:18 fullnode chia_full_node[2092772]:
```