### PR TITLE
just raise, not raise e when reraising

### DIFF
--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -224,7 +224,7 @@ def get_current_passphrase() -> Optional[str]:
             current_passphrase = obtain_current_passphrase()
         except Exception as e:
             print(f"Unable to confirm current passphrase: {e}")
-            raise e
+            raise
 
     return current_passphrase
 

--- a/chia/cmds/rpc.py
+++ b/chia/cmds/rpc.py
@@ -33,7 +33,7 @@ async def call_endpoint(service: str, endpoint: str, request: Dict[str, Any], co
     except ClientResponseError as e:
         if e.code == 404:
             raise Exception(f"Invalid endpoint for {service}: {endpoint}")
-        raise e
+        raise
     except Exception as e:
         raise Exception(f"Request failed: {e}")
     finally:

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -291,7 +291,7 @@ async def add_token(args: dict, wallet_client: WalletRpcClient, fingerprint: int
         if "fromhex()" in str(e):
             print(f"{asset_id} is not a valid Asset ID")
         else:
-            raise e
+            raise
 
 
 async def make_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -474,9 +474,9 @@ class FullNode:
                             raise
                         finally:
                             self.log.info(f"Added blocks {height}-{end_height}")
-        except (asyncio.CancelledError, Exception) as e:
+        except (asyncio.CancelledError, Exception):
             self.sync_store.batch_syncing.remove(peer.peer_node_id)
-            raise e
+            raise
         self.sync_store.batch_syncing.remove(peer.peer_node_id)
         return True
 
@@ -525,9 +525,9 @@ class FullNode:
             if found_fork_point:
                 for response in reversed(responses):
                     await self.respond_block(response, peer)
-        except (asyncio.CancelledError, Exception) as e:
+        except (asyncio.CancelledError, Exception):
             self.sync_store.backtrack_syncing[peer.peer_node_id] -= 1
-            raise e
+            raise
 
         self.sync_store.backtrack_syncing[peer.peer_node_id] -= 1
         return found_fork_point
@@ -2085,9 +2085,9 @@ class FullNode:
             except ValidationError as e:
                 self.mempool_manager.remove_seen(spend_name)
                 return MempoolInclusionStatus.FAILED, e.code
-            except Exception as e:
+            except Exception:
                 self.mempool_manager.remove_seen(spend_name)
-                raise e
+                raise
             async with self._blockchain_lock_low_priority:
                 if self.mempool_manager.get_spendbundle(spend_name) is not None:
                     self.mempool_manager.remove_seen(spend_name)

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -601,7 +601,7 @@ class ChiaServer:
                         except Exception as e:
                             tb = traceback.format_exc()
                             connection.log.error(f"Exception: {e}, {connection.get_peer_logging()}. {tb}")
-                            raise e
+                            raise
                         return None
 
                     response: Optional[Message] = await asyncio.wait_for(wrapped_coroutine(), timeout=timeout)

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -292,7 +292,7 @@ class KeyringWrapper:
                 passphrase_store.set_password(MASTER_PASSPHRASE_SERVICE_NAME, MASTER_PASSPHRASE_USER_NAME, passphrase)
             except KeyringError as e:
                 if not warn_if_macos_errSecInteractionNotAllowed(e):
-                    raise e
+                    raise
         return None
 
     def remove_master_passphrase_from_credential_store(self) -> None:
@@ -300,15 +300,15 @@ class KeyringWrapper:
         if passphrase_store is not None:
             try:
                 passphrase_store.delete_password(MASTER_PASSPHRASE_SERVICE_NAME, MASTER_PASSPHRASE_USER_NAME)
-            except PasswordDeleteError as e:
+            except PasswordDeleteError:
                 if (
                     passphrase_store.get_credential(MASTER_PASSPHRASE_SERVICE_NAME, MASTER_PASSPHRASE_USER_NAME)
                     is not None
                 ):
-                    raise e
+                    raise
             except KeyringError as e:
                 if not warn_if_macos_errSecInteractionNotAllowed(e):
-                    raise e
+                    raise
         return None
 
     def get_master_passphrase_from_credential_store(self) -> Optional[str]:
@@ -318,7 +318,7 @@ class KeyringWrapper:
                 return passphrase_store.get_password(MASTER_PASSPHRASE_SERVICE_NAME, MASTER_PASSPHRASE_USER_NAME)
             except KeyringError as e:
                 if not warn_if_macos_errSecInteractionNotAllowed(e):
-                    raise e
+                    raise
         return None
 
     def get_master_passphrase_hint(self) -> Optional[str]:
@@ -453,7 +453,7 @@ class KeyringWrapper:
             print(f"\nMigration failed: {e}")
             print("Leaving legacy keyring intact")
             self.legacy_keyring = migration_results.legacy_keyring  # Restore the legacy keyring
-            raise e
+            raise
 
         return success
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -206,7 +206,7 @@ class WalletNode:
         except KeychainProxyConnectionFailure as e:
             tb = traceback.format_exc()
             self.log.error(f"Missing keychain_proxy: {e} {tb}")
-            raise e  # Re-raise so that the caller can decide whether to continue or abort
+            raise  # Re-raise so that the caller can decide whether to continue or abort
 
         return key
 


### PR DESCRIPTION
`raise e` for a caught exception `e` injects additional lines into the traceback for the place where the exception is being re-raised.  This is generally not wanted.  To re-raise an existing exception that is being responded to just `raise`.

```
Aug 07 12:13:57 fullnode chia_full_node[2092772]: 2022-08-07T12:13:57.698 full_node full_node_server        : ERROR    Exception: Failed to fetch block 2366366 from {'host': '68.162.149.83', 'port': 8444}, timed out <class 'ValueError'>, closing connection {'host': '68.162.149.83', 'port': 8444}. Traceback (most recent call last):
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/server/server.py", line 607, in api_call
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     response: Optional[Message] = await asyncio.wait_for(wrapped_coroutine(), timeout=timeout)
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/usr/lib/python3.8/asyncio/tasks.py", line 455, in wait_for
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     return await fut
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/server/server.py", line 604, in wrapped_coroutine
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     raise e
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/server/server.py", line 597, in wrapped_coroutine
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     result = await coroutine
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/full_node/full_node_api.py", line 123, in new_peak
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     return await self.full_node.new_peak(request, peer)
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/full_node/full_node.py", line 596, in new_peak
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     if await self.short_sync_backtrack(
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/full_node/full_node.py", line 530, in short_sync_backtrack
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     raise e
Aug 07 12:13:57 fullnode chia_full_node[2092772]:   File "/farm/chia-blockchain/chia/full_node/full_node.py", line 515, in short_sync_backtrack
Aug 07 12:13:57 fullnode chia_full_node[2092772]:     raise ValueError(f"Failed to fetch block {curr_height} from {peer.get_peer_logging()}, timed out")
Aug 07 12:13:57 fullnode chia_full_node[2092772]: ValueError: Failed to fetch block 2366366 from {'host': '68.162.149.83', 'port': 8444}, timed out
```