### PR TITLE
ask the DB to count unspent small coins

### DIFF
--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -4,7 +4,7 @@ import sqlite3
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32, uint64
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -51,7 +51,17 @@ class WalletCoinStore:
 
             await conn.execute("CREATE INDEX IF NOT EXISTS wallet_id on coin_record(wallet_id)")
 
+            await conn.execute("CREATE INDEX IF NOT EXISTS coin_amount on coin_record(amount)")
+
         return self
+
+    async def count_small_unspent(self, cutoff: int) -> int:
+        amount_bytes = bytes(uint64(cutoff))
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            row = await execute_fetchone(
+                conn, "SELECT COUNT(*) FROM coin_record WHERE amount < ? AND spent=0", (amount_bytes,)
+            )
+            return int(0 if row is None else row[0])
 
     async def get_multiple_coin_records(self, coin_names: List[bytes32]) -> List[WalletCoinRecord]:
         """Return WalletCoinRecord(s) that have a coin name in the specified list"""
@@ -176,7 +186,7 @@ class WalletCoinStore:
 
         return [self.coin_record_from_row(row) for row in rows]
 
-    async def rollback_to_block(self, height: int):
+    async def rollback_to_block(self, height: int) -> None:
         """
         Rolls back the blockchain to block_index. All coins confirmed after this point are removed.
         All coins spent after this point are set to unspent. Can be -1 (rollback all)

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -668,9 +668,8 @@ class WalletStateManager:
         if xch_spam_amount <= 1:
             return new_coin_state
 
-        all_unspent: Set[WalletCoinRecord] = await self.coin_store.get_all_unspent_coins()
         spam_filter_after_n_txs = self.config.get("spam_filter_after_n_txs", 200)
-        small_unspent_count = len([r for r in all_unspent if r.coin.amount < xch_spam_amount])
+        small_unspent_count = await self.coin_store.count_small_unspent(xch_spam_amount)
 
         # if small_unspent_count > spam_filter_after_n_txs:
         filtered_cs: List[CoinState] = []

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -422,3 +422,35 @@ async def test_rollback_to_block() -> None:
         assert not new_r4.spent
         assert new_r4.spent_block_height == 0
         assert new_r4 != r4
+
+
+@pytest.mark.asyncio
+async def test_count_small_unspent() -> None:
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletCoinStore.create(db_wrapper)
+
+        coin_1 = Coin(token_bytes(32), token_bytes(32), uint64(1))
+        coin_2 = Coin(token_bytes(32), token_bytes(32), uint64(2))
+        coin_3 = Coin(token_bytes(32), token_bytes(32), uint64(4))
+
+        r1 = record(coin_1, confirmed=1, spent=0)
+        r2 = record(coin_2, confirmed=2, spent=0)
+        r3 = record(coin_3, confirmed=3, spent=0)
+
+        await store.add_coin_record(r1)
+        await store.add_coin_record(r2)
+        await store.add_coin_record(r3)
+
+        assert await store.count_small_unspent(5) == 3
+        assert await store.count_small_unspent(4) == 2
+        assert await store.count_small_unspent(3) == 2
+        assert await store.count_small_unspent(2) == 1
+        assert await store.count_small_unspent(1) == 0
+
+        await store.set_spent(coin_2.name(), uint32(12))
+
+        assert await store.count_small_unspent(5) == 2
+        assert await store.count_small_unspent(4) == 1
+        assert await store.count_small_unspent(3) == 1
+        assert await store.count_small_unspent(2) == 1
+        assert await store.count_small_unspent(1) == 0


### PR DESCRIPTION
instead of fetching every unspent coin from the DB, just to count in python. It's a lot faster.

main:

![chia-hotspot-98-107-main-spam-filter](https://user-images.githubusercontent.com/661450/188912498-5d04b9ad-c91d-4da8-aaa5-f74fe5c85248.png)

patched:

![chia-hotspot-78-81-patched](https://user-images.githubusercontent.com/661450/188912445-cc154dcb-7d6f-4d11-9f82-d89a940d4a52.png)
