### PR TITLE
Bump chia_rs dependency

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Optional
-from chia_rs import MEMPOOL_MODE, COND_CANON_INTS, NO_NEG_DIV
+from chia_rs import MEMPOOL_MODE, NO_NEG_DIV
 
 from chia.consensus.cost_calculator import NPCResult
 from chia.types.spend_bundle_conditions import SpendBundleConditions
@@ -33,7 +33,6 @@ def get_name_puzzle_conditions(
         return NPCResult(uint16(Err.INVALID_BLOCK_COST.value), None, uint64(0))
 
     # mempool mode also has these rules apply
-    assert (MEMPOOL_MODE & COND_CANON_INTS) != 0
     assert (MEMPOOL_MODE & NO_NEG_DIV) != 0
 
     if mempool_mode:
@@ -42,7 +41,7 @@ def get_name_puzzle_conditions(
         # conditions must use integers in canonical encoding (i.e. no redundant
         # leading zeros)
         # the division operator may not be used with negative operands
-        flags = COND_CANON_INTS | NO_NEG_DIV
+        flags = NO_NEG_DIV
 
     try:
         err, result = GENERATOR_MOD.run_as_generator(max_cost, flags, block_program, block_program_args)

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -5,7 +5,7 @@ from clvm import SExp
 from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
 from clvm.serialize import sexp_from_stream, sexp_to_stream
-from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, run_generator
+from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, run_generator, tree_hash
 from clvm_tools.curry import uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -249,13 +249,8 @@ class SerializedProgram:
             return True
         return self._buf != other._buf
 
-    def get_tree_hash(self, *args: bytes32) -> bytes32:
-        """
-        Any values in `args` that appear in the tree
-        are presumed to have been hashed already.
-        """
-        tmp = sexp_from_stream(io.BytesIO(self._buf), SExp.to)
-        return _tree_hash(tmp, set(args))
+    def get_tree_hash(self) -> bytes32:
+        return tree_hash(self._buf)
 
     def run_mempool_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
         return self._run(max_cost, MEMPOOL_MODE, *args)

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -340,7 +340,7 @@ def parse_optional(f: BinaryIO, parse_inner_type_f: ParseFunctionType) -> Option
 def parse_rust(f: BinaryIO, f_type: Type[Any]) -> Any:
     assert isinstance(f, io.BytesIO)
     buf = f.getbuffer()
-    ret, advance = f_type.parse_rust(bytes(buf[f.tell() :]))
+    ret, advance = f_type.parse_rust(buf[f.tell() :])
     f.seek(advance, os.SEEK_CUR)
     return ret
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ dependencies = [
     "chiapos==1.0.10",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.5",  # Currying, Program.to, other conveniences
-    "chia_rs==0.1.5",
+    "chia_rs==0.1.7",
     "clvm-tools-rs==0.1.19",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.1",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
This bumps `chia_rs` to the most recent verision (0.1.7).

The main updates are:

* the complex logic to handle redundant leading zeroes in conditions has been removed. Now that we've soft-forked away allowing it. This also removes one of the flags to `run_as_generator()` controlling whether leading zeros are allowed or not. They are always disallowed now. https://github.com/Chia-Network/chia_rs/pull/43
* `parse_rust()` on rust types implementing the Streamable protocol now takes a buffer (rather than `bytes`). This avoids copying the whole input buffer every time `parse_rust()` is invoked. This turned out to be expensive during wallet sync. https://github.com/Chia-Network/chia_rs/pull/32
* A new function `tree_hash()` is exposed from the rust module to compute the tree-hash on a serialized program directly, avoiding parsing it into rust first. This speeds up wallet sync as we have to validate the tree hash of each incoming coin. https://github.com/Chia-Network/clvm_rs/pull/200 https://github.com/Chia-Network/chia_rs/pull/49