### PR TITLE
rpc: Recover `_set_state_changed_callback` call in `start_rpc_server`

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -373,6 +373,7 @@ async def start_rpc_server(
             max_request_body_size = 1024 ** 2
 
         rpc_server = RpcServer.create(rpc_api, rpc_api.service_name, stop_cb, root_path, net_config)
+        rpc_server.rpc_api.service._set_state_changed_callback(rpc_server.state_changed)
         await rpc_server.start(root_path, self_hostname, rpc_port, max_request_body_size)
 
         if connect_to_daemon:


### PR DESCRIPTION
This was unintentionally removed in #12768