### PR TITLE
separate process global setup for daemon

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -169,15 +169,6 @@ class WebSocketServer:
                 ssl.OPENSSL_VERSION,
             )
 
-        def master_close_cb():
-            asyncio.create_task(self.stop())
-
-        try:
-            asyncio.get_running_loop().add_signal_handler(signal.SIGINT, master_close_cb)
-            asyncio.get_running_loop().add_signal_handler(signal.SIGTERM, master_close_cb)
-        except NotImplementedError:
-            self.log.info("Not implemented")
-
         app = web.Application(client_max_size=self.daemon_max_message_size)
         app.add_routes([web.get("/", self.incoming_connection)])
         self.websocket_runner = web.AppRunner(app, access_log=None, logger=self.log, keepalive_timeout=300)
@@ -191,6 +182,16 @@ class WebSocketServer:
             ssl_context=self.ssl_context,
         )
         await site.start()
+
+    async def setup_process_global_state(self) -> None:
+        try:
+            asyncio.get_running_loop().add_signal_handler(signal.SIGINT, self._accept_signal)
+            asyncio.get_running_loop().add_signal_handler(signal.SIGTERM, self._accept_signal)
+        except NotImplementedError:
+            self.log.info("Not implemented")
+
+    def _accept_signal(self, signal_number: int, stack_frame=None):
+        asyncio.create_task(self.stop())
 
     def cancel_task_safe(self, task: Optional[asyncio.Task]):
         if task is not None:
@@ -1363,6 +1364,7 @@ async def async_run_daemon(root_path: Path, wait_for_unlock: bool = False) -> in
                 shutdown_event,
                 run_check_keys_on_unlock=wait_for_unlock,
             )
+            await ws_server.setup_process_global_state()
             await ws_server.start()
             await shutdown_event.wait()
             log.info("Daemon WebSocketServer closed")

--- a/chia/simulator/simulator_test_tools.py
+++ b/chia/simulator/simulator_test_tools.py
@@ -144,6 +144,7 @@ async def get_full_chia_simulator(
     with Lockfile.create(daemon_launch_lock_path(chia_root)):
         shutdown_event = asyncio.Event()
         ws_server = WebSocketServer(chia_root, ca_crt_path, ca_key_path, crt_path, key_path, shutdown_event)
+        await ws_server.setup_process_global_state()
         await ws_server.start()  # type: ignore[no-untyped-call]
 
         async for simulator in start_simulator(chia_root, automated_testing):


### PR DESCRIPTION
This separates the process global setup, just signals for now, so that it can be not called when running tests.  This form is modeled after the same behavior on the the `Service` class.