### PR TITLE
Add support for pending transactions to `get_mempool_item_by_tx_id()` #9443

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -747,9 +747,10 @@ class FullNodeRpcApi:
     async def get_mempool_item_by_tx_id(self, request: Dict) -> EndpointResult:
         if "tx_id" not in request:
             raise ValueError("No tx_id in request")
+        include_pending: bool = request.get("include_pending", False)
         tx_id: bytes32 = bytes32.from_hexstr(request["tx_id"])
 
-        item = self.service.mempool_manager.get_mempool_item(tx_id)
+        item = self.service.mempool_manager.get_mempool_item(tx_id, include_pending)
         if item is None:
             raise ValueError(f"Tx id 0x{tx_id.hex()} not in the mempool")
 

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -231,9 +231,11 @@ class FullNodeRpcClient(RpcClient):
             converted[bytes32(hexstr_to_bytes(tx_id_hex))] = item
         return converted
 
-    async def get_mempool_item_by_tx_id(self, tx_id: bytes32) -> Optional[Dict]:
+    async def get_mempool_item_by_tx_id(self, tx_id: bytes32, include_pending: bool = False) -> Optional[Dict]:
         try:
-            response = await self.fetch("get_mempool_item_by_tx_id", {"tx_id": tx_id.hex()})
+            response = await self.fetch(
+                "get_mempool_item_by_tx_id", {"tx_id": tx_id.hex(), "include_pending": include_pending}
+            )
             return response["mempool_item"]
         except Exception:
             return None

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -5,6 +5,7 @@ from typing import List
 
 import pytest
 from blspy import AugSchemeMPL
+from clvm.casts import int_to_bytes
 
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.signage_point import SignagePoint
@@ -15,6 +16,8 @@ from chia.simulator.block_tools import get_signage_point, test_constants
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
 from chia.simulator.time_out_assert import time_out_assert
 from chia.simulator.wallet_tools import WalletTool
+from chia.types.condition_opcodes import ConditionOpcode
+from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
@@ -137,6 +140,7 @@ class TestRpc:
             assert len(await client.get_all_mempool_items()) == 0
             assert len(await client.get_all_mempool_tx_ids()) == 0
             assert (await client.get_mempool_item_by_tx_id(spend_bundle.name())) is None
+            assert (await client.get_mempool_item_by_tx_id(spend_bundle.name(), False)) is None
 
             await client.push_tx(spend_bundle)
             coin = spend_bundle.additions()[0]
@@ -155,6 +159,27 @@ class TestRpc:
                 == spend_bundle
             )
             assert (await client.get_coin_record_by_name(coin.name())) is None
+
+            # Verify that the include_pending arg to get_mempool_item_by_tx_id works
+            coin_to_spend_pending = list(blocks[-1].get_included_reward_coins())[1]
+            ahr = ConditionOpcode.ASSERT_HEIGHT_RELATIVE  # to force pending/potential
+            condition_dic = {ahr: [ConditionWithArgs(ahr, [int_to_bytes(100)])]}
+            spend_bundle_pending = wallet.generate_signed_transaction(
+                coin_to_spend_pending.amount,
+                ph_receiver,
+                coin_to_spend_pending,
+                condition_dic=condition_dic,
+            )
+            await client.push_tx(spend_bundle_pending)
+            assert (
+                await client.get_mempool_item_by_tx_id(spend_bundle_pending.name(), False)
+            ) is None  # not strictly in the mempool
+            assert (
+                SpendBundle.from_json_dict(
+                    (await client.get_mempool_item_by_tx_id(spend_bundle_pending.name(), True))["spend_bundle"]
+                )
+                == spend_bundle_pending  # pending entry into mempool, so include_pending fetches
+            )
 
             await full_node_api_1.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
 


### PR DESCRIPTION
Co-Authored-By: @rwarren
Co-Authored-By: @emlowe 

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
Purpose: This PR is a clone of #9443 that had an unsigned commit


<!-- What is the current behavior?** (You can also link to an open issue here) -->
Current Behavior: https://github.com/Chia-Network/chia-blockchain/pull/9443 cannot be merged due to the first commit being unsigned


<!-- What is the new behavior (if this is a feature change)? -->
New Behavior: I took https://patch-diff.githubusercontent.com/raw/Chia-Network/chia-blockchain/pull/9443.diff and applied it on top of `main` in my branch, while also attributing credit to all who contributed in the original PR. There should be no drift in the intended effect of the original PR, and this one.


<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->
Breaking changes: None


<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
