### PR TITLE
extend allowed duration in block tools update callback

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -228,7 +228,7 @@ class BlockTools:
         self.total_result = PlotRefreshResult()
 
         def test_callback(event: PlotRefreshEvents, update_result: PlotRefreshResult):
-            assert update_result.duration < 5
+            assert update_result.duration < 15
             if event == PlotRefreshEvents.started:
                 self.total_result = PlotRefreshResult()
 


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/actions/runs/3185807311/jobs/5195866349#step:16:487
```python-traceback
________ ERROR at setup of TestMempoolManager.test_invalid_block_index _________
[gw3] darwin -- Python 3.10.7 /Users/runner/work/chia-blockchain/chia-blockchain/venv/bin/python
venv/lib/python3.10/site-packages/pytest_asyncio/plugin.py:293: in _asyncgen_fixture_wrapper
    result = event_loop.run_until_complete(setup())
../../../hostedtoolcache/Python/3.10.7/x64/lib/python3.10/asyncio/base_events.py:646: in run_until_complete
    return future.result()
venv/lib/python3.10/site-packages/pytest_asyncio/plugin.py:275: in setup
    res = await gen_obj.__anext__()
tests/conftest.py:437: in one_node_one_block
    nodes, _, bt = await async_gen.__anext__()
tests/setup_nodes.py:213: in setup_simulators_and_wallets
    await create_block_tools_async(
chia/simulator/block_tools.py:2113: in create_block_tools_async
    await bt.setup_plots()
chia/simulator/block_tools.py:337: in setup_plots
    assert len(self.plot_manager.plots) == len(self.expected_plots)
E   AssertionError
---------------------------- Captured stdout setup -----------------------------
  create_block_tools_async called 25 times
Found private CA in /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpwl0ved2d, using it to generate TLS certificates
BlockTools daemon port: 46514
------------------------------ Captured log setup ------------------------------
22:37:05 chia.plotting.manager: ERROR _refresh_callback raised:  with the traceback: Traceback (most recent call last):
  File "/Users/runner/work/chia-blockchain/chia-blockchain/chia/plotting/manager.py", line 194, in _refresh_task
    self._refresh_callback(PlotRefreshEvents.batch_processed, batch_result)
  File "/Users/runner/work/chia-blockchain/chia-blockchain/chia/simulator/block_tools.py", line 231, in test_callback
    assert update_result.duration < 5
AssertionError
```
