### PR TITLE
Made it able to RAM plot with bladebit2

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -660,17 +660,17 @@ class WebSocketServer:
         p = request.get("p")  # Pool pubkey
         c = request.get("c")  # Pool contract address
 
-        command_args: List[str] = []
-        command_args.append(f"-n{n}")
-        command_args.append(f"-d{d}")
-        command_args.append(f"-r{r}")
+        command_args: List[str] = ["-n", str(n), "-d", d, "-r", str(r)]
 
         if f is not None:
-            command_args.append(f"-f{f}")
+            command_args.append("-f")
+            command_args.append(str(f))
         if p is not None:
-            command_args.append(f"-p{p}")
+            command_args.append("-p")
+            command_args.append(str(p))
         if c is not None:
-            command_args.append(f"-c{c}")
+            command_args.append("-c")
+            command_args.append(str(c))
 
         return command_args
 
@@ -685,15 +685,11 @@ class WebSocketServer:
         x = request["x"]  # Exclude final directory
         override_k = request["overrideK"]  # Force plot sizes < k32
 
-        command_args: List[str] = []
-        command_args.append(f"-k{k}")
-        command_args.append(f"-t{t}")
-        command_args.append(f"-2{t2}")
-        command_args.append(f"-b{b}")
-        command_args.append(f"-u{u}")
+        command_args: List[str] = ["-k", str(k), "-t", t, "-2", t2, "-b", str(b), "-u", str(u)]
 
         if a is not None:
-            command_args.append(f"-a{a}")
+            command_args.append("-a")
+            command_args.append(str(a))
         if e is True:
             command_args.append("-e")
         if x is True:
@@ -707,12 +703,12 @@ class WebSocketServer:
         plot_type = request["plot_type"]
         assert plot_type == "ramplot" or plot_type == "diskplot"
 
+        command_args: List[str] = []
+
         if plot_type == "ramplot":
             w = request.get("w", False)  # Warm start
             m = request.get("m", False)  # Disable NUMA
             no_cpu_affinity = request.get("no_cpu_affinity", False)
-
-            command_args: List[str] = []
 
             if w is True:
                 command_args.append("--warmstart")
@@ -741,8 +737,6 @@ class WebSocketServer:
         no_t1_direct = request.get("no_t1_direct", False)
         no_t2_direct = request.get("no_t2_direct", False)
 
-        command_args: List[str] = []
-
         if w is True:
             command_args.append("--warmstart")
         if m is True:
@@ -750,11 +744,14 @@ class WebSocketServer:
         if no_cpu_affinity is True:
             command_args.append("--no-cpu-affinity")
 
-        command_args.append(f"-t{t1}")
+        command_args.append(f"-t")
+        command_args.append(t1)
         if t2:
-            command_args.append(f"-2{t2}")
+            command_args.append(f"-2")
+            command_args.append(t2)
         if u:
-            command_args.append(f"-u{u}")
+            command_args.append("-u")
+            command_args.append(str(u))
         if cache:
             command_args.append("--cache")
             command_args.append(str(cache))

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -744,10 +744,10 @@ class WebSocketServer:
         if no_cpu_affinity is True:
             command_args.append("--no-cpu-affinity")
 
-        command_args.append(f"-t")
+        command_args.append("-t")
         command_args.append(t1)
         if t2:
-            command_args.append(f"-2")
+            command_args.append("-2")
             command_args.append(t2)
         if u:
             command_args.append("-u")

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -211,10 +211,8 @@ def plot_bladebit(args, chia_root_path, root_path):
         return
 
     if found and int(version_or_exception[0]) < 2:
-        print(
-            f"Version {'.'.join(version_or_exception)} is detected."
-            f"bladebit < 2 is not supported any more."
-        )
+        print(f"Version {'.'.join(version_or_exception)} is detected.")
+        print(f"bladebit < 2 is not supported any more.")
         return
 
     bladebit_executable_path = get_bladebit_executable_path(root_path)
@@ -239,45 +237,45 @@ def plot_bladebit(args, chia_root_path, root_path):
     plot_type = "ramplot" if args.plot_type == "ramplot" else "diskplot"
     call_args = [
         os.fspath(bladebit_executable_path),
-        "-t",
+        "--threads",
         str(args.threads),
-        "-n",
+        "--count",
         str(args.count),
-        "-f",
+        "--farmer-key",
         bytes(plot_keys.farmer_public_key).hex(),
     ]
     if plot_keys.pool_public_key is not None:
-        call_args.append("-p")
+        call_args.append("--pool-key")
         call_args.append(bytes(plot_keys.pool_public_key).hex())
     if plot_keys.pool_contract_address is not None:
