### PR TITLE
use `Logger.warning()` instead of the deprecated `Logger.warn()`

### DIFF
--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -217,7 +217,7 @@ class FullNodeDiscovery:
                 )
                 return
             if self.resolver is None:
-                self.log.warn("Skipping DNS query: asyncresolver not initialized.")
+                self.log.warning("Skipping DNS query: asyncresolver not initialized.")
                 return
             for rdtype in ["A", "AAAA"]:
                 peers: List[TimestampedPeerInfo] = []
@@ -234,7 +234,7 @@ class FullNodeDiscovery:
                 if len(peers) > 0:
                     await self._respond_peers_common(full_node_protocol.RespondPeers(peers), None, False)
         except Exception as e:
-            self.log.warn(f"querying DNS introducer failed: {e}")
+            self.log.warning(f"querying DNS introducer failed: {e}")
 
     async def on_connect_callback(self, peer: ws.WSChiaConnection):
         if self.server.on_connect is not None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -253,7 +253,7 @@ class WalletNode:
 
         if self.config.get("enable_profiler", False):
             if sys.getprofile() is not None:
-                self.log.warn("not enabling profiler, getprofile() is already set")
+                self.log.warning("not enabling profiler, getprofile() is already set")
             else:
                 asyncio.create_task(profile_task(self.root_path, "wallet", self.log))
 


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/actions/runs/3173913911/jobs/5170075702
```python-traceback
Traceback (most recent call last):
  File "/Users/runner/work/chia-blockchain/chia-blockchain/chia/server/node_discovery.py", line 299, in _connect_to_peers
    await self._query_dns(dns_address)
  File "/Users/runner/work/chia-blockchain/chia-blockchain/chia/server/node_discovery.py", line 237, in _query_dns
    self.log.warn(f"querying DNS introducer failed: {e}")
  File "/Users/runner/hostedtoolcache/Python/3.10.7/x64/lib/python3.10/logging/__init__.py", line 1492, in warn
    warnings.warn("The 'warn' method is deprecated, "
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
