### PR TITLE
Minimized a chance where `sudo` prompts users for password

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -186,6 +186,12 @@ find_openssl
 PACKAGE_INSTALL_REQUIRED=
 if [ -z "$INSTALL_PYTHON_PATH" ] || [ -z "$SQLITE_VERSION" ] || [ -z "$OPENSSL_VERSION_STRING" ]; then
   PACKAGE_INSTALL_REQUIRED=1
+elif $UBUNTU || $DEBIAN; then
+  # Even if python/sqlite/openssl are installed, Ubuntu and Debian need pythonXXX-venv package.
+  PYTHON_VENV_INSTALLED=$(dpkg-query -W python3\*-venv 2>/dev/null | wc -l)
+  if [ "$PYTHON_VENV_INSTALLED" -lt 1 ]; then
+    PACKAGE_INSTALL_REQUIRED=1
+  fi
 fi
 
 # Manage npm and other install requirements on an OS specific basis

--- a/install.sh
+++ b/install.sh
@@ -188,7 +188,7 @@ if [ -z "$INSTALL_PYTHON_PATH" ] || [ -z "$SQLITE_VERSION" ] || [ -z "$OPENSSL_V
   PACKAGE_INSTALL_REQUIRED=1
 elif $UBUNTU || $DEBIAN; then
   # Even if python/sqlite/openssl are installed, Ubuntu and Debian need pythonXXX-venv package.
-  PYTHON_VENV_INSTALLED=$(dpkg-query -W python3\*-venv 2>/dev/null | wc -l)
+  PYTHON_VENV_INSTALLED=$(dpkg -l | grep 'python3.*-venv' -c)
   if [ "$PYTHON_VENV_INSTALLED" -lt 1 ]; then
     PACKAGE_INSTALL_REQUIRED=1
   fi

--- a/install.sh
+++ b/install.sh
@@ -164,20 +164,24 @@ if [ -n "$INSTALL_PYTHON_VERSION" ]; then
 fi
 
 find_sqlite() {
+  set +e
   if [ -n "$INSTALL_PYTHON_PATH" ]; then
     # Check sqlite3 version bound to python
     SQLITE_VERSION=$($INSTALL_PYTHON_PATH -c 'import sqlite3; print(sqlite3.sqlite_version)')
     SQLITE_MAJOR_VER=$(echo "$SQLITE_VERSION" | cut -d'.' -f1)
     SQLITE_MINOR_VER=$(echo "$SQLITE_VERSION" | cut -d'.' -f2)
   fi
+  set -e
 }
 
 find_openssl() {
+  set +e
   if [ -n "$INSTALL_PYTHON_PATH" ]; then
     # Check openssl version python will use
     OPENSSL_VERSION_STRING=$($INSTALL_PYTHON_PATH -c 'import ssl; print(ssl.OPENSSL_VERSION)')
     OPENSSL_VERSION_INT=$($INSTALL_PYTHON_PATH -c 'import ssl; print(ssl.OPENSSL_VERSION_NUMBER)')
   fi
+  set -e
 }
 
 find_sqlite

--- a/install.sh
+++ b/install.sh
@@ -33,11 +33,6 @@ do
   esac
 done
 
-if [ -n "$EXTRAS" ] && [ "$SKIP_PACKAGE_INSTALL" = "1" ]; then
-  echo "-d and -s cannot be both specified at once"
-  exit 1
-fi
-
 UBUNTU=false
 DEBIAN=false
 if [ "$(uname)" = "Linux" ]; then

--- a/install.sh
+++ b/install.sh
@@ -188,7 +188,8 @@ if [ -z "$INSTALL_PYTHON_PATH" ] || [ -z "$SQLITE_VERSION" ] || [ -z "$OPENSSL_V
   PACKAGE_INSTALL_REQUIRED=1
 elif $UBUNTU || $DEBIAN; then
   # Even if python/sqlite/openssl are installed, Ubuntu and Debian need pythonXXX-venv package.
-  PYTHON_VENV_INSTALLED=$(dpkg -l | grep 'python3.*-venv' -c)
+  # `grep -c` returns exit code 1 if nothing matches, so adding `|| true` is required here.
+  PYTHON_VENV_INSTALLED=$(dpkg -l | grep 'python3.*-venv' -c) || true
   if [ "$PYTHON_VENV_INSTALLED" -lt 1 ]; then
     PACKAGE_INSTALL_REQUIRED=1
   fi

--- a/install.sh
+++ b/install.sh
@@ -3,10 +3,11 @@
 set -o errexit
 
 USAGE_TEXT="\
-Usage: $0 [-adh]
+Usage: $0 [-adsh]
 
   -a                          automated install, no questions
   -d                          install development dependencies
+  -s                          skip python package installation and just do pip install
   -h                          display this help and exit
 "
 
@@ -16,18 +17,26 @@ usage() {
 
 PACMAN_AUTOMATED=
 EXTRAS=
+SKIP_PACKAGE_INSTALL=
 
-while getopts adh flag
+while getopts adsh flag
 do
   case "${flag}" in
     # automated
     a) PACMAN_AUTOMATED=--noconfirm;;
     # development
     d) EXTRAS=${EXTRAS}dev,;;
+    # simple install
+    s) SKIP_PACKAGE_INSTALL=1;;
     h) usage; exit 0;;
     *) echo; usage; exit 1;;
   esac
 done
