### PR TITLE
Freebsd improvements when checking for legacy key

### DIFF
--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -112,7 +112,7 @@ class KeyringWrapper:
         self.keys_root_path = keys_root_path
         if force_legacy:
             legacy_keyring = get_legacy_keyring_instance()
-            if check_legacy_keyring_keys_present(legacy_keyring):
+            if legacy_keyring is not None and check_legacy_keyring_keys_present(legacy_keyring):
                 self.legacy_keyring = legacy_keyring
         else:
             self.refresh_keyrings()


### PR DESCRIPTION
Issue: #13282 Optional[Credential] = keyring.get_credential(keychain_service, current_user) -> AttributeError: 'NoneType' object has no attribute 'get_credential'

Freebsd platform fails to migrate in previous releases or in 1.5.1+ versions it fails to start farmer because there is a NoneType object from keyring.get_credential. This just checks for that when trying to set the legacy_keyring.