### PR TITLE
(release) Replace localhost with 127.0.0.1 for tests (#13324)

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -85,7 +85,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.block_cache import BlockCache
-from chia.util.config import load_config, lock_config, override_config, save_config
+from chia.util.config import config_path_for_filename, load_config, lock_config, override_config, save_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import Err
 from chia.util.hash import std_hash
@@ -170,6 +170,9 @@ class BlockTools:
                 private_ca_crt_and_key=get_next_private_ca_cert_and_key(),
                 node_certs_and_keys=get_next_nodes_certs_and_keys(),
             )
+            with lock_config(root_path=root_path, filename="config.yaml"):
+                path = config_path_for_filename(root_path=root_path, filename="config.yaml")
+                path.write_text(path.read_text().replace("localhost", "127.0.0.1"))
         self._config = load_config(self.root_path, "config.yaml")
         if automated_testing:
             if config_overrides is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def block_tools_fixture(get_keychain) -> BlockTools:
 # to run the tests, change the `self_hostname` fixture
 @pytest_asyncio.fixture(scope="session")
 def self_hostname():
-    return "localhost"
+    return "127.0.0.1"
 
 
 # NOTE:


### PR DESCRIPTION
* Replace localhost with 127.0.0.1 in block tools config

* also make self_hostname fixture be 127.0.0.1

* Move config rewrite inside `automated_testing` conditional

(cherry picked from commit ec056f59b39cf511295048971d289537d9513620)