+
+if [ -n "$EXTRAS" ] && [ "$SKIP_PACKAGE_INSTALL" = "1" ]; then
+  echo "-d and -s cannot be both specified at once"
+  exit 1
+fi
 
 UBUNTU=false
 DEBIAN=false
@@ -122,20 +131,16 @@ install_python3_and_sqlite3_from_source_with_yum() {
   cd "$CURRENT_WD"
 }
 
-check_python_version() {
-  set +e
-  PYTHON_VERSION=$1
-  PYTHON_MAJOR_VER=$(echo "$PYTHON_VERSION" | cut -d'.' -f1)
-  PYTHON_MINOR_VER=$(echo "$PYTHON_VERSION" | cut -d'.' -f2)
-
-  if [ "$PYTHON_MAJOR_VER" -ne "3" ] || [ "$PYTHON_MINOR_VER" -lt "7" ] || [ "$PYTHON_MINOR_VER" -ge "11" ]; then
-    set -e
-    return 1
-  fi
-
-  set -e
-  return 0
-}
+# You can specify preferred python version by exporting `INSTALL_PYTHON_VERSION`
+# e.g. `export INSTALL_PYTHON_VERSION=3.8`
+INSTALL_PYTHON_PATH=
+PYTHON_MAJOR_VER=
+PYTHON_MINOR_VER=
+SQLITE_VERSION=
+SQLITE_MAJOR_VER=
+SQLITE_MINOR_VER=
+OPENSSL_VERSION_STRING=
+OPENSSL_VERSION_INT=
 
 find_python() {
   set +e
@@ -147,31 +152,16 @@ find_python() {
       fi
     fi
   done
-  echo $BEST_VERSION
+
+  if [ -n "$BEST_VERSION" ]; then
+    INSTALL_PYTHON_VERSION="$BEST_VERSION"
+    INSTALL_PYTHON_PATH=python${INSTALL_PYTHON_VERSION}
+    PY3_VER=$($INSTALL_PYTHON_PATH --version | cut -d ' ' -f2)
+    PYTHON_MAJOR_VER=$(echo "$PY3_VER" | cut -d'.' -f1)
+    PYTHON_MINOR_VER=$(echo "$PY3_VER" | cut -d'.' -f2)
+  fi
   set -e
 }
-
-INSTALL_PYTHON_PATH=
-SQLITE_VERSION=
-SQLITE_MAJOR_VER=
-SQLITE_MINOR_VER=
-OPENSSL_VERSION_STRING=
-OPENSSL_VERSION_INT=
-
-if [ -z "$INSTALL_PYTHON_VERSION" ]; then
-  INSTALL_PYTHON_VERSION=$(find_python)
-fi
-
-if [ -n "$INSTALL_PYTHON_VERSION" ]; then
-  INSTALL_PYTHON_PATH=python${INSTALL_PYTHON_VERSION}
-  PY3_VERSION=$($INSTALL_PYTHON_PATH --version | cut -d ' ' -f2)
-  check_python_version "$PY3_VERSION"
-  CHECK_PYTHON_VER_RESULT=$?
-  if [ "$CHECK_PYTHON_VER_RESULT" != "0" ]; then
-    INSTALL_PYTHON_VERSION=
-    INSTALL_PYTHON_PATH=
-  fi
-fi
 
 find_sqlite() {
   set +e
@@ -194,96 +184,79 @@ find_openssl() {
   set -e
 }
 
-find_sqlite
-find_openssl
-
-PACKAGE_INSTALL_REQUIRED=1
-if [ -n "$INSTALL_PYTHON_PATH" ] && [ -n "$SQLITE_VERSION" ] && [ -n "$OPENSSL_VERSION_STRING" ]; then
-  if $UBUNTU || $DEBIAN; then
-    # Even if python/sqlite/openssl are installed, Ubuntu and Debian need pythonXXX-venv package.
-    # `grep -c` returns exit code 1 if nothing matches, so adding `|| true` is required here.
-    PYTHON_VENV_INSTALLED=$(dpkg -l | grep 'python3.*-venv' -c) || true
-    if [ "$PYTHON_VENV_INSTALLED" -gt 0 ]; then
-      PACKAGE_INSTALL_REQUIRED=0
-    fi
-  else
-      PACKAGE_INSTALL_REQUIRED=0
-  fi
-fi
-
 # Manage npm and other install requirements on an OS specific basis
-if [ "$PACKAGE_INSTALL_REQUIRED" = "1" ]; then
-  if [ "$(uname)" = "Linux" ]; then
-    #LINUX=1
-    if [ "$UBUNTU_PRE_20" = "1" ]; then
-      # Ubuntu
-      echo "Installing on Ubuntu pre 20.*."
-      sudo apt-get update
-      # distutils must be installed as well to avoid a complaint about ensurepip while
-      # creating the venv.  This may be related to a mis-check while using or
-      # misconfiguration of the secondary Python version 3.7.  The primary is Python 3.6.
-      sudo apt-get install -y python3.7-venv python3.7-distutils openssl
-    elif [ "$UBUNTU_20" = "1" ]; then
-      echo "Installing on Ubuntu 20.*."
-      sudo apt-get update
-      sudo apt-get install -y python3.8-venv openssl
-    elif [ "$UBUNTU_21" = "1" ]; then
-      echo "Installing on Ubuntu 21.*."
-      sudo apt-get update
-      sudo apt-get install -y python3.9-venv openssl
-    elif [ "$UBUNTU_22" = "1" ]; then
-      echo "Installing on Ubuntu 22.* or newer."
-      sudo apt-get update
-      sudo apt-get install -y python3.10-venv openssl
-    elif [ "$DEBIAN" = "true" ]; then
-      echo "Installing on Debian."
-      sudo apt-get update
-      sudo apt-get install -y python3-venv openssl
-    elif type pacman >/dev/null 2>&1 && [ -f "/etc/arch-release" ]; then
-      # Arch Linux
-      # Arch provides latest python version. User will need to manually install python 3.9 if it is not present
-      echo "Installing on Arch Linux."
-      case $(uname -m) in
-        x86_64|aarch64)
-          sudo pacman ${PACMAN_AUTOMATED} -S --needed git openssl
-          ;;
-        *)
-          echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
-          exit 1
-          ;;
-      esac
-    elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
-      # AMZN 2
-      echo "Installing on Amazon Linux 2."
-      if ! command -v python3.9 >/dev/null 2>&1; then
-        install_python3_and_sqlite3_from_source_with_yum
-      fi
-    elif type yum >/dev/null 2>&1 && [ -f "/etc/centos-release" ]; then
-      # CentOS
-      echo "Install on CentOS."
-      if ! command -v python3.9 >/dev/null 2>&1; then
-        install_python3_and_sqlite3_from_source_with_yum
-      fi
-    elif type yum >/dev/null 2>&1 && [ -f "/etc/redhat-release" ] && grep Rocky /etc/redhat-release; then
-      echo "Installing on Rocky."
-      # TODO: make this smarter about getting the latest version
-      sudo yum install --assumeyes python39 openssl
-    elif type yum >/dev/null 2>&1 && [ -f "/etc/redhat-release" ] || [ -f "/etc/fedora-release" ]; then
-      # Redhat or Fedora
-      echo "Installing on Redhat/Fedora."
-      if ! command -v python3.9 >/dev/null 2>&1; then
-        sudo yum install -y python39 openssl
-      fi
+if [ "$SKIP_PACKAGE_INSTALL" = "1" ]; then
+  echo "Skipping system package installation"
+elif [ "$(uname)" = "Linux" ]; then
+  #LINUX=1
+  if [ "$UBUNTU_PRE_20" = "1" ]; then
+    # Ubuntu
+    echo "Installing on Ubuntu pre 20.*."
+    sudo apt-get update
+    # distutils must be installed as well to avoid a complaint about ensurepip while
+    # creating the venv.  This may be related to a mis-check while using or
+    # misconfiguration of the secondary Python version 3.7.  The primary is Python 3.6.
+    sudo apt-get install -y python3.7-venv python3.7-distutils openssl
+  elif [ "$UBUNTU_20" = "1" ]; then
+    echo "Installing on Ubuntu 20.*."
+    sudo apt-get update
+    sudo apt-get install -y python3.8-venv openssl
+  elif [ "$UBUNTU_21" = "1" ]; then
+    echo "Installing on Ubuntu 21.*."
+    sudo apt-get update
+    sudo apt-get install -y python3.9-venv openssl
+  elif [ "$UBUNTU_22" = "1" ]; then
+    echo "Installing on Ubuntu 22.* or newer."
+    sudo apt-get update
+    sudo apt-get install -y python3.10-venv openssl
+  elif [ "$DEBIAN" = "true" ]; then
+    echo "Installing on Debian."
+    sudo apt-get update
+    sudo apt-get install -y python3-venv openssl
+  elif type pacman >/dev/null 2>&1 && [ -f "/etc/arch-release" ]; then
+    # Arch Linux
+    # Arch provides latest python version. User will need to manually install python 3.9 if it is not present
+    echo "Installing on Arch Linux."
+    case $(uname -m) in
+      x86_64|aarch64)
+        sudo pacman ${PACMAN_AUTOMATED} -S --needed git openssl
+        ;;
+      *)
+        echo "Incompatible CPU architecture. Must be x86_64 or aarch64."
+        exit 1
+        ;;
+    esac
+  elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f "/etc/fedora-release" ]; then
+    # AMZN 2
+    echo "Installing on Amazon Linux 2."
+    if ! command -v python3.9 >/dev/null 2>&1; then
+      install_python3_and_sqlite3_from_source_with_yum
     fi
