### PR TITLE
rust tree_hash()

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -95,12 +95,15 @@ class Program(SExp):
         """
         return _sexp_replace(self, self.to, **kwargs)
 
-    def get_tree_hash(self, *args: bytes32) -> bytes32:
+    def get_tree_hash_precalc(self, *args: bytes32) -> bytes32:
         """
         Any values in `args` that appear in the tree
         are presumed to have been hashed already.
         """
         return sha256_treehash(self, set(args))
+
+    def get_tree_hash(self) -> bytes32:
+        return bytes32(tree_hash(bytes(self)))
 
     def run_with_cost(self, max_cost: int, args) -> Tuple[int, "Program"]:
         prog_args = Program.to(args)
@@ -250,7 +253,7 @@ class SerializedProgram:
         return self._buf != other._buf
 
     def get_tree_hash(self) -> bytes32:
-        return tree_hash(self._buf)
+        return bytes32(tree_hash(self._buf))
 
     def run_mempool_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
         return self._run(max_cost, MEMPOOL_MODE, *args)

--- a/chia/wallet/did_wallet/did_wallet_puzzles.py
+++ b/chia/wallet/did_wallet/did_wallet_puzzles.py
@@ -59,7 +59,7 @@ def get_inner_puzhash_by_p2(
     singleton_struct = Program.to((SINGLETON_MOD_HASH, (launcher_id, LAUNCHER_PUZZLE_HASH)))
     return DID_INNERPUZ_MOD.curry(
         p2_puzhash, backup_ids_hash, num_of_backup_ids_needed, singleton_struct, metadata
-    ).get_tree_hash(p2_puzhash)
+    ).get_tree_hash_precalc(p2_puzhash)
 
 
 def create_fullpuz(innerpuz: Program, launcher_id: bytes32) -> Program:

--- a/chia/wallet/puzzles/singleton_top_layer.py
+++ b/chia/wallet/puzzles/singleton_top_layer.py
@@ -178,7 +178,7 @@ def adapt_inner_to_singleton(inner_puzzle: Program) -> Program:
 
 def adapt_inner_puzzle_hash_to_singleton(inner_puzzle_hash: bytes32) -> bytes32:
     puzzle = adapt_inner_to_singleton(Program.to(inner_puzzle_hash))
-    return puzzle.get_tree_hash(inner_puzzle_hash)
+    return puzzle.get_tree_hash_precalc(inner_puzzle_hash)
 
 
 def remove_singleton_truth_wrapper(puzzle: Program) -> Program:

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -168,7 +168,7 @@ class Offer:
                         a
                         for a in matching_spend_additions
                         if a.puzzle_hash
-                        == construct_puzzle(puzzle_driver, OFFER_HASH).get_tree_hash(OFFER_HASH)  # type: ignore
+                        == construct_puzzle(puzzle_driver, OFFER_HASH).get_tree_hash_precalc(OFFER_HASH)  # type: ignore
                     ]
                     if len(additions_w_amount_and_puzhash) == 1:
                         coins_for_this_spend.append(additions_w_amount_and_puzhash[0])


### PR DESCRIPTION
It's faster to serialize `Program` and run the rust `tree_hash()` function on it, than to run the python `_tree_hash()` implementation.

Also, the second parameter to `get_tree_hash()` is used in three places. Not passing in any precomputed hashes is by far the most common case, so I split the function in two. One with and one without the pre-calculated hashes.

The three calls in these functions were changed to use the new `get_tree_hash_precalc()`.
```
chia/wallet/did_wallet/did_wallet_puzzles.py
chia/wallet/puzzles/singleton_top_layer.py
chia/wallet/trading/offer.py
```

This speeds up creation of puzzle hashes in the wallet.

| CPU usage | before | after | after / before |
| --- | --- | --- | --- |
| Program.tree_hash() | 26.34% | 15.83% | 60% |

before:
![chia-hotspot-0-1-tree-hash-baseline](https://user-images.githubusercontent.com/661450/184288391-c74a7285-65f8-4cab-afa2-3e053867aed4.png)

after:

![chia-hotspot-0-1-patched](https://user-images.githubusercontent.com/661450/184288402-98691f62-2831-473e-bf4a-98e754849a7e.png)

