### PR TITLE
Update endpoint for flake8 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
         args: ['--filter-files']
         minimum_pre_commit_version: '2.9.2'
         additional_dependencies: [isort==5.10.1]
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
     - id: flake8


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
Flake8 runs using a pre-commit tool in CI. The endpoint for the flake8 repository on gitlab.com 404s. This PR moves the flake8 repo URL to the one on github.com.



<!-- What is the current behavior?** (You can also link to an open issue here) -->
Old behavior:
CI fails because the repo on gitlab does not exist anymore: https://github.com/Chia-Network/chia-blockchain/actions/runs/3468193956/jobs/5793770364#step:9:28


<!-- What is the new behavior (if this is a feature change)? -->
New behavior:
CI succeeds because the repo is still available on github.


<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->
Does this introduce a breaking change:
No breaking change.


<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->
Testing notes:
It is a test configuration change.


<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
