### PR TITLE
remove all_puzzle_hashes from wallet_puzzle_store

### DIFF
--- a/tests/wallet/test_puzzle_store.py
+++ b/tests/wallet/test_puzzle_store.py
@@ -55,17 +55,6 @@ class TestPuzzleStore:
 
             assert await db.puzzle_hash_exists(derivation_recs[0].puzzle_hash) is True
 
-            phs_1 = [derivation_recs[0].puzzle_hash]
-            phs_2 = [32 * bytes([1]), derivation_recs[0].puzzle_hash]
-            phs_3 = [derivation_recs[0].puzzle_hash, 32 * bytes([1])]
-            phs_4 = [32 * bytes([1]), 32 * bytes([2])]
-            phs_5 = []
-            assert await db.one_of_puzzle_hashes_exists(phs_1) is True
-            assert await db.one_of_puzzle_hashes_exists(phs_2) is True
-            assert await db.one_of_puzzle_hashes_exists(phs_3) is True
-            assert await db.one_of_puzzle_hashes_exists(phs_4) is False
-            assert await db.one_of_puzzle_hashes_exists(phs_5) is False
-
             assert await db.index_for_pubkey(derivation_recs[4].pubkey) == 2
             assert await db.index_for_puzzle_hash(derivation_recs[2].puzzle_hash) == 1
             assert await db.wallet_info_for_puzzle_hash(derivation_recs[2].puzzle_hash) == (


### PR DESCRIPTION
This is a simplification of this class ahead of optimizing it.

This patch:
* removes the ever-growing set of `all_puzzle_hashes`. The utility of this set seems quite questionable.
* removes the `one_of_puzzle_hashes_exists()` function (which seems to be the only reason why `all_puzzle_hashes` exists). This function is only used by a test.
* removes the test for `one_of_puzzle_hashes_exists()`