### PR TITLE
tests: Drop redundant RPC server instances in DataLayer tests

### DIFF
--- a/chia/server/start_data_layer.py
+++ b/chia/server/start_data_layer.py
@@ -10,6 +10,7 @@ from chia.rpc.data_layer_rpc_api import DataLayerRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.server.outbound_message import NodeType
 from chia.server.start_service import RpcInfo, Service, async_run
+from chia.server.start_wallet import WalletNode
 from chia.util.chia_logging import initialize_logging
 from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
@@ -26,12 +27,19 @@ log = logging.getLogger(__name__)
 def create_data_layer_service(
     root_path: pathlib.Path,
     config: Dict[str, Any],
+    wallet_service: Optional[Service[WalletNode]] = None,
     connect_to_daemon: bool = True,
 ) -> Service[DataLayer]:
     service_config = config[SERVICE_NAME]
     self_hostname = config["self_hostname"]
     wallet_rpc_port = service_config["wallet_peer"]["port"]
-    wallet_rpc_init = WalletRpcClient.create(self_hostname, uint16(wallet_rpc_port), root_path, config)
+    if wallet_service is None:
+        wallet_root_path = root_path
+        wallet_config = config
+    else:
+        wallet_root_path = wallet_service.root_path
+        wallet_config = wallet_service.config
+    wallet_rpc_init = WalletRpcClient.create(self_hostname, uint16(wallet_rpc_port), wallet_root_path, wallet_config)
     data_layer = DataLayer(config=service_config, root_path=root_path, wallet_rpc_init=wallet_rpc_init)
     api = DataLayerAPI(data_layer)
     network_id = service_config["selected_network"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,12 @@ async def wallet_node_sim_and_wallet():
 
 
 @pytest_asyncio.fixture(scope="function")
+async def one_wallet_and_one_simulator_services():
+    async for _ in setup_simulators_and_wallets(1, 1, {}, yield_services=True):
+        yield _
+
+
+@pytest_asyncio.fixture(scope="function")
 async def wallet_node_100_pk():
     async for _ in setup_simulators_and_wallets(1, 1, {}, initial_num_public_keys=100):
         yield _

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -4,6 +4,7 @@ from typing import AsyncIterator, Dict, List, Tuple, Optional, Union
 from pathlib import Path
 
 from chia.consensus.constants import ConsensusConstants
+from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.shared_protocol import Capability
 from chia.server.server import ChiaServer
@@ -32,6 +33,7 @@ from chia.simulator.socket import find_available_listen_port
 
 
 SimulatorsAndWallets = Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]
+SimulatorsAndWalletsServices = Tuple[List[Service[FullNode]], List[Service[WalletNode]], BlockTools]
 
 
 def cleanup_keyring(keyring: TempKeyring):

--- a/tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -1,15 +1,10 @@
 import asyncio
 import logging
-from typing import AsyncIterator
 
 import pytest
-import pytest_asyncio
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.data_layer.data_layer_wallet import Mirror, SingletonRecord
-from chia.rpc.full_node_rpc_api import FullNodeRpcApi
-from chia.rpc.rpc_server import start_rpc_server
-from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert
@@ -17,32 +12,29 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.db_wallet.db_wallet_puzzles import create_mirror_puzzle
-from tests.setup_nodes import SimulatorsAndWallets, setup_simulators_and_wallets
+from tests.setup_nodes import SimulatorsAndWalletsServices
 from tests.util.rpc import validate_get_routes
 
 log = logging.getLogger(__name__)
 
 
 class TestWalletRpc:
-    @pytest_asyncio.fixture(scope="function")
-    async def two_wallet_nodes(self) -> AsyncIterator[SimulatorsAndWallets]:
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
-            yield _
-
     @pytest.mark.parametrize(
         "trusted",
         [True, False],
     )
     @pytest.mark.asyncio
     async def test_wallet_make_transaction(
-        self, two_wallet_nodes: SimulatorsAndWallets, trusted: bool, self_hostname: str
+        self, two_wallet_nodes_services: SimulatorsAndWalletsServices, trusted: bool, self_hostname: str
     ) -> None:
         num_blocks = 5
