### PR TITLE
implement SerializedProgram.curry() to speed up puzzle-hash generation

### DIFF
--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -13,7 +13,7 @@ from chia.protocols.wallet_protocol import CoinState
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.spend_bundle import SpendBundle
@@ -497,7 +497,7 @@ class DIDWallet:
     def puzzle_for_pk(self, pubkey: G1Element) -> Program:
         if self.did_info.origin_coin is not None:
             innerpuz = did_wallet_puzzles.create_innerpuz(
-                puzzle_for_pk(pubkey),
+                puzzle_for_pk(pubkey).to_program(),
                 self.did_info.backup_ids,
                 self.did_info.num_of_backup_ids_needed,
                 self.did_info.origin_coin.name(),
@@ -1012,13 +1012,13 @@ class DIDWallet:
         puzzle = await self.get_new_p2_inner_puzzle()
         return puzzle.get_tree_hash()
 
-    async def get_new_p2_inner_puzzle(self) -> Program:
+    async def get_new_p2_inner_puzzle(self) -> SerializedProgram:
         return await self.standard_wallet.get_new_puzzle()
 
     async def get_new_did_innerpuz(self, origin_id=None) -> Program:
         if self.did_info.origin_coin is not None:
             innerpuz = did_wallet_puzzles.create_innerpuz(
-                await self.get_new_p2_inner_puzzle(),
+                (await self.get_new_p2_inner_puzzle()).to_program(),
                 self.did_info.backup_ids,
                 uint64(self.did_info.num_of_backup_ids_needed),
                 self.did_info.origin_coin.name(),
@@ -1026,7 +1026,7 @@ class DIDWallet:
             )
         elif origin_id is not None:
             innerpuz = did_wallet_puzzles.create_innerpuz(
-                await self.get_new_p2_inner_puzzle(),
+                (await self.get_new_p2_inner_puzzle()).to_program(),
                 self.did_info.backup_ids,
                 uint64(self.did_info.num_of_backup_ids_needed),
                 origin_id,
@@ -1051,7 +1051,7 @@ class DIDWallet:
         # In a selling case, the seller should clean the recovery list then transfer to the new owner.
         assert self.did_info.origin_coin is not None
         return did_wallet_puzzles.create_innerpuz(
-            puzzle_for_pk(pubkey),
+            puzzle_for_pk(pubkey).to_program(),
             self.did_info.backup_ids,
             uint64(self.did_info.num_of_backup_ids_needed),
             self.did_info.origin_coin.name(),
@@ -1064,7 +1064,7 @@ class DIDWallet:
         )
         assert self.did_info.origin_coin is not None
         inner_puzzle: Program = did_wallet_puzzles.create_innerpuz(
-            puzzle_for_pk(record.pubkey),
+            puzzle_for_pk(record.pubkey).to_program(),
             self.did_info.backup_ids,
             self.did_info.num_of_backup_ids_needed,
             self.did_info.origin_coin.name(),

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -184,10 +184,12 @@ class NFTWallet:
             return
         p2_puzzle = puzzle_for_pk(derivation_record.pubkey)
         if uncurried_nft.supports_did:
-            inner_puzzle = nft_puzzles.recurry_nft_puzzle(uncurried_nft, coin_spend.solution.to_program(), p2_puzzle)
+            inner_puzzle = nft_puzzles.recurry_nft_puzzle(
+                uncurried_nft, coin_spend.solution.to_program(), p2_puzzle.to_program()
+            )
 
         else:
-            inner_puzzle = p2_puzzle
+            inner_puzzle = p2_puzzle.to_program()
         child_puzzle: Program = nft_puzzles.create_full_puzzle(
             singleton_id,
             Program.to(metadata),
@@ -334,12 +336,16 @@ class NFTWallet:
             # WARNING: wallets should always ignore DID value for eve coins as they can be set
             #          to any DID without approval
             inner_puzzle = create_ownership_layer_puzzle(
-                launcher_coin.name(), b"", p2_inner_puzzle, percentage, royalty_puzzle_hash=royalty_puzzle_hash
+                launcher_coin.name(),
+                b"",
+                p2_inner_puzzle.to_program(),
+                percentage,
+                royalty_puzzle_hash=royalty_puzzle_hash,
             )
             self.log.debug("Got back ownership inner puzzle: %s", disassemble(inner_puzzle))
         else:
             self.log.debug("Creating standard NFT")
-            inner_puzzle = p2_inner_puzzle
+            inner_puzzle = p2_inner_puzzle.to_program()
 
         # singleton eve puzzle
         eve_fullpuz = nft_puzzles.create_full_puzzle(

--- a/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -61,17 +61,17 @@ from typing import Union
 from blspy import G1Element, PrivateKey
 from clvm.casts import int_from_bytes
 
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 
-from .load_clvm import load_clvm
+from .load_clvm import load_serialized_clvm
 from .p2_conditions import puzzle_for_conditions
 
-DEFAULT_HIDDEN_PUZZLE = Program.from_bytes(bytes.fromhex("ff0980"))
+DEFAULT_HIDDEN_PUZZLE = SerializedProgram.from_bytes(b"\xff\x09\x80")
 
 DEFAULT_HIDDEN_PUZZLE_HASH = DEFAULT_HIDDEN_PUZZLE.get_tree_hash()  # this puzzle `(x)` always fails
 
-MOD = load_clvm("p2_delegated_puzzle_or_hidden_puzzle.clvm")
+MOD = load_serialized_clvm("p2_delegated_puzzle_or_hidden_puzzle.clvm")
 
 PublicKeyProgram = Union[bytes, Program]
 
@@ -102,21 +102,23 @@ def calculate_synthetic_secret_key(secret_key: PrivateKey, hidden_puzzle_hash: b
     return synthetic_secret_key
 
 
-def puzzle_for_synthetic_public_key(synthetic_public_key: G1Element) -> Program:
+def puzzle_for_synthetic_public_key(synthetic_public_key: G1Element) -> SerializedProgram:
     return MOD.curry(bytes(synthetic_public_key))
 
 
-def puzzle_for_public_key_and_hidden_puzzle_hash(public_key: G1Element, hidden_puzzle_hash: bytes32) -> Program:
+def puzzle_for_public_key_and_hidden_puzzle_hash(
+    public_key: G1Element, hidden_puzzle_hash: bytes32
+) -> SerializedProgram:
     synthetic_public_key = calculate_synthetic_public_key(public_key, hidden_puzzle_hash)
 
     return puzzle_for_synthetic_public_key(synthetic_public_key)
 
 
-def puzzle_for_public_key_and_hidden_puzzle(public_key: G1Element, hidden_puzzle: Program) -> Program:
+def puzzle_for_public_key_and_hidden_puzzle(public_key: G1Element, hidden_puzzle: Program) -> SerializedProgram:
     return puzzle_for_public_key_and_hidden_puzzle_hash(public_key, hidden_puzzle.get_tree_hash())
 
 
-def puzzle_for_pk(public_key: G1Element) -> Program:
+def puzzle_for_pk(public_key: G1Element) -> SerializedProgram:
     return puzzle_for_public_key_and_hidden_puzzle_hash(public_key, DEFAULT_HIDDEN_PUZZLE_HASH)
 
 

--- a/tests/clvm/test_serialized_program.py
+++ b/tests/clvm/test_serialized_program.py
@@ -1,5 +1,6 @@
 from chia.types.blockchain_format.program import Program, SerializedProgram, INFINITE_COST
 from chia.wallet.puzzles.load_clvm import load_clvm
+from clvm_tools.binutils import assemble
 
 SHA256TREE_MOD = load_clvm("sha256tree_module.clvm")
 
@@ -10,14 +11,37 @@ def test_tree_hash():
     s = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
     assert s.get_tree_hash() == p.get_tree_hash()
 
+
 def test_program_execution():
     p_result = SHA256TREE_MOD.run(SHA256TREE_MOD)
     sp = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
     cost, sp_result = sp.run_with_cost(INFINITE_COST, sp)
     assert p_result == sp_result
 
+
 def test_serialization():
     s0 = SerializedProgram.from_bytes(b"\x00")
     p0 = Program.from_bytes(b"\x00")
     print(s0, p0)
     assert bytes(p0) == bytes(s0)
+
+
+def check_idempotency(f, *args):
+    prg = Program.to(f)
+    curried = prg.curry(*args)
+
+    sprg = SerializedProgram.from_bytes(bytes(prg))
+    scurried = sprg.curry(*args)
+
+    assert bytes(scurried) == bytes(curried)
+
+
+def test_curry():
+
+    f = assemble("(+ 2 5)")
+    check_idempotency(f, 200, 30)
+
+    f = assemble("(+ 2 5)")
+    args = assemble("(+ (q . 50) (q . 60))")
+    # passing "args" here wraps the arguments in a list
+    check_idempotency(f, args)

--- a/tests/clvm/test_serialized_program.py
+++ b/tests/clvm/test_serialized_program.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 from chia.types.blockchain_format.program import Program, SerializedProgram, INFINITE_COST
 from chia.wallet.puzzles.load_clvm import load_clvm
 
@@ -7,21 +5,19 @@ SHA256TREE_MOD = load_clvm("sha256tree_module.clvm")
 
 
 # TODO: test multiple args
-class TestSerializedProgram(TestCase):
-    def test_tree_hash(self):
-        p = SHA256TREE_MOD
-        s = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
-        self.assertEqual(s.get_tree_hash(), p.get_tree_hash())
+def test_tree_hash():
+    p = SHA256TREE_MOD
+    s = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
+    assert s.get_tree_hash() == p.get_tree_hash()
 
-    def test_program_execution(self):
-        p_result = SHA256TREE_MOD.run(SHA256TREE_MOD)
-        sp = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
-        cost, sp_result = sp.run_with_cost(INFINITE_COST, sp)
-        self.assertEqual(p_result, sp_result)
+def test_program_execution():
+    p_result = SHA256TREE_MOD.run(SHA256TREE_MOD)
+    sp = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
+    cost, sp_result = sp.run_with_cost(INFINITE_COST, sp)
+    assert p_result == sp_result
 
-    def test_serialization(self):
-        s0 = SerializedProgram.from_bytes(b"\x00")
-        p0 = Program.from_bytes(b"\x00")
-        print(s0, p0)
-        # TODO: enable when clvm updated for minimal encoding of zero
-        # self.assertEqual(bytes(p0), bytes(s0))
+def test_serialization():
+    s0 = SerializedProgram.from_bytes(b"\x00")
+    p0 = Program.from_bytes(b"\x00")
+    print(s0, p0)
+    assert bytes(p0) == bytes(s0)

--- a/tests/clvm/test_singletons.py
+++ b/tests/clvm/test_singletons.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Optional
 
 from blspy import AugSchemeMPL, G1Element, G2Element, PrivateKey
 
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.coin import Coin
 from chia.types.coin_spend import CoinSpend
@@ -88,16 +88,16 @@ class TestSingleton:
             # Generate starting info
             key_lookup = KeyTool()
             pk: G1Element = G1Element.from_bytes(public_key_for_index(1, key_lookup))
-            starting_puzzle: Program = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(pk)  # noqa
+            starting_puzzle: SerializedProgram = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(pk)
 
             if version == 0:
                 from chia.wallet.puzzles import singleton_top_layer
 
-                adapted_puzzle: Program = singleton_top_layer.adapt_inner_to_singleton(starting_puzzle)  # noqa
+                adapted_puzzle: Program = singleton_top_layer.adapt_inner_to_singleton(starting_puzzle.to_program())
             else:
                 from chia.wallet.puzzles import singleton_top_layer_v1_1 as singleton_top_layer
 
-                adapted_puzzle = starting_puzzle
+                adapted_puzzle = starting_puzzle.to_program()
             adapted_puzzle_hash: bytes32 = adapted_puzzle.get_tree_hash()
 
             # Get our starting standard coin created

--- a/tests/core/make_block_generator.py
+++ b/tests/core/make_block_generator.py
@@ -4,7 +4,7 @@ import blspy
 
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
@@ -22,15 +22,15 @@ def int_to_public_key(index: int) -> blspy.G1Element:
     return private_key_from_int.get_g1()
 
 
-def puzzle_hash_for_index(index: int, puzzle_hash_db: dict) -> bytes32:
+def puzzle_hash_for_index(index: int, puzzle_hash_db: Dict[bytes32, SerializedProgram]) -> bytes32:
     public_key: blspy.G1Element = int_to_public_key(index)
-    puzzle: Program = puzzle_for_pk(public_key)
+    puzzle: SerializedProgram = puzzle_for_pk(public_key)
     puzzle_hash: bytes32 = puzzle.get_tree_hash()
     puzzle_hash_db[puzzle_hash] = puzzle
     return puzzle_hash
 
 
-def make_fake_coin(index: int, puzzle_hash_db: dict) -> Coin:
+def make_fake_coin(index: int, puzzle_hash_db: Dict[bytes32, SerializedProgram]) -> Coin:
     """
     Make a fake coin with parent id equal to the index (ie. a genesis block coin)
 
@@ -48,7 +48,7 @@ def conditions_for_payment(coin) -> Program:
 
 
 def make_spend_bundle(count: int) -> SpendBundle:
-    puzzle_hash_db: Dict = dict()
+    puzzle_hash_db: Dict[bytes32, SerializedProgram] = {}
     coins = [make_fake_coin(_, puzzle_hash_db) for _ in range(count)]
 
     coin_spends = []

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -132,7 +132,7 @@ class TestCostCalculation:
             "88bc9360319e7c54ab42e19e974288a2d7a817976f7633f4b43f36ce72074e59c4ab8ddac362202f3e366f0aebbb6280"
         )
         puzzle = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(G1Element.from_bytes(pk))
-        disassembly = binutils.disassemble(puzzle)
+        disassembly = binutils.disassemble(puzzle.to_program())
         program = SerializedProgram.from_bytes(
             binutils.assemble(
                 f"(q ((0x3d2331635a58c0d49912bc1427d7db51afe3f20a7b4bcaffa17ee250dcbcbfaa {disassembly} 300"
@@ -245,16 +245,14 @@ class TestCostCalculation:
         public_key = bytes.fromhex(
             "af949b78fa6a957602c3593a3d6cb7711e08720415dad83" "1ab18adacaa9b27ec3dda508ee32e24bc811c0abc5781ae21"
         )
-        puzzle_program = SerializedProgram.from_bytes(
-            p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(G1Element.from_bytes(public_key))
+        puzzle_program: SerializedProgram = p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(
+            G1Element.from_bytes(public_key)
         )
         conditions = binutils.assemble(
             "((51 0x699eca24f2b6f4b25b16f7a418d0dc4fc5fce3b9145aecdda184158927738e3e 10)"
             " (51 0x847bb2385534070c39a39cc5dfdc7b35e2db472dc0ab10ab4dec157a2178adbf 0x00cbba106df6))"
         )
-        solution_program = SerializedProgram.from_bytes(
-            p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)
-        )
+        solution_program: SerializedProgram = p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)
 
         with assert_runtime(seconds=0.1, label=request.node.name):
             total_cost = 0

--- a/tests/wallet/nft_wallet/test_nft_puzzles.py
+++ b/tests/wallet/nft_wallet/test_nft_puzzles.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 from clvm.casts import int_from_bytes
 
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.nft_wallet import uncurry_nft
 from chia.wallet.nft_wallet.nft_puzzles import (
@@ -103,7 +103,7 @@ def test_nft_transfer_puzzle_hashes():
     assert expected_ph == calculated_ph
 
 
-def make_a_new_solution() -> Tuple[Program, Program]:
+def make_a_new_solution() -> Tuple[SerializedProgram, Program]:
     destination = int_to_public_key(2)
     p2_puzzle = puzzle_for_pk(destination)
     puzhash = p2_puzzle.get_tree_hash()
@@ -132,7 +132,7 @@ def make_a_new_solution() -> Tuple[Program, Program]:
     return p2_puzzle, solution
 
 
-def make_a_new_ownership_layer_puzzle() -> Tuple[Program, Program]:
+def make_a_new_ownership_layer_puzzle() -> Tuple[SerializedProgram, Program]:
     pubkey = int_to_public_key(1)
     innerpuz = puzzle_for_pk(pubkey)
     old_did = Program.to("test_2").get_tree_hash()
@@ -144,7 +144,7 @@ def make_a_new_ownership_layer_puzzle() -> Tuple[Program, Program]:
         2000,
     )
     curried_inner = innerpuz
-    curried_ownership_layer = construct_ownership_layer(old_did, curried_tp, curried_inner)
+    curried_ownership_layer = construct_ownership_layer(old_did, curried_tp, curried_inner.to_program())
     return innerpuz, curried_ownership_layer
 
 
@@ -187,8 +187,8 @@ def test_transfer_puzzle_builder() -> None:
     assert unft is not None
     assert unft.nft_state_layer == clvm_nft_puzzle
     assert unft.inner_puzzle == ownership_puzzle
-    assert unft.p2_puzzle == p2_puzzle
-    ol_puzzle = recurry_nft_puzzle(unft, solution, sp2_puzzle)
+    assert bytes(unft.p2_puzzle) == bytes(p2_puzzle)
+    ol_puzzle = recurry_nft_puzzle(unft, solution, sp2_puzzle.to_program())
     nft_puzzle = create_nft_layer_puzzle_with_curry_params(
         Program.to(metadata), NFT_METADATA_UPDATER_DEFAULT.get_tree_hash(), ol_puzzle
     )

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -10,7 +10,7 @@ from chia.protocols.full_node_protocol import RespondBlock
 from chia.server.server import ChiaServer
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
@@ -803,7 +803,7 @@ class TestWalletSimulator:
         puzzle_hashes = []
         for i in range(211):
             pubkey = master_sk_to_wallet_sk(wallet_node.wallet_state_manager.private_key, uint32(i)).get_g1()
-            puzzle: Program = wallet.puzzle_for_pk(pubkey)
+            puzzle: SerializedProgram = wallet.puzzle_for_pk(pubkey)
             puzzle_hash: bytes32 = puzzle.get_tree_hash()
             puzzle_hashes.append(puzzle_hash)
 


### PR DESCRIPTION
The main motivation behind this is to speed up generating new puzzle hashes. The bottleneck right now is `puzzle_for_pk()` and `get_tree_hash()`.

`puzzle_for_pk()` is slow because it has to call `curry()`, and `get_tree_hash()` is slow because it has to operate on `Program` (the python tree structure) instead of `SerializedProgram`.

This patch implements `curry()` to operate directly on `SerializedProgram`, which avoids the critical path from having to parse the program and speeds up `curry()` as well as `get_tree_hash()`.

| operation | before | after | after / before |
| --- | --- | --- | --- |
| puzzle_for_pk() | 17.15% | 9.64% | 0.56 |
| get_tree_hash() | 25.40% | 6.62% | 0.25 |

The profile from current main:
![chia-hotspot-0](https://user-images.githubusercontent.com/661450/185082885-32d88010-8019-4f51-bf50-f1542772a1f3.png)

The profile with this patch:
![chia-hotspot-0-patched](https://user-images.githubusercontent.com/661450/185083238-e9df6aff-cd52-448d-b31c-424c7892479d.png)

