### PR TITLE
Rust coin state

### DIFF
--- a/chia/protocols/wallet_protocol.py
+++ b/chia/protocols/wallet_protocol.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
+from chia_rs import CoinState, RespondToPhUpdates
+
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -13,6 +15,9 @@ from chia.util.streamable import Streamable, streamable
 Protocol between wallet (SPV node) and full node.
 Note: When changing this file, also change protocol_message_types.py, and the protocol version in shared_protocol.py
 """
+
+
+__all__ = ["CoinState", "RespondToPhUpdates"]
 
 
 @streamable
@@ -178,12 +183,13 @@ class RespondHeaderBlocks(Streamable):
     header_blocks: List[HeaderBlock]
 
 
-@streamable
-@dataclass(frozen=True)
-class CoinState(Streamable):
-    coin: Coin
-    spent_height: Optional[uint32]
-    created_height: Optional[uint32]
+# This class is implemented in Rust
+# @streamable
+# @dataclass(frozen=True)
+# class CoinState(Streamable):
+#    coin: Coin
+#    spent_height: Optional[uint32]
+#    created_height: Optional[uint32]
 
 
 @streamable
@@ -193,12 +199,13 @@ class RegisterForPhUpdates(Streamable):
     min_height: uint32
 
 
-@streamable
-@dataclass(frozen=True)
-class RespondToPhUpdates(Streamable):
-    puzzle_hashes: List[bytes32]
-    min_height: uint32
-    coin_states: List[CoinState]
+# This class is implemented in Rust
+# @streamable
+# @dataclass(frozen=True)
+# class RespondToPhUpdates(Streamable):
+#    puzzle_hashes: List[bytes32]
+#    min_height: uint32
+#    coin_states: List[CoinState]
 
 
 @streamable

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1714,8 +1714,8 @@ class WalletRpcApi:
                     coin_state.coin,
                     None,
                     full_puzzle,
-                    launcher_coin[0].spent_height,
-                    coin_state.created_height if coin_state.created_height else uint32(0),
+                    uint32(launcher_coin[0].spent_height),
+                    uint32(coin_state.created_height) if coin_state.created_height else uint32(0),
                 )
             )
         except Exception as e:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -377,7 +377,7 @@ class DIDWallet:
             )[0]
             assert parent_state.spent_height is not None
             puzzle_solution_request = wallet_protocol.RequestPuzzleSolution(
-                coin.parent_coin_info, parent_state.spent_height
+                coin.parent_coin_info, uint32(parent_state.spent_height)
             )
             response = await peer.request_puzzle_solution(puzzle_solution_request)
             req_puz_sol = response.response

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -218,7 +218,7 @@ class NFTWallet:
             and len(launcher_coin_states) == 1
             and launcher_coin_states[0].spent_height is not None
         )
-        mint_height: uint32 = launcher_coin_states[0].spent_height
+        mint_height: uint32 = uint32(launcher_coin_states[0].spent_height)
         self.log.info("Adding a new NFT to wallet: %s", child_coin)
 
         # all is well, lets add NFT to our local db
@@ -229,7 +229,7 @@ class NFTWallet:
         )
         if coin_states is not None:
             parent_coin = coin_states[0].coin
-            confirmed_height = coin_states[0].spent_height
+            confirmed_height = None if coin_states[0].spent_height is None else uint32(coin_states[0].spent_height)
 
         if parent_coin is None or confirmed_height is None:
             raise ValueError("Error finding parent")

--- a/chia/wallet/util/peer_request_cache.py
+++ b/chia/wallet/util/peer_request_cache.py
@@ -49,9 +49,9 @@ class PeerRequestCache:
     def add_to_states_validated(self, coin_state: CoinState) -> None:
         cs_height: Optional[uint32] = None
         if coin_state.spent_height is not None:
-            cs_height = coin_state.spent_height
+            cs_height = uint32(coin_state.spent_height)
         elif coin_state.created_height is not None:
-            cs_height = coin_state.created_height
+            cs_height = uint32(coin_state.created_height)
         self._states_validated.put(coin_state.get_hash(), cs_height)
 
     def get_height_timestamp(self, height: uint32) -> Optional[uint64]:

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -296,9 +296,9 @@ def get_block_challenge(
 
 def last_change_height_cs(cs: CoinState) -> uint32:
     if cs.spent_height is not None:
-        return cs.spent_height
+        return uint32(cs.spent_height)
     if cs.created_height is not None:
-        return cs.created_height
+        return uint32(cs.created_height)
 
     # Reorgs should be processed at the beginning
     return uint32(0)

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1268,8 +1268,10 @@ class WalletNode:
         if await can_use_peer_request_cache(coin_state, peer_request_cache, fork_height):
             return True
 
-        spent_height = coin_state.spent_height
-        confirmed_height = coin_state.created_height
+        spent_height: Optional[uint32] = None if coin_state.spent_height is None else uint32(coin_state.spent_height)
+        confirmed_height: Optional[uint32] = (
+            None if coin_state.created_height is None else uint32(coin_state.created_height)
+        )
         current = await self.wallet_state_manager.coin_store.get_coin_record(coin_state.coin.name())
         # if remote state is same as current local state we skip validation
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ dependencies = [
     "chiapos==1.0.10",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.5",  # Currying, Program.to, other conveniences
-    "chia_rs==0.1.7",
+    "chia_rs==0.1.8",
     "clvm-tools-rs==0.1.19",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.1",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/util/test_network_protocol_test.py
+++ b/tests/util/test_network_protocol_test.py
@@ -23,6 +23,9 @@ def types_in_module(mod: Any) -> Set[str]:
         obj = getattr(mod, sym)
         if hasattr(obj, "__module__") and obj.__module__ == mod_name:
             ret.append(sym)
+
+    if hasattr(mod, "__all__"):
+        ret += getattr(mod, "__all__")
     return set(ret)
 
 


### PR DESCRIPTION
The motivation for this patch is to speed up `subscribe_to_phs()` in the wallet. For wallet with a lot of transactions, and many puzzle hashes, parsing the response for this RPC is very slow.

| operation | before | after | after / before |
| --- | --- | --- | --- |
| subscribe_to_phs() | 53.29% | 0.88% | 0.0165 |

Profile from main:
![chia-hotspot-3-main](https://user-images.githubusercontent.com/661450/185102830-1ebefc31-5827-497b-bdc5-9863e44e01c7.png)

Profile with this patch:
![chia-hotspot-3-patched](https://user-images.githubusercontent.com/661450/185102860-1a9c1b03-a425-45e1-ab29-ba38fd29ae59.png)
