### PR TITLE
farm fewer blocks for wallet offer tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 # flake8: noqa E402 # See imports after multiprocessing.set_start_method
 import multiprocessing
 import os
-from secrets import token_bytes
 
 import pytest
 import pytest_asyncio
@@ -16,7 +15,6 @@ from chia.server.start_service import Service
 from chia.clvm.spend_sim import SimClient, SpendSim
 from chia.protocols import full_node_protocol
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.config import create_default_chia_config, lock_and_load_config
 from chia.util.ints import uint16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -550,8 +550,8 @@ async def wallets_prefarm(two_wallet_nodes, self_hostname, trusted):
     """
     Sets up the node with 10 blocks, and returns a payer and payee wallet.
     """
-    farm_blocks = 10
-    buffer = 4
+    farm_blocks = 3
+    buffer = 1
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api = full_nodes[0]
     full_node_server = full_node_api.server

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -38,6 +38,9 @@ class TestCATTrades:
         wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
         wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
+        initial_maker_balance = await wallet_maker.get_confirmed_balance()
+        initial_taker_balance = await wallet_taker.get_confirmed_balance()
+
         # Create two new CATs, one in each wallet
         async with wallet_node_maker.wallet_state_manager.lock:
             cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
@@ -66,8 +69,8 @@ class TestCATTrades:
         )
 
         # Create the trade parameters
-        MAKER_CHIA_BALANCE = 20 * 1000000000000 - 100
-        TAKER_CHIA_BALANCE = 20 * 1000000000000 - 100
+        MAKER_CHIA_BALANCE = initial_maker_balance - 100
+        TAKER_CHIA_BALANCE = initial_taker_balance - 100
         await time_out_assert(25, wallet_maker.get_confirmed_balance, MAKER_CHIA_BALANCE)
         await time_out_assert(25, wallet_taker.get_unconfirmed_balance, TAKER_CHIA_BALANCE)
         MAKER_CAT_BALANCE = 100
@@ -369,9 +372,14 @@ class TestCATTrades:
         wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
         wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
+        maker_funds = await wallet_maker.get_confirmed_balance()
+        taker_funds = await wallet_taker.get_confirmed_balance()
+
+        xch_to_cat_amount = uint64(100)
+
         async with wallet_node_maker.wallet_state_manager.lock:
             cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
-                wallet_node_maker.wallet_state_manager, wallet_maker, {"identifier": "genesis_by_id"}, uint64(100)
+                wallet_node_maker.wallet_state_manager, wallet_maker, {"identifier": "genesis_by_id"}, xch_to_cat_amount
             )
 
             tx_queue: List[TransactionRecord] = await wallet_node_maker.wallet_state_manager.tx_store.get_not_sent()
@@ -382,12 +390,10 @@ class TestCATTrades:
         for i in range(1, buffer_blocks):
             await full_node.farm_new_transaction_block(FarmNewBlockProtocol(token_bytes()))
 
-        await time_out_assert(15, cat_wallet_maker.get_confirmed_balance, 100)
-        await time_out_assert(15, cat_wallet_maker.get_unconfirmed_balance, 100)
-        MAKER_CHIA_BALANCE = 20 * 1000000000000 - 100
-        MAKER_CAT_BALANCE = 100
-        TAKER_CHIA_BALANCE = 20 * 1000000000000
-        await time_out_assert(15, wallet_maker.get_confirmed_balance, MAKER_CHIA_BALANCE)
+        await time_out_assert(15, cat_wallet_maker.get_confirmed_balance, xch_to_cat_amount)
+        await time_out_assert(15, cat_wallet_maker.get_unconfirmed_balance, xch_to_cat_amount)
+        maker_funds -= xch_to_cat_amount
+        await time_out_assert(15, wallet_maker.get_confirmed_balance, maker_funds)
 
         cat_for_chia = {
             wallet_maker.id(): 1,
@@ -432,9 +438,9 @@ class TestCATTrades:
         #     Offer.from_bytes(trade_take.offer).to_valid_spend().name(),
         # )
 
-        FEE = uint64(2000000000000)
+        fee = uint64(2_000_000_000_000)
 
-        txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=FEE)
+        txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=fee)
         await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
         for tx in txs:
             if tx.spend_bundle is not None:
