### PR TITLE
Updating old reference to chia peer -a

### DIFF
--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -48,7 +48,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: Dict[st
         print(f"Current Blockchain Status: Not Synced. Peak height: {peak.height}")
     else:
         print("\nSearching for an initial chain\n")
-        print("You may be able to expedite with 'chia show -a host:port' using a known node.\n")
+        print("You may be able to expedite with 'chia peer -a host:port' using a known node.\n")
 
     if peak is not None:
         if peak.is_transaction_block:

--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -48,7 +48,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: Dict[st
         print(f"Current Blockchain Status: Not Synced. Peak height: {peak.height}")
     else:
         print("\nSearching for an initial chain\n")
-        print("You may be able to expedite with 'chia peer -a host:port' using a known node.\n")
+        print("You may be able to expedite with 'chia peer full_node -a host:port' using a known node.\n")
 
     if peak is not None:
         if peak.is_transaction_block:


### PR DESCRIPTION
Updating the cli command reference in the output when no initial chain is found:
```
Searching for an initial chain

You may be able to expedite with 'chia show -a host:port' using a known node.

Blockchain has no blocks yet
```