### PR TITLE
cmds: Key label support for CLI - `chia keys label`

### DIFF
--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -22,12 +22,20 @@ def keys_cmd(ctx: click.Context):
 
 
 @keys_cmd.command("generate", short_help="Generates and adds a key to keychain")
+@click.option(
+    "--label",
+    "-l",
+    default=None,
+    help="Enter the label for the key",
+    type=str,
+    required=False,
+)
 @click.pass_context
-def generate_cmd(ctx: click.Context):
+def generate_cmd(ctx: click.Context, label: Optional[str]):
     from .init_funcs import check_keys
     from .keys_funcs import generate_and_add
 
-    generate_and_add()
+    generate_and_add(label)
     check_keys(ctx.obj["root_path"])
 
 
@@ -61,21 +69,74 @@ def show_cmd(show_mnemonic_seed, non_observer_derivation):
     type=str,
     required=False,
 )
+@click.option(
+    "--label",
+    "-l",
+    default=None,
+    help="Enter the label for the key",
+    type=str,
+    required=False,
+)
 @click.pass_context
-def add_cmd(ctx: click.Context, filename: str):
+def add_cmd(ctx: click.Context, filename: str, label: Optional[str]):
     from .init_funcs import check_keys
+    from .keys_funcs import query_and_add_private_key_seed
 
+    mnemonic = None
     if filename:
         from pathlib import Path
-        from .keys_funcs import add_private_key_seed
 
         mnemonic = Path(filename).read_text().rstrip()
-        add_private_key_seed(mnemonic)
-    else:
-        from .keys_funcs import query_and_add_private_key_seed
 
-        query_and_add_private_key_seed()
+    query_and_add_private_key_seed(mnemonic, label)
     check_keys(ctx.obj["root_path"])
+
+
+@keys_cmd.group("label", short_help="Manage your key labels")
+def label_cmd():
+    pass
+
+
+@label_cmd.command("show", short_help="Show the labels of all available keys")
+def show_label_cmd():
+    from .keys_funcs import show_all_key_labels
+
+    show_all_key_labels()
+
+
+@label_cmd.command("set", short_help="Set the label of a key")
+@click.option(
+    "--fingerprint",
+    "-f",
+    help="Enter the fingerprint of the key you want to use",
+    type=int,
+    required=True,
+)
+@click.option(
+    "--label",
+    "-l",
+    help="Enter the new label for the key",
+    type=str,
+    required=True,
+)
+def set_label_cmd(fingerprint: int, label: str):
+    from .keys_funcs import set_key_label
+
+    set_key_label(fingerprint, label)
+
+
+@label_cmd.command("delete", short_help="Delete the label of a key")
+@click.option(
+    "--fingerprint",
+    "-f",
+    help="Enter the fingerprint of the key you want to use",
+    type=int,
+    required=True,
+)
+def delete_label_cmd(fingerprint: int):
+    from .keys_funcs import delete_key_label
+
+    delete_key_label(fingerprint)
 
 
 @keys_cmd.command("delete", short_help="Delete a key by its pk fingerprint in hex form")

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -16,6 +16,7 @@ from chia.util.errors import KeychainNotSet
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import KeychainException
+from chia.util.file_keyring import MAX_LABEL_LENGTH
 from chia.util.ints import uint32
 from chia.util.keychain import Keychain, bytes_to_mnemonic, generate_mnemonic, mnemonic_to_seed
 from chia.util.keyring_wrapper import KeyringWrapper
@@ -52,35 +53,77 @@ def generate_and_print():
     return mnemonic
 
 
-def generate_and_add():
+def generate_and_add(label: Optional[str]):
     """
     Generates a seed for a private key, prints the mnemonic to the terminal, and adds the key to the keyring.
     """
     unlock_keyring()
-    mnemonic = generate_mnemonic()
     print("Generating private key")
-    add_private_key_seed(mnemonic)
+    query_and_add_private_key_seed(mnemonic=generate_mnemonic(), label=label)
 
 
-def query_and_add_private_key_seed():
+def query_and_add_private_key_seed(mnemonic: Optional[str], label: Optional[str] = None):
     unlock_keyring()
-    mnemonic = input("Enter the mnemonic you want to use: ")
-    add_private_key_seed(mnemonic)
+    if mnemonic is None:
+        mnemonic = input("Enter the mnemonic you want to use: ")
+    if label is None:
+        label = input("Enter the label you want to assign to this key (Press Enter to skip): ")
+        if len(label) == 0:
+            label = None
+    add_private_key_seed(mnemonic, label)
 
 
-def add_private_key_seed(mnemonic: str):
+def add_private_key_seed(mnemonic: str, label: Optional[str]):
     """
-    Add a private key seed to the keyring, with the given mnemonic.
+    Add a private key seed to the keyring, with the given mnemonic and an optional label.
     """
     unlock_keyring()
     try:
