### PR TITLE
introduce an UncurriedPuzzle class

### DIFF
--- a/chia/wallet/cat_wallet/cat_outer_puzzle.py
+++ b/chia/wallet/cat_wallet/cat_outer_puzzle.py
@@ -23,7 +23,7 @@ class CATOuterPuzzle:
     _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
-    _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
+    _get_inner_puzzle: Callable[[PuzzleInfo, UncurriedPuzzle], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
     def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
@@ -40,14 +40,14 @@ class CATOuterPuzzle:
             constructor_dict["also"] = next_constructor.info
         return PuzzleInfo(constructor_dict)
 
-    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
-        args = match_cat_puzzle(uncurry_puzzle(puzzle_reveal))
+    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
+        args = match_cat_puzzle(puzzle_reveal)
         if args is None:
             raise ValueError("This driver is not for the specified puzzle reveal")
         _, _, inner_puzzle = args
         also = constructor.also()
         if also is not None:
-            deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, inner_puzzle)
+            deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, uncurry_puzzle(inner_puzzle))
             return deep_inner_puzzle
         else:
             return inner_puzzle

--- a/chia/wallet/cat_wallet/cat_outer_puzzle.py
+++ b/chia/wallet/cat_wallet/cat_outer_puzzle.py
@@ -15,18 +15,19 @@ from chia.wallet.cat_wallet.cat_utils import (
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
 from chia.wallet.puzzles.cat_loader import CAT_MOD
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle, uncurry_puzzle
 
 
 @dataclass(frozen=True)
 class CATOuterPuzzle:
-    _match: Callable[[Program], Optional[PuzzleInfo]]
+    _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
     _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
-    def match(self, puzzle: Program) -> Optional[PuzzleInfo]:
-        args = match_cat_puzzle(*puzzle.uncurry())
+    def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
+        args = match_cat_puzzle(puzzle)
         if args is None:
             return None
         _, tail_hash, inner_puzzle = args
@@ -34,13 +35,13 @@ class CATOuterPuzzle:
             "type": "CAT",
             "tail": "0x" + tail_hash.as_python().hex(),
         }
-        next_constructor = self._match(inner_puzzle)
+        next_constructor = self._match(uncurry_puzzle(inner_puzzle))
         if next_constructor is not None:
             constructor_dict["also"] = next_constructor.info
         return PuzzleInfo(constructor_dict)
 
     def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
-        args = match_cat_puzzle(*puzzle_reveal.uncurry())
+        args = match_cat_puzzle(uncurry_puzzle(puzzle_reveal))
         if args is None:
             raise ValueError("This driver is not for the specified puzzle reveal")
         _, _, inner_puzzle = args
@@ -97,7 +98,7 @@ class CATOuterPuzzle:
             if also is not None:
                 puzzle = self._construct(also, puzzle)
                 solution = self._solve(also, solver, inner_puzzle, inner_solution)
-            args = match_cat_puzzle(*parent_spend.puzzle_reveal.to_program().uncurry())
+            args = match_cat_puzzle(uncurry_puzzle(parent_spend.puzzle_reveal.to_program()))
             assert args is not None
             _, _, parent_inner_puzzle = args
             spendable_cats.append(

--- a/chia/wallet/cat_wallet/cat_utils.py
+++ b/chia/wallet/cat_wallet/cat_utils.py
@@ -11,6 +11,7 @@ from chia.types.spend_bundle import CoinSpend, SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.cat_loader import CAT_MOD
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle
 
 NULL_SIGNATURE = G2Element()
 
@@ -30,13 +31,13 @@ class SpendableCAT:
     limitations_program_reveal: Program = Program.to([])
 
 
-def match_cat_puzzle(mod: Program, curried_args: Program) -> Optional[Iterator[Program]]:
+def match_cat_puzzle(puzzle: UncurriedPuzzle) -> Optional[Iterator[Program]]:
     """
     Given the curried puzzle and args, test if it's a CAT and,
     if it is, return the curried arguments
     """
-    if mod == CAT_MOD:
-        ret: Iterator[Program] = curried_args.as_iter()
+    if puzzle.mod == CAT_MOD:
+        ret: Iterator[Program] = puzzle.args.as_iter()
         return ret
     else:
         return None

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -53,6 +53,7 @@ from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
@@ -351,7 +352,7 @@ class CATWallet:
     async def puzzle_solution_received(self, coin_spend: CoinSpend, parent_coin: Coin) -> None:
         coin_name = coin_spend.coin.name()
         puzzle: Program = Program.from_bytes(bytes(coin_spend.puzzle_reveal))
-        args = match_cat_puzzle(*puzzle.uncurry())
+        args = match_cat_puzzle(uncurry_puzzle(puzzle))
         if args is not None:
             mod_hash, genesis_coin_checker_hash, inner_puzzle = args
             self.log.info(f"parent: {coin_name.hex()} inner_puzzle for parent is {inner_puzzle}")
@@ -469,7 +470,7 @@ class CATWallet:
     async def sign(self, spend_bundle: SpendBundle) -> SpendBundle:
         sigs: List[G2Element] = []
         for spend in spend_bundle.coin_spends:
-            args = match_cat_puzzle(*spend.puzzle_reveal.to_program().uncurry())
+            args = match_cat_puzzle(uncurry_puzzle(spend.puzzle_reveal.to_program()))
             if args is not None:
                 _, _, inner_puzzle = args
                 puzzle_hash = inner_puzzle.get_tree_hash()

--- a/chia/wallet/driver_protocol.py
+++ b/chia/wallet/driver_protocol.py
@@ -5,10 +5,11 @@ from typing_extensions import Protocol
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle
 
 
 class DriverProtocol(Protocol):
-    def match(self, puzzle: Program) -> Optional[PuzzleInfo]:
+    def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
         ...
 
     def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:

--- a/chia/wallet/driver_protocol.py
+++ b/chia/wallet/driver_protocol.py
@@ -12,7 +12,7 @@ class DriverProtocol(Protocol):
     def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
         ...
 
-    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
+    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
         ...
 
     def get_inner_solution(self, constructor: PuzzleInfo, solution: Program) -> Optional[Program]:

--- a/chia/wallet/nft_wallet/metadata_outer_puzzle.py
+++ b/chia/wallet/nft_wallet/metadata_outer_puzzle.py
@@ -9,15 +9,15 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint64
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
 from chia.wallet.puzzles.load_clvm import load_clvm
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle, uncurry_puzzle
 
 NFT_STATE_LAYER_MOD = load_clvm("nft_state_layer.clvm")
 NFT_STATE_LAYER_MOD_HASH = NFT_STATE_LAYER_MOD.get_tree_hash()
 
 
-def match_metadata_layer_puzzle(puzzle: Program) -> Tuple[bool, List[Program]]:
-    mod, meta_args = puzzle.uncurry()
-    if mod == NFT_STATE_LAYER_MOD:
-        return True, list(meta_args.as_iter())
+def match_metadata_layer_puzzle(puzzle: UncurriedPuzzle) -> Tuple[bool, List[Program]]:
+    if puzzle.mod == NFT_STATE_LAYER_MOD:
+        return True, list(puzzle.args.as_iter())
     return False, []
 
 
@@ -31,13 +31,13 @@ def solution_for_metadata_layer(amount: uint64, inner_solution: Program) -> Prog
 
 @dataclass(frozen=True)
 class MetadataOuterPuzzle:
-    _match: Callable[[Program], Optional[PuzzleInfo]]
+    _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
     _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
-    def match(self, puzzle: Program) -> Optional[PuzzleInfo]:
+    def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
         matched, curried_args = match_metadata_layer_puzzle(puzzle)
         if matched:
             _, metadata, updater_hash, inner_puzzle = curried_args
@@ -46,7 +46,7 @@ class MetadataOuterPuzzle:
                 "metadata": disassemble(metadata),  # type: ignore
                 "updater_hash": "0x" + updater_hash.as_python().hex(),
             }
