### PR TITLE
Fixed a crash that happens when plot directory config is empty

### DIFF
--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -67,7 +67,7 @@ class PlotRefreshResult:
 def get_plot_directories(root_path: Path, config: Dict = None) -> List[str]:
     if config is None:
         config = load_config(root_path, "config.yaml")
-    return config["harvester"]["plot_directories"]
+    return config["harvester"]["plot_directories"] or []
 
 
 def get_plot_filenames(root_path: Path) -> Dict[Path, List[Path]]:
@@ -91,6 +91,8 @@ def add_plot_directory(root_path: Path, str_path: str) -> Dict:
     with lock_and_load_config(root_path, "config.yaml") as config:
         if str(Path(str_path).resolve()) in get_plot_directories(root_path, config):
             raise ValueError(f"Path already added: {path}")
+        if not config["harvester"]["plot_directories"]:
+            config["harvester"]["plot_directories"] = []
         config["harvester"]["plot_directories"].append(str(Path(str_path).resolve()))
         save_config(root_path, "config.yaml", config)
     return config


### PR DESCRIPTION
This seems to be a very rare case but it's actually observed that `config["harvester"]["plot_directories"]` is empty and cause a crash.