### PR TITLE
data layer - wait for creation tx in test

### DIFF
--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -852,6 +852,7 @@ async def offer_setup_fixture(
             data_rpc_api = DataLayerRpcApi(data_layer)
 
             create_response = await data_rpc_api.create_data_store({})
+            await full_node_api.process_transaction_records(records=create_response["txs"])
 
             store_setups.append(
                 StoreSetup(


### PR DESCRIPTION
Meant to address https://github.com/Chia-Network/chia-blockchain/runs/8093224796?check_suite_focus=true.

```python-traceback
__________ ERROR at setup of test_make_and_cancel_offer[one for one] __________
[gw1] win32 -- Python 3.8.10 d:\a\chia-blockchain\chia-blockchain\venv\scripts\python.exe
tests\core\data_layer\test_data_rpc.py:880: in offer_setup_fixture
    await maker.api.subscribe(request={"id": taker.id.hex(), "urls": ["http://127:0:0:1/8000"]})
chia\rpc\data_layer_rpc_api.py:253: in subscribe
    await self.service.subscribe(store_id=store_id_bytes, urls=urls)
chia\data_layer\data_layer.py:430: in subscribe
    await self.wallet_rpc.dl_track_new(subscription.tree_id)
chia\rpc\wallet_rpc_client.py:727: in dl_track_new
    await self.fetch("dl_track_new", request)
chia\rpc\rpc_client.py:49: in fetch
    raise ValueError(res_json)
E   ValueError: {'error': 'Launcher ID 7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3 is not a valid coin', 'success': False}
```