### PR TITLE
Set GUI binary name to chia-blockchain in the Ubuntu DEB

### DIFF
--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -83,17 +83,21 @@ if [ "$PLATFORM" = "arm64" ]; then
   sudo gem install public_suffix -v 4.0.7
   sudo gem install fpm
   echo USE_SYSTEM_FPM=true electron-builder build --linux deb --arm64 \
+    --config.extraMetadata.name=chia-blockchain \
     --config.productName="$PRODUCT_NAME" --config.linux.desktop.Name="Chia Blockchain" \
     --config.deb.packageName="chia-blockchain"
   USE_SYSTEM_FPM=true electron-builder build --linux deb --arm64 \
+    --config.extraMetadata.name=chia-blockchain \
     --config.productName="$PRODUCT_NAME" --config.linux.desktop.Name="Chia Blockchain" \
     --config.deb.packageName="chia-blockchain"
   LAST_EXIT_CODE=$?
 else
   echo electron-builder build --linux deb --x64 \
+    --config.extraMetadata.name=chia-blockchain \
     --config.productName="$PRODUCT_NAME" --config.linux.desktop.Name="Chia Blockchain" \
     --config.deb.packageName="chia-blockchain"
   electron-builder build --linux deb --x64 \
+    --config.extraMetadata.name=chia-blockchain \
     --config.productName="$PRODUCT_NAME" --config.linux.desktop.Name="Chia Blockchain" \
     --config.deb.packageName="chia-blockchain"
   LAST_EXIT_CODE=$?


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
Set the GUI binary name in the DEB to `chia-blockchain`. Note the install location is still `/opt/chia`


<!-- What is the current behavior?** (You can also link to an open issue here) -->
Current: GUI binary name is `@chiagui`. This was an unexpected change in 1.6.1 due to electron-builder changes


<!-- What is the new behavior (if this is a feature change)? -->
New: GUI binary name is `chia-blockchain`


<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->
Breaking: Changes the GUI binary name back to the original prior to 1.6.1


<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->
Testing: Binary in `/opt/chia/chia-blockchain` should launch the chia GUI


<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
