### PR TITLE
Add `farmer-no-node` and `farmer-no-node-no-wallet` start modes

### DIFF
--- a/chia/util/service_groups.py
+++ b/chia/util/service_groups.py
@@ -5,6 +5,8 @@ SERVICES_FOR_GROUP = {
     "node": "chia_full_node".split(),
     "harvester": "chia_harvester".split(),
     "farmer": "chia_harvester chia_farmer chia_full_node chia_wallet".split(),
+    "farmer-no-node": "chia_harvester chia_farmer chia_wallet".split(),
+    "farmer-no-node-no-wallet": "chia_harvester chia_farmer".split(),
     "farmer-no-wallet": "chia_harvester chia_farmer chia_full_node".split(),
     "farmer-only": "chia_farmer".split(),
     "timelord": "chia_timelord_launcher chia_timelord chia_full_node".split(),


### PR DESCRIPTION
This add two new start modes, which are handy for chia-docker use:

- `farmer-no-node`: starts farmer + harvester + wallet
- `farmer-no-node-no-wallet`: starts farmer + harvester

This supplements `farmer` (farmer + harvester + node + wallet) and `farmer-only` (farmer) modes.