-            next_constructor = self._match(inner_puzzle)
+            next_constructor = self._match(uncurry_puzzle(inner_puzzle))
             if next_constructor is not None:
                 constructor_dict["also"] = next_constructor.info
             return PuzzleInfo(constructor_dict)
@@ -64,7 +64,7 @@ class MetadataOuterPuzzle:
         return puzzle_for_metadata_layer(constructor["metadata"], constructor["updater_hash"], inner_puzzle)
 
     def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
-        matched, curried_args = match_metadata_layer_puzzle(puzzle_reveal)
+        matched, curried_args = match_metadata_layer_puzzle(uncurry_puzzle(puzzle_reveal))
         if matched:
             _, _, _, inner_puzzle = curried_args
             also = constructor.also()

--- a/chia/wallet/nft_wallet/metadata_outer_puzzle.py
+++ b/chia/wallet/nft_wallet/metadata_outer_puzzle.py
@@ -34,7 +34,7 @@ class MetadataOuterPuzzle:
     _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
-    _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
+    _get_inner_puzzle: Callable[[PuzzleInfo, UncurriedPuzzle], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
     def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
@@ -63,13 +63,13 @@ class MetadataOuterPuzzle:
             inner_puzzle = self._construct(also, inner_puzzle)
         return puzzle_for_metadata_layer(constructor["metadata"], constructor["updater_hash"], inner_puzzle)
 
-    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
-        matched, curried_args = match_metadata_layer_puzzle(uncurry_puzzle(puzzle_reveal))
+    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
+        matched, curried_args = match_metadata_layer_puzzle(puzzle_reveal)
         if matched:
             _, _, _, inner_puzzle = curried_args
             also = constructor.also()
             if also is not None:
-                deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, inner_puzzle)
+                deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, uncurry_puzzle(inner_puzzle))
                 return deep_inner_puzzle
             else:
                 return inner_puzzle

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -40,6 +40,7 @@ from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 _T_NFTWallet = TypeVar("_T_NFTWallet", bound="NFTWallet")
 
@@ -523,7 +524,7 @@ class NFTWallet:
         nft_coin: Optional[NFTCoinInfo] = self.get_nft(nft_id)
         if nft_coin is None:
             raise ValueError("An asset ID was specified that this wallet doesn't track")
-        puzzle_info: Optional[PuzzleInfo] = match_puzzle(nft_coin.full_puzzle)
+        puzzle_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_coin.full_puzzle))
         if puzzle_info is None:
             raise ValueError("Internal Error: NFT wallet is tracking a non NFT coin")
         else:

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -33,6 +33,7 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
 )
 from chia.wallet.trading.offer import OFFER_MOD, OFFER_MOD_HASH, NotarizedPayment, Offer
 from chia.wallet.transaction_record import TransactionRecord
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.debug_spend_bundle import disassemble
 from chia.wallet.util.transaction_type import TransactionType
@@ -40,7 +41,6 @@ from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
-from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 _T_NFTWallet = TypeVar("_T_NFTWallet", bound="NFTWallet")
 

