### PR TITLE
Fix several bugs with untrusted sync, and correct sync status

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -750,7 +750,7 @@ class PoolWallet:
             history: List[Tuple[uint32, CoinSpend]] = await self.get_spend_history()
             last_height: uint32 = history[-1][0]
             if (
-                self.wallet_state_manager.blockchain.get_peak_height()
+                await self.wallet_state_manager.blockchain.get_finished_sync_up_to()
                 <= last_height + current_state.current.relative_lock_height
             ):
                 raise ValueError(
@@ -786,7 +786,7 @@ class PoolWallet:
             history: List[Tuple[uint32, CoinSpend]] = await self.get_spend_history()
             last_height: uint32 = history[-1][0]
             if (
-                self.wallet_state_manager.blockchain.get_peak_height()
+                await self.wallet_state_manager.blockchain.get_finished_sync_up_to()
                 <= last_height + current_state.current.relative_lock_height
             ):
                 raise ValueError(

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -393,7 +393,9 @@ class WalletRpcApi:
     ##########################################################################################
 
     async def get_sync_status(self, request: Dict) -> EndpointResult:
-        syncing = self.service.wallet_state_manager.sync_mode
+        sync_mode = self.service.wallet_state_manager.sync_mode
+        has_pending_queue_items = self.service.new_peak_queue.has_pending_data_process_items()
+        syncing = sync_mode or has_pending_queue_items
         synced = await self.service.wallet_state_manager.synced()
         return {"synced": synced, "syncing": syncing, "genesis_initialized": True}
 

--- a/chia/wallet/util/new_peak_queue.py
+++ b/chia/wallet/util/new_peak_queue.py
@@ -53,18 +53,28 @@ class NewPeakItem:
 class NewPeakQueue:
     def __init__(self, inner_queue: asyncio.PriorityQueue):
         self._inner_queue: asyncio.PriorityQueue = inner_queue
+        self._pending_data_process_items: int = 0
 
     async def subscribe_to_coin_ids(self, coin_ids: List[bytes32]):
+        self._pending_data_process_items += 1
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.COIN_ID_SUBSCRIPTION, coin_ids))
 
     async def subscribe_to_puzzle_hashes(self, puzzle_hashes: List[bytes32]):
+        self._pending_data_process_items += 1
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION, puzzle_hashes))
 
     async def full_node_state_updated(self, coin_state_update: CoinStateUpdate, peer: WSChiaConnection):
+        self._pending_data_process_items += 1
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.FULL_NODE_STATE_UPDATED, (coin_state_update, peer)))
 
     async def new_peak_wallet(self, new_peak: NewPeakWallet, peer: WSChiaConnection):
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.NEW_PEAK_WALLET, (new_peak, peer)))
 
     async def get(self) -> NewPeakItem:
-        return await self._inner_queue.get()
+        item: NewPeakItem = await self._inner_queue.get()
+        if item.item_type != NewPeakQueueTypes.NEW_PEAK_WALLET:
+            self._pending_data_process_items -= 1
+        return item
+
+    def has_pending_data_process_items(self) -> bool:
+        return self._pending_data_process_items > 0

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -150,13 +150,6 @@ class WalletBlockchain(BlockchainInterface):
 
         await self._basic_store.remove_object("PEAK_BLOCK")
 
-    def get_peak_height(self) -> uint32:
-        # The peak height is the latest height that we know of in the blockchain, it does not mean
-        # that we have downloaded all transactions up to that height.
-        if self._peak is None:
-            return uint32(0)
-        return self._peak.height
-
     async def set_peak_block(self, block: HeaderBlock, timestamp: Optional[uint64] = None):
         await self._basic_store.set_object("PEAK_BLOCK", block)
         self._peak = block

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -689,7 +689,14 @@ class WalletNode:
 
         # If there is a fork, we need to ensure that we roll back in trusted mode to properly handle reorgs
         cache: PeerRequestCache = self.get_cache_for_peer(peer)
-        if trusted and fork_height is not None and height is not None and fork_height != height - 1:
+
+        if (
+            trusted
+            and fork_height is not None
+            and height is not None
+            and fork_height != height - 1
+            and peer.peer_node_id in self.synced_peers
+        ):
             # only one peer told us to rollback so only clear for that peer
             await self.perform_atomic_rollback(fork_height, cache=cache)
         else:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -766,9 +766,10 @@ class WalletNode:
                     try:
                         self.log.info(f"new coin state received ({idx}-" f"{idx + len(states) - 1}/ {len(items)})")
                         await self.wallet_state_manager.new_coin_state(states, peer, fork_height)
