### PR TITLE
add --fingerprint option to chia keys show

### DIFF
--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -72,9 +72,9 @@ def generate_cmd(ctx: click.Context, label: Optional[str]):
 )
 @click.pass_context
 def show_cmd(ctx: click.Context, show_mnemonic_seed, non_observer_derivation, json, fingerprint):
-    from .keys_funcs import show_all_keys
+    from .keys_funcs import show_keys
 
-    show_all_keys(ctx.obj["root_path"], show_mnemonic_seed, non_observer_derivation, json, fingerprint)
+    show_keys(ctx.obj["root_path"], show_mnemonic_seed, non_observer_derivation, json, fingerprint)
 
 
 @keys_cmd.command("add", short_help="Add a private key by mnemonic")

--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -39,7 +39,7 @@ def generate_cmd(ctx: click.Context, label: Optional[str]):
     check_keys(ctx.obj["root_path"])
 
 
-@keys_cmd.command("show", short_help="Displays all the keys in keychain")
+@keys_cmd.command("show", short_help="Displays all the keys in keychain or the key with the given fingerprint")
 @click.option(
     "--show-mnemonic-seed", help="Show the mnemonic seed of the keys", default=False, show_default=True, is_flag=True
 )
@@ -62,11 +62,19 @@ def generate_cmd(ctx: click.Context, label: Optional[str]):
     show_default=True,
     is_flag=True,
 )
+@click.option(
+    "--fingerprint",
+    "-f",
+    help="Enter the fingerprint of the key you want to view",
+    type=int,
+    required=False,
+    default=None,
+)
 @click.pass_context
-def show_cmd(ctx: click.Context, show_mnemonic_seed, non_observer_derivation, json):
+def show_cmd(ctx: click.Context, show_mnemonic_seed, non_observer_derivation, json, fingerprint):
     from .keys_funcs import show_all_keys
 
-    show_all_keys(ctx.obj["root_path"], show_mnemonic_seed, non_observer_derivation, json)
+    show_all_keys(ctx.obj["root_path"], show_mnemonic_seed, non_observer_derivation, json, fingerprint)
 
 
 @keys_cmd.command("add", short_help="Add a private key by mnemonic")

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -126,7 +126,7 @@ def delete_key_label(fingerprint: int) -> None:
         sys.exit(f"Error: {e}")
 
 
-def show_all_keys(
+def show_keys(
     root_path: Path, show_mnemonic: bool, non_observer_derivation: bool, json_output: bool, fingerprint: Optional[int]
 ):
     """

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -126,13 +126,18 @@ def delete_key_label(fingerprint: int) -> None:
         sys.exit(f"Error: {e}")
 
 
-def show_all_keys(root_path: Path, show_mnemonic: bool, non_observer_derivation: bool, json_output: bool):
+def show_all_keys(
+    root_path: Path, show_mnemonic: bool, non_observer_derivation: bool, json_output: bool, fingerprint: Optional[int]
+):
     """
     Prints all keys and mnemonics (if available).
     """
     unlock_keyring()
     config = load_config(root_path, "config.yaml")
-    all_keys = Keychain().get_keys(True)
+    if fingerprint is None:
+        all_keys = Keychain().get_keys(True)
+    else:
+        all_keys = [Keychain().get_key(fingerprint, True)]
     selected = config["selected_network"]
     prefix = config["network_overrides"]["config"][selected]["address_prefix"]
 

--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -378,6 +378,35 @@ class TestKeysCommands:
         # assert result.exit_code == 0
         assert result.output.find(f"Fingerprint: {TEST_FINGERPRINT}") != -1
 
+    def test_show_fingerprint(self, keyring_with_one_key, tmp_path):
+        """
+        Test that the `chia keys show --fingerprint` command shows the correct key.
+        """
+
+        keychain = keyring_with_one_key
+
+        # add a key
+        keychain.add_private_key(generate_mnemonic())
+        assert len(keychain.get_all_private_keys()) == 2
+
+        keys_root_path = keychain.keyring_wrapper.keys_root_path
+        base_params = [
+            "--no-force-legacy-keyring-migration",
+            "--root-path",
+            os.fspath(tmp_path),
+            "--keys-root-path",
+            os.fspath(keys_root_path),
+        ]
+        runner = CliRunner()
+        cmd_params = ["keys", "show", "--fingerprint", TEST_FINGERPRINT]
+        # Generate a new config
+        assert runner.invoke(cli, [*base_params, "init"]).exit_code == 0
+        # Run the command
+        result: Result = runner.invoke(cli, [*base_params, *cmd_params])
+
+        # assert result.exit_code == 0
+        assert len([word for word in result.output.split() if word == "Fingerprint:"]) == 1
+
     def test_show_json(self, keyring_with_one_key, tmp_path):
         """
         Test that the `chia keys show --json` command shows the correct key.

--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -404,8 +404,10 @@ class TestKeysCommands:
         # Run the command
         result: Result = runner.invoke(cli, [*base_params, *cmd_params])
 
-        # assert result.exit_code == 0
-        assert len([word for word in result.output.split() if word == "Fingerprint:"]) == 1
+        assert result.exit_code == 0
+        fingerprints = [line for line in result.output.splitlines() if "Fingerprint:" in line]
+        assert len(fingerprints) == 1
+        assert str(TEST_FINGERPRINT) in fingerprints[0]
 
     def test_show_json(self, keyring_with_one_key, tmp_path):
         """


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
this pr adds a --fingerprint option to chia keys show


<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
```
(venv) PS C:\Users\jackm\GitHub\chia-blockchain> chia keys show --fingerprint 1116336227
Showing all public keys derived from your master seed and private key:

Label: test
Fingerprint: 1116336227
Master public key (m): a09cef259f31c5daaf3a0d237033721fb746075c6d809245103affb02a8bfaed3e2930d86e9e66a2e7a2fcb4b67a3f5c
Farmer public key (m/12381/8444/0/0): b094f390a391d10eda509f3f8fade8e3e432a6f0d1ad078108814fdfc43f81f6efd714692450c4f75228b9746eef4095
Pool public key (m/12381/8444/1/0): 81fcb6d215887f694516d3d478253f61e017d20b06b4a7d761c5e63775ce25ec56ca6f9f1adc737a75f38eefd2305fbc
First wallet address: txch17papy3kfhrx7cl6xupnhgdwkf992hqlunpv4sggjmfcykel4nx5snwkt4t

```