### PR TITLE
use get_puzzle_and_solution_for_coin() from chia_rs

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -7,7 +7,6 @@ from typing import Optional, List, Dict, Tuple, Any, Type, TypeVar
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.mempool_item import MempoolItem
 from chia.util.ints import uint64, uint32
 from chia.util.hash import std_hash
@@ -386,9 +385,9 @@ class SimClient:
         if error:
             return None
         else:
-            puzzle_ser: SerializedProgram = SerializedProgram.from_program(Program.to(puzzle))
-            solution_ser: SerializedProgram = SerializedProgram.from_program(Program.to(solution))
-            return CoinSpend(coin_record.coin, puzzle_ser, solution_ser)
+            assert puzzle is not None
+            assert solution is not None
+            return CoinSpend(coin_record.coin, puzzle, solution)
 
     async def get_all_mempool_tx_ids(self) -> List[bytes32]:
         return list(self.service.mempool_manager.mempool.spends.keys())

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -30,7 +30,6 @@ from chia.protocols.wallet_protocol import (
 from chia.server.outbound_message import Message, make_msg
 from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.pool_target import PoolTarget
-from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.coin_record import CoinRecord
@@ -1291,10 +1290,10 @@ class FullNodeAPI:
         if error is not None:
             return reject_msg
 
-        pz = Program.to(puzzle)
-        sol = Program.to(solution)
+        assert puzzle is not None
+        assert solution is not None
 
-        wrapper = PuzzleSolutionResponse(coin_name, height, pz, sol)
+        wrapper = PuzzleSolutionResponse(coin_name, height, puzzle, solution)
         response = wallet_protocol.RespondPuzzleSolution(wrapper)
         response_msg = make_msg(ProtocolMessageTypes.respond_puzzle_solution, response)
         return response_msg

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Optional, Tuple
-from chia_rs import MEMPOOL_MODE, NO_NEG_DIV
+from chia_rs import MEMPOOL_MODE, NO_NEG_DIV, get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia.types.blockchain_format.coin import Coin
 
 from chia.consensus.cost_calculator import NPCResult
@@ -12,9 +12,11 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64, uint16
 from chia.wallet.puzzles.rom_bootstrap_generator import get_generator
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import SerializedProgram
 from chia.wallet.puzzles.load_clvm import load_serialized_clvm
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
+
+from chia.types.blockchain_format.program import Program
 
 GENERATOR_MOD = get_generator()
 
@@ -62,24 +64,24 @@ def get_name_puzzle_conditions(
 
 def get_puzzle_and_solution_for_coin(
     generator: BlockGenerator, coin: Coin
-) -> Tuple[Optional[Exception], Optional[Program], Optional[Program]]:
+) -> Tuple[Optional[Exception], Optional[SerializedProgram], Optional[SerializedProgram]]:
     try:
-        args = [bytes(a) for a in generator.generator_refs]
-        cost, result = generator.program.run_with_cost(DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM, DESERIALIZE_MOD, args)
+        args = bytearray(b"\xff")
+        args += bytes(DESERIALIZE_MOD)
+        args += b"\xff"
+        args += bytes(Program.to([bytes(a) for a in generator.generator_refs]))
+        args += b"\x80\x80"
 
-        requested_parent = Program.to(coin.parent_coin_info)
-        requested_amount = Program.to(coin.amount)
+        puzzle, solution = get_puzzle_and_solution_for_coin_rust(
+            bytes(generator.program),
+            bytes(args),
+            DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+            coin.parent_coin_info,
+            coin.amount,
+            coin.puzzle_hash,
+        )
 
-        coin_spends = result.first()
-        for spend in coin_spends.as_iter():
-            parent, puzzle, amount, solution = spend.as_iter()
-            if (
-                parent == requested_parent
-                and amount == requested_amount
-                and Program.to(puzzle).get_tree_hash() == coin.puzzle_hash
-            ):
-                return None, Program.to(puzzle), Program.to(solution)
-        return ValueError(f"coin not found {coin.name().hex()}"), None, None
+        return None, SerializedProgram.from_bytes(puzzle), SerializedProgram.from_bytes(solution)
     except Exception as e:
         return e, None, None
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ dependencies = [
     "chiapos==1.0.10",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.5",  # Currying, Program.to, other conveniences
-    "chia_rs==0.1.8",
+    "chia_rs==0.1.9",
     "clvm-tools-rs==0.1.19",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.1",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -87,8 +87,8 @@ class TestCostCalculation:
         assert coin_spend.coin.name() == npc_result.conds.spends[0].coin_id
         error, puzzle, solution = get_puzzle_and_solution_for_coin(program, coin_spend.coin)
         assert error is None
-        assert puzzle == coin_spend.puzzle_reveal.to_program()
-        assert solution == coin_spend.solution.to_program()
+        assert puzzle == coin_spend.puzzle_reveal
+        assert solution == coin_spend.solution
 
         assert npc_result.conds.cost == ConditionCost.CREATE_COIN.value + ConditionCost.AGG_SIG.value + 404560
 
@@ -296,7 +296,7 @@ async def test_get_puzzle_and_solution_for_coin_performance():
     # benchmark the function to pick out the puzzle and solution for a specific
     # coin
     generator = BlockGenerator(LARGE_BLOCK.transactions_generator, [], [])
-    with assert_runtime(seconds=20, label="get_puzzle_and_solution_for_coin"):
+    with assert_runtime(seconds=7, label="get_puzzle_and_solution_for_coin"):
         for i in range(3):
             for c in spends:
                 err, puzzle, solution = get_puzzle_and_solution_for_coin(generator, c)


### PR DESCRIPTION
This bumps the `chia_rs` dependency to 0.1.9, which has an implementation of `get_puzzle_and_solution_for_coin()`. It also switches over `chia-blockchain` to use that function.

One noteworthy difference is that the rust implementation returns `SerializedProgram` for both the puzzle and the solution. This ends up being more efficient in most cases since we mostly just turn around and serializes these over the wallet protocol.

To quantify the speedup, the `tests/core/test_cost_calculation.py::test_get_puzzle_and_solution_for_coin_performance` benchmark has the improvement.

| benchmark | before | after | after / before |
| --- | --- | --- | --- |
| get_puzzle_and_solution_for_coin() | 8.67s | 2.86s | 32.99% |

The output from the benchmark can be found here: https://github.com/Chia-Network/chia-blockchain/runs/8163694887?check_suite_focus=true#step:10:35

The rust implementation can be found here: https://github.com/Chia-Network/chia_rs/blob/main/src/gen/get_puzzle_and_solution.rs#L48