-        call_args.append("-c")
+        call_args.append("--pool-contract")
         call_args.append(plot_keys.pool_contract_address)
     if args.warmstart:
-        call_args.append("-w")
+        call_args.append("--warm-start")
     if args.id is not None and args.id != b"":
-        call_args.append("-i")
+        call_args.append("--plot-id")
         call_args.append(args.id.hex())
-    if args.verbose:
-        call_args.append("-v")
-    if args.nonuma:
-        call_args.append("-m")
     if "memo" in args and args.memo is not None and args.memo != b"":
         call_args.append("--memo")
         call_args.append(args.memo)
+    if args.nonuma:
+        call_args.append("--no-numa")
+    if args.no_cpu_affinity:
+        call_args.append("--no-cpu-affinity")
+    if args.verbose:
+        call_args.append("--verbose")
 
     call_args.append(plot_type)
 
     if "buckets" in args and args.buckets:
-        call_args.append("-b")
+        call_args.append("--buckets")
         call_args.append(str(args.buckets))
     if "tmpdir" in args and args.tmpdir:
-        call_args.append("-t1")
+        call_args.append("--temp1")
         call_args.append(str(args.tmpdir))
     if "tmpdir2" in args and args.tmpdir2:
-        call_args.append("-t2")
+        call_args.append("--temp2")
         call_args.append(str(args.tmpdir2))
-    if "no_cpu_affinity" in args and args.no_cpu_affinity:
-        call_args.append("--no-cpu-affinity")
     if "cache" in args and args.cache is not None:
         call_args.append("--cache")
         call_args.append(str(args.cache))

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -211,16 +211,13 @@ def plot_bladebit(args, chia_root_path, root_path):
         return
 
     version = None
+    actual_version = None
     if args.plotter == "bladebit":
-        version = 1
+        version = actual_version = 1
         if found and version_or_exception[0] != "1":
-            print(
-                f"You're trying to run bladebit version 1"
-                f" but currently version {'.'.join(version_or_exception)} is installed"
-            )
-            return
+            actual_version = 2
     elif args.plotter == "bladebit2":