-  elif [ "$(uname)" = "Darwin" ]; then
-    echo "Installing on macOS."
-    if ! type brew >/dev/null 2>&1; then
-      echo "Installation currently requires brew on macOS - https://brew.sh/"
-      exit 1
+  elif type yum >/dev/null 2>&1 && [ -f "/etc/centos-release" ]; then
+    # CentOS
+    echo "Install on CentOS."
+    if ! command -v python3.9 >/dev/null 2>&1; then
+      install_python3_and_sqlite3_from_source_with_yum
     fi
-    echo "Installing OpenSSL"
-    brew install openssl
+  elif type yum >/dev/null 2>&1 && [ -f "/etc/redhat-release" ] && grep Rocky /etc/redhat-release; then
+    echo "Installing on Rocky."
+    # TODO: make this smarter about getting the latest version
+    sudo yum install --assumeyes python39 openssl
+  elif type yum >/dev/null 2>&1 && [ -f "/etc/redhat-release" ] || [ -f "/etc/fedora-release" ]; then
+    # Redhat or Fedora
+    echo "Installing on Redhat/Fedora."
+    if ! command -v python3.9 >/dev/null 2>&1; then
+      sudo yum install -y python39 openssl
+    fi
   fi
+elif [ "$(uname)" = "Darwin" ]; then
+  echo "Installing on macOS."
+  if ! type brew >/dev/null 2>&1; then
+    echo "Installation currently requires brew on macOS - https://brew.sh/"
+    exit 1
+  fi
+  echo "Installing OpenSSL"
+  brew install openssl
 fi
 
 if [ "$(uname)" = "OpenBSD" ]; then
