### PR TITLE
Avoid creating a list and enable short circuit behavior in `bundle_suitable_for_compression()`

### DIFF
--- a/chia/full_node/bundle_tools.py
+++ b/chia/full_node/bundle_tools.py
@@ -100,10 +100,7 @@ def puzzle_suitable_for_compression(puzzle: SerializedProgram) -> bool:
 
 
 def bundle_suitable_for_compression(bundle: SpendBundle):
-    ok = []
-    for coin_spend in bundle.coin_spends:
-        ok.append(puzzle_suitable_for_compression(coin_spend.puzzle_reveal))
-    return all(ok)
+    return all(puzzle_suitable_for_compression(coin_spend.puzzle_reveal) for coin_spend in bundle.coin_spends)
 
 
 def compressed_coin_spend_entry_list(bundle: SpendBundle) -> List:


### PR DESCRIPTION
This avoids the creation of the list entirely.  In so doing it also allows `all()` to return `False` on the first uncompressable spend it finds instead of analyzing all of them first.