### PR TITLE
Use shatree for calculating merkle root

### DIFF
--- a/chia/wallet/puzzles/merkle_utils.clib
+++ b/chia/wallet/puzzles/merkle_utils.clib
@@ -4,8 +4,8 @@
             (simplify_merkle_proof
 
                 (if (logand 1 bitpath)
-                    (sha256 0x00 (f hashes_path) leaf_hash)
-                    (sha256 0x00 leaf_hash (f hashes_path))
+                    (sha256 0x02 (f hashes_path) leaf_hash)
+                    (sha256 0x02 leaf_hash (f hashes_path))
                 )
                 (c (lsh bitpath -1) (r hashes_path))
             )

--- a/chia/wallet/util/merkle_utils.py
+++ b/chia/wallet/util/merkle_utils.py
@@ -6,7 +6,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 TupleTree = Any  # Union[bytes32, Tuple["TupleTree", "TupleTree"]]
 Proof_Tree_Type = Any  # Union[bytes32, Tuple[bytes32, "Proof_Tree_Type"]]
 
-HASH_TREE_PREFIX = bytes([0])
+HASH_TREE_PREFIX = bytes([2])
 
 
 # paths here are not quite the same a `NodePath` paths. We don't need the high order bit


### PR DESCRIPTION
The opposite of #12860 where we change the wallet to match the DL instead