### PR TITLE
Adding submodule branch override to Install-gui.ps1

### DIFF
--- a/Install-gui.ps1
+++ b/Install-gui.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = "Stop"
+$SUBMODULE_BRANCH = $args[0]
 
 if ($null -eq (Get-ChildItem env:VIRTUAL_ENV -ErrorAction SilentlyContinue))
 {
@@ -16,6 +17,14 @@ if ($null -eq (Get-Command node -ErrorAction SilentlyContinue))
 Write-Output "Running 'git submodule update --init --recursive'."
 Write-Output ""
 git submodule update --init --recursive
+if ( $SUBMODULE_BRANCH ) {
+  git fetch --all
+  git reset --hard $SUBMODULE_BRANCH
+  Write-Host ""
+  Write-Host "Building the GUI with branch $SUBMODULE_BRANCH"
+  Write-Host ""
+}
+
 
 Push-Location
 try {

--- a/Install-gui.ps1
+++ b/Install-gui.ps1
@@ -20,9 +20,9 @@ git submodule update --init --recursive
 if ( $SUBMODULE_BRANCH ) {
   git fetch --all
   git reset --hard $SUBMODULE_BRANCH
-  Write-Host ""
-  Write-Host "Building the GUI with branch $SUBMODULE_BRANCH"
-  Write-Host ""
+  Write-Output ""
+  Write-Output "Building the GUI with branch $SUBMODULE_BRANCH"
+  Write-Output ""
 }
 
 


### PR DESCRIPTION
To add feature parity with `install-gui.sh`.

```
.\Install-gui.ps1 release/1.6.1
Running 'git submodule update --init --recursive'.

Fetching origin
Fetching chiabee
HEAD is now at fa5bcf3e8 leverage argparse for `chia plotters` help (#13742)

Building the GUI with branch release/1.6.1


> root@1.6.1-rc2.dev3 postinstall
> npm run bootstrap && cross-env prettier --write '**/package.json' '**/package-lock.json'


> root@1.6.1-rc2.dev3 bootstrap
> lerna bootstrap

lerna notice cli v5.5.2
lerna info Bootstrapping 6 packages
...
Chia blockchain Install-gui.ps1 completed.

Type 'cd chia-blockchain-gui' and then 'npm run electron' to start the GUI.
```

Tested on Windows 11 with no errors