### PR TITLE
no traceback for unknown wallet id request to nft_get_nfts

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1500,7 +1500,10 @@ class WalletRpcApi:
 
     async def nft_get_nfts(self, request) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
-        nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
+        try:
+            nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
+        except KeyError:
+            return {"success": False, "error": f"Unable to find wallet ID: {wallet_id}"}
         nfts = nft_wallet.get_current_nfts()
         nft_info_list = []
         for nft in nfts:


### PR DESCRIPTION
Previously got:

```python-traceback
Aug 13 22:55:23 fullnode chia_wallet[58418]: 2022-08-13T22:55:23.873 wallet chia.rpc.util              : WARNING  Error while handling message: Traceback (most recent call last):
Aug 13 22:55:23 fullnode chia_wallet[58418]:   File "/farm/chia-blockchain/chia/rpc/util.py", line 16, in inner
Aug 13 22:55:23 fullnode chia_wallet[58418]:     res_object = await f(request_data)
Aug 13 22:55:23 fullnode chia_wallet[58418]:   File "/farm/chia-blockchain/chia/rpc/wallet_rpc_api.py", line 1501, in nft_get_nfts
Aug 13 22:55:23 fullnode chia_wallet[58418]:     nft_wallet: NFTWallet = self.service.wallet_state_manager.wallets[wallet_id]
Aug 13 22:55:23 fullnode chia_wallet[58418]: KeyError: 1723200746
```