### PR TITLE
make setup.py more normal, except in our exceptional case

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -44,7 +44,7 @@ fi
 
 export BUILD_VDF_BENCH=Y # Installs the useful vdf_bench test of CPU squaring speed
 THE_PATH=$(python -c 'import pkg_resources; print( pkg_resources.get_distribution("chiavdf").location)' 2>/dev/null)/vdf_client
-CHIAVDF_VERSION=$(python -c 'from setup import dependencies; t = [_ for _ in dependencies if _.startswith("chiavdf")][0]; print(t)')
+CHIAVDF_VERSION=$(python -c 'import os; os.environ["CHIA_SKIP_SETUP"] = "1"; from setup import dependencies; t = [_ for _ in dependencies if _.startswith("chiavdf")][0]; print(t)')
 
 ubuntu_cmake_install() {
 	UBUNTU_PRE_2004=$(python -c 'import subprocess; process = subprocess.run(["lsb_release", "-rs"], stdout=subprocess.PIPE); print(float(process.stdout) < float(20.04))')

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import os
+
 from setuptools import setup
 
 dependencies = [
@@ -150,5 +152,5 @@ kwargs = dict(
 )
 
 
-if __name__ == "__main__":
+if len(os.environ.get("CHIA_SKIP_SETUP", "")) < 1:
     setup(**kwargs)  # type: ignore


### PR DESCRIPTION
There are multiple other more proper ways to address this, but this is a quick fix so that `setup.py` looks more like various other tooling expects it to.