### PR TITLE
Add default of 0 for amount with add_mirror cli

### DIFF
--- a/chia/cmds/data.py
+++ b/chia/cmds/data.py
@@ -292,7 +292,9 @@ def add_missing_files(ids: Optional[str], overwrite: bool, foldername: Optional[
 
 @data_cmd.command("add_mirror", short_help="Publish mirror urls on chain")
 @click.option("-i", "--id", help="Store id", type=str, required=True)
-@click.option("-a", "--amount", help="Amount to spend for this mirror, in mojos", type=int, required=True)
+@click.option(
+    "-a", "--amount", help="Amount to spend for this mirror, in mojos", type=int, default=0, show_default=True
+)
 @click.option(
     "-u",
     "--url",


### PR DESCRIPTION
Update `chia data add_mirror` to use a default amount value of 0. Users can still override as needed but the amount is no longer required to be specified

Fixes #13364 