### PR TITLE
util: Simplify `unlocks_keyring` and move it with `obtain_current_passphrase` into `cmds`

### DIFF
--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from chia.consensus.coinbase import create_puzzlehash_for_pk
+from chia.cmds.passphrase_funcs import obtain_current_passphrase
 from chia.daemon.client import connect_to_daemon_and_validate
 from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate, wrap_local_keychain
 from chia.util.bech32m import encode_puzzle_hash
@@ -16,13 +17,27 @@ from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import KeychainException
 from chia.util.ints import uint32
-from chia.util.keychain import Keychain, bytes_to_mnemonic, generate_mnemonic, mnemonic_to_seed, unlock_keyring
+from chia.util.keychain import Keychain, bytes_to_mnemonic, generate_mnemonic, mnemonic_to_seed
+from chia.util.keyring_wrapper import KeyringWrapper
 from chia.wallet.derive_keys import (
     master_sk_to_farmer_sk,
     master_sk_to_pool_sk,
     master_sk_to_wallet_sk,
     master_sk_to_wallet_sk_unhardened,
 )
+
+
+def unlock_keyring() -> None:
+    """
+    Used to unlock the keyring interactively, if necessary
+    """
+
+    try:
+        if KeyringWrapper.get_shared_instance().has_master_passphrase():
+            obtain_current_passphrase(use_passphrase_cache=True)
+    except Exception as e:
+        print(f"Unable to unlock the keyring: {e}")
+        sys.exit(1)
 
 
 def generate_and_print():

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -16,13 +16,7 @@ from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import KeychainException
 from chia.util.ints import uint32
