### PR TITLE
coin interest optimization for trade records

### DIFF
--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -96,7 +96,7 @@ class TradeManager:
 
     async def get_coins_of_interest(
         self,
-    ) -> List[bytes32]:
+    ) -> Set[bytes32]:
         """
         Returns list of coins we want to check if they are included in filter,
         These will include coins that belong to us and coins that that on other side of treade

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -96,18 +96,15 @@ class TradeManager:
 
     async def get_coins_of_interest(
         self,
-    ) -> Dict[bytes32, Coin]:
+    ) -> List[bytes32]:
         """
         Returns list of coins we want to check if they are included in filter,
         These will include coins that belong to us and coins that that on other side of treade
         """
-        coins = await self.trade_store.get_coins_of_interest_with_trade_statuses(
+        coin_ids = await self.trade_store.get_coin_ids_of_interest_with_trade_statuses(
             trade_statuses=[TradeStatus.PENDING_ACCEPT, TradeStatus.PENDING_CONFIRM, TradeStatus.PENDING_CANCEL]
         )
-        interested_dict = {}
-        for coin in coins:
-            interested_dict[coin.name()] = coin
-        return interested_dict
+        return coin_ids
 
     async def get_trade_by_coin(self, coin: Coin) -> Optional[TradeRecord]:
         all_trades = await self.get_all_trades()

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -19,6 +19,7 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.payment import Payment
 from chia.wallet.puzzle_drivers import PuzzleInfo
+from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import NotarizedPayment, Offer
 from chia.wallet.trading.trade_status import TradeStatus
@@ -28,7 +29,6 @@ from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
-from chia.wallet.puzzles.load_clvm import load_clvm
 
 OFFER_MOD = load_clvm("settlement_payments.clvm")
 
@@ -101,19 +101,12 @@ class TradeManager:
         Returns list of coins we want to check if they are included in filter,
         These will include coins that belong to us and coins that that on other side of treade
         """
-        all_pending = []
-        pending_accept = await self.get_offers_with_status(TradeStatus.PENDING_ACCEPT)
-        pending_confirm = await self.get_offers_with_status(TradeStatus.PENDING_CONFIRM)
-        pending_cancel = await self.get_offers_with_status(TradeStatus.PENDING_CANCEL)
-        all_pending.extend(pending_accept)
-        all_pending.extend(pending_confirm)
-        all_pending.extend(pending_cancel)
+        coins = await self.trade_store.get_coins_of_interest_with_trade_statuses(
+            trade_statuses=[TradeStatus.PENDING_ACCEPT, TradeStatus.PENDING_CONFIRM, TradeStatus.PENDING_CANCEL]
+        )
         interested_dict = {}
-
-        for trade in all_pending:
-            for coin in trade.coins_of_interest:
-                interested_dict[coin.name()] = coin
-
+        for coin in coins:
+            interested_dict[coin.name()] = coin
         return interested_dict
 
     async def get_trade_by_coin(self, coin: Coin) -> Optional[TradeRecord]:

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -1,9 +1,10 @@
+import logging
 from time import perf_counter
 from typing import List, Optional, Tuple
 
 import aiosqlite
-import logging
 
+from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.db_wrapper import DBWrapper2
@@ -11,6 +12,35 @@ from chia.util.errors import Err
 from chia.util.ints import uint8, uint32
 from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.trade_status import TradeStatus
+
+
+async def migrate_coin_of_interest(log: logging.Logger, db: aiosqlite.Connection) -> None:
+    log.info("Beginning migration of coin_of_interest_to_trade_record lookup table")
+
+    start_time = perf_counter()
+    cursor = await db.execute("SELECT trade_record, trade_id from trade_records")
+    rows = await cursor.fetchall()
+    await cursor.close()
+
+    inserts: List[Tuple[bytes32, bytes, str]] = []
+    for row in rows:
+        record: TradeRecord = TradeRecord.from_bytes(row[0])
+        for coin in record.coins_of_interest:
+            inserts.append((coin.name(), coin.to_bytes(), record.trade_id.hex()))
+
+    if not inserts:
+        # no trades to migrate
+        return
+    try:
+        await db.executemany(
+            "INSERT INTO coin_of_interest_to_trade_record " "(coin_id, coin, trade_id) " "VALUES(?, ?, ?)", inserts
+        )
+    except (aiosqlite.OperationalError, aiosqlite.IntegrityError):
+        log.exception("Failed to migrate  in trade_records")
+        raise
+
+    end_time = perf_counter()
+    log.info(f"Completed migration of {len(inserts)} records in {end_time - start_time} seconds")
 
 
 async def migrate_is_my_offer(log: logging.Logger, db_connection: aiosqlite.Connection) -> None:
