### PR TITLE
Revert rate limiting messages from `warning` back to `debug`

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -399,7 +399,7 @@ class WSChiaConnection:
             message, self.local_capabilities, self.peer_capabilities
         ):
             if not is_localhost(self.peer_host):
-                self.log.warning(
+                self.log.debug(
                     f"Rate limiting ourselves. message type: {ProtocolMessageTypes(message.type).name}, "
                     f"peer: {self.peer_host}"
                 )


### PR DESCRIPTION
In 1.5.1 this was changed from `debug` to `warning` causing a lot of excess noise in default logging as reported in https://github.com/Chia-Network/chia-blockchain/issues/13132

If there is an underlying issue that is causing this noise, it can still be identified with debug logging, but for the majority of users configured with `log_level: WARNING` or `INFO` this change suppresses the noise which is inflating log files a lot.