### PR TITLE
Update workflows to use GITHUB_OUTPUT (signed commits)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get pip cache dir (Windows)
         if: matrix.os.matrix == 'Windows'
-        id: pip-cache-win
+        id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -57,21 +57,9 @@ jobs:
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache pip (Windows)
-        if: matrix.os.matrix == 'Windows'
-        uses: actions/cache@v3
-        with:
-          # Note that new runners may break this https://github.com/actions/cache/issues/292
-          path: ${{ steps.pip-cache-win.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Cache pip
-        if: matrix.os.matrix != 'Windows'
         uses: actions/cache@v3
         with:
-          # Note that new runners may break this https://github.com/actions/cache/issues/292
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip
         uses: actions/cache@v3

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,7 +45,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Get pip cache dir (Windows)
+        if: matrix.os.matrix == 'Windows'
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+
       - name: Get pip cache dir
+        if: matrix.os.matrix != 'Windows'
         id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,14 +45,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Get pip cache dir (Windows)
-        if: matrix.os.matrix == 'Windows'
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-
       - name: Get pip cache dir
-        if: matrix.os.matrix != 'Windows'
         id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get pip cache dir (Windows)
         if: matrix.os.matrix == 'Windows'
-        id: pip-cache
+        id: pip-cache-win
         run: |
           echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -57,9 +57,21 @@ jobs:
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache pip
+      - name: Cache pip (Windows)
+        if: matrix.os.matrix == 'Windows'
         uses: actions/cache@v3
         with:
+          # Note that new runners may break this https://github.com/actions/cache/issues/292
+          path: ${{ steps.pip-cache-win.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache pip
+        if: matrix.os.matrix != 'Windows'
+        uses: actions/cache@v3
+        with:
+          # Note that new runners may break this https://github.com/actions/cache/issues/292
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
           restore-keys: |

--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -1,6 +1,7 @@
 name: 📦🚀 Build Installer - Linux DEB ARM64
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'long_lived/**'

--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -67,7 +67,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "::set-output name=CHIA_INSTALLER_VERSION::$(python3 ./build_scripts/installer-version.py)"
+        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
         deactivate
 
     - name: Test for secrets access
@@ -78,10 +78,10 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> $GITHUB_OUTPUT
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo ::set-output name=HAS_GLUE_SECRET::${HAS_GLUE_SECRET}
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> $GITHUB_OUTPUT
       env:
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
         GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
@@ -150,7 +150,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "::set-output name=GUI_REF::${gui_ref}"
+        echo "GUI_REF=${gui_ref}" >> $GITHUB_OUTPUT
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -247,8 +247,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-        echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -68,7 +68,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "::set-output name=CHIA_INSTALLER_VERSION::$(python3 ./build_scripts/installer-version.py)"
+        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
         deactivate
 
     - name: Test for secrets access
@@ -79,10 +79,10 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> GITHUB_OUTPUT
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo ::set-output name=HAS_GLUE_SECRET::${HAS_GLUE_SECRET}
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> GITHUB_OUTPUT
       env:
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
         GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
@@ -151,7 +151,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "::set-output name=GUI_REF::${gui_ref}"
+        echo "GUI_REF=${gui_ref}" >> $GITHUB_OUTPUT
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -248,8 +248,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-        echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -67,7 +67,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "::set-output name=CHIA_INSTALLER_VERSION::$(python3 ./build_scripts/installer-version.py)"
+        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
         deactivate
 
     - name: Test for secrets access
@@ -78,10 +78,10 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> GITHUB_OUTPUT
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo ::set-output name=HAS_GLUE_SECRET::${HAS_GLUE_SECRET}
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> GITHUB_OUTPUT
       env:
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
         GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
@@ -150,7 +150,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "::set-output name=GUI_REF::${gui_ref}"
+        echo "GUI_REF=${gui_ref}" >> $GITHUB_OUTPUT
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -248,8 +248,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-          echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-          echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -1,6 +1,7 @@
 name: 📦🚀 Build Installers - MacOS
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'long_lived/**'

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -78,13 +78,13 @@ jobs:
           unset HAS_GLUE_SECRET
 
           if [ -n "$APPLE_SECRET" ]; then HAS_APPLE_SECRET='true' ; fi
-          echo ::set-output name=HAS_APPLE_SECRET::${HAS_APPLE_SECRET}
+          echo HAS_APPLE_SECRET=${HAS_APPLE_SECRET} >> $GITHUB_OUTPUT
 
           if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-          echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
+          echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> GITHUB_OUTPUT
 
           if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-          echo ::set-output name=HAS_GLUE_SECRET::${HAS_GLUE_SECRET}
+          echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> GITHUB_OUTPUT
         env:
           APPLE_SECRET: "${{ secrets.APPLE_DEV_ID_APP }}"
           AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
@@ -96,7 +96,7 @@ jobs:
           python3 -m venv ../venv
           . ../venv/bin/activate
           pip install setuptools_scm
-          echo "::set-output name=CHIA_INSTALLER_VERSION::$(python3 ./build_scripts/installer-version.py)"
+          echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
           deactivate
 
       - name: Setup Python environment
@@ -165,7 +165,7 @@ jobs:
         run: |
           gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
           echo "${gui_ref}"
-          echo "::set-output name=GUI_REF::${gui_ref}"
+          echo "GUI_REF=${gui_ref}" >> $GITHUB_OUTPUT
           echo "rm -rf ./chia-blockchain-gui"
           rm -rf ./chia-blockchain-gui
 
@@ -261,8 +261,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         id: tag-name
         run: |
-          echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-          echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
 
       - name: Upload release artifacts
         if: env.RELEASE == 'true'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "dir=$(npm config get cache)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Cache npm
       uses: actions/cache@v3
@@ -70,7 +70,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Cache pip
       uses: actions/cache@v3
@@ -99,13 +99,13 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
-        echo "::set-output name=HAS_SIGNING_SECRET::${HAS_SIGNING_SECRET}"
+        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >> $GITHUB_OUTPUT
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> $GITHUB_OUTPUT
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo ::set-output name=HAS_GLUE_SECRET::${HAS_GLUE_SECRET}
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> $GITHUB_OUTPUT
       env:
         SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
@@ -127,7 +127,7 @@ jobs:
         pip3 install setuptools_scm
         $env:CHIA_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
         echo "$env:CHIA_INSTALLER_VERSION"
-        echo "::set-output name=CHIA_INSTALLER_VERSION::$env:CHIA_INSTALLER_VERSION"
+        echo "CHIA_INSTALLER_VERSION=$env:CHIA_INSTALLER_VERSION" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
         deactivate
 
       # Get the most recent release from chia-plotter-madmax
@@ -195,7 +195,7 @@ jobs:
         $gui_ref = git submodule status chia-blockchain-gui
         $gui_ref = $gui_ref -replace "^ | chia-blockchain-gui.*$",""
         echo $gui_ref
-        echo "::set-output name=GUI_REF::$gui_ref"
+        echo "GUI_REF=$gui_ref" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
         echo "Remove-Item -Recurse -Force .\chia-blockchain-gui"
         Remove-Item -Recurse -Force .\chia-blockchain-gui
 
@@ -252,7 +252,7 @@ jobs:
       run: |
         GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
         CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-        echo ::set-output name=CHIA_DEV_BUILD::${CHIA_DEV_BUILD}
+        echo CHIA_DEV_BUILD=${CHIA_DEV_BUILD} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
         echo ${CHIA_DEV_BUILD}
         pwd
         aws s3 cp chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${CHIA_INSTALLER_VERSION}.exe s3://download.chia.net/dev/ChiaSetup-${CHIA_DEV_BUILD}.exe
@@ -300,8 +300,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
       run: |
-        echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-        echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -58,7 +58,7 @@ jobs:
       id: npm-cache
       shell: bash
       run: |
-        echo "dir=$(npm config get cache)" >>"$GITHUB_OUTPUT"
+        echo "dir=$(npm config get cache)" >>$GITHUB_OUTPUT
 
     - name: Cache npm
       uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
       id: pip-cache
       shell: bash
       run: |
-        echo "dir=$(pip cache dir)" >>"$GITHUB_OUTPUT"
+        echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
 
     - name: Cache pip
       uses: actions/cache@v3
@@ -101,13 +101,13 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
-        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >>"$GITHUB_OUTPUT"
+        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >>$GITHUB_OUTPUT
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>"$GITHUB_OUTPUT"
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >>"$GITHUB_OUTPUT"
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >>$GITHUB_OUTPUT
       env:
         SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
@@ -123,13 +123,14 @@ jobs:
     # Create our own venv outside of the git directory JUST for getting the ACTUAL version so that install can't break it
     - name: Get version number
       id: version_number
+      shell: bash
       run: |
         python -m venv ..\venv
-        . ..\venv\Scripts\Activate.ps1
+        . ..\venv\bin\activate
         pip3 install setuptools_scm
-        $env:CHIA_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
-        echo "$env:CHIA_INSTALLER_VERSION"
-        echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >>"$GITHUB_ENV"
+        CHIA_INSTALLER_VERSION=$(python .\build_scripts\installer-version.py)
+        echo "$CHIA_INSTALLER_VERSION"
+        echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >>$GITHUB_OUTPUT
         deactivate
 
       # Get the most recent release from chia-plotter-madmax
@@ -197,7 +198,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "GUI_REF=${gui_ref}" >>"$GITHUB_OUTPUT"
+        echo "GUI_REF=${gui_ref}" >>$GITHUB_OUTPUT
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -254,7 +255,7 @@ jobs:
       run: |
         GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
         CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-        echo CHIA_DEV_BUILD=${CHIA_DEV_BUILD} >>"$GITHUB_OUTPUT"
+        echo CHIA_DEV_BUILD=${CHIA_DEV_BUILD} >>$GITHUB_OUTPUT
         echo ${CHIA_DEV_BUILD}
         pwd
         aws s3 cp chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${CHIA_INSTALLER_VERSION}.exe s3://download.chia.net/dev/ChiaSetup-${CHIA_DEV_BUILD}.exe
@@ -303,8 +304,8 @@ jobs:
       id: tag-name
       shell: bash
       run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >>"$GITHUB_OUTPUT"
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >>"$GITHUB_OUTPUT"
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >>$GITHUB_OUTPUT
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >>$GITHUB_OUTPUT
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -80,7 +80,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       name: Install Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -80,7 +80,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - uses: actions/setup-python@v4
+    - uses: Chia-Network/actions/setup-python@main
       name: Install Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -125,10 +125,10 @@ jobs:
       id: version_number
       shell: bash
       run: |
-        python -m venv ..\venv
-        . ..\venv\bin\activate
+        python -m venv ../venv
+        . ../venv/bin/activate
         pip3 install setuptools_scm
-        CHIA_INSTALLER_VERSION=$(python .\build_scripts\installer-version.py)
+        CHIA_INSTALLER_VERSION=$(python ./build_scripts/installer-version.py)
         echo "$CHIA_INSTALLER_VERSION"
         echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >>$GITHUB_OUTPUT
         deactivate

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -58,7 +58,7 @@ jobs:
       id: npm-cache
       shell: bash
       run: |
-        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+        echo "dir=$(npm config get cache)" >>"$GITHUB_OUTPUT"
 
     - name: Cache npm
       uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
       id: pip-cache
       shell: bash
       run: |
-        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >>"$GITHUB_OUTPUT"
 
     - name: Cache pip
       uses: actions/cache@v3
@@ -101,13 +101,13 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
-        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >> $GITHUB_OUTPUT
+        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >>"$GITHUB_OUTPUT"
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> $GITHUB_OUTPUT
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>"$GITHUB_OUTPUT"
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> $GITHUB_OUTPUT
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >>"$GITHUB_OUTPUT"
       env:
         SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
@@ -129,7 +129,7 @@ jobs:
         pip3 install setuptools_scm
         $env:CHIA_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
         echo "$env:CHIA_INSTALLER_VERSION"
-        echo "CHIA_INSTALLER_VERSION=$env:CHIA_INSTALLER_VERSION" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >>"$GITHUB_ENV"
         deactivate
 
       # Get the most recent release from chia-plotter-madmax
@@ -193,13 +193,13 @@ jobs:
 
     - name: Prepare GUI cache
       id: gui-ref
+      shell: bash
       run: |
-        $gui_ref = git submodule status chia-blockchain-gui
-        $gui_ref = $gui_ref -replace "^ | chia-blockchain-gui.*$",""
-        echo $gui_ref
-        echo "GUI_REF=$gui_ref" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-        echo "Remove-Item -Recurse -Force .\chia-blockchain-gui"
-        Remove-Item -Recurse -Force .\chia-blockchain-gui
+        gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
+        echo "${gui_ref}"
+        echo "GUI_REF=${gui_ref}" >>"$GITHUB_OUTPUT"
+        echo "rm -rf ./chia-blockchain-gui"
+        rm -rf ./chia-blockchain-gui
 
     - name: Cache GUI
       uses: actions/cache@v3
@@ -254,7 +254,7 @@ jobs:
       run: |
         GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
         CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-        echo CHIA_DEV_BUILD=${CHIA_DEV_BUILD} | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo CHIA_DEV_BUILD=${CHIA_DEV_BUILD} >>"$GITHUB_OUTPUT"
         echo ${CHIA_DEV_BUILD}
         pwd
         aws s3 cp chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${CHIA_INSTALLER_VERSION}.exe s3://download.chia.net/dev/ChiaSetup-${CHIA_DEV_BUILD}.exe
@@ -301,9 +301,10 @@ jobs:
     - name: Get tag name
       if: startsWith(github.ref, 'refs/tags/')
       id: tag-name
+      shell: bash
       run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >>"$GITHUB_OUTPUT"
+        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >>"$GITHUB_OUTPUT"
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -56,8 +56,9 @@ jobs:
 
     - name: Get npm cache directory
       id: npm-cache
+      shell: bash
       run: |
-        echo "dir=$(npm config get cache)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
     - name: Cache npm
       uses: actions/cache@v3
@@ -69,8 +70,9 @@ jobs:
 
     - name: Get pip cache dir
       id: pip-cache
+      shell: bash
       run: |
-        echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache pip
       uses: actions/cache@v3

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -126,9 +126,9 @@ jobs:
       shell: bash
       run: |
         python -m venv ../venv
-        . ../venv/bin/activate
+        . ..\\venv\\bin\\activate
         pip3 install setuptools_scm
-        CHIA_INSTALLER_VERSION=$(python ./build_scripts/installer-version.py)
+        CHIA_INSTALLER_VERSION=$(python .\\build_scripts\\installer-version.py)
         echo "$CHIA_INSTALLER_VERSION"
         echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >>$GITHUB_OUTPUT
         deactivate

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -126,9 +126,9 @@ jobs:
       shell: bash
       run: |
         python -m venv ../venv
-        . ..\\venv\\bin\\activate
+        source ../venv/Scripts/activate
         pip3 install setuptools_scm
-        CHIA_INSTALLER_VERSION=$(python .\\build_scripts\\installer-version.py)
+        CHIA_INSTALLER_VERSION=$(python ./build_scripts/installer-version.py)
         echo "$CHIA_INSTALLER_VERSION"
         echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >>$GITHUB_OUTPUT
         deactivate

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -14,8 +14,8 @@ jobs:
         if: "!github.event.release.prerelease"
         id: tag-name
         run: |
-          echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
-          echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
       - name: Start release
         if: "!github.event.release.prerelease"
         run: |

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -35,7 +35,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Python environment
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -35,7 +35,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Python environment
-      uses: actions/setup-python@v4
+      uses: Chia-Network/actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -145,14 +145,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Get pip cache dir (Windows)
-        if: matrix.os.matrix == 'Windows'
-        id: pip-cache
-        run: |
-          echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
-
       - name: Get pip cache dir
-        if: matrix.os.matrix != 'Windows'
         id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -147,6 +147,7 @@ jobs:
 
       - name: Get pip cache dir
         id: pip-cache
+        shell: bash
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -122,7 +122,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python.action }}
 

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Get pip cache dir (Windows)
         if: matrix.os.matrix == 'Windows'
-        id: pip-cache
+        id: pip-cache-win
         run: |
           echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -157,7 +157,20 @@ jobs:
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
+      - name: Cache pip (Windows)
+        if: matrix.os.matrix == 'Windows'
+        uses: actions/cache@v3
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
+        with:
+          # Note that new runners may break this https://github.com/actions/cache/issues/292
+          path: ${{ steps.pip-cache-win.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Cache pip
+        if: matrix.os.matrix != 'Windows'
         uses: actions/cache@v3
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Get pip cache dir (Windows)
         if: matrix.os.matrix == 'Windows'
-        id: pip-cache-win
+        id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -157,20 +157,7 @@ jobs:
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache pip (Windows)
-        if: matrix.os.matrix == 'Windows'
-        uses: actions/cache@v3
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1
-        with:
-          # Note that new runners may break this https://github.com/actions/cache/issues/292
-          path: ${{ steps.pip-cache-win.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Cache pip
-        if: matrix.os.matrix != 'Windows'
         uses: actions/cache@v3
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MIN: 1

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -122,7 +122,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python.action }}
 

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Get pip cache dir
         id: pip-cache
         run: |
-          echo "::set-output name=dir::$(pip cache dir)"
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip
         uses: actions/cache@v3

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -145,7 +145,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: Get pip cache dir (Windows)
+        if: matrix.os.matrix == 'Windows'
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
+
       - name: Get pip cache dir
+        if: matrix.os.matrix != 'Windows'
         id: pip-cache
         run: |
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           python tests/build-job-matrix.py --per directory --verbose > matrix.json
           cat matrix.json
-          echo ::set-output name=configuration::$(cat matrix.json)
-          echo ::set-output name=matrix_mode::${{ ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || 'all' }}
+          echo configuration=$(cat matrix.json) >> $GITHUB_OUTPUT
+          echo matrix_mode=${{ ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || 'all' }} >> $GITHUB_OUTPUT
 
     outputs:
       configuration: ${{ steps.configure.outputs.configuration }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: '3.9'
 
@@ -114,7 +114,7 @@ jobs:
           path: coverage-data
 
       - name: Set up ${{ matrix.python.name }}
-        uses: actions/setup-python@v4
+        uses: Chia-Network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python.action }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
           path: coverage-data
 
       - name: Set up ${{ matrix.python.name }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python.action }}
 

--- a/.github/workflows/trigger-docker-dev.yml
+++ b/.github/workflows/trigger-docker-dev.yml
@@ -24,7 +24,7 @@ jobs:
           unset HAS_SECRET
 
           if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_SECRET='true' ; fi
-          echo ::set-output name=HAS_SECRET::${HAS_SECRET}
+          echo HAS_SECRET=${HAS_SECRET} >> $GITHUB_OUTPUT
         env:
           GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
 

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         unset HAS_SECRET
         if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo ::set-output name=HAS_SECRET::${HAS_SECRET}
+        echo HAS_SECRET=${HAS_SECRET} >> $GITHUB_OUTPUT
       env:
         SECRET: "${{ secrets.test_pypi_password }}"
 

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       name: Install Python
       with:
         python-version: '3.8'

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
-    - uses: actions/setup-python@v4
+    - uses: Chia-Network/actions/setup-python@main
       name: Install Python
       with:
         python-version: '3.8'


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
This PR is a copy of https://github.com/Chia-Network/chia-blockchain/pull/13730 that includes signed commits.


<!-- What is the current behavior?** (You can also link to an open issue here) -->
Use GITHUB_OUTPUT in workflows instead of set-output.

GitHub is deprecating set-output as per their blog:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


<!-- What is the new behavior (if this is a feature change)? -->
There is no change in behavior with these changes from the prior.


<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
