### PR TITLE
improve dl rpc tests

### DIFF
--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -122,10 +122,12 @@ async def bare_data_layer_api_fixture(tmp_path: Path, bt: BlockTools) -> AsyncIt
         data_rpc_api = DataLayerRpcApi(data_layer)
         yield data_rpc_api
 
+
 def check_mempool_spend_count(full_node_api: FullNodeSimulator, num_of_spends):
     return len(full_node_api.full_node.mempool_manager.mempool.sorted_spends) == num_of_spends
 
-async def check_singleton_confirmed(dl:DataLayer, tree_id):
+
+async def check_singleton_confirmed(dl: DataLayer, tree_id):
     return await dl.wallet_rpc.dl_latest_singleton(tree_id, True) != None
 
 
@@ -151,7 +153,7 @@ async def test_create_insert_get(one_wallet_node_and_rpc: nodes_with_port, tmp_p
         store_id = bytes32(hexstr_to_bytes(res["id"]))
         await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-        await time_out_assert(2, check_singleton_confirmed, True, data_layer, store_id )
+        await time_out_assert(2, check_singleton_confirmed, True, data_layer, store_id)
         res = await data_rpc_api.batch_update({"id": store_id.hex(), "changelist": changelist})
         update_tx_rec0 = res["tx_id"]
         await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -30,6 +30,7 @@ from chia.wallet.trading.offer import Offer as TradingOffer
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_node import WalletNode
 from tests.setup_nodes import setup_simulators_and_wallets
+from tests.util.wallet_is_synced import wallet_is_synced
 from tests.wallet.rl_wallet.test_rl_rpc import is_transaction_confirmed
 
 pytestmark = pytest.mark.data_layer
@@ -132,7 +133,8 @@ async def init_wallet_and_node(one_wallet_node_and_rpc: nodes_with_port) -> node
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
     funds = calculate_pool_reward(uint32(1)) + calculate_base_farmer_reward(uint32(1))
-    await time_out_assert(5, wallet_node.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
+    await time_out_assert(10, wallet_is_synced, True, wallet_node, full_node_api)
+    assert wallet_node.wallet_state_manager.main_wallet.get_confirmed_balance(funds)
     wallet_rpc_api = WalletRpcApi(wallet_node)
     return wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt
 

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -128,7 +128,7 @@ def check_mempool_spend_count(full_node_api: FullNodeSimulator, num_of_spends):
 
 
 async def check_singleton_confirmed(dl: DataLayer, tree_id):
-    return await dl.wallet_rpc.dl_latest_singleton(tree_id, True) != None
+    return await dl.wallet_rpc.dl_latest_singleton(tree_id, True) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -123,11 +123,11 @@ async def bare_data_layer_api_fixture(tmp_path: Path, bt: BlockTools) -> AsyncIt
         yield data_rpc_api
 
 
-def check_mempool_spend_count(full_node_api: FullNodeSimulator, num_of_spends):
+def check_mempool_spend_count(full_node_api: FullNodeSimulator, num_of_spends: int) -> bool:
     return len(full_node_api.full_node.mempool_manager.mempool.sorted_spends) == num_of_spends
 
 
-async def check_singleton_confirmed(dl: DataLayer, tree_id):
+async def check_singleton_confirmed(dl: DataLayer, tree_id: bytes32) -> bool:
     return await dl.wallet_rpc.dl_latest_singleton(tree_id, True) is not None
 
 
@@ -391,12 +391,9 @@ async def test_get_roots(one_wallet_node_and_rpc: nodes_with_port, tmp_path: Pat
     assert wallet_node.server
     await wallet_node.server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
     ph = await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash()
-    for i in range(0, num_blocks):
-        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-        await asyncio.sleep(0.5)
-    funds = sum(
-        [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
-    )
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+    funds = calculate_pool_reward(uint32(1)) + calculate_base_farmer_reward(uint32(1))
     await time_out_assert(90, wallet_node.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
     wallet_rpc_api = WalletRpcApi(wallet_node)
     async with init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path) as data_layer:
@@ -404,16 +401,16 @@ async def test_get_roots(one_wallet_node_and_rpc: nodes_with_port, tmp_path: Pat
         res = await data_rpc_api.create_data_store({})
         assert res is not None
         store_id1 = bytes32(hexstr_to_bytes(res["id"]))
-        for i in range(0, num_blocks):
-            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-            await asyncio.sleep(0.2)
+        await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+        await time_out_assert(2, check_singleton_confirmed, True, data_layer, store_id1)
 
         res = await data_rpc_api.create_data_store({})
         assert res is not None
         store_id2 = bytes32(hexstr_to_bytes(res["id"]))
-        for i in range(0, num_blocks):
-            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-            await asyncio.sleep(0.2)
+        await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+        await time_out_assert(2, check_singleton_confirmed, True, data_layer, store_id2)
 
         key1 = b"a"
         value1 = b"\x01\x02"
@@ -426,10 +423,8 @@ async def test_get_roots(one_wallet_node_and_rpc: nodes_with_port, tmp_path: Pat
         changelist.append({"action": "insert", "key": key3.hex(), "value": value3.hex()})
         res = await data_rpc_api.batch_update({"id": store_id1.hex(), "changelist": changelist})
         update_tx_rec0 = res["tx_id"]
-        await asyncio.sleep(1)
-        for i in range(0, num_blocks):
-            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-            await asyncio.sleep(0.2)
+        await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
         await time_out_assert(15, is_transaction_confirmed, True, "this is unused", wallet_rpc_api, update_tx_rec0)
         roots = await data_rpc_api.get_roots({"ids": [store_id1.hex(), store_id2.hex()]})
         assert roots["root_hashes"][1]["id"] == store_id2
@@ -444,10 +439,8 @@ async def test_get_roots(one_wallet_node_and_rpc: nodes_with_port, tmp_path: Pat
         changelist.append({"action": "insert", "key": key5.hex(), "value": value5.hex()})
         res = await data_rpc_api.batch_update({"id": store_id2.hex(), "changelist": changelist})
         update_tx_rec1 = res["tx_id"]
-        await asyncio.sleep(1)
-        for i in range(0, num_blocks):
-            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-            await asyncio.sleep(0.2)
+        await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
         await time_out_assert(15, is_transaction_confirmed, True, "this is unused", wallet_rpc_api, update_tx_rec1)
         roots = await data_rpc_api.get_roots({"ids": [store_id1.hex(), store_id2.hex()]})
         assert roots["root_hashes"][1]["id"] == store_id2

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -139,13 +139,15 @@ async def init_wallet_and_node(one_wallet_node_and_rpc: nodes_with_port) -> node
 
 async def farm_block_check_singelton(
     data_layer: DataLayer, full_node_api: FullNodeSimulator, ph: bytes32, store_id: bytes32
-):
+) -> None:
     await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
     await time_out_assert(5, check_singleton_confirmed, True, data_layer, store_id)
 
 
-async def farm_block_with_spend(full_node_api: FullNodeSimulator, ph: bytes32, tx_rec, wallet_rpc_api: WalletRpcApi):
+async def farm_block_with_spend(
+    full_node_api: FullNodeSimulator, ph: bytes32, tx_rec: bytes32, wallet_rpc_api: WalletRpcApi
+) -> None:
     await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
     await time_out_assert(5, is_transaction_confirmed, True, "this is unused", wallet_rpc_api, tx_rec)

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -602,7 +602,7 @@ async def test_get_owned_stores(one_wallet_node_and_rpc: nodes_with_port, tmp_pa
 @pytest.mark.asyncio
 async def test_subscriptions(one_wallet_node_and_rpc: nodes_with_port, tmp_path: Path) -> None:
     num_blocks = 4
-    bt, full_node_api, ph, wallet_rpc_api, wallet_rpc_port = await init_wallet_and_node(one_wallet_node_and_rpc)
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(one_wallet_node_and_rpc)
     async with init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path) as data_layer:
         data_rpc_api = DataLayerRpcApi(data_layer)
 

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -593,7 +593,7 @@ async def test_get_owned_stores(one_wallet_node_and_rpc: nodes_with_port, tmp_pa
         await time_out_assert(2, check_mempool_spend_count, True, full_node_api, 1)
         for i in range(0, num_blocks):
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-            await asyncio.sleep(0.2)
+            await asyncio.sleep(0.5)
 
         response = await data_rpc_api.get_owned_stores(request={})
         store_ids = sorted(bytes32.from_hexstr(id) for id in response["store_ids"])


### PR DESCRIPTION
checking mempool state and dl wallet store to avoid races while farming blocks
this removes the need to farm multiple blocks and using sleeps

also makes the tests run much faster 