### PR TITLE
cmds: `ctx.exit` -> `raise click.ClickException`

### DIFF
--- a/chia/cmds/beta.py
+++ b/chia/cmds/beta.py
@@ -40,8 +40,7 @@ def configure(ctx: click.Context, path: Optional[str], interval: Optional[int]) 
     root_path = ctx.obj["root_path"]
     with lock_and_load_config(root_path, "config.yaml") as config:
         if "beta" not in config:
-            # TODO: to be fixed soon
-            ctx.exit("beta test mode is not enabled, enable it first with `chia beta enable`")  # type: ignore[arg-type]
+            raise click.ClickException("beta test mode is not enabled, enable it first with `chia beta enable`")
 
         # Adjust the path
         if path is None:
@@ -60,8 +59,7 @@ def configure(ctx: click.Context, path: Optional[str], interval: Optional[int]) 
             try:
                 validate_metrics_log_interval(metrics_log_interval)
             except ValueError as e:
-                # TODO: to be fixed soon
-                ctx.exit(str(e))  # type: ignore[arg-type]
+                raise click.ClickException(str(e))
 
         update_beta_config(True, beta_root_path, metrics_log_interval, config)
         save_config(root_path, "config.yaml", config)
@@ -84,8 +82,7 @@ def enable_cmd(ctx: click.Context, force: bool, path: Optional[str]) -> None:
     root_path = ctx.obj["root_path"]
     with lock_and_load_config(root_path, "config.yaml") as config:
         if config.get("beta", {}).get("enabled", False):
-            # TODO: to be fixed soon
-            ctx.exit("beta test mode is already enabled")  # type: ignore[arg-type]
+            raise click.ClickException("beta test mode is already enabled")
 
         if not force and not prompt_beta_warning():
             ctx.abort()
@@ -113,8 +110,7 @@ def disable_cmd(ctx: click.Context) -> None:
     root_path = ctx.obj["root_path"]
     with lock_and_load_config(root_path, "config.yaml") as config:
         if not config.get("beta", {}).get("enabled", False):
-            # TODO: to be fixed soon
-            ctx.exit("beta test mode is not enabled")  # type: ignore[arg-type]
+            raise click.ClickException("beta test mode is not enabled")
         config["beta"]["enabled"] = False
         save_config(root_path, "config.yaml", config)
 
@@ -128,14 +124,12 @@ def prepare_submission_cmd(ctx: click.Context) -> None:
     with lock_and_load_config(ctx.obj["root_path"], "config.yaml") as config:
         beta_root_path = config.get("beta", {}).get("path", None)
         if beta_root_path is None:
-            # TODO: to be fixed soon
-            ctx.exit("beta test mode not enabled. Run `chia beta enable` first.")  # type: ignore[arg-type]
+            raise click.ClickException("beta test mode not enabled. Run `chia beta enable` first.")
     beta_root_path = Path(beta_root_path)
     validate_beta_path(beta_root_path)
     available_results = sorted([path for path in beta_root_path.iterdir() if path.is_dir()])
     if len(available_results) == 0:
-        # TODO: to be fixed soon
-        ctx.exit(f"No beta logs found in {str(beta_root_path)!r}.")  # type: ignore[arg-type]
+        raise click.ClickException(f"No beta logs found in {str(beta_root_path)!r}.")
     print("Available versions:")
     for i in range(len(available_results)):
         print(f"    [{i + 1}] {available_results[i].name}")
@@ -146,8 +140,7 @@ def prepare_submission_cmd(ctx: click.Context) -> None:
             raise IndexError()
         prepare_result = available_results[int(user_input) - 1]
     except IndexError:
-        # TODO: to be fixed soon
-        ctx.exit(f"Invalid choice: {user_input}")  # type: ignore[arg-type]
+        raise click.ClickException(f"Invalid choice: {user_input}")
     plotting_path = Path(prepare_result / "plotting")
     chia_blockchain_path = Path(prepare_result / "chia-blockchain")
     chia_logs = prepare_logs(plotting_path, prepare_chia_blockchain_log)
@@ -171,9 +164,8 @@ def prepare_submission_cmd(ctx: click.Context) -> None:
 
     if files_added == 0:
         submission_file_path.unlink()
-        # TODO: to be fixed soon
         message = f"No logs files found in {str(plotting_path)!r} and {str(chia_blockchain_path)!r}."
-        ctx.exit(message)  # type: ignore[arg-type]
+        raise click.ClickException(message)
 
     print(f"\nDone. You can find the prepared submission data in {submission_file_path}.")
 
@@ -184,8 +176,7 @@ def status(ctx: click.Context) -> None:
     with lock_and_load_config(ctx.obj["root_path"], "config.yaml") as config:
         beta_config = config.get("beta")
         if beta_config is None:
-            # TODO: to be fixed soon
-            ctx.exit("beta test mode is not enabled, enable it first with `chia beta enable`")  # type: ignore[arg-type]
+            raise click.ClickException("beta test mode is not enabled, enable it first with `chia beta enable`")
 
     print(f"enabled: {beta_config['enabled']}")
     print(f"path: {beta_config['path']}")


### PR DESCRIPTION
`ctx.exit` expects an `int` only.