--- a/chia/wallet/nft_wallet/ownership_outer_puzzle.py
+++ b/chia/wallet/nft_wallet/ownership_outer_puzzle.py
@@ -33,7 +33,7 @@ class OwnershipOuterPuzzle:
     _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
-    _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
+    _get_inner_puzzle: Callable[[PuzzleInfo, UncurriedPuzzle], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
     def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
@@ -70,13 +70,13 @@ class OwnershipOuterPuzzle:
             transfer_program = self._construct(transfer_program_info, inner_puzzle)
         return puzzle_for_ownership_layer(constructor["owner"], transfer_program, inner_puzzle)
 
-    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
-        matched, curried_args = match_ownership_layer_puzzle(uncurry_puzzle(puzzle_reveal))
+    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
+        matched, curried_args = match_ownership_layer_puzzle(puzzle_reveal)
         if matched:
             _, _, _, inner_puzzle = curried_args
             also = constructor.also()
             if also is not None:
-                deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, inner_puzzle)
+                deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, uncurry_puzzle(inner_puzzle))
                 return deep_inner_puzzle
             else:
                 return inner_puzzle

--- a/chia/wallet/nft_wallet/ownership_outer_puzzle.py
+++ b/chia/wallet/nft_wallet/ownership_outer_puzzle.py
@@ -7,14 +7,14 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
 from chia.wallet.puzzles.load_clvm import load_clvm
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle, uncurry_puzzle
 
 OWNERSHIP_LAYER_MOD = load_clvm("nft_ownership_layer.clvm")
 
 
-def match_ownership_layer_puzzle(puzzle: Program) -> Tuple[bool, List[Program]]:
-    mod, args = puzzle.uncurry()
-    if mod == OWNERSHIP_LAYER_MOD:
-        return True, list(args.as_iter())
+def match_ownership_layer_puzzle(puzzle: UncurriedPuzzle) -> Tuple[bool, List[Program]]:
+    if puzzle.mod == OWNERSHIP_LAYER_MOD:
+        return True, list(puzzle.args.as_iter())
     return False, []
 
 
@@ -30,18 +30,18 @@ def solution_for_ownership_layer(inner_solution: Program) -> Program:
 
 @dataclass(frozen=True)
 class OwnershipOuterPuzzle:
-    _match: Callable[[Program], Optional[PuzzleInfo]]
+    _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
     _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
-    def match(self, puzzle: Program) -> Optional[PuzzleInfo]:
+    def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
         matched, curried_args = match_ownership_layer_puzzle(puzzle)
         if matched:
             _, current_owner, transfer_program, inner_puzzle = curried_args
             owner_bytes: bytes = current_owner.as_python()
-            tp_match: Optional[PuzzleInfo] = self._match(transfer_program)
+            tp_match: Optional[PuzzleInfo] = self._match(uncurry_puzzle(transfer_program))
             constructor_dict = {
                 "type": "ownership",
                 "owner": "()" if owner_bytes == b"" else "0x" + owner_bytes.hex(),
@@ -49,7 +49,7 @@ class OwnershipOuterPuzzle:
                     disassemble(transfer_program) if tp_match is None else tp_match.info  # type: ignore
                 ),
             }
-            next_constructor = self._match(inner_puzzle)
+            next_constructor = self._match(uncurry_puzzle(inner_puzzle))
             if next_constructor is not None:
                 constructor_dict["also"] = next_constructor.info
             return PuzzleInfo(constructor_dict)
@@ -71,7 +71,7 @@ class OwnershipOuterPuzzle:
         return puzzle_for_ownership_layer(constructor["owner"], transfer_program, inner_puzzle)
 
     def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
-        matched, curried_args = match_ownership_layer_puzzle(puzzle_reveal)
+        matched, curried_args = match_ownership_layer_puzzle(uncurry_puzzle(puzzle_reveal))
         if matched:
             _, _, _, inner_puzzle = curried_args
             also = constructor.also()

--- a/chia/wallet/nft_wallet/singleton_outer_puzzle.py
+++ b/chia/wallet/nft_wallet/singleton_outer_puzzle.py
@@ -22,7 +22,7 @@ class SingletonOuterPuzzle:
     _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
-    _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
+    _get_inner_puzzle: Callable[[PuzzleInfo, UncurriedPuzzle], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
     def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
@@ -51,13 +51,13 @@ class SingletonOuterPuzzle:
         launcher_hash = constructor["launcher_ph"] if "launcher_ph" in constructor else SINGLETON_LAUNCHER_HASH
         return puzzle_for_singleton(constructor["launcher_id"], inner_puzzle, launcher_hash)
 
-    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
-        matched, curried_args = match_singleton_puzzle(uncurry_puzzle(puzzle_reveal))
+    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
+        matched, curried_args = match_singleton_puzzle(puzzle_reveal)
         if matched:
             _, inner_puzzle = curried_args
             also = constructor.also()
             if also is not None:
-                deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, inner_puzzle)
+                deep_inner_puzzle: Optional[Program] = self._get_inner_puzzle(also, uncurry_puzzle(inner_puzzle))
                 return deep_inner_puzzle
             else:
                 return inner_puzzle

--- a/chia/wallet/nft_wallet/transfer_program_puzzle.py
+++ b/chia/wallet/nft_wallet/transfer_program_puzzle.py
@@ -42,7 +42,7 @@ class TransferProgramPuzzle:
     _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
