### PR TITLE
make DBWrapper2 handle more connection setup

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -1,4 +1,3 @@
-import aiosqlite
 import random
 from pathlib import Path
 
@@ -104,9 +103,9 @@ class SpendSim:
             uri = f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
         else:
             uri = f"file:{db_path}"
-        connection = await aiosqlite.connect(uri, uri=True)
-        self.db_wrapper = DBWrapper2(connection)
-        await self.db_wrapper.add_connection(await aiosqlite.connect(uri, uri=True))
+
+        self.db_wrapper = await DBWrapper2.create(database=uri, uri=True, reader_count=1)
+
         coin_store = await CoinStore.create(self.db_wrapper)
         self.mempool_manager = MempoolManager(coin_store, defaults)
         self.defaults = defaults

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -12,7 +12,6 @@ import traceback
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 
-import aiosqlite
 import sqlite3
 from blspy import AugSchemeMPL
 
@@ -70,14 +69,13 @@ from chia.util.bech32m import encode_puzzle_hash
 from chia.util.check_fork_next_block import check_fork_next_block
 from chia.util.condition_tools import pkm_pairs
 from chia.util.config import PEER_DB_PATH_KEY_DEPRECATED, process_config_start_method
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, create_connection
 from chia.util.errors import ConsensusError, Err, ValidationError
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.path import path_from_root
 from chia.util.safe_cancel_task import cancel_task_safe
 from chia.util.profiler import profile_task
 from chia.util.memory_profiler import mem_profile_task
-from datetime import datetime
 from chia.util.db_synchronous import db_synchronous_on
 from chia.util.db_version import lookup_db_version, set_db_version_async
 
@@ -221,33 +219,25 @@ class FullNode:
         # These many respond_transaction tasks can be active at any point in time
         self.respond_transaction_semaphore = asyncio.Semaphore(200)
         # create the store (db) and full node instance
-        db_connection = await aiosqlite.connect(self.db_path)
-        db_version: int = await lookup_db_version(db_connection)
+        # TODO: is this standardized and thus able to be handled by DBWrapper2?
+        async with await create_connection(self.db_path) as db_connection:
+            db_version: int = await lookup_db_version(db_connection)
         self.log.info(f"using blockchain database {self.db_path}, which is version {db_version}")
 
+        sql_log_path: Optional[Path] = None
         if self.config.get("log_sqlite_cmds", False):
             sql_log_path = path_from_root(self.root_path, "log/sql.log")
             self.log.info(f"logging SQL commands to {sql_log_path}")
 
-            def sql_trace_callback(req: str) -> None:
-                timestamp = datetime.now().strftime("%H:%M:%S.%f")
-                log = open(sql_log_path, "a")
-                log.write(timestamp + " " + req + "\n")
-                log.close()
-
-            await db_connection.set_trace_callback(sql_trace_callback)
-
-        self.db_wrapper = DBWrapper2(db_connection, db_version=db_version)
-
-        # add reader threads for the DB
-        for i in range(self.config.get("db_readers", 4)):
-            c = await aiosqlite.connect(self.db_path)
-            if self.config.get("log_sqlite_cmds", False):
-                await c.set_trace_callback(sql_trace_callback)
-            await self.db_wrapper.add_connection(c)
+        self.db_wrapper = await DBWrapper2.create(
+            self.db_path,
+            db_version=db_version,
+            reader_count=4,
+            log_path=sql_log_path,
+        )
 
         await (await db_connection.execute("pragma journal_mode=wal")).close()
-        db_sync = db_synchronous_on(self.config.get("db_sync", "auto"), self.db_path)
+        db_sync = db_synchronous_on(self.config.get("db_sync", "auto"))
         self.log.info(f"opening blockchain DB: synchronous={db_sync}")
         await (await db_connection.execute("pragma synchronous={}".format(db_sync))).close()
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -220,8 +220,8 @@ class FullNode:
         self.respond_transaction_semaphore = asyncio.Semaphore(200)
         # create the store (db) and full node instance
         # TODO: is this standardized and thus able to be handled by DBWrapper2?
-        async with await create_connection(self.db_path) as db_connection:
-            db_version: int = await lookup_db_version(db_connection)
+        with contextlib.closing(await create_connection(self.db_path)) as db_connection:
+            db_version = await lookup_db_version(db_connection)
         self.log.info(f"using blockchain database {self.db_path}, which is version {db_version}")
 
         sql_log_path: Optional[Path] = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -229,13 +229,15 @@ class FullNode:
             sql_log_path = path_from_root(self.root_path, "log/sql.log")
             self.log.info(f"logging SQL commands to {sql_log_path}")
 
+        db_sync = db_synchronous_on(self.config.get("db_sync", "auto"))
+        self.log.info(f"opening blockchain DB: synchronous={db_sync}")
+
         self.db_wrapper = await DBWrapper2.create(
             self.db_path,
             db_version=db_version,
             reader_count=4,
             log_path=sql_log_path,
-            journal_mode="WAL",
-            synchronous=db_synchronous_on(self.config.get("db_sync", "auto")),
+            synchronous=db_sync,
         )
 
         if self.db_wrapper.db_version != 2:

--- a/chia/util/db_synchronous.py
+++ b/chia/util/db_synchronous.py
@@ -1,7 +1,4 @@
-from pathlib import Path
-
-
-def db_synchronous_on(setting: str, db_path: Path) -> str:
+def db_synchronous_on(setting: str) -> str:
     if setting == "on":
         return "NORMAL"
     if setting == "off":

--- a/tests/core/full_node/ram_db.py
+++ b/tests/core/full_node/ram_db.py
@@ -2,7 +2,6 @@ from typing import Tuple
 from pathlib import Path
 
 import random
-import aiosqlite
 
 from chia.consensus.blockchain import Blockchain
 from chia.consensus.constants import ConsensusConstants
@@ -13,9 +12,7 @@ from chia.util.db_wrapper import DBWrapper2
 
 async def create_ram_blockchain(consensus_constants: ConsensusConstants) -> Tuple[DBWrapper2, Blockchain]:
     uri = f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
-    connection = await aiosqlite.connect(uri, uri=True)
-    db_wrapper = DBWrapper2(connection)
-    await db_wrapper.add_connection(await aiosqlite.connect(uri, uri=True))
+    db_wrapper = await DBWrapper2.create(database=uri, uri=True, reader_count=1)
     block_store = await BlockStore.create(db_wrapper)
     coin_store = await CoinStore.create(db_wrapper)
     blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, Path("."), 2)

--- a/tests/core/test_db_validation.py
+++ b/tests/core/test_db_validation.py
@@ -4,7 +4,6 @@ from contextlib import closing
 from pathlib import Path
 from typing import List
 
-import aiosqlite
 import pytest
 
 from chia.cmds.db_validate_func import validate_v2
@@ -128,10 +127,8 @@ def test_db_validate_in_main_chain(invalid_in_chain: bool) -> None:
 
 
 async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
-    db_wrapper = DBWrapper2(await aiosqlite.connect(db_file), 2)
+    db_wrapper = await DBWrapper2.create(database=db_file, reader_count=1, db_version=2)
     try:
-        await db_wrapper.add_connection(await aiosqlite.connect(db_file))
-
         async with db_wrapper.writer_maybe_transaction() as conn:
             # this is done by chia init normally
             await conn.execute("CREATE TABLE database_version(version int)")

--- a/tests/db/test_db_wrapper.py
+++ b/tests/db/test_db_wrapper.py
@@ -113,6 +113,24 @@ async def test_writers_nests() -> None:
 
 
 @pytest.mark.asyncio
+async def test_writer_journal_mode_wal() -> None:
+    async with DBConnection(2) as db_wrapper:
+        async with db_wrapper.writer() as connection:
+            async with connection.execute("PRAGMA journal_mode") as cursor:
+                result = await cursor.fetchone()
+                assert result == ("wal",)
+
+
+@pytest.mark.asyncio
+async def test_reader_journal_mode_wal() -> None:
+    async with DBConnection(2) as db_wrapper:
+        async with db_wrapper.reader_no_transaction() as connection:
+            async with connection.execute("PRAGMA journal_mode") as cursor:
+                result = await cursor.fetchone()
+                assert result == ("wal",)
+
+
+@pytest.mark.asyncio
 async def test_partial_failure() -> None:
     values = []
     async with DBConnection(2) as db_wrapper:

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -3,7 +3,6 @@ import pickle
 from pathlib import Path
 from typing import List, Optional
 
-import aiosqlite
 import tempfile
 
 from chia.consensus.blockchain import Blockchain
@@ -21,9 +20,7 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int):
 
     if db_path.exists():
         db_path.unlink()
-    connection = await aiosqlite.connect(db_path)
-    wrapper = DBWrapper2(connection, db_version)
-    await wrapper.add_connection(await aiosqlite.connect(db_path))
+    wrapper = await DBWrapper2.create(database=db_path, reader_count=1, db_version=db_version)
 
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)

--- a/tests/util/db_connection.py
+++ b/tests/util/db_connection.py
@@ -5,17 +5,6 @@ import tempfile
 import aiosqlite
 
 
-async def log_conn(c: aiosqlite.Connection, name: str) -> aiosqlite.Connection:
-    # uncomment this to debug sqlite interactions
-    # from datetime import datetime
-    # import sys
-    # def sql_trace_callback(req: str):
-    #    timestamp = datetime.now().strftime("%H:%M:%S.%f")
-    #    sys.stdout.write(timestamp + " " + name + " " + req + "\n")
-    # await c.set_trace_callback(sql_trace_callback)
-    return c
-
-
 class DBConnection:
     def __init__(self, db_version: int) -> None:
         self.db_version = db_version
@@ -24,11 +13,8 @@ class DBConnection:
         self.db_path = Path(tempfile.NamedTemporaryFile().name)
         if self.db_path.exists():
             self.db_path.unlink()
-        connection = await aiosqlite.connect(self.db_path)
-        self._db_wrapper = DBWrapper2(await log_conn(connection, "writer"), self.db_version)
+        self._db_wrapper = await DBWrapper2.create(database=self.db_path, reader_count=4, db_version=self.db_version)
 
-        for i in range(4):
-            await self._db_wrapper.add_connection(await log_conn(await aiosqlite.connect(self.db_path), f"reader-{i}"))
         return self._db_wrapper
 
     async def __aexit__(self, exc_t, exc_v, exc_tb) -> None:


### PR DESCRIPTION
Optional follow ups:
- only open and close the sql trace log file once
- read the db version in the wrapper, though defaults must be provided still

Draft for:
- [x] self review
