### PR TITLE
use rust parser for Program.from_bytes()

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 from typing import Callable, Dict, List, Set, Tuple, Optional, Any
 
@@ -32,11 +33,18 @@ class Program(SExp):
         sexp_to_stream(self, f)
 
     @classmethod
-    def from_bytes(cls, blob: bytes) -> "Program":
-        f = io.BytesIO(blob)
-        result = cls.parse(f)  # noqa
-        assert f.read() == b""
-        return result
+    def from_bytes(cls, blob: bytes) -> Program:
+        # this runs the program "1", which just returns the first arugment.
+        # the first argument is the buffer we want to parse. This effectively
+        # leverages the rust parser and LazyNode, making it a lot faster to
+        # parse serialized programs into a python compatible structure
+        cost, ret = run_chia_program(
+            b"\x01",
+            blob,
+            50,
+            0,
+        )
+        return Program.to(ret)
 
     @classmethod
     def fromhex(cls, hexstr: str) -> "Program":


### PR DESCRIPTION
This significantly speeds up parsing of puzzles in the wallet. Especially with generalized NFTs with nested puzzles.

I consider this a stop-gap until we get @richardkiss new clvm parser that's compatible with the existing python API.

To quantify this gain:

| call | before | after | after / before |
| --- | --- | --- | --- |
| Offer.from_bytes() | 8.05s | 6.55s | 81.4% |

note how the `to_program()` frame disappears from the profile:

before:
![offer-parsing-main](https://user-images.githubusercontent.com/661450/187070705-7e2b5803-2394-46c3-9f63-529b7a212406.png)

after:
![offer-parsing-patched](https://user-images.githubusercontent.com/661450/187070720-cf208e27-e638-4543-a8df-2e9833631db4.png)

