### PR TITLE
check for macOS ARM 3.8 wheels

### DIFF
--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -50,11 +50,6 @@ jobs:
               matrix: macos
             python-version: '3.7'
           - os:
-              matrix: macos
-            arch:
-              matrix: arm
-            python-version: '3.8'
-          - os:
               matrix: windows
             arch:
               matrix: arm


### PR DESCRIPTION
Draft for:
- [x] https://github.com/Chia-Network/bls-signatures/pull/346
- [x] https://github.com/Chia-Network/chiavdf/pull/134
- [x] https://github.com/Chia-Network/chiabip158/pull/19
- [x] https://github.com/Chia-Network/chiapos/pull/339
- [x] https://github.com/Chia-Network/chia_rs/pull/72
- [ ] Above being published
- [ ] Review all matrices to make sure macOS ARM 3.8 is included (aka, not excluded).