@@ -78,6 +108,28 @@ class TradeStore:
                 )
             )
 
+            await conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS coin_of_interest_to_trade_record("
+                    " trade_id text,"
+                    " coin_id blob,"
+                    " coin blob )"
+                )
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS coin_to_trade_record_index on "
+                "coin_of_interest_to_trade_record(trade_id, coin_id)"
+            )
+
+            trades_not_emtpy = await (await conn.execute("SELECT trade_id FROM trade_records LIMIT 1")).fetchone()
+            coins_emtpy = not await (
+                await conn.execute("SELECT coin_id FROM coin_of_interest_to_trade_record LIMIT 1")
+            ).fetchone()
+            # run migration if we find any existing rows in trade records
+            if trades_not_emtpy and coins_emtpy:
+                migrate_coin_of_interest_col = True
+            else:
+                migrate_coin_of_interest_col = False
             # Attempt to add the is_my_offer column. If successful, migrate is_my_offer to the new column.
             needs_is_my_offer_migration: bool = False
             try:
@@ -92,6 +144,8 @@ class TradeStore:
 
             if needs_is_my_offer_migration:
                 await migrate_is_my_offer(self.log, conn)
+            if migrate_coin_of_interest_col:
+                await migrate_coin_of_interest(self.log, conn)
 
         return self
 
@@ -115,6 +169,17 @@ class TradeStore:
                 ),
             )
             await cursor.close()
