### PR TITLE
server: Move api call processing into `WSChiaConnection`

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -8,8 +8,7 @@ import traceback
 from dataclasses import dataclass, field
 from ipaddress import IPv4Network, IPv6Address, IPv6Network, ip_address, ip_network
 from pathlib import Path
-from secrets import token_bytes
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from aiohttp import (
     ClientResponseError,
@@ -27,23 +26,20 @@ from typing_extensions import final
 
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.protocol_state_machine import message_requires_reply
-from chia.protocols.protocol_timing import API_EXCEPTION_BAN_SECONDS, INVALID_PROTOCOL_BAN_SECONDS
-from chia.protocols.shared_protocol import Capability, protocol_version
+from chia.protocols.protocol_timing import INVALID_PROTOCOL_BAN_SECONDS
+from chia.protocols.shared_protocol import protocol_version
 from chia.server.introducer_peers import IntroducerPeers
 from chia.server.outbound_message import Message, NodeType
 from chia.server.ssl_context import private_ssl_paths, public_ssl_paths
-from chia.server.ws_connection import WSChiaConnection
+from chia.server.ws_connection import ConnectionCallback, WSChiaConnection
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
-from chia.util.api_decorators import get_metadata
 from chia.util.errors import Err, ProtocolError
-from chia.util.ints import uint8, uint16
+from chia.util.ints import uint16
 from chia.util.network import WebServer, is_in_network, is_localhost
 from chia.util.ssl_check import verify_ssl_certs_and_keys
 
 max_message_size = 50 * 1024 * 1024  # 50MB
-
-ConnectionCallback = Callable[[WSChiaConnection], Awaitable[None]]
 
 
 def ssl_context_for_server(
@@ -137,20 +133,14 @@ class ChiaServer:
     exempt_peer_networks: List[Union[IPv4Network, IPv6Network]]
     all_connections: Dict[bytes32, WSChiaConnection] = field(default_factory=dict)
     on_connect: Optional[ConnectionCallback] = None
-    incoming_messages: asyncio.Queue[Tuple[Message, WSChiaConnection]] = field(default_factory=asyncio.Queue)
     shut_down_event: asyncio.Event = field(default_factory=asyncio.Event)
     introducer_peers: Optional[IntroducerPeers] = None
-    incoming_task: Optional[asyncio.Task[None]] = None
     gc_task: Optional[asyncio.Task[None]] = None
     webserver: Optional[WebServer] = None
     connection_close_task: Optional[asyncio.Task[None]] = None
     received_message_callback: Optional[ConnectionCallback] = None
-    api_tasks: Dict[bytes32, asyncio.Task[None]] = field(default_factory=dict)
-    execute_tasks: Set[bytes32] = field(default_factory=set)
-    tasks_from_peer: Dict[bytes32, Set[bytes32]] = field(default_factory=dict)
     banned_peers: Dict[str, float] = field(default_factory=dict)
     invalid_protocol_ban_seconds = INVALID_PROTOCOL_BAN_SECONDS
-    api_exception_ban_seconds = API_EXCEPTION_BAN_SECONDS
 
     @classmethod
     def create(
@@ -278,8 +268,6 @@ class ChiaServer:
     async def start_server(self, prefer_ipv6: bool, on_connect: Optional[ConnectionCallback] = None) -> None:
         if self.webserver is not None:
             raise RuntimeError("ChiaServer already started")
-        if self.incoming_task is None:
-            self.incoming_task = asyncio.create_task(self.incoming_api_task())
         if self.gc_task is None:
             self.gc_task = asyncio.create_task(self.garbage_collect_connections_task())
 
@@ -324,11 +312,12 @@ class ChiaServer:
             connection = WSChiaConnection.create(
                 self._local_type,
                 ws,
+                self.api,
                 self._port,
                 self.log,
                 False,
+                self.received_message_callback,
                 request.remote,
-                self.incoming_messages,
                 self.connection_closed,
                 peer_id,
                 self._inbound_rate_limit_percent,
@@ -471,11 +460,12 @@ class ChiaServer:
             connection = WSChiaConnection.create(
                 self._local_type,
                 ws,
+                self.api,
                 self._port,
                 self.log,
                 True,
+                self.received_message_callback,
                 target_node.host,
-                self.incoming_messages,
                 self.connection_closed,
                 peer_id,
                 self._inbound_rate_limit_percent,
@@ -549,125 +539,10 @@ class ChiaServer:
                     f"Invalid connection type for connection {connection.peer_host},"
                     f" while closing. Handshake never finished."
                 )
-            self.cancel_tasks_from_peer(connection.peer_node_id)
+            connection.cancel_tasks()
             on_disconnect = getattr(self.node, "on_disconnect", None)
             if on_disconnect is not None:
                 on_disconnect(connection)
-
-    def cancel_tasks_from_peer(self, peer_id: bytes32) -> None:
-        if peer_id not in self.tasks_from_peer:
-            return None
-
-        task_ids = self.tasks_from_peer[peer_id]
-        for task_id in task_ids:
-            if task_id in self.execute_tasks:
-                continue
-            task = self.api_tasks[task_id]
-            task.cancel()
-
-    async def incoming_api_task(self) -> None:
-        while True:
-            payload_inc, connection_inc = await self.incoming_messages.get()
-            if payload_inc is None or connection_inc is None:
-                continue
-
-            async def api_call(full_message: Message, connection: WSChiaConnection, task_id: bytes32) -> None:
-                start_time = time.time()
-                message_type = ""
-                try:
-                    if self.received_message_callback is not None:
-                        await self.received_message_callback(connection)
-                    connection.log.debug(
-                        f"<- {ProtocolMessageTypes(full_message.type).name} from peer "
-                        f"{connection.peer_node_id} {connection.peer_host}"
-                    )
-                    message_type = ProtocolMessageTypes(full_message.type).name
-
-                    f = getattr(self.api, message_type, None)
-
-                    if f is None:
-                        self.log.error(f"Non existing function: {message_type}")
-                        raise ProtocolError(Err.INVALID_PROTOCOL_MESSAGE, [message_type])
-
-                    metadata = get_metadata(function=f)
-                    if metadata is None:
-                        self.log.error(f"Peer trying to call non api function {message_type}")
-                        raise ProtocolError(Err.INVALID_PROTOCOL_MESSAGE, [message_type])
-
-                    # If api is not ready ignore the request
-                    if hasattr(self.api, "api_ready"):
-                        if self.api.api_ready is False:
-                            return None
-
-                    timeout: Optional[int] = 600
-                    if metadata.execute_task:
-                        # Don't timeout on methods with execute_task decorator, these need to run fully
-                        self.execute_tasks.add(task_id)
-                        timeout = None
-
-                    if metadata.peer_required:
-                        coroutine = f(full_message.data, connection)
-                    else:
-                        coroutine = f(full_message.data)
-
-                    async def wrapped_coroutine() -> Optional[Message]:
-                        try:
-                            # hinting Message here is compensating for difficulty around hinting of the callbacks
-                            result: Message = await coroutine
-                            return result
-                        except asyncio.CancelledError:
-                            pass
-                        except Exception as e:
-                            tb = traceback.format_exc()
-                            connection.log.error(f"Exception: {e}, {connection.get_peer_logging()}. {tb}")
-                            raise
-                        return None
-
-                    response: Optional[Message] = await asyncio.wait_for(wrapped_coroutine(), timeout=timeout)
-                    connection.log.debug(
-                        f"Time taken to process {message_type} from {connection.peer_node_id} is "
-                        f"{time.time() - start_time} seconds"
-                    )
-
-                    if response is not None:
-                        response_message = Message(response.type, full_message.id, response.data)
-                        await connection.send_message(response_message)
-                    # check that this call needs a reply
-
-                    elif message_requires_reply(ProtocolMessageTypes(full_message.type)) and connection.has_capability(
-                        Capability.NONE_RESPONSE
-                    ):
-                        # this peer can accept None reply's, send empty msg back so he doesn't wait for timeout
-                        response_message = Message(
-                            uint8(ProtocolMessageTypes.none_response.value), full_message.id, b""
-                        )
-                        await connection.send_message(response_message)
-                except TimeoutError:
-                    connection.log.error(f"Timeout error for: {message_type}")
-                except Exception as e:
-                    if self.connection_close_task is None:
-                        tb = traceback.format_exc()
-                        connection.log.error(
-                            f"Exception: {e} {type(e)}, closing connection {connection.get_peer_logging()}. {tb}"
-                        )
-                    else:
-                        connection.log.debug(f"Exception: {e} while closing connection")
-                    # TODO: actually throw one of the errors from errors.py and pass this to close
-                    await connection.close(self.api_exception_ban_seconds, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
-                finally:
-                    if task_id in self.api_tasks:
-                        self.api_tasks.pop(task_id)
-                    if task_id in self.tasks_from_peer[connection.peer_node_id]:
-                        self.tasks_from_peer[connection.peer_node_id].remove(task_id)
-                    if task_id in self.execute_tasks:
-                        self.execute_tasks.remove(task_id)
-
-            task_id: bytes32 = bytes32(token_bytes(32))
-            api_task = asyncio.create_task(api_call(payload_inc, connection_inc, task_id))
-            self.api_tasks[task_id] = api_task
-            if connection_inc.peer_node_id not in self.tasks_from_peer:
-                self.tasks_from_peer[connection_inc.peer_node_id] = set()
-            self.tasks_from_peer[connection_inc.peer_node_id].add(task_id)
 
     async def send_to_others(
         self,
@@ -738,13 +613,8 @@ class ChiaServer:
         self.connection_close_task = asyncio.create_task(self.close_all_connections())
         if self.webserver is not None:
             self.webserver.close()
-        for task_id, task in self.api_tasks.items():
-            task.cancel()
 
         self.shut_down_event.set()
-        if self.incoming_task is not None:
-            self.incoming_task.cancel()
-            self.incoming_task = None
         if self.gc_task is not None:
             self.gc_task.cancel()
             self.gc_task = None

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -6,7 +6,8 @@ import logging
 import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from secrets import token_bytes
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from aiohttp import ClientSession, WSCloseCode, WSMessage, WSMsgType
 from aiohttp.client import ClientWebSocketResponse
@@ -15,8 +16,8 @@ from typing_extensions import Protocol, final
 
 from chia.cmds.init_funcs import chia_full_version_str
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.protocols.protocol_state_machine import message_response_ok
-from chia.protocols.protocol_timing import INTERNAL_PROTOCOL_ERROR_BAN_SECONDS
+from chia.protocols.protocol_state_machine import message_requires_reply, message_response_ok
+from chia.protocols.protocol_timing import API_EXCEPTION_BAN_SECONDS, INTERNAL_PROTOCOL_ERROR_BAN_SECONDS
 from chia.protocols.shared_protocol import Capability, Handshake
 from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.rate_limits import RateLimiter
@@ -35,6 +36,7 @@ from chia.util.streamable import Streamable
 LENGTH_BYTES: int = 4
 
 WebSocket = Union[WebSocketResponse, ClientWebSocketResponse]
+ConnectionCallback = Callable[["WSChiaConnection"], Awaitable[None]]
 
 
 class ConnectionClosedCallbackProtocol(Protocol):
@@ -57,6 +59,7 @@ class WSChiaConnection:
     """
 
     ws: WebSocket
+    api: Any
     local_type: NodeType
     local_port: int
     local_capabilities_for_handshake: List[Tuple[uint16, str]]
@@ -74,8 +77,12 @@ class WSChiaConnection:
     is_outbound: bool
 
     # Messaging
-    incoming_queue: asyncio.Queue[Tuple[Message, WSChiaConnection]]
+    received_message_callback: Optional[ConnectionCallback]
+    incoming_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue)
     outgoing_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue)
+    api_tasks: Dict[bytes32, asyncio.Task[None]] = field(default_factory=dict)
+    # Contains task ids of api tasks which should not be canceled
+    execute_tasks: Set[bytes32] = field(default_factory=set)
 
     # ChiaConnection metrics
     creation_time: float = field(default_factory=time.time)
@@ -85,6 +92,7 @@ class WSChiaConnection:
 
     peer_server_port: Optional[uint16] = None
     inbound_task: Optional[asyncio.Task[None]] = None
+    incoming_message_task: Optional[asyncio.Task[None]] = None
     outbound_task: Optional[asyncio.Task[None]] = None
     active: bool = False  # once handshake is successful this will be changed to True
     _close_event: asyncio.Event = field(default_factory=asyncio.Event)
@@ -105,11 +113,12 @@ class WSChiaConnection:
         cls,
         local_type: NodeType,
         ws: WebSocket,
+        api: Any,
         server_port: int,
         log: logging.Logger,
         is_outbound: bool,
+        received_message_callback: Optional[ConnectionCallback],
         peer_host: str,
-        incoming_queue: asyncio.Queue[Tuple[Message, WSChiaConnection]],
         close_callback: Optional[ConnectionClosedCallbackProtocol],
         peer_id: bytes32,
         inbound_rate_limit_percent: int,
@@ -133,6 +142,7 @@ class WSChiaConnection:
 
         return cls(
             ws=ws,
+            api=api,
             local_type=local_type,
             local_port=server_port,
             local_capabilities_for_handshake=local_capabilities_for_handshake,
@@ -146,7 +156,7 @@ class WSChiaConnection:
             outbound_rate_limiter=RateLimiter(incoming=False, percentage_of_limit=outbound_rate_limit_percent),
             inbound_rate_limiter=RateLimiter(incoming=True, percentage_of_limit=inbound_rate_limit_percent),
             is_outbound=is_outbound,
-            incoming_queue=incoming_queue,
+            received_message_callback=received_message_callback,
             session=session,
         )
 
@@ -226,6 +236,7 @@ class WSChiaConnection:
 
         self.outbound_task = asyncio.create_task(self.outbound_handler())
         self.inbound_task = asyncio.create_task(self.inbound_handler())
+        self.incoming_message_task = asyncio.create_task(self.incoming_message_handler())
 
     async def close(
         self,
@@ -255,6 +266,8 @@ class WSChiaConnection:
         try:
             if self.inbound_task is not None:
                 self.inbound_task.cancel()
+            if self.incoming_message_task is not None:
+                self.incoming_message_task.cancel()
             if self.outbound_task is not None:
                 self.outbound_task.cancel()
             if self.ws is not None and self.ws.closed is False:
@@ -262,6 +275,7 @@ class WSChiaConnection:
             if self.session is not None:
                 await self.session.close()
             self.cancel_pending_requests()
+            self.cancel_tasks()
         except Exception:
             error_stack = traceback.format_exc()
             self.log.warning(f"Exception closing socket: {error_stack}")
@@ -288,6 +302,12 @@ class WSChiaConnection:
             except Exception as e:
                 self.log.error(f"Failed setting event for {message_id}: {e} {traceback.format_exc()}")
 
+    def cancel_tasks(self) -> None:
+        for task_id, task in self.api_tasks.copy().items():
+            if task_id in self.execute_tasks:
+                continue
+            task.cancel()
+
     async def outbound_handler(self) -> None:
         try:
             while not self.closed:
@@ -311,6 +331,96 @@ class WSChiaConnection:
                 self.log.error(f"Exception: {e} with {self.peer_host}")
                 self.log.error(f"Exception Stack: {error_stack}")
 
+    async def _api_call(self, full_message: Message, task_id: bytes32) -> None:
+        start_time = time.time()
+        message_type = ""
+        try:
+            if self.received_message_callback is not None:
+                await self.received_message_callback(self)
+            self.log.debug(
+                f"<- {ProtocolMessageTypes(full_message.type).name} from peer " f"{self.peer_node_id} {self.peer_host}"
+            )
+            message_type = ProtocolMessageTypes(full_message.type).name
+
+            f = getattr(self.api, message_type, None)
+
+            if f is None:
+                self.log.error(f"Non existing function: {message_type}")
+                raise ProtocolError(Err.INVALID_PROTOCOL_MESSAGE, [message_type])
+
+            metadata = get_metadata(function=f)
+            if metadata is None:
+                self.log.error(f"Peer trying to call non api function {message_type}")
+                raise ProtocolError(Err.INVALID_PROTOCOL_MESSAGE, [message_type])
+
+            # If api is not ready ignore the request
+            if hasattr(self.api, "api_ready"):
+                if self.api.api_ready is False:
+                    return None
+
+            timeout: Optional[int] = 600
+            if metadata.execute_task:
+                # Don't timeout on methods with execute_task decorator, these need to run fully
+                self.execute_tasks.add(task_id)
+                timeout = None
+
+            if metadata.peer_required:
+                coroutine = f(full_message.data, self)
+            else:
+                coroutine = f(full_message.data)
+
+            async def wrapped_coroutine() -> Optional[Message]:
+                try:
+                    # hinting Message here is compensating for difficulty around hinting of the callbacks
+                    result: Message = await coroutine
+                    return result
+                except asyncio.CancelledError:
+                    pass
+                except Exception as e:
+                    tb = traceback.format_exc()
+                    self.log.error(f"Exception: {e}, {self.get_peer_logging()}. {tb}")
+                    raise
+                return None
+
+            response: Optional[Message] = await asyncio.wait_for(wrapped_coroutine(), timeout=timeout)
+            self.log.debug(
+                f"Time taken to process {message_type} from {self.peer_node_id} is "
+                f"{time.time() - start_time} seconds"
+            )
+
+            if response is not None:
+                response_message = Message(response.type, full_message.id, response.data)
+                await self.send_message(response_message)
+            # check that this call needs a reply
+            elif message_requires_reply(ProtocolMessageTypes(full_message.type)) and self.has_capability(
+                Capability.NONE_RESPONSE
+            ):
+                # this peer can accept None reply's, send empty msg back, so it doesn't wait for timeout
+                response_message = Message(uint8(ProtocolMessageTypes.none_response.value), full_message.id, b"")
+                await self.send_message(response_message)
+        except TimeoutError:
+            self.log.error(f"Timeout error for: {message_type}")
+        except Exception as e:
+            if not self.closed:
+                tb = traceback.format_exc()
+                self.log.error(f"Exception: {e} {type(e)}, closing connection {self.get_peer_logging()}. {tb}")
+            else:
+                self.log.debug(f"Exception: {e} while closing connection")
+            # TODO: actually throw one of the errors from errors.py and pass this to close
+            await self.close(API_EXCEPTION_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
+        finally:
+            if task_id in self.api_tasks:
+                self.api_tasks.pop(task_id)
+            if task_id in self.execute_tasks:
+                self.execute_tasks.remove(task_id)
+
+    async def incoming_message_handler(self) -> None:
+        while True:
+            message = await self.incoming_queue.get()
+            task_id: bytes32 = bytes32(token_bytes(32))
+            api_task = asyncio.create_task(self._api_call(message, task_id))
+            self.api_tasks[task_id] = api_task
+
     async def inbound_handler(self) -> None:
         try:
             while not self.closed:
@@ -321,7 +431,7 @@ class WSChiaConnection:
                         event = self.pending_requests[message.id]
                         event.set()
                     else:
-                        await self.incoming_queue.put((message, self))
+                        await self.incoming_queue.put(message)
                 else:
                     continue
         except asyncio.CancelledError:

--- a/chia/simulator/time_out_assert.py
+++ b/chia/simulator/time_out_assert.py
@@ -48,7 +48,7 @@ def time_out_messages(incoming_queue: asyncio.Queue, msg_name: str, count: int =
         if incoming_queue.qsize() < count:
             return False
         for _ in range(count):
-            response = (await incoming_queue.get())[0].type
+            response = (await incoming_queue.get()).type
             if ProtocolMessageTypes(response).name != msg_name:
                 # log.warning(f"time_out_message: found {response} instead of {msg_name}")
                 return False

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -58,7 +58,7 @@ from tests.util.wallet_is_synced import wallet_is_synced
 async def new_transaction_not_requested(incoming, new_spend):
     await asyncio.sleep(3)
     while not incoming.empty():
-        response, peer = await incoming.get()
+        response = await incoming.get()
         if (
             response is not None
             and isinstance(response, Message)
@@ -73,7 +73,7 @@ async def new_transaction_not_requested(incoming, new_spend):
 async def new_transaction_requested(incoming, new_spend):
     await asyncio.sleep(1)
     while not incoming.empty():
-        response, peer = await incoming.get()
+        response = await incoming.get()
         if (
             response is not None
             and isinstance(response, Message)

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-
 import aiohttp
 import pytest
 
@@ -20,17 +18,17 @@ async def establish_connection(server: ChiaServer, self_hostname: str, ssl_conte
     timeout = aiohttp.ClientTimeout(total=10)
     dummy_port = 5  # this does not matter
     async with aiohttp.ClientSession(timeout=timeout) as session:
-        incoming_queue: asyncio.Queue = asyncio.Queue()
         url = f"wss://{self_hostname}:{server._port}/ws"
         ws = await session.ws_connect(url, autoclose=False, autoping=True, ssl=ssl_context)
         wsc = WSChiaConnection.create(
             NodeType.FULL_NODE,
             ws,
+            server.api,
             server._port,
             server.log,
             True,
+            server.received_message_callback,
             self_hostname,
-            incoming_queue,
             None,
             bytes32(b"\x00" * 32),
             100,

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -44,7 +44,7 @@ async def get_all_messages_in_queue(queue):
     all_messages = []
     await asyncio.sleep(2)
     while not queue.empty():
-        message, peer = await queue.get()
+        message = await queue.get()
         all_messages.append(message)
     return all_messages
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->

We currently have one queue `ChiaServer.incoming_queue` which gets passed to each new connection and all connections just push their messages into this queue as they come in. Whenever messages are put into the queue they are read by `ChiaServer.imcoming_task` and transformed into async tasks to complete the related api method with now limit like how many tasks will be created at the time. From my understanding this may lead to unfair prioritising for connections sending more/faster messages because its not really possible to limit concurrent tasks per connection in a reasonable way?

With this PR the api call processing gets moved into the `WSChiaConnection` class where each connection gets its own queue so that we can better coordinate tasks from all connections and get some limiting of active task per connection but this can/should be done in a separate PR.

<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
