### PR TITLE
bump chia_rs version to 0.1.16

### DIFF
--- a/chia/types/spend_bundle_conditions.py
+++ b/chia/types/spend_bundle_conditions.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from chia_rs import Spend, SpendBundleConditions
+from chia_rs import ELIGIBLE_FOR_DEDUP, Spend, SpendBundleConditions
 
-__all__ = ["Spend", "SpendBundleConditions"]
+__all__ = ["Spend", "SpendBundleConditions", "ELIGIBLE_FOR_DEDUP"]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ dependencies = [
     "chiapos==1.0.11",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
-    "chia_rs==0.1.14",
+    "chia_rs==0.1.16",
     "clvm-tools-rs==0.1.25",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.3",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/core/full_node/test_generator_tools.py
+++ b/tests/core/full_node/test_generator_tools.py
@@ -23,6 +23,7 @@ spends: List[Spend] = [
             (phs[4], uint64(0), b"1" * 300),
         ],
         [],
+        0,
     ),
     Spend(
         coin_ids[1],
@@ -35,6 +36,7 @@ spends: List[Spend] = [
             (phs[7], uint64(0), b"1" * 300),
         ],
         [],
+        0,
     ),
 ]
 

--- a/tests/core/full_node/test_hint_management.py
+++ b/tests/core/full_node/test_hint_management.py
@@ -29,6 +29,7 @@ spends: List[Spend] = [
             (phs[4], uint64(3), b"1" * 32),
         ],
         [],
+        0,
     ),
     Spend(
         coin_ids[2],
@@ -41,6 +42,7 @@ spends: List[Spend] = [
             (phs[9], uint64(123), b"1" * 32),
         ],
         [],
+        0,
     ),
     Spend(
         coin_ids[1],
@@ -52,6 +54,7 @@ spends: List[Spend] = [
             (phs[6], uint64(5), b"1" * 3),
         ],
         [],
+        0,
     ),
 ]
 

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -2405,7 +2405,7 @@ class TestPkmPairs:
 
     def test_no_agg_sigs(self):
         # one create coin: h1 amount: 1 and not hint
-        spends = [Spend(self.h3, self.h4, None, 0, [(self.h1, 1, b"")], [])]
+        spends = [Spend(self.h3, self.h4, None, 0, [(self.h1, 1, b"")], [], 0)]
         conds = SpendBundleConditions(spends, 0, 0, 0, [], 0)
         pks, msgs = pkm_pairs(conds, b"foobar")
         assert pks == []
@@ -2413,7 +2413,7 @@ class TestPkmPairs:
 
     def test_agg_sig_me(self):
 
-        spends = [Spend(self.h1, self.h2, None, 0, [], [(bytes48(self.pk1), b"msg1"), (bytes48(self.pk2), b"msg2")])]
+        spends = [Spend(self.h1, self.h2, None, 0, [], [(bytes48(self.pk1), b"msg1"), (bytes48(self.pk2), b"msg2")], 0)]
         conds = SpendBundleConditions(spends, 0, 0, 0, [], 0)
         pks, msgs = pkm_pairs(conds, b"foobar")
         assert [bytes(pk) for pk in pks] == [bytes(self.pk1), bytes(self.pk2)]
@@ -2427,7 +2427,7 @@ class TestPkmPairs:
 
     def test_agg_sig_mixed(self):
 
-        spends = [Spend(self.h1, self.h2, None, 0, [], [(bytes48(self.pk1), b"msg1")])]
+        spends = [Spend(self.h1, self.h2, None, 0, [], [(bytes48(self.pk1), b"msg1")], 0)]
         conds = SpendBundleConditions(spends, 0, 0, 0, [(bytes48(self.pk2), b"msg2")], 0)
         pks, msgs = pkm_pairs(conds, b"foobar")
         assert [bytes(pk) for pk in pks] == [bytes(self.pk2), bytes(self.pk1)]

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -2317,7 +2317,7 @@ class TestMaliciousGenerators:
     def test_duplicate_coin_announces(self, request, opcode):
         condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
 
-        with assert_runtime(seconds=7, label=request.node.name):
+        with assert_runtime(seconds=9, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False)
 
         assert npc_result.error is None

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -9,7 +9,7 @@ from chia.types.generator_types import BlockGenerator
 from chia.util.ints import uint32
 from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.consensus.condition_costs import ConditionCost
-from chia.types.spend_bundle_conditions import Spend
+from chia.types.spend_bundle_conditions import Spend, ELIGIBLE_FOR_DEDUP
 
 MAX_COST = int(1e15)
 COST_PER_BYTE = int(12000)
@@ -112,6 +112,7 @@ class TestROM:
             seconds_relative=0,
             create_coin=[(bytes([0] * 31 + [1]), 500, None)],
             agg_sig_me=[],
+            flags=ELIGIBLE_FOR_DEDUP,
         )
 
         assert npc_result.conds.spends == [spend]


### PR DESCRIPTION
This new version includes a flags field in `Spend` returned from `run_generator()`. The one feature this is used for currently is to indicate whether the spend is eligible for spend-deduplication, a feature currently being worked on in the mempool.

Specifically, a spend is eligible for deduplication if it did not produce any `AGG_SIG_ME` or `AGG_SIG_UNSAFE` conditions. i.e. it was not signed.