### PR TITLE
Fix missing wallet `state_changed` events

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -187,7 +187,12 @@ class WalletRpcApi:
             # Metrics is the only current consumer for this event
             payloads.append(create_payload_dict(change, change_data, self.service_name, "metrics"))
 
-        if "wallet_id" in change_data or "additional_data" in change_data:
+        if change in {
+            "offer_cancelled", "offer_added", "wallet_created", "did_coin_added",
+            "nft_coin_added", "nft_coin_removed", "nft_coin_updated", "nft_coin_did_set",
+            "new_block", "coin_removed", "coin_added", "new_derivation_index",
+            "added_stray_cat", "pending_transaction", "tx_update",
+        }:
             payloads.append(create_payload_dict("state_changed", change_data, self.service_name, "wallet_ui"))
 
         return payloads

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -188,10 +188,21 @@ class WalletRpcApi:
             payloads.append(create_payload_dict(change, change_data, self.service_name, "metrics"))
 
         if change in {
-            "offer_cancelled", "offer_added", "wallet_created", "did_coin_added",
-            "nft_coin_added", "nft_coin_removed", "nft_coin_updated", "nft_coin_did_set",
-            "new_block", "coin_removed", "coin_added", "new_derivation_index",
-            "added_stray_cat", "pending_transaction", "tx_update",
+            "offer_cancelled",
+            "offer_added",
+            "wallet_created",
+            "did_coin_added",
+            "nft_coin_added",
+            "nft_coin_removed",
+            "nft_coin_updated",
+            "nft_coin_did_set",
+            "new_block",
+            "coin_removed",
+            "coin_added",
+            "new_derivation_index",
+            "added_stray_cat",
+            "pending_transaction",
+            "tx_update",
         }:
             payloads.append(create_payload_dict("state_changed", change_data, self.service_name, "wallet_ui"))
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -490,13 +490,11 @@ class WalletStateManager:
         """
         if self.state_changed_callback is None:
             return None
-        change_data: Dict[str, Any] = {}
+        change_data: Dict[str, Any] = {"state": state}
         if wallet_id is not None:
             change_data["wallet_id"] = wallet_id
         if data_object is not None:
             change_data["additional_data"] = data_object
-        if len(change_data) > 0:
-            change_data["state"] = state
         self.state_changed_callback(state, change_data)
 
     def tx_pending_changed(self) -> None:


### PR DESCRIPTION
Fixed an issue where wallet `state_changed` events listed below were not notified to subscribers:
- wallet_created
- added_stray_cat
- offer_cancelled
- offer_added
- new_block