### PR TITLE
Add `running_services` command to list all running services

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1104,7 +1104,9 @@ class WebSocketServer:
     async def is_running(self, request: Dict[str, Any]) -> Dict[str, Any]:
         service = request.get("service", "*")
         services_to_check = (
-            service.split(",") if service != "*" else list(set([*self.services.keys(), *self.connections.keys()]))
+            list(map(str.strip, service.split(",")))
+            if service != "*"
+            else list(set([*self.services.keys(), *self.connections.keys()]))
         )
         responses = []
         for service_name in services_to_check:

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1123,7 +1123,7 @@ class WebSocketServer:
         services = (
             requested_services
             if len(requested_services) > 0
-            else list(set([*self.services.keys(), *self.connections.keys()]))
+            else list({*self.services.keys(), *self.connections.keys()})
         )
         running_services = [service_name for service_name in services if self.is_service_running(service_name)]
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1125,10 +1125,7 @@ class WebSocketServer:
             if len(requested_services) > 0
             else list(set([*self.services.keys(), *self.connections.keys()]))
         )
-        running_services = []
-        for service_name in services:
-            if self.is_service_running(service_name):
-                running_services.append(service_name)
+        running_services = [service_name for service_name in services if self.is_service_running(service_name)]
 
         return {"success": True, "running_services": running_services}
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -327,7 +327,7 @@ class WebSocketServer:
         elif command == "stop_service":
             response = await self.stop_service(cast(Dict[str, Any], data))
         elif command == "running_services":
-            response = await self.running_services(cast(Dict[str, Any], data))
+            response = await self.running_services(data)
         elif command == "is_running":
             response = await self.is_running(cast(Dict[str, Any], data))
         elif command == "is_keyring_locked":
@@ -1119,12 +1119,7 @@ class WebSocketServer:
         return is_running
 
     async def running_services(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        requested_services = request.get("services", [])
-        services = (
-            requested_services
-            if len(requested_services) > 0
-            else list({*self.services.keys(), *self.connections.keys()})
-        )
+        services = list({*self.services.keys(), *self.connections.keys()})
         running_services = [service_name for service_name in services if self.is_service_running(service_name)]
 
         return {"success": True, "running_services": running_services}

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -188,7 +188,7 @@ async def test_is_running_wildcard():
         connections: Dict[str, Optional[List[Any]]]
 
         async def is_running(self, request: Dict[str, Any]) -> Dict[str, Any]:
-            return await WebSocketServer.is_running(self, request)
+            return await WebSocketServer.is_running(self, request)  # type: ignore
 
     # Mock daemon server without any registered services/connections
     lonelyDaemon = Daemon(services={}, connections={})

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -37,13 +37,22 @@ class Daemon:
     connections: Dict[str, Optional[List[Any]]]
 
     def is_service_running(self, service_name: str) -> bool:
-        return WebSocketServer.is_service_running(self, service_name)
+        # Squelch mypy error:
+        # Argument 1 to "is_service_running" of "WebSocketServer" has incompatible type "Daemon";
+        #   expected "WebSocketServer"
+        return WebSocketServer.is_service_running(self, service_name)  # type: ignore [arg-type]
 
     async def running_services(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return await WebSocketServer.running_services(self, request)
+        # Squelch mypy error:
+        # Argument 1 to "running_services" of "WebSocketServer" has incompatible type "Daemon";
+        #   expected "WebSocketServer"
+        return await WebSocketServer.running_services(self, request)  # type: ignore [arg-type]
 
     async def is_running(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return await WebSocketServer.is_running(self, request)
+        # Squelch mypy error:
+        # Argument 1 to "is_running" of "WebSocketServer" has incompatible type "Daemon";
+        #   expected "WebSocketServer"
+        return await WebSocketServer.is_running(self, request)  # type: ignore [arg-type]
 
 
 test_key_data = KeyData.from_mnemonic(


### PR DESCRIPTION
Issue #13313 

Added a `running_services` command to return the list of running services registered with the daemon. This complements the existing `is_running` command which only returns a response for a single requested service name.

The request doesn't take any params.

Request:
```{"ack": false, "command": "running_services", "data": {}, "destination": "daemon", "origin": "client", "request_id": "43dc226cef76963ddd56c7068972947f373918c24b0fdf5bfa767a1340271da6"}```

Response:
```{"ack": true, "command": "running_services", "data": {"running_services": ["chia_wallet", "chia_farmer", "chia_harvester", "chia_full_node"], "success": true}, "destination": "client", "origin": "daemon", "request_id": "43dc226cef76963ddd56c7068972947f373918c24b0fdf5bfa767a1340271da6"}```
