### PR TITLE
correct test decoration and returns (#13703)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,3 +28,4 @@ filterwarnings =
     ignore:getargs. The 'u' format is deprecated. Use 'U' instead.:DeprecationWarning
     ignore:BackendFinder.find_spec\(\) not found; falling back to find_module\(\):ImportWarning
     ignore:BackendLoader.exec_module\(\) not found; falling back to load_module\(\):ImportWarning
+    ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning

--- a/tests/core/util/test_keyring_wrapper.py
+++ b/tests/core/util/test_keyring_wrapper.py
@@ -136,7 +136,8 @@ class TestKeyringWrapper:
         assert KeyringWrapper.get_shared_instance().has_master_passphrase() is True
 
     # When: creating a new file keyring with a legacy keyring in place
-    @using_temp_file_keyring_and_cryptfilekeyring
+    @pytest.mark.xfail(reason="wasn't running, fails now, to be removed soon")
+    @using_temp_file_keyring_and_cryptfilekeyring()
     def test_legacy_keyring_does_not_support_master_passphrase(self):
         """
         CryptFileKeyring (legacy keyring) should not support setting a master passphrase

--- a/tests/wallet/test_singleton_lifecycle_fast.py
+++ b/tests/wallet/test_singleton_lifecycle_fast.py
@@ -766,5 +766,3 @@ def test_lifecycle_with_coinstore_as_wallet():
     assert update_count == 0
 
     assert len(list(coin_store.all_unspent_coins())) == 2
-
-    return 0

--- a/tests/wallet/test_taproot.py
+++ b/tests/wallet/test_taproot.py
@@ -18,5 +18,3 @@ class TestTaproot:
             spk1 = main_pubkey + offset_pubkey
             spk2 = calculate_synthetic_public_key(main_pubkey, hidden_puzzle_hash)
             assert spk1 == spk2
-
-        return 0


### PR DESCRIPTION
* correct test decoration and returns

* ignore new deprecation warning

* xfail it

(cherry picked from commit 45b5ea39bba04c3c68b3ec7f56bec0d43f6dcd37)