@@ -456,9 +462,9 @@ class TestCATTrades:
         # await time_out_assert(15, get_trade_and_status, TradeStatus.FAILED, trade_manager_taker, trade_take)
 
         await time_out_assert(15, wallet_maker.get_pending_change_balance, 0)
-        await time_out_assert(15, wallet_maker.get_confirmed_balance, MAKER_CHIA_BALANCE - FEE)
-        await time_out_assert(15, cat_wallet_maker.get_confirmed_balance, MAKER_CAT_BALANCE)
-        await time_out_assert(15, wallet_taker.get_confirmed_balance, TAKER_CHIA_BALANCE)
+        await time_out_assert(15, wallet_maker.get_confirmed_balance, maker_funds - fee)
+        await time_out_assert(15, cat_wallet_maker.get_confirmed_balance, xch_to_cat_amount)
+        await time_out_assert(15, wallet_taker.get_confirmed_balance, taker_funds)
 
         peer = wallet_node_taker.get_full_node_peer()
         assert peer is not None

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -34,12 +34,13 @@ buffer_blocks = 4
 class TestCATTrades:
     @pytest.mark.asyncio
     async def test_cat_trades(self, wallets_prefarm):
-        wallet_node_maker, wallet_node_taker, full_node = wallets_prefarm
+        (
+            [wallet_node_maker, initial_maker_balance],
+            [wallet_node_taker, initial_taker_balance],
+            full_node,
+        ) = wallets_prefarm
         wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
         wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
-
-        initial_maker_balance = await wallet_maker.get_confirmed_balance()
-        initial_taker_balance = await wallet_taker.get_confirmed_balance()
 
         # Create two new CATs, one in each wallet
         async with wallet_node_maker.wallet_state_manager.lock:
@@ -368,12 +369,13 @@ class TestCATTrades:
 
     @pytest.mark.asyncio
     async def test_trade_cancellation(self, wallets_prefarm):
-        wallet_node_maker, wallet_node_taker, full_node = wallets_prefarm
+        (
+            [wallet_node_maker, maker_funds],
+            [wallet_node_taker, taker_funds],
+            full_node,
+        ) = wallets_prefarm
         wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
         wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
-
-        maker_funds = await wallet_maker.get_confirmed_balance()
-        taker_funds = await wallet_taker.get_confirmed_balance()
 
         xch_to_cat_amount = uint64(100)
 

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -41,7 +41,11 @@ def get_parent_branch(value: bytes32, proof: Tuple[int, List[bytes32]]) -> Tuple
 )
 @pytest.mark.asyncio
 async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
-    wallet_node_maker, wallet_node_taker, full_node_api = wallets_prefarm
+    (
+        [wallet_node_maker, maker_funds],
+        [wallet_node_taker, taker_funds],
+        full_node_api,
+    ) = wallets_prefarm
     assert wallet_node_maker.wallet_state_manager is not None
     assert wallet_node_taker.wallet_state_manager is not None
     wsm_maker = wallet_node_maker.wallet_state_manager
@@ -49,9 +53,6 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
 
     wallet_maker = wsm_maker.main_wallet
     wallet_taker = wsm_taker.main_wallet
-
-    maker_funds = await wallet_maker.get_confirmed_balance()
-    taker_funds = await wallet_taker.get_confirmed_balance()
 
     async with wsm_maker.lock:
         dl_wallet_maker = await DataLayerWallet.create_new_dl_wallet(wsm_maker, wallet_maker)
@@ -226,7 +227,7 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
 )
 @pytest.mark.asyncio
 async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> None:
-    wallet_node, _, full_node_api = wallets_prefarm
+    [wallet_node, _], [_, _], full_node_api = wallets_prefarm
     assert wallet_node.wallet_state_manager is not None
     wsm = wallet_node.wallet_state_manager
 
@@ -289,7 +290,11 @@ async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> Non
 )
 @pytest.mark.asyncio
 async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
-    wallet_node_maker, wallet_node_taker, full_node_api = wallets_prefarm
+    (
+        [wallet_node_maker, maker_funds],
+        [wallet_node_taker, taker_funds],
+        full_node_api,
+    ) = wallets_prefarm
     assert wallet_node_maker.wallet_state_manager is not None
     assert wallet_node_taker.wallet_state_manager is not None
     wsm_maker = wallet_node_maker.wallet_state_manager
