### PR TITLE
Adding shell completion files

### DIFF
--- a/chia-complete.bash
+++ b/chia-complete.bash
@@ -1,0 +1,29 @@
+_chia_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _CHIA_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_chia_completion_setup() {
+    complete -o nosort -F _chia_completion chia
+}
+
+_chia_completion_setup;
+

--- a/chia-complete.zsh
+++ b/chia-complete.zsh
@@ -1,0 +1,35 @@
+#compdef chia
+
+_chia_completion() {
+    local -a completions
+    local -a completions_with_descriptions
+    local -a response
+    (( ! $+commands[chia] )) && return 1
+
+    response=("${(@f)$(env COMP_WORDS="${words[*]}" COMP_CWORD=$((CURRENT-1)) _CHIA_COMPLETE=zsh_complete chia)}")
+
+    for type key descr in ${response}; do
+        if [[ "$type" == "plain" ]]; then
+            if [[ "$descr" == "_" ]]; then
+                completions+=("$key")
+            else
+                completions_with_descriptions+=("$key":"$descr")
+            fi
+        elif [[ "$type" == "dir" ]]; then
+            _path_files -/
+        elif [[ "$type" == "file" ]]; then
+            _path_files -f
+        fi
+    done
+
+    if [ -n "$completions_with_descriptions" ]; then
+        _describe -V unsorted completions_with_descriptions -U
+    fi
+
+    if [ -n "$completions" ]; then
+        compadd -U -V unsorted -a completions
+    fi
+}
+
+compdef _chia_completion chia;
+

--- a/chia.fish
+++ b/chia.fish
@@ -1,0 +1,22 @@
+function _chia_completion;
+    set -l response;
+
+    for value in (env _CHIA_COMPLETE=fish_complete COMP_WORDS=(commandline -cp) COMP_CWORD=(commandline -t) chia);
+        set response $response $value;
+    end;
+
+    for completion in $response;
+        set -l metadata (string split "," $completion);
+
+        if test $metadata[1] = "dir";
+            __fish_complete_directories $metadata[2];
+        else if test $metadata[1] = "file";
+            __fish_complete_path $metadata[2];
+        else if test $metadata[1] = "plain";
+            echo $metadata[2];
+        end;
+    end;
+end;
+
+complete --no-files --command chia --arguments "(_chia_completion)";
+


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
This PR adds the generated shell completion files which can be generated by the following commands:
`_CHIA_COMPLETE=bash_source chia`
`_CHIA_COMPLETE=zsh_source chia`
`_CHIA_COMPLETE=fish_source chia`

<!-- What is the current behavior?** (You can also link to an open issue here) -->
Currently, there is no documented mention of this being possible, as it may have been unknown (I stumbled upon this https://click.palletsprojects.com/en/8.1.x/shell-completion/#enabling-completion).


<!-- What is the new behavior (if this is a feature change)? -->
The user may source these files once their venv is activated.
For possible future tasks, we may want to do one (or many) of the following:
- For users who install from src, as a final step of `install.sh`, it may be desirable to inject a `source chia-complete.bash` into the relevant `venv/bin/activate` script, so that the completion is activated when the venv is activated
- When packaging the installers, we may want to unpack these to a standardized location (for example: `/usr/share/chia/chia-complete.bash` for bash)
- We may want to add a CLI command to generate this file, i.e.: `chia completion --bash`
- It may be best to simply document the availability of this feature, and perhaps recommend how this can get added to their dotfiles, or what not to do (going the `eval` route would lead to a sluggish experience)


<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->

<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->

https://user-images.githubusercontent.com/8990544/204255728-69109215-a314-47cb-8200-e697871bc1c6.mp4

