### PR TITLE
tests: Fix `BlockTools` import

### DIFF
--- a/tests/core/daemon/test_keychain_proxy.py
+++ b/tests/core/daemon/test_keychain_proxy.py
@@ -8,7 +8,8 @@ import pytest
 import pytest_asyncio
 
 from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate
-from chia.simulator.setup_services import BlockTools, setup_daemon
+from chia.simulator.block_tools import BlockTools
+from chia.simulator.setup_services import setup_daemon
 from chia.util.keychain import KeyData
 
 TEST_KEY_1 = KeyData.generate(label="🚽🍯")


### PR DESCRIPTION
The file was added in #13936 which was merged before #13932 which  enabled `mypy` in `setup_services` leading to the pre-commit failure.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
