### PR TITLE
No traceback for OSError 113 in WSChiaConnection.outbound_handler()

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -262,12 +262,16 @@ class WSChiaConnection:
                     await self._send_message(msg)
         except asyncio.CancelledError:
             pass
-        except (BrokenPipeError, ConnectionResetError, TimeoutError) as e:
-            self.log.warning(f"{e} {self.peer_host}")
         except Exception as e:
-            error_stack = traceback.format_exc()
-            self.log.error(f"Exception: {e} with {self.peer_host}")
-            self.log.error(f"Exception Stack: {error_stack}")
+            if (
+                isinstance(e, (BrokenPipeError, ConnectionResetError, TimeoutError))
+                or (isinstance(e, OSError) and e.errno in {113})
+            ):
+                self.log.warning(f"{e} {self.peer_host}")
+            else:
+                error_stack = traceback.format_exc()
+                self.log.error(f"Exception: {e} with {self.peer_host}")
+                self.log.error(f"Exception Stack: {error_stack}")
 
     async def inbound_handler(self):
         try:

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -263,9 +263,8 @@ class WSChiaConnection:
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            if (
-                isinstance(e, (BrokenPipeError, ConnectionResetError, TimeoutError))
-                or (isinstance(e, OSError) and e.errno in {113})
+            if isinstance(e, (BrokenPipeError, ConnectionResetError, TimeoutError)) or (
+                isinstance(e, OSError) and e.errno in {113}
             ):
                 self.log.warning(f"{e} {self.peer_host}")
             else:


### PR DESCRIPTION
```python-traceback
Aug 16 21:24:08 fullnode chia_full_node[58416]: 2022-08-16T21:24:08.489 full_node full_node_server        : ERROR    Exception: [Errno 113] No route to host with 121.236.62.254
Aug 16 21:24:08 fullnode chia_full_node[58416]: 2022-08-16T21:24:08.490 full_node full_node_server        : ERROR    Exception Stack: Traceback (most recent call last):
Aug 16 21:24:08 fullnode chia_full_node[58416]:   File "/farm/chia-blockchain/chia/server/ws_connection.py", line 262, in outbound_handler
Aug 16 21:24:08 fullnode chia_full_node[58416]:     await self._send_message(msg)
Aug 16 21:24:08 fullnode chia_full_node[58416]:   File "/farm/chia-blockchain/chia/server/ws_connection.py", line 416, in _send_message
Aug 16 21:24:08 fullnode chia_full_node[58416]:     await self.ws.send_bytes(encoded)
Aug 16 21:24:08 fullnode chia_full_node[58416]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/web_ws.py", line 315, in send_bytes
Aug 16 21:24:08 fullnode chia_full_node[58416]:     await self._writer.send(data, binary=True, compress=compress)
Aug 16 21:24:08 fullnode chia_full_node[58416]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/http_websocket.py", line 688, in send
Aug 16 21:24:08 fullnode chia_full_node[58416]:     await self._send_frame(message, WSMsgType.BINARY, compress)
Aug 16 21:24:08 fullnode chia_full_node[58416]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/http_websocket.py", line 659, in _send_frame
Aug 16 21:24:08 fullnode chia_full_node[58416]:     await self.protocol._drain_helper()
Aug 16 21:24:08 fullnode chia_full_node[58416]:   File "/farm/chia-blockchain/venv/lib/python3.8/site-packages/aiohttp/base_protocol.py", line 87, in _drain_helper
Aug 16 21:24:08 fullnode chia_full_node[58416]:     await asyncio.shield(waiter)
Aug 16 21:24:08 fullnode chia_full_node[58416]:   File "/usr/lib/python3.8/asyncio/selector_events.py", line 848, in _read_ready__data_received
Aug 16 21:24:08 fullnode chia_full_node[58416]:     data = self._sock.recv(self.max_size)
Aug 16 21:24:08 fullnode chia_full_node[58416]: OSError: [Errno 113] No route to host
Aug 16 21:24:08 fullnode chia_full_node[58416]:
```