### PR TITLE
chiavdf==1.0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 dependencies = [
     "aiofiles==22.1.0",  # Async IO for files
     "blspy==1.0.16",  # Signature library
-    "chiavdf==1.0.7",  # timelord and vdf verification
+    "chiavdf==1.0.8",  # timelord and vdf verification
     "chiabip158==1.1",  # bip158-style wallet filters
     "chiapos==1.0.11",  # proof of space
     "clvm==0.9.7",


### PR DESCRIPTION
https://github.com/Chia-Network/chiavdf/compare/1.0.7..1.0.8

The inspiration specifically is that 1.0.7 has a single threaded `mpir.dll` included.  This was being trompled by the multithreadded copy from `blspy` in normal installs.  Over in the poetry PR the ordering was different resulting in failures.  https://github.com/Chia-Network/chia-blockchain/actions/runs/3382221967/jobs/5616952939