### PR TITLE
cmds|daemon: Improve legacy keyring migration enforcement

### DIFF
--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -193,7 +193,7 @@ async def migrate_keys(root_path: Path, forced: bool = False) -> bool:
 
     deprecation_message = (
         "\nLegacy keyring support is deprecated and will be removed in version 1.5.2. "
-        "You need to migrate your keyring to continue using Chia."
+        "You need to migrate your keyring to continue using Chia.\n"
     )
 
     # Check if the keyring needs a full migration (i.e. if it's using the old keyring)
@@ -252,7 +252,7 @@ async def migrate_keys(root_path: Path, forced: bool = False) -> bool:
             if keys_present:
                 print(" Verified")
                 print()
-                response = prompt_yes_no("Remove key(s) from old keyring?")
+                response = prompt_yes_no("Remove key(s) from old keyring (recommended)?")
                 if response:
                     legacy_keyring.delete_keys(keys_to_migrate)
                     print(f"Removed {len(keys_to_migrate)} key(s) from old keyring")

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -7,7 +8,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from chia.consensus.coinbase import create_puzzlehash_for_pk
+from chia.daemon.client import connect_to_daemon_and_validate
+from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate, wrap_local_keychain
 from chia.util.bech32m import encode_puzzle_hash
+from chia.util.errors import KeychainNotSet
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint32
@@ -183,7 +187,7 @@ def verify(message: str, public_key: str, signature: str):
     print(AugSchemeMPL.verify(public_key, messageBytes, signature))
 
 
-def migrate_keys(forced: bool = False):
+async def migrate_keys(root_path: Path, forced: bool = False) -> bool:
     from chia.util.keyring_wrapper import KeyringWrapper
     from chia.util.misc import prompt_yes_no
 
@@ -197,8 +201,30 @@ def migrate_keys(forced: bool = False):
         print(deprecation_message)
         KeyringWrapper.get_shared_instance().migrate_legacy_keyring_interactive()
     else:
-        keys_to_migrate, legacy_keyring = Keychain.get_keys_needing_migration()
-        if len(keys_to_migrate) > 0 and legacy_keyring is not None:
+        log = logging.getLogger("migrate_keys")
+        config = load_config(root_path, "config.yaml")
+        # Connect to the daemon here first to see if ts running since `connect_to_keychain_and_validate` just tries to
+        # connect forever if it's not up.
+        keychain_proxy: Optional[KeychainProxy] = None
+        daemon = await connect_to_daemon_and_validate(root_path, config, quiet=True)
+        if daemon is not None:
+            await daemon.close()
+            keychain_proxy = await connect_to_keychain_and_validate(root_path, log)
+        if keychain_proxy is None:
+            keychain_proxy = wrap_local_keychain(Keychain(), log=log)
+
+        try:
+            legacy_keyring = Keychain(force_legacy=True)
+            all_sks = await keychain_proxy.get_all_private_keys()
+            all_legacy_sks = legacy_keyring.get_all_private_keys()
+            set_legacy_sks = {str(x[0]) for x in all_legacy_sks}
+            set_sks = {str(x[0]) for x in all_sks}
+            missing_legacy_keys = set_legacy_sks - set_sks
+            keys_to_migrate = [x for x in all_legacy_sks if str(x[0]) in missing_legacy_keys]
+        except KeychainNotSet:
+            keys_to_migrate = []
+
+        if len(keys_to_migrate) > 0:
             print(deprecation_message)
             print(f"Found {len(keys_to_migrate)} key(s) that need migration:")
             for key, _ in keys_to_migrate:
@@ -206,19 +232,24 @@ def migrate_keys(forced: bool = False):
 
             print()
             if not prompt_yes_no("Migrate these keys?"):
-                sys.exit("Migration aborted, can't run any chia commands.")
+                await keychain_proxy.close()
+                print("Migration aborted, can't run any chia commands.")
+                return False
 
-            keychain = Keychain()
             for sk, seed_bytes in keys_to_migrate:
                 mnemonic = bytes_to_mnemonic(seed_bytes)
-                keychain.add_private_key(mnemonic, "")
+                await keychain_proxy.add_private_key(mnemonic, "")
                 fingerprint = sk.get_g1().get_fingerprint()
                 print(f"Added private key with public key fingerprint {fingerprint}")
 
             print(f"Migrated {len(keys_to_migrate)} key(s)")
 
             print("Verifying migration results...", end="")
