### PR TITLE
retryAfter: 5 (24x) for conflict check

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -17,5 +17,6 @@ jobs:
         with:
           dirtyLabel: "merge_conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          retryAfter: 2
           commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
           commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           dirtyLabel: "merge_conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          retryAfter: 2
+          # targeting 2 minutes of retry, longest observed window thus far is ~30 seconds
+          retryAfter: 5
+          retryMax: 24
           commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
           commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."

--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are behind main
-        uses: eps1lon/actions-label-merge-conflict@v2.0.1
+        uses: Chia-Network/actions/label-conflict@main
         with:
-          dirtyLabel: "merge_conflict"
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          labelToAddOnConflict: "merge_conflict"
+          secretToken: "${{ secrets.GITHUB_TOKEN }}"
           # targeting 2 minutes of retry, longest observed window thus far is ~30 seconds
-          retryAfter: 5
+          retryIntervalSec: 5
           retryMax: 24
-          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
-          commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."
+          commentToAddOnConflict: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
+          commentToAddOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."


### PR DESCRIPTION
I don't really know how long the `UNKNOWN` mergeability state usually takes to resolve but that is the trigger for the 120 second delays on each PR in that state.  This can be seen if you look through the action source and run the workflow with debug enabled.  I don't believe I've seen it rerun more than one out of the 5 (at least default) retries.  I propose this 2 second retry to start and see how it goes.  Unless it repeats multiple times this should induce no extra load in terms of queries and will reduce runner load by not having the runner sitting there doing nothing for two minutes.

```
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]{
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]  "mergeable": "UNKNOWN",
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]  "number": 13389,
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]  "permalink": "https://github.com/Chia-Network/chia-blockchain/pull/13389",
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]  "title": "Delete DID wallet after transfer",
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]  "updatedAt": "2022-09-09T16:29:20Z",
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]  "labels": {
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]    "nodes": []
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]  }
Sun, 11 Sep 2022 14:30:48 GMT
##[debug]}
Sun, 11 Sep 2022 14:30:48 GMT
for PR "Delete DID wallet after transfer": Retrying after 120s.
Sun, 11 Sep 2022 14:32:48 GMT
retrying with 5 retries remaining.
```

Draft for:
- [x] Consideration of actual retry behavior
- [x] Seeing if https://github.com/Chia-Network/chia-blockchain/pull/13424 fixes it with the new retry logic