### PR TITLE
fix coin selection cli decimal handling & splitting issue

### DIFF
--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -207,7 +207,7 @@ async def async_split(args: Dict[str, Any], wallet_client: WalletRpcClient, fing
         print("Try using a smaller fee or amount.")
         return
     additions: List[Dict[str, Union[uint64, bytes32]]] = []
-    puzzle_hashes: Set[bytes32] = set()  # we use a set for speed.
+    puzzle_hashes: Set[bytes32] = set()  # use a set for fast membership checks
     for i in range(number_of_coins):  # for readability.
         target_ph: bytes32 = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), unique_addresses))
         if target_ph in puzzle_hashes:  # if this ph is used by another coin that is being created, we cant use it.

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -207,13 +207,11 @@ async def async_split(args: Dict[str, Any], wallet_client: WalletRpcClient, fing
         print("Try using a smaller fee or amount.")
         return
     additions: List[Dict[str, Union[uint64, bytes32]]] = []
-    puzzle_hashes: Set[bytes32] = set()  # use a set for fast membership checks
+    puzzle_hashes: Set[bytes32] = set()  # use a set for fast duplicate checks
     for i in range(number_of_coins):  # for readability.
         target_ph: bytes32 = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), unique_addresses))
-        if target_ph in puzzle_hashes:  # if this ph is used by another coin that is being created, we cant use it.
-            target_ph = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), new_address=False))
-            if target_ph in puzzle_hashes:  # we need to get a new address because the second address is also used.
-                target_ph = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), new_address=True))
+        if target_ph in puzzle_hashes:  # if this ph is used by another coin that is being created, we get a new addr.
+            target_ph = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), new_address=True))
         puzzle_hashes.add(target_ph)  # add ph to list of ph's that we are using to avoid duplicates.
         additions.append({"amount": final_amount_per_coin, "puzzle_hash": target_ph})
     transaction: TransactionRecord = await wallet_client.send_transaction_multi(

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -179,6 +179,7 @@ async def async_split(args: Dict[str, Any], wallet_client: WalletRpcClient, fing
     fee = Decimal(args["fee"])
     # new args
     amount_per_coin = Decimal(args["amount_per_coin"])
+    unique_addresses = bool(args["unique_addresses"])
     target_coin_id: bytes32 = bytes32.from_hexstr(args["target_coin_id"])
     if number_of_coins > 500:
         print(f"{number_of_coins} coins is greater then the maximum limit of 500 coins.")
@@ -206,8 +207,8 @@ async def async_split(args: Dict[str, Any], wallet_client: WalletRpcClient, fing
         print("Try using a smaller fee or amount.")
         return
     additions: List[Dict[str, Union[uint64, bytes32]]] = []
-    for i in range(number_of_coins):  # for readability, we always use new addresses to avoid reusing within this tx.
-        target_ph: bytes32 = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), True))
+    for i in range(number_of_coins):  # for readability.
+        target_ph: bytes32 = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), unique_addresses))
         additions.append({"amount": final_amount_per_coin, "puzzle_hash": target_ph})
     transaction: TransactionRecord = await wallet_client.send_transaction_multi(
         str(wallet_id), additions, [removal_coin_record.coin], final_fee

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from decimal import Decimal
-from typing import Any, Dict, List, Tuple, Union, Set
+from typing import Any, Dict, List, Set, Tuple, Union
 
 from chia.cmds.wallet_funcs import get_mojo_per_unit, get_wallet_type, print_balance
 from chia.rpc.wallet_rpc_client import WalletRpcClient

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -179,7 +179,6 @@ async def async_split(args: Dict[str, Any], wallet_client: WalletRpcClient, fing
     fee = Decimal(args["fee"])
     # new args
     amount_per_coin = Decimal(args["amount_per_coin"])
-    unique_addresses = bool(args["unique_addresses"])
     target_coin_id: bytes32 = bytes32.from_hexstr(args["target_coin_id"])
     if number_of_coins > 500:
         print(f"{number_of_coins} coins is greater then the maximum limit of 500 coins.")
@@ -207,8 +206,8 @@ async def async_split(args: Dict[str, Any], wallet_client: WalletRpcClient, fing
         print("Try using a smaller fee or amount.")
         return
     additions: List[Dict[str, Union[uint64, bytes32]]] = []
-    for i in range(number_of_coins):  # for readability.
-        target_ph: bytes32 = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), unique_addresses))
+    for i in range(number_of_coins):  # for readability, we always use new addresses to avoid reusing within this tx.
+        target_ph: bytes32 = decode_puzzle_hash(await wallet_client.get_next_address(str(wallet_id), True))
         additions.append({"amount": final_amount_per_coin, "puzzle_hash": target_ph})
     transaction: TransactionRecord = await wallet_client.send_transaction_multi(
         str(wallet_id), additions, [removal_coin_record.coin], final_fee

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -88,7 +88,7 @@ def print_coins(
                 break
             coin, conf_height = coins[i + j]
             address = encode_puzzle_hash(coin.puzzle_hash, addr_prefix)
-            amount_str = print_balance(coin.amount, mojo_per_unit, addr_prefix)
+            amount_str = print_balance(coin.amount, mojo_per_unit, addr_prefix, True)
             print(f"Coin ID: 0x{coin.name().hex()}")
             print(target_string.format(address, amount_str, conf_height))
 

--- a/chia/cmds/coins.py
+++ b/chia/cmds/coins.py
@@ -215,7 +215,6 @@ def combine_cmd(
     type=str,
     required=True,
 )
-@click.option("-u", "--unique_addresses", is_flag=True, help="Generate a new address for each coin.")
 @click.option("-t", "--target-coin-id", type=str, required=True, help="The coin id of the coin we are splitting.")
 def split_cmd(
     wallet_rpc_port: Optional[int],
@@ -224,7 +223,6 @@ def split_cmd(
     number_of_coins: int,
     fee: str,
     amount_per_coin: str,
-    unique_addresses: bool,
     target_coin_id: str,
 ) -> None:
     extra_params = {
@@ -232,7 +230,6 @@ def split_cmd(
         "number_of_coins": number_of_coins,
         "fee": fee,
         "amount_per_coin": amount_per_coin,
-        "unique_addresses": unique_addresses,
         "target_coin_id": target_coin_id,
     }
     from .coin_funcs import async_split

--- a/chia/cmds/coins.py
+++ b/chia/cmds/coins.py
@@ -215,6 +215,7 @@ def combine_cmd(
     type=str,
     required=True,
 )
+@click.option("-u", "--unique_addresses", is_flag=True, help="Generate a new address for each coin.")
 @click.option("-t", "--target-coin-id", type=str, required=True, help="The coin id of the coin we are splitting.")
 def split_cmd(
     wallet_rpc_port: Optional[int],
@@ -223,6 +224,7 @@ def split_cmd(
     number_of_coins: int,
     fee: str,
     amount_per_coin: str,
+    unique_addresses: bool,
     target_coin_id: str,
 ) -> None:
     extra_params = {
@@ -230,6 +232,7 @@ def split_cmd(
         "number_of_coins": number_of_coins,
         "fee": fee,
         "amount_per_coin": amount_per_coin,
+        "unique_addresses": unique_addresses,
         "target_coin_id": target_coin_id,
     }
     from .coin_funcs import async_split

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -706,7 +706,7 @@ def wallet_coin_unit(typ: WalletType, address_prefix: str) -> Tuple[str, int]:
 
 
 def print_balance(amount: int, scale: int, address_prefix: str, *, decimal_only: bool = False) -> str:
-    if decimal_only:
+    if decimal_only:  # dont use scientific notation.
         final_amount = f"{amount / scale:.12f}"
     else:
         final_amount = f"{amount / scale}"

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -705,7 +705,7 @@ def wallet_coin_unit(typ: WalletType, address_prefix: str) -> Tuple[str, int]:
     return "", units["mojo"]
 
 
-def print_balance(amount: int, scale: int, address_prefix: str, decimal_only: bool = False) -> str:
+def print_balance(amount: int, scale: int, address_prefix: str, *, decimal_only: bool = False) -> str:
     if decimal_only:
         final_amount = f"{amount / scale:.12f}"
     else:

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -705,8 +705,12 @@ def wallet_coin_unit(typ: WalletType, address_prefix: str) -> Tuple[str, int]:
     return "", units["mojo"]
 
 
-def print_balance(amount: int, scale: int, address_prefix: str) -> str:
-    ret = f"{amount / scale} {address_prefix} "
+def print_balance(amount: int, scale: int, address_prefix: str, decimal_only: bool = False) -> str:
+    if decimal_only:
+        final_amount = f"{amount / scale:.12f}"
+    else:
+        final_amount = f"{amount / scale}"
+    ret = f"{final_amount} {address_prefix} "
     if scale > 1:
         ret += f"({amount} mojo)"
     return ret


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
This pr fixes the decimal handling & fixes randomly occurring coin splitting failure


<!-- What is the current behavior?** (You can also link to an open issue here) -->
BAD: coin splitting fails if we are unlucky enough to get the same address twice.


<!-- What is the new behavior (if this is a feature change)? -->
Fixed: splitting works & chia wallet coins list is always in decimals and not ever in scientific notation.


<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->
Tested by @jack60612 and @esaung 


<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
OLD output:
```
Confirmed coins:
Coin ID: 0xb184db94bcf65fa1921b4a1355405fece87012f58d0060d8c412244857e6a7d7
        Address: xch1np4emf0ha4cu0k52qet0vtrw8h90lm8gt92ga6n9rler8wan5yls28fgvc Amount: 1e-12 xch (1 mojo), Confirmed in block: 2512321

Coin ID: 0x013cea7ae44acca77b42e762ce73aaeb4a0cc012b661db85c8fe0d4674b8b7db
        Address: xch1vnzlgtncha606ejtn3puyhdp835rxzent30dev6aqc8ph6ks8ensyg9yn3 Amount: 1.098994e-06 xch (1098994 mojo), Confirmed in block: 2498230
```
NEW output:
```
Confirmed coins:
Coin ID: 0xb184db94bcf65fa1921b4a1355405fece87012f58d0060d8c412244857e6a7d7
        Address: xch1np4emf0ha4cu0k52qet0vtrw8h90lm8gt92ga6n9rler8wan5yls28fgvc Amount: 0.000000000001 xch (1 mojo), Confirmed in block: 2512321

Coin ID: 0x013cea7ae44acca77b42e762ce73aaeb4a0cc012b661db85c8fe0d4674b8b7db
        Address: xch1vnzlgtncha606ejtn3puyhdp835rxzent30dev6aqc8ph6ks8ensyg9yn3 Amount: 0.000001098994 xch (1098994 mojo), Confirmed in block: 2498230
```