### PR TITLE
Couple of small key migration changes to speed up launching

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -58,7 +58,7 @@ def monkey_patch_click() -> None:
 @click.option(
     "--force-legacy-keyring-migration/--no-force-legacy-keyring-migration",
     default=True,
-    help="Force legacy keyring migration. Legacy keyring support will be dropped in 1.5.2!",
+    help="Force legacy keyring migration. Legacy keyring support will be removed in an upcoming version!",
 )
 @click.pass_context
 def cli(

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -192,7 +192,7 @@ async def migrate_keys(root_path: Path, forced: bool = False) -> bool:
     from chia.util.misc import prompt_yes_no
 
     deprecation_message = (
-        "\nLegacy keyring support is deprecated and will be removed in version 1.5.2. "
+        "\nLegacy keyring support is deprecated and will be removed in an upcoming version. "
         "You need to migrate your keyring to continue using Chia.\n"
     )
 
@@ -201,6 +201,10 @@ async def migrate_keys(root_path: Path, forced: bool = False) -> bool:
         print(deprecation_message)
         await KeyringWrapper.get_shared_instance().migrate_legacy_keyring_interactive()
     else:
+        already_checked_marker = KeyringWrapper.get_shared_instance().keys_root_path / ".checked_legacy_migration"
+        if forced and already_checked_marker.exists():
+            return True
+
         log = logging.getLogger("migrate_keys")
         config = load_config(root_path, "config.yaml")
         # Connect to the daemon here first to see if ts running since `connect_to_keychain_and_validate` just tries to
@@ -263,6 +267,8 @@ async def migrate_keys(root_path: Path, forced: bool = False) -> bool:
             return True
         elif not forced:
             print("No keys need migration")
+        if already_checked_marker.parent.exists():
+            already_checked_marker.touch()
         await keychain_proxy.close()
     return True
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -11,11 +11,7 @@ from chia.wallet.util.wallet_types import WalletType
 @click.group("wallet", short_help="Manage your wallet")
 @click.pass_context
 def wallet_cmd(ctx: click.Context) -> None:
-    import asyncio
-    from .keys_funcs import migrate_keys
-
-    if ctx.obj["force_legacy_keyring_migration"] and not asyncio.run(migrate_keys(ctx.obj["root_path"], True)):
-        sys.exit(1)
+    pass
 
 
 @wallet_cmd.command("get_transaction", short_help="Get a transaction")


### PR DESCRIPTION
* Skip legacy keyring migration check for wallet commands
* Skip subsequent incremental legacy keyring migration checks

(This is the release/1.5.1 variation of #12948)