### PR TITLE
Do no trigger the pending tx handler in some cases

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1429,7 +1429,8 @@ class WalletStateManager:
         all_coins_names.extend([coin.name() for coin in tx_record.removals])
 
         await self.add_interested_coin_ids(all_coins_names)
-        self.tx_pending_changed()
+        if tx_record.spend_bundle is not None:
+            self.tx_pending_changed()
         self.state_changed("pending_transaction", tx_record.wallet_id)
 
     async def add_transaction(self, tx_record: TransactionRecord):


### PR DESCRIPTION
When claiming rewards for a self-pooling plotnft, the end user will see multiple "ALREADY_INCLUDING_TRANSACTION" errors on the console (if using the CLI) and printed in the log (both CLI and GUI).
This is because the action for claiming creates multiple individual transactions, and adding one transaction can cause the other transaction already in the pending list to be resent.  
Adjust the pending tx handler to only get called in cases where there is a tx.spend_bundle present