-    _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
+    _get_inner_puzzle: Callable[[PuzzleInfo, UncurriedPuzzle], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
     def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
@@ -67,7 +67,7 @@ class TransferProgramPuzzle:
             constructor["launcher_id"], constructor["royalty_address"], constructor["royalty_percentage"]
         )
 
-    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
+    def get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
         return None
 
     def get_inner_solution(self, constructor: PuzzleInfo, solution: Program) -> Optional[Program]:

--- a/chia/wallet/nft_wallet/transfer_program_puzzle.py
+++ b/chia/wallet/nft_wallet/transfer_program_puzzle.py
@@ -7,14 +7,14 @@ from chia.util.ints import uint16
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
 from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.wallet.puzzles.singleton_top_layer_v1_1 import SINGLETON_LAUNCHER_HASH, SINGLETON_MOD_HASH
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle
 
 TRANSFER_PROGRAM_MOD = load_clvm("nft_ownership_transfer_program_one_way_claim_with_royalties.clvm")
 
 
-def match_transfer_program_puzzle(puzzle: Program) -> Tuple[bool, List[Program]]:
-    mod, args = puzzle.uncurry()
-    if mod == TRANSFER_PROGRAM_MOD:
-        return True, list(args.as_iter())
+def match_transfer_program_puzzle(puzzle: UncurriedPuzzle) -> Tuple[bool, List[Program]]:
+    if puzzle.mod == TRANSFER_PROGRAM_MOD:
+        return True, list(puzzle.args.as_iter())
     return False, []
 
 
@@ -39,13 +39,13 @@ def solution_for_transfer_program(
 
 @dataclass(frozen=True)
 class TransferProgramPuzzle:
-    _match: Callable[[Program], Optional[PuzzleInfo]]
+    _match: Callable[[UncurriedPuzzle], Optional[PuzzleInfo]]
     _construct: Callable[[PuzzleInfo, Program], Program]
     _solve: Callable[[PuzzleInfo, Solver, Program, Program], Program]
     _get_inner_puzzle: Callable[[PuzzleInfo, Program], Optional[Program]]
     _get_inner_solution: Callable[[PuzzleInfo, Program], Optional[Program]]
 
-    def match(self, puzzle: Program) -> Optional[PuzzleInfo]:
+    def match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
         matched, curried_args = match_transfer_program_puzzle(puzzle)
         if matched:
             singleton_struct, royalty_puzzle_hash, percentage = curried_args

--- a/chia/wallet/outer_puzzles.py
+++ b/chia/wallet/outer_puzzles.py
@@ -18,7 +18,7 @@ This file provides a central location for acquiring drivers for outer puzzles li
 A driver for a puzzle must include the following functions:
   - match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]
     - Given a puzzle reveal, return a PuzzleInfo object that can be used to reconstruct it later
-  - get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
+  - get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
     - Given a PuzzleInfo object and a puzzle reveal, pull out this outer puzzle's inner puzzle
   - asset_id(self, constructor: PuzzleInfo) -> Optional[bytes32]
     - Given a PuzzleInfo object, generate a 32 byte ID for use in dictionaries, etc.