-                        await self.wallet_state_manager.blockchain.set_finished_sync_up_to(
-                            last_change_height_cs(states[-1]) - 1
-                        )
+                        if update_finished_height:
+                            await self.wallet_state_manager.blockchain.set_finished_sync_up_to(
+                                last_change_height_cs(states[-1]) - 1
+                            )
                     except Exception as e:
                         tb = traceback.format_exc()
                         self.log.error(f"Error adding states.. {e} {tb}")

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -995,7 +995,8 @@ class WalletNode:
 
         else:
             far_behind: bool = (
-                new_peak.height - self.wallet_state_manager.blockchain.get_peak_height() > self.LONG_SYNC_THRESHOLD
+                new_peak.height - await self.wallet_state_manager.blockchain.get_finished_sync_up_to()
+                > self.LONG_SYNC_THRESHOLD
             )
 
             # check if claimed peak is heavier or same as our current peak
@@ -1158,7 +1159,7 @@ class WalletNode:
 
         blocks.reverse()
         # Roll back coins and transactions
-        peak_height = self.wallet_state_manager.blockchain.get_peak_height()
+        peak_height = await self.wallet_state_manager.blockchain.get_finished_sync_up_to()
         if fork_height < peak_height:
             self.log.info(f"Rolling back to {fork_height}")
             # we should clear all peers since this is a full rollback

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -120,7 +120,7 @@ class WalletNode:
     node_peaks: Dict[bytes32, Tuple[uint32, bytes32]] = dataclasses.field(default_factory=dict)
     validation_semaphore: Optional[asyncio.Semaphore] = None
     local_node_synced: bool = False
-    LONG_SYNC_THRESHOLD: int = 200
+    LONG_SYNC_THRESHOLD: int = 300
     last_wallet_tx_resend_time: int = 0
     # Duration in seconds
     wallet_tx_resend_timeout_secs: int = 1800

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -507,8 +507,9 @@ class WalletStateManager:
             return False
 
         latest_timestamp = self.blockchain.get_latest_timestamp()
+        has_pending_queue_items = self.wallet_node.new_peak_queue.has_pending_data_process_items()
 
-        if latest_timestamp > int(time.time()) - 10 * 60:
+        if latest_timestamp > int(time.time()) - 5 * 60 and not has_pending_queue_items:
             return True
         return False
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -884,6 +884,17 @@ class WalletStateManager:
             local_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(coin_name)
             self.log.debug("%s: %s", coin_name, coin_state)
 
+            # If we already have this coin, and it was spent and confirmed at the same heights, then we return (done)
+            if local_record is not None:
+                local_spent = None
+                if local_record.spent_block_height != 0:
+                    local_spent = local_record.spent_block_height
+                if (
+                    local_spent == coin_state.spent_height
+                    and local_record.confirmed_block_height == coin_state.created_height
+                ):
+                    continue
+
             wallet_id: Optional[uint32] = None
             wallet_type: Optional[WalletType] = None
             if wallet_info is not None:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -884,17 +884,6 @@ class WalletStateManager:
             local_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(coin_name)
             self.log.debug("%s: %s", coin_name, coin_state)
 
-            # If we already have this coin, and it was spent and confirmed at the same heights, then we return (done)
-            if local_record is not None:
-                local_spent = None
-                if local_record.spent_block_height != 0:
-                    local_spent = local_record.spent_block_height
-                if (
-                    local_spent == coin_state.spent_height
-                    and local_record.confirmed_block_height == coin_state.created_height
-                ):
-                    continue
-
             wallet_id: Optional[uint32] = None
             wallet_type: Optional[WalletType] = None
             if wallet_info is not None:

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -15,7 +15,7 @@ from tests.util.misc import assert_runtime
 
 
 def wallet_height_at_least(wallet_node, h):
-    height = wallet_node.wallet_state_manager.blockchain.get_peak_height()
+    height = await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()
     if height == h:
         return True
     return False

