### PR TITLE
fix test flakes

### DIFF
--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -71,8 +71,10 @@ async def farm_transaction_block(full_node_api: FullNodeSimulator, wallet_node: 
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
     await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
 
-async def check_spends_in_mempool(full_node_api: FullNodeSimulator, num_of_spends = 1):
+
+async def check_spends_in_mempool(full_node_api: FullNodeSimulator, num_of_spends=1):
     return len(full_node_api.full_node.mempool_manager.mempool.sorted_spends) == num_of_spends
+
 
 async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: WalletNode, spend_bundle: SpendBundle):
     await time_out_assert(

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -904,6 +904,7 @@ async def test_nft_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert res["success"]
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
     await farm_transaction_block(full_node_api, wallet_1_node)
+    await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 0)
     await time_out_assert(5, wallet_is_synced, True, wallet_1_node, full_node_api)
 
     nft_wallet_id_1 = (

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -84,16 +84,6 @@ async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: Wallet
     assert full_node_api.full_node.mempool_manager.get_spendbundle(spend_bundle.name()) is None
 
 
-async def wallet_height_exactly(wallet: WalletNode, h: uint64):
-    height = await wallet.wallet_state_manager.blockchain.get_finished_sync_up_to()
-    return height == h
-
-
-async def check_wallet_entries(wallet: WalletNode, wallet_type: WalletType) -> bool:
-    nft_wallets = await wallet.wallet_state_manager.get_all_wallet_info_entries(wallet_type=wallet_type)
-    return len(nft_wallets) > 0
-
-
 async def generate_funds(full_node_api: FullNodeSimulator, wallet_bundle: WalletBundle, num_blocks: int = 1):
     wallet_id = 1
     initial_balances = await wallet_bundle.rpc_client.get_wallet_balance(str(wallet_id))

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -572,7 +572,7 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert name == next(iter(DEFAULT_CATS.items()))[1]["name"]
 
     # TODO: Investigate why farming only one block here makes it flaky
-    for _ in range(5):
+    for _ in range(1):
         await farm_transaction_block(full_node_api, wallet_node)
 
     await time_out_assert(15, wallet_is_synced, True, wallet_node, full_node_api)
@@ -639,7 +639,7 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     cat_wallet_id = res["wallet_id"]
     cat_asset_id = bytes32.fromhex(res["asset_id"])
     # TODO: Investigate why farming only two blocks here makes it flaky
-    for _ in range(5):
+    for _ in range(1):
         await farm_transaction_block(full_node_api, wallet_node)
     await time_out_assert(15, wallet_is_synced, True, wallet_node, full_node_api)
     await time_out_assert(20, get_confirmed_balance, 20, wallet_1_rpc, cat_wallet_id)
@@ -757,7 +757,7 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     full_node_api: FullNodeSimulator = env.full_node.api
     wallet_1_id = wallet_1.id()
 
-    await generate_funds(env.full_node.api, env.wallet_1, 10)
+    await generate_funds(env.full_node.api, env.wallet_1, 5)
 
     # Create a DID wallet
     res = await wallet_1_rpc.create_new_did_wallet(amount=1, name="Profile 1")
@@ -790,7 +790,7 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     res = await wallet_1_rpc.create_did_backup_file(did_wallet_id_0, "backup.did")
     assert res["success"]
 
-    for _ in range(20):
+    for _ in range(3):
         await farm_transaction_block(full_node_api, wallet_1_node)
         import asyncio
 
@@ -883,7 +883,7 @@ async def test_nft_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     def have_nfts():
         return len(nft_wallet.get_current_nfts()) > 0
 
-    await time_out_assert(30, have_nfts, True)
+    await time_out_assert(15, have_nfts, True)
 
     # Test with the hex version of nft_id
     nft_id = nft_wallet.get_current_nfts()[0].coin.name().hex()

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -576,8 +576,8 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert name == next(iter(DEFAULT_CATS.items()))[1]["name"]
     await time_out_assert(5, check_spends_in_mempool, True, full_node_api)
     await farm_transaction_block(full_node_api, wallet_node)
-    await time_out_assert(5, wallet_is_synced, True, wallet_node, full_node_api)
-    await time_out_assert(5, get_confirmed_balance, 20, client, cat_0_id)
+    await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+    await time_out_assert(10, get_confirmed_balance, 20, client, cat_0_id)
     bal_0 = await client.get_wallet_balance(cat_0_id)
     assert bal_0["pending_coin_removal_count"] == 0
     assert bal_0["unspent_coin_count"] == 1
@@ -790,12 +790,8 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     res = await wallet_1_rpc.create_did_backup_file(did_wallet_id_0, "backup.did")
     assert res["success"]
 
-    for _ in range(3):
-        await farm_transaction_block(full_node_api, wallet_1_node)
-        import asyncio
-
-        await asyncio.sleep(0.5)
-
+    await time_out_assert(5, check_spends_in_mempool, True, full_node_api)
+    await farm_transaction_block(full_node_api, wallet_1_node)
     # Update recovery list
     res = await wallet_1_rpc.update_did_recovery_list(did_wallet_id_0, [did_id_0], 1)
     assert res["success"]
@@ -803,8 +799,8 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert res["num_required"] == 1
     assert res["recovery_list"][0] == did_id_0
 
-    for _ in range(3):
-        await farm_transaction_block(full_node_api, wallet_1_node)
+    await time_out_assert(5, check_spends_in_mempool, True, full_node_api)
+    await farm_transaction_block(full_node_api, wallet_1_node)
 
     # Update metadata
     with pytest.raises(ValueError, match="Wallet with id 1 is not a DID one"):
@@ -812,22 +808,21 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     res = await wallet_1_rpc.update_did_metadata(did_wallet_id_0, {"Twitter": "Https://test"})
     assert res["success"]
 
-    for _ in range(3):
-        await farm_transaction_block(full_node_api, wallet_1_node)
+    await farm_transaction_block(full_node_api, wallet_1_node)
 
     res = await wallet_1_rpc.get_did_metadata(did_wallet_id_0)
     assert res["metadata"]["Twitter"] == "Https://test"
 
-    for _ in range(3):
-        await farm_transaction_block(full_node_api, wallet_1_node)
+    await time_out_assert(5, check_spends_in_mempool, True, full_node_api)
+    await farm_transaction_block(full_node_api, wallet_1_node)
 
     # Transfer DID
     addr = encode_puzzle_hash(await wallet_2.get_new_puzzlehash(), "txch")
     res = await wallet_1_rpc.did_transfer_did(did_wallet_id_0, addr, 0, True)
     assert res["success"]
 
-    for _ in range(3):
-        await farm_transaction_block(full_node_api, wallet_1_node)
+    await time_out_assert(5, check_spends_in_mempool, True, full_node_api)
+    await farm_transaction_block(full_node_api, wallet_1_node)
 
     async def num_wallets() -> int:
         return len(await wallet_2_node.wallet_state_manager.get_all_wallet_info_entries())

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -84,6 +84,16 @@ async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: Wallet
     assert full_node_api.full_node.mempool_manager.get_spendbundle(spend_bundle.name()) is None
 
 
+async def wallet_height_exactly(wallet: WalletNode, h: uint64):
+    height = await wallet.wallet_state_manager.blockchain.get_finished_sync_up_to()
+    return height == h
+
+
+async def check_wallet_entries(wallet: WalletNode, wallet_type: WalletType) -> bool:
+    nft_wallets = await wallet.wallet_state_manager.get_all_wallet_info_entries(wallet_type=wallet_type)
+    return len(nft_wallets) > 0
+
+
 async def generate_funds(full_node_api: FullNodeSimulator, wallet_bundle: WalletBundle, num_blocks: int = 1):
     wallet_id = 1
     initial_balances = await wallet_bundle.rpc_client.get_wallet_balance(str(wallet_id))
@@ -906,7 +916,7 @@ async def test_nft_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     await farm_transaction_block(full_node_api, wallet_1_node)
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 0)
     await time_out_assert(5, wallet_is_synced, True, wallet_1_node, full_node_api)
-
+    await time_out_assert(5, wallet_is_synced, True, wallet_2_node, full_node_api)
     nft_wallet_id_1 = (
         await wallet_2_node.wallet_state_manager.get_all_wallet_info_entries(wallet_type=WalletType.NFT)
     )[0].id

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1,4 +1,3 @@
-import asyncio
 import dataclasses
 import json
 import logging
@@ -73,7 +72,6 @@ async def farm_transaction_block(full_node_api: FullNodeSimulator, wallet_node: 
     await time_out_assert(20, wallet_is_synced, True, wallet_node, full_node_api)
 
 async def check_spends_in_mempool(full_node_api: FullNodeSimulator, num_of_spends = 1):
-    await asyncio.sleep(0.1)
     return len(full_node_api.full_node.mempool_manager.mempool.sorted_spends) == num_of_spends
 
 async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: WalletNode, spend_bundle: SpendBundle):


### PR DESCRIPTION
assert spend is in mempool before farming blocks

reduce farmed blocks in tests

reduce timeouts

make tests consistent