### PR TITLE
skip setproctitle test

### DIFF
--- a/tests/core/test_setproctitle.py
+++ b/tests/core/test_setproctitle.py
@@ -1,8 +1,5 @@
-import unittest
-
 from chia.util.setproctitle import setproctitle
 
 
-class TestSetProcTitle(unittest.TestCase):
-    def test_does_not_crash(self):
-        setproctitle("chia test title")
+def test_does_not_crash():
+    setproctitle("chia test title")

--- a/tests/core/test_setproctitle.py
+++ b/tests/core/test_setproctitle.py
@@ -1,4 +1,10 @@
+import pytest
+
 from chia.util.setproctitle import setproctitle
+
+pytestmark = pytest.mark.skip(
+    reason="this test ends up hanging frequently and needs to be rewritten with a subprocess and a title check",
+)
 
 
 def test_does_not_crash():


### PR DESCRIPTION
This test modifies global process state which should be done in a subprocess not the main pytest process.  Also, perhaps we could just make setproctitle mandatory and not need to put our maybe-present shim in the middle, at which point this isn't a test.  The test should also check the title was actually set.  And more...