--- a/tests/core/full_node/test_mempool_performance.py
+++ b/tests/core/full_node/test_mempool_performance.py
@@ -14,7 +14,7 @@ from chia.simulator.time_out_assert import time_out_assert
 from tests.util.misc import assert_runtime
 
 
-def wallet_height_at_least(wallet_node, h):
+async def wallet_height_at_least(wallet_node, h):
     height = await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()
     if height == h:
         return True

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -719,7 +719,7 @@ class TestPoolWalletRpc:
             assert bal["confirmed_wallet_balance"] == 0
             assert len(await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(2)) == 0
             assert (
-                wallet_node_0.wallet_state_manager.blockchain.get_peak_height()
+                await wallet_node_0.wallet_state_manager.blockchain.get_finished_sync_up_to()
                 == full_node_api.full_node.blockchain.get_peak().height
             )
             # Balance stars at 6 XCH and 5 more blocks are farmed, total 22 XCH

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -150,7 +150,9 @@ class TestPoolWalletRpc:
         )
         total_block_rewards = await get_total_block_rewards(PREFARMED_BLOCKS)
         await time_out_assert(20, wallet_0.get_confirmed_balance, total_block_rewards)
-        await time_out_assert(20, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
+        await time_out_assert(
+            20, wallet_node_0.wallet_state_manager.blockchain.get_finished_sync_up_to, PREFARMED_BLOCKS
+        )
 
         our_ph = await wallet_0.get_new_puzzlehash()
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
@@ -219,7 +221,9 @@ class TestPoolWalletRpc:
             PeerInfo(self_hostname, uint16(full_node_api.full_node.server._port)), None
         )
         total_block_rewards = await get_total_block_rewards(PREFARMED_BLOCKS)
