### PR TITLE
plotters: Only produce beta logs if `beta: true`, not if it just exists

### DIFF
--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -16,7 +16,7 @@ from chia.util.config import lock_and_load_config
 def get_optional_beta_plot_log_file(root_path: Path, plotter: str) -> Iterator[Optional[TextIO]]:
     beta_log_path: Optional[Path] = None
     with lock_and_load_config(root_path, "config.yaml") as config:
-        if "beta" in config:
+        if config.get("beta", {}).get("enabled", False):
             file_name = f"{plotter}_{datetime.now().strftime('%m_%d_%Y__%H_%M_%S')}.log"
             beta_log_path = Path(config["beta"]["path"]) / chia_full_version_str() / "plotting" / file_name
             beta_log_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
I missed to adjust this after the latest refactoring to check the actual value of `beta`, not its existence in #12389.