### PR TITLE
Ms.plot sync flake

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,32 +480,16 @@ async def two_nodes_one_block(wallet_a):
 
 
 @pytest_asyncio.fixture(scope="function")
+async def farmer_no_harvesters_not_started(
+    tmp_path: Path, bt: BlockTools
+) -> AsyncIterator[Tuple[List[Service], Service]]:
+    async for _ in setup_farmer_multi_harvester(bt, 0, tmp_path, test_constants, start_services=False):
+        yield _
+
+
+@pytest_asyncio.fixture(scope="function")
 async def farmer_one_harvester(tmp_path: Path, bt: BlockTools) -> AsyncIterator[Tuple[List[Service], Service]]:
     async for _ in setup_farmer_multi_harvester(bt, 1, tmp_path, test_constants, start_services=True):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
-async def farmer_one_harvester_not_started(
-    tmp_path: Path, bt: BlockTools
-) -> AsyncIterator[Tuple[List[Service], Service]]:
-    async for _ in setup_farmer_multi_harvester(bt, 1, tmp_path, test_constants, start_services=False):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
-async def farmer_two_harvester_not_started(
-    tmp_path: Path, bt: BlockTools
-) -> AsyncIterator[Tuple[List[Service], Service]]:
-    async for _ in setup_farmer_multi_harvester(bt, 2, tmp_path, test_constants, start_services=False):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
-async def farmer_three_harvester_not_started(
-    tmp_path: Path, bt: BlockTools
-) -> AsyncIterator[Tuple[List[Service], Service]]:
-    async for _ in setup_farmer_multi_harvester(bt, 3, tmp_path, test_constants, start_services=False):
         yield _
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,15 +480,17 @@ async def two_nodes_one_block(wallet_a):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def farmer_no_harvesters_not_started(
-    tmp_path: Path, bt: BlockTools
-) -> AsyncIterator[Tuple[List[Service], Service]]:
-    async for _ in setup_farmer_multi_harvester(bt, 0, tmp_path, test_constants, start_services=False):
-        yield _
+async def farmer_not_started(tmp_path: Path, bt: BlockTools) -> AsyncIterator[Tuple[Service, BlockTools]]:
+    async for _, farmer_services, block_tools in setup_farmer_multi_harvester(
+        bt, 0, tmp_path, test_constants, start_services=False
+    ):
+        yield farmer_services, block_tools
 
 
 @pytest_asyncio.fixture(scope="function")
-async def farmer_one_harvester(tmp_path: Path, bt: BlockTools) -> AsyncIterator[Tuple[List[Service], Service]]:
+async def farmer_one_harvester(
+    tmp_path: Path, bt: BlockTools
+) -> AsyncIterator[Tuple[List[Service], Service, BlockTools]]:
     async for _ in setup_farmer_multi_harvester(bt, 1, tmp_path, test_constants, start_services=True):
         yield _
 

--- a/tests/farmer_harvester/test_farmer_harvester.py
+++ b/tests/farmer_harvester/test_farmer_harvester.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from typing import Tuple, List
+from typing import List, Tuple
 
 import pytest
 
@@ -9,6 +9,7 @@ from chia.harvester.harvester import Harvester
 from chia.server.start_service import Service
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.time_out_assert import time_out_assert
+from chia.util.ints import uint16
 from chia.util.keychain import generate_mnemonic
 from tests.plot_sync.util import start_harvester_service
 from tests.setup_nodes import setup_harvesters
