### PR TITLE
server: Drop broken message types logging

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -5,14 +5,11 @@ import logging
 import ssl
 import time
 import traceback
-from collections import Counter
 from dataclasses import dataclass, field
 from ipaddress import IPv4Network, IPv6Address, IPv6Network, ip_address, ip_network
 from pathlib import Path
 from secrets import token_bytes
-from typing import Any, Callable
-from typing import Counter as typing_Counter
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from aiohttp import (
     ClientResponseError,
@@ -553,14 +550,12 @@ class ChiaServer:
             task.cancel()
 
     async def incoming_api_task(self) -> None:
-        message_types: typing_Counter[str] = Counter()  # Used for debugging information.
         while True:
             payload_inc, connection_inc = await self.incoming_messages.get()
             if payload_inc is None or connection_inc is None:
                 continue
 
             async def api_call(full_message: Message, connection: WSChiaConnection, task_id):
-                nonlocal message_types
                 start_time = time.time()
                 message_type = ""
                 try:
@@ -571,11 +566,8 @@ class ChiaServer:
                         f"{connection.peer_node_id} {connection.peer_host}"
                     )
                     message_type = ProtocolMessageTypes(full_message.type).name
-                    message_types[message_type] += 1
 
                     f = getattr(self.api, message_type, None)
-                    if len(message_types) % 100 == 0:
-                        self.log.debug(f"Message types: {[(m, n) for m, n in sorted(message_types.items()) if n != 0]}")
 
                     if f is None:
                         self.log.error(f"Non existing function: {message_type}")
@@ -636,7 +628,6 @@ class ChiaServer:
                     # TODO: actually throw one of the errors from errors.py and pass this to close
                     await connection.close(self.api_exception_ban_seconds, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
                 finally:
-                    message_types[message_type] -= 1
                     if task_id in self.api_tasks:
                         self.api_tasks.pop(task_id)
                     if task_id in self.tasks_from_peer[connection.peer_node_id]:


### PR DESCRIPTION
Seems like the idea was to log an overview of message types for the  currently active api calls whenever we have multiples of 100 running.  This currently isn't working at all because `len(message_types) % 100 ==  0` will only trigger if there are 100 different message types in the  counter (we don't even have that much different messages). A fix would  be to check `message_types.total() % 100 == 0`. But then, if we hover  around 100 active messages this will repeatedly trigger logs since we  decrement for each processed message, im not sure this all makes much  sense and we anyway log all received message types with `DEBUG` logs so  i decided to just drop this. If someone thinks we should keep it with  the fix or has ideas to make this a more reasonable log instead of  dropping it, let me know :)

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
