### PR TITLE
debug_spend_bundle -- print coin id as hex string

### DIFF
--- a/chia/wallet/util/debug_spend_bundle.py
+++ b/chia/wallet/util/debug_spend_bundle.py
@@ -68,7 +68,7 @@ def debug_spend_bundle(spend_bundle, agg_sig_additional_data=DEFAULT_CONSTANTS.A
             continue
 
         print(f"consuming coin {dump_coin(coin)}")
-        print(f"  with id {coin_name}")
+        print(f"  with id {coin_name.hex()}")
         print()
         print(f"\nbrun -y main.sym '{bu_disassemble(puzzle_reveal)}' '{bu_disassemble(solution)}'")
         error, conditions, cost = conditions_dict_for_solution(puzzle_reveal, solution, INFINITE_COST)
@@ -123,19 +123,19 @@ def debug_spend_bundle(spend_bundle, agg_sig_additional_data=DEFAULT_CONSTANTS.A
     print("spent coins")
     for coin in sorted(spent, key=lambda _: _.name()):
         print(f"  {dump_coin(coin)}")
-        print(f"      => spent coin id {coin.name()}")
+        print(f"      => spent coin id {coin.name().hex()}")
     print()
     print("created coins")
     for coin in sorted(created, key=lambda _: _.name()):
         print(f"  {dump_coin(coin)}")
-        print(f"      => created coin id {coin.name()}")
+        print(f"      => created coin id {coin.name().hex()}")
 
     if ephemeral:
         print()
         print("ephemeral coins")
         for coin in sorted(ephemeral, key=lambda _: _.name()):
             print(f"  {dump_coin(coin)}")
-            print(f"      => created coin id {coin.name()}")
+            print(f"      => created coin id {coin.name().hex()}")
 
     created_coin_announcement_pairs = [(_, std_hash(b"".join(_)).hex()) for _ in created_coin_announcements]
     if created_coin_announcement_pairs:


### PR DESCRIPTION
`print(f"      => created coin id {coin.name()}")` display bytes on console when running `cdv inspect spendbundles --debug`. Add `hex()` to make it display hex string instead.

## Before:
```
spent coins
  (0xfc669e48c63de848a7159610118f21d96efeb328af1876afd91a17cf1fecda97 0x5dcd5eca9a5919a0e435b671bd693bfdf845383563ae8565ae66bcdc3f27b598 0x00e8d4a51000)
      => spent coin id b'|r\x02\x01\xf8TPs\x9c\xf2^\x1a\xbdY\xc5\x1dI\xbcd!\xfc\xf4\xaa\xe5\xfe\xecI\xf7[P\xdf\xc2'
  (0xdf2cf850264c22b8bfe7da999b56b8a6689c9ce25be52d0807fe12ed8c9e1b5b 0x6ee43a3c617c5a1ec62ffeff1b605fb53ecc81ba8ccd4024eaff9befc53c6145 0x00e8d4a51001)
      => spent coin id b'\xc9\xaaV\r\xc2]\xed\xba\xa2\xa7\xa6\x18\r9)\x95\x95\xba\x1a\xc1\xcag\x7f\x9f_\x1e\xec\xb5\x87K\x82\xaa'

created coins
  (0xb341aa0befd1a1b9199677fff0a8874cc6f2a26dc20b70f5b4810a74bf9b3aa2 0xd3f29a4d3413d20d8bf5691beb8c9b6e15c953b4f4ad71d5e5ed35869b0d4afc 0x01d1a94a2001)
      => created coin id b'\x84*kI\x94\x88i\xfc\x7f\xd1\xe0\x19\xf4:\xa5O\xe7\xdc\xa6\xf0\xd2\x02\x01 \xb3\x83\x0c\x1c\xc4)\xcf+'

ephemeral coins
  (0xc9aa560dc25dedbaa2a7a6180d39299595ba1ac1ca677f9f5f1eecb5874b82aa 0xeff07522495060c066f66f32acc2a77e3a3e737aca8baea4d1a64ea4cdc13da9 0x01d1a94a2001)
      => created coin id b'\xb3A\xaa\x0b\xef\xd1\xa1\xb9\x19\x96w\xff\xf0\xa8\x87L\xc6\xf2\xa2m\xc2\x0bp\xf5\xb4\x81\nt\xbf\x9b:\xa2'
```

## After:
```
spent coins
  (0xfc669e48c63de848a7159610118f21d96efeb328af1876afd91a17cf1fecda97 0x5dcd5eca9a5919a0e435b671bd693bfdf845383563ae8565ae66bcdc3f27b598 0x00e8d4a51000)
      => spent coin id 7c720201f85450739cf25e1abd59c51d49bc6421fcf4aae5feec49f75b50dfc2
  (0xdf2cf850264c22b8bfe7da999b56b8a6689c9ce25be52d0807fe12ed8c9e1b5b 0x6ee43a3c617c5a1ec62ffeff1b605fb53ecc81ba8ccd4024eaff9befc53c6145 0x00e8d4a51001)
      => spent coin id c9aa560dc25dedbaa2a7a6180d39299595ba1ac1ca677f9f5f1eecb5874b82aa

created coins
  (0xb341aa0befd1a1b9199677fff0a8874cc6f2a26dc20b70f5b4810a74bf9b3aa2 0xd3f29a4d3413d20d8bf5691beb8c9b6e15c953b4f4ad71d5e5ed35869b0d4afc 0x01d1a94a2001)
      => created coin id 842a6b49948869fc7fd1e019f43aa54fe7dca6f0d2020120b3830c1cc429cf2b

ephemeral coins
  (0xc9aa560dc25dedbaa2a7a6180d39299595ba1ac1ca677f9f5f1eecb5874b82aa 0xeff07522495060c066f66f32acc2a77e3a3e737aca8baea4d1a64ea4cdc13da9 0x01d1a94a2001)
      => created coin id b341aa0befd1a1b9199677fff0a8874cc6f2a26dc20b70f5b4810a74bf9b3aa2
```