### PR TITLE
less pip install and activate for windows build

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -189,6 +189,8 @@ jobs:
       run: |
         .\Install.ps1 -d
 
+    - uses: chia-network/actions/activate-venv@main
+
     - name: Prepare GUI cache
       id: gui-ref
       run: |
@@ -221,7 +223,6 @@ jobs:
       run: |
         $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
         $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
-        .\venv\Scripts\Activate.ps1
         cd .\build_scripts
         .\build_windows-2-installer.ps1
 
@@ -263,11 +264,6 @@ jobs:
       run: |
          certutil.exe -hashfile ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe SHA256 > ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256
          ls ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\
-
-    - name: Install py3createtorrent
-      if: env.FULL_RELEASE == 'true'
-      run: |
-        pip3 install py3createtorrent
 
     - name: Create torrent
       if: env.FULL_RELEASE == 'true'


### PR DESCRIPTION
This is more inline with the other workflows and also makes sure we keep the py3createtorrent version selection centralized.  This isn't critical in the present setup where it isn't even pinned, but in the future when we get to a dependency lock file it will be good to not have these random versions being installed in various places.