### PR TITLE
don't run the get_offered_coins post-init check

### DIFF
--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -97,13 +97,6 @@ class Offer:
         return announcements
 
     def __post_init__(self) -> None:
-        # Verify that there is at least something being offered
-        offered_coins: Dict[Optional[bytes32], List[Coin]] = self.get_offered_coins()
-        if offered_coins == {}:
-            raise ValueError("Bundle is not offering anything")
-        if self.get_requested_payments() == {}:
-            raise ValueError("Bundle is not requesting anything")
-
         # Verify that there are no duplicate payments
         for payments in self.requested_payments.values():
             payment_programs: List[bytes32] = [p.name() for p in payments]


### PR DESCRIPTION
It's very expensive.

@Quexington Is this check a security feature? I get the impression it's mostly a debug assertion

To quantify the cost:

| operation | before | after | after / before |
| --- | --- | --- | --- |
| Offer.from_bytes() | 7.73s | 3.57s | 46.18% |


before:
![offer-parsing-main](https://user-images.githubusercontent.com/661450/187073839-5f3da1d8-b242-4249-9781-ff8e3992cbd1.png)

after:
![offer-parsing-patched](https://user-images.githubusercontent.com/661450/187073845-3fc75f02-c2ce-4a34-ba0c-2f862b15e3eb.png)

