### PR TITLE
Replace localhost with 127.0.0.1 for tests

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -91,7 +91,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.block_cache import BlockCache
-from chia.util.config import load_config, lock_config, override_config, save_config
+from chia.util.config import config_path_for_filename, load_config, lock_config, override_config, save_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import Err
 from chia.util.hash import std_hash
@@ -184,6 +184,9 @@ class BlockTools:
                 private_ca_crt_and_key=self.ssl_ca_cert_and_key_wrapper.collateral.cert_and_key,
                 node_certs_and_keys=self.ssl_nodes_certs_and_keys_wrapper.collateral.certs_and_keys,
             )
+        with lock_config(root_path=root_path, filename="config.yaml"):
+            path = config_path_for_filename(root_path=root_path, filename="config.yaml")
+            path.write_text(path.read_text().replace("localhost", "127.0.0.1"))
         self._config = load_config(self.root_path, "config.yaml")
         if automated_testing:
             if config_overrides is None:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -184,9 +184,9 @@ class BlockTools:
                 private_ca_crt_and_key=self.ssl_ca_cert_and_key_wrapper.collateral.cert_and_key,
                 node_certs_and_keys=self.ssl_nodes_certs_and_keys_wrapper.collateral.certs_and_keys,
             )
-        with lock_config(root_path=root_path, filename="config.yaml"):
-            path = config_path_for_filename(root_path=root_path, filename="config.yaml")
-            path.write_text(path.read_text().replace("localhost", "127.0.0.1"))
+            with lock_config(root_path=root_path, filename="config.yaml"):
+                path = config_path_for_filename(root_path=root_path, filename="config.yaml")
+                path.write_text(path.read_text().replace("localhost", "127.0.0.1"))
         self._config = load_config(self.root_path, "config.yaml")
         if automated_testing:
             if config_overrides is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def block_tools_fixture(get_keychain) -> BlockTools:
 # to run the tests, change the `self_hostname` fixture
 @pytest_asyncio.fixture(scope="session")
 def self_hostname():
-    return "localhost"
+    return "127.0.0.1"
 
 
 # NOTE:


### PR DESCRIPTION
This is an effort to mitigate the flaky 404 errors (and others) in our tests.  This is intended to avoid exercising the problem in our tests and another real fix to handle it should be implemented.

From what I can tell the issue is that when we start a server using port 0 in an effort to get any unused port, enabling concurrent test execution, we then only track the port but use `localhost` as the host when connecting with the client.  I am unsure of the detailed mechanics of resolving `localhost`, but I did observe requests from a client in one test process being handled by a server in another test in another process.  When this happened I was able to confirm that the incorrectly reached server _did_ have that port open but on IPv6 `::1` while the intended server had that port for IPv4 `127.0.0.1`.  A real solution would be to track not just the port but the host and port or full address tuples (2-tuple for IPv4 and 5-tuple for IPv6, I believe).  That is...  not trivial and not quick, though I did start for a bit in https://github.com/Chia-Network/chia-blockchain/pull/13328.  This also reaches into the old `self_hostname` topic that we all were displeased with the state of.  But anyways, this hard coding of `127.0.0.1` seems to have eliminated the 404s entirely, perhaps along with other flakes where the crossing of servers still yielded a server of the expected type, hence no 404, but also could trigger failures of any number of other sorts.

I believe this is not really an issue in at least most production setups since there we will specify port numbers which will require that whatever socket is opened, IPv4 or IPv6 or both, would have that port number.

I think this is a good fix for the 404 and related issues.  Since it is both ready and minimally intrusive, I think we can consider it for merging to `main` and then cherry picking to `release/1.6.0`.  From there we can continue, with hopefully a bit less noise, addressing other flaky tests.  The test results below suggest the DataLayer and NFT tests are good candidates to start with.  Though note that DataLayer tests should be checked and worked on on `release/1.6.0`.