### PR TITLE
Increase job timeout for NFT wallet tests

### DIFF
--- a/tests/wallet/nft_wallet/config.py
+++ b/tests/wallet/nft_wallet/config.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
+job_timeout = 45
 checkout_blocks_and_plots = True


### PR DESCRIPTION
Increase NFT wallet job timeout to 45 mins