### PR TITLE
util: Implement key label support for `Keychain` and `KeychainServer`

### DIFF
--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -332,6 +332,7 @@ class Keychain:
         except Exception:
             if label is not None:
                 self.keyring_wrapper.delete_label(fingerprint)
+            raise
 
         return key
 

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -192,6 +192,7 @@ class KeyDataSecrets(Streamable):
 class KeyData(Streamable):
     fingerprint: uint32
     public_key: G1Element
+    label: Optional[str]
     secrets: Optional[KeyDataSecrets]
 
     def __post_init__(self) -> None:
@@ -203,21 +204,22 @@ class KeyData(Streamable):
             raise KeychainKeyDataMismatch("fingerprint")
 
     @classmethod
-    def from_mnemonic(cls, mnemonic: str) -> KeyData:
+    def from_mnemonic(cls, mnemonic: str, label: Optional[str] = None) -> KeyData:
         private_key = AugSchemeMPL.key_gen(mnemonic_to_seed(mnemonic))
         return cls(
             fingerprint=private_key.get_g1().get_fingerprint(),
             public_key=private_key.get_g1(),
+            label=label,
             secrets=KeyDataSecrets.from_mnemonic(mnemonic),
         )
 
     @classmethod
-    def from_entropy(cls, entropy: bytes) -> KeyData:
-        return cls.from_mnemonic(bytes_to_mnemonic(entropy))
+    def from_entropy(cls, entropy: bytes, label: Optional[str] = None) -> KeyData:
+        return cls.from_mnemonic(bytes_to_mnemonic(entropy), label)
 
     @classmethod
-    def generate(cls) -> KeyData:
-        return cls.from_mnemonic(generate_mnemonic())
+    def generate(cls, label: Optional[str] = None) -> KeyData:
+        return cls.from_mnemonic(generate_mnemonic(), label)
 
     @property
     def mnemonic(self) -> List[str]:
@@ -284,6 +286,7 @@ class Keychain:
         return KeyData(
             fingerprint=public_key.get_fingerprint(),
             public_key=public_key,
+            label=self.keyring_wrapper.get_label(public_key.get_fingerprint()),
             secrets=KeyDataSecrets.from_entropy(entropy) if include_secrets else None,
         )
 
@@ -299,7 +302,7 @@ class Keychain:
             except KeychainUserNotFound:
                 return index
 
-    def add_private_key(self, mnemonic: str) -> PrivateKey:
+    def add_private_key(self, mnemonic: str, label: Optional[str] = None) -> PrivateKey:
         """
         Adds a private key to the keychain, with the given entropy and passphrase. The
         keychain itself will store the public key, and the entropy bytes,
@@ -315,12 +318,35 @@ class Keychain:
             # Prevents duplicate add
             raise KeychainFingerprintExists(fingerprint)
 
-        self.keyring_wrapper.set_passphrase(
-            self.service,
-            get_private_key_user(self.user, index),
-            bytes(key.get_g1()).hex() + entropy.hex(),
-        )
+        # Try to set the label first, it may fail if the label is invalid or already exists.
+        # This can probably just be moved into `FileKeyring.set_passphrase` after the legacy keyring stuff was dropped.
+        if label is not None:
+            self.keyring_wrapper.set_label(fingerprint, label)
+
+        try:
+            self.keyring_wrapper.set_passphrase(
+                self.service,
+                get_private_key_user(self.user, index),
+                bytes(key.get_g1()).hex() + entropy.hex(),
+            )
+        except Exception:
+            if label is not None:
+                self.keyring_wrapper.delete_label(fingerprint)
+
         return key
+
+    def set_label(self, fingerprint: int, label: str) -> None:
+        """
+        Assigns the given label to the first key with the given fingerprint.
+        """
+        self.get_key(fingerprint)  # raise if the fingerprint doesn't exist
+        self.keyring_wrapper.set_label(fingerprint, label)
+
+    def delete_label(self, fingerprint: int) -> None:
+        """
+        Removes the label assigned to the key with the given fingerprint.
+        """
+        self.keyring_wrapper.delete_label(fingerprint)
 
     def get_first_private_key(self) -> Optional[Tuple[PrivateKey, bytes]]:
         """

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -281,12 +281,13 @@ class Keychain:
         str_bytes = bytes.fromhex(read_str)
 
         public_key = G1Element.from_bytes(str_bytes[: G1Element.SIZE])
