### PR TITLE
implement a more efficient Program.uncurry()

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import io
 from typing import Callable, Dict, List, Set, Tuple, Optional, Any
 
@@ -6,7 +7,6 @@ from clvm.casts import int_from_bytes
 from clvm.EvalError import EvalError
 from clvm.serialize import sexp_from_stream, sexp_to_stream
 from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, run_generator, tree_hash
-from clvm_tools.curry import uncurry
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.hash import std_hash
@@ -136,11 +136,37 @@ class Program(SExp):
             fixed_args = [4, (1, arg), fixed_args]
         return Program.to([2, (1, self), fixed_args])
 
-    def uncurry(self) -> Tuple["Program", "Program"]:
-        r = uncurry(self)
-        if r is None:
+    def uncurry(self) -> Tuple[Program, Program]:
+        def match(o: SExp, expected: bytes) -> None:
+            if o.atom != expected:
+                raise ValueError(f"expected: {expected.hex()}")
+
+        try:
+            # (2 (1 . <mod>) <args>)
+            ev, quoted_inner, args_list = self.as_iter()
+            match(ev, b"\x02")
+            match(quoted_inner.pair[0], b"\x01")
+            mod = quoted_inner.pair[1]
+            args = []
+            while args_list.pair is not None:
+                # (4 (1 . <arg>) <rest>)
+                cons, quoted_arg, rest = args_list.as_iter()
+                match(cons, b"\x04")
+                match(quoted_arg.pair[0], b"\x01")
+                args.append(quoted_arg.pair[1])
+                args_list = rest
+            match(args_list, b"\x01")
+            return Program.to(mod), Program.to(args)
+        except ValueError:  # too many values to unpack
+            # when unpacking as_iter()
+            # or when a match() fails
             return self, self.to(0)
-        return r
+        except TypeError:  # NoneType not subscriptable
+            # when an object is not a pair or atom as expected
+            return self, self.to(0)
+        except EvalError:  # first of non-cons
+            # when as_iter() fails
+            return self, self.to(0)
 
     def as_int(self) -> int:
         return int_from_bytes(self.as_atom())


### PR DESCRIPTION
This significantly speeds up parsing generalized offers, especially with nested puzzles. We do a lot of uncurrying when matching puzzles to types of coins.

This also drops the dependency of clvm_tools.uncurry.

To quantify the speed-up:

| call | before | after | after / before |
| --- | --- | --- | --- |
| Offer.from_bytes() | 7.8s | 3.73s | 47.8% |
| uncurry CPU | 53.93% | 5.24% | 9.72% |

before:
![offer-parsing-main](https://user-images.githubusercontent.com/661450/187071035-25d3af63-8aee-4af6-aef4-f45fa874764a.png)

after:

![offer-parsing-patched](https://user-images.githubusercontent.com/661450/187071042-8eeb496e-bd7d-4b12-88dd-30e636b7f948.png)