-        sk = Keychain().add_private_key(mnemonic)
+        sk = Keychain().add_private_key(mnemonic, label)
         fingerprint = sk.get_g1().get_fingerprint()
         print(f"Added private key with public key fingerprint {fingerprint}")
 
     except (ValueError, KeychainException) as e:
         print(e)
-        return None
+
+
+def show_all_key_labels() -> None:
+    unlock_keyring()
+    fingerprint_width = 11
+
+    def print_line(fingerprint: str, label: str) -> None:
+        fingerprint_text = ("{0:<" + str(fingerprint_width) + "}").format(fingerprint)
+        label_text = ("{0:<" + str(MAX_LABEL_LENGTH) + "}").format(label)
+        print("| " + fingerprint_text + " | " + label_text + " |")
+
+    keys = Keychain().get_keys()
+
+    if len(keys) == 0:
+        sys.exit("No keys are present in the keychain. Generate them with 'chia keys generate'")
+
+    print_line("fingerprint", "label")
+    print_line("-" * fingerprint_width, "-" * MAX_LABEL_LENGTH)
+
+    for key_data in keys:
+        print_line(str(key_data.fingerprint), key_data.label or "No label assigned")
+
+
+def set_key_label(fingerprint: int, label: str) -> None:
+    unlock_keyring()
+    try:
+        Keychain().set_label(fingerprint, label)
+        print(f"label {label!r} assigned to {fingerprint!r}")
+    except Exception as e:
+        sys.exit(f"Error: {e}")
+
+
+def delete_key_label(fingerprint: int) -> None:
+    unlock_keyring()
+    try:
+        Keychain().delete_label(fingerprint)
+        print(f"label removed for {fingerprint!r}")
+    except Exception as e:
+        sys.exit(f"Error: {e}")
 
 
 def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
@@ -90,20 +133,23 @@ def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
     unlock_keyring()
     root_path = DEFAULT_ROOT_PATH
     config = load_config(root_path, "config.yaml")
-    private_keys = Keychain().get_all_private_keys()
+    all_keys = Keychain().get_keys(True)
     selected = config["selected_network"]
     prefix = config["network_overrides"]["config"][selected]["address_prefix"]
-    if len(private_keys) == 0:
+    if len(all_keys) == 0:
         print("There are no saved private keys")
         return None
     msg = "Showing all public keys derived from your master seed and private key:"
     if show_mnemonic:
         msg = "Showing all public and private keys"
     print(msg)
-    for sk, seed in private_keys:
+    for key_data in all_keys:
+        sk = key_data.private_key
         print("")
-        print("Fingerprint:", sk.get_g1().get_fingerprint())
-        print("Master public key (m):", sk.get_g1())
+        if key_data.label is not None:
+            print("Label:", key_data.label)
+        print("Fingerprint:", key_data.fingerprint)
+        print("Master public key (m):", key_data.public_key)
         print(
             "Farmer public key (m/12381/8444/0/0):",
             master_sk_to_farmer_sk(sk).get_g1(),
@@ -116,14 +162,13 @@ def show_all_keys(show_mnemonic: bool, non_observer_derivation: bool):
         )
         wallet_address: str = encode_puzzle_hash(create_puzzlehash_for_pk(first_wallet_sk.get_g1()), prefix)
         print(f"First wallet address{' (non-observer)' if non_observer_derivation else ''}: {wallet_address}")
-        assert seed is not None
         if show_mnemonic:
             print("Master private key (m):", bytes(sk).hex())
             print(
                 "First wallet secret key (m/12381/8444/2/0):",
                 master_sk_to_wallet_sk(sk, uint32(0)),
             )
-            mnemonic = bytes_to_mnemonic(seed)
+            mnemonic = bytes_to_mnemonic(key_data.entropy)
             print("  Mnemonic seed (24 secret words):")
             print(mnemonic)
 


### PR DESCRIPTION
This PR implements key label support for the CLI. For that it adds a new `chia keys label` subcommand: 

```
chia keys label -h
Usage: chia keys label [OPTIONS] COMMAND [ARGS]...

Options:
  -h, --help  Show this message and exit.

Commands:
  delete  Delete the label of a key
  set     Set the label of a key
  show    Show the labels of all available keys
```

And it also adds a new parameter to `chia keys add` and `chia keys generate`:

```
-l, --label TEXT      Enter the label for the key
```

Based on:
- #12883 