@@ -54,13 +55,14 @@ async def test_harvester_handshake(
         return farmer.harvester_handshake_task is not None
 
     # First remove all keys from the keychain
+    assert bt.local_keychain is not None
     bt.local_keychain.delete_all_keys()
     # Handshake task and plot manager thread should not be running yet
     assert farmer.harvester_handshake_task is None
     # Start farmer
     await farmer_service.start()
 
-    sh = setup_harvesters(bt, 1, tmp_path, bt.constants, farmer_service._server._port, start_services=False)
+    sh = setup_harvesters(bt, 1, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)
 
     harvester_services: List[Service] = await sh.__anext__()
     harvester_service = harvester_services[0]

--- a/tests/farmer_harvester/test_farmer_harvester.py
+++ b/tests/farmer_harvester/test_farmer_harvester.py
@@ -5,13 +5,11 @@ from typing import List, Tuple
 import pytest
 
 from chia.farmer.farmer import Farmer
-from chia.harvester.harvester import Harvester
 from chia.server.start_service import Service
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.time_out_assert import time_out_assert
 from chia.util.ints import uint16
 from chia.util.keychain import generate_mnemonic
-from tests.plot_sync.util import start_harvester_service
 from tests.setup_nodes import setup_harvesters
 
 

--- a/tests/farmer_harvester/test_farmer_harvester.py
+++ b/tests/farmer_harvester/test_farmer_harvester.py
@@ -18,10 +18,11 @@ def farmer_is_started(farmer):
 
 
 @pytest.mark.asyncio
-async def test_start_with_empty_keychain(farmer_no_harvesters_not_started):
-    _, farmer_service, bt = farmer_no_harvesters_not_started
+async def test_start_with_empty_keychain(farmer_not_started: Tuple[Service, BlockTools]):
+    farmer_service, bt = farmer_not_started
     farmer: Farmer = farmer_service._node
     # First remove all keys from the keychain
+    assert bt.local_keychain is not None
     bt.local_keychain.delete_all_keys()
     # Make sure the farmer service is not initialized yet
     assert not farmer.started
@@ -39,10 +40,8 @@ async def test_start_with_empty_keychain(farmer_no_harvesters_not_started):
 
 
 @pytest.mark.asyncio
-async def test_harvester_handshake(
-    tmp_path: Path, farmer_no_harvesters_not_started: Tuple[List[Service], Service, BlockTools]
-):
-    _, farmer_service, bt = farmer_no_harvesters_not_started
+async def test_harvester_handshake(tmp_path: Path, farmer_not_started: Tuple[Service, BlockTools]):
+    farmer_service, bt = farmer_not_started
     # harvester_service = harvesters[0]
     farmer = farmer_service._node
 

--- a/tests/plot_sync/test_plot_sync.py
+++ b/tests/plot_sync/test_plot_sync.py
@@ -3,7 +3,7 @@ import functools
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from shutil import copy
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, AsyncGenerator, Callable, List, Optional, Tuple
 
 import pytest
 import pytest_asyncio
@@ -24,7 +24,7 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.time_out_assert import time_out_assert
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
-from chia.util.ints import uint8, uint32, uint64
+from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.util.streamable import _T_Streamable
 from tests.plot_sync.util import start_harvester_service
 from tests.plotting.test_plot_manager import Directory, MockPlotInfo
@@ -272,7 +272,7 @@ class Environment:
 @pytest_asyncio.fixture(scope="function")
 async def environment(
     tmp_path: Path, farmer_no_harvesters_not_started: Tuple[List[Service], Service, BlockTools]
-) -> Environment:
+) -> AsyncGenerator[Environment, None]:
     def new_test_dir(name: str, plot_list: List[Path]) -> Directory:
         return Directory(tmp_path / "plots" / name, plot_list)
 
