### PR TITLE
fix performance issue in wallet with offers

### DIFF
--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -199,7 +199,7 @@ class TradeManager:
 
         coins_of_interest = []
         for trade_offer in all_pending:
-            coins_of_interest.extend([c.name() for c in Offer.from_bytes(trade_offer.offer).get_involved_coins()])
+            coins_of_interest.extend([c.name() for c in trade_offer.coins_of_interest])
 
         result = {}
         coin_records = await self.wallet_state_manager.coin_store.get_multiple_coin_records(coins_of_interest)


### PR DESCRIPTION
Skip parsing (and computing) offers just to get to the involved coins, instead use the DB field for coins_of_interest. This fixes a serious performance issue in wallets containing offers.

@Quexington please confirm that this field is in fact the same as what you get from `get_involved_coins()` on an offer.

| operation | before | after | after / before |
| -- | -- | -- | -- |
| chia wallet show | 376s | 0.75s | 0.2% |

Before this change, the wallet profile for `chia wallet show` in the test wallet looked like this:
![chia-hotspot-main](https://user-images.githubusercontent.com/661450/187076069-80f4a0e6-97f6-4706-b325-2e1285d4f97b.png)
