### PR TITLE
tests: Wait for the expected `Receiver` in `Farmer.plot_sync_receivers`

### DIFF
--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -12,6 +12,7 @@ import pytest
 import pytest_asyncio
 
 from chia.consensus.coinbase import create_puzzlehash_for_pk
+from chia.farmer.farmer import Farmer
 from chia.plot_sync.receiver import Receiver
 from chia.plotting.util import add_plot_directory
 from chia.protocols import farmer_protocol
@@ -46,6 +47,15 @@ async def wait_for_plot_sync(receiver: Receiver, previous_last_sync_id: uint64) 
     def wait():
         current_last_sync_id = receiver.last_sync().sync_id
         return current_last_sync_id != 0 and current_last_sync_id != previous_last_sync_id
+
+    await time_out_assert(30, wait)
+
+
+async def wait_for_synced_receiver(farmer: Farmer, harvester_id: bytes32) -> None:
+    def wait():
+        return (
+            harvester_id in farmer.plot_sync_receivers and not farmer.plot_sync_receivers[harvester_id].initial_sync()
+        )
 
     await time_out_assert(30, wait)
 
@@ -490,6 +500,7 @@ async def test_farmer_get_harvester_plots_endpoints(
         expected_page_count = ceil(total_count / page_size)
         for page in range(expected_page_count):
             request = dataclasses.replace(request, page=uint32(page))
+            await wait_for_synced_receiver(farmer_service._api.farmer, harvester_id)
             page_result = await endpoint(farmer_rpc_client, request)
             offset = page * page_size
             expected_plots = plots[offset : offset + page_size]


### PR DESCRIPTION
This attempts to fix flakiness like in: https://github.com/Chia-Network/chia-blockchain/runs/7788054899

```
2022-08-11T13:44:30.2622222Z tests/core/test_farmer_harvester_rpc.py:493: in test_farmer_get_harvester_plots_endpoints
2022-08-11T13:44:30.2622847Z     page_result = await endpoint(farmer_rpc_client, request)
2022-08-11T13:44:30.2625859Z chia/rpc/farmer_rpc_client.py:70: in get_harvester_plots_keys_missing
2022-08-11T13:44:30.2626915Z     return await self.fetch("get_harvester_plots_keys_missing", dataclass_to_json_dict(request))
2022-08-11T13:44:30.2627361Z chia/rpc/rpc_client.py:49: in fetch
2022-08-11T13:44:30.2627696Z     raise ValueError(res_json)
2022-08-11T13:44:30.2629908Z E   ValueError: {'error': 'Receiver missing for 294e432c0891aedc586571384789c5897c6f6fd9930696e8d64bd2db69744fa1', 'success': False}
```

Actually this should only happen if the harvester gets disconnected from the farmer. Not sure why this would happen here in this test but with this PR it should wait until the farmer is back if this happens before it fires the RPC request.