+        fingerprint = public_key.get_fingerprint()
         entropy = str_bytes[G1Element.SIZE : G1Element.SIZE + 32]
 
         return KeyData(
-            fingerprint=public_key.get_fingerprint(),
+            fingerprint=fingerprint,
             public_key=public_key,
-            label=self.keyring_wrapper.get_label(public_key.get_fingerprint()),
+            label=self.keyring_wrapper.get_label(fingerprint),
             secrets=KeyDataSecrets.from_entropy(entropy) if include_secrets else None,
         )
 

--- a/tests/core/util/test_keychain.py
+++ b/tests/core/util/test_keychain.py
@@ -13,6 +13,8 @@ from chia.util.errors import (
     KeychainKeyDataMismatch,
     KeychainSecretsMissing,
     KeychainFingerprintNotFound,
+    KeychainLabelExists,
+    KeychainLabelInvalid,
 )
 from chia.util.ints import uint32
 from chia.util.keychain import (
@@ -107,6 +109,41 @@ class TestKeychain(unittest.TestCase):
         assert kc.get_first_public_key() is not None
 
     @using_temp_file_keyring()
+    def test_add_private_key_label(self):
+        keychain: Keychain = Keychain(user="testing-1.8.0", service="chia-testing-1.8.0")
+
+        key_data_0 = KeyData.generate(label="key_0")
+        key_data_1 = KeyData.generate(label="key_1")
+        key_data_2 = KeyData.generate(label=None)
+
+        keychain.add_private_key(mnemonic=key_data_0.mnemonic_str(), label=key_data_0.label)
+        assert key_data_0 == keychain.get_key(key_data_0.fingerprint, include_secrets=True)
+
+        # Try to add a new key with an existing label should raise
+        with pytest.raises(KeychainLabelExists) as e:
+            keychain.add_private_key(mnemonic=key_data_1.mnemonic_str(), label=key_data_0.label)
+        assert e.value.fingerprint == key_data_0.fingerprint
+        assert e.value.label == key_data_0.label
+
+        # Adding the same key with a valid label should work fine
+        keychain.add_private_key(mnemonic=key_data_1.mnemonic_str(), label=key_data_1.label)
+        assert key_data_1 == keychain.get_key(key_data_1.fingerprint, include_secrets=True)
+
+        # Trying to add an existing key should not have an impact on the existing label
+        with pytest.raises(KeychainFingerprintExists):
+            keychain.add_private_key(mnemonic=key_data_0.mnemonic_str(), label="other label")
+        assert key_data_0 == keychain.get_key(key_data_0.fingerprint, include_secrets=True)
+
+        # Adding a key with no label should not assign any label
+        keychain.add_private_key(mnemonic=key_data_2.mnemonic_str(), label=key_data_2.label)
+        assert key_data_2 == keychain.get_key(key_data_2.fingerprint, include_secrets=True)
+
+        # All added keys should still be valid with their label
+        assert all(
+            key_data in [key_data_0, key_data_1, key_data_2] for key_data in keychain.get_keys(include_secrets=True)
+        )
+
+    @using_temp_file_keyring()
     def test_bip39_eip2333_test_vector(self):
         kc: Keychain = Keychain(user="testing-1.8.0", service="chia-testing-1.8.0")
         kc.delete_all_keys()
@@ -171,29 +208,33 @@ def test_key_data_secrets_creation(input_data: object, from_method: Callable[...
     assert secrets.private_key == private_key
 
 
-def test_key_data_generate() -> None:
-    key_data = KeyData.generate()
+@pytest.mark.parametrize("label", [None, "key"])
+def test_key_data_generate(label: Optional[str]) -> None:
+    key_data = KeyData.generate(label)
     assert key_data.private_key == AugSchemeMPL.key_gen(mnemonic_to_seed(key_data.mnemonic_str()))
     assert key_data.entropy == bytes_from_mnemonic(key_data.mnemonic_str())
     assert key_data.public_key == key_data.private_key.get_g1()
     assert key_data.fingerprint == key_data.private_key.get_g1().get_fingerprint()
+    assert key_data.label == label
 
 
+@pytest.mark.parametrize("label", [None, "key"])
 @pytest.mark.parametrize(
     "input_data, from_method", [(mnemonic, KeyData.from_mnemonic), (entropy, KeyData.from_entropy)]
 )
-def test_key_data_creation(input_data: object, from_method: Callable[..., KeyData]) -> None:
-    key_data = from_method(input_data)
+def test_key_data_creation(input_data: object, from_method: Callable[..., KeyData], label: Optional[str]) -> None:
+    key_data = from_method(input_data, label)
     assert key_data.fingerprint == fingerprint
     assert key_data.public_key == public_key
     assert key_data.mnemonic == mnemonic.split()
     assert key_data.mnemonic_str() == mnemonic
     assert key_data.entropy == entropy
     assert key_data.private_key == private_key
+    assert key_data.label == label
 
 
 def test_key_data_without_secrets() -> None:
-    key_data = KeyData(fingerprint, public_key, None)
+    key_data = KeyData(fingerprint, public_key, None, None)
     assert key_data.secrets is None
 
     with pytest.raises(KeychainSecretsMissing):
@@ -225,11 +266,13 @@ def test_key_data_secrets_post_init(input_data: Tuple[List[str], bytes, PrivateK
 @pytest.mark.parametrize(
     "input_data, data_type",
     [
-        ((fingerprint, G1Element(), KeyDataSecrets(mnemonic.split(), entropy, private_key)), "public_key"),
-        ((fingerprint, G1Element(), None), "fingerprint"),
+        ((fingerprint, G1Element(), None, KeyDataSecrets(mnemonic.split(), entropy, private_key)), "public_key"),
+        ((fingerprint, G1Element(), None, None), "fingerprint"),
     ],
 )
-def test_key_data_post_init(input_data: Tuple[uint32, G1Element, Optional[KeyDataSecrets]], data_type: str) -> None:
+def test_key_data_post_init(
+    input_data: Tuple[uint32, G1Element, Optional[str], Optional[KeyDataSecrets]], data_type: str
+) -> None:
     with pytest.raises(KeychainKeyDataMismatch, match=data_type):
         KeyData(*input_data)
 
@@ -283,3 +326,92 @@ def test_get_keys(include_secrets: bool, get_temp_keyring: Keychain):
         assert keychain.get_keys(include_secrets) == expected_keys
     # Should be empty again
     assert keychain.get_keys(include_secrets) == []
+
+
+def test_set_label(get_temp_keyring: Keychain) -> None:
+    keychain: Keychain = get_temp_keyring
+    # Generate a key and add it without label
+    key_data_0 = KeyData.generate(label=None)
+    keychain.add_private_key(mnemonic=key_data_0.mnemonic_str(), label=None)
+    assert key_data_0 == keychain.get_key(key_data_0.fingerprint, include_secrets=True)
+    # Set a label and validate it
+    key_data_0 = replace(key_data_0, label="key_0")
+    assert key_data_0.label is not None
+    keychain.set_label(fingerprint=key_data_0.fingerprint, label=key_data_0.label)
+    assert key_data_0 == keychain.get_key(fingerprint=key_data_0.fingerprint, include_secrets=True)
+    # Try to add the same label for a fingerprint where don't have a key for
+    with pytest.raises(KeychainFingerprintNotFound):
+        keychain.set_label(fingerprint=123456, label=key_data_0.label)
+    # Add a second key
+    key_data_1 = KeyData.generate(label="key_1")
+    assert key_data_1.label is not None
+    keychain.add_private_key(key_data_1.mnemonic_str())
+    # Try to set the already existing label for the second key
+    with pytest.raises(KeychainLabelExists) as e:
+        keychain.set_label(fingerprint=key_data_1.fingerprint, label=key_data_0.label)
+    assert e.value.fingerprint == key_data_0.fingerprint
+    assert e.value.label == key_data_0.label
+
+    # Set a different label to the second key and validate it
+    keychain.set_label(fingerprint=key_data_1.fingerprint, label=key_data_1.label)
+    assert key_data_0 == keychain.get_key(fingerprint=key_data_0.fingerprint, include_secrets=True)
+    # All added keys should still be valid with their label
+    assert all(key_data in [key_data_0, key_data_1] for key_data in keychain.get_keys(include_secrets=True))
+
+
+@pytest.mark.parametrize(
+    "label, message",
+    [
+        ("", "label can't be empty or whitespace only"),
+        ("   ", "label can't be empty or whitespace only"),
+        ("a\nb", "label can't contain newline or tab"),
+        ("a\tb", "label can't contain newline or tab"),
+        ("a" * 66, "label exceeds max length: 66/65"),
+        ("a" * 70, "label exceeds max length: 70/65"),
+    ],
+)
+def test_set_label_invalid_labels(label: str, message: str, get_temp_keyring: Keychain) -> None:
+    keychain: Keychain = get_temp_keyring
+    key_data = KeyData.generate()
+    keychain.add_private_key(key_data.mnemonic_str())
+    with pytest.raises(KeychainLabelInvalid, match=message) as e:
+        keychain.set_label(key_data.fingerprint, label)
+    assert e.value.label == label
+
+
+def test_delete_label(get_temp_keyring: Keychain) -> None:
+    keychain: Keychain = get_temp_keyring
+    # Generate two keys and add them to the keychain
+    key_data_0 = KeyData.generate(label="key_0")
+    key_data_1 = KeyData.generate(label="key_1")
+
+    def assert_delete_raises():
+        # Try to delete the labels should fail now since they are gone already
+        for key_data in [key_data_0, key_data_1]:
+            with pytest.raises(KeychainFingerprintNotFound) as e:
+                keychain.delete_label(key_data.fingerprint)
+            assert e.value.fingerprint == key_data.fingerprint
+
+    # Should pass here since the keys are not added yet
+    assert_delete_raises()
+
+    for key in [key_data_0, key_data_1]:
+        keychain.add_private_key(mnemonic=key.mnemonic_str(), label=key.label)
+        assert key == keychain.get_key(key.fingerprint, include_secrets=True)
+    # Delete the label of the first key, validate it was removed and make sure the other key retains its label
+    keychain.delete_label(key_data_0.fingerprint)
+    assert replace(key_data_0, label=None) == keychain.get_key(key_data_0.fingerprint, include_secrets=True)
+    assert key_data_1 == keychain.get_key(key_data_1.fingerprint, include_secrets=True)
+    # Re-add the label of the first key
+    assert key_data_0.label is not None
+    keychain.set_label(key_data_0.fingerprint, key_data_0.label)
+    # Delete the label of the second key
+    keychain.delete_label(key_data_1.fingerprint)
+    assert key_data_0 == keychain.get_key(key_data_0.fingerprint, include_secrets=True)
+    assert replace(key_data_1, label=None) == keychain.get_key(key_data_1.fingerprint, include_secrets=True)
+    # Delete the label of the first key again, now both should have no label
+    keychain.delete_label(key_data_0.fingerprint)
+    assert replace(key_data_0, label=None) == keychain.get_key(key_data_0.fingerprint, include_secrets=True)
+    assert replace(key_data_1, label=None) == keychain.get_key(key_data_1.fingerprint, include_secrets=True)
+    # Should pass here since the key labels are both removed here
+    assert_delete_raises()


### PR DESCRIPTION
This PR implements key label support for the `Keychain` and `KeychainServer` classes.


Changes to the daemon websocket interface: 
- Adds the new command `set_label` to set a name for fingerprint
- Adds the new command `delete_label` to delete the name for fingerprint
- Adds the `label` parameter to the `add_private_key` method to assign a label when adding keys


Based on: 
- #12830 
- #12843 
-  #13054