@@ -297,9 +302,6 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
 
     wallet_maker = wsm_maker.main_wallet
     wallet_taker = wsm_taker.main_wallet
-
-    maker_funds = await wallet_maker.get_confirmed_balance()
-    taker_funds = await wallet_taker.get_confirmed_balance()
 
     async with wsm_maker.lock:
         dl_wallet_maker = await DataLayerWallet.create_new_dl_wallet(wsm_maker, wallet_maker)

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -50,10 +50,8 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     wallet_maker = wsm_maker.main_wallet
     wallet_taker = wsm_taker.main_wallet
 
-    funds = 20000000000000
-
-    await time_out_assert(10, wallet_maker.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_taker.get_confirmed_balance, funds)
+    maker_funds = await wallet_maker.get_confirmed_balance()
+    taker_funds = await wallet_taker.get_confirmed_balance()
 
     async with wsm_maker.lock:
         dl_wallet_maker = await DataLayerWallet.create_new_dl_wallet(wsm_maker, wallet_maker)
@@ -65,22 +63,28 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     maker_root, _ = build_merkle_tree(MAKER_ROWS)
     taker_root, _ = build_merkle_tree(TAKER_ROWS)
 
+    fee = uint64(1_999_999_999_999)
+
     dl_record, std_record, launcher_id_maker = await dl_wallet_maker.generate_new_reporter(
-        maker_root, fee=uint64(1999999999999)
+        maker_root, fee=fee
     )
     assert await dl_wallet_maker.get_latest_singleton(launcher_id_maker) is not None
     await wsm_maker.add_pending_transaction(dl_record)
     await wsm_maker.add_pending_transaction(std_record)
     await full_node_api.process_transaction_records(records=[dl_record, std_record])
+    maker_funds -= fee
+    maker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_maker, maker_root)
 
     dl_record, std_record, launcher_id_taker = await dl_wallet_taker.generate_new_reporter(
-        taker_root, fee=uint64(1999999999999)
+        taker_root, fee=fee
     )
     assert await dl_wallet_taker.get_latest_singleton(launcher_id_taker) is not None
     await wsm_taker.add_pending_transaction(dl_record)
     await wsm_taker.add_pending_transaction(std_record)
     await full_node_api.process_transaction_records(records=[dl_record, std_record])
+    taker_funds -= fee
+    taker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_taker, launcher_id_taker, taker_root)
 
     peer = wallet_node_taker.get_full_node_peer()
@@ -102,6 +106,8 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     maker_branch, maker_branch_proof = get_parent_branch(maker_addition, maker_proofs[maker_addition])
     taker_branch, taker_branch_proof = get_parent_branch(taker_addition, taker_proofs[taker_addition])
 
+    fee = uint64(2_000_000_000_000)
+
     success, offer_maker, error = await trade_manager_maker.create_offer_for_ids(
         {launcher_id_maker: -1, launcher_id_taker: 1},
         solver=Solver(
@@ -117,7 +123,7 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
                 }
             }
         ),
-        fee=uint64(2000000000000),
+        fee=fee,
     )
     assert error is None
     assert success is True
@@ -166,7 +172,7 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
                 ],
             }
         ),
-        fee=uint64(2000000000000),
+        fee=fee,
     )
     assert error is None
     assert success is True
@@ -197,17 +203,19 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
         ]
     }
 
-    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, funds - 2000000000000)
-    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, funds - 4000000000000)
+    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, maker_funds)
+    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, taker_funds - fee)
 
     # Let's hack a way to await this offer's confirmation
     offer_record = dataclasses.replace(dl_record, spend_bundle=Offer.from_bytes(offer_taker.offer).bundle)
     await full_node_api.process_transaction_records(records=[offer_record])
+    maker_funds -= fee
+    taker_funds -= fee
 
-    await time_out_assert(15, wallet_maker.get_confirmed_balance, funds - 4000000000000)
-    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, funds - 4000000000000)
-    await time_out_assert(15, wallet_taker.get_confirmed_balance, funds - 4000000000000)
-    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, funds - 4000000000000)
+    await time_out_assert(15, wallet_maker.get_confirmed_balance, maker_funds)
+    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, maker_funds)
+    await time_out_assert(15, wallet_taker.get_confirmed_balance, taker_funds)
+    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, taker_funds)
 
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_taker, taker_root)
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_taker, launcher_id_maker, maker_root)
@@ -227,10 +235,6 @@ async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> Non
     wsm = wallet_node.wallet_state_manager
 
     wallet = wsm.main_wallet
