### PR TITLE
pools: Make `PoolWallet` a `dataclass`

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -3,7 +3,7 @@ import asyncio
 import dataclasses
 import logging
 import time
-from typing import Any, Optional, Set, Tuple, List, Dict, TYPE_CHECKING
+from typing import cast, Any, Optional, Set, Tuple, List, Dict, TYPE_CHECKING
 from typing_extensions import final
 
 from blspy import PrivateKey, G2Element, G1Element
@@ -1004,4 +1004,4 @@ class PoolWallet:
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol
 
-    _dummy: WalletProtocol = PoolWallet()  # type: ignore[call-arg]  # Ignore missing args for type checks
+    _dummy: WalletProtocol = cast(PoolWallet, None)

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
 import time
 from typing import Any, Optional, Set, Tuple, List, Dict, TYPE_CHECKING
+from typing_extensions import final
 
 from blspy import PrivateKey, G2Element, G1Element
 
@@ -59,6 +61,8 @@ from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.util.transaction_type import TransactionType
 
 
+@final
+@dataclasses.dataclass
 class PoolWallet:
     MINIMUM_INITIAL_BALANCE = 1
     MINIMUM_RELATIVE_LOCK_HEIGHT = 5
@@ -68,12 +72,12 @@ class PoolWallet:
     wallet_state_manager: Any
     log: logging.Logger
     wallet_info: WalletInfo
-    target_state: Optional[PoolState]
-    next_transaction_fee: uint64
     standard_wallet: Wallet
     wallet_id: int
