### PR TITLE
Ensure `chia-blockchain` still opens UI on Linux

### DIFF
--- a/build_scripts/assets/deb/postinst.sh
+++ b/build_scripts/assets/deb/postinst.sh
@@ -4,3 +4,4 @@
 set -e
 
 ln -s /opt/chia/resources/app.asar.unpacked/daemon/chia /usr/bin/chia || true
+ln -s /opt/chia/chia-blockchain /usr/bin/chia-blockchain || true

--- a/build_scripts/assets/deb/prerm.sh
+++ b/build_scripts/assets/deb/prerm.sh
@@ -4,3 +4,4 @@
 set -e
 
 unlink /usr/bin/chia || true
+unlink /usr/bin/chia-blockchain || true

--- a/build_scripts/assets/rpm/postinst.sh
+++ b/build_scripts/assets/rpm/postinst.sh
@@ -4,3 +4,4 @@
 set -e
 
 ln -s /opt/chia/resources/app.asar.unpacked/daemon/chia /usr/bin/chia || true
+ln -s /opt/chia/chia-blockchain /usr/bin/chia-blockchain || true

--- a/build_scripts/assets/rpm/prerm.sh
+++ b/build_scripts/assets/rpm/prerm.sh
@@ -4,3 +4,4 @@
 set -e
 
 unlink /usr/bin/chia || true
+unlink /usr/bin/chia-blockchain || true


### PR DESCRIPTION
Resolves https://github.com/Chia-Network/chia-blockchain/issues/13847

Tested on amd64/arm64 ubuntu and amd64 fedora (for coverage on all the debs and the rpm) and the symlink for chia-blockchain opens the UI as expected.