### PR TITLE
daemon: Recover `sys.stdout.close()` call

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1363,7 +1363,7 @@ async def async_run_daemon(root_path: Path, wait_for_unlock: bool = False) -> in
             await ws_server.start()
             await shutdown_event.wait()
             log.info("Daemon WebSocketServer closed")
-            # sys.stdout.close()
+            sys.stdout.close()
             return 0
     except LockfileError:
         print("daemon: already launching")


### PR DESCRIPTION
Fixing the following output on macOS when starting/stopping the daemon on CLI:

```
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

This was commented out here https://github.com/Chia-Network/chia-blockchain/pull/7249/files#diff-b8e70126694c0407702f1d792f6b3845e9cb1e6b8a78f9387a368b3d9e8c9900R1164 (db87ff31372c6f13228175ea39e932ad4970f676 this commit), let me know if this was for some reason @paninaro.