### PR TITLE
 lookup the coin records in bulk

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -876,12 +876,16 @@ class WalletStateManager:
         used_up_to = -1
         ph_to_index_cache: LRUCache = LRUCache(100)
 
-        for coin_state in coin_states:
+        local_records: List[Optional[WalletCoinRecord]] = await self.coin_store.get_coin_records(
+            [st.coin.name() for st in coin_states]
+        )
+
+        assert len(local_records) == len(coin_states)
+        for coin_state, local_record in zip(coin_states, local_records):
             coin_name: bytes32 = coin_state.coin.name()
             wallet_info: Optional[Tuple[uint32, WalletType]] = await self.get_wallet_id_for_puzzle_hash(
                 coin_state.coin.puzzle_hash
             )
-            local_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(coin_name)
             self.log.debug("%s: %s", coin_name, coin_state)
 
             # If we already have this coin, and it was spent and confirmed at the same heights, then we return (done)
@@ -967,10 +971,10 @@ class WalletStateManager:
                     )
                     await self.coin_store.add_coin_record(record)
                     # Coin first received
-                    coin_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(
+                    parent_coin_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(
                         coin_state.coin.parent_coin_info
                     )
-                    if coin_record is not None and wallet_type.value == coin_record.wallet_type:
+                    if parent_coin_record is not None and wallet_type.value == parent_coin_record.wallet_type:
                         change = True
                     else:
                         change = False
@@ -1251,8 +1255,8 @@ class WalletStateManager:
             pool_reward = True
 
         farm_reward = False
-        coin_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(coin.parent_coin_info)
-        if coin_record is not None and wallet_type.value == coin_record.wallet_type:
+        parent_coin_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(coin.parent_coin_info)
+        if parent_coin_record is not None and wallet_type.value == parent_coin_record.wallet_type:
             change = True
         else:
             change = False

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -94,6 +94,20 @@ async def test_persistance() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bulk_get() -> None:
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletCoinStore.create(db_wrapper)
+        await store.add_coin_record(record_1)
+        await store.add_coin_record(record_2)
+        await store.add_coin_record(record_3)
+        await store.add_coin_record(record_4)
+
+        store = await WalletCoinStore.create(db_wrapper)
+        records = await store.get_coin_records([coin_1.name(), coin_2.name(), token_bytes(32), coin_4.name()])
+        assert records == [record_1, record_2, None, record_4]
+
+
+@pytest.mark.asyncio
 async def test_set_spent() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)


### PR DESCRIPTION
When adding coins to the wallet. This shaves off about 9% from sync-time the toilet wallet:

| operation | before | after | after / before |
| --- | --- | --- | --- |
| wallet sync | 89.77s | 81.85s | 91.2% |