-    _owner_sk_and_index: Optional[Tuple[PrivateKey, uint32]]
-    _update_pool_config_after_sync_task: Optional[asyncio.Task]
+    next_transaction_fee: uint64 = uint64(0)
+    target_state: Optional[PoolState] = None
+    _owner_sk_and_index: Optional[Tuple[PrivateKey, uint32]] = None
+    _update_pool_config_after_sync_task: Optional[asyncio.Task] = None
 
     """
     From the user's perspective, this is not a wallet at all, but a way to control
@@ -341,8 +345,9 @@ class PoolWallet:
             self.log.error(f"Exception rewinding: {e}")
             return False
 
-    @staticmethod
+    @classmethod
     async def create(
+        cls,
         wallet_state_manager: Any,
         wallet: Wallet,
         launcher_coin_id: bytes32,
@@ -350,60 +355,58 @@ class PoolWallet:
         block_height: uint32,
         *,
         name: str = None,
-    ):
+    ) -> PoolWallet:
         """
         This creates a new PoolWallet with only one spend: the launcher spend. The DB MUST be committed after calling
         this method.
         """
-        self = PoolWallet()
-        self._owner_sk_and_index = None
-        self.wallet_state_manager = wallet_state_manager
-
-        self.wallet_info = await wallet_state_manager.user_store.create_wallet(
+        wallet_info = await wallet_state_manager.user_store.create_wallet(
             "Pool wallet", WalletType.POOLING_WALLET.value, ""
         )
-        self.wallet_id = self.wallet_info.id
-        self.standard_wallet = wallet
-        self.target_state = None
-        self.next_transaction_fee = uint64(0)
-        self.log = logging.getLogger(name if name else __name__)
-        self._update_pool_config_after_sync_task = None
+
+        pool_wallet = cls(
+            wallet_state_manager=wallet_state_manager,
+            log=logging.getLogger(name if name else __name__),
+            wallet_info=wallet_info,
+            wallet_id=wallet_info.id,
+            standard_wallet=wallet,
+        )
 
         launcher_spend: Optional[CoinSpend] = None
         for spend in block_spends:
             if spend.coin.name() == launcher_coin_id:
                 launcher_spend = spend
         assert launcher_spend is not None
-        await self.wallet_state_manager.pool_store.add_spend(self.wallet_id, launcher_spend, block_height)
-        await self.update_pool_config()
+        await wallet_state_manager.pool_store.add_spend(pool_wallet.wallet_id, launcher_spend, block_height)
+        await pool_wallet.update_pool_config()
 
-        p2_puzzle_hash: bytes32 = (await self.get_current_state()).p2_singleton_puzzle_hash
-        await self.wallet_state_manager.add_new_wallet(self, self.wallet_info.id, create_puzzle_hashes=False)
-        await self.wallet_state_manager.add_interested_puzzle_hashes([p2_puzzle_hash], [self.wallet_id])
-        return self
+        p2_puzzle_hash: bytes32 = (await pool_wallet.get_current_state()).p2_singleton_puzzle_hash
+        await wallet_state_manager.add_new_wallet(pool_wallet, pool_wallet.wallet_id, create_puzzle_hashes=False)
+        await wallet_state_manager.add_interested_puzzle_hashes([p2_puzzle_hash], [pool_wallet.wallet_id])
 
-    @staticmethod
+        return pool_wallet
+
+    @classmethod
     async def create_from_db(
+        cls,
         wallet_state_manager: Any,
         wallet: Wallet,
         wallet_info: WalletInfo,
         name: str = None,
-    ):
+    ) -> PoolWallet:
         """
         This creates a PoolWallet from DB. However, all data is already handled by WalletPoolStore, so we don't need
         to do anything here.
         """
-        self = PoolWallet()
-        self._owner_sk_and_index = None
-        self.wallet_state_manager = wallet_state_manager
-        self.wallet_id = wallet_info.id
-        self.standard_wallet = wallet
-        self.wallet_info = wallet_info
-        self.target_state = None
-        self.log = logging.getLogger(name if name else __name__)
-        self._update_pool_config_after_sync_task = None
-        await self.update_pool_config()
-        return self
+        pool_wallet = cls(
+            wallet_state_manager=wallet_state_manager,
+            log=logging.getLogger(name if name else __name__),
+            wallet_info=wallet_info,
+            wallet_id=wallet_info.id,
+            standard_wallet=wallet,
+        )
+        await pool_wallet.update_pool_config()
+        return pool_wallet
 
     @staticmethod
     async def create_new_pool_wallet_transaction(
@@ -1001,4 +1004,4 @@ class PoolWallet:
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol
 
-    _dummy: WalletProtocol = PoolWallet()
+    _dummy: WalletProtocol = PoolWallet()  # type: ignore[call-arg]  # Ignore missing args for type checks

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -72,7 +72,6 @@ class PoolWallet:
     next_transaction_fee: uint64
     standard_wallet: Wallet
     wallet_id: int
-    singleton_list: List[Coin]
     _owner_sk_and_index: Optional[Tuple[PrivateKey, uint32]]
     _update_pool_config_after_sync_task: Optional[asyncio.Task]
 

--- a/tests/pools/test_pool_wallet.py
+++ b/tests/pools/test_pool_wallet.py
@@ -94,13 +94,13 @@ async def test_update_pool_config_new_config(monkeypatch: Any) -> None:
     monkeypatch.setattr(PoolWallet, "get_current_state", mock_get_current_state)
 
     # Create an empty PoolWallet and populate only the required fields
-    wallet = PoolWallet()
-    # We need a standard wallet to provide a puzzlehash
-    wallet.standard_wallet = cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph))
-    # We need a wallet state manager to hold a root_path member
-    wallet.wallet_state_manager = MockWalletStateManager()
-    # We need a log object, but we don't care about how it's used
-    wallet.log = MagicMock()
+    wallet = PoolWallet(
+        wallet_state_manager=MockWalletStateManager(),
+        standard_wallet=cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph)),
+        log=MagicMock(),
+        wallet_info=MagicMock(),
+        wallet_id=MagicMock(),
+    )
 
     await wallet.update_pool_config()
 
@@ -177,13 +177,13 @@ async def test_update_pool_config_existing_payout_instructions(monkeypatch: Any)
     monkeypatch.setattr(PoolWallet, "get_current_state", mock_get_current_state)
 
     # Create an empty PoolWallet and populate only the required fields
-    wallet = PoolWallet()
-    # We need a standard wallet to provide a puzzlehash
-    wallet.standard_wallet = cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph))
-    # We need a wallet state manager to hold a root_path member
-    wallet.wallet_state_manager = MockWalletStateManager()
-    # We need a log object, but we don't care about how it's used
-    wallet.log = MagicMock()
+    wallet = PoolWallet(
+        wallet_state_manager=MockWalletStateManager(),
+        standard_wallet=cast(Any, MockStandardWallet(canned_puzzlehash=payout_instructions_ph)),
+        log=MagicMock(),
+        wallet_info=MagicMock(),
+        wallet_id=MagicMock(),
+    )
 
     await wallet.update_pool_config()
 


### PR DESCRIPTION
This fixes plotnft state transition failures introduced by #12796 / #13231 when the ploftnft was created from DB on startup like below: 

```
2022-09-12T09:34:41.272 wallet chia.wallet.wallet_node    : ERROR    Error adding states.. 'PoolWallet' object has no attribute '_update_pool_config_after_sync_task' Traceback (most recent call last):
  File "/home/dustinface/chia-blockchain/chia/wallet/wallet_node.py", line 780, in receive_state_from_peer
    await self.wallet_state_manager.new_coin_state(states, peer, fork_height)
  File "/home/dustinface/chia-blockchain/chia/wallet/wallet_state_manager.py", line 1138, in new_coin_state
    success = await wallet.apply_state_transition(cs, curr_coin_state.spent_height)
  File "/home/dustinface/chia-blockchain/chia/pools/pool_wallet.py", line 301, in apply_state_transition
    await self.update_pool_config_after_sync()  # Update pool config after we finish syncing.
  File "/home/dustinface/chia-blockchain/chia/pools/pool_wallet.py", line 310, in update_pool_config_after_sync
    if self._update_pool_config_after_sync_task is None or self._update_pool_config_after_sync_task.done():
AttributeError: 'PoolWallet' object has no attribute '_update_pool_config_after_sync_task'
```

By making `PoolWallet` a `dataclass` with the default assignment for `_update_pool_config_after_sync_task ` https://github.com/Chia-Network/chia-blockchain/blob/07f36255beb28c8d86ced0327ad4a095381514c8/chia/pools/pool_wallet.py#L79

---- 

A less distractive fix/patch would be to copy/paste this line https://github.com/Chia-Network/chia-blockchain/blob/f4023c47be4941181315063e959a11875d46c5ce/chia/pools/pool_wallet.py#L370 into `PoolWallet.create_from_db`. Im fine with retargeting this PR to `main` and opening the single line fix into release if someone wants to complain :)

 