@@ -302,7 +302,7 @@ async def environment(
     farmer: Farmer = farmer_service._node
     await farmer_service.start()
 
-    sh = setup_harvesters(bt, 2, tmp_path, bt.constants, farmer_service._server._port, start_services=False)
+    sh = setup_harvesters(bt, 2, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)
     harvester_services: List[Service] = await sh.__anext__()
     harvesters: List[Harvester] = [await start_harvester_service(service) for service in harvester_services]
     for harvester in harvesters:

--- a/tests/plot_sync/test_plot_sync.py
+++ b/tests/plot_sync/test_plot_sync.py
@@ -29,6 +29,7 @@ from chia.util.streamable import _T_Streamable
 from tests.plot_sync.util import start_harvester_service
 from tests.plotting.test_plot_manager import Directory, MockPlotInfo
 from tests.plotting.util import get_test_plots
+from tests.setup_nodes import setup_harvesters
 
 
 def synced(sender: Sender, receiver: Receiver, previous_last_sync_id: int) -> bool:
@@ -270,7 +271,7 @@ class Environment:
 
 @pytest_asyncio.fixture(scope="function")
 async def environment(
-    tmp_path: Path, farmer_two_harvester_not_started: Tuple[List[Service], Service, BlockTools]
+    tmp_path: Path, farmer_no_harvesters_not_started: Tuple[List[Service], Service, BlockTools]
 ) -> Environment:
     def new_test_dir(name: str, plot_list: List[Path]) -> Directory:
         return Directory(tmp_path / "plots" / name, plot_list)
@@ -296,11 +297,13 @@ async def environment(
         with open(path, "wb") as file:
             file.write(bytes(100))
 
-    harvester_services: List[Service]
     farmer_service: Service
-    harvester_services, farmer_service, bt = farmer_two_harvester_not_started
+    _, farmer_service, bt = farmer_no_harvesters_not_started
     farmer: Farmer = farmer_service._node
     await farmer_service.start()
+
+    sh = setup_harvesters(bt, 2, tmp_path, bt.constants, farmer_service._server._port, start_services=False)
+    harvester_services: List[Service] = await sh.__anext__()
     harvesters: List[Harvester] = [await start_harvester_service(service) for service in harvester_services]
     for harvester in harvesters:
         # Remove default plot directory for this tests
@@ -313,7 +316,7 @@ async def environment(
 
     assert len(farmer.plot_sync_receivers) == 2
 
-    return Environment(
+    yield Environment(
         tmp_path,
         harvester_services,
         farmer_service,
@@ -328,6 +331,8 @@ async def environment(
         dir_duplicates,
         [ExpectedResult() for _ in harvesters],
     )
+    with pytest.raises(StopAsyncIteration):
+        await sh.__anext__()
 
 
 @pytest.mark.asyncio

--- a/tests/plot_sync/test_plot_sync.py
+++ b/tests/plot_sync/test_plot_sync.py
@@ -271,7 +271,7 @@ class Environment:
 
 @pytest_asyncio.fixture(scope="function")
 async def environment(
-    tmp_path: Path, farmer_no_harvesters_not_started: Tuple[List[Service], Service, BlockTools]
+    tmp_path: Path, farmer_not_started: Tuple[Service, BlockTools]
 ) -> AsyncGenerator[Environment, None]:
     def new_test_dir(name: str, plot_list: List[Path]) -> Directory:
         return Directory(tmp_path / "plots" / name, plot_list)
@@ -298,7 +298,7 @@ async def environment(
             file.write(bytes(100))
 
     farmer_service: Service
-    _, farmer_service, bt = farmer_no_harvesters_not_started
+    farmer_service, bt = farmer_not_started
     farmer: Farmer = farmer_service._node
     await farmer_service.start()
 

--- a/tests/plot_sync/test_sync_simulated.py
+++ b/tests/plot_sync/test_sync_simulated.py
@@ -281,11 +281,11 @@ def create_example_plots(count: int) -> List[PlotInfo]:
 @pytest.mark.asyncio
 async def test_sync_simulated(
     tmp_path: Path,
-    farmer_no_harvesters_not_started: Tuple[List[Service], Service, BlockTools],
+    farmer_not_started: Tuple[Service, BlockTools],
     event_loop: asyncio.events.AbstractEventLoop,
 ) -> None:
     farmer_service: Service
-    _, farmer_service, bt = farmer_no_harvesters_not_started
+    farmer_service, bt = farmer_not_started
     await farmer_service.start()
     sh = setup_harvesters(bt, 3, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)
     harvester_services: List[Service] = await sh.__anext__()
@@ -368,13 +368,13 @@ async def test_sync_simulated(
 @pytest.mark.asyncio
 async def test_farmer_error_simulation(
     tmp_path: Path,
-    farmer_no_harvesters_not_started: Tuple[List[Service], Service, BlockTools],
+    farmer_not_started: Tuple[Service, BlockTools],
     event_loop: asyncio.events.AbstractEventLoop,
     simulate_error: ErrorSimulation,
 ) -> None:
     Constants.message_timeout = 5
     farmer_service: Service
-    _, farmer_service, bt = farmer_no_harvesters_not_started
+    farmer_service, bt = farmer_not_started
     await farmer_service.start()
     sh = setup_harvesters(bt, 1, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)
     harvester_services: List[Service] = await sh.__anext__()
@@ -401,12 +401,12 @@ async def test_farmer_error_simulation(
 @pytest.mark.asyncio
 async def test_sync_reset_cases(
     tmp_path: Path,
-    farmer_no_harvesters_not_started: Tuple[List[Service], Service, BlockTools],
+    farmer_not_started: Tuple[Service, BlockTools],
     event_loop: asyncio.events.AbstractEventLoop,
     simulate_error: ErrorSimulation,
 ) -> None:
     farmer_service: Service
-    _, farmer_service, bt = farmer_no_harvesters_not_started
+    farmer_service, bt = farmer_not_started
     await farmer_service.start()
 
     sh = setup_harvesters(bt, 1, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)

--- a/tests/plot_sync/test_sync_simulated.py
+++ b/tests/plot_sync/test_sync_simulated.py
@@ -25,7 +25,7 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.time_out_assert import time_out_assert
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.generator_tools import list_to_batches
-from chia.util.ints import int16, uint64
+from chia.util.ints import int16, uint16, uint64
 from tests.plot_sync.util import start_harvester_service
 from tests.setup_nodes import setup_harvesters
 
@@ -287,7 +287,7 @@ async def test_sync_simulated(
     farmer_service: Service
     _, farmer_service, bt = farmer_no_harvesters_not_started
     await farmer_service.start()
-    sh = setup_harvesters(bt, 3, tmp_path, bt.constants, farmer_service._server._port, start_services=False)
+    sh = setup_harvesters(bt, 3, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)
     harvester_services: List[Service] = await sh.__anext__()
     farmer: Farmer = farmer_service._node
     test_runner: TestRunner = await create_test_runner(harvester_services, farmer_service, event_loop)
@@ -376,7 +376,7 @@ async def test_farmer_error_simulation(
     farmer_service: Service
     _, farmer_service, bt = farmer_no_harvesters_not_started
     await farmer_service.start()
-    sh = setup_harvesters(bt, 1, tmp_path, bt.constants, farmer_service._server._port, start_services=False)
+    sh = setup_harvesters(bt, 1, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)
     harvester_services: List[Service] = await sh.__anext__()
 
     test_runner: TestRunner = await create_test_runner(harvester_services, farmer_service, event_loop)
@@ -405,12 +405,11 @@ async def test_sync_reset_cases(
     event_loop: asyncio.events.AbstractEventLoop,
     simulate_error: ErrorSimulation,
 ) -> None:
-    harvester_services: List[Service]
     farmer_service: Service
-    harvester_services, farmer_service, bt = farmer_no_harvesters_not_started
+    _, farmer_service, bt = farmer_no_harvesters_not_started
     await farmer_service.start()
 
-    sh = setup_harvesters(bt, 1, tmp_path, bt.constants, farmer_service._server._port, start_services=False)
+    sh = setup_harvesters(bt, 1, tmp_path, bt.constants, uint16(farmer_service._server._port), start_services=False)
     harvester_services: List[Service] = await sh.__anext__()
     test_runner: TestRunner = await create_test_runner(harvester_services, farmer_service, event_loop)
     test_data: TestData = test_runner.test_data[0]


### PR DESCRIPTION
This fixes the flaky `plot_sync` tests which say that you cannot bind a port that is in use.
The fix is to use port 0 for the farmer instead of `find_available_port`.