-
-    funds = 20000000000000
-
-    await time_out_assert(10, wallet.get_unconfirmed_balance, funds)
 
     async with wsm.lock:
         dl_wallet = await DataLayerWallet.create_new_dl_wallet(wsm, wallet)
@@ -270,13 +274,13 @@ async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> Non
                 }
             }
         ),
-        fee=uint64(2000000000000),
+        fee=uint64(2_000_000_000_000),
     )
     assert error is None
     assert success is True
     assert offer is not None
 
-    cancellation_txs = await trade_manager.cancel_pending_offer_safely(offer.trade_id, fee=uint64(2000000000000))
+    cancellation_txs = await trade_manager.cancel_pending_offer_safely(offer.trade_id, fee=uint64(2_000_000_000_000))
     assert len(cancellation_txs) == 3
     await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager, offer)
     await full_node_api.process_transaction_records(records=cancellation_txs)
@@ -298,10 +302,8 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     wallet_maker = wsm_maker.main_wallet
     wallet_taker = wsm_taker.main_wallet
 
-    funds = 20000000000000
-
-    await time_out_assert(10, wallet_maker.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_taker.get_confirmed_balance, funds)
+    maker_funds = await wallet_maker.get_confirmed_balance()
+    taker_funds = await wallet_taker.get_confirmed_balance()
 
     async with wsm_maker.lock:
         dl_wallet_maker = await DataLayerWallet.create_new_dl_wallet(wsm_maker, wallet_maker)
@@ -313,38 +315,48 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     maker_root, _ = build_merkle_tree(MAKER_ROWS)
     taker_root, _ = build_merkle_tree(TAKER_ROWS)
 
+    fee = uint64(1_999_999_999_999)
+
     dl_record, std_record, launcher_id_maker_1 = await dl_wallet_maker.generate_new_reporter(
-        maker_root, fee=uint64(1999999999999)
+        maker_root, fee=fee
     )
     assert await dl_wallet_maker.get_latest_singleton(launcher_id_maker_1) is not None
     await wsm_maker.add_pending_transaction(dl_record)
     await wsm_maker.add_pending_transaction(std_record)
     await full_node_api.process_transaction_records(records=[dl_record, std_record])
+    maker_funds -= fee
+    maker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_maker_1, maker_root)
     dl_record, std_record, launcher_id_maker_2 = await dl_wallet_maker.generate_new_reporter(
-        maker_root, fee=uint64(1999999999999)
+        maker_root, fee=fee
     )
     assert await dl_wallet_maker.get_latest_singleton(launcher_id_maker_2) is not None
     await wsm_maker.add_pending_transaction(dl_record)
     await wsm_maker.add_pending_transaction(std_record)
     await full_node_api.process_transaction_records(records=[dl_record, std_record])
+    maker_funds -= fee
+    maker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_maker_2, maker_root)
 
     dl_record, std_record, launcher_id_taker_1 = await dl_wallet_taker.generate_new_reporter(
-        taker_root, fee=uint64(1999999999999)
+        taker_root, fee=fee
     )
     assert await dl_wallet_taker.get_latest_singleton(launcher_id_taker_1) is not None
     await wsm_taker.add_pending_transaction(dl_record)
     await wsm_taker.add_pending_transaction(std_record)
     await full_node_api.process_transaction_records(records=[dl_record, std_record])
+    taker_funds -= fee
+    taker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_taker, launcher_id_taker_1, taker_root)
     dl_record, std_record, launcher_id_taker_2 = await dl_wallet_taker.generate_new_reporter(
-        taker_root, fee=uint64(1999999999999)
+        taker_root, fee=fee
     )
     assert await dl_wallet_taker.get_latest_singleton(launcher_id_taker_2) is not None
     await wsm_taker.add_pending_transaction(dl_record)
     await wsm_taker.add_pending_transaction(std_record)
     await full_node_api.process_transaction_records(records=[dl_record, std_record])
+    taker_funds -= fee
+    taker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_taker, launcher_id_taker_2, taker_root)
 
     peer = wallet_node_taker.get_full_node_peer()