@@ -294,26 +267,25 @@ elif [ "$(uname)" = "FreeBSD" ]; then
   export BUILD_VDF_CLIENT=${BUILD_VDF_CLIENT:-N}
 fi
 
-if [ "$PACKAGE_INSTALL_REQUIRED" = "1" ]; then
-  INSTALL_PYTHON_VERSION=$(find_python)
+if [ "$INSTALL_PYTHON_VERSION" = "" ]; then
+  echo "Searching available python executables..."
+  find_python
+else
+  echo "Python $INSTALL_PYTHON_VERSION is requested"
   INSTALL_PYTHON_PATH=python${INSTALL_PYTHON_VERSION}
-  if ! command -v "$INSTALL_PYTHON_PATH" >/dev/null; then
-    echo "${INSTALL_PYTHON_PATH} was not found"
-    exit 1
-  fi
+  PY3_VER=$($INSTALL_PYTHON_PATH --version | cut -d ' ' -f2)
+  PYTHON_MAJOR_VER=$(echo "$PY3_VER" | cut -d'.' -f1)
+  PYTHON_MINOR_VER=$(echo "$PY3_VER" | cut -d'.' -f2)
+fi
 
-  find_sqlite
-  find_openssl
-elif ! command -v "$INSTALL_PYTHON_PATH" >/dev/null; then
+if ! command -v "$INSTALL_PYTHON_PATH" >/dev/null; then
   echo "${INSTALL_PYTHON_PATH} was not found"
   exit 1
 fi
 
