### PR TITLE
Revert "Fixed an issue where `chia plotters` command showed stack trace (#13734)"

### DIFF
--- a/chia/cmds/plotters.py
+++ b/chia/cmds/plotters.py
@@ -2,22 +2,6 @@ import click
 from chia.plotters.plotters import call_plotters
 
 
-def usage():
-    print("""Usage: chia plotters COMMAND [ARGS]...
-
-    Run plotters, show plotter versions
-
-Options:
-  -h, --help  Show this message and exit
-
-Commands:
-  version    Show installed plotter versions
-  chiapos    Create a plot with the default chia plotter
-  madmax     Create a plot with madMAx
-  bladebit   Create a plot with bladebit
-  bladebit2  Create a plot with bladebit2""")
-
-
 @click.command(
     "plotters",
     short_help="Advanced plotting options",
@@ -27,8 +11,4 @@ Commands:
 @click.pass_context
 @click.argument("args", nargs=-1)
 def plotters_cmd(ctx: click.Context, args):
-    if len(args) < 1 or args[0] in ["-h", "--help"]:
-        usage()
-        return
-
     call_plotters(ctx.obj["root_path"], args)


### PR DESCRIPTION
This reverts commit 0d8b5ab7631a9716e29359c1f37cddb820483ace due to black issues https://github.com/Chia-Network/chia-blockchain/actions/runs/3346938506/jobs/5544354728 and an alternative using the argparse framework already in use for this particular CLI https://github.com/Chia-Network/chia-blockchain/pull/13742.
