### PR TITLE
Lots of blocks are being synced, extend the timeouts

### DIFF
--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -370,8 +370,8 @@ class TestWalletSync:
 
         for wallet_node, wallet_server in wallets:
             wallet = wallet_node.wallet_state_manager.main_wallet
-            await time_out_assert(20, wallet.get_confirmed_balance, funds)
-            await time_out_assert(20, get_tx_count, 2 * (num_blocks - 1), wallet_node.wallet_state_manager, 1)
+            await time_out_assert(60, wallet.get_confirmed_balance, funds)
+            await time_out_assert(60, get_tx_count, 2 * (num_blocks - 1), wallet_node.wallet_state_manager, 1)
 
         # Reorg blocks that carry reward
         num_blocks = 30
@@ -382,8 +382,8 @@ class TestWalletSync:
 
         for wallet_node, wallet_server in wallets:
             wallet = wallet_node.wallet_state_manager.main_wallet
-            await time_out_assert(20, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
-            await time_out_assert(20, wallet.get_confirmed_balance, 0)
+            await time_out_assert(60, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
+            await time_out_assert(60, wallet.get_confirmed_balance, 0)
 
     @pytest.mark.asyncio
     async def test_wallet_reorg_get_coinbase(self, two_wallet_nodes, default_400_blocks, self_hostname):


### PR DESCRIPTION
400 blocks are being synced to the wallet so it can take a bit of time 