### PR TITLE
run expensive API requests in separate thread

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -3,6 +3,7 @@ import dataclasses
 import logging
 import time
 import traceback
+import functools
 from secrets import token_bytes
 from typing import Dict, List, Optional, Tuple, Set
 
@@ -47,10 +48,11 @@ from chia.types.transaction_queue_entry import TransactionQueueEntry
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.api_decorators import api_request, peer_required, bytes_required, execute_task, reply_type
 from chia.util.full_block_utils import header_block_from_block
-from chia.util.generator_tools import get_block_header
+from chia.util.generator_tools import get_block_header, tx_removals_and_additions
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.merkle_set import MerkleSet
+from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 
 
 class FullNodeAPI:
@@ -1106,15 +1108,39 @@ class FullNodeAPI:
             msg = make_msg(ProtocolMessageTypes.reject_header_request, RejectHeaderRequest(request.height))
             return msg
         block: Optional[FullBlock] = await self.full_node.block_store.get_full_block(header_hash)
-        if block is not None:
-            tx_removals, tx_additions, _ = await self.full_node.blockchain.get_tx_removals_and_additions(block)
-            header_block = get_block_header(block, tx_additions, tx_removals)
-            msg = make_msg(
-                ProtocolMessageTypes.respond_block_header,
-                wallet_protocol.RespondBlockHeader(header_block),
+        if block is None:
+            return None
+
+        tx_removals: List[bytes32] = []
+        tx_additions: List[Coin] = []
+
+        if block.transactions_generator is not None:
+
+            block_generator: Optional[BlockGenerator] = await self.full_node.blockchain.get_block_generator(block)
+            # get_block_generator() returns None in case the block we specify
+            # does not have a generator (i.e. is not a transaction block).
+            # in this case we've already made sure `block` does have a
+            # transactions_generator, so the block_generator should always be set
+            assert block_generator is not None, "failed to get block_generator for tx-block"
+
+            npc_result = await asyncio.get_running_loop().run_in_executor(
+                self.executor,
+                functools.partial(
+                    get_name_puzzle_conditions,
+                    block_generator,
+                    self.full_node.constants.MAX_BLOCK_COST_CLVM,
+                    cost_per_byte=self.full_node.constants.COST_PER_BYTE,
+                    mempool_mode=False,
+                ),
             )
-            return msg
-        return None
+
+            tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
+        header_block = get_block_header(block, tx_additions, tx_removals)
+        msg = make_msg(
+            ProtocolMessageTypes.respond_block_header,
+            wallet_protocol.RespondBlockHeader(header_block),
+        )
+        return msg
 
     @api_request
     async def request_additions(self, request: wallet_protocol.RequestAdditions) -> Optional[Message]:
@@ -1298,10 +1324,9 @@ class FullNodeAPI:
 
         block_generator: Optional[BlockGenerator] = await self.full_node.blockchain.get_block_generator(block)
         assert block_generator is not None
-        error, puzzle, solution = await asyncio.get_running_loop().run_in_executor(self.executor,
-            get_puzzle_and_solution_for_coin,
-            block_generator,
-            coin_record.coin)
+        error, puzzle, solution = await asyncio.get_running_loop().run_in_executor(
+            self.executor, get_puzzle_and_solution_for_coin, block_generator, coin_record.coin
+        )
 
         if error is not None:
             return reject_msg

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ dependencies = [
     "chiapos==1.0.10",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.5",  # Currying, Program.to, other conveniences
-    "chia_rs==0.1.9",
+    "chia_rs==0.1.10",
     "clvm-tools-rs==0.1.19",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.1",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
This moves two expensive API request calls into a 1-thread `ThreadPoolExecutor` in `full_node_api`.

1. request puzzle and solution from coin
2. get block header

Both of these are expensive because they have to run the block program (and pull referenced blocks from DB, but those are async). Running the block generator program is currently done in the main thread, blocking the main loop.