### PR TITLE
plot_sync: Change log level to `INFO` in `Receiver.reset`

### DIFF
--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -102,7 +102,7 @@ class Receiver:
             log.error(f"_update_callback: node_id {self.connection().peer_node_id}, raised {e}")
 
     def reset(self) -> None:
-        log.error(f"reset: node_id {self.connection().peer_node_id}, current_sync: {self._current_sync}")
+        log.info(f"reset: node_id {self.connection().peer_node_id}, current_sync: {self._current_sync}")
         self._current_sync = Sync()
         self._last_sync = Sync()
         self._plots.clear()


### PR DESCRIPTION
It's not necessarily an error, could be just a harvester restart.