### PR TITLE
Fix chia farm summary if using a remote full node

### DIFF
--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -40,7 +40,7 @@ async def get_blockchain_state(rpc_port: Optional[int]) -> Optional[Dict[str, An
     blockchain_state = None
     try:
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-        self_hostname = config["self_hostname"]
+        self_hostname = config["farmer"]["full_node_peer"]["host"]
         if rpc_port is None:
             rpc_port = config["full_node"]["rpc_port"]
         client = await FullNodeRpcClient.create(self_hostname, uint16(rpc_port), DEFAULT_ROOT_PATH, config)
@@ -60,7 +60,7 @@ async def get_average_block_time(rpc_port: Optional[int]) -> float:
     try:
         blocks_to_compare = 500
         config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
-        self_hostname = config["self_hostname"]
+        self_hostname = config["farmer"]["full_node_peer"]["host"]
         if rpc_port is None:
             rpc_port = config["full_node"]["rpc_port"]
         client = await FullNodeRpcClient.create(self_hostname, uint16(rpc_port), DEFAULT_ROOT_PATH, config)


### PR DESCRIPTION
If the farmer is configured to use a remote node ```chia farm summary``` displays some errors:

```
chia farm summary
Connection error. Check if full node is running at 8555
Farming status: Not available
Total chia farmed: ...
User transaction fees: ...
Block rewards: ...
Last height farmed: ...
Local Harvester
   1251 plots of size: 123.814 TiB
Remote Harvester for IP: 192.168.0.59
   340 plots of size: 33.651 TiB
Remote Harvester for IP: 192.168.0.70
   1650 plots of size: 163.306 TiB
Plot count for all harvesters: 3241
Total size of plots: 320.771 TiB
Estimated network space: Unknown
Expected time to win: Unknown
Note: log into your key using 'chia wallet show' to see rewards for each key
```

This PR fixes it to show:

```
Farming status: Farming
Total chia farmed: ...
User transaction fees: ...
Block rewards: ...
Last height farmed: ...
Local Harvester
   1251 plots of size: 123.814 TiB
Remote Harvester for IP: 192.168.0.59
   340 plots of size: 33.651 TiB
Remote Harvester for IP: 192.168.0.70
   1650 plots of size: 163.306 TiB
Plot count for all harvesters: 3241
Total size of plots: 320.771 TiB
Estimated network space: 20.743 EiB
Expected time to win: 2 weeks and 1 day
Note: log into your key using 'chia wallet show' to see rewards for each key
```