### PR TITLE
I can set a Chia Server to download a Data Store from last full data file,

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -31,7 +31,7 @@ from chia.data_layer.data_layer_util import (
 )
 from chia.data_layer.data_layer_wallet import DataLayerWallet, Mirror, SingletonRecord, verify_offer
 from chia.data_layer.data_store import DataStore
-from chia.data_layer.download_data import insert_from_delta_file, write_files_for_root
+from chia.data_layer.download_data import insert_from_delta_file, insert_from_full_file, write_files_for_root
 from chia.rpc.rpc_server import default_get_connections
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.server.outbound_message import NodeType
@@ -375,16 +375,28 @@ class DataLayer:
 
             try:
                 timeout = self.config.get("client_timeout", 15)
-                success = await insert_from_delta_file(
-                    self.data_store,
-                    tree_id,
-                    root.generation,
-                    [record.root for record in reversed(to_download)],
-                    server_info,
-                    self.server_files_location,
-                    timeout,
-                    self.log,
-                )
+                if self.config.get("use_last_full_tree_file", False) and root.generation == 0:
+                    success = await insert_from_full_file(
+                        self.data_store,
+                        tree_id,
+                        singleton_record.generation,
+                        to_download[0].root,
+                        server_info,
+                        self.server_files_location,
+                        timeout,
+                        self.log,
+                    )
+                else:
+                    success = await insert_from_delta_file(
+                        self.data_store,
+                        tree_id,
+                        root.generation,
+                        [record.root for record in reversed(to_download)],
+                        server_info,
+                        self.server_files_location,
+                        timeout,
+                        self.log,
+                    )
                 if success:
                     self.log.info(
                         f"Finished downloading and validating {tree_id}. "

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -185,3 +185,53 @@ async def insert_from_delta_file(
             raise
 
     return True
+
+
+async def insert_from_full_file(
+    data_store: DataStore,
+    tree_id: bytes32,
+    existing_generation: int,
+    root_hash: bytes32,
+    server_info: ServerInfo,
+    client_foldername: Path,
+    timeout: int,
+    log: logging.Logger,
+) -> bool:
+    timestamp = int(time.time())
+    filename = get_full_tree_filename(tree_id, root_hash, existing_generation)
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(server_info.url + "/" + filename, timeout=timeout) as resp:
+                resp.raise_for_status()
+
+                target_filename = client_foldername.joinpath(filename)
+                text = await resp.read()
+                target_filename.write_bytes(text)
+    except Exception:
+        await data_store.server_misses_file(tree_id, server_info, timestamp)
+        raise
+
+    log.info(f"Successfully downloaded full file {filename}.")
+    try:
+        await insert_into_data_store_from_file(
+            data_store,
+            tree_id,
+            None if root_hash == bytes32([0] * 32) else root_hash,
+            client_foldername.joinpath(filename),
+        )
+        log.info(
+            f"Successfully inserted hash {root_hash} from full file. "
+            f"Generation: {existing_generation}. Tree id: {tree_id}."
+        )
+        await data_store.received_correct_file(tree_id, server_info)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        target_filename = client_foldername.joinpath(filename)
+        os.remove(target_filename)
+        await data_store.received_incorrect_file(tree_id, server_info, timestamp)
+        await data_store.rollback_to_generation(tree_id, existing_generation - 1)
+        raise
+
+    return True


### PR DESCRIPTION
Let's consider DataStores that are changed often and the keys overwritten often. An application that connects via RPC with Chia (a project of mine) must download these DataStores, but starting from item 1 the time taken to download all versions is very long. Furthermore, in "ecological" terms, unloading more than necessary has an impact.
This development allows you to download the latest version at the first request. This way you can build a dedicated server for this. I developed in server terms with a backward compatible explicit key so that it is explicit that the files located "\data_layer\db\server_files_location_mainnet" are not useful for mirroring. Its best use and with a docker to have a fast DataStore reader.
This is a first step sufficient to solve the problem, if accepted in the future it is also possible to reduce the files created in '\data_layer\db\server_files_location_mainnet'.