### PR TITLE
fix `chia show -s` with other options as well

### DIFF
--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -86,7 +86,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: Dict[st
             print(f"{b.height:>9} | {b.header_hash}")
     else:
         print("Blockchain has no blocks yet")
-    return True
+    return False
 
 
 async def print_block_from_hash(


### PR DESCRIPTION
Regression introduced in https://github.com/Chia-Network/chia-blockchain/commit/b2c058970fd46e59b553d455c06c54131f4ff1fc results in `chia show -s` combined with anything else only showing the state regardless.