-        version = 2
+        version = actual_version = 2
         if found and version_or_exception[0] != "2":
             print(
                 f"You're trying to run bladebit version 2"
@@ -280,6 +277,8 @@ def plot_bladebit(args, chia_root_path, root_path):
         call_args.append(args.memo)
     if version > 1:
         call_args.append("diskplot")
+    elif version == 1 and actual_version > 1:
+        call_args.append("ramplot")
     if args.buckets:
         call_args.append("-b")
         call_args.append(str(args.buckets))

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -272,47 +272,47 @@ def plot_bladebit(args, chia_root_path, root_path):
         call_args.append("-v")
     if args.nonuma:
         call_args.append("-m")
-    if args.memo is not None and args.memo != b"":
+    if "memo" in args and args.memo is not None and args.memo != b"":
         call_args.append("--memo")
         call_args.append(args.memo)
     if version > 1:
         call_args.append("diskplot")
     elif version == 1 and actual_version > 1:
         call_args.append("ramplot")
-    if args.buckets:
+    if "buckets" in args and args.buckets:
         call_args.append("-b")
         call_args.append(str(args.buckets))
-    if args.tmpdir:
+    if "tmpdir" in args and args.tmpdir:
         call_args.append("-t1")
         call_args.append(str(args.tmpdir))
-    if args.tmpdir2:
+    if "tmpdir2" in args and args.tmpdir2:
         call_args.append("-t2")
         call_args.append(str(args.tmpdir2))
-    if args.no_cpu_affinity:
+    if "no_cpu_affinity" in args and args.no_cpu_affinity:
         call_args.append("--no-cpu-affinity")
-    if args.cache is not None:
+    if "cache" in args and args.cache is not None:
         call_args.append("--cache")
         call_args.append(str(args.cache))
-    if args.f1_threads:
+    if "f1_threads" in args and args.f1_threads:
         call_args.append("--f1-threads")
         call_args.append(str(args.f1_threads))
-    if args.fp_threads:
+    if "fp_threads" in args and args.fp_threads:
         call_args.append("--fp-threads")
         call_args.append(str(args.fp_threads))
-    if args.c_threads:
+    if "c_threads" in args and args.c_threads:
         call_args.append("--c-threads")
         call_args.append(str(args.c_threads))
-    if args.p2_threads:
+    if "p2_threads" in args and args.p2_threads:
         call_args.append("--p2-threads")
         call_args.append(str(args.p2_threads))
-    if args.p3_threads:
+    if "p3_threads" in args and args.p3_threads:
         call_args.append("--p3-threads")
         call_args.append(str(args.p3_threads))
-    if args.alternate:
+    if "alternate" in args and args.alternate:
         call_args.append("--alternate")
-    if args.no_t1_direct:
+    if "no_t1_direct" in args and args.no_t1_direct:
         call_args.append("--no-t1-direct")
-    if args.no_t2_direct:
+    if "no_t2_direct" in args and args.no_t2_direct:
         call_args.append("--no-t2-direct")
 
     call_args.append(args.finaldir)

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -212,7 +212,7 @@ def plot_bladebit(args, chia_root_path, root_path):
 
     if found and int(version_or_exception[0]) < 2:
         print(f"Version {'.'.join(version_or_exception)} is detected.")
-        print(f"bladebit < 2 is not supported any more.")
+        print("bladebit < 2 is not supported any more.")
         return
 
     bladebit_executable_path = get_bladebit_executable_path(root_path)

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -97,6 +97,7 @@ bladebit_ram_plotter_options = [
     Options.ID,
     Options.BLADEBIT_WARMSTART,
     Options.BLADEBIT_NONUMA,
+    Options.BLADEBIT_NO_CPU_AFFINITY,
     Options.VERBOSE,
     Options.CONNECT_TO_DAEMON,
     Options.FINAL_DIR,
@@ -451,9 +452,7 @@ def call_plotters(root_path: Path, args):
     install_parser = subparsers.add_parser("install", help=deprecation_warning)
     install_parser.add_argument("install_plotter", type=str, nargs="*")
 
-    deprecation_warning_bb2 = (
-        "[DEPRECATED] 'chia plotters bladebit2' was integrated to 'chia plotters bladebit'"
-    )
+    deprecation_warning_bb2 = "[DEPRECATED] 'chia plotters bladebit2' was integrated to 'chia plotters bladebit'"
     bladebit2_parser = subparsers.add_parser("bladebit2", help=deprecation_warning_bb2)
     bladebit2_parser.add_argument("bladebit2_plotter", type=str, nargs="*")
 

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -88,7 +88,7 @@ madmax_plotter_options = [
     Options.FINAL_DIR,
 ]
 
-bladebit_plotter_options = [
+bladebit_ram_plotter_options = [
     Options.NUM_THREADS,
     Options.PLOT_COUNT,
     Options.FARMERKEY,
@@ -102,7 +102,7 @@ bladebit_plotter_options = [
     Options.FINAL_DIR,
 ]
 
-bladebit2_plotter_options = [
+bladebit_disk_plotter_options = [
     Options.NUM_THREADS,
     Options.PLOT_COUNT,
     Options.FARMERKEY,
@@ -437,8 +437,13 @@ def call_plotters(root_path: Path, args):
 
     build_parser(subparsers, root_path, chia_plotter_options, "chiapos", "Create a plot with the default chia plotter")
     build_parser(subparsers, root_path, madmax_plotter_options, "madmax", "Create a plot with madMAx")
-    build_parser(subparsers, root_path, bladebit_plotter_options, "bladebit", "Create a plot with bladebit")
-    build_parser(subparsers, root_path, bladebit2_plotter_options, "bladebit2", "Create a plot with bladebit2")
+
+    bladebit_parser = subparsers.add_parser("bladebit", help="Create a plot with bladebit")
+    subparsers_bb = bladebit_parser.add_subparsers(dest="plot_type", required=True)
+    build_parser(subparsers_bb, root_path, bladebit_ram_plotter_options, "ramplot", "Create a plot using RAM")
+    build_parser(subparsers_bb, root_path, bladebit_disk_plotter_options, "diskplot", "Create a plot using disk")
+
+    subparsers.add_parser("version", help="Show plotter versions")
 
     deprecation_warning = (
         "[DEPRECATED] 'chia plotters install' is no longer available. Use install-plotter.sh/ps1 instead."
@@ -446,7 +451,11 @@ def call_plotters(root_path: Path, args):
     install_parser = subparsers.add_parser("install", help=deprecation_warning)
     install_parser.add_argument("install_plotter", type=str, nargs="*")
 
-    subparsers.add_parser("version", help="Show plotter versions")
+    deprecation_warning_bb2 = (
+        "[DEPRECATED] 'chia plotters bladebit2' was integrated to 'chia plotters bladebit'"
+    )
+    bladebit2_parser = subparsers.add_parser("bladebit2", help=deprecation_warning_bb2)
+    bladebit2_parser.add_argument("bladebit2_plotter", type=str, nargs="*")
 
     args = plotters.parse_args(args)
 
@@ -456,12 +465,14 @@ def call_plotters(root_path: Path, args):
         plot_chia(args, chia_root_path)
     elif args.plotter == "madmax":
         plot_madmax(args, chia_root_path, root_path)
-    elif args.plotter.startswith("bladebit"):
+    elif args.plotter == "bladebit":
         plot_bladebit(args, chia_root_path, root_path)
     elif args.plotter == "version":
         show_plotters_version(chia_root_path)
     elif args.plotter == "install":
         print(deprecation_warning)
+    elif args.plotter == "bladebit2":
+        print(deprecation_warning_bb2)
 
 
 def get_available_plotters(root_path) -> Dict[str, Any]:


### PR DESCRIPTION
# Changelog

## Removed
- Dropped support for bladebit < 2
- `chia plotters bladebit2` command has been removed and integrated to `chia plotters bladebit`
## Changed
- `chia plotters bladebit` command now requires sub command `ramplot` / `diskplot`.  

```
$ chia plotters bladebit diskplot -h
usage: chia plotters bladebit diskplot [-h] [-r THREADS] [-n COUNT] [-f FARMERKEY] [-p POOL_KEY] [-c CONTRACT] [-i ID] [-w] [--nonuma] [-v] -d FINALDIR
                                       [--no-cpu-affinity] [--cache CACHE] [--f1-threads F1_THREADS] [--fp-threads FP_THREADS] [--c-threads C_THREADS]        
                                       [--p2-threads P2_THREADS] [--p3-threads P3_THREADS] [--alternate] -t TMPDIR [-2 TMPDIR2] [-u BUCKETS] [-m MEMO]        
                                       [--no-t1-direct] [--no-t2-direct]

optional arguments:
  -h, --help            show this help message and exit
  -r THREADS, --threads THREADS
                        Num threads.
  -n COUNT, --count COUNT
                        Number of plots to create (default = 1)
  -f FARMERKEY, --farmerkey FARMERKEY
                        Farmer Public Key (48 bytes)
  -p POOL_KEY, --pool-key POOL_KEY
                        Pool Public Key (48 bytes)
  -c CONTRACT, --contract CONTRACT
                        Pool Contract Address (64 chars)
  -i ID, --id ID        Plot id
  -w, --warmstart       Warm start
  --nonuma              Disable numa
  -v, --verbose         Set verbose
  -d FINALDIR, --final_dir FINALDIR
                        Final directory.
  --no-cpu-affinity     Disable assigning automatic thread affinity
  --cache CACHE         Size of cache to reserve for I/O
  --f1-threads F1_THREADS
                        Override the thread count for F1 generation
  --fp-threads FP_THREADS
                        Override the thread count for forward propagation
  --c-threads C_THREADS
                        Override the thread count for C table processing
  --p2-threads P2_THREADS
                        Override the thread count for Phase 2
  --p3-threads P3_THREADS
                        Override the thread count for Phase 3
  --alternate           Halves the temp2 cache size requirements by alternating bucket writing methods between tables
  -t TMPDIR, --tmp_dir TMPDIR
                        Temporary directory 1.
  -2 TMPDIR2, --tmp_dir2 TMPDIR2
                        Temporary directory 2.
  -u BUCKETS, --buckets BUCKETS
                        Number of buckets.
  -m MEMO, --memo MEMO  Memo variable.
  --no-t1-direct        Disable direct I/O on the temp 1 directory
  --no-t2-direct        Disable direct I/O on the temp 2 directory
```

```
$ chia plotters bladebit ramplot -h 
usage: chia plotters bladebit ramplot [-h] [-r THREADS] [-n COUNT] [-f FARMERKEY] [-p POOL_KEY] [-c CONTRACT] [-i ID] [-w] [--nonuma] [--no-cpu-affinity]
                                      [-v] -d FINALDIR

optional arguments:
  -h, --help            show this help message and exit
  -r THREADS, --threads THREADS
                        Num threads.
  -n COUNT, --count COUNT
                        Number of plots to create (default = 1)
  -f FARMERKEY, --farmerkey FARMERKEY
                        Farmer Public Key (48 bytes)
  -p POOL_KEY, --pool-key POOL_KEY
                        Pool Public Key (48 bytes)
  -c CONTRACT, --contract CONTRACT
                        Pool Contract Address (64 chars)
  -i ID, --id ID        Plot id
  -w, --warmstart       Warm start
  --nonuma              Disable numa
  --no-cpu-affinity     Disable assigning automatic thread affinity
  -v, --verbose         Set verbose
  -d FINALDIR, --final_dir FINALDIR
                        Final directory.
```
