### PR TITLE
util: Hint `ApiMetadata.message_class` with `Optional[Type[Streamable]]`

### DIFF
--- a/chia/util/api_decorators.py
+++ b/chia/util/api_decorators.py
@@ -27,7 +27,7 @@ class ApiMetadata:
     bytes_required: bool = False
     execute_task: bool = False
     reply_types: List[ProtocolMessageTypes] = field(default_factory=list)
-    message_class: Optional[Any] = None
+    message_class: Any = None
 
 
 def get_metadata(function: Callable[..., object]) -> ApiMetadata:

--- a/chia/util/api_decorators.py
+++ b/chia/util/api_decorators.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional, TypeVar, Union, get_type_hints
+from typing import Callable, List, Optional, Type, TypeVar, Union, get_type_hints
 
 from typing_extensions import Concatenate, ParamSpec
 
@@ -27,7 +27,7 @@ class ApiMetadata:
     bytes_required: bool = False
     execute_task: bool = False
     reply_types: List[ProtocolMessageTypes] = field(default_factory=list)
-    message_class: Any = None
+    message_class: Optional[Type[Streamable]] = None
 
 
 def get_metadata(function: Callable[..., object]) -> ApiMetadata:


### PR DESCRIPTION
Im working towards more strict mypy in `chia.server.ws_connection` and  this change helps there while (i think) it still retains the same  behaviour.