### PR TITLE
Fix bug in remove_plot_directory

### DIFF
--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -101,7 +101,7 @@ def remove_plot_directory(root_path: Path, str_path: str) -> None:
     with lock_and_load_config(root_path, "config.yaml") as config:
         str_paths: List[str] = get_plot_directories(root_path, config)
         # If path str matches exactly, remove
-        if str_path not in str_paths:
+        if str_path in str_paths:
             str_paths.remove(str_path)
 
         # If path matches full path, remove


### PR DESCRIPTION
If user tries to remove a plot directory that is not currently in the plot directories list, a runtime error is generated:

```
root@farmer01:/chia-blockchain# chia plots remove -d /foobar
Traceback (most recent call last):
  File "/chia-blockchain/venv/bin/chia", line 8, in <module>
    sys.exit(main())
  File "/chia-blockchain/chia/cmds/chia.py", line 147, in main
    cli()  # pylint: disable=no-value-for-parameter
  File "/chia-blockchain/venv/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/chia-blockchain/venv/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/chia-blockchain/venv/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/chia-blockchain/venv/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/chia-blockchain/venv/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/chia-blockchain/venv/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/chia-blockchain/venv/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/chia-blockchain/chia/cmds/plots.py", line 215, in remove_cmd
    remove_plot_directory(ctx.obj["root_path"], final_dir)
  File "/chia-blockchain/chia/plotting/util.py", line 105, in remove_plot_directory
    str_paths.remove(str_path)
ValueError: list.remove(x): x not in list
```

It looks like this was introduced in the commit linked below - I'm not sure why "in" was changed to "not in" but it doesn't seem to make sense for this logic. This pull requests reverts this commit by removing "not" to avoid this runtime error.

https://github.com/Chia-Network/chia-blockchain/commit/c400d816afa7a8a54cf872deb787aaa3a144363b
