### PR TITLE
Remove boolean from atari DB.

### DIFF
--- a/chia/data_layer/dl_wallet_store.py
+++ b/chia/data_layer/dl_wallet_store.py
@@ -176,7 +176,7 @@ class DataLayerStore:
             if only_confirmed:
                 # get latest confirmed root
                 cursor = await conn.execute(
-                    "SELECT * from singleton_records WHERE launcher_id=? and confirmed = TRUE "
+                    "SELECT * from singleton_records WHERE launcher_id=? and confirmed = 1 "
                     "ORDER BY generation DESC LIMIT 1",
                     (launcher_id,),
                 )


### PR DESCRIPTION
The Linux Debian installer build now uses an older version of SQLite that does not support `BOOLEAN`, `TRUE`, and `FALSE`.

```
Exception from 'data': {'error': "{'error': 'no such column: TRUE', 'success': False}", 'success': False}
```
```
2022-09-01T15:21:20.324 data_layer chia.rpc.util          : WARNING  Error while handling message: Traceback (most recent call last):
  File "chia/rpc/util.py", line 16, in inner
  File "chia/rpc/data_layer_rpc_api.py", line 143, in get_keys_values
  File "chia/data_layer/data_layer.py", line 212, in get_keys_values
  File "chia/data_layer/data_layer.py", line 269, in _update_confirmation_status
  File "chia/rpc/wallet_rpc_client.py", line 739, in dl_latest_singleton
  File "chia/rpc/rpc_client.py", line 49, in fetch
ValueError: {'error': 'no such column: TRUE', 'success': False}
```