@@ -369,6 +381,8 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     taker_root, taker_proofs = build_merkle_tree(TAKER_ROWS)
     maker_branch, maker_branch_proof = get_parent_branch(maker_addition, maker_proofs[maker_addition])
     taker_branch, taker_branch_proof = get_parent_branch(taker_addition, taker_proofs[taker_addition])
+
+    fee = uint64(2_000_000_000_000)
 
     success, offer_maker, error = await trade_manager_maker.create_offer_for_ids(
         {launcher_id_maker_1: -1, launcher_id_taker_1: 1, launcher_id_maker_2: -1, launcher_id_taker_2: 1},
@@ -398,7 +412,7 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
                 },
             }
         ),
-        fee=uint64(2000000000000),
+        fee=fee,
     )
     assert error is None
     assert success is True
@@ -445,23 +459,26 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
                 ],
             }
         ),
-        fee=uint64(2000000000000),
+        fee=fee,
     )
     assert error is None
     assert success is True
     assert offer_taker is not None
 
-    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, funds - 4000000000000)
-    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, funds - 6000000000000)
+    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, maker_funds)
+    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, taker_funds - fee)
 
     # Let's hack a way to await this offer's confirmation
     offer_record = dataclasses.replace(dl_record, spend_bundle=Offer.from_bytes(offer_taker.offer).bundle)
     await full_node_api.process_transaction_records(records=[offer_record])
 
-    await time_out_assert(15, wallet_maker.get_confirmed_balance, funds - 6000000000000)
-    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, funds - 6000000000000)
-    await time_out_assert(15, wallet_taker.get_confirmed_balance, funds - 6000000000000)
-    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, funds - 6000000000000)
+    maker_funds -= fee
+    taker_funds -= fee
+
+    await time_out_assert(15, wallet_maker.get_confirmed_balance, maker_funds)
+    await time_out_assert(15, wallet_maker.get_unconfirmed_balance, maker_funds)
+    await time_out_assert(15, wallet_taker.get_confirmed_balance, taker_funds)
+    await time_out_assert(15, wallet_taker.get_unconfirmed_balance, taker_funds)
 
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_taker_1, taker_root)
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_taker_2, taker_root)

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -65,9 +65,7 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
 
     fee = uint64(1_999_999_999_999)
 
-    dl_record, std_record, launcher_id_maker = await dl_wallet_maker.generate_new_reporter(
-        maker_root, fee=fee
-    )
+    dl_record, std_record, launcher_id_maker = await dl_wallet_maker.generate_new_reporter(maker_root, fee=fee)
     assert await dl_wallet_maker.get_latest_singleton(launcher_id_maker) is not None
     await wsm_maker.add_pending_transaction(dl_record)
     await wsm_maker.add_pending_transaction(std_record)
@@ -76,9 +74,7 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     maker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_maker, maker_root)
 
-    dl_record, std_record, launcher_id_taker = await dl_wallet_taker.generate_new_reporter(
-        taker_root, fee=fee
-    )
+    dl_record, std_record, launcher_id_taker = await dl_wallet_taker.generate_new_reporter(taker_root, fee=fee)
     assert await dl_wallet_taker.get_latest_singleton(launcher_id_taker) is not None
     await wsm_taker.add_pending_transaction(dl_record)
     await wsm_taker.add_pending_transaction(std_record)
@@ -317,9 +313,7 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
 
     fee = uint64(1_999_999_999_999)
 
-    dl_record, std_record, launcher_id_maker_1 = await dl_wallet_maker.generate_new_reporter(
-        maker_root, fee=fee
-    )
+    dl_record, std_record, launcher_id_maker_1 = await dl_wallet_maker.generate_new_reporter(maker_root, fee=fee)
     assert await dl_wallet_maker.get_latest_singleton(launcher_id_maker_1) is not None
     await wsm_maker.add_pending_transaction(dl_record)
     await wsm_maker.add_pending_transaction(std_record)
@@ -327,9 +321,7 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     maker_funds -= fee
     maker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_maker_1, maker_root)
-    dl_record, std_record, launcher_id_maker_2 = await dl_wallet_maker.generate_new_reporter(
-        maker_root, fee=fee
-    )
+    dl_record, std_record, launcher_id_maker_2 = await dl_wallet_maker.generate_new_reporter(maker_root, fee=fee)
     assert await dl_wallet_maker.get_latest_singleton(launcher_id_maker_2) is not None
     await wsm_maker.add_pending_transaction(dl_record)
     await wsm_maker.add_pending_transaction(std_record)
