### PR TITLE
Avoid the auto-naming mess by saying more about the coverage job in its name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
       runs-on: windows-latest
 
   coverage:
-    name: Coverage
+    name: ${{ matrix.os.emoji }} Coverage - ${{ matrix.python.name }}
     runs-on: ${{ matrix.os.runs-on }}
     needs:
       - macos


### PR DESCRIPTION
```
Coverage (🐧, ubuntu, Ubuntu, ubuntu-latest, 3.9, 3.9, 3.9, 3.9, 3.9)
```
to
```
🐧 Coverage 3.9
```