### PR TITLE
Increase job timeout for NFT wallet tests (#13675)

### DIFF
--- a/tests/wallet/nft_wallet/config.py
+++ b/tests/wallet/nft_wallet/config.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
+job_timeout = 45
 checkout_blocks_and_plots = True


### PR DESCRIPTION
(cherry picked from commit fe490d9e04d78e0d13e92aef671358310f989369)
