### PR TITLE
instrumentation of asyncio tasks

### DIFF
--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 import sys
 from multiprocessing import freeze_support
@@ -85,6 +86,13 @@ async def async_main() -> int:
 
 def main() -> int:
     freeze_support()
+    if os.getenv("CHIA_INSTRUMENT_NODE", 0) != 0:
+        import atexit
+
+        from chia.util.task_timing import start_task_instrumentation, stop_task_instrumentation
+
+        start_task_instrumentation()
+        atexit.register(stop_task_instrumentation)
     return async_run(async_main())
 
 

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -1,4 +1,5 @@
 import pathlib
+import os
 from multiprocessing import freeze_support
 import sys
 from typing import Dict, Optional
@@ -112,6 +113,12 @@ async def async_main() -> int:
 
 def main() -> int:
     freeze_support()
+    if os.getenv("CHIA_INSTRUMENT_WALLET", 0) != 0:
+        from chia.util.task_timing import start_task_instrumentation, stop_task_instrumentation
+        import atexit
+
+        start_task_instrumentation()
+        atexit.register(stop_task_instrumentation)
     return async_run(async_main())
 
 

--- a/chia/util/task_timing.py
+++ b/chia/util/task_timing.py
@@ -246,10 +246,12 @@ def stop_task_instrumentation() -> None:
         total_duration = 0.0
         for name, fun_info in call_tree.items():
             total_duration = max(total_duration, fun_info.duration)
-        if total_duration == 0:
-            total_duration = 0.0000001
 
-        if len(call_tree) <= 1:
+        if total_duration < 0.001:
+            continue
+
+        # ignore trivial call trees
+        if len(call_tree) <= 2:
             continue
 
         filter_frames = set()
@@ -269,9 +271,9 @@ def stop_task_instrumentation() -> None:
                 f.write(
                     f'frame_{fun_info.fun_id} [shape=box, label="{fun_info.name}()\\l'
                     f"{fun_info.file}\\l"
-                    f"time: {fun_info.duration:0.3f}s\\l"
-                    f"calls:{fun_info.num_calls}\\l"
-                    f'percent: {percent}%\\l"]\n'
+                    f"{fun_info.duration*1000:0.2f}ms\\n"
+                    f"{fun_info.num_calls}x\\n"
+                    f'{percent}%"]\n'
                 )
 
             # print all edges (calls)
@@ -288,7 +290,7 @@ def stop_task_instrumentation() -> None:
                         continue
                     f.write(
                         f"frame_{caller_info.fun_id} -> frame_{fun_info.fun_id} "
-                        f'[label="{duration:0.3f}s",'
+                        f'[label="{duration*100/total_duration:0.3f}%",'
                         f"penwidth={0.5+(duration*6/total_duration):0.2f}]\n"
                     )
             f.write("}\n")

