### PR TITLE
cmds: Adjust default log level for `chia plots`

### DIFF
--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -37,7 +37,7 @@ def plots_cmd(ctx: click.Context):
     root_path: Path = ctx.obj["root_path"]
     if not root_path.is_dir():
         raise RuntimeError("Please initialize (or migrate) your config directory with 'chia init'")
-    initialize_logging("", {"log_stdout": True}, root_path)
+    initialize_logging("", {"log_level": "INFO", "log_stdout": True}, root_path)
 
 
 @plots_cmd.command("create", short_help="Create plots")


### PR DESCRIPTION
In https://github.com/chia-network/chia-blockchain/pull/13569 i changed the default log level to `WARNING` if there is no level in the config provided to `initialize_logging`, this was `INFO` before but i still think `WARNING` makes sense hence this PR adds the `INFO` level to the initialisation in `chia plots`.