### PR TITLE
optimize get_block_store

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -9,11 +9,12 @@ from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.weight_proof import SubEpochChallengeSegment, SubEpochSegments
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.errors import Err
-from chia.util.full_block_utils import generator_from_block
+from chia.util.full_block_utils import block_info_from_block, generator_from_block
 from chia.util.ints import uint32
 from chia.util.lru_cache import LRUCache
+from chia.util.full_block_utils import GeneratorBlockInfo
 
 log = logging.getLogger(__name__)
 
@@ -320,6 +321,37 @@ class BlockStore:
                     ret.append(self.maybe_decompress(row[0]))
                 return ret
 
+    async def get_block_info(self, header_hash: bytes32) -> Optional[GeneratorBlockInfo]:
+
+        cached = self.block_cache.get(header_hash)
+        if cached is not None:
+            log.debug(f"cache hit for block {header_hash.hex()}")
+            return GeneratorBlockInfo(
+                cached.foliage.prev_block_hash, cached.transactions_generator, cached.transactions_generator_ref_list
+            )
+
+        formatted_str = "SELECT block, height from full_blocks WHERE header_hash=?"
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            row = await execute_fetchone(conn, formatted_str, (self.maybe_to_hex(header_hash),))
+            if row is None:
+                return None
+            if self.db_wrapper.db_version == 2:
+                block_bytes = zstd.decompress(row[0])
+            else:
+                block_bytes = row[0]
+
+            try:
+                return block_info_from_block(block_bytes)
+            except Exception as e:
+                log.error(f"cheap parser failed for block at height {row[1]}: {e}")
+                # this is defensive, on the off-chance that
+                # block_info_from_block() fails, fall back to the reliable
+                # definition of parsing a block
+                b = FullBlock.from_bytes(block_bytes)
+                return GeneratorBlockInfo(
+                    b.foliage.prev_block_hash, b.transactions_generator, b.transactions_generator_ref_list
+                )
+
     async def get_generator(self, header_hash: bytes32) -> Optional[SerializedProgram]:
 
         cached = self.block_cache.get(header_hash)
@@ -329,24 +361,23 @@ class BlockStore:
 
         formatted_str = "SELECT block, height from full_blocks WHERE header_hash=?"
         async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute(formatted_str, (self.maybe_to_hex(header_hash),)) as cursor:
-                row = await cursor.fetchone()
-                if row is None:
-                    return None
-                if self.db_wrapper.db_version == 2:
-                    block_bytes = zstd.decompress(row[0])
-                else:
-                    block_bytes = row[0]
+            row = await execute_fetchone(conn, formatted_str, (self.maybe_to_hex(header_hash),))
+            if row is None:
+                return None
+            if self.db_wrapper.db_version == 2:
+                block_bytes = zstd.decompress(row[0])
+            else:
+                block_bytes = row[0]
 
-                try:
-                    return generator_from_block(block_bytes)
-                except Exception as e:
-                    log.error(f"cheap parser failed for block at height {row[1]}: {e}")
-                    # this is defensive, on the off-chance that
-                    # generator_from_block() fails, fall back to the reliable
-                    # definition of parsing a block
-                    b = FullBlock.from_bytes(block_bytes)
-                    return b.transactions_generator
+            try:
+                return generator_from_block(block_bytes)
+            except Exception as e:
+                log.error(f"cheap parser failed for block at height {row[1]}: {e}")
+                # this is defensive, on the off-chance that
+                # generator_from_block() fails, fall back to the reliable
+                # definition of parsing a block
+                b = FullBlock.from_bytes(block_bytes)
+                return b.transactions_generator
 
     async def get_generators_at(self, heights: List[uint32]) -> List[SerializedProgram]:
         assert self.db_wrapper.db_version == 2

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -343,7 +343,7 @@ class BlockStore:
             try:
                 return block_info_from_block(block_bytes)
             except Exception as e:
-                log.error(f"cheap parser failed for block at height {row[1]}: {e}")
+                log.exception(f"cheap parser failed for block at height {row[1]}: {e}")
                 # this is defensive, on the off-chance that
                 # block_info_from_block() fails, fall back to the reliable
                 # definition of parsing a block

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -27,6 +27,7 @@ from chia.protocols.wallet_protocol import (
     CoinState,
     RespondSESInfo,
 )
