### PR TITLE
leverage argparse for `chia plotters` help

### DIFF
--- a/chia/cmds/plotters.py
+++ b/chia/cmds/plotters.py
@@ -2,22 +2,6 @@ import click
 from chia.plotters.plotters import call_plotters
 
 
-def usage():
-    print("""Usage: chia plotters COMMAND [ARGS]...
-
-    Run plotters, show plotter versions
-
-Options:
-  -h, --help  Show this message and exit
-
-Commands:
-  version    Show installed plotter versions
-  chiapos    Create a plot with the default chia plotter
-  madmax     Create a plot with madMAx
-  bladebit   Create a plot with bladebit
-  bladebit2  Create a plot with bladebit2""")
-
-
 @click.command(
     "plotters",
     short_help="Advanced plotting options",
@@ -27,8 +11,4 @@ Commands:
 @click.pass_context
 @click.argument("args", nargs=-1)
 def plotters_cmd(ctx: click.Context, args):
-    if len(args) < 1 or args[0] in ["-h", "--help"]:
-        usage()
-        return
-
     call_plotters(ctx.obj["root_path"], args)

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -136,7 +136,7 @@ def get_plotters_root_path(root_path: Path) -> Path:
 
 
 def build_parser(subparsers, root_path, option_list, name, plotter_desc):
-    parser = subparsers.add_parser(name, description=plotter_desc)
+    parser = subparsers.add_parser(name, help=plotter_desc)
     for option in option_list:
         if option is Options.K:
             parser.add_argument(
@@ -435,22 +435,24 @@ def call_plotters(root_path: Path, args):
     plotters = argparse.ArgumentParser("chia plotters", description="Available options.")
     subparsers = plotters.add_subparsers(help="Available options", dest="plotter")
 
-    build_parser(subparsers, root_path, chia_plotter_options, "chiapos", "Chiapos Plotter")
-    build_parser(subparsers, root_path, madmax_plotter_options, "madmax", "Madmax Plotter")
-    build_parser(subparsers, root_path, bladebit_plotter_options, "bladebit", "Bladebit Plotter")
-    build_parser(subparsers, root_path, bladebit2_plotter_options, "bladebit2", "Bladebit2 Plotter")
+    build_parser(subparsers, root_path, chia_plotter_options, "chiapos", "Create a plot with the default chia plotter")
+    build_parser(subparsers, root_path, madmax_plotter_options, "madmax", "Create a plot with madMAx")
+    build_parser(subparsers, root_path, bladebit_plotter_options, "bladebit", "Create a plot with bladebit")
+    build_parser(subparsers, root_path, bladebit2_plotter_options, "bladebit2", "Create a plot with bladebit2")
 
     deprecation_warning = (
         "[DEPRECATED] 'chia plotters install' is no longer available. Use install-plotter.sh/ps1 instead."
     )
-    install_parser = subparsers.add_parser("install", description=deprecation_warning)
+    install_parser = subparsers.add_parser("install", help=deprecation_warning)
     install_parser.add_argument("install_plotter", type=str, nargs="*")
 
-    subparsers.add_parser("version", description="Show plotter versions")
+    subparsers.add_parser("version", help="Show plotter versions")
 
     args = plotters.parse_args(args)
 
-    if args.plotter == "chiapos":
+    if args.plotter is None:
+        plotters.print_help()
+    elif args.plotter == "chiapos":
         plot_chia(args, chia_root_path)
     elif args.plotter == "madmax":
         plot_madmax(args, chia_root_path, root_path)


### PR DESCRIPTION
Alternative to https://github.com/Chia-Network/chia-blockchain/pull/13734.

```console
$ venv/bin/chia plotters
usage: chia plotters [-h] {chiapos,madmax,bladebit,bladebit2,install,version} ...

Available options.

positional arguments:
  {chiapos,madmax,bladebit,bladebit2,install,version}
                        Available options
    chiapos             Create a plot with the default chia plotter
    madmax              Create a plot with madMAx
    bladebit            Create a plot with bladebit
    bladebit2           Create a plot with bladebit2
    install             [DEPRECATED] 'chia plotters install' is no longer available. Use install-plotter.sh/ps1 instead.
    version             Show plotter versions

options:
  -h, --help            show this help message and exit

```

Draft for:
- [x] https://github.com/Chia-Network/chia-blockchain/pull/13743