### PR TITLE
Correct /get_routes and /healthz to return a boolean for success

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -159,7 +159,7 @@ class RpcServer:
 
     async def _get_routes(self, request: Dict[str, Any]) -> EndpointResult:
         return {
-            "success": "true",
+            "success": True,
             "routes": list(self.get_routes().keys()),
         }
 
@@ -253,7 +253,7 @@ class RpcServer:
 
     async def healthz(self, request: Dict[str, Any]) -> EndpointResult:
         return {
-            "success": "true",
+            "success": True,
         }
 
     async def ws_api(self, message: WsRpcMessage) -> Optional[Dict[str, object]]:


### PR DESCRIPTION
Draft for:
- [x] back-compat considerations
  - reviewers can chatter about this

Note: we should note in the release notes this is an API change to the response for these. All the other RPCs return success as a boolean, so this change makes these work consistently with the other (which is a good thing)