### PR TITLE
Revert "astroid!=2.12.6, !=2.12.7 (#13338)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ upnp_dependencies = [
 ]
 
 dev_dependencies = [
-    # TODO: remove after https://github.com/PyCQA/pylint/issues/7425 is resolved
-    "astroid!=2.12.6, !=2.12.7",
     "build",
     "coverage",
     "pre-commit",


### PR DESCRIPTION
This reverts commit 4fecc3f6c18f6e0a49e0301cc476fb16231e13aa.

These could be left in but we generally don't bother to track anything but the currently used version.