### PR TITLE
add simple fix to set farmer response timer for `SP: 0`

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2166,6 +2166,8 @@ class FullNode:
                     f"RC hash: {request.end_of_slot_bundle.reward_chain.get_hash()}, "
                     f"Deficit {request.end_of_slot_bundle.reward_chain.deficit}"
                 )
+                # Reset farmer response timer for sub slot (SP 0)
+                self.signage_point_times[0] = time.time()
                 # Notify full nodes of the new sub-slot
                 broadcast = full_node_protocol.NewSignagePointOrEndOfSubSlot(
                     request.end_of_slot_bundle.challenge_chain.challenge_chain_end_of_slot_vdf.challenge,


### PR DESCRIPTION
The farmer response timer was not set for a sub-slot, so the farmer response times for `SP: 0` was always calculated compared to the node start time (like described in issues #11869, #10900).

This PR simply sets the current timer for `signage_point_times[0]` for every `Finished sub slot`, similar like it is done for every [signage point](https://github.com/Chia-Network/chia-blockchain/blob/d2e4454d9b095e9325ae9e6a26175b3e4a7835a9/chia/full_node/full_node.py#L1377).

Tested this PR for a day and this is how the log entry looks like for `SP: 0`:
```
2022-10-18T16:04:27.784 full_node chia.full_node.full_node: INFO     Added unfinished_block f3373fa8bed41628382b3b632eb006b778e1e005d46c53aa32bb02e48ccdae8c, not farmed by us, SP: 0 farmer response time: 2.9763, Pool pk xch1t928mpwlcqk8mfr5ssnddzz7x5h5g5s7wkqxglqfqus9ue9d0mxsfjz20y, validation time: 0.0911 seconds, pre_validation time 0.1332, cost: 3982917263, percent full: 36.208%
2022-10-18T16:14:30.065 full_node chia.full_node.full_node: INFO     Added unfinished_block bfa32d73571a3fcb635ab6a3e803fa149316f7bc9c9d79b859bbfb7592d8777d, not farmed by us, SP: 0 farmer response time: 9.4207, Pool pk xch1frf8kw7tt0enylr4shdqpwjmc8nj95pvgelc8tsz4ll6n3xdeylsnj837w, validation time: 0.1059 seconds, pre_validation time 0.2090, cost: 5005641799, percent full: 45.506%
2022-10-18T16:24:27.446 full_node chia.full_node.full_node: INFO     Added unfinished_block b9931fd10db06148554638ce01f465cf486c67ea9dd29ea99dd90b8caae842f1, not farmed by us, SP: 0 farmer response time: 6.2586, Pool pk xch1f0ryxk6qn096hefcwrdwpuph2hm24w69jnzezhkfswk0z2jar7aq5zzpfj, validation time: 0.0890 seconds, pre_validation time 0.0691, cost: 269905227, percent full: 2.454%
2022-10-18T17:14:16.060 full_node chia.full_node.full_node: INFO     Added unfinished_block 361d5c83738b6c2198db4071f7a3b95d03f8471c7670cadbcff8e40b58f94d25, not farmed by us, SP: 0 farmer response time: 3.7862, Pool pk xch19f084mvup8f8yr0rlnt6v73j8lgpadywqh6e0mujjm9ru6c32t7qnlvlpu, validation time: 0.0742 seconds, pre_validation time 0.1581, cost: 3601111823, percent full: 32.737%
2022-10-18T17:24:16.039 full_node chia.full_node.full_node: INFO     Added unfinished_block 0a2794dea52e0a7a76cd6f27481ad7db73473786e9a0aafce1192e60e288d47b, not farmed by us, SP: 0 farmer response time: 2.1710, Pool pk xch1jp6frj3ecddur7dxak3n7lq0j75ltquh2zyd44epdu0d6704y2hqyky5hf, validation time: 0.0866 seconds, pre_validation time 0.0808, cost: 367285444, percent full: 3.339%
2022-10-18T17:24:25.611 full_node chia.full_node.full_node: INFO     Added unfinished_block 009915c81aac6684ef360f0749a1f88368d5d6dc88291907470faa9e3fe05c2f, not farmed by us, SP: 0 farmer response time: 11.6842, Pool pk xch1h3xkag97hga5whn7x43kr482uf5m92v3ggc8rwmhfcrkwwdmxmmqkxjl0m, validation time: 0.0702 seconds, pre_validation time 0.1483, cost: 4669512084, percent full: 42.45%
2022-10-18T18:43:49.548 full_node chia.full_node.full_node: INFO     Added unfinished_block 723bb244c16acd1255cc770686cd3d98e36e481f70849bc345c9adfe235db0d8, not farmed by us, SP: 0 farmer response time: 2.0857, Pool pk xch1qcx5x8368jnlqrtlu8vr7thuqdjk96pg9ak0eh3vcr2px5j3qw9qwet07r, validation time: 0.0686 seconds, pre_validation time 0.0188, cost: 127570856, percent full: 1.16%
2022-10-18T18:44:12.872 full_node chia.full_node.full_node: INFO     Added unfinished_block d8af0e19a9c9c4162789efa4c9386025f9432edc274f17f01f5458ba6d663b46, not farmed by us, SP: 0 farmer response time: 25.3769, Pool pk xch1ugz3lyv84eg7xawc7qr20ext5v0qvmzvq7wwvrpwgys730dalj5sq4q2a3, validation time: 0.0816 seconds, pre_validation time 0.0370, cost: 2446225353, percent full: 22.238%
2022-10-18T18:53:46.379 full_node chia.full_node.full_node: INFO     Added unfinished_block ad080ff6ec6ddf4870cc989e8764d17115b7e2345ab1f0ddf266665dc9ee6db0, not farmed by us, SP: 0 farmer response time: 3.1045, Pool pk xch19y82e2dvvuldg63handuq3uc696h48nn0psgrr3lg09wtg4mpyjszt5859, validation time: 0.0685 seconds, pre_validation time 0.0466, cost: 223842253, percent full: 2.035%
```