### PR TITLE
always use Chia-Network/actions/setup-python

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        uses: actions/setup-python@v3
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -80,7 +80,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - uses: actions/setup-python@v3
+    - uses: Chia-Network/actions/setup-python@main
       name: Install Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -35,7 +35,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Python environment
-      uses: actions/setup-python@v3
+      uses: Chia-Network/actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -122,7 +122,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        uses: actions/setup-python@v3
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python.action }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: '3.9'
 
@@ -114,7 +114,7 @@ jobs:
           path: coverage-data
 
       - name: Set up ${{ matrix.python.name }}
-        uses: actions/setup-python@v3
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python.action }}
 

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
-    - uses: actions/setup-python@v3
+    - uses: Chia-Network/actions/setup-python@main
       name: Install Python
       with:
         python-version: '3.8'


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/actions/runs/3366161605
```
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/setup-python, actions/setup-python
```

The CI runs had lots of annotations such as above that inspired this change.  But aside from that I think we may as well consistently use our own wrapper.

Draft for:
- [x] self consideration
