### PR TITLE
Bump datalayer tests to 60 minute timeout `:[`

### DIFF
--- a/tests/core/data_layer/config.py
+++ b/tests/core/data_layer/config.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
 parallel = 4
-job_timeout = 40
+job_timeout = 60
 checkout_blocks_and_plots = True


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/actions/runs/3371261657/usage

ubuntu / 🐧 core.data_layer - 3.8    43m 10s
windows / 🪟 core.data_layer - 3.7    37m 7s
windows / 🪟 core.data_layer - 3.9    33m 57s
windows / 🪟 core.data_layer - 3.8    32m 7s
windows / 🪟 core.data_layer - 3.9    32m 36s
windows / 🪟 core.data_layer - 3.8    32m 27s
macos / 🍎 core.data_layer - 3.9    32m 20s
windows / 🪟 core.data_layer - 3.7    32m 12s
macos / 🍎 core.data_layer - 3.9    31m 5s
windows / 🪟 core.data_layer - 3.7    31m 55s