### PR TITLE
util: Introduce `get_key`/`get_keys` in `Keychain` + `KeychainServer`

### DIFF
--- a/chia/daemon/keychain_server.py
+++ b/chia/daemon/keychain_server.py
@@ -2,9 +2,13 @@ import logging
 
 from blspy import PrivateKey
 from chia.cmds.init_funcs import check_keys
-from chia.util.keychain import Keychain
+from chia.util.errors import KeychainException, KeychainFingerprintNotFound
+from chia.util.ints import uint32
+from chia.util.keychain import KeyData, Keychain
+from chia.util.streamable import streamable, Streamable
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, cast, Type
 
 # Commands that are handled by the KeychainServer
 keychain_commands = [
@@ -15,6 +19,8 @@ keychain_commands = [
     "get_all_private_keys",
     "get_first_private_key",
     "get_key_for_fingerprint",
+    "get_key",
+    "get_keys",
 ]
 
 log = logging.getLogger(__name__)
@@ -24,6 +30,37 @@ KEYCHAIN_ERR_LOCKED = "keyring is locked"
 KEYCHAIN_ERR_NO_KEYS = "no keys present"
 KEYCHAIN_ERR_KEY_NOT_FOUND = "key not found"
 KEYCHAIN_ERR_MALFORMED_REQUEST = "malformed request"
+
+
+@streamable
+@dataclass(frozen=True)
+class GetKeyResponse(Streamable):
+    key: KeyData
+
+
+@streamable
+@dataclass(frozen=True)
+class GetKeyRequest(Streamable):
+    fingerprint: uint32
+    include_secrets: bool = False
+
+    def run(self, keychain: Keychain) -> GetKeyResponse:
+        return GetKeyResponse(key=keychain.get_key(self.fingerprint, self.include_secrets))
+
+
+@streamable
+@dataclass(frozen=True)
+class GetKeysResponse(Streamable):
+    keys: List[KeyData]
+
+
+@streamable
+@dataclass(frozen=True)
+class GetKeysRequest(Streamable):
+    include_secrets: bool = False
+
+    def run(self, keychain: Keychain) -> GetKeysResponse:
+        return GetKeysResponse(keys=keychain.get_keys(self.include_secrets))
 
 
 class KeychainServer:
@@ -72,6 +109,10 @@ class KeychainServer:
                 return await self.get_first_private_key(cast(Dict[str, Any], data))
             elif command == "get_key_for_fingerprint":
                 return await self.get_key_for_fingerprint(cast(Dict[str, Any], data))
+            elif command == "get_key":
+                return await self.run_request(data, GetKeyRequest)
+            elif command == "get_keys":
+                return await self.run_request(data, GetKeysRequest)
             return {}
         except Exception as e:
             log.exception(e)
@@ -145,6 +186,35 @@ class KeychainServer:
         self.get_keychain_for_request(request).delete_key_by_fingerprint(fingerprint)
 
         return {"success": True}
+
+    async def run_request(self, request_dict: Dict[str, Any], request_type: Type[Any]) -> Dict[str, Any]:
+        keychain = self.get_keychain_for_request(request_dict)
+        if keychain.is_keyring_locked():
+            return {"success": False, "error": KEYCHAIN_ERR_LOCKED}
+
+        try:
+            request = request_type.from_json_dict(request_dict)
+        except Exception as e:
+            return {
+                "success": False,
+                "error": KEYCHAIN_ERR_MALFORMED_REQUEST,
+                "error_details": {"message": str(e)},
+            }
+
+        try:
+            return {"success": True, **request.run(keychain).to_json_dict()}
+        except KeychainFingerprintNotFound as e:
+            return {
+                "success": False,
+                "error": KEYCHAIN_ERR_KEY_NOT_FOUND,
+                "error_details": {"fingerprint": e.fingerprint},
+            }
+        except KeychainException as e:
+            return {
+                "success": False,
+                "error": KEYCHAIN_ERR_MALFORMED_REQUEST,
+                "error_details": {"message": str(e)},
+            }
 
     async def get_all_private_keys(self, request: Dict[str, Any]) -> Dict[str, Any]:
         all_keys: List[Dict[str, Any]] = []

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -257,6 +257,11 @@ class KeychainFingerprintError(KeychainException):
         super().__init__(f"fingerprint {str(fingerprint)!r} {message}")
 
 
+class KeychainFingerprintNotFound(KeychainFingerprintError):
+    def __init__(self, fingerprint: int) -> None:
+        super().__init__(fingerprint, "not found")
+
+
 class KeychainFingerprintExists(KeychainFingerprintError):
     def __init__(self, fingerprint: int) -> None:
         super().__init__(fingerprint, "already exists")


### PR DESCRIPTION
This is preparation for the key name support where in a follow up the key name gets added to `KeyData`.  Adds the two new methods:
- `get_key` to fetch a `KeyData` entry based on a fingerprint
- `get_keys` to fetch the `KeyData` entries of all keys in the keychain. 

There is a parameter `include_secrets` (defaults to false) in the related methods and the server requests which allows to hide/show the secrets.

Based on: 
- #12772 
- #12752 