-        await time_out_assert(20, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
+        await time_out_assert(
+            20, wallet_node_0.wallet_state_manager.blockchain.get_finished_sync_up_to, PREFARMED_BLOCKS
+        )
 
         await time_out_assert(20, wallet_0.get_confirmed_balance, total_block_rewards)
 
@@ -293,7 +297,9 @@ class TestPoolWalletRpc:
         total_block_rewards = await get_total_block_rewards(PREFARMED_BLOCKS)
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         await time_out_assert(20, wallet_0.get_confirmed_balance, total_block_rewards)
-        await time_out_assert(20, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
+        await time_out_assert(
+            20, wallet_node_0.wallet_state_manager.blockchain.get_finished_sync_up_to, PREFARMED_BLOCKS
+        )
         await time_out_assert(20, wallet_is_synced, True, wallet_node_0, full_node_api)
 
         our_ph_1 = await wallet_0.get_new_puzzlehash()
@@ -431,7 +437,9 @@ class TestPoolWalletRpc:
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         total_block_rewards = await get_total_block_rewards(PREFARMED_BLOCKS)
         await time_out_assert(20, wallet_0.get_confirmed_balance, total_block_rewards)
-        await time_out_assert(20, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
+        await time_out_assert(
+            20, wallet_node_0.wallet_state_manager.blockchain.get_finished_sync_up_to, PREFARMED_BLOCKS
+        )
 
         our_ph = await wallet_0.get_new_puzzlehash()
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
@@ -544,7 +552,9 @@ class TestPoolWalletRpc:
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         total_block_rewards = await get_total_block_rewards(PREFARMED_BLOCKS)
         await time_out_assert(20, wallet_0.get_confirmed_balance, total_block_rewards)
-        await time_out_assert(20, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
+        await time_out_assert(
+            20, wallet_node_0.wallet_state_manager.blockchain.get_finished_sync_up_to, PREFARMED_BLOCKS
+        )
 
         our_ph = await wallet_0.get_new_puzzlehash()
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
@@ -630,7 +640,9 @@ class TestPoolWalletRpc:
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
         total_block_rewards = await get_total_block_rewards(PREFARMED_BLOCKS)
         await time_out_assert(20, wallet_0.get_confirmed_balance, total_block_rewards)
-        await time_out_assert(20, wallet_node_0.wallet_state_manager.blockchain.get_peak_height, PREFARMED_BLOCKS)
+        await time_out_assert(
+            20, wallet_node_0.wallet_state_manager.blockchain.get_finished_sync_up_to, PREFARMED_BLOCKS
+        )
 
         await time_out_assert(20, wallet_is_synced, True, wallet_node_0, full_node_api)
         our_ph = await wallet_0.get_new_puzzlehash()

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -710,6 +710,7 @@ class TestPoolWalletRpc:
             assert bal["confirmed_wallet_balance"] == 0
 
             # Claim another 1.75
+            await time_out_assert(20, wallet_is_synced, True, wallet_node_0, full_node_api)
             ret = await client.pw_absorb_rewards(2, fee)
             absorb_tx: TransactionRecord = ret["transaction"]
             await time_out_assert(
@@ -868,6 +869,7 @@ class TestPoolWalletRpc:
                 fetched: Optional[TransactionRecord] = await client.get_transaction(wid, tx.name)
                 return fetched is not None and fetched.is_in_mempool()
 
+            await time_out_assert(20, wallet_is_synced, True, wallet_node_0, full_node_api)
             join_pool: Dict = await client.pw_join_pool(
                 wallet_id,
                 pool_ph,

--- a/tests/util/wallet_is_synced.py
+++ b/tests/util/wallet_is_synced.py
@@ -7,7 +7,8 @@ from chia.wallet.wallet_node import WalletNode
 async def wallet_is_synced(wallet_node: WalletNode, full_node_api: FullNodeAPI) -> bool:
     wallet_height = await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()
     full_node_height = full_node_api.full_node.blockchain.get_peak_height()
-    return wallet_height == full_node_height
+    has_pending_queue_items = wallet_node.new_peak_queue.has_pending_data_process_items()
+    return wallet_height == full_node_height and not has_pending_queue_items
 
 
 async def wallets_are_synced(wns: List[WalletNode], full_node_api: FullNodeAPI) -> bool:

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -24,6 +24,7 @@ from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_state_manager import WalletStateManager
+from tests.util.wallet_is_synced import wallet_is_synced
 
 
 async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:
@@ -363,6 +364,7 @@ async def test_nft_wallet_rpc_creation_and_list(two_wallet_nodes: Any, trusted: 
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
     await time_out_assert(30, wallet_node_0.wallet_state_manager.synced, True)
     api_0 = WalletRpcApi(wallet_node_0)
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     nft_wallet_0 = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(nft_wallet_0, dict)
     assert nft_wallet_0.get("success")
@@ -461,6 +463,7 @@ async def test_nft_wallet_rpc_update_metadata(two_wallet_nodes: Any, trusted: An
     api_0 = WalletRpcApi(wallet_node_0)
     await time_out_assert(30, wallet_node_0.wallet_state_manager.synced, True)
     await time_out_assert(30, wallet_node_1.wallet_state_manager.synced, True)
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     nft_wallet_0 = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(nft_wallet_0, dict)
     assert nft_wallet_0.get("success")
@@ -624,16 +627,19 @@ async def test_nft_with_did_wallet_creation(two_wallet_nodes: Any, trusted: Any)
     hex_did_id = did_wallet.get_my_DID()
     hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(wallet_node_0.config))
 
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id))
     assert isinstance(res, dict)
     assert res.get("success")
     nft_wallet_0_id = res["wallet_id"]
 
     # this shouldn't work
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id))
     assert res["wallet_id"] == nft_wallet_0_id
 
     # now create NFT wallet with P2 standard puzzle for inner puzzle
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 0"))
     assert res["wallet_id"] != nft_wallet_0_id
     nft_wallet_p2_puzzle = res["wallet_id"]
@@ -787,6 +793,7 @@ async def test_nft_rpc_mint(two_wallet_nodes: Any, trusted: Any) -> None:
     await time_out_assert(30, wallet_0.get_pending_change_balance, 0)
     did_id = encode_puzzle_hash(bytes32.from_hexstr(did_wallet.get_my_DID()), AddressType.DID.hrp(wallet_node_0.config))
 
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=did_id))
     assert isinstance(res, dict)
     assert res.get("success")
@@ -905,6 +912,7 @@ async def test_nft_transfer_nft_with_did(two_wallet_nodes: Any, trusted: Any) ->
     hex_did_id = did_wallet.get_my_DID()
     hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(wallet_node_0.config))
 
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id))
     assert isinstance(res, dict)
     assert res.get("success")
