### PR TITLE
Add a new protocol message for faster puzzle/solution fetching

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1283,8 +1283,7 @@ class FullNodeAPI:
         request: Union[wallet_protocol.RequestPuzzleSolution, wallet_protocol.RequestPuzzleSolutionWithCoinInfo],
     ) -> Optional[Message]:
         if isinstance(request, wallet_protocol.RequestPuzzleSolutionWithCoinInfo):
-            requested_coin = Coin(request.parent_id, request.puzzle_hash, request.amount)
-            coin_name: bytes32 = requested_coin.name()
+            coin_name: bytes32 = request.coin.name()
         else:
             coin_name = request.coin_name
         height = request.height
@@ -1307,7 +1306,7 @@ class FullNodeAPI:
         assert block_generator is not None
         if isinstance(request, wallet_protocol.RequestPuzzleSolutionWithCoinInfo):
             error, puzzle, solution = get_puzzle_and_solution_for_coin_with_full_info(
-                block_generator, requested_coin, self.full_node.constants.MAX_BLOCK_COST_CLVM
+                block_generator, request.coin, self.full_node.constants.MAX_BLOCK_COST_CLVM
             )
         else:
             error, puzzle, solution = get_puzzle_and_solution_for_coin(

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -87,18 +87,16 @@ def get_puzzle_and_solution_for_coin_with_full_info(generator: BlockGenerator, c
         requested_puzzle_hash = coin.puzzle_hash
         requested_amount = Program.to(coin.amount)
 
-        while True:
-            if coin_spend_list.pair is None:
-                raise ValueError(f"coin spend could not be found for coin {bytes32(coin.name())} in specified block")
-            coin_spend = coin_spend_list.first()
+        for spend in coin_spend_list.as_iter():
+            parent, puzzle, amount, solution = spend.as_iter()
             if (
-                coin_spend.at("f") == requested_parent
-                and coin_spend.at("rrf") == requested_amount
-                and coin_spend.at("rf").get_tree_hash() == requested_puzzle_hash  # tree hash last for performance
+                parent == requested_parent
+                and amount == requested_amount
+                and puzzle.get_tree_hash() == requested_puzzle_hash
             ):
-                return None, coin_spend.at("rf"), coin_spend.at("rrrf")
-            else:
-                coin_spend_list = coin_spend_list.rest()
+                return None, puzzle, solution
+
+        raise ValueError(f"coin spend could not be found for coin {bytes32(coin.name())} in specified block")
 
     except Exception as e:
         return e, None, None

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -13,11 +13,11 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64, uint16
 from chia.wallet.puzzles.generator_loader import GENERATOR_FOR_SINGLE_COIN_MOD
-from chia.wallet.puzzles.load_clvm import load_clvm
+from chia.wallet.puzzles.load_clvm import load_serialized_clvm
 from chia.wallet.puzzles.rom_bootstrap_generator import get_generator
 
 GENERATOR_MOD = get_generator()
-DESERIALIZE_MOD = load_clvm("chialisp_deserialisation.clvm", package_or_requirement="chia.wallet.puzzles")
+DESERIALIZE_MOD = load_serialized_clvm("chialisp_deserialisation.clvm", package_or_requirement="chia.wallet.puzzles")
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def get_puzzle_and_solution_for_coin_with_full_info(generator: BlockGenerator, c
         block_program = generator.program
 
         cost, result = block_program.run_with_cost(
-            max_cost, [DESERIALIZE_MOD, [bytes(g) for g in generator.generator_refs]]
+            max_cost, DESERIALIZE_MOD, [bytes(g) for g in generator.generator_refs]
         )
 
         coin_spend_list = result.first()

--- a/chia/protocols/protocol_message_types.py
+++ b/chia/protocols/protocol_message_types.py
@@ -108,3 +108,4 @@ class ProtocolMessageTypes(Enum):
     request_block_headers = 86
     reject_block_headers = 87
     respond_block_headers = 88
+    request_puzzle_solution_with_coin_info = 89

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 from chia.util.ints import uint8, uint16
 from chia.util.streamable import Streamable, streamable
 
-protocol_version = "0.0.34"
+protocol_version = "0.0.35"
 
 """
 Handshake when establishing a connection between two servers.
@@ -24,6 +24,8 @@ class Capability(IntEnum):
     # if peer A support v3 and peer B supports v2, they should send:
     # (BASE, RATE_LIMITS_V2, RATE_LIMITS_V3), and (BASE, RATE_LIMITS_V2) respectively. They will use the V2 limits.
     RATE_LIMITS_V2 = 3
+    # Allows a more performant fetch of puzzles and solutions by specifying the full coin info rather than just the name
+    PUZZLE_SOLUTION_WITH_COIN_INFO = 4
 
 
 @streamable
@@ -42,4 +44,5 @@ capabilities = [
     (uint16(Capability.BASE.value), "1"),
     (uint16(Capability.BLOCK_HEADERS.value), "1"),
     (uint16(Capability.RATE_LIMITS_V2.value), "1"),
+    (uint16(Capability.PUZZLE_SOLUTION_WITH_COIN_INFO.value), "1"),
 ]

--- a/chia/protocols/wallet_protocol.py
+++ b/chia/protocols/wallet_protocol.py
@@ -8,7 +8,7 @@ from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint8, uint32, uint128
+from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.streamable import Streamable, streamable
 
 """
@@ -24,6 +24,15 @@ __all__ = ["CoinState", "RespondToPhUpdates"]
 @dataclass(frozen=True)
 class RequestPuzzleSolution(Streamable):
     coin_name: bytes32
+    height: uint32
+
+
+@streamable
+@dataclass(frozen=True)
+class RequestPuzzleSolutionWithCoinInfo(Streamable):
+    parent_id: bytes32
+    puzzle_hash: bytes32
+    amount: uint64
     height: uint32
 
 

--- a/chia/protocols/wallet_protocol.py
+++ b/chia/protocols/wallet_protocol.py
@@ -8,7 +8,7 @@ from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint8, uint32, uint64, uint128
+from chia.util.ints import uint8, uint32, uint128
 from chia.util.streamable import Streamable, streamable
 
 """

--- a/chia/protocols/wallet_protocol.py
+++ b/chia/protocols/wallet_protocol.py
@@ -30,9 +30,7 @@ class RequestPuzzleSolution(Streamable):
 @streamable
 @dataclass(frozen=True)
 class RequestPuzzleSolutionWithCoinInfo(Streamable):
-    parent_id: bytes32
-    puzzle_hash: bytes32
-    amount: uint64
+    coin: Coin
     height: uint32
 
 

--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -111,6 +111,7 @@ rate_limits = {
             ProtocolMessageTypes.request_peers: RLSettings(10, 100),
             ProtocolMessageTypes.respond_peers: RLSettings(10, 1 * 1024 * 1024),
             ProtocolMessageTypes.request_puzzle_solution: RLSettings(1000, 100),
+            ProtocolMessageTypes.request_puzzle_solution_with_coin_info: RLSettings(1000, 100),
             ProtocolMessageTypes.respond_puzzle_solution: RLSettings(1000, 1024 * 1024),
             ProtocolMessageTypes.reject_puzzle_solution: RLSettings(1000, 100),
             ProtocolMessageTypes.new_peak_wallet: RLSettings(200, 300),

--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -111,7 +111,7 @@ rate_limits = {
             ProtocolMessageTypes.request_peers: RLSettings(10, 100),
             ProtocolMessageTypes.respond_peers: RLSettings(10, 1 * 1024 * 1024),
             ProtocolMessageTypes.request_puzzle_solution: RLSettings(1000, 100),
-            ProtocolMessageTypes.request_puzzle_solution_with_coin_info: RLSettings(1000, 100),
+            ProtocolMessageTypes.request_puzzle_solution_with_coin_info: RLSettings(3000, 100),
             ProtocolMessageTypes.respond_puzzle_solution: RLSettings(1000, 1024 * 1024),
             ProtocolMessageTypes.reject_puzzle_solution: RLSettings(1000, 100),
             ProtocolMessageTypes.new_peak_wallet: RLSettings(200, 300),

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -396,9 +396,7 @@ async def fetch_puzzle_solution_with_coin_info(height: uint32, coin: Coin, peer:
     if Capability.PUZZLE_SOLUTION_WITH_COIN_INFO in peer.peer_capabilities:
         solution_response = await peer.request_puzzle_solution_with_coin_info(
             wallet_protocol.RequestPuzzleSolutionWithCoinInfo(
-                bytes32(coin.parent_coin_info),
-                bytes32(coin.puzzle_hash),
-                uint64(coin.amount),
+                coin,
                 height,
             )
         )

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -406,8 +406,12 @@ async def fetch_puzzle_solution_with_coin_info(height: uint32, coin: Coin, peer:
         )
     if solution_response is None or not isinstance(solution_response, wallet_protocol.RespondPuzzleSolution):
         raise ValueError(f"Was not able to obtain solution {solution_response}")
-    assert solution_response.response.puzzle.get_tree_hash() == coin.puzzle_hash
-    assert solution_response.response.coin_name == coin.name()
+    if (
+        solution_response.response.puzzle.get_tree_hash() != coin.puzzle_hash
+        or solution_response.response.coin_name != coin.name()
+    ):
+        # should we be banning here or something?
+        raise ValueError(f"Invalid puzzle/solution response from peer {peer.peer_host}")
 
     return CoinSpend(
         coin,

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -32,7 +32,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
-from chia.util.ints import uint32, uint64
+from chia.util.ints import uint32
 from chia.util.merkle_set import confirm_not_included_already_hashed, confirm_included_already_hashed, MerkleSet
 from chia.wallet.util.peer_request_cache import PeerRequestCache
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -54,6 +54,7 @@ from chia.wallet.util.peer_request_cache import PeerRequestCache, can_use_peer_r
 from chia.wallet.util.wallet_sync_utils import (
     fetch_header_blocks_in_range,
     fetch_last_tx_from_peer,
+    fetch_puzzle_solution_with_coin_info,
     last_change_height_cs,
     request_and_validate_additions,
     request_and_validate_removals,
@@ -1532,19 +1533,7 @@ class WalletNode:
         return True
 
     async def fetch_puzzle_solution(self, height: uint32, coin: Coin, peer: WSChiaConnection) -> CoinSpend:
-        solution_response = await peer.request_puzzle_solution(
-            wallet_protocol.RequestPuzzleSolution(coin.name(), height)
-        )
-        if solution_response is None or not isinstance(solution_response, wallet_protocol.RespondPuzzleSolution):
-            raise ValueError(f"Was not able to obtain solution {solution_response}")
-        assert solution_response.response.puzzle.get_tree_hash() == coin.puzzle_hash
-        assert solution_response.response.coin_name == coin.name()
-
-        return CoinSpend(
-            coin,
-            solution_response.response.puzzle,
-            solution_response.response.solution,
-        )
+        return await fetch_puzzle_solution_with_coin_info(height, coin, peer)
 
     async def get_coin_state(
         self, coin_names: List[bytes32], peer: WSChiaConnection, fork_height: Optional[uint32] = None

--- a/tests/generator/test_compression.py
+++ b/tests/generator/test_compression.py
@@ -12,7 +12,10 @@ from chia.full_node.bundle_tools import (
     spend_bundle_to_serialized_coin_spend_entry_list,
 )
 from chia.full_node.generator import run_generator_unsafe, create_generator_args
-from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
+from chia.full_node.mempool_check_conditions import (
+    get_puzzle_and_solution_for_coin,
+    get_puzzle_and_solution_for_coin_with_full_info,
+)
 from chia.types.blockchain_format.program import Program, SerializedProgram, INFINITE_COST
 from chia.types.generator_types import BlockGenerator, CompressorArg
 from chia.types.spend_bundle import SpendBundle
@@ -146,14 +149,22 @@ class TestCompression(TestCase):
         start, end = match_standard_transaction_at_any_index(original_generator)
         ca = CompressorArg(uint32(0), SerializedProgram.from_bytes(original_generator), start, end)
         c = compressed_spend_bundle_solution(ca, sb)
-        removal = sb.coin_spends[0].coin.name()
-        error, puzzle, solution = get_puzzle_and_solution_for_coin(c, removal, INFINITE_COST)
+        removal = sb.coin_spends[0].coin
+        error, puzzle, solution = get_puzzle_and_solution_for_coin(c, removal.name(), INFINITE_COST)
+        assert error is None
+        assert bytes(puzzle) == bytes(sb.coin_spends[0].puzzle_reveal)
+        assert bytes(solution) == bytes(sb.coin_spends[0].solution)
+        error, puzzle, solution = get_puzzle_and_solution_for_coin_with_full_info(c, removal, INFINITE_COST)
         assert error is None
         assert bytes(puzzle) == bytes(sb.coin_spends[0].puzzle_reveal)
         assert bytes(solution) == bytes(sb.coin_spends[0].solution)
         # Test non compressed generator as well
         s = simple_solution_generator(sb)
-        error, puzzle, solution = get_puzzle_and_solution_for_coin(s, removal, INFINITE_COST)
+        error, puzzle, solution = get_puzzle_and_solution_for_coin(s, removal.name(), INFINITE_COST)
+        assert error is None
+        assert bytes(puzzle) == bytes(sb.coin_spends[0].puzzle_reveal)
+        assert bytes(solution) == bytes(sb.coin_spends[0].solution)
+        error, puzzle, solution = get_puzzle_and_solution_for_coin_with_full_info(c, removal, INFINITE_COST)
         assert error is None
         assert bytes(puzzle) == bytes(sb.coin_spends[0].puzzle_reveal)
         assert bytes(solution) == bytes(sb.coin_spends[0].solution)

--- a/tests/util/test_network_protocol_test.py
+++ b/tests/util/test_network_protocol_test.py
@@ -64,6 +64,7 @@ def test_missing_messages() -> None:
         "RequestChildren",
         "RequestHeaderBlocks",
         "RequestPuzzleSolution",
+        "RequestPuzzleSolutionWithCoinInfo",
         "RequestRemovals",
         "RequestSESInfo",
         "RespondAdditions",


### PR DESCRIPTION
Basically we make the current puzzle/solution request with a coin name instead of the full coin info.  The full node finds the block generator which has all of the coin spends in it, but importantly the coin spends have only the following information [parent_id, puzzle_reveal, amount].  This means in order to identify if a particular spend is the one the wallet is requesting it has to tree hash the puzzle_reveal then calculate the coin name using that info.  Since tree hashing was recently found to be an expensive operation and since that call basically forces a full node to do probably 20-30 treehashes on average before it finds the correct spend, I would imagine that's one of the things that makes the call pretty slow.