### PR TITLE
include memos in get_puzzle_and_solution return value

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -712,7 +712,10 @@ class FullNodeRpcApi:
         assert puzzle is not None
         assert solution is not None
 
-        return {"coin_solution": CoinSpend(coin_record.coin, puzzle, solution)}
+        coin_solution = CoinSpend(coin_record.coin, puzzle, solution)
+        memos = coin_solution.get_memos()
+
+        return {"coin_solution": coin_solution, "memos": memos}
 
     async def get_additions_and_removals(self, request: Dict) -> EndpointResult:
         if "header_hash" not in request:

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -38,6 +38,6 @@ class CoinSpend(Streamable):
                 if type(condition[3]) != list:
                     # If it's not a list, it's not the correct format
                     continue
-                return condition[3][0].decode()
+                return str(condition[3][0].decode())
 
         return ""


### PR DESCRIPTION
I am working on something similar in concept to [marmot minter](https://github.com/Yostra/marmot_minter). Part of he workflow entails passing information in the memo of a transaction from the sender to the receiver. In order to enable and simplify that via RPC, this PR patches that ability into `get_puzzle_and_solution`.

1) This code was added to the `CoinSpend`:
https://github.com/Yostra/marmot_minter/blob/40ff182ee21e3566d3d071aa5f9f3592c4b950eb/marmot_server.py#L56

2) `get_puzzle_and_solution` returns an additional field along with the serialized `CoinSpend`:
`return {"coin_solution": coin_solution, "memos": memos}`

This is nonbreaking both in inputs and outputs. It could be made opt-in with an `include_memos` if that's better.