--- a/chia/util/task_timing.py
+++ b/chia/util/task_timing.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+import sys
+import time
+from types import FrameType
+from typing import Any, Dict, List
+
+# This is a development utility that instruments tasks (coroutines) and records
+# wall-clock time they spend in various functions. Since it relies on
+# setprofile(), it cannot be combined with other profilers.
+
+# to enable this instrumentation, set one of the environment variables:
+
+#   CHIA_INSTRUMENT_NODE=1
+#   CHIA_INSTRUMENT_WALLET=1
+
+# Before starting the daemon.
+
+# When exiting, profiles will be written to the `task-profile-<pid>` directory.
+# To generate call trees, run:
+
+# python chia/util/task_timing.py task-profile-<pid>
+
+
+class FrameInfo:
+    call_timestamp: float
+    stack_pos: int
+
+    def __init__(self) -> None:
+        self.call_timestamp = 0.0
+        self.stack_pos = 0
+
+
+class TaskInfo:
+    stack: Dict[FrameType, FrameInfo]
+    stack_pos: int
+
+    def __init__(self) -> None:
+        self.stack = {}
+        self.stack_pos = 0
+
+
+g_next_id: int = 0
+
+
+class FunctionInfo:
+    name: str
+    file: str
+    num_calls: int
+    duration: float
+    callers: Dict[str, float]
+    fun_id: int
+
+    def __init__(self, name: str, file: str) -> None:
+        global g_next_id
+
+        self.name = name
+        self.file = file
+        self.num_calls = 0
+        self.duration = 0.0
+        self.callers = {}
+        self.fun_id = g_next_id
+        g_next_id += 1
+
+
+# maps tasks to call-treea
+g_function_infos: Dict[str, Dict[str, FunctionInfo]] = {}
+
+g_tasks: Dict[asyncio.Task[Any], TaskInfo] = {}
+
+g_cwd = os.getcwd() + "/"
+
+# the frame object has the following members:
+#   clear
+#   f_back
+#   f_builtins
+#   f_code (type: "code")
+#   f_globals
+#   f_lasti
+#   f_lineno
+#   f_locals
+#   f_trace
+#   f_trace_lines
+#   f_trace_opcodes
+
+# the code class has the following members:
+#   co_argcount
+#   co_cellvars
+#   co_code
+#   co_consts
+#   co_filename
+#   co_firstlineno
+#   co_flags
+#   co_freevars
+#   co_kwonlyargcount
+#   co_lnotab
+#   co_name
+#   co_names
+#   co_nlocals
+#   co_posonlyargcount
+#   co_stacksize
+#   co_varnames
+#   replace
+
+# documented here: https://docs.python.org/3/library/inspect.html
+
+
+def get_stack(frame: FrameType) -> str:
+    ret = ""
+    code = frame.f_code
+    while code.co_flags & inspect.CO_COROUTINE:  # pylint: disable=no-member
+        ret = f"/{code.co_name}{ret}"
+        if frame.f_back is None:
+            break
+        frame = frame.f_back
+        code = frame.f_code
+    return ret
+
+
+def strip_filename(name: str) -> str:
+    if "/site-packages/" in name:
+        return name.split("/site-packages/", 1)[1]
+    if "/lib/" in name:
+        return name.split("/lib/", 1)[1]
+    if name.startswith(g_cwd):
+        return name[len(g_cwd) :]
+    return name
+
+
+def get_fun(frame: FrameType) -> str:
+    code = frame.f_code
+    return f"{code.co_name}"
+
+
+def get_file(frame: FrameType) -> str:
+    code = frame.f_code
+    return f"{strip_filename(code.co_filename)}:{code.co_firstlineno}"
+
+
+def trace_fun(frame: FrameType, event: str, arg: Any) -> None:
+
+    if event in ["c_call", "c_return", "c_exception"]:
+        return
+
+    # we only care about instrumenting co-routines
+    if (frame.f_code.co_flags & inspect.CO_COROUTINE) == 0:  # pylint: disable=no-member
+        # with open("instrumentation.log", "a") as f:
+        #    f.write(f"[1]    {event} {get_fun(frame)}\n")
+        return
+
+    task = asyncio.current_task()
+    if task is None:
+        return
+
+    global g_tasks
+    global g_function_infos
+
+    ti = g_tasks.get(task)
+    if ti is None:
+        ti = TaskInfo()
+        g_tasks[task] = ti
+
+    # t = f"{task.get_name()}"
+
+    if event == "call":
+        fi = ti.stack.get(frame)
+        if fi is not None:
+            ti.stack_pos = fi.stack_pos
+            # with open("instrumentation.log", "a") as f:
+            #    indent = " " * ti.stack_pos
+            #    f.write(f"{indent}RESUME {t} {get_stack(frame)}\n")
+        else:
+            fi = FrameInfo()
+            fi.stack_pos = ti.stack_pos
+            fi.call_timestamp = time.perf_counter()
+            ti.stack[frame] = fi
+            ti.stack_pos += 1
+
+    # indent = " " * ti.stack_pos
+    # with open("instrumentation.log", "a") as f:
+    #    f.write(f"{indent}CALL {t} {get_stack(frame)}\n")
+
+    elif event == "return":
+
+        fi = ti.stack.get(frame)
+        assert fi is not None
+
+        #        indent = " " * (fi.stack_pos)
+        if asyncio.isfuture(arg):
+            # this means the function was suspended
+            # don't pop it from the stack
+            pass
+            # with open("instrumentation.log", "a") as f:
+            #    f.write(f"{indent}SUSPEND {t} {get_stack(frame)}\n")
+        else:
+
+            # with open("instrumentation.log", "a") as f:
+            #    f.write(f"{indent}RETURN {t} {get_stack(frame)}\n")
+
+            now = time.perf_counter()
+            duration = now - fi.call_timestamp
+
+            task_name = task.get_name()
+            fun_name = get_fun(frame)
+            fun_file = get_file(frame)
+            task_tree = g_function_infos.get(task_name)
+            if task_tree is None:
+                task_tree = {}
+                g_function_infos[task_name] = task_tree
+            fun_info = task_tree.get(fun_file)
+            if fun_info is None:
+                fun_info = FunctionInfo(fun_name, fun_file)
+                task_tree[fun_file] = fun_info
+
+            if frame.f_back is not None:
+                n = get_file(frame.f_back)
+                if n in fun_info.callers:
+                    fun_info.callers[n] += duration
+                else:
+                    fun_info.callers[n] = duration
+            fun_info.num_calls += 1
+            fun_info.duration += duration
+
+            del ti.stack[frame]
+        ti.stack_pos = fi.stack_pos - 1
+
+
+def start_task_instrumentation() -> None:
+    sys.setprofile(trace_fun)
+
+
+def stop_task_instrumentation() -> None:
+    sys.setprofile(None)
+    global g_function_infos
+
+    target_dir = f"task-profile-{os.getpid()}"
+    try:
+        os.mkdir(target_dir)
+    except Exception:
+        pass
+    for task, call_tree in g_function_infos.items():
+        dot_file_name = f"{target_dir}/" + task + ".dot"
+        total_duration = 0.0
+        for name, fun_info in call_tree.items():
+            total_duration = max(total_duration, fun_info.duration)
+        if total_duration == 0:
+            total_duration = 0.0000001
+
+        if len(call_tree) <= 1:
+            continue
+
+        filter_frames = set()
+
+        with open(dot_file_name, "w") as f:
+            f.write("digraph {\n")
+
+            # print all nodes (functions)
+            for name, fun_info in call_tree.items():
+
+                # frames that are less than 0.1% of the total wall-clock time are
+                # filtered
+                if fun_info.duration / total_duration < 0.001:
+                    filter_frames.add(name)
+                    continue
+                percent = f"{fun_info.duration * 100 / total_duration:0.2f}"
+                f.write(
+                    f'frame_{fun_info.fun_id} [shape=box, label="{fun_info.name}()\\l'
+                    f"{fun_info.file}\\l"
+                    f"time: {fun_info.duration:0.3f}s\\l"
+                    f"calls:{fun_info.num_calls}\\l"
+                    f'percent: {percent}%\\l"]\n'
+                )
+
+            # print all edges (calls)
+            for name, fun_info in call_tree.items():
+
+                if name in filter_frames:
+                    continue
+
+                for caller, duration in fun_info.callers.items():
+                    caller_info = call_tree.get(caller)
+                    if caller_info is None:
+                        continue
+                    if caller_info.file in filter_frames:
+                        continue
+                    f.write(
+                        f"frame_{caller_info.fun_id} -> frame_{fun_info.fun_id} "
+                        f'[label="{duration:0.3f}s",'
+                        f"penwidth={0.5+(duration*6/total_duration):0.2f}]\n"
+                    )
+            f.write("}\n")
+
+
+if __name__ == "__main__":
+    import glob
+    import pathlib
+    import subprocess
+
+    profile_dir = pathlib.Path(sys.argv[1])
+    queue: List[subprocess.Popen[bytes]] = []
+    for file in glob.glob(str(profile_dir / "*.dot")):
+        print(file)
+        if os.path.exists(file + ".png"):
+            continue
+
+        if len(queue) > 15:
+            oldest = queue.pop(0)
+            oldest.wait()
+
+        with open(file + ".png", "w+") as f:
+            queue.append(subprocess.Popen(["dot", "-Tpng", file], stdout=f))
+
+    while len(queue) > 0:
+        oldest = queue.pop(0)
+        oldest.wait()

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1,3 +1,4 @@
+import sys
 import asyncio
 import dataclasses
 import logging
@@ -242,7 +243,10 @@ class WalletNode:
             return False
 
         if self.config.get("enable_profiler", False):
-            asyncio.create_task(profile_task(self.root_path, "wallet", self.log))
+            if sys.getprofile() is not None:
+                self.log.warn("not enabling profiler, getprofile() is already set")
+            else:
+                asyncio.create_task(profile_task(self.root_path, "wallet", self.log))
 
         path: Path = get_wallet_db_path(self.root_path, self.config, str(private_key.get_g1().get_fingerprint()))
         path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This adds a developer tool that measures where tasks spend their wall-clock time. This can help pin-point delays that are not caused by needing to use a lot of CPU.


Here's an example output from syncing the wallet:
![Task-33 dot](https://user-images.githubusercontent.com/661450/185481915-dbb386ae-690e-4580-9b76-28fc9fd3a50f.png)

