### PR TITLE
Disable some tests

### DIFF
--- a/tests/core/test_merkle_set.py
+++ b/tests/core/test_merkle_set.py
@@ -304,6 +304,7 @@ def rand_hash(rng: random.Random) -> bytes32:
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip("This test is expensive and has already convinced us there are no discrepancies")
 async def test_merkle_set_random_regression():
     rng = random.Random()
     rng.seed(123456)

--- a/tests/util/test_full_block_utils.py
+++ b/tests/util/test_full_block_utils.py
@@ -233,24 +233,26 @@ def get_full_blocks() -> Iterator[FullBlock]:
                                     )
 
 
-class TestFullBlockParser:
-    @pytest.mark.asyncio
-    async def test_parser(self):
+@pytest.mark.asyncio
+@pytest.mark.skip("This test is expensive and has already convinced us the parser works")
+async def test_parser(self):
 
-        # loop over every combination of Optionals being set and not set
-        # along with random values for the FullBlock fields. Ensure
-        # generator_from_block() successfully parses out the generator object
-        # correctly
-        for block in get_full_blocks():
-            block_bytes = bytes(block)
-            gen = generator_from_block(block_bytes)
-            assert gen == block.transactions_generator
-            # this doubles the run-time of this test, with questionable utility
-            # assert gen == FullBlock.from_bytes(block_bytes).transactions_generator
+    # loop over every combination of Optionals being set and not set
+    # along with random values for the FullBlock fields. Ensure
+    # generator_from_block() successfully parses out the generator object
+    # correctly
+    for block in get_full_blocks():
+        block_bytes = bytes(block)
+        gen = generator_from_block(block_bytes)
+        assert gen == block.transactions_generator
+        # this doubles the run-time of this test, with questionable utility
+        # assert gen == FullBlock.from_bytes(block_bytes).transactions_generator
 
-    @pytest.mark.asyncio
-    async def test_header_block(self):
-        for block in get_full_blocks():
-            hb: HeaderBlock = get_block_header(block, [], [])
-            hb_bytes = header_block_from_block(memoryview(bytes(block)))
-            assert HeaderBlock.from_bytes(hb_bytes) == hb
+
+@pytest.mark.asyncio
+@pytest.mark.skip("This test is expensive and has already convinced us the parser works")
+async def test_header_block(self):
+    for block in get_full_blocks():
+        hb: HeaderBlock = get_block_header(block, [], [])
+        hb_bytes = header_block_from_block(memoryview(bytes(block)))
+        assert HeaderBlock.from_bytes(hb_bytes) == hb


### PR DESCRIPTION
This PR disables 3 tests.

* There's a test that came with the new `compute_merkle_set_root()` function, to ensure it computed the same root hash as the previous implementation. It might make sense to keep the test around, but disabled, in case we make changes to this function in the future. We still need the previous implementation, since it's used to *build* the merkle trees, the new function just *validates* a root.
* There's a fast "parser" for `FullBlock` structure, that skips fields rather than building a structure with the values. This is used in a few places where we're interested in just a few fields. It saves a lot of time. The test attempts to build an exhaustive set of all (interesting) `FullBlock` states to ensure the parser result matches the (slow) complete `FullBlock` parser. Building a large set of interesting `FullBlock` states will be handy in the future, so we should keep the code around, but we don't need to run this test at every CI run. It takes about 4 minutes on a fast machine. The two tests are for pulling out different parts of the full block.