### PR TITLE
Fix trades between fungible assets <-> fungible assets + nfts

### DIFF
--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -796,7 +796,7 @@ class NFTWallet:
 
         trade_prices: List[List[Union[uint64, bytes32]]] = []
         for asset, amount in fungible_asset_dict.items():  # requested fungible items
-            if amount > 0:
+            if amount > 0 and offer_side_royalty_split > 0:
                 settlement_ph: bytes32 = (
                     OFFER_MOD_HASH if asset is None else construct_puzzle(driver_dict[asset], OFFER_MOD).get_tree_hash()
                 )
@@ -817,7 +817,7 @@ class NFTWallet:
 
         royalty_payments: Dict[Optional[bytes32], List[Tuple[bytes32, Payment]]] = {}
         for asset, amount in fungible_asset_dict.items():  # offered fungible items
-            if amount < 0:
+            if amount < 0 and request_side_royalty_split > 0:
                 payment_list: List[Tuple[bytes32, Payment]] = []
                 for launcher_id, address, percentage in required_royalty_info:
                     extra_royalty_amount = uint64(
@@ -893,7 +893,7 @@ class NFTWallet:
 
                 # First, sending all the coins to the OFFER_MOD
                 if wallet.type() == WalletType.STANDARD_WALLET:
-                    payments = royalty_payments[asset]
+                    payments = royalty_payments[asset] if asset in royalty_payments else []
                     tx = await wallet.generate_signed_transaction(
                         abs(amount),
                         Offer.ph(),
@@ -916,7 +916,7 @@ class NFTWallet:
                         trade_prices_list=trade_prices,
                     )
                 else:
-                    payments = royalty_payments[asset]
+                    payments = royalty_payments[asset] if asset in royalty_payments else []
                     txs = await wallet.generate_signed_transaction(
                         [abs(amount), *(p.amount for _, p in payments)],
                         [Offer.ph()] * (len(payments) + 1),

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1494,7 +1494,7 @@ async def test_complex_nft_offer(two_wallet_nodes: Any, trusted: Any) -> None:
     # Try another permutation
     complex_nft_offer = {
         cat_wallet_maker.id(): CAT_REQUESTED * -1,
-        1: XCH_REQUESTED/2,
+        1: int(XCH_REQUESTED / 2),
         bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): CAT_REQUESTED,
         nft_to_offer_asset_id_maker: 1,
     }
@@ -1529,8 +1529,8 @@ async def test_complex_nft_offer(two_wallet_nodes: Any, trusted: Any) -> None:
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
 
     # Now let's make sure the final wallet state is correct
-    funds_maker = int(funds_maker + XCH_REQUESTED/2)
-    funds_taker = int(funds_taker - XCH_REQUESTED/2)
+    funds_maker = int(funds_maker + XCH_REQUESTED / 2)
+    funds_taker = int(funds_taker - XCH_REQUESTED / 2)
 
     await time_out_assert(30, wallet_maker.get_unconfirmed_balance, funds_maker)
     await time_out_assert(30, wallet_maker.get_confirmed_balance, funds_maker)

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1466,17 +1466,19 @@ async def test_complex_nft_offer(two_wallet_nodes: Any, trusted: Any) -> None:
         else:
             return uint128(await cat_wallet.get_confirmed_balance())
 
+    taker_cat_funds_maker = CAT_REQUESTED + maker_cat_royalties_expected
+    maker_cat_funds_taker = CAT_REQUESTED + taker_cat_royalties_expected
     await time_out_assert(
         30,
         get_cat_wallet_and_check_balance,
-        CAT_REQUESTED + maker_cat_royalties_expected,
+        taker_cat_funds_maker,
         cat_wallet_taker.get_asset_id(),
         wsm_maker,
     )
     await time_out_assert(
         30,
         get_cat_wallet_and_check_balance,
-        CAT_REQUESTED + taker_cat_royalties_expected,
+        maker_cat_funds_taker,
         cat_wallet_maker.get_asset_id(),
         wsm_taker,
     )
@@ -1488,3 +1490,70 @@ async def test_complex_nft_offer(two_wallet_nodes: Any, trusted: Any) -> None:
     assert nft_to_offer_asset_id_maker == taker_nfts[0].nft_id
     assert nft_to_offer_asset_id_taker_1 in [nft.nft_id for nft in maker_nfts]
     assert nft_to_offer_asset_id_taker_2 in [nft.nft_id for nft in maker_nfts]
+
+    # Try another permutation
+    complex_nft_offer = {
+        cat_wallet_maker.id(): CAT_REQUESTED * -1,
+        1: XCH_REQUESTED/2,
+        bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): CAT_REQUESTED,
+        nft_to_offer_asset_id_maker: 1,
+    }
+
+    driver_dict = {
+        nft_to_offer_asset_id_maker: match_puzzle(uncurry_puzzle(taker_nfts[0].full_puzzle)),
+        bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): PuzzleInfo(
+            {
+                "type": "CAT",
+                "tail": "0x" + cat_wallet_taker.get_asset_id(),
+            }
+        ),
+    }
+
+    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+        complex_nft_offer, driver_dict=driver_dict, fee=uint64(0)
+    )
+    assert error is None
+    assert success
+    assert trade_make is not None
+
+    success, trade_take, error = await trade_manager_taker.respond_to_offer(
+        Offer.from_bytes(trade_make.offer),
+        wallet_node_taker.get_full_node_peer(),
+        fee=uint64(0),
+    )
+    assert error is None
+    assert success
+    assert trade_take is not None
+    await time_out_assert(20, mempool_not_empty, True, full_node_api)
+
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
+
+    # Now let's make sure the final wallet state is correct
+    funds_maker = int(funds_maker + XCH_REQUESTED/2)
+    funds_taker = int(funds_taker - XCH_REQUESTED/2)
+
+    await time_out_assert(30, wallet_maker.get_unconfirmed_balance, funds_maker)
+    await time_out_assert(30, wallet_maker.get_confirmed_balance, funds_maker)
+    await time_out_assert(30, wallet_taker.get_unconfirmed_balance, funds_taker)
+    await time_out_assert(30, wallet_taker.get_confirmed_balance, funds_taker)
+
+    await time_out_assert(
+        30,
+        get_cat_wallet_and_check_balance,
+        taker_cat_funds_maker + CAT_REQUESTED,
+        cat_wallet_taker.get_asset_id(),
+        wsm_maker,
+    )
+    await time_out_assert(
+        30,
+        get_cat_wallet_and_check_balance,
+        maker_cat_funds_taker + CAT_REQUESTED,
+        cat_wallet_maker.get_asset_id(),
+        wsm_taker,
+    )
+    maker_nfts = await basic_nft_wallet_maker.get_current_nfts()
+    taker_nfts = await basic_nft_wallet_taker.get_current_nfts()
+    await time_out_assert(30, len, 3, maker_nfts)
+    await time_out_assert(30, len, 0, taker_nfts)
+
+    assert nft_to_offer_asset_id_maker in [nft.nft_id for nft in maker_nfts]


### PR DESCRIPTION
Some bad code means that royalties attempt to get split between 0 NFTs too which result is a division by zero error.