+from chia.types.block_protocol import BlockInfo
 from chia.server.outbound_message import Message, make_msg
 from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.pool_target import PoolTarget
@@ -1279,7 +1280,7 @@ class FullNodeAPI:
         if header_hash is None:
             return reject_msg
 
-        block = await self.full_node.block_store.get_block_info(header_hash)
+        block: Optional[BlockInfo] = await self.full_node.block_store.get_block_info(header_hash)
 
         if block is None or block.transactions_generator is None:
             return reject_msg

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1279,7 +1279,7 @@ class FullNodeAPI:
         if header_hash is None:
             return reject_msg
 
-        block: Optional[FullBlock] = await self.full_node.block_store.get_full_block(header_hash)
+        block = await self.full_node.block_store.get_block_info(header_hash)
 
         if block is None or block.transactions_generator is None:
             return reject_msg

--- a/chia/util/full_block_utils.py
+++ b/chia/util/full_block_utils.py
@@ -1,5 +1,6 @@
 import io
-from typing import Callable, List, Optional
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
 
 from blspy import G1Element, G2Element
 from chia_rs import serialized_length
@@ -9,6 +10,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import TransactionsInfo
 from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint32
 
 
 def skip_list(buf: memoryview, skip_item: Callable[[memoryview], memoryview]) -> memoryview:
@@ -166,6 +168,16 @@ def skip_foliage(buf: memoryview) -> memoryview:
     return skip_optional(buf, skip_g2_element)  # foliage_transaction_block_signature
 
 
+def prev_hash_from_foliage(buf: memoryview) -> Tuple[memoryview, bytes32]:
+    prev_hash = buf[:32]  # prev_block_hash
+    buf = skip_bytes32(buf)  # prev_block_hash
+    buf = skip_bytes32(buf)  # reward_block_hash
+    buf = skip_foliage_block_data(buf)  # foliage_block_data
+    buf = skip_g2_element(buf)  # foliage_block_data_signature
+    buf = skip_optional(buf, skip_bytes32)  # foliage_transaction_block_hash
+    return skip_optional(buf, skip_g2_element), bytes32(prev_hash)  # foliage_transaction_block_signature
+
+
 def skip_foliage_transaction_block(buf: memoryview) -> memoryview:
     # buf = skip_bytes32(buf)  # prev_transaction_block_hash
     # buf = skip_uint64(buf)  # timestamp
@@ -212,6 +224,47 @@ def generator_from_block(buf: memoryview) -> Optional[SerializedProgram]:
     buf = buf[1:]
     length = serialized_length(buf)
     return SerializedProgram.from_bytes(bytes(buf[:length]))