@@ -338,9 +330,7 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     maker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_maker_2, maker_root)
 
-    dl_record, std_record, launcher_id_taker_1 = await dl_wallet_taker.generate_new_reporter(
-        taker_root, fee=fee
-    )
+    dl_record, std_record, launcher_id_taker_1 = await dl_wallet_taker.generate_new_reporter(taker_root, fee=fee)
     assert await dl_wallet_taker.get_latest_singleton(launcher_id_taker_1) is not None
     await wsm_taker.add_pending_transaction(dl_record)
     await wsm_taker.add_pending_transaction(std_record)
@@ -348,9 +338,7 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     taker_funds -= fee
     taker_funds -= 1
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_taker, launcher_id_taker_1, taker_root)
-    dl_record, std_record, launcher_id_taker_2 = await dl_wallet_taker.generate_new_reporter(
-        taker_root, fee=fee
-    )
+    dl_record, std_record, launcher_id_taker_2 = await dl_wallet_taker.generate_new_reporter(taker_root, fee=fee)
     assert await dl_wallet_taker.get_latest_singleton(launcher_id_taker_2) is not None
     await wsm_taker.add_pending_transaction(dl_record)
     await wsm_taker.add_pending_transaction(std_record)

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -527,7 +527,11 @@ async def is_singleton_confirmed_and_root(dl_wallet: DataLayerWallet, lid: bytes
 )
 @pytest.mark.asyncio
 async def test_mirrors(wallets_prefarm: Any, trusted: bool) -> None:
-    wallet_node_1, wallet_node_2, full_node_api = wallets_prefarm
+    (
+        [wallet_node_1, _],
+        [wallet_node_2, _],
+        full_node_api,
+    ) = wallets_prefarm
     assert wallet_node_1.wallet_state_manager is not None
     assert wallet_node_2.wallet_state_manager is not None
     wsm_1 = wallet_node_1.wallet_state_manager

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -536,11 +536,6 @@ async def test_mirrors(wallets_prefarm: Any, trusted: bool) -> None:
     wallet_1 = wsm_1.main_wallet
     wallet_2 = wsm_2.main_wallet
 
-    funds = 20000000000000
-
-    await time_out_assert(10, wallet_1.get_unconfirmed_balance, funds)
-    await time_out_assert(10, wallet_2.get_confirmed_balance, funds)
-
     async with wsm_1.lock:
         dl_wallet_1 = await DataLayerWallet.create_new_dl_wallet(wsm_1, wallet_1)
     async with wsm_2.lock:
@@ -569,7 +564,7 @@ async def test_mirrors(wallets_prefarm: Any, trusted: bool) -> None:
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_1, launcher_id_2, bytes32([0] * 32))
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_2, launcher_id_1, bytes32([0] * 32))
 
-    txs = await dl_wallet_1.create_new_mirror(launcher_id_2, uint64(3), [b"foo", b"bar"], fee=uint64(1999999999999))
+    txs = await dl_wallet_1.create_new_mirror(launcher_id_2, uint64(3), [b"foo", b"bar"], fee=uint64(1_999_999_999_999))
     additions: List[Coin] = []
     for tx in txs:
         if tx.spend_bundle is not None:
@@ -586,7 +581,7 @@ async def test_mirrors(wallets_prefarm: Any, trusted: bool) -> None:
         15, dl_wallet_2.get_mirrors_for_launcher, [dataclasses.replace(mirror, ours=False)], launcher_id_2
     )
 
-    txs = await dl_wallet_1.delete_mirror(mirror.coin_id, peer_1, fee=uint64(2000000000000))
+    txs = await dl_wallet_1.delete_mirror(mirror.coin_id, peer_1, fee=uint64(2_000_000_000_000))
     for tx in txs:
         await wsm_1.add_pending_transaction(tx)
     await full_node_api.process_transaction_records(records=txs)


### PR DESCRIPTION
Somewhere there was a timeout waiting on the wallet balance to be as expected.  I looked back and there were 24 blocks being farmed in the fixture.  Turns out that 7 is enough.  I also made the relevant tests agnostic to the initial balance, presuming it is sufficient for them.