### PR TITLE
Factor out member functions of `ProofOfSpace` to be free functions

### DIFF
--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -23,6 +23,7 @@ from chia.consensus.pot_iterations import (
 )
 from chia.consensus.vdf_info_computation import get_signage_point_vdf_info
 from chia.types.blockchain_format.classgroup import ClassgroupElement
+from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import ChallengeChainSubSlot, RewardChainSubSlot, SubSlotProofs
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
@@ -484,8 +485,8 @@ def validate_unfinished_header_block(
     else:
         cc_sp_hash = header_block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
 
-    q_str: Optional[bytes32] = header_block.reward_chain_block.proof_of_space.verify_and_get_quality_string(
-        constants, challenge, cc_sp_hash
+    q_str: Optional[bytes32] = verify_and_get_quality_string(
+        header_block.reward_chain_block.proof_of_space, constants, challenge, cc_sp_hash
     )
     if q_str is None:
         return None, ValidationError(Err.INVALID_POSPACE)

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -21,6 +21,7 @@ from chia.consensus.pot_iterations import calculate_iterations_quality, is_overf
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin
+from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.full_block import FullBlock
@@ -239,8 +240,8 @@ async def pre_validate_blocks_multiprocessing(
             cc_sp_hash: bytes32 = challenge
         else:
             cc_sp_hash = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
-        q_str: Optional[bytes32] = block.reward_chain_block.proof_of_space.verify_and_get_quality_string(
-            constants, challenge, cc_sp_hash
+        q_str: Optional[bytes32] = verify_and_get_quality_string(
+            block.reward_chain_block.proof_of_space, constants, challenge, cc_sp_hash
         )
         if q_str is None:
             for i, block_i in enumerate(blocks):

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -30,7 +30,11 @@ from chia.server.server import ssl_context_for_root
 from chia.server.ws_connection import WSChiaConnection
 from chia.ssl.create_ssl import get_mozilla_ca_crt
 from chia.types.blockchain_format.pool_target import PoolTarget
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace
+from chia.types.blockchain_format.proof_of_space import (
+    generate_plot_public_key,
+    generate_taproot_sk,
+    verify_and_get_quality_string,
+)
 from chia.util.api_decorators import api_request
 from chia.util.ints import uint32, uint64
 
@@ -80,7 +84,8 @@ class FarmerAPI:
 
         sps = self.farmer.sps[new_proof_of_space.sp_hash]
         for sp in sps:
-            computed_quality_string = new_proof_of_space.proof.verify_and_get_quality_string(
+            computed_quality_string = verify_and_get_quality_string(
+                new_proof_of_space.proof,
                 self.farmer.constants,
                 new_proof_of_space.challenge_hash,
                 new_proof_of_space.sp_hash,
@@ -201,10 +206,10 @@ class FarmerAPI:
                 for sk in self.farmer.get_private_keys():
                     pk = sk.get_g1()
                     if pk == response.farmer_pk:
-                        agg_pk = ProofOfSpace.generate_plot_public_key(response.local_pk, pk, True)
+                        agg_pk = generate_plot_public_key(response.local_pk, pk, True)
                         assert agg_pk == new_proof_of_space.proof.plot_public_key
                         sig_farmer = AugSchemeMPL.sign(sk, m_to_sign, agg_pk)
-                        taproot_sk: PrivateKey = ProofOfSpace.generate_taproot_sk(response.local_pk, pk)
+                        taproot_sk: PrivateKey = generate_taproot_sk(response.local_pk, pk)
                         taproot_sig: G2Element = AugSchemeMPL.sign(taproot_sk, m_to_sign, agg_pk)
 
                         plot_signature = AugSchemeMPL.aggregate(
@@ -307,8 +312,8 @@ class FarmerAPI:
         assert pospace is not None
         include_taproot: bool = pospace.pool_contract_puzzle_hash is not None
 
-        computed_quality_string = pospace.verify_and_get_quality_string(
-            self.farmer.constants, response.challenge_hash, response.sp_hash
+        computed_quality_string = verify_and_get_quality_string(
+            pospace, self.farmer.constants, response.challenge_hash, response.sp_hash
         )
         if computed_quality_string is None:
             self.farmer.log.warning(f"Have invalid PoSpace {pospace}")
@@ -323,10 +328,10 @@ class FarmerAPI:
             for sk in self.farmer.get_private_keys():
                 pk = sk.get_g1()
                 if pk == response.farmer_pk:
-                    agg_pk = ProofOfSpace.generate_plot_public_key(response.local_pk, pk, include_taproot)
+                    agg_pk = generate_plot_public_key(response.local_pk, pk, include_taproot)
                     assert agg_pk == pospace.plot_public_key
                     if include_taproot:
-                        taproot_sk: PrivateKey = ProofOfSpace.generate_taproot_sk(response.local_pk, pk)
+                        taproot_sk: PrivateKey = generate_taproot_sk(response.local_pk, pk)
                         taproot_share_cc_sp: G2Element = AugSchemeMPL.sign(taproot_sk, challenge_chain_sp, agg_pk)
                         taproot_share_rc_sp: G2Element = AugSchemeMPL.sign(taproot_sk, reward_chain_sp, agg_pk)
                     else:
@@ -394,10 +399,10 @@ class FarmerAPI:
                 ) = response.message_signatures[1]
                 pk = sk.get_g1()
                 if pk == response.farmer_pk:
-                    agg_pk = ProofOfSpace.generate_plot_public_key(response.local_pk, pk, include_taproot)
+                    agg_pk = generate_plot_public_key(response.local_pk, pk, include_taproot)
                     assert agg_pk == pospace.plot_public_key
                     if include_taproot:
-                        taproot_sk = ProofOfSpace.generate_taproot_sk(response.local_pk, pk)
+                        taproot_sk = generate_taproot_sk(response.local_pk, pk)
                         foliage_sig_taproot: G2Element = AugSchemeMPL.sign(taproot_sk, foliage_block_data_hash, agg_pk)
                         foliage_transaction_block_sig_taproot: G2Element = AugSchemeMPL.sign(
                             taproot_sk, foliage_transaction_block_hash, agg_pk

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -58,6 +58,7 @@ from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.limited_semaphore import LimitedSemaphoreFullError
 from chia.util.merkle_set import MerkleSet
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
+from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 
 
 class FullNodeAPI:
@@ -720,8 +721,8 @@ class FullNodeAPI:
             # 3. In a future sub-slot that we already know of
 
             # Checks that the proof of space is valid
-            quality_string: Optional[bytes32] = request.proof_of_space.verify_and_get_quality_string(
-                self.full_node.constants, cc_challenge_hash, request.challenge_chain_sp
+            quality_string: Optional[bytes32] = verify_and_get_quality_string(
+                request.proof_of_space, self.full_node.constants, cc_challenge_hash, request.challenge_chain_sp
             )
             assert quality_string is not None and len(quality_string) == 32
 

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -42,6 +42,7 @@ from chia.util.block_cache import BlockCache
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.setproctitle import getproctitle, setproctitle
+from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 
 log = logging.getLogger(__name__)
 
@@ -1306,7 +1307,8 @@ def _validate_pospace_recent_chain(
     else:
         cc_sp_hash = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
     assert cc_sp_hash is not None
-    q_str = block.reward_chain_block.proof_of_space.verify_and_get_quality_string(
+    q_str = verify_and_get_quality_string(
+        block.reward_chain_block.proof_of_space,
         constants,
         challenge if not overflow else prev_challenge,
         cc_sp_hash,
@@ -1353,7 +1355,8 @@ def __validate_pospace(
 
     # validate proof of space
     assert sub_slot_data.proof_of_space is not None
-    q_str = sub_slot_data.proof_of_space.verify_and_get_quality_string(
+    q_str = verify_and_get_quality_string(
+        sub_slot_data.proof_of_space,
         constants,
         challenge,
         cc_sp_hash,

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -16,7 +16,12 @@ from chia.protocols.harvester_protocol import Plot, PlotSyncResponse
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.server.outbound_message import make_msg
 from chia.server.ws_connection import WSChiaConnection
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace
+from chia.types.blockchain_format.proof_of_space import (
+    ProofOfSpace,
+    calculate_pos_challenge,
+    generate_plot_public_key,
+    passes_plot_filter,
+)
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.api_decorators import api_request
 from chia.util.ints import uint8, uint32, uint64
@@ -81,7 +86,7 @@ class HarvesterAPI:
             # so it should be run in a thread pool.
             try:
                 plot_id = plot_info.prover.get_id()
-                sp_challenge_hash = ProofOfSpace.calculate_pos_challenge(
+                sp_challenge_hash = calculate_pos_challenge(
                     plot_id,
                     new_challenge.challenge_hash,
                     new_challenge.sp_hash,
@@ -183,7 +188,7 @@ class HarvesterAPI:
                 # Passes the plot filter (does not check sp filter yet though, since we have not reached sp)
                 # This is being executed at the beginning of the slot
                 total += 1
-                if ProofOfSpace.passes_plot_filter(
+                if passes_plot_filter(
                     self.harvester.constants,
                     try_plot_info.prover.get_id(),
                     new_challenge.challenge_hash,
@@ -269,7 +274,7 @@ class HarvesterAPI:
             assert isinstance(pool_public_key_or_puzzle_hash, bytes32)
             include_taproot = True
 
-        agg_pk = ProofOfSpace.generate_plot_public_key(local_sk.get_g1(), farmer_public_key, include_taproot)
+        agg_pk = generate_plot_public_key(local_sk.get_g1(), farmer_public_key, include_taproot)
 
         # This is only a partial signature. When combined with the farmer's half, it will
         # form a complete PrependSignature.

--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -12,7 +12,7 @@ from blspy import G1Element
 from chiapos import DiskProver
 
 from chia.plotting.util import parse_plot_info
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace
+from chia.types.blockchain_format.proof_of_space import generate_plot_public_key
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint16, uint64
 from chia.util.misc import VersionedBlob
@@ -68,7 +68,7 @@ class CacheEntry:
 
         local_sk = master_sk_to_local_sk(local_master_sk)
 
-        plot_public_key: G1Element = ProofOfSpace.generate_plot_public_key(
+        plot_public_key: G1Element = generate_plot_public_key(
             local_sk.get_g1(), farmer_public_key, pool_contract_puzzle_hash is not None
         )
 

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -11,7 +11,11 @@ from chiapos import DiskPlotter
 
 from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate, wrap_local_keychain
 from chia.plotting.util import stream_plot_info_ph, stream_plot_info_pk
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace
+from chia.types.blockchain_format.proof_of_space import (
+    calculate_plot_id_ph,
+    calculate_plot_id_pk,
+    generate_plot_public_key,
+)
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import decode_puzzle_hash
 from chia.util.keychain import Keychain
@@ -189,17 +193,17 @@ async def create_plots(
         # The plot public key is the combination of the harvester and farmer keys
         # New plots will also include a taproot of the keys, for extensibility
         include_taproot: bool = keys.pool_contract_puzzle_hash is not None
-        plot_public_key = ProofOfSpace.generate_plot_public_key(
+        plot_public_key = generate_plot_public_key(
             master_sk_to_local_sk(sk).get_g1(), keys.farmer_public_key, include_taproot
         )
 
         # The plot id is based on the harvester, farmer, and pool keys
         if keys.pool_public_key is not None:
-            plot_id: bytes32 = ProofOfSpace.calculate_plot_id_pk(keys.pool_public_key, plot_public_key)
+            plot_id: bytes32 = calculate_plot_id_pk(keys.pool_public_key, plot_public_key)
             plot_memo: bytes32 = stream_plot_info_pk(keys.pool_public_key, keys.farmer_public_key, sk)
         else:
             assert keys.pool_contract_puzzle_hash is not None
-            plot_id = ProofOfSpace.calculate_plot_id_ph(keys.pool_contract_puzzle_hash, plot_public_key)
+            plot_id = calculate_plot_id_ph(keys.pool_contract_puzzle_hash, plot_public_key)
             plot_memo = stream_plot_info_ph(keys.pool_contract_puzzle_hash, keys.farmer_public_key, sk)
 
         if args.plotid is not None:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -75,7 +75,14 @@ from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.foliage import Foliage, FoliageBlockData, FoliageTransactionBlock, TransactionsInfo
 from chia.types.blockchain_format.pool_target import PoolTarget
 from chia.types.blockchain_format.program import INFINITE_COST
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace
+from chia.types.blockchain_format.proof_of_space import (
+    ProofOfSpace,
+    calculate_pos_challenge,
+    generate_plot_public_key,
+    generate_taproot_sk,
+    passes_plot_filter,
+    verify_and_get_quality_string,
+)
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlockUnfinished
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import (
@@ -464,12 +471,12 @@ class BlockTools:
                     assert isinstance(pool_pk_or_ph, bytes32)
                     include_taproot = True
                 local_sk = master_sk_to_local_sk(local_master_sk)
-                agg_pk = ProofOfSpace.generate_plot_public_key(local_sk.get_g1(), farmer_sk.get_g1(), include_taproot)
+                agg_pk = generate_plot_public_key(local_sk.get_g1(), farmer_sk.get_g1(), include_taproot)
                 assert agg_pk == plot_pk
                 harv_share = AugSchemeMPL.sign(local_sk, m, agg_pk)
                 farm_share = AugSchemeMPL.sign(farmer_sk, m, agg_pk)
                 if include_taproot:
-                    taproot_sk: PrivateKey = ProofOfSpace.generate_taproot_sk(local_sk.get_g1(), farmer_sk.get_g1())
+                    taproot_sk: PrivateKey = generate_taproot_sk(local_sk.get_g1(), farmer_sk.get_g1())
                     taproot_share: G2Element = AugSchemeMPL.sign(taproot_sk, m, agg_pk)
                 else:
                     taproot_share = G2Element()
@@ -1250,8 +1257,8 @@ class BlockTools:
             plot_id: bytes32 = plot_info.prover.get_id()
             if force_plot_id is not None and plot_id != force_plot_id:
                 continue
-            if ProofOfSpace.passes_plot_filter(constants, plot_id, challenge_hash, signage_point):
-                new_challenge: bytes32 = ProofOfSpace.calculate_pos_challenge(plot_id, challenge_hash, signage_point)
+            if passes_plot_filter(constants, plot_id, challenge_hash, signage_point):
+                new_challenge: bytes32 = calculate_pos_challenge(plot_id, challenge_hash, signage_point)
                 qualities = plot_info.prover.get_qualities_for_challenge(new_challenge)
 
                 for proof_index, quality_str in enumerate(qualities):
@@ -1279,9 +1286,7 @@ class BlockTools:
                         else:
                             assert isinstance(pool_public_key_or_puzzle_hash, bytes32)
                             include_taproot = True
-                        plot_pk = ProofOfSpace.generate_plot_public_key(
-                            local_sk.get_g1(), farmer_public_key, include_taproot
-                        )
+                        plot_pk = generate_plot_public_key(local_sk.get_g1(), farmer_public_key, include_taproot)
                         proof_of_space: ProofOfSpace = ProofOfSpace(
                             new_challenge,
                             plot_info.pool_public_key,
@@ -1509,8 +1514,8 @@ def load_block_list(
             assert full_block.reward_chain_block.challenge_chain_sp_vdf is not None
             challenge = full_block.reward_chain_block.challenge_chain_sp_vdf.challenge
             sp_hash = full_block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
-        quality_str = full_block.reward_chain_block.proof_of_space.verify_and_get_quality_string(
-            constants, challenge, sp_hash
+        quality_str = verify_and_get_quality_string(
+            full_block.reward_chain_block.proof_of_space, constants, challenge, sp_hash
         )
         assert quality_str is not None
         required_iters: uint64 = calculate_iterations_quality(

--- a/chia/timelord/iters_from_block.py
+++ b/chia/timelord/iters_from_block.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Optional, Tuple, Union
 
 from chia.consensus.pot_iterations import calculate_ip_iters, calculate_iterations_quality, calculate_sp_iters
+from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock, RewardChainBlockUnfinished
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint64
@@ -20,7 +21,8 @@ def iters_from_block(
     else:
         cc_sp = reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
 
-    quality_string: Optional[bytes32] = reward_chain_block.proof_of_space.verify_and_get_quality_string(
+    quality_string: Optional[bytes32] = verify_and_get_quality_string(
+        reward_chain_block.proof_of_space,
         constants,
         reward_chain_block.pos_ss_cc_challenge_hash,
         cc_sp,

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -25,95 +25,96 @@ class ProofOfSpace(Streamable):
     size: uint8
     proof: bytes
 
-    def get_plot_id(self) -> bytes32:
-        assert self.pool_public_key is None or self.pool_contract_puzzle_hash is None
-        if self.pool_public_key is None:
-            assert self.pool_contract_puzzle_hash is not None
-            return self.calculate_plot_id_ph(self.pool_contract_puzzle_hash, self.plot_public_key)
-        return self.calculate_plot_id_pk(self.pool_public_key, self.plot_public_key)
 
-    def verify_and_get_quality_string(
-        self,
-        constants: ConsensusConstants,
-        original_challenge_hash: bytes32,
-        signage_point: bytes32,
-    ) -> Optional[bytes32]:
-        # Exactly one of (pool_public_key, pool_contract_puzzle_hash) must not be None
-        if (self.pool_public_key is None) and (self.pool_contract_puzzle_hash is None):
-            log.error("Fail 1")
-            return None
-        if (self.pool_public_key is not None) and (self.pool_contract_puzzle_hash is not None):
-            log.error("Fail 2")
-            return None
-        if self.size < constants.MIN_PLOT_SIZE:
-            log.error("Fail 3")
-            return None
-        if self.size > constants.MAX_PLOT_SIZE:
-            log.error("Fail 4")
-            return None
-        plot_id: bytes32 = self.get_plot_id()
-        new_challenge: bytes32 = ProofOfSpace.calculate_pos_challenge(plot_id, original_challenge_hash, signage_point)
+def get_plot_id(pos: ProofOfSpace) -> bytes32:
+    assert pos.pool_public_key is None or pos.pool_contract_puzzle_hash is None
+    if pos.pool_public_key is None:
+        assert pos.pool_contract_puzzle_hash is not None
+        return calculate_plot_id_ph(pos.pool_contract_puzzle_hash, pos.plot_public_key)
+    return calculate_plot_id_pk(pos.pool_public_key, pos.plot_public_key)
 
-        if new_challenge != self.challenge:
-            log.error("New challenge is not challenge")
-            return None
 
-        if not ProofOfSpace.passes_plot_filter(constants, plot_id, original_challenge_hash, signage_point):
-            log.error("Fail 5")
-            return None
+def verify_and_get_quality_string(
+    pos: ProofOfSpace,
+    constants: ConsensusConstants,
+    original_challenge_hash: bytes32,
+    signage_point: bytes32,
+) -> Optional[bytes32]:
+    # Exactly one of (pool_public_key, pool_contract_puzzle_hash) must not be None
+    if (pos.pool_public_key is None) and (pos.pool_contract_puzzle_hash is None):
+        log.error("Fail 1")
+        return None
+    if (pos.pool_public_key is not None) and (pos.pool_contract_puzzle_hash is not None):
+        log.error("Fail 2")
+        return None
+    if pos.size < constants.MIN_PLOT_SIZE:
+        log.error("Fail 3")
+        return None
+    if pos.size > constants.MAX_PLOT_SIZE:
+        log.error("Fail 4")
+        return None
+    plot_id: bytes32 = get_plot_id(pos)
+    new_challenge: bytes32 = calculate_pos_challenge(plot_id, original_challenge_hash, signage_point)
 
-        return self.get_quality_string(plot_id)
+    if new_challenge != pos.challenge:
+        log.error("New challenge is not challenge")
+        return None
 
-    def get_quality_string(self, plot_id: bytes32) -> Optional[bytes32]:
-        quality_str = Verifier().validate_proof(plot_id, self.size, self.challenge, bytes(self.proof))
-        if not quality_str:
-            return None
-        return bytes32(quality_str)
+    if not passes_plot_filter(constants, plot_id, original_challenge_hash, signage_point):
+        log.error("Fail 5")
+        return None
 
-    @staticmethod
-    def passes_plot_filter(
-        constants: ConsensusConstants,
-        plot_id: bytes32,
-        challenge_hash: bytes32,
-        signage_point: bytes32,
-    ) -> bool:
-        plot_filter: BitArray = BitArray(
-            ProofOfSpace.calculate_plot_filter_input(plot_id, challenge_hash, signage_point)
-        )
-        return plot_filter[: constants.NUMBER_ZERO_BITS_PLOT_FILTER].uint == 0
+    return get_quality_string(pos, plot_id)
 
-    @staticmethod
-    def calculate_plot_filter_input(plot_id: bytes32, challenge_hash: bytes32, signage_point: bytes32) -> bytes32:
-        return std_hash(plot_id + challenge_hash + signage_point)
 
-    @staticmethod
-    def calculate_pos_challenge(plot_id: bytes32, challenge_hash: bytes32, signage_point: bytes32) -> bytes32:
-        return std_hash(ProofOfSpace.calculate_plot_filter_input(plot_id, challenge_hash, signage_point))
+def get_quality_string(pos: ProofOfSpace, plot_id: bytes32) -> Optional[bytes32]:
+    quality_str = Verifier().validate_proof(plot_id, pos.size, pos.challenge, bytes(pos.proof))
+    if not quality_str:
+        return None
+    return bytes32(quality_str)
 
-    @staticmethod
-    def calculate_plot_id_pk(
-        pool_public_key: G1Element,
-        plot_public_key: G1Element,
-    ) -> bytes32:
-        return std_hash(bytes(pool_public_key) + bytes(plot_public_key))
 
-    @staticmethod
-    def calculate_plot_id_ph(
-        pool_contract_puzzle_hash: bytes32,
-        plot_public_key: G1Element,
-    ) -> bytes32:
-        return std_hash(bytes(pool_contract_puzzle_hash) + bytes(plot_public_key))
+def passes_plot_filter(
+    constants: ConsensusConstants,
+    plot_id: bytes32,
+    challenge_hash: bytes32,
+    signage_point: bytes32,
+) -> bool:
+    plot_filter: BitArray = BitArray(calculate_plot_filter_input(plot_id, challenge_hash, signage_point))
+    return plot_filter[: constants.NUMBER_ZERO_BITS_PLOT_FILTER].uint == 0
 
-    @staticmethod
-    def generate_taproot_sk(local_pk: G1Element, farmer_pk: G1Element) -> PrivateKey:
-        taproot_message: bytes = bytes(local_pk + farmer_pk) + bytes(local_pk) + bytes(farmer_pk)
-        taproot_hash: bytes32 = std_hash(taproot_message)
-        return AugSchemeMPL.key_gen(taproot_hash)
 
-    @staticmethod
-    def generate_plot_public_key(local_pk: G1Element, farmer_pk: G1Element, include_taproot: bool = False) -> G1Element:
-        if include_taproot:
-            taproot_sk: PrivateKey = ProofOfSpace.generate_taproot_sk(local_pk, farmer_pk)
-            return local_pk + farmer_pk + taproot_sk.get_g1()
-        else:
-            return local_pk + farmer_pk
+def calculate_plot_filter_input(plot_id: bytes32, challenge_hash: bytes32, signage_point: bytes32) -> bytes32:
+    return std_hash(plot_id + challenge_hash + signage_point)
+
+
+def calculate_pos_challenge(plot_id: bytes32, challenge_hash: bytes32, signage_point: bytes32) -> bytes32:
+    return std_hash(calculate_plot_filter_input(plot_id, challenge_hash, signage_point))
+
+
+def calculate_plot_id_pk(
+    pool_public_key: G1Element,
+    plot_public_key: G1Element,
+) -> bytes32:
+    return std_hash(bytes(pool_public_key) + bytes(plot_public_key))
+
+
+def calculate_plot_id_ph(
+    pool_contract_puzzle_hash: bytes32,
+    plot_public_key: G1Element,
+) -> bytes32:
+    return std_hash(bytes(pool_contract_puzzle_hash) + bytes(plot_public_key))
+
+
+def generate_taproot_sk(local_pk: G1Element, farmer_pk: G1Element) -> PrivateKey:
+    taproot_message: bytes = bytes(local_pk + farmer_pk) + bytes(local_pk) + bytes(farmer_pk)
+    taproot_hash: bytes32 = std_hash(taproot_message)
+    return AugSchemeMPL.key_gen(taproot_hash)
+
+
+def generate_plot_public_key(local_pk: G1Element, farmer_pk: G1Element, include_taproot: bool = False) -> G1Element:
+    if include_taproot:
+        taproot_sk: PrivateKey = generate_taproot_sk(local_pk, farmer_pk)
+        return local_pk + farmer_pk + taproot_sk.get_g1()
+    else:
+        return local_pk + farmer_pk

--- a/tests/core/custom_types/test_proof_of_space.py
+++ b/tests/core/custom_types/test_proof_of_space.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from secrets import token_bytes
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace  # pylint: disable=E0401
+from chia.types.blockchain_format.proof_of_space import passes_plot_filter
 
 
 class TestProofOfSpace:
@@ -19,7 +19,7 @@ class TestProofOfSpace:
             plot_id = token_bytes(32)
             sp_output = token_bytes(32)
 
-            if ProofOfSpace.passes_plot_filter(DEFAULT_CONSTANTS, plot_id, challenge_hash, sp_output):
+            if passes_plot_filter(DEFAULT_CONSTANTS, plot_id, challenge_hash, sp_output):
                 success_count += 1
 
         assert abs((success_count * target_filter / num_trials) - 1) < 0.35

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -52,7 +52,7 @@ from tests.core.make_block_generator import make_spend_bundle
 from tests.core.node_height import node_height_at_least
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 from chia.types.blockchain_format.foliage import Foliage, TransactionsInfo, FoliageTransactionBlock
-from chia.types.blockchain_format.proof_of_space import ProofOfSpace
+from chia.types.blockchain_format.proof_of_space import ProofOfSpace, calculate_pos_challenge, calculate_plot_id_pk
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlockUnfinished
 
 
@@ -1270,9 +1270,9 @@ class TestFullNodeProtocol:
 
                 if committment > 5:
                     if pos.pool_public_key is None:
-                        plot_id = ProofOfSpace.calculate_plot_id_ph(pos.pool_contract_puzzle_hash, public_key)
+                        plot_id = calculate_plot_id_pk(pos.pool_contract_puzzle_hash, public_key)
                     else:
-                        plot_id = ProofOfSpace.calculate_plot_id_pk(pos.pool_public_key, public_key)
+                        plot_id = calculate_plot_id_pk(pos.pool_public_key, public_key)
                     original_challenge_hash = block.reward_chain_block.pos_ss_cc_challenge_hash
 
                     if block.reward_chain_block.challenge_chain_sp_vdf is None:
@@ -1280,7 +1280,7 @@ class TestFullNodeProtocol:
                         cc_sp_hash = original_challenge_hash
                     else:
                         cc_sp_hash = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
-                    challenge = ProofOfSpace.calculate_pos_challenge(plot_id, original_challenge_hash, cc_sp_hash)
+                    challenge = calculate_pos_challenge(plot_id, original_challenge_hash, cc_sp_hash)
 
                 else:
                     challenge = pos.challenge

--- a/tests/weight_proof/test_weight_proof.py
+++ b/tests/weight_proof/test_weight_proof.py
@@ -23,6 +23,7 @@ from chia.full_node.weight_proof import (
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
 from chia.util.ints import uint32, uint64
+from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 
 
 def count_sub_epochs(blockchain, last_hash) -> int:
@@ -75,7 +76,8 @@ async def load_blocks_dont_validate(
         else:
             cc_sp = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
 
-        quality_string: Optional[bytes32] = block.reward_chain_block.proof_of_space.verify_and_get_quality_string(
+        quality_string: Optional[bytes32] = verify_and_get_quality_string(
+            block.reward_chain_block.proof_of_space,
             test_constants,
             block.reward_chain_block.pos_ss_cc_challenge_hash,
             cc_sp,


### PR DESCRIPTION
This is a step to allow for the `ProofOfSpace` class to be turned into a rust native type without also having to move all these member functions' logic into rust.

Why would we want `ProofOfSpace` to be a rust type? Two reasons:

1. It means we can serialize and deserialize the type (and types that contain a `ProofOfSpace` object) in rust, which is a *lot* faster than our Streamable implementation in python
2. We need this type the Wallet SDK, and it would let us share the same definition. The Wallet SDK is rust-only in order to support the WASM target.

The main change is in the `proof_of_space.py` file. Please review this with ignore-whitespace enabled (as all the functions were moved one indentation level to the left. All other changes are only to call these functions as free functions rather than members.