@@ -56,7 +56,7 @@ def solve_puzzle(constructor: PuzzleInfo, solver: Solver, inner_puzzle: Program,
     return driver_lookup[AssetType(constructor.type())].solve(constructor, solver, inner_puzzle, inner_solution)
 
 
-def get_inner_puzzle(constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
+def get_inner_puzzle(constructor: PuzzleInfo, puzzle_reveal: UncurriedPuzzle) -> Optional[Program]:
     return driver_lookup[AssetType(constructor.type())].get_inner_puzzle(constructor, puzzle_reveal)
 
 

--- a/chia/wallet/outer_puzzles.py
+++ b/chia/wallet/outer_puzzles.py
@@ -10,12 +10,13 @@ from chia.wallet.nft_wallet.ownership_outer_puzzle import OwnershipOuterPuzzle
 from chia.wallet.nft_wallet.singleton_outer_puzzle import SingletonOuterPuzzle
 from chia.wallet.nft_wallet.transfer_program_puzzle import TransferProgramPuzzle
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle
 
 """
 This file provides a central location for acquiring drivers for outer puzzles like CATs, NFTs, etc.
 
 A driver for a puzzle must include the following functions:
-  - match(self, puzzle: Program) -> Optional[PuzzleInfo]
+  - match(self, puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]
     - Given a puzzle reveal, return a PuzzleInfo object that can be used to reconstruct it later
   - get_inner_puzzle(self, constructor: PuzzleInfo, puzzle_reveal: Program) -> Optional[Program]:
     - Given a PuzzleInfo object and a puzzle reveal, pull out this outer puzzle's inner puzzle
@@ -39,7 +40,7 @@ class AssetType(Enum):
     ROYALTY_TRANSFER_PROGRAM = "royalty transfer program"
 
 
-def match_puzzle(puzzle: Program) -> Optional[PuzzleInfo]:
+def match_puzzle(puzzle: UncurriedPuzzle) -> Optional[PuzzleInfo]:
     for driver in driver_lookup.values():
         potential_info: Optional[PuzzleInfo] = driver.match(puzzle)
         if potential_info is not None:

--- a/chia/wallet/puzzles/singleton_top_layer_v1_1.py
+++ b/chia/wallet/puzzles/singleton_top_layer_v1_1.py
@@ -9,6 +9,7 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint64
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.load_clvm import load_clvm
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle
 
 SINGLETON_MOD = load_clvm("singleton_top_layer_v1_1.clvm")
 SINGLETON_MOD_HASH = SINGLETON_MOD.get_tree_hash()
@@ -157,10 +158,9 @@ MELT_CONDITION = [ConditionOpcode.CREATE_COIN, 0, ESCAPE_VALUE]
 #
 
 
-def match_singleton_puzzle(puzzle: Program) -> Tuple[bool, Iterator[Program]]:
-    mod, curried_args = puzzle.uncurry()
-    if mod == SINGLETON_MOD:
-        return True, curried_args.as_iter()
+def match_singleton_puzzle(puzzle: UncurriedPuzzle) -> Tuple[bool, Iterator[Program]]:
+    if puzzle.mod == SINGLETON_MOD:
+        return True, puzzle.args.as_iter()
     else:
         return False, iter(())
 

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -29,6 +29,7 @@ from chia.wallet.util.puzzle_compression import (
     decompress_object_with_puzzles,
     lowest_best_version,
 )
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 OFFER_MOD = load_clvm("settlement_payments.clvm")
 OFFER_MOD_HASH = OFFER_MOD.get_tree_hash()
@@ -143,7 +144,7 @@ class Offer:
             parent_solution: Program = parent_spend.solution.to_program()
             additions: List[Coin] = [a for a in parent_spend.additions() if a not in self.bundle.removals()]
 
-            puzzle_driver = match_puzzle(parent_puzzle)
+            puzzle_driver = match_puzzle(uncurry_puzzle(parent_puzzle))
             if puzzle_driver is not None:
                 asset_id = create_asset_id(puzzle_driver)
                 inner_puzzle: Optional[Program] = get_inner_puzzle(puzzle_driver, parent_puzzle)
@@ -443,7 +444,7 @@ class Offer:
         driver_dict: Dict[bytes32, PuzzleInfo] = {}
         leftover_coin_spends: List[CoinSpend] = []
         for coin_spend in bundle.coin_spends:
-            driver = match_puzzle(coin_spend.puzzle_reveal.to_program())
+            driver = match_puzzle(uncurry_puzzle(coin_spend.puzzle_reveal.to_program()))
             if driver is not None:
                 asset_id = create_asset_id(driver)
                 assert asset_id is not None

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -29,7 +29,7 @@ from chia.wallet.util.puzzle_compression import (
     decompress_object_with_puzzles,
     lowest_best_version,
 )
-from chia.wallet.uncurried_puzzle import uncurry_puzzle
+from chia.wallet.uncurried_puzzle import UncurriedPuzzle, uncurry_puzzle
 
 OFFER_MOD = load_clvm("settlement_payments.clvm")
 OFFER_MOD_HASH = OFFER_MOD.get_tree_hash()
@@ -140,11 +140,11 @@ class Offer:
         for parent_spend in self.bundle.coin_spends:
             coins_for_this_spend: List[Coin] = []
 
-            parent_puzzle: Program = parent_spend.puzzle_reveal.to_program()
+            parent_puzzle: UncurriedPuzzle = uncurry_puzzle(parent_spend.puzzle_reveal.to_program())
             parent_solution: Program = parent_spend.solution.to_program()
             additions: List[Coin] = [a for a in parent_spend.additions() if a not in self.bundle.removals()]
 
-            puzzle_driver = match_puzzle(uncurry_puzzle(parent_puzzle))
+            puzzle_driver = match_puzzle(parent_puzzle)
             if puzzle_driver is not None:
                 asset_id = create_asset_id(puzzle_driver)
                 inner_puzzle: Optional[Program] = get_inner_puzzle(puzzle_driver, parent_puzzle)

--- a/chia/wallet/uncurried_puzzle.py
+++ b/chia/wallet/uncurried_puzzle.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from chia.types.blockchain_format.program import Program
+
+
+@dataclass(frozen=True)
+class UncurriedPuzzle:
+    mod: Program
+    args: Program
+
+
+def uncurry_puzzle(puzzle: Program) -> UncurriedPuzzle:
+    return UncurriedPuzzle(*puzzle.uncurry())

--- a/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
+++ b/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
@@ -12,6 +12,7 @@ from chia.wallet.cat_wallet.cat_utils import construct_cat_puzzle
 from chia.wallet.outer_puzzles import construct_puzzle, get_inner_puzzle, get_inner_solution, match_puzzle, solve_puzzle
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
 from chia.wallet.puzzles.cat_loader import CAT_MOD
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 
 def test_cat_outer_puzzle() -> None:
@@ -19,7 +20,7 @@ def test_cat_outer_puzzle() -> None:
     tail = bytes32([0] * 32)
     cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, tail, ACS)
     double_cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, tail, cat_puzzle)
-    cat_driver: Optional[PuzzleInfo] = match_puzzle(double_cat_puzzle)
+    cat_driver: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(double_cat_puzzle))
 
     assert cat_driver is not None
     assert cat_driver.type() == "CAT"

--- a/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
+++ b/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
@@ -20,7 +20,8 @@ def test_cat_outer_puzzle() -> None:
     tail = bytes32([0] * 32)
     cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, tail, ACS)
     double_cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, tail, cat_puzzle)
-    cat_driver: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(double_cat_puzzle))
+    uncurried_cat_puzzle = uncurry_puzzle(double_cat_puzzle)
+    cat_driver: Optional[PuzzleInfo] = match_puzzle(uncurried_cat_puzzle)
 
     assert cat_driver is not None
     assert cat_driver.type() == "CAT"
@@ -30,7 +31,7 @@ def test_cat_outer_puzzle() -> None:
     assert inside_cat_driver.type() == "CAT"
     assert inside_cat_driver["tail"] == tail
     assert construct_puzzle(cat_driver, ACS) == double_cat_puzzle
-    assert get_inner_puzzle(cat_driver, double_cat_puzzle) == ACS
+    assert get_inner_puzzle(cat_driver, uncurried_cat_puzzle) == ACS
 
     # Set up for solve
     parent_coin = Coin(tail, double_cat_puzzle.get_tree_hash(), uint64(100))

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -21,8 +21,8 @@ from chia.wallet.outer_puzzles import create_asset_id, match_puzzle
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
-from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
+from chia.wallet.util.compute_memos import compute_memos
 
 # from clvm_tools.binutils import disassemble
 from tests.util.wallet_is_synced import wallets_are_synced

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -22,6 +22,7 @@ from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 # from clvm_tools.binutils import disassemble
 from tests.util.wallet_is_synced import wallets_are_synced
@@ -159,7 +160,7 @@ async def test_nft_offer_sell_nft(two_wallet_nodes: Any, trusted: Any) -> None:
     assert len(coins_taker) == 0
 
     nft_to_offer = coins_maker[0]
-    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_to_offer_asset_id: bytes32 = create_asset_id(nft_to_offer_info)  # type: ignore
     xch_requested = 1000
     maker_fee = uint64(433)
@@ -316,7 +317,7 @@ async def test_nft_offer_request_nft(two_wallet_nodes: Any, trusted: Any) -> Non
     assert len(coins_taker) == 1
 
     nft_to_request = coins_taker[0]
-    nft_to_request_info: Optional[PuzzleInfo] = match_puzzle(nft_to_request.full_puzzle)
+    nft_to_request_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_request.full_puzzle))
 
     assert isinstance(nft_to_request_info, PuzzleInfo)
     nft_to_request_asset_id = create_asset_id(nft_to_request_info)
@@ -491,7 +492,7 @@ async def test_nft_offer_sell_did_to_did(two_wallet_nodes: Any, trusted: Any) ->
     assert len(coins_taker) == 0
 
     nft_to_offer = coins_maker[0]
-    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_to_offer_asset_id: bytes32 = create_asset_id(nft_to_offer_info)  # type: ignore
     xch_requested = 1000
     maker_fee = uint64(433)
@@ -690,7 +691,7 @@ async def test_nft_offer_sell_nft_for_cat(two_wallet_nodes: Any, trusted: Any) -
     await time_out_assert(20, cat_wallet_maker.get_confirmed_balance, maker_cat_balance)
     await time_out_assert(20, cat_wallet_taker.get_confirmed_balance, taker_cat_balance)
     nft_to_offer = coins_maker[0]
-    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_to_offer_asset_id: bytes32 = create_asset_id(nft_to_offer_info)  # type: ignore
     cats_requested = 1000
     maker_fee = uint64(433)
@@ -892,7 +893,7 @@ async def test_nft_offer_request_nft_for_cat(two_wallet_nodes: Any, trusted: boo
     await time_out_assert(15, cat_wallet_taker.get_confirmed_balance, taker_cat_balance)
 
     nft_to_request = coins_taker[0]
-    nft_to_request_info: Optional[PuzzleInfo] = match_puzzle(nft_to_request.full_puzzle)
+    nft_to_request_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_request.full_puzzle))
     nft_to_request_asset_id: bytes32 = create_asset_id(nft_to_request_info)  # type: ignore
     cats_requested = 10000
     maker_fee = uint64(433)
@@ -1026,7 +1027,7 @@ async def test_nft_offer_sell_cancel(two_wallet_nodes: Any, trusted: Any) -> Non
     assert len(coins_maker) == 1
 
     nft_to_offer = coins_maker[0]
-    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_to_offer_asset_id: bytes32 = create_asset_id(nft_to_offer_info)  # type: ignore
     xch_requested = 1000
     maker_fee = uint64(433)
@@ -1147,7 +1148,7 @@ async def test_nft_offer_sell_cancel_in_batch(two_wallet_nodes: Any, trusted: An
     assert len(coins_maker) == 1
 
     nft_to_offer = coins_maker[0]
-    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_to_offer_asset_id: bytes32 = create_asset_id(nft_to_offer_info)  # type: ignore
     xch_requested = 1000
     maker_fee = uint64(433)
@@ -1367,8 +1368,8 @@ async def test_complex_nft_offer(two_wallet_nodes: Any, trusted: Any) -> None:
     }
 
     driver_dict = {
-        nft_to_offer_asset_id_taker_1: match_puzzle(nft_wallet_taker.my_nft_coins[0].full_puzzle),
-        nft_to_offer_asset_id_taker_2: match_puzzle(nft_wallet_taker.my_nft_coins[1].full_puzzle),
+        nft_to_offer_asset_id_taker_1: match_puzzle(uncurry_puzzle(nft_wallet_taker.my_nft_coins[0].full_puzzle)),
+        nft_to_offer_asset_id_taker_2: match_puzzle(uncurry_puzzle(nft_wallet_taker.my_nft_coins[1].full_puzzle)),
         bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): PuzzleInfo(
             {
                 "type": "CAT",

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -18,9 +18,9 @@ from chia.wallet.outer_puzzles import create_asset_id, match_puzzle
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from tests.util.wallet_is_synced import wallets_are_synced
 from tests.wallet.nft_wallet.test_nft_1_offers import mempool_not_empty
-from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 
 async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -20,6 +20,7 @@ from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
 from tests.util.wallet_is_synced import wallets_are_synced
 from tests.wallet.nft_wallet.test_nft_1_offers import mempool_not_empty
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 
 async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32) -> bool:
@@ -114,7 +115,7 @@ async def test_nft_offer_with_fee(two_wallet_nodes: Any, trusted: Any) -> None:
     taker_balance_pre = await wallet_taker.get_confirmed_balance()
 
     nft_to_offer = coins_maker[0]
-    nft_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_asset_id: bytes32 = create_asset_id(nft_info)  # type: ignore
     driver_dict: Dict[bytes32, Optional[PuzzleInfo]] = {nft_asset_id: nft_info}
 
@@ -163,7 +164,7 @@ async def test_nft_offer_with_fee(two_wallet_nodes: Any, trusted: Any) -> None:
     taker_balance_pre = await wallet_taker.get_confirmed_balance()
 
     nft_to_buy = coins_taker[0]
-    nft_to_buy_info: Optional[PuzzleInfo] = match_puzzle(nft_to_buy.full_puzzle)
+    nft_to_buy_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_buy.full_puzzle))
     nft_to_buy_asset_id: bytes32 = create_asset_id(nft_to_buy_info)  # type: ignore
     driver_dict_to_buy: Dict[bytes32, Optional[PuzzleInfo]] = {nft_to_buy_asset_id: nft_to_buy_info}
 
@@ -283,7 +284,7 @@ async def test_nft_offer_cancellations(two_wallet_nodes: Any, trusted: Any) -> N
     # taker_balance_pre = await wallet_taker.get_confirmed_balance()
 
     nft_to_offer = coins_maker[0]
-    nft_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_asset_id: bytes32 = create_asset_id(nft_info)  # type: ignore
     driver_dict: Dict[bytes32, Optional[PuzzleInfo]] = {nft_asset_id: nft_info}
 
@@ -413,7 +414,7 @@ async def test_nft_offer_with_metadata_update(two_wallet_nodes: Any, trusted: An
 
     coins_maker = nft_wallet_maker.my_nft_coins
     updated_nft = coins_maker[0]
-    updated_nft_info = match_puzzle(updated_nft.full_puzzle)
+    updated_nft_info = match_puzzle(uncurry_puzzle(updated_nft.full_puzzle))
 
     assert url_to_add in updated_nft_info.also().info["metadata"]  # type: ignore
 
@@ -422,7 +423,7 @@ async def test_nft_offer_with_metadata_update(two_wallet_nodes: Any, trusted: An
     taker_balance_pre = await wallet_taker.get_confirmed_balance()
 
     nft_to_offer = coins_maker[0]
-    nft_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_asset_id: bytes32 = create_asset_id(nft_info)  # type: ignore
     driver_dict: Dict[bytes32, Optional[PuzzleInfo]] = {nft_asset_id: nft_info}
 
@@ -579,7 +580,7 @@ async def test_nft_offer_nft_for_cat(two_wallet_nodes: Any, trusted: Any) -> Non
     taker_cat_taker_balance_pre = await cat_wallet_taker.get_confirmed_balance()
 
     nft_to_offer = coins_maker[0]
-    nft_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_asset_id: bytes32 = create_asset_id(nft_info)  # type: ignore
     driver_dict: Dict[bytes32, Optional[PuzzleInfo]] = {nft_asset_id: nft_info}
 
@@ -631,7 +632,7 @@ async def test_nft_offer_nft_for_cat(two_wallet_nodes: Any, trusted: Any) -> Non
     taker_cat_amount = 500
 
     nft_to_buy = coins_taker[0]
-    nft_to_buy_info: Optional[PuzzleInfo] = match_puzzle(nft_to_buy.full_puzzle)
+    nft_to_buy_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_buy.full_puzzle))
     nft_to_buy_asset_id: bytes32 = create_asset_id(nft_to_buy_info)  # type: ignore
 
     driver_dict_to_buy: Dict[bytes32, Optional[PuzzleInfo]] = {
@@ -773,11 +774,11 @@ async def test_nft_offer_nft_for_nft(two_wallet_nodes: Any, trusted: Any) -> Non
     taker_balance_pre = await wallet_taker.get_confirmed_balance()
 
     nft_to_offer = coins_maker[0]
-    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(nft_to_offer.full_puzzle)
+    nft_to_offer_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
     nft_to_offer_asset_id: bytes32 = create_asset_id(nft_to_offer_info)  # type: ignore
 
     nft_to_take = coins_taker[0]
-    nft_to_take_info: Optional[PuzzleInfo] = match_puzzle(nft_to_take.full_puzzle)
+    nft_to_take_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_take.full_puzzle))
     nft_to_take_asset_id: bytes32 = create_asset_id(nft_to_take_info)  # type: ignore
 
     driver_dict: Dict[bytes32, Optional[PuzzleInfo]] = {

--- a/tests/wallet/nft_wallet/test_nft_puzzles.py
+++ b/tests/wallet/nft_wallet/test_nft_puzzles.py
@@ -15,8 +15,8 @@ from chia.wallet.nft_wallet.nft_puzzles import (
 from chia.wallet.outer_puzzles import match_puzzle
 from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_for_pk, solution_for_conditions
-from tests.core.make_block_generator import int_to_public_key
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
+from tests.core.make_block_generator import int_to_public_key
 
 SINGLETON_MOD = load_clvm("singleton_top_layer_v1_1.clvm")
 LAUNCHER_PUZZLE = load_clvm("singleton_launcher.clvm")

--- a/tests/wallet/nft_wallet/test_nft_puzzles.py
+++ b/tests/wallet/nft_wallet/test_nft_puzzles.py
@@ -16,6 +16,7 @@ from chia.wallet.outer_puzzles import match_puzzle
 from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_for_pk, solution_for_conditions
 from tests.core.make_block_generator import int_to_public_key
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 SINGLETON_MOD = load_clvm("singleton_top_layer_v1_1.clvm")
 LAUNCHER_PUZZLE = load_clvm("singleton_launcher.clvm")
@@ -64,7 +65,7 @@ def test_nft_transfer_puzzle_hashes():
 
     nft_puz = SINGLETON_MOD.curry(SINGLETON_STRUCT, metadata_puz)
 
-    nft_info = match_puzzle(nft_puz)
+    nft_info = match_puzzle(uncurry_puzzle(nft_puz))
     assert nft_info.also().also() is not None
 
     unft = uncurry_nft.UncurriedNFT.uncurry(*nft_puz.uncurry())

--- a/tests/wallet/nft_wallet/test_ownership_outer_puzzle.py
+++ b/tests/wallet/nft_wallet/test_ownership_outer_puzzle.py
@@ -9,6 +9,7 @@ from chia.wallet.nft_wallet.ownership_outer_puzzle import puzzle_for_ownership_l
 from chia.wallet.nft_wallet.transfer_program_puzzle import puzzle_for_transfer_program
 from chia.wallet.outer_puzzles import construct_puzzle, get_inner_puzzle, get_inner_solution, match_puzzle, solve_puzzle
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 
 def test_ownership_outer_puzzle() -> None:
@@ -27,10 +28,10 @@ def test_ownership_outer_puzzle() -> None:
     ownership_puzzle: Program = puzzle_for_ownership_layer(owner, transfer_program, ACS)
     ownership_puzzle_empty: Program = puzzle_for_ownership_layer(NIL, transfer_program, ACS)
     ownership_puzzle_default: Program = puzzle_for_ownership_layer(owner, transfer_program_default, ACS)
-    ownership_driver: Optional[PuzzleInfo] = match_puzzle(ownership_puzzle)
-    ownership_driver_empty: Optional[PuzzleInfo] = match_puzzle(ownership_puzzle_empty)
-    ownership_driver_default: Optional[PuzzleInfo] = match_puzzle(ownership_puzzle_default)
-    transfer_program_driver: Optional[PuzzleInfo] = match_puzzle(transfer_program_default)
+    ownership_driver: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(ownership_puzzle))
+    ownership_driver_empty: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(ownership_puzzle_empty))
+    ownership_driver_default: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(ownership_puzzle_default))
+    transfer_program_driver: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(transfer_program_default))
 
     assert ownership_driver is not None
     assert ownership_driver_empty is not None

--- a/tests/wallet/nft_wallet/test_ownership_outer_puzzle.py
+++ b/tests/wallet/nft_wallet/test_ownership_outer_puzzle.py
@@ -49,7 +49,7 @@ def test_ownership_outer_puzzle() -> None:
     assert construct_puzzle(ownership_driver, ACS) == ownership_puzzle
     assert construct_puzzle(ownership_driver_empty, ACS) == ownership_puzzle_empty
     assert construct_puzzle(ownership_driver_default, ACS) == ownership_puzzle_default
-    assert get_inner_puzzle(ownership_driver, ownership_puzzle) == ACS
+    assert get_inner_puzzle(ownership_driver, uncurry_puzzle(ownership_puzzle)) == ACS
 
     # Set up for solve
     inner_solution = Program.to(

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -56,6 +56,7 @@ from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint32, uint64
 from chia.wallet.cat_wallet.cat_utils import match_cat_puzzle
+from chia.wallet.uncurried_puzzle import uncurry_puzzle
 
 
 @dataclass
@@ -106,7 +107,7 @@ def run_generator(block_generator: BlockGenerator, constants: ConsensusConstants
     for spend in coin_spends.as_iter():
 
         parent, puzzle, amount, solution = spend.as_iter()
-        args = match_cat_puzzle(*puzzle.uncurry())
+        args = match_cat_puzzle(uncurry_puzzle(puzzle))
 
         if args is None:
             continue


### PR DESCRIPTION
containing the mod and args from a puzzle that has already been uncurried. Pass this around to functions that want to access the uncurried puzzle, to avoid uncurrying the same puzzle multiple times.

This speeds up the wallet, especially for generalized NFTs where puzzles are matched against multiple kinds.

| call | before | after | after / before |
| --- | --- | --- | --- |
| Offer.from_bytes() |  7.82s |  4.99s | 63.81% |
| uncurry() CPU | 54% | 26.36% | 48.81% |
| uncurry() calls | 4600 | 1300 | 28.26% |

Since these measurements were made, other optimizations to `Offer.from_bytes()` as well as `uncurry()` have landed in `main`. The number of calls benchmark should still accurately represent the effect of this patch.

before:
![offer-parsing-main](https://user-images.githubusercontent.com/661450/187071515-bbbd78a7-817a-42b3-b412-096722a5efe0.png)


after:

![offer-parsing-patched](https://user-images.githubusercontent.com/661450/187071528-86136e3e-89e2-44a6-bab4-ebe0ff35c58f.png)

