### PR TITLE
Remove "Total iterations since start" from chia show -s

### DIFF
--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -21,7 +21,6 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: Dict[st
     sub_slot_iters = blockchain_state["sub_slot_iters"]
     synced = blockchain_state["sync"]["synced"]
     sync_mode = blockchain_state["sync"]["sync_mode"]
-    total_iters = peak.total_iters if peak is not None else 0
     num_blocks: int = 10
     network_name = config["selected_network"]
     genesis_challenge = config["farmer"]["network_overrides"]["constants"][network_name]["GENESIS_CHALLENGE"]

--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -73,7 +73,6 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: Dict[st
         print(format_bytes(blockchain_state["space"]))
         print(f"Current difficulty: {difficulty}")
         print(f"Current VDF sub_slot_iters: {sub_slot_iters}")
-        print("Total iterations since the start of the blockchain:", total_iters)
         print("\n  Height: |   Hash:")
 
         added_blocks: List[BlockRecord] = []


### PR DESCRIPTION
Total iterations since start was very useful back in the beta/rc development days. However, the average farmer or node runner can go get such stats from an explorer and doesn't really care on a day to day monitoring basis. This also saves one line of terminal space.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/30377676/186990205-7ec0676f-867c-442b-9a06-fbc04462bb60.png">
