### PR TITLE
Start subscription with a snapshot

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -375,7 +375,7 @@ class DataLayer:
 
             try:
                 timeout = self.config.get("client_timeout", 15)
-                if self.config.get("use_last_full_tree_file", False) and root.generation == 0:
+                if self.config.get("use_snapshot", False) and root.generation == 0:
                     success = await insert_from_full_file(
                         self.data_store,
                         tree_id,

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1107,7 +1107,7 @@ class DataStore:
             await self._insert_root(tree_id=tree_id, node_hash=node_hash, status=status, generation=snapshot_generation)
             # Don't update the ancestor table for non-committed status.
             if status == Status.COMMITTED:
-                await self.build_ancestor_table_for_latest_root(tree_id=tree_id)
+                await self.build_ancestor_table_for_latest_root(tree_id, snapshot_generation)
 
     async def get_node_by_key(
         self,

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -55,7 +55,7 @@ async def insert_into_data_store_from_file(
     tree_id: bytes32,
     root_hash: Optional[bytes32],
     filename: Path,
-    generation: Optional[int] = None,
+    snapshot_generation: Optional[int] = None,
 ) -> None:
     with open(filename, "rb") as reader:
         while True:
@@ -82,9 +82,13 @@ async def insert_into_data_store_from_file(
             serialized_node = SerializedNode.from_bytes(serialize_nodes_bytes)
 
             node_type = NodeType.TERMINAL if serialized_node.is_terminal else NodeType.INTERNAL
-            await data_store.insert_node(node_type, serialized_node.value1, serialized_node.value2)
 
-    await data_store.insert_root_with_ancestor_table(tree_id, root_hash, Status.COMMITTED, generation)
+            print(f"insert node. Serialized:{serialized_node}")
+            await data_store.insert_node(node_type, serialized_node.value1, serialized_node.value2)
+            print("post insert node.")
+    print("Pre Ancestor")
+    await data_store.insert_root_with_ancestor_table(tree_id, root_hash, Status.COMMITTED, snapshot_generation)
+    print("Post Ancestor")
 
 
 async def write_files_for_root(

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -580,6 +580,8 @@ data_layer:
   selected_network: *selected_network
   # If True, starts an RPC server at the following port
   start_rpc_server: True
+  # If true, when you subscribe to a DL, first of all you download last full and start from it. 
+  use_snapshot: False
   # TODO: what considerations are there in choosing this?
   rpc_port: 8562
   rpc_server_max_request_body_size: 26214400

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 ; logging options
 log_cli = False
-addopts = -rP --verbose --tb=short -n auto -p no:monitor 
+addopts = --verbose --tb=short -n auto -p no:monitor 
 log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 ; logging options
 log_cli = False
-addopts = --verbose --tb=short -n auto -p no:monitor
+addopts = -rP --verbose --tb=short -n auto -p no:monitor 
 log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -56,7 +56,7 @@ def create_example_fixture(request: SubRequest) -> Callable[[DataStore, bytes32]
 
 @pytest.fixture(name="database_uri")
 def database_uri_fixture() -> str:
-    return f"C:\\temp\\dl{random.randint(0, 99999999)}.sqlite"
+    return f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
 
 
 @pytest.fixture(name="tree_id", scope="function")

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -56,7 +56,7 @@ def create_example_fixture(request: SubRequest) -> Callable[[DataStore, bytes32]
 
 @pytest.fixture(name="database_uri")
 def database_uri_fixture() -> str:
-    return f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
+    return f"C:\\temp\\dl{random.randint(0, 99999999)}.sqlite"
 
 
 @pytest.fixture(name="tree_id", scope="function")

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -1266,6 +1266,8 @@ async def test_data_server_files_from_snapshot(
                     changelist.append({"action": "delete", "key": key})
                 counter += 1
             value = countergeneration.to_bytes(4, byteorder="big")
+            key = (9000 + countergeneration).to_bytes(4, byteorder="big")
+            changelist.append({"action": "insert", "key": key, "value": value})
             changelist.append({"action": "delete", "key": key_check_all_generation})
             changelist.append({"action": "insert", "key": key_check_all_generation, "value": value})
             # if countergeneration == 3:
@@ -1301,6 +1303,8 @@ async def test_data_server_files_from_snapshot(
             else:
                 await insert_into_data_store_from_file(data_store, tree_id, root.node_hash, tmp_path.joinpath(filename))
             current_root = await data_store.get_tree_root(tree_id=tree_id)
+            node = await data_store.get_node_by_key((9000 + generation).to_bytes(4, byteorder="big"), tree_id)
+            assert node.value == generation.to_bytes(4, byteorder="big")
             node = await data_store.get_node_by_key(key=key_check_all_generation, tree_id=tree_id)
             assert node.value == generation.to_bytes(4, byteorder="big")
             assert current_root.node_hash == root.node_hash

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -1236,7 +1236,7 @@ async def test_data_server_files_from_snapshot(
 ) -> None:
     roots: List[Root] = []
     num_batches = 10
-    num_ops_per_batch = 0
+    num_ops_per_batch = 100
     generation_of_snapshot = 5
     key_check_all_generation = hexstr_to_bytes("746573745F636865636B")
     # key_check_after_snapshot = hexstr_to_bytes("746573745F6265666F7265")


### PR DESCRIPTION
Let's consider DataStores that are changed often and the keys overwritten often. An application that connects via RPC with Chia (a project of mine) must download these DataStores, but starting from item 1 the time taken to download all versions is very long. Furthermore, in "ecological" terms, unloading more than necessary has an impact.
This development allows you to download the latest version at the first request. This way you can build a dedicated server for this. I developed in server terms with a backward compatible explicit key so that it is explicit that the files located "\data_layer\db\server_files_location_mainnet" are not useful for mirroring. Its best use and with a docker to have a fast DataStore reader.
in other words, "WE TREAT THE LAST FULL FILE AS A SNAPSHOT"