### PR TITLE
Unify SimulatorsAndWallets and remove extra bt from datalayer related tests

### DIFF
--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -30,7 +30,7 @@ from tests.util.keyring import TempKeyring
 from tests.util.socket import find_available_listen_port
 
 
-SimulatorsAndWallets = Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]]
+SimulatorsAndWallets = Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]
 
 
 def cleanup_keyring(keyring: TempKeyring):

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, List, Tuple
+from typing import AsyncIterator, List
 
 import pytest
 import pytest_asyncio
@@ -6,12 +6,10 @@ import pytest_asyncio
 from chia.cmds.units import units
 from chia.types.peer_info import PeerInfo
 from tests.block_tools import create_block_tools_async
-from chia.server.server import ChiaServer
-from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.util.ints import uint16, uint32, uint64
-from chia.wallet.wallet_node import WalletNode
 from tests.core.node_height import node_height_at_least
 from tests.setup_nodes import (
+    SimulatorsAndWallets,
     setup_full_node,
     setup_full_system,
     test_constants,
@@ -61,7 +59,7 @@ async def simulation(bt):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def one_wallet_node() -> AsyncIterator[Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]]]:
+async def one_wallet_node() -> AsyncIterator[SimulatorsAndWallets]:
     async for _ in setup_simulators_and_wallets(simulator_count=1, wallet_count=1, dic={}):
         yield _
 
@@ -130,9 +128,9 @@ class TestSimulation:
     async def test_simulation_process_blocks(
         self,
         count,
-        one_wallet_node: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]],
+        one_wallet_node: SimulatorsAndWallets,
     ):
-        [[full_node_api], _] = one_wallet_node
+        [[full_node_api], _, _] = one_wallet_node
 
         # Starting at the beginning.
         assert full_node_api.full_node.blockchain.get_peak_height() is None
@@ -148,9 +146,9 @@ class TestSimulation:
     async def test_simulation_farm_blocks(
         self,
         count,
-        one_wallet_node: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]],
+        one_wallet_node: SimulatorsAndWallets,
     ):
-        [[full_node_api], [[wallet_node, wallet_server]]] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
 
         await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
 
@@ -198,9 +196,9 @@ class TestSimulation:
         self,
         amount: int,
         coin_count: int,
-        one_wallet_node: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]],
+        one_wallet_node: SimulatorsAndWallets,
     ):
-        [[full_node_api], [[wallet_node, wallet_server]]] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
 
         await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
 
@@ -228,11 +226,11 @@ class TestSimulation:
     @pytest.mark.asyncio
     async def test_wait_transaction_records_entered_mempool(
         self,
-        one_wallet_node: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]],
+        one_wallet_node: SimulatorsAndWallets,
     ) -> None:
         repeats = 50
         tx_amount = 1
-        [[full_node_api], [[wallet_node, wallet_server]]] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
 
         await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
 
@@ -264,11 +262,11 @@ class TestSimulation:
     @pytest.mark.asyncio
     async def test_process_transaction_records(
         self,
-        one_wallet_node: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]],
+        one_wallet_node: SimulatorsAndWallets,
     ) -> None:
         repeats = 50
         tx_amount = 1
-        [[full_node_api], [[wallet_node, wallet_server]]] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
 
         await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
 
@@ -306,9 +304,9 @@ class TestSimulation:
     async def test_create_coins_with_amounts(
         self,
         amounts: List[int],
-        one_wallet_node: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]],
+        one_wallet_node: SimulatorsAndWallets,
     ) -> None:
-        [[full_node_api], [[wallet_node, wallet_server]]] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
 
         await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
 
@@ -338,9 +336,9 @@ class TestSimulation:
     async def test_create_coins_with_invalid_amounts_raises(
         self,
         amounts: List[int],
-        one_wallet_node: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]],
+        one_wallet_node: SimulatorsAndWallets,
     ) -> None:
-        [[full_node_api], [[wallet_node, wallet_server]]] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
 
         await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
 

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -68,7 +68,7 @@ class TestDLWallet:
     )
     @pytest.mark.asyncio
     async def test_initial_creation(self, wallet_node: SimulatorsAndWallets, trusted: bool) -> None:
-        full_nodes, wallets = wallet_node
+        full_nodes, wallets, _ = wallet_node
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]
@@ -116,7 +116,7 @@ class TestDLWallet:
     )
     @pytest.mark.asyncio
     async def test_get_owned_singletons(self, wallet_node: SimulatorsAndWallets, trusted: bool) -> None:
-        full_nodes, wallets = wallet_node
+        full_nodes, wallets, _ = wallet_node
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]
@@ -168,7 +168,7 @@ class TestDLWallet:
     )
     @pytest.mark.asyncio
     async def test_tracking_non_owned(self, two_wallet_nodes: SimulatorsAndWallets, trusted: bool) -> None:
-        full_nodes, wallets = two_wallet_nodes
+        full_nodes, wallets, _ = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]
@@ -243,7 +243,7 @@ class TestDLWallet:
     )
     @pytest.mark.asyncio
     async def test_lifecycle(self, wallet_node: SimulatorsAndWallets, trusted: bool) -> None:
-        full_nodes, wallets = wallet_node
+        full_nodes, wallets, _ = wallet_node
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]
@@ -338,7 +338,7 @@ class TestDLWallet:
     )
     @pytest.mark.asyncio
     async def test_rebase(self, two_wallet_nodes: SimulatorsAndWallets, trusted: bool) -> None:
-        full_nodes, wallets = two_wallet_nodes
+        full_nodes, wallets, _ = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]

--- a/tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import AsyncIterator, List, Tuple
+from typing import AsyncIterator
 
 import pytest
 import pytest_asyncio
@@ -11,23 +11,16 @@ from chia.rpc.full_node_rpc_api import FullNodeRpcApi
 from chia.rpc.rpc_server import start_rpc_server
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
-from chia.server.server import ChiaServer
-from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.db_wallet.db_wallet_puzzles import create_mirror_puzzle
-from chia.wallet.wallet_node import WalletNode
-from tests.block_tools import BlockTools
-from tests.setup_nodes import setup_simulators_and_wallets
+from tests.setup_nodes import SimulatorsAndWallets, setup_simulators_and_wallets
 from tests.time_out_assert import time_out_assert
 from tests.util.rpc import validate_get_routes
 
 log = logging.getLogger(__name__)
-
-
-SimulatorsAndWallets = Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]]]
 
 
 class TestWalletRpc:
@@ -42,10 +35,10 @@ class TestWalletRpc:
     )
     @pytest.mark.asyncio
     async def test_wallet_make_transaction(
-        self, two_wallet_nodes: SimulatorsAndWallets, trusted: bool, bt: BlockTools, self_hostname: str
+        self, two_wallet_nodes: SimulatorsAndWallets, trusted: bool, self_hostname: str
     ) -> None:
         num_blocks = 5
-        full_nodes, wallets = two_wallet_nodes
+        full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]


### PR DESCRIPTION
This adapts to bd5d4b1 that got checkpointed into atari through db29a5b.