-            if Keychain.verify_keys_present(keys_to_migrate):
+            all_sks = await keychain_proxy.get_all_private_keys()
+            await keychain_proxy.close()
+            set_sks = {str(x[0]) for x in all_sks}
+            keys_present = set_sks.issuperset(set(map(lambda x: str(x[0]), keys_to_migrate)))
+            if keys_present:
                 print(" Verified")
                 print()
                 response = prompt_yes_no("Remove key(s) from old keyring?")
@@ -228,10 +259,12 @@ def migrate_keys(forced: bool = False):
                 print("Migration complete")
             else:
                 print(" Failed")
-                sys.exit(1)
-            sys.exit(0)
+                return False
+            return True
         elif not forced:
             print("No keys need migration")
+        await keychain_proxy.close()
+    return True
 
 
 def _clear_line_part(n: int):

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -199,7 +199,7 @@ async def migrate_keys(root_path: Path, forced: bool = False) -> bool:
     # Check if the keyring needs a full migration (i.e. if it's using the old keyring)
     if Keychain.needs_migration():
         print(deprecation_message)
-        KeyringWrapper.get_shared_instance().migrate_legacy_keyring_interactive()
+        await KeyringWrapper.get_shared_instance().migrate_legacy_keyring_interactive()
     else:
         log = logging.getLogger("migrate_keys")
         config = load_config(root_path, "config.yaml")

--- a/chia/cmds/passphrase.py
+++ b/chia/cmds/passphrase.py
@@ -12,8 +12,8 @@ from chia.util.config import load_config
 def passphrase_cmd(ctx: click.Context):
     from .keys_funcs import migrate_keys
 