+
+
+# this implements the BlockInfo protocol
+@dataclass(frozen=True)
+class GeneratorBlockInfo:
+    prev_header_hash: bytes32
+    transactions_generator: Optional[SerializedProgram]
+    transactions_generator_ref_list: List[uint32]
+
+
+def block_info_from_block(buf: memoryview) -> GeneratorBlockInfo:
+    buf = skip_list(buf, skip_end_of_sub_slot_bundle)  # finished_sub_slots
+    buf = skip_reward_chain_block(buf)  # reward_chain_block
+    buf = skip_optional(buf, skip_vdf_proof)  # challenge_chain_sp_proof
+    buf = skip_vdf_proof(buf)  # challenge_chain_ip_proof
+    buf = skip_optional(buf, skip_vdf_proof)  # reward_chain_sp_proof
+    buf = skip_vdf_proof(buf)  # reward_chain_ip_proof
+    buf = skip_optional(buf, skip_vdf_proof)  # infused_challenge_chain_ip_proof
+    buf, prev_hash = prev_hash_from_foliage(buf)  # foliage
+    buf = skip_optional(buf, skip_foliage_transaction_block)  # foliage_transaction_block
+    buf = skip_optional(buf, skip_transactions_info)  # transactions_info
+
+    # this is the transactions_generator optional
+    generator = None
+    if buf[0] != 0:
+        buf = buf[1:]
+        length = serialized_length(buf)
+        generator = SerializedProgram.from_bytes(bytes(buf[:length]))
+        buf = buf[length:]
+    else:
+        buf = buf[1:]
+
+    refs_length = uint32.from_bytes(buf[:4])
+    buf = buf[4:]
+
+    refs = []
+    for i in range(refs_length):
+        refs.append(uint32.from_bytes(buf[:4]))
+        buf = buf[4:]
+
+    return GeneratorBlockInfo(prev_hash, generator, refs)
 
 
 def header_block_from_block(

--- a/tests/util/test_full_block_utils.py
+++ b/tests/util/test_full_block_utils.py
@@ -21,7 +21,7 @@ from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
-from chia.util.full_block_utils import generator_from_block, header_block_from_block
+from chia.util.full_block_utils import block_info_from_block, generator_from_block, header_block_from_block
 from chia.util.generator_tools import get_block_header
 from chia.util.ints import uint8, uint32, uint64, uint128
 
@@ -203,6 +203,13 @@ def get_finished_sub_slots() -> Generator[List[EndOfSubSlotBundle], None, None]:
     yield [s for s in get_end_of_sub_slot()]
 
 
+def get_ref_list() -> Generator[List[uint32], None, None]:
+    yield []
+    yield [uint32(1), uint32(2), uint32(3), uint32(4)]
+    yield [uint32(256)]
+    yield [uint32(0xFFFFFFFF)]
+
+
 def get_full_blocks() -> Iterator[FullBlock]:
     random.seed(123456789)
 
@@ -217,25 +224,26 @@ def get_full_blocks() -> Iterator[FullBlock]:
                         for reward_chain_sp_proof in [vdf_proof(), None]:
                             for infused_challenge_chain_ip_proof in [vdf_proof(), None]:
                                 for finished_sub_slots in get_finished_sub_slots():
-                                    yield FullBlock(
-                                        finished_sub_slots,
-                                        reward_chain_block,
-                                        challenge_chain_sp_proof,
-                                        vdf_proof(),  # challenge_chain_ip_proof
-                                        reward_chain_sp_proof,
-                                        vdf_proof(),  # reward_chain_ip_proof
-                                        infused_challenge_chain_ip_proof,
-                                        foliage,
-                                        foliage_transaction_block,
-                                        transactions_info,
-                                        generator,  # transactions_generator
-                                        [],  # transactions_generator_ref_list
-                                    )
+                                    for refs_list in get_ref_list():
+                                        yield FullBlock(
+                                            finished_sub_slots,
+                                            reward_chain_block,
+                                            challenge_chain_sp_proof,
+                                            vdf_proof(),  # challenge_chain_ip_proof
+                                            reward_chain_sp_proof,
+                                            vdf_proof(),  # reward_chain_ip_proof
+                                            infused_challenge_chain_ip_proof,
+                                            foliage,
+                                            foliage_transaction_block,
+                                            transactions_info,
+                                            generator,  # transactions_generator
+                                            refs_list,  # transactions_generator_ref_list
+                                        )
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip("This test is expensive and has already convinced us the parser works")
-async def test_parser(self):
+# @pytest.mark.skip("This test is expensive and has already convinced us the parser works")
+async def test_parser():
 
     # loop over every combination of Optionals being set and not set
     # along with random values for the FullBlock fields. Ensure
@@ -245,13 +253,17 @@ async def test_parser(self):
         block_bytes = bytes(block)
         gen = generator_from_block(block_bytes)
         assert gen == block.transactions_generator
+        bi = block_info_from_block(block_bytes)
+        assert block.transactions_generator == bi.transactions_generator
+        assert block.prev_header_hash == bi.prev_header_hash
+        assert block.transactions_generator_ref_list == bi.transactions_generator_ref_list
         # this doubles the run-time of this test, with questionable utility
         # assert gen == FullBlock.from_bytes(block_bytes).transactions_generator
 
 
 @pytest.mark.asyncio
 @pytest.mark.skip("This test is expensive and has already convinced us the parser works")
-async def test_header_block(self):
+async def test_header_block():
     for block in get_full_blocks():
         hb: HeaderBlock = get_block_header(block, [], [])
         hb_bytes = header_block_from_block(memoryview(bytes(block)))


### PR DESCRIPTION
for `get_puzzle_and_solution_for_coin()` to not parse the full block. We just need the block generator, pre_hash and generator refs.

Once we switch over to the rust implementation to pull out the puzzle and solution for a coin, the `get_full_block()` call is a significant cost. This patch reduces it.