### PR TITLE
strip input before bech32 decoding

### DIFF
--- a/chia/util/bech32m.py
+++ b/chia/util/bech32m.py
@@ -67,6 +67,7 @@ def bech32_encode(hrp: str, data: List[int]) -> str:
 
 def bech32_decode(bech: str, max_length: int = 90) -> Tuple[Optional[str], Optional[List[int]]]:
     """Validate a Bech32 string, and determine HRP and data."""
+    bech = bech.strip()
     if (any(ord(x) < 33 or ord(x) > 126 for x in bech)) or (bech.lower() != bech and bech.upper() != bech):
         return (None, None)
     bech = bech.lower()

--- a/tests/wallet/test_bech32m.py
+++ b/tests/wallet/test_bech32m.py
@@ -10,6 +10,7 @@ def test_valid_imports():
     test_strings = [
         "A1LQFN3A",
         "a1lqfn3a",
+        "\n a1lqfn3a \n",
         "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6",
         "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx",
         "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8",
@@ -29,6 +30,7 @@ def test_invalid_imports():
         "an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
         "qyrz8wqd2c9m",
         "1qyrz8wqd2c9m",
+        "\n 1qyrz8wqd2c9m \n",
         "y1b0jsk6g",
         "lt1igcx5c0",
         "in1muywd",


### PR DESCRIPTION
this avoids leading and trailing whitespace causing offer processing to fail