-check_python_version "$INSTALL_PYTHON_PATH"
-CHECK_PYTHON_VER_RESULT=$?
-if [ "$CHECK_PYTHON_VER_RESULT" != "0" ]; then
+if [ "$PYTHON_MAJOR_VER" -ne "3" ] || [ "$PYTHON_MINOR_VER" -lt "7" ] || [ "$PYTHON_MINOR_VER" -ge "11" ]; then
   echo "Chia requires Python version >= 3.7 and  < 3.11.0" >&2
-  echo "Current Python version = $PYTHON_VERSION" >&2
+  echo "Current Python version = $INSTALL_PYTHON_VERSION" >&2
   # If Arch, direct to Arch Wiki
   if type pacman >/dev/null 2>&1 && [ -f "/etc/arch-release" ]; then
     echo "Please see https://wiki.archlinux.org/title/python#Old_versions for support." >&2
@@ -323,6 +295,7 @@ if [ "$CHECK_PYTHON_VER_RESULT" != "0" ]; then
 fi
 echo "Python version is $INSTALL_PYTHON_VERSION"
 
+find_sqlite
 echo "SQLite version for Python is ${SQLITE_VERSION}"
 if [ "$SQLITE_MAJOR_VER" -lt "3" ] || [ "$SQLITE_MAJOR_VER" = "3" ] && [ "$SQLITE_MINOR_VER" -lt "8" ]; then
   echo "Only sqlite>=3.8 is supported"
@@ -331,6 +304,7 @@ fi
 
 # There is also ssl.OPENSSL_VERSION_INFO returning a tuple
 # 1.1.1n corresponds to 269488367 as an integer
+find_openssl
 echo "OpenSSL version for Python is ${OPENSSL_VERSION_STRING}"
 if [ "$OPENSSL_VERSION_INT" -lt "269488367" ]; then
   echo "WARNING: OpenSSL versions before 3.0.2, 1.1.1n, or 1.0.2zd are vulnerable to CVE-2022-0778"


### PR DESCRIPTION
If `python`, `sqlite`, `openssl` are already available, we don't need to run `sudo apt install xxx`.
This PR tries to minimize the chance to prompt users for their password.