-from chia.util.keychain import (
-    Keychain,
-    bytes_to_mnemonic,
-    generate_mnemonic,
-    mnemonic_to_seed,
-    unlocks_keyring,
-)
+from chia.util.keychain import Keychain, bytes_to_mnemonic, generate_mnemonic, mnemonic_to_seed, unlock_keyring
 from chia.wallet.derive_keys import (
     master_sk_to_farmer_sk,
     master_sk_to_pool_sk,
@@ -43,29 +37,27 @@ def generate_and_print():
     return mnemonic
 
 
-@unlocks_keyring()
 def generate_and_add():
     """
     Generates a seed for a private key, prints the mnemonic to the terminal, and adds the key to the keyring.
     """
-
+    unlock_keyring()
     mnemonic = generate_mnemonic()
     print("Generating private key")
     add_private_key_seed(mnemonic)
 
 
-@unlocks_keyring()
 def query_and_add_private_key_seed():
+    unlock_keyring()
     mnemonic = input("Enter the mnemonic you want to use: ")
     add_private_key_seed(mnemonic)
 
 
-@unlocks_keyring()
 def add_private_key_seed(mnemonic: str):
     """
     Add a private key seed to the keyring, with the given mnemonic.
     """
-
+    unlock_keyring()
     try:
         sk = Keychain().add_private_key(mnemonic)
         fingerprint = sk.get_g1().get_fingerprint()
@@ -76,11 +68,11 @@ def add_private_key_seed(mnemonic: str):
         return None
 
 
-@unlocks_keyring()
 def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
     """
     Prints all keys and mnemonics (if available).
     """
+    unlock_keyring()
     root_path = DEFAULT_ROOT_PATH
     config = load_config(root_path, "config.yaml")
     private_keys = Keychain().get_all_private_keys()
@@ -121,11 +113,11 @@ def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
             print(mnemonic)
 
 
-@unlocks_keyring()
 def delete(fingerprint: int):
     """
     Delete a key by its public key fingerprint (which is an integer).
     """
+    unlock_keyring()
     print(f"Deleting private_key with fingerprint {fingerprint}")
     Keychain().delete_key_by_fingerprint(fingerprint)
 
@@ -655,8 +647,8 @@ def derive_child_key(
                 print(f"{key_type_str} private key {i}{hd_path}: {private_key_string_repr(sk)}")
 
 
-@unlocks_keyring()
 def private_key_for_fingerprint(fingerprint: int) -> Optional[PrivateKey]:
+    unlock_keyring()
     private_keys = Keychain().get_all_private_keys()
 
     for sk, _ in private_keys:

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -43,7 +43,7 @@ def generate_and_print():
     return mnemonic
 
 
-@unlocks_keyring(use_passphrase_cache=True)
+@unlocks_keyring()
 def generate_and_add():
     """
     Generates a seed for a private key, prints the mnemonic to the terminal, and adds the key to the keyring.
@@ -54,13 +54,13 @@ def generate_and_add():
     add_private_key_seed(mnemonic)
 
 
-@unlocks_keyring(use_passphrase_cache=True)
+@unlocks_keyring()
 def query_and_add_private_key_seed():
     mnemonic = input("Enter the mnemonic you want to use: ")
     add_private_key_seed(mnemonic)
 
 
-@unlocks_keyring(use_passphrase_cache=True)
+@unlocks_keyring()
 def add_private_key_seed(mnemonic: str):
     """
     Add a private key seed to the keyring, with the given mnemonic.
@@ -76,7 +76,7 @@ def add_private_key_seed(mnemonic: str):
         return None
 
 
-@unlocks_keyring(use_passphrase_cache=True)
+@unlocks_keyring()
 def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
     """
     Prints all keys and mnemonics (if available).
@@ -121,7 +121,7 @@ def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
             print(mnemonic)
 
 
-@unlocks_keyring(use_passphrase_cache=True)
+@unlocks_keyring()
 def delete(fingerprint: int):
     """
     Delete a key by its public key fingerprint (which is an integer).
@@ -655,7 +655,7 @@ def derive_child_key(
                 print(f"{key_type_str} private key {i}{hd_path}: {private_key_string_repr(sk)}")
 
 
-@unlocks_keyring(use_passphrase_cache=True)
+@unlocks_keyring()
 def private_key_for_fingerprint(fingerprint: int) -> Optional[PrivateKey]:
     private_keys = Keychain().get_all_private_keys()
 

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -54,7 +54,7 @@ def symmetric_key_from_passphrase(passphrase: str, salt: bytes) -> bytes:
 
 
 def get_symmetric_key(salt: bytes) -> bytes:
-    from chia.util.keychain import obtain_current_passphrase
+    from chia.cmds.passphrase_funcs import obtain_current_passphrase
 
     try:
         passphrase = obtain_current_passphrase(use_passphrase_cache=True)

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -86,7 +86,7 @@ def obtain_current_passphrase(prompt: str = DEFAULT_PASSPHRASE_PROMPT, use_passp
     raise KeychainMaxUnlockAttempts()
 
 
-def unlocks_keyring(use_passphrase_cache=False):
+def unlocks_keyring():
     """
     Decorator used to unlock the keyring interactively, if necessary
     """
@@ -95,7 +95,7 @@ def unlocks_keyring(use_passphrase_cache=False):
         def wrapper(*args, **kwargs):
             try:
                 if KeyringWrapper.get_shared_instance().has_master_passphrase():
-                    obtain_current_passphrase(use_passphrase_cache=use_passphrase_cache)
+                    obtain_current_passphrase(use_passphrase_cache=True)
             except Exception as e:
                 print(f"Unable to unlock the keyring: {e}")
                 sys.exit(1)
@@ -251,7 +251,7 @@ class Keychain:
                 return index
             index += 1
 
-    @unlocks_keyring(use_passphrase_cache=True)
+    @unlocks_keyring()
     def add_private_key(self, mnemonic: str) -> PrivateKey:
         """
         Adds a private key to the keychain, with the given entropy and passphrase. The

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -86,24 +86,17 @@ def obtain_current_passphrase(prompt: str = DEFAULT_PASSPHRASE_PROMPT, use_passp
     raise KeychainMaxUnlockAttempts()
 
 
-def unlocks_keyring():
+def unlock_keyring() -> None:
     """
-    Decorator used to unlock the keyring interactively, if necessary
+    Used to unlock the keyring interactively, if necessary
     """
 
-    def inner(func):
-        def wrapper(*args, **kwargs):
-            try:
-                if KeyringWrapper.get_shared_instance().has_master_passphrase():
-                    obtain_current_passphrase(use_passphrase_cache=True)
-            except Exception as e:
-                print(f"Unable to unlock the keyring: {e}")
-                sys.exit(1)
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return inner
+    try:
+        if KeyringWrapper.get_shared_instance().has_master_passphrase():
+            obtain_current_passphrase(use_passphrase_cache=True)
+    except Exception as e:
+        print(f"Unable to unlock the keyring: {e}")
+        sys.exit(1)
 
 
 def bip39_word_list() -> str:

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -251,7 +251,6 @@ class Keychain:
                 return index
             index += 1
 
-    @unlocks_keyring()
     def add_private_key(self, mnemonic: str) -> PrivateKey:
         """
         Adds a private key to the keychain, with the given entropy and passphrase. The

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -1,29 +1,22 @@
-import colorama
 import pkg_resources
 import sys
 import unicodedata
 
 from bitstring import BitArray  # pyright: reportMissingImports=false
 from blspy import AugSchemeMPL, G1Element, PrivateKey  # pyright: reportMissingImports=false
-from chia.util.errors import KeychainNotSet, KeychainMaxUnlockAttempts, KeychainFingerprintExists
+from chia.util.errors import KeychainNotSet, KeychainFingerprintExists
 from chia.util.hash import std_hash
 from chia.util.keyring_wrapper import KeyringWrapper
 from hashlib import pbkdf2_hmac
 from pathlib import Path
 from secrets import token_bytes
-from time import sleep
 from typing import Any, Dict, List, Optional, Tuple
 
 
 CURRENT_KEY_VERSION = "1.8"
 DEFAULT_USER = f"user-chia-{CURRENT_KEY_VERSION}"  # e.g. user-chia-1.8
 DEFAULT_SERVICE = f"chia-{DEFAULT_USER}"  # e.g. chia-user-chia-1.8
-DEFAULT_PASSPHRASE_PROMPT = (
-    colorama.Fore.YELLOW + colorama.Style.BRIGHT + "(Unlock Keyring)" + colorama.Style.RESET_ALL + " Passphrase: "
-)  # noqa: E501
-FAILED_ATTEMPT_DELAY = 0.5
 MAX_KEYS = 100
-MAX_RETRIES = 3
 MIN_PASSPHRASE_LEN = 8
 
 
@@ -43,60 +36,6 @@ def set_keys_root_path(keys_root_path: Path) -> None:
     Used to set the keys_root_path prior to instantiating the KeyringWrapper shared instance.
     """
     KeyringWrapper.set_keys_root_path(keys_root_path)
-
-
-def obtain_current_passphrase(prompt: str = DEFAULT_PASSPHRASE_PROMPT, use_passphrase_cache: bool = False) -> str:
-    """
-    Obtains the master passphrase for the keyring, optionally using the cached
-    value (if previously set). If the passphrase isn't already cached, the user is
-    prompted interactively to enter their passphrase a max of MAX_RETRIES times
-    before failing.
-    """
-    from chia.cmds.passphrase_funcs import prompt_for_passphrase
-
-    if use_passphrase_cache:
-        passphrase, validated = KeyringWrapper.get_shared_instance().get_cached_master_passphrase()
-        if passphrase:
-            # If the cached passphrase was previously validated, we assume it's... valid
-            if validated:
-                return passphrase
-
-            # Cached passphrase needs to be validated
-            if KeyringWrapper.get_shared_instance().master_passphrase_is_valid(passphrase):
-                KeyringWrapper.get_shared_instance().set_cached_master_passphrase(passphrase, validated=True)
-                return passphrase
-            else:
-                # Cached passphrase is bad, clear the cache
-                KeyringWrapper.get_shared_instance().set_cached_master_passphrase(None)
-
-    # Prompt interactively with up to MAX_RETRIES attempts
-    for i in range(MAX_RETRIES):
-        colorama.init()
-
-        passphrase = prompt_for_passphrase(prompt)
-
-        if KeyringWrapper.get_shared_instance().master_passphrase_is_valid(passphrase):
-            # If using the passphrase cache, and the user inputted a passphrase, update the cache
-            if use_passphrase_cache:
-                KeyringWrapper.get_shared_instance().set_cached_master_passphrase(passphrase, validated=True)
-            return passphrase
-
-        sleep(FAILED_ATTEMPT_DELAY)
-        print("Incorrect passphrase\n")
-    raise KeychainMaxUnlockAttempts()
-
-
-def unlock_keyring() -> None:
-    """
-    Used to unlock the keyring interactively, if necessary
-    """
-
-    try:
-        if KeyringWrapper.get_shared_instance().has_master_passphrase():
-            obtain_current_passphrase(use_passphrase_cache=True)
-    except Exception as e:
-        print(f"Unable to unlock the keyring: {e}")
-        sys.exit(1)
 
 
 def bip39_word_list() -> str:


### PR DESCRIPTION
- Drops the unused parameter 
- Makes it not longer be a decorator but just a normal function call. Im not sure why making it a decorator would be better here since it just makes hinting complex. Let me know if i miss the point of it. 
- Moves it alongside with `obtain_current_passphrase` into `chia.cmds.util` since this code is CLI stuff actually.

This is a first step to get rid of CLI code in keychain related parts, there are still places which need to be fixed.