### PR TITLE
Add download progress log and stream in aiohttp

### DIFF
--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -146,11 +146,25 @@ async def insert_from_delta_file(
             async with aiohttp.ClientSession() as session:
                 async with session.get(server_info.url + "/" + filename, timeout=timeout) as resp:
                     resp.raise_for_status()
-
+                    size = int(resp.headers.get("content-length", 0))
+                    log.debug(f"Downloading delta file {filename}. Size {size} bytes.")
+                    progress_byte = 0
+                    progress_percentage = "{:.0%}".format(0)
                     target_filename = client_foldername.joinpath(filename)
-                    text = await resp.read()
-                    target_filename.write_bytes(text)
+                    with target_filename.open(mode="wb") as f:
+                        async for chunk, end_of_http_chunk in resp.content.iter_chunks():
+                            f.write(chunk)
+                            if log.isEnabledFor(logging.INFO):
+                                progress_byte += len(chunk)
+                                new_percentage = "{:.0%}".format(progress_byte / size)
+                                if new_percentage != progress_percentage:
+                                    progress_percentage = new_percentage
+                                    log.info(
+                                        f"Downloading delta file {filename}. {progress_percentage} of {size} bytes."
+                                    )
         except Exception:
+            target_filename = client_foldername.joinpath(filename)
+            os.remove(target_filename)
             await data_store.server_misses_file(tree_id, server_info, timestamp)
             raise
 

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -152,16 +152,15 @@ async def insert_from_delta_file(
                     progress_percentage = "{:.0%}".format(0)
                     target_filename = client_foldername.joinpath(filename)
                     with target_filename.open(mode="wb") as f:
-                        async for chunk, end_of_http_chunk in resp.content.iter_chunks():
+                        async for chunk, _ in resp.content.iter_chunks():
                             f.write(chunk)
-                            if log.isEnabledFor(logging.INFO):
-                                progress_byte += len(chunk)
-                                new_percentage = "{:.0%}".format(progress_byte / size)
-                                if new_percentage != progress_percentage:
-                                    progress_percentage = new_percentage
-                                    log.info(
-                                        f"Downloading delta file {filename}. {progress_percentage} of {size} bytes."
-                                    )
+                            progress_byte += len(chunk)
+                            new_percentage = "{:.0%}".format(progress_byte / size)
+                            if new_percentage != progress_percentage:
+                                progress_percentage = new_percentage
+                                log.info(
+                                    f"Downloading delta file {filename}. {progress_percentage} of {size} bytes."
+                                )
         except Exception:
             target_filename = client_foldername.joinpath(filename)
             os.remove(target_filename)

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -158,9 +158,7 @@ async def insert_from_delta_file(
                             new_percentage = "{:.0%}".format(progress_byte / size)
                             if new_percentage != progress_percentage:
                                 progress_percentage = new_percentage
-                                log.info(
-                                    f"Downloading delta file {filename}. {progress_percentage} of {size} bytes."
-                                )
+                                log.info(f"Downloading delta file {filename}. {progress_percentage} of {size} bytes.")
         except Exception:
             target_filename = client_foldername.joinpath(filename)
             os.remove(target_filename)


### PR DESCRIPTION
When downloading large files it is useful to have a progress. This is a first step, having it in the log file which opens the way to persisting it in SQLite or in memory and requesting it via RPC.
Furthermore, the download approach is more stream-to-file-oriented and should require less memory resources and more performance.