### PR TITLE
towncrier for the changelog

### DIFF
--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -28,7 +28,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        submodules: recursive
 
     - uses: Chia-Network/actions/setup-python@main
       name: Install Python

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Require change fragment
       run: |
-        towncrier check --compare-with "${{ github.event.pull_request.base.ref }}"
+        towncrier check --compare-with "origin/${{ github.event.pull_request.base.ref }}"
 
     - name: Lint source with black
       run: |

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -50,6 +50,10 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install .[dev]
 
+    - name: Require change fragment
+      run: |
+        towncrier check --compare-with "${{ github.event.pull_request.base.ref }}"
+
     - name: Lint source with black
       run: |
         black --check --diff .
@@ -83,3 +87,36 @@ jobs:
         TWINE_NON_INTERACTIVE: 1
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: twine upload --non-interactive --skip-existing --verbose 'dist/*'
+
+  build_changelog:
+    name: Build changelog
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - uses: Chia-Network/actions/setup-python@main
+      name: Install Python
+      with:
+        python-version: '3.8'
+
+    - uses: ./.github/actions/install
+      with:
+        python-version: '3.8'
+        development: true
+
+    - uses: chia-network/actions/activate-venv@main
+
+    - name: Build changelog
+      run: |
+        towncrier build
+
+    - name: Publish changelog artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: changelog
+        path: CHANGELOG.md
+        if-no-files-found: error

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -97,6 +97,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: ${{ github.event.head.sha }}
 
     - uses: Chia-Network/actions/setup-python@main
       name: Install Python

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -117,10 +117,6 @@ jobs:
       run: |
         towncrier build --yes
 
-    - name: Create complete changelog summary
-      run: |
-        cat CHANGELOG.md >> $GITHUB_STEP_SUMMARY
-
     - name: Publish changelog artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -96,7 +96,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: ${{ github.event.head.sha }}
 
     - uses: Chia-Network/actions/setup-python@main
       name: Install Python

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -112,7 +112,7 @@ jobs:
 
     - name: Build changelog
       run: |
-        towncrier build
+        towncrier build --yes
 
     - name: Publish changelog artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -109,9 +109,17 @@ jobs:
 
     - uses: chia-network/actions/activate-venv@main
 
+    - name: Create single version changlog summary
+      run: |
+        towncrier build --yes --draft >> $GITHUB_STEP_SUMMARY
+
     - name: Build changelog
       run: |
         towncrier build --yes
+
+    - name: Create complete changelog summary
+      run: |
+        cat CHANGELOG.md >> $GITHUB_STEP_SUMMARY
 
     - name: Publish changelog artifact
       uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+<!-- towncrier start string -->
 ## 1.6.1 Chia blockchain 2022-11-03
 
 ### Added

--- a/changes/.gitignore
+++ b/changes/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/changes/template.md
+++ b/changes/template.md
@@ -1,0 +1,13 @@
+## {{ versiondata.version }} Chia blockchain {{ versiondata.date }}
+
+{% for section, _ in sections.items() %}
+{% for category, val in definitions.items() if category in sections[section]%}
+### {{ definitions[category]['name'] }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+- {{ text }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/changes/x.added
+++ b/changes/x.added
@@ -1,0 +1,1 @@
+Started using towncrier.  https://towncrier.readthedocs.io/en/stable/

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ dev_dependencies = [
     "aiohttp_cors",  # For blackd
     "ipython",  # For asyncio debugging
     "pyinstaller==5.3",
+    "towncrier",
     "types-aiofiles",
     "types-cryptography",
     "types-pkg_resources",

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,29 @@
+[tool.towncrier]
+directory = "changes"
+filename = "CHANGELOG.md"
+package = "chia"
+start_string = "<!-- towncrier start string -->"
+template = "changes/template.md"
+#title_format = "{version} {name} {project_date}"
+#underlines = " "
+
+[tool.towncrier.fragment.added]
+name ="Added"
+
+[tool.towncrier.fragment.changed]
+name = "Changed"
+
+[tool.towncrier.fragment.deprecated]
+name = "Deprecated"
+
+[tool.towncrier.fragment.removed]
+name = "Removed"
+
+[tool.towncrier.fragment.fixed]
+name = "Fixed"
+
+[tool.towncrier.fragment.security]
+name = "Security"
+
+[tool.towncrier.fragment.misc]
+showcontent = false


### PR DESCRIPTION
[Towncrier](https://towncrier.readthedocs.io/en/stable/) builds changelogs from change fragment (newsfragment) files in the `changes/` directory.  A basic PR deserving of a changelog entry should create a file such as `changes/13882.added` with content in markdown format of the existing changelog.  Using separate files avoids the constant merge conflicts that would be present if everyone directly added items to the ends of the sections in the final changelog file.  One of the PR checks verifies that such a file is being introduced or modified by the PR.  When ready to make a release, Towncrier is run to consume these fragments and add them to the `CHANGELOG.md` file.  At this time the consumed fragments are deleted and the updated `CHANGELOG.md` is committed.  The intent presently is to retain the existing sections and format of the changelog.  Additionally, in each PR the changelog is built and provided as both a most-recent-version summary on the workflow summary page as well as being available as a downloadable artifact with the full generated `CHANGELOG.md`.  See https://github.com/Chia-Network/chia-blockchain/actions/runs/3431382476 for example.

More fragments are visible in the test PR https://github.com/Chia-Network/chia-blockchain/pull/13884 such as at https://github.com/Chia-Network/chia-blockchain/actions/runs/3431499033#summary-9397068321.

There are various benefits to this approach.

- No vendor lock-in.  We are not storing our data exclusively in GitHub, not using the GitHub tooling to process that data, and our changelog management isn't forced to be tied to the actual PR objects.
- Any user at any time can render the changelog, including locally, to see what it looks like in final form.  This means the rendered changelog can be reviewed as part of reviewing the associated PR.
- All changes are tracked in git as granularly as we make them.  Since we require reviews this means that all changes get reviewed.
- Changelog entries can be created without a one to one relationship to a PR.  Some PRs need no changelog entry because they are any of a number of forms of internal changes.  Some PRs need multiple entries because they are deprecating or removing one thing and adding a replacement for it.  There are certainly other situations as well.
- Thank yous, links to issues, documentation, PRs, etc can be readily added without them awkwardly sitting in the PR title.
- The changelog fragment is shown in the PR diff view along all the other source changes that should be reviewed for the PR.
- Other groups, such as product or comms, can view and suggest changes to the fragments whenever they choose.  This can be done by viewing the latest rendered changelog via `main` builds or their own PR and providing edits to the relevant files.  These changes will go through the normal review process instead of just anyone changing any PR title and tags whenever.

Draft for:
- [ ] Being more than an exploration
- [ ] Test multiline, code block, links, etc fragments
- [ ] Add blankline between sections https://github.com/Chia-Network/chia-blockchain/actions/runs/3431499033/jobs/5719701176/summary_raw
- [ ] Discuss how to handling having references to PRs and issues for context.  The relevant automatic feature for this is presently being disregarded since our final format in the past has excluded these links.  But, they are used during processing of the changelog and thus we need to put some consideration into this.