### PR TITLE
util|rpc: Refactor `RpcEnvironment` -> `WebServer`

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -188,7 +188,6 @@ class RpcServer:
             await self.client_session.close()
         if self.webserver is not None:
             await self.webserver.await_closed()
-            self.webserver = None
         if self.daemon_connection_task is not None:
             await self.daemon_connection_task
             self.daemon_connection_task = None

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -1,10 +1,19 @@
 import socket
+from aiohttp import web
+from dataclasses import dataclass
 from ipaddress import ip_address, IPv4Network, IPv6Network
 from typing import Iterable, List, Tuple, Union, Any, Optional, Dict
 from chia.server.outbound_message import NodeType
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
+
+
+@dataclass(frozen=True)
+class WebServer:
+    runner: web.AppRunner
+    site: web.TCPSite
+    listen_port: uint16
 
 
 def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Network]]) -> bool:

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -1,19 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import logging
 import socket
+import ssl
+
 from aiohttp import web
+from aiohttp.log import web_logger
 from dataclasses import dataclass
 from ipaddress import ip_address, IPv4Network, IPv6Network
 from typing import Iterable, List, Tuple, Union, Any, Optional, Dict
+from typing_extensions import final
 from chia.server.outbound_message import NodeType
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 
 
-@dataclass(frozen=True)
+@final
+@dataclass
 class WebServer:
     runner: web.AppRunner
-    site: web.TCPSite
     listen_port: uint16
+    _close_task: Optional[asyncio.Task[None]] = None
+
+    @classmethod
+    async def create(
+        cls,
+        hostname: str,
+        port: uint16,
+        routes: List[web.RouteDef],
+        max_request_body_size: int = 1024 ** 2,  # Default `client_max_size` from web.Application
+        ssl_context: Optional[ssl.SSLContext] = None,
+        keepalive_timeout: int = 75,  # Default from aiohttp.web
+        shutdown_timeout: int = 60,  # Default `shutdown_timeout` from web.TCPSite
+        prefer_ipv6: bool = False,
+        logger: logging.Logger = web_logger,
+    ) -> WebServer:
+        app = web.Application(client_max_size=max_request_body_size, logger=logger)
+        runner = web.AppRunner(app, access_log=None, keepalive_timeout=keepalive_timeout)
+
+        runner.app.add_routes(routes)
+        await runner.setup()
+        site = web.TCPSite(runner, hostname, int(port), ssl_context=ssl_context, shutdown_timeout=shutdown_timeout)
+        await site.start()
+
+        #
+        # On a dual-stack system, we want to get the (first) IPv4 port unless
+        # prefer_ipv6 is set in which case we use the IPv6 port
+        #
+        if port == 0:
+            port = select_port(prefer_ipv6, runner.addresses)
+
+        return cls(runner=runner, listen_port=uint16(port))
+
+    async def _close(self) -> None:
+        await self.runner.shutdown()
+        await self.runner.cleanup()
+
+    def close(self) -> None:
+        self._close_task = asyncio.create_task(self._close())
+
+    async def await_closed(self) -> None:
+        if self._close_task is None:
+            raise RuntimeError("WebServer stop not triggered")
+        await self._close_task
+        self._close_task = None
 
 
 def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Network]]) -> bool:

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -30,7 +30,7 @@ class WebServer:
         hostname: str,
         port: uint16,
         routes: List[web.RouteDef],
-        max_request_body_size: int = 1024 ** 2,  # Default `client_max_size` from web.Application
+        max_request_body_size: int = 1024**2,  # Default `client_max_size` from web.Application
         ssl_context: Optional[ssl.SSLContext] = None,
         keepalive_timeout: int = 75,  # Default from aiohttp.web
         shutdown_timeout: int = 60,  # Default `shutdown_timeout` from web.TCPSite

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -65,7 +65,6 @@ class WebServer:
         if self._close_task is None:
             raise RuntimeError("WebServer stop not triggered")
         await self._close_task
-        self._close_task = None
 
 
 def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Network]]) -> bool:

--- a/tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -323,6 +323,8 @@ async def test_nft_mint_from_did_rpc(two_wallet_nodes: Any, trusted: Any, self_h
     finally:
         client.close()
         client_node.close()
+        rpc_server.close()
+        rpc_server_node.close()
         await client.await_closed()
         await client_node.await_closed()
         await rpc_server.await_closed()
@@ -505,6 +507,8 @@ async def test_nft_mint_from_did_rpc_no_royalties(two_wallet_nodes: Any, trusted
     finally:
         client.close()
         client_node.close()
+        rpc_server.close()
+        rpc_server_node.close()
         await client.await_closed()
         await client_node.await_closed()
         await rpc_server.await_closed()
@@ -905,6 +909,8 @@ async def test_nft_mint_from_xch_rpc(two_wallet_nodes: Any, trusted: Any, self_h
     finally:
         client.close()
         client_node.close()
+        rpc_server.close()
+        rpc_server_node.close()
         await client.await_closed()
         await client_node.await_closed()
         await rpc_server.await_closed()


### PR DESCRIPTION
I want to use it in `ChiaServer`, `DataLayerServer` and `WebSocketServer` also.. this PR changes:
- Move `rpc.rpc_server.RpcEnviroment` -> `util.network.WebServer`
- Move the creation into `WebServer`
- Make sure the shutdown does what it's supposed to do
- Drop not needed `site` attribute

Based on: 
- #13514 
- #13518 