+            # remove all current coin ids
+            await conn.execute(
+                "DELETE FROM coin_of_interest_to_trade_record WHERE trade_id=?", (record.trade_id.hex(),)
+            )
+            # now recreate them all
+            inserts: List[Tuple[bytes32, bytes, str]] = []
+            for coin in record.coins_of_interest:
+                inserts.append((coin.name(), coin.to_bytes(), record.trade_id.hex()))
+            await conn.executemany(
+                "INSERT INTO coin_of_interest_to_trade_record " "(coin_id, coin, trade_id) " "VALUES(?, ?, ?)", inserts
+            )
 
     async def set_status(self, trade_id: bytes32, status: TradeStatus, index: uint32 = uint32(0)):
         """
@@ -232,6 +297,25 @@ class TradeStore:
         records = []
         for row in rows:
             record = TradeRecord.from_bytes(row[0])
+            records.append(record)
+
+        return records
+
+    async def get_coins_of_interest_with_trade_statuses(self, trade_statuses: List[TradeStatus]) -> List[Coin]:
+        """
+        Checks DB for TradeRecord with id: id and returns it.
+        """
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            cursor = await conn.execute(
+                "SELECT distinct c.coin from coin_of_interest_to_trade_record c, trade_records t "
+                "WHERE t.status in (%s) AND c.trade_id = t.trade_id" % ",".join("?" * len(trade_statuses)),
+                ([x.value for x in trade_statuses]),
+            )
+            rows = await cursor.fetchall()
+            await cursor.close()
+        records = []
+        for row in rows:
+            record = Coin.from_bytes(row[0])
             records.append(record)
 
         return records

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -20,7 +20,7 @@ async def migrate_coin_of_interest(log: logging.Logger, db: aiosqlite.Connection
     start_time = perf_counter()
     rows = await db.execute_fetchall("SELECT trade_record, trade_id from trade_records")
 
-    inserts: List[Tuple[bytes32, bytes]] = []
+    inserts: List[Tuple[bytes32, bytes32]] = []
     for row in rows:
         record: TradeRecord = TradeRecord.from_bytes(row[0])
         for coin in record.coins_of_interest:
@@ -83,7 +83,7 @@ class TradeStore:
 
     @classmethod
     async def create(
-        cls, db_wrapper: DBWrapper2, cache_size: uint32 = uint32(600000), name: str = None
+        cls, db_wrapper: DBWrapper2, cache_size: uint32 = uint32(600000), name: Optional[str] = None
     ) -> "TradeStore":
         self = cls()
 
@@ -276,7 +276,7 @@ class TradeStore:
             row = await cursor.fetchone()
             await cursor.close()
         if row is not None:
-            record = TradeRecord.from_bytes(row[0])
+            record: TradeRecord = TradeRecord.from_bytes(row[0])
             return record
         return None
 
@@ -488,7 +488,7 @@ class TradeStore:
 
         return records
 
-    async def rollback_to_block(self, block_index):
+    async def rollback_to_block(self, block_index: int) -> None:
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             # Delete from storage

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1,13 +1,14 @@
-import sys
 import asyncio
 import dataclasses
 import logging
 import multiprocessing
 import random
+import sys
 import time
 import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
+
 from blspy import AugSchemeMPL, PrivateKey, G2Element, G1Element
 from packaging.version import Version
 
@@ -1233,8 +1234,8 @@ class WalletNode:
 
     async def get_coin_ids_to_subscribe(self, min_height: int) -> List[bytes32]:
         all_coin_names: Set[bytes32] = await self.wallet_state_manager.coin_store.get_coin_names_to_check(min_height)
-        removed_dict = await self.wallet_state_manager.trade_manager.get_coins_of_interest()
-        all_coin_names.update(removed_dict.keys())
+        removed_names = await self.wallet_state_manager.trade_manager.get_coins_of_interest()
+        all_coin_names.update(set(removed_names))
         all_coin_names.update(await self.wallet_state_manager.interested_store.get_interested_coin_ids())
         return list(all_coin_names)
 

--- a/tests/wallet/test_wallet_trade_store.py
+++ b/tests/wallet/test_wallet_trade_store.py
@@ -1,0 +1,70 @@
+import time
+from secrets import token_bytes
+
+import pytest
+
+from chia.types.blockchain_format.coin import Coin
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint32, uint64
+from chia.wallet.trade_record import TradeRecord
+from chia.wallet.trading.trade_status import TradeStatus
+from chia.wallet.trading.trade_store import TradeStore
+from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_coin_record import WalletCoinRecord
+from chia.wallet.wallet_coin_store import WalletCoinStore
+from tests.util.db_connection import DBConnection
+
+coin_1 = Coin(token_bytes(32), token_bytes(32), uint64(12311))
+coin_2 = Coin(coin_1.parent_coin_info, token_bytes(32), uint64(12312))
+coin_3 = Coin(coin_1.parent_coin_info, token_bytes(32), uint64(12313))
+record_1 = WalletCoinRecord(coin_1, uint32(4), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
+record_2 = WalletCoinRecord(coin_2, uint32(5), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
+record_3 = WalletCoinRecord(coin_3, uint32(6), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
+
+
+@pytest.mark.asyncio
+async def test_get_coins_of_interest_with_trade_statuses() -> None:
+    async with DBConnection(1) as db_wrapper:
+        coin_store = await WalletCoinStore.create(db_wrapper)
+        trade_store = await TradeStore.create(db_wrapper)
+        await coin_store.add_coin_record(record_1)
+        await coin_store.add_coin_record(record_2)
+        await coin_store.add_coin_record(record_3)
+
+        tr1_name: bytes32 = bytes32(token_bytes(32))
+        tr1 = TradeRecord(
+            confirmed_at_index=uint32(0),
+            accepted_at_time=None,
+            created_at_time=uint64(time.time()),
+            is_my_offer=True,
+            sent=uint32(0),
+            offer=bytes([1, 2, 3]),
+            taken_offer=None,
+            coins_of_interest=[coin_2],
+            trade_id=tr1_name,
+            status=uint32(TradeStatus.PENDING_ACCEPT.value),
+            sent_to=[],
+        )
+        await trade_store.add_trade_record(tr1)
+
+        tr2_name: bytes32 = bytes32(token_bytes(32))
+        tr2 = TradeRecord(
+            confirmed_at_index=uint32(0),
+            accepted_at_time=None,
+            created_at_time=uint64(time.time()),
+            is_my_offer=True,
+            sent=uint32(0),
+            offer=bytes([1, 2, 3]),
+            taken_offer=None,
+            coins_of_interest=[coin_1, coin_3],
+            trade_id=tr2_name,
+            status=uint32(TradeStatus.PENDING_CONFIRM.value),
+            sent_to=[],
+        )
+        await trade_store.add_trade_record(tr2)
+
+        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [
+            coin_1,
+            coin_3,
+        ]
+        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [coin_2]

--- a/tests/wallet/test_wallet_trade_store.py
+++ b/tests/wallet/test_wallet_trade_store.py
@@ -69,6 +69,24 @@ async def test_get_coins_of_interest_with_trade_statuses() -> None:
         ]
         assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [coin_2]
 
+        # test replace trade record
+        tr2_1 = TradeRecord(
+            confirmed_at_index=uint32(0),
+            accepted_at_time=None,
+            created_at_time=uint64(time.time()),
+            is_my_offer=True,
+            sent=uint32(0),
+            offer=bytes([1, 2, 3]),
+            taken_offer=None,
+            coins_of_interest=[coin_2],
+            trade_id=tr2_name,
+            status=uint32(TradeStatus.PENDING_CONFIRM.value),
+            sent_to=[],
+        )
+        await trade_store.add_trade_record(tr2_1)
+
+        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [coin_2]
+
         # test migration
         async with trade_store.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute("DELETE FROM coin_of_interest_to_trade_record")

--- a/tests/wallet/test_wallet_trade_store.py
+++ b/tests/wallet/test_wallet_trade_store.py
@@ -63,11 +63,13 @@ async def test_get_coins_of_interest_with_trade_statuses() -> None:
         )
         await trade_store.add_trade_record(tr2)
 
-        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [
-            coin_1,
-            coin_3,
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [
+            coin_1.name(),
+            coin_3.name(),
         ]
-        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [coin_2]
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [
+            coin_2.name()
+        ]
 
         # test replace trade record
         tr2_1 = TradeRecord(
@@ -85,15 +87,19 @@ async def test_get_coins_of_interest_with_trade_statuses() -> None:
         )
         await trade_store.add_trade_record(tr2_1)
 
-        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [coin_2]
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [
+            coin_2.name()
+        ]
 
         # test migration
         async with trade_store.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute("DELETE FROM coin_of_interest_to_trade_record")
 
-        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == []
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == []
 
         async with trade_store.db_wrapper.writer_maybe_transaction() as conn:
             await migrate_coin_of_interest(trade_store.log, conn)
 
-        assert await trade_store.get_coins_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [coin_2]
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [
+            coin_2.name()
+        ]

--- a/tests/wallet/test_wallet_trade_store.py
+++ b/tests/wallet/test_wallet_trade_store.py
@@ -63,13 +63,13 @@ async def test_get_coins_of_interest_with_trade_statuses() -> None:
         )
         await trade_store.add_trade_record(tr2)
 
-        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == {
             coin_1.name(),
             coin_3.name(),
-        ]
-        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [
+        }
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == {
             coin_2.name()
-        ]
+        }
 
         # test replace trade record
         tr2_1 = TradeRecord(
@@ -87,19 +87,19 @@ async def test_get_coins_of_interest_with_trade_statuses() -> None:
         )
         await trade_store.add_trade_record(tr2_1)
 
-        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == [
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_CONFIRM]) == {
             coin_2.name()
-        ]
+        }
 
         # test migration
         async with trade_store.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute("DELETE FROM coin_of_interest_to_trade_record")
 
-        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == []
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == set()
 
         async with trade_store.db_wrapper.writer_maybe_transaction() as conn:
             await migrate_coin_of_interest(trade_store.log, conn)
 
-        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == [
+        assert await trade_store.get_coin_ids_of_interest_with_trade_statuses([TradeStatus.PENDING_ACCEPT]) == {
             coin_2.name()
-        ]
+        }


### PR DESCRIPTION
this one makes a big difference for users with a lot of offers (tested on bulk minter)

we currently load all trade records, extract their coins of interest and then filter through all. This patch creates a lookup table  so we can handle many more trade records as we're not loading everything in memory and reduces time complexity. 