@@ -1056,6 +1064,7 @@ async def test_update_metadata_for_nft_did(two_wallet_nodes: Any, trusted: Any) 
     hex_did_id = did_wallet.get_my_DID()
     hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(wallet_node_0.config))
 
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id))
     assert isinstance(res, dict)
     assert res.get("success")
@@ -1181,6 +1190,7 @@ async def test_nft_set_did(two_wallet_nodes: Any, trusted: Any) -> None:
     hex_did_id = did_wallet.get_my_DID()
     hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(wallet_node_0.config))
 
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(res, dict)
     assert res.get("success")
@@ -1334,6 +1344,7 @@ async def test_set_nft_status(two_wallet_nodes: Any, trusted: Any) -> None:
 
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
+    await time_out_assert(30, wallet_is_synced, True, wallet_node_0, full_node_api)
     res = await api_0.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 1"))
     assert isinstance(res, dict)
     assert res.get("success")

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -540,6 +540,8 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
 
     # Creates a CAT wallet with 100 mojos and a CAT with 20 mojos
     await client.create_new_cat_and_wallet(uint64(100))
+    await time_out_assert(20, client.get_synced)
+
     res = await client.create_new_cat_and_wallet(uint64(20))
     assert res["success"]
     cat_0_id = res["wallet_id"]

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -27,7 +27,7 @@ from tests.util.wallet_is_synced import wallet_is_synced
 from tests.weight_proof.test_weight_proof import load_blocks_dont_validate
 
 
-def wallet_height_at_least(wallet_node, h):
+async def wallet_height_at_least(wallet_node, h):
     height = await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()
     if height == h:
         return True

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -28,7 +28,7 @@ from tests.weight_proof.test_weight_proof import load_blocks_dont_validate
 
 
 def wallet_height_at_least(wallet_node, h):
-    height = wallet_node.wallet_state_manager.blockchain.get_peak_height()
+    height = await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()
     if height == h:
         return True
     return False
@@ -302,7 +302,9 @@ class TestWalletSync:
         for wallet_node, wallet_server in wallets:
             await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
 
-            log.info(f"wallet node height is {wallet_node.wallet_state_manager.blockchain.get_peak_height()}")
+            log.info(
+                f"wallet node height is {await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()}"
+            )
             await time_out_assert(600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) - 1)
 
             await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -727,7 +727,7 @@ class TestWalletSimulator:
         await time_out_assert(20, wallet_2.get_confirmed_balance, 1000)
         funds -= 1000
 
-        await time_out_assert(20, wallet_node.wallet_state_manager.blockchain.get_peak_height, 7)
+        await time_out_assert(20, wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to, 7)
         peak = full_node_api.full_node.blockchain.get_peak()
         assert peak is not None
         peak_height = peak.height
@@ -746,7 +746,7 @@ class TestWalletSimulator:
         )
 
         await time_out_assert(20, full_node_api.full_node.blockchain.get_peak_height, peak_height + 3)
-        await time_out_assert(20, wallet_node.wallet_state_manager.blockchain.get_peak_height, peak_height + 3)
+        await time_out_assert(20, wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to, peak_height + 3)
 
         # Farm a few blocks so we can confirm the resubmitted transaction
         for i in range(0, num_blocks):

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -52,19 +52,19 @@ class TestWalletBlockchain:
             chain = await WalletBlockchain.create(store, test_constants)
 
             assert (await chain.get_peak_block()) is None
-            assert chain.get_peak_height() == 0
+            assert await chain.get_finished_sync_up_to() == 0
             assert chain.get_latest_timestamp() == 0
 
             await chain.new_valid_weight_proof(weight_proof, records)
             assert (await chain.get_peak_block()) is not None
-            assert chain.get_peak_height() == 499
+            assert await chain.get_finished_sync_up_to() == 499
             assert chain.get_latest_timestamp() > 0
 
             await chain.new_valid_weight_proof(weight_proof_short, records_short)
-            assert chain.get_peak_height() == 499
+            assert await chain.get_finished_sync_up_to() == 499
 
             await chain.new_valid_weight_proof(weight_proof_long, records_long)
-            assert chain.get_peak_height() == 505
+            assert await chain.get_finished_sync_up_to() == 505
 
             header_blocks = []
             for block in default_1000_blocks:
@@ -88,11 +88,11 @@ class TestWalletBlockchain:
             )
             assert res == ReceiveBlockResult.INVALID_BLOCK
 
-            assert chain.get_peak_height() == 505
+            assert await chain.get_finished_sync_up_to() == 505
 
             for block in header_blocks[506:]:
                 res, err = await chain.receive_block(block)
                 assert res == ReceiveBlockResult.NEW_PEAK
-                assert chain.get_peak_height() == block.height
+                assert await chain.get_finished_sync_up_to() == block.height
 
-            assert chain.get_peak_height() == 999
+            assert await chain.get_finished_sync_up_to() == 999

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -52,19 +52,18 @@ class TestWalletBlockchain:
             chain = await WalletBlockchain.create(store, test_constants)
 
             assert (await chain.get_peak_block()) is None
-            assert await chain.get_finished_sync_up_to() == 0
             assert chain.get_latest_timestamp() == 0
 
             await chain.new_valid_weight_proof(weight_proof, records)
             assert (await chain.get_peak_block()) is not None
-            assert await chain.get_finished_sync_up_to() == 499
+            assert (await chain.get_peak_block()).height == 499
             assert chain.get_latest_timestamp() > 0
 
             await chain.new_valid_weight_proof(weight_proof_short, records_short)
-            assert await chain.get_finished_sync_up_to() == 499
+            assert (await chain.get_peak_block()).height == 499
 
             await chain.new_valid_weight_proof(weight_proof_long, records_long)
-            assert await chain.get_finished_sync_up_to() == 505
+            assert (await chain.get_peak_block()).height == 505
 
             header_blocks = []
             for block in default_1000_blocks:
@@ -88,11 +87,11 @@ class TestWalletBlockchain:
             )
             assert res == ReceiveBlockResult.INVALID_BLOCK
 
-            assert await chain.get_finished_sync_up_to() == 505
+            assert (await chain.get_peak_block()).height == 505
 
             for block in header_blocks[506:]:
                 res, err = await chain.receive_block(block)
                 assert res == ReceiveBlockResult.NEW_PEAK
-                assert await chain.get_finished_sync_up_to() == block.height
+                assert (await chain.get_peak_block()).height == block.height
 
-            assert await chain.get_finished_sync_up_to() == 999
+            assert (await chain.get_peak_block()).height == 999


### PR DESCRIPTION
This should fix missing wallets and incorrect balance when local node is not synced, and wallet is connected to untrusted nodes.

## Fix 1
Scenario:
Global Blockchain is at 2.4 million height.
Local node is partially synced to 1.9 million. The wallet connects to the local node, and a few other untrusted nodes. The wallet subscribes to standard wallet puzzle hashes. The local node responds with some of the coins (only standard XCH at this point) up to it's synced height. The wallet DOES receive these states, even though local node isn't synced. Note that we are not checking for created CATs, NFT wallets, etc, since we aren't fully syncing, just responding to some PH subscriptions.
The wallet mistakenly sets `finished_sync_up_to`. (see the diff of this PR).
The wallet doesn't sync to the local node since it's not synced. But it starts syncing to another node.
Since the height is at 1.9 million, it will only process things that happened after that height. Since the CATs and NFT wallets were created at an earlier height, these are completely skipped. 
The height will be set to 2.4 million now.
secondary sync might find the missing items though.

## Fix 2
Even if the secondary sync finds the new stuff, there is another issue. The syncing full node will be sending state updates to the wallet whenever it sees a new TX. These state updates can trigger a rollback of DB to the fork point (which is the outdated local node's height) meaning all new stuff is reverted. 

## Fix 3
After rolling back, why didn't the new peaks from the untrusted peers trigger another long sync? The reason is that there are two peak heights in the wallet: `peak_height` and `finished_sync_up_to`. When we rollback, we only rollback the latter. however when we receive a new peak, we use the `peak_height`, which is not correct... I changed that in this PR. However this needs to be tested, as I'm not 100% sure all edge cases are covered.

## Fix 4
Don't show wallet synced until the wallet is actually synced. This means processing all pending subscriptions. 

## Fix 5
Change some constants to reduce issues. Only do a long sync if we are 300 blocks behind. Consider wallet "not synced" unless the latest peak is 5 old at most.

Going forward we need to change wallet sync to be reliable and do things in an established order, with correct behavior when things go wrong. Sync is way too complex, as can be seen by weird bugs like this.

TODO: add tests