### PR TITLE
Fix comments in initial config where puzzle hash should be receive address

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -202,7 +202,7 @@ harvester:
     key: "config/ssl/ca/chia_ca.key"
 
 pool:
-  # Replace this with a real puzzle hash
+  # Replace this with a real receive address
   # xch_target_address: txch102gkhhzs60grx7cfnpng5n6rjecr89r86l5s8xux2za8k820cxsq64ssdg
   logging: *logging
   network_overrides: *network_overrides
@@ -222,7 +222,7 @@ farmer:
 
   pool_public_keys: []
 
-  # Replace this with a real puzzle hash
+  # Replace this with a real receive address
   # xch_target_address: txch102gkhhzs60grx7cfnpng5n6rjecr89r86l5s8xux2za8k820cxsq64ssdg
 
   # If True, starts an RPC server at the following port


### PR DESCRIPTION
These instructions should be suggesting an address rather than a puzzle hash.