### PR TITLE
Fix test race condition with reorged txs

### DIFF
--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -369,7 +369,15 @@ class TestPoolWalletRpc:
         def mempool_not_empty() -> bool:
             return len(full_node_api.full_node.mempool_manager.mempool.spends.keys()) > 0
 
+        def mempool_empty() -> bool:
+            return len(full_node_api.full_node.mempool_manager.mempool.spends.keys()) == 0
+
+        await client.delete_unconfirmed_transactions("1")
+        await farm_blocks(full_node_api, our_ph_2, 1)
+        await time_out_assert(20, wallet_is_synced, True, wallet_node_0, full_node_api)
+
         for i in range(5):
+            await time_out_assert(10, mempool_empty)
             res = await client.create_new_cat_and_wallet(20)
             summaries_response = await client.get_wallets()
             assert res["success"]


### PR DESCRIPTION
based on a recent failure on CI. The reorg in the test causes a lot of orphaned TXs to be unconfirmed, so checking the mempool for more than one TX was not reliable. 