### PR TITLE
revert change to change OR REPLACE -> OR FAIL in wallet_coin_store

### DIFF
--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -73,7 +73,7 @@ class WalletCoinStore:
         assert record.spent == (record.spent_block_height != 0)
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute_insert(
-                "INSERT OR FAIL INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     name.hex(),
                     record.confirmed_block_height,

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -1,4 +1,3 @@
-import sqlite3
 from secrets import token_bytes
 
 import pytest
@@ -73,9 +72,11 @@ async def test_add_replace_get() -> None:
         store = await WalletCoinStore.create(db_wrapper)
 
         assert await store.get_coin_record(coin_1.name()) is None
+        await store.add_coin_record(record_1)
+
+        # adding duplicates is fine, we replace existing entry
         await store.add_coin_record(record_replaced)
-        with pytest.raises(sqlite3.IntegrityError):
-            await store.add_coin_record(record_1)
+
         await store.add_coin_record(record_2)
         await store.add_coin_record(record_3)
         await store.add_coin_record(record_4)
@@ -111,8 +112,10 @@ async def test_get_records_by_puzzle_hash() -> None:
 
         await store.add_coin_record(record_4)
         await store.add_coin_record(record_5)
-        with pytest.raises(sqlite3.IntegrityError):
-            await store.add_coin_record(record_5)
+
+        # adding duplicates is fine, we replace existing entry
+        await store.add_coin_record(record_5)
+
         await store.add_coin_record(record_6)
         assert len(await store.get_coin_records_by_puzzle_hash(record_6.coin.puzzle_hash)) == 2  # 4 and 6
         assert len(await store.get_coin_records_by_puzzle_hash(token_bytes(32))) == 0


### PR DESCRIPTION
There's not enough test coverage to make this change with confidence, and it's not necessary.

I made this change as part of another PR where (as far as I can tell) we no longer rely on replacing existing entries. I made this change to ensure we aren't (in the tests).

But I'm having  second thoughts about this change. The test coverage is probably not good enough to tell us whether we still need this or not.

This was my original change, that this PR reverts: https://github.com/Chia-Network/chia-blockchain/pull/12391