### PR TITLE
Fixing test Arch install

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -157,7 +157,8 @@ jobs:
     - name: Prepare Arch
       if: ${{ matrix.distribution.type == 'arch' }}
       run: |
-        pacman --noconfirm --refresh base --sync git sudo
+        pacman --noconfirm -Syu
+        pacman --noconfirm -S base git sudo openssl-1.1
         # The behavior we follow in install.sh is unique with Arch in that
         # we leave it to the user to install the appropriate version of python,
         # so we need to install python here in order for the test to succeed.


### PR DESCRIPTION
Improved simulated Arch user environment, and added additional `openssl-1.1` package to prevent breakage.