-    if ctx.obj["force_legacy_keyring_migration"]:
-        migrate_keys(True)
+    if ctx.obj["force_legacy_keyring_migration"] and not asyncio.run(migrate_keys(ctx.obj["root_path"], True)):
+        sys.exit(1)
 
 
 @passphrase_cmd.command(

--- a/chia/cmds/start.py
+++ b/chia/cmds/start.py
@@ -11,11 +11,7 @@ from chia.util.service_groups import all_groups
 def start_cmd(ctx: click.Context, restart: bool, group: str) -> None:
     import asyncio
     from .start_funcs import async_start
-    from .keys_funcs import migrate_keys
-
-    if ctx.obj["force_legacy_keyring_migration"]:
-        migrate_keys(True)
 
     root_path = ctx.obj["root_path"]
     config = load_config(root_path, "config.yaml")
-    asyncio.run(async_start(root_path, config, group, restart))
+    asyncio.run(async_start(root_path, config, group, restart, ctx.obj["force_legacy_keyring_migration"]))

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from chia.cmds.keys_funcs import migrate_keys
 from chia.cmds.passphrase_funcs import get_current_passphrase
 from chia.daemon.client import DaemonProxy, connect_to_daemon_and_validate
 from chia.util.errors import KeychainMaxUnlockAttempts
@@ -50,7 +51,9 @@ async def create_start_daemon_connection(root_path: Path, config: Dict[str, Any]
     return None
 
 
-async def async_start(root_path: Path, config: Dict[str, Any], group: str, restart: bool) -> None:
+async def async_start(
+    root_path: Path, config: Dict[str, Any], group: str, restart: bool, force_keyring_migration: bool
+) -> None:
     try:
         daemon = await create_start_daemon_connection(root_path, config)
     except KeychainMaxUnlockAttempts:
@@ -60,6 +63,11 @@ async def async_start(root_path: Path, config: Dict[str, Any], group: str, resta
     if daemon is None:
         print("Failed to create the chia daemon")
         return None
+
+    if force_keyring_migration:
+        if not await migrate_keys(root_path, True):
+            await daemon.close()
+            sys.exit(1)
 
     for service in services_for_groups(group):
         if await daemon.is_running(service_name=service):

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from typing import Any, Dict, Optional, Tuple
 
@@ -13,8 +14,8 @@ from chia.wallet.util.wallet_types import WalletType
 def wallet_cmd(ctx: click.Context) -> None:
     from .keys_funcs import migrate_keys
 
-    if ctx.obj["force_legacy_keyring_migration"]:
-        migrate_keys(True)
+    if ctx.obj["force_legacy_keyring_migration"] and not asyncio.run(migrate_keys(ctx.obj["root_path"], True)):
+        sys.exit(1)
 
 
 @wallet_cmd.command("get_transaction", short_help="Get a transaction")

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1,4 +1,3 @@
-import asyncio
 import sys
 from typing import Any, Dict, Optional, Tuple
 
@@ -12,6 +11,7 @@ from chia.wallet.util.wallet_types import WalletType
 @click.group("wallet", short_help="Manage your wallet")
 @click.pass_context
 def wallet_cmd(ctx: click.Context) -> None:
+    import asyncio
     from .keys_funcs import migrate_keys
 
     if ctx.obj["force_legacy_keyring_migration"] and not asyncio.run(migrate_keys(ctx.obj["root_path"], True)):

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -514,7 +514,6 @@ class WebSocketServer:
             Keychain.set_master_passphrase(
                 current_passphrase,
                 new_passphrase,
-                allow_migration=False,
                 passphrase_hint=passphrase_hint,
                 save_passphrase=save_passphrase,
             )

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -499,34 +499,6 @@ class Keychain:
         KeyringWrapper.get_shared_instance().migrate_legacy_keyring(cleanup_legacy_keyring=cleanup_legacy_keyring)
 
     @staticmethod
-    def get_keys_needing_migration() -> Tuple[List[Tuple[PrivateKey, bytes]], Optional["Keychain"]]:
-        try:
-            legacy_keyring: Keychain = Keychain(force_legacy=True)
-        except KeychainNotSet:
-            # No legacy keyring available, so no keys need to be migrated
-            return [], None
-        keychain = Keychain()
-        all_legacy_sks = legacy_keyring.get_all_private_keys()
-        all_sks = keychain.get_all_private_keys()
-        set_legacy_sks = {str(x[0]) for x in all_legacy_sks}
-        set_sks = {str(x[0]) for x in all_sks}
-        missing_legacy_keys = set_legacy_sks - set_sks
-        keys_needing_migration = [x for x in all_legacy_sks if str(x[0]) in missing_legacy_keys]
-
-        return keys_needing_migration, legacy_keyring
-
-    @staticmethod
-    def verify_keys_present(keys_to_verify: List[Tuple[PrivateKey, bytes]]) -> bool:
-        """
-        Verifies that the given keys are present in the keychain.
-        """
-        keychain = Keychain()
-        all_sks = keychain.get_all_private_keys()
-        set_sks = {str(x[0]) for x in all_sks}
-        keys_present = set_sks.issuperset(set(map(lambda x: str(x[0]), keys_to_verify)))
-        return keys_present
-
-    @staticmethod
     def passphrase_is_optional() -> bool:
         """
         Returns whether a user-supplied passphrase is optional, as specified by the passphrase requirements.

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -224,7 +224,6 @@ class Keychain:
 
         self.keyring_wrapper = keyring_wrapper
 
-    @unlocks_keyring(use_passphrase_cache=True)
     def _get_pk_and_entropy(self, user: str) -> Optional[Tuple[G1Element, bytes]]:
         """
         Returns the keychain contents for a specific 'user' (key index). The contents

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -491,7 +491,6 @@ class Keychain:
                 current_passphrase=None,
                 new_passphrase=passphrase,
                 write_to_keyring=False,
-                allow_migration=False,
                 passphrase_hint=passphrase_hint,
                 save_passphrase=save_passphrase,
             )
@@ -571,7 +570,6 @@ class Keychain:
         current_passphrase: Optional[str],
         new_passphrase: str,
         *,
-        allow_migration: bool = True,
         passphrase_hint: Optional[str] = None,
         save_passphrase: bool = False,
     ) -> None:
@@ -582,7 +580,6 @@ class Keychain:
         KeyringWrapper.get_shared_instance().set_master_passphrase(
             current_passphrase,
             new_passphrase,
-            allow_migration=allow_migration,
             passphrase_hint=passphrase_hint,
             save_passphrase=save_passphrase,
         )


### PR DESCRIPTION
This helps to avoid the repeated unlock keyring prompts and slightly adjusts two comments. 

The fix for the unlock prompts is changing the `migrate_keys` function to use the daemon via `KeychainProxy` if it's running instead of creating a separate `Keychain` instance which needs to be unlocked every time. 

----

Note that 1f23b3d5e166a0c53bcbc4129db6992219303005 is also done in #12850 but is needed here because:
- There is imo a bug in `KeyringWrapper` constructor where we assign the legacy keyring to `KeyringWrapper.keyring` if `force_legacy=True` https://github.com/Chia-Network/chia-blockchain/blob/535d21e6796ab67895d2658ff5337781fab04048/chia/util/keyring_wrapper.py#L118
- Even if the above bug is fixed, the decorator will still try to unlock the file keyring because we use the shared instance in there https://github.com/Chia-Network/chia-blockchain/blob/535d21e6796ab67895d2658ff5337781fab04048/chia/util/keychain.py#L97