-        full_nodes, wallets, bt = two_wallet_nodes
-        full_node_api = full_nodes[0]
+        [full_node_service], wallet_services, bt = two_wallet_nodes_services
+        full_node_api = full_node_service._api
         full_node_server = full_node_api.full_node.server
-        wallet_node, server_2 = wallets[0]
-        wallet_node_2, server_3 = wallets[1]
+        wallet_node = wallet_services[0]._node
+        server_2 = wallet_node.server
+        wallet_node_2 = wallet_services[1]._node
+        server_3 = wallet_node_2.server
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
 
@@ -63,56 +55,26 @@ class TestWalletRpc:
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]
         )
 
-        wallet_rpc_api = WalletRpcApi(wallet_node)
-        wallet_rpc_api_2 = WalletRpcApi(wallet_node_2)
-
-        config = bt.config
-        hostname = config["self_hostname"]
-        daemon_port = config["daemon_port"]
-
-        def stop_node_cb() -> None:
-            pass
-
-        full_node_rpc_api = FullNodeRpcApi(full_node_api.full_node)
-
-        rpc_server_node = await start_rpc_server(
-            full_node_rpc_api,
-            hostname,
-            daemon_port,
-            uint16(0),
-            stop_node_cb,
-            bt.root_path,
-            config,
-            connect_to_daemon=False,
-        )
-        rpc_server_wallet_1 = await start_rpc_server(
-            wallet_rpc_api,
-            hostname,
-            daemon_port,
-            uint16(0),
-            stop_node_cb,
-            bt.root_path,
-            config,
-            connect_to_daemon=False,
-        )
-        rpc_server_wallet_2 = await start_rpc_server(
-            wallet_rpc_api_2,
-            hostname,
-            daemon_port,
-            uint16(0),
-            stop_node_cb,
-            bt.root_path,
-            config,
-            connect_to_daemon=False,
-        )
-
         await time_out_assert(15, wallet.get_confirmed_balance, initial_funds)
         await time_out_assert(15, wallet.get_unconfirmed_balance, initial_funds)
 
-        client = await WalletRpcClient.create(self_hostname, rpc_server_wallet_1.listen_port, bt.root_path, config)
-        await validate_get_routes(client, wallet_rpc_api)
-        client_2 = await WalletRpcClient.create(self_hostname, rpc_server_wallet_2.listen_port, bt.root_path, config)
-        await validate_get_routes(client_2, wallet_rpc_api_2)
+        assert wallet_services[0].rpc_server is not None
+        assert wallet_services[1].rpc_server is not None
+
+        client = await WalletRpcClient.create(
+            self_hostname,
+            wallet_services[0].rpc_server.listen_port,
+            wallet_services[0].root_path,
+            wallet_services[0].config,
+        )
+        await validate_get_routes(client, wallet_services[0].rpc_server.rpc_api)
+        client_2 = await WalletRpcClient.create(
+            self_hostname,
+            wallet_services[1].rpc_server.listen_port,
+            wallet_services[1].root_path,
+            wallet_services[1].config,
+        )
+        await validate_get_routes(client_2, wallet_services[1].rpc_server.rpc_api)
 
         try:
             merkle_root: bytes32 = bytes32([0] * 32)
@@ -261,10 +223,6 @@ class TestWalletRpc:
         finally:
             # Checks that the RPC manages to stop the node
             client.close()
-            rpc_server_node.close()
-            rpc_server_wallet_1.close()
-            rpc_server_wallet_2.close()
+            client_2.close()
             await client.await_closed()
-            await rpc_server_node.await_closed()
-            await rpc_server_wallet_1.await_closed()
-            await rpc_server_wallet_2.await_closed()
+            await client_2.await_closed()


### PR DESCRIPTION
Just use the existing ones from the services.