### PR TITLE
create tasks for stopping services

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -208,7 +208,9 @@ class WebSocketServer:
     async def stop(self) -> Dict[str, Any]:
         self.cancel_task_safe(self.ping_job)
         service_names = list(self.services.keys())
-        stop_service_jobs = [kill_service(self.root_path, self.services, s_n) for s_n in service_names]
+        stop_service_jobs = [
+            asyncio.create_task(kill_service(self.root_path, self.services, s_n)) for s_n in service_names
+        ]
         if stop_service_jobs:
             await asyncio.wait(stop_service_jobs)
         self.services.clear()


### PR DESCRIPTION
https://docs.python.org/3.11/whatsnew/changelog.html#changelog
> bpo-34790: Remove passing coroutine objects to asyncio.wait().

In Python 3.11 `asyncio.wait()` does not automatically create tasks from
coroutines passed to it.  This manually creates the tasks prior to calling
`asyncio.wait()`.

Draft for:
- [x] testing out in https://github.com/Chia-Network/chia-blockchain/pull/11407

(cherry picked from commit 855b5d1a960b51653f7cb32e12fc97f019e868ce)
