### PR TITLE
Occasional sleep to allow wallet to respond to pings

### DIFF
--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1712,6 +1712,8 @@ async def validate_weight_proof_inner(
             await asyncio.sleep(0)
 
         for vdf_task in vdf_tasks:
+            while not vdf_task.done():
+                await asyncio.sleep(10)
             validated = vdf_task.result()
             if not validated:
                 return False, []


### PR DESCRIPTION
I was getting a close signal from the keychain while validating weight proof:
I think this is because `Future.result()` is a blocking call.


``` 
2022-08-11T12:19:18.856 wallet chia.full_node.weight_proof: INFO     validating 6206 sub epochs
2022-08-11T12:19:18.857 wallet chia.full_node.weight_proof: INFO     validate weight proof peak height 2383374
2022-08-11T12:19:20.505 wallet wallet                     : INFO     Reconnecting to peer {'host': '127.0.0.1', 'port': 8444}
2022-08-11T12:19:20.511 wallet wallet_server              : INFO     Cannot connect to host 127.0.0.1:8444 ssl:<ssl.SSLContext object at 0x7f78f37923c0> [Connect call failed ('127.0.0.1', 8444)]
2022-08-11T12:19:52.065 wallet chia.wallet.wallet_node    : INFO     It took 33.27067971229553 time to validate the weight proof
2022-08-11T12:19:52.068 wallet wallet                     : INFO     Reconnecting to peer {'host': '127.0.0.1', 'port': 8444}
2022-08-11T12:19:52.071 wallet chia.wallet.wallet_node    : INFO     Close signal received from keychain, we probably timed out.
2022-08-11T12:19:52.072 wallet chia.wallet.wallet_node    : INFO     Reconnecting to keychain at wss://localhost:55400.
```