### PR TITLE
Don't re-create fee estimator on each new block when Mempool is recreated

### DIFF
--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -45,7 +45,7 @@ class ConsensusConstants:
     GENESIS_PRE_FARM_POOL_PUZZLE_HASH: bytes32  # The block at height must pay out to this pool puzzle hash
     GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: bytes32  # The block at height must pay out to this farmer puzzle hash
     MAX_VDF_WITNESS_SIZE: int  # The maximum number of classgroup elements within an n-wesolowski proof
-    # Size of mempool = 10x the size of block
+    # Size of mempool = (MEMPOOL_BLOCK_BUFFER * the size of block)
     MEMPOOL_BLOCK_BUFFER: int
     # Max coin amount uint(1 << 64). This allows coin amounts to fit in 64 bits. This is around 18M chia.
     MAX_COIN_AMOUNT: int

--- a/chia/full_node/bitcoin_fee_estimator.py
+++ b/chia/full_node/bitcoin_fee_estimator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from datetime import datetime
 
 from chia.full_node.fee_estimate_store import FeeStore
@@ -33,10 +32,13 @@ class BitcoinFeeEstimator(FeeEstimatorInterface):
         )
 
     def new_block(self, block_info: FeeBlockInfo) -> None:
+        # if len(block_info.included_items) > 0:
+        #    breakpoint()
         self.tracker.process_block(block_info.block_height, block_info.included_items)
 
     def add_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
         self.last_mempool_info = mempool_info
+        self.tracker.add_tx(mempool_item)
 
     def remove_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
         self.last_mempool_info = mempool_info
@@ -73,10 +75,10 @@ class BitcoinFeeEstimator(FeeEstimatorInterface):
         return self.tracker
 
 
-def create_bitcoin_fee_estimator(max_block_cost_clvm: uint64, log: logging.Logger) -> BitcoinFeeEstimator:
+def create_bitcoin_fee_estimator(max_block_cost_clvm: uint64) -> BitcoinFeeEstimator:
     # fee_store and fee_tracker are particular to the BitcoinFeeEstimator, and
     # are not necessary if a different fee estimator is used.
     fee_store = FeeStore()
-    fee_tracker = FeeTracker(log, fee_store)
+    fee_tracker = FeeTracker(fee_store)
     smart_fee_estimator = SmartFeeEstimator(fee_tracker, max_block_cost_clvm)
     return BitcoinFeeEstimator(fee_tracker, smart_fee_estimator)

--- a/chia/full_node/fee_estimator.py
+++ b/chia/full_node/fee_estimator.py
@@ -81,4 +81,4 @@ class SmartFeeEstimator:
             return FeeEstimate("Not enough data", r.requested_time, FeeRate(uint64(0)))
         else:
             # convert from mojo / 1000 clvm_cost to mojo / 1 clvm_cost
-            return FeeEstimate(None, r.requested_time, FeeRate(uint64(fee / 1000)))
+            return FeeEstimate(None, r.requested_time, FeeRate(uint64(fee / 1000)))  # XXX

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 
 from sortedcontainers import SortedDict
 
-from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.fee_estimation import FeeMempoolInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.types.blockchain_format.coin import Coin
@@ -18,7 +17,13 @@ from chia.util.ints import uint64
 
 
 class Mempool:
-    def __init__(self, max_size_in_cost: int, minimum_fee_per_cost_to_replace: uint64, max_block_cost_clvm: uint64):
+    def __init__(
+        self,
+        max_size_in_cost: int,
+        minimum_fee_per_cost_to_replace: uint64,
+        max_block_cost_clvm: uint64,
+        fee_estimator: FeeEstimatorInterface,
+    ):
         self.log = logging.getLogger(__name__)
         self.spends: Dict[bytes32, MempoolItem] = {}
         self.sorted_spends: SortedDict = SortedDict()
@@ -26,7 +31,7 @@ class Mempool:
         self.max_size_in_cost: int = max_size_in_cost
         self.total_mempool_cost: int = 0
         self.minimum_fee_per_cost_to_replace: uint64 = minimum_fee_per_cost_to_replace
-        self.fee_estimator: FeeEstimatorInterface = create_bitcoin_fee_estimator(max_block_cost_clvm, self.log)
+        self.fee_estimator = fee_estimator
 
     def get_min_fee_rate(self, cost: int) -> float:
         """

--- a/chia/wallet/util/debug_spend_bundle.py
+++ b/chia/wallet/util/debug_spend_bundle.py
@@ -65,7 +65,7 @@ def debug_spend_bundle(spend_bundle, agg_sig_additional_data=DEFAULT_CONSTANTS.A
 
         if puzzle_reveal.get_tree_hash() != coin_spend.coin.puzzle_hash:
             print("*** BAD PUZZLE REVEAL")
-            print(f"{puzzle_reveal.get_tree_hash().hex()} vs {coin_spend.coin.puzzle_hash.hex()}")
+            print(f"COINSPEND={puzzle_reveal.get_tree_hash().hex()} vs COIN={coin_spend.coin.puzzle_hash.hex()}")
             print("*" * 80)
             continue
 

--- a/tests/core/full_node/test_mempool.py
+++ b/tests/core/full_node/test_mempool.py
@@ -11,6 +11,7 @@ from clvm_tools import binutils
 
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.cost_calculator import NPCResult
+from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.mempool import Mempool
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
@@ -148,7 +149,8 @@ class TestMempool:
 
         max_block_cost_clvm = 40000000
         max_mempool_cost = max_block_cost_clvm * 5
-        mempool = Mempool(max_mempool_cost, uint64(5), uint64(max_block_cost_clvm))
+        fee_estimator = create_bitcoin_fee_estimator(max_block_cost_clvm)
+        mempool = Mempool(max_mempool_cost, uint64(5), uint64(max_block_cost_clvm), fee_estimator)
         assert mempool.get_min_fee_rate(104000) == 0
 
         with pytest.raises(ValueError):

--- a/tests/core/mempool/test_mempool_fee_estimator.py
+++ b/tests/core/mempool/test_mempool_fee_estimator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from random import Random
 
 import pytest
@@ -22,10 +21,8 @@ from tests.util.db_connection import DBConnection
 
 @pytest.mark.asyncio
 async def test_basics() -> None:
-    log = logging.getLogger(__name__)
-
     fee_store = FeeStore()
-    fee_tracker = FeeTracker(log, fee_store)
+    fee_tracker = FeeTracker(fee_store)
 
     wallet_tool = WalletTool(test_constants)
     ph = wallet_tool.get_new_puzzlehash()

--- a/tests/fee_estimation/test_fee_estimation_unit_tests.py
+++ b/tests/fee_estimation/test_fee_estimation_unit_tests.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 def test_interface() -> None:
     max_block_cost_clvm = uint64(1000 * 1000)
-    estimator: FeeEstimatorInterface = create_bitcoin_fee_estimator(max_block_cost_clvm, log)
+    estimator: FeeEstimatorInterface = create_bitcoin_fee_estimator(max_block_cost_clvm)
     target_times = [0, 120, 300]
     estimates = [estimator.estimate_fee_rate(time_offset_seconds=time) for time in target_times]
     current_fee_rate = estimator.estimate_fee_rate(
@@ -35,13 +35,13 @@ def test_interface() -> None:
 
 def test_estimator_create() -> None:
     max_block_cost_clvm = uint64(1000 * 1000)
-    estimator = create_bitcoin_fee_estimator(max_block_cost_clvm, log)
+    estimator = create_bitcoin_fee_estimator(max_block_cost_clvm)
     assert estimator is not None
 
 
 def test_single_estimate() -> None:
     max_block_cost_clvm = uint64(1000 * 1000)
-    estimator = create_bitcoin_fee_estimator(max_block_cost_clvm, log)
+    estimator = create_bitcoin_fee_estimator(max_block_cost_clvm)
     height = uint32(1)
     estimator.new_block(FeeBlockInfo(height, []))
     fee_rate = estimator.estimate_fee_rate(time_offset_seconds=40 * height)
@@ -71,7 +71,7 @@ def test_steady_fee_pressure() -> None:
     We expect the estimator to converge on this FeeRate value.
     """
     max_block_cost_clvm = uint64(1000 * 1000)
-    estimator = create_bitcoin_fee_estimator(max_block_cost_clvm, log)
+    estimator = create_bitcoin_fee_estimator(max_block_cost_clvm)
     wallet_tool = WalletTool(test_constants)
     cost = uint64(5000000)
     fee = uint64(10000000)
@@ -107,7 +107,7 @@ def test_fee_estimation_inception() -> None:
     transaction block wait time we have observed.
     """
     max_block_cost_clvm = uint64(1000 * 1000)
-    estimator1 = create_bitcoin_fee_estimator(max_block_cost_clvm, log)
+    estimator1 = create_bitcoin_fee_estimator(max_block_cost_clvm)
     wallet_tool = WalletTool(test_constants)
     cost = uint64(5000000)
     fee = uint64(10000000)
@@ -130,7 +130,7 @@ def test_fee_estimation_inception() -> None:
     assert e == [2, 2, 2, 2, 2, 2, 2]
 
     ##########################################################
-    estimator5 = create_bitcoin_fee_estimator(max_block_cost_clvm, log)
+    estimator5 = create_bitcoin_fee_estimator(max_block_cost_clvm)
 
     for height in range(start, end):
         height = uint32(height)

--- a/tests/fee_estimation/test_long.py
+++ b/tests/fee_estimation/test_long.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+import pytest
+from blspy import G2Element
+from chia_rs import Coin
+
+from chia.clvm.spend_sim import SimClient, SpendSim
+from chia.consensus.constants import ConsensusConstants
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.full_node.bitcoin_fee_estimator import BitcoinFeeEstimator
+from chia.full_node.fee_tracker import FeeStat
+from chia.full_node.mempool_manager import MempoolManager
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.clvm_cost import CLVMCost
+from chia.types.coin_record import CoinRecord
+from chia.types.coin_spend import CoinSpend
+from chia.types.fee_rate import FeeRate
+from chia.types.mempool_item import MempoolItem
+from chia.types.mojos import Mojos
+from chia.types.spend_bundle import SpendBundle
+from chia.util.errors import Err, ValidationError
+from chia.util.ints import uint64
+
+log = logging.getLogger(__name__)
+
+the_puzzle_hash = bytes32(
+    bytes.fromhex("9dcf97a184f32623d11a73124ceb99a5709b083721e878a16d78f596718ba7b2")
+)  # Program.to(1)
+
+
+@dataclass(frozen=True)
+class CoinPair:
+    coin: Coin
+    fee_coin: Coin
+
+
+# xxx break dep: mempoolmangager / mempool info
+async def farm(
+    sim: SpendSim,
+    puzzle_hash: bytes32,
+    item_inclusion_filter: Optional[Callable[[MempoolManager, MempoolItem], bool]] = None,
+) -> Tuple[List[Coin], List[Coin], List[Coin]]:
+    additions, removals = await sim.farm_block(puzzle_hash)  # , item_inclusion_filter)
+    height = sim.get_height()
+    new_reward_coins = sim.block_records[height].reward_claims_incorporated
+    return additions, removals, new_reward_coins
+
+
+def make_tx_sb(from_coin: Coin) -> SpendBundle:
+    coin_spend = CoinSpend(
+        from_coin,
+        Program.to(1),
+        Program.to([[51, from_coin.puzzle_hash, from_coin.amount]]),
+    )
+    spend_bundle = SpendBundle([coin_spend], G2Element())
+    return spend_bundle
+
+
+async def select_fee_coin(sim_client: SimClient, avoid_coins: List[Coin], puzzle_hash: bytes32, fee: int) -> Coin:
+    assert fee >= 0
+    spendable_coins: List[CoinRecord] = await sim_client.get_coin_records_by_puzzle_hash(puzzle_hash)
+    for cr in spendable_coins:
+        if cr.coin in avoid_coins:
+            continue
+        if cr.coin.amount >= fee:
+            return cr.coin
+    raise RuntimeError(f"No spendable coin has enough value to add a fee of {fee}")
+
+
+def add_fee(sb: SpendBundle, fee: int, fee_coin: Coin, recv_puzzle_hash: bytes32) -> Tuple[SpendBundle, Coin]:
+    fee_sb = SpendBundle(
+        [
+            CoinSpend(
+                fee_coin,
+                Program.to(1),
+                Program.to([[51, recv_puzzle_hash, fee_coin.amount - fee]]),
+            )
+        ],
+        G2Element(),
+    )
+    change_coin = Coin(fee_coin.name(), recv_puzzle_hash, fee_coin.amount - fee)
+    return SpendBundle.aggregate([sb, fee_sb]), change_coin
+
+
+async def transfer_coins(
+    sim: SpendSim,
+    sim_client: SimClient,
+    input_pairs: Set[CoinPair],
+    phs: List[bytes32],
+    fees: List[uint64],
+    fee_change_ph: bytes32,
+    item_inclusion_filter: Optional[Callable[[MempoolManager, MempoolItem], bool]],
+) -> Tuple[Set[CoinPair], Set[CoinPair]]:
+    """
+    Returns Tuple(new_spend_coins, new_fee_coins)
+    """
+    assert len(input_pairs) == len(fees)
+
+    if any([v < 0 for v in fees]):
+        raise ValueError("fees members must not be negative")
+    tx_push_count = 0
+    mempool_conflicts = set()
+    double_spends = set()
+    for input_pair, ph, fee in zip(input_pairs, phs, fees):
+        from_coin = input_pair.coin
+        fee_coin = input_pair.fee_coin
+        spend_bundle: SpendBundle = make_tx_sb(from_coin)
+        assert spend_bundle.additions()[0].amount == spend_bundle.removals()[0].amount
+
+        assert fee <= fee_coin.amount
+        sb_with_fee, change_coin = add_fee(spend_bundle, fee, fee_coin, fee_change_ph)
+        assert sb_with_fee.fees() == fee
+
+        try:
+            await sim_client.service.mempool_manager.pre_validate_spendbundle(sb_with_fee, None, sb_with_fee.name())
+        except ValidationError as e:
+            if len(e.args) > 0 and e.args[0] == Err.BLOCK_COST_EXCEEDS_MAX:
+                log.warning("Block full")
+                break
+        status, err = await sim_client.push_tx(sb_with_fee)
+        tx_push_count += 1
+        if err:
+            log.error(err)
+            if err == Err.MEMPOOL_CONFLICT:
+                mempool_conflicts.add(input_pair)
+                continue
+            if err == Err.DOUBLE_SPEND:
+                double_spends.add(input_pair)
+                continue
+            log.error(input_pairs)
+            sb_with_fee.debug()  # type: ignore
+            raise RuntimeError(err)
+
+    additions, removals_list, new_reward_coins = await farm(
+        sim, puzzle_hash=the_puzzle_hash, item_inclusion_filter=item_inclusion_filter
+    )
+
+    removals = set(removals_list)
+    spent_coins = set([p.coin for p in input_pairs]) & removals
+    spent_fee_coins = set([p.fee_coin for p in input_pairs]) & removals
+
+    new_coin_records = await sim_client.get_coin_records_by_parent_ids([c.name() for c in spent_coins])
+    new_fee_records = await sim_client.get_coin_records_by_parent_ids([f.name() for f in spent_fee_coins])
+    assert len(new_coin_records) == len(new_fee_records)
+
+    new_pairs = set([CoinPair(c.coin, f.coin) for c, f in zip(new_coin_records, new_fee_records)])
+
+    for p in new_pairs:
+        assert p.coin in additions
+        assert p.fee_coin in additions
+
+    unspent_pairs = set()
+    for p in input_pairs:
+        fee_removed = p.fee_coin in removals
+        coin_removed = p.coin in removals
+        assert (fee_removed and coin_removed) or ((not fee_removed) and (not coin_removed))
+        if p.coin not in removals:
+            unspent_pairs.add(p)
+
+    return (unspent_pairs, new_pairs)
+
+
+async def init_test(
+    puzzle_hash: bytes32, spends_per_block: int, *, constants: Optional[Dict[str, Any]]
+) -> Tuple[SpendSim, SimClient, BitcoinFeeEstimator, Set[CoinPair]]:
+    defaults: ConsensusConstants = DEFAULT_CONSTANTS
+    assert constants
+    sim = await SpendSim.create(
+        defaults=defaults.replace(
+            MAX_BLOCK_COST_CLVM=constants["MAX_BLOCK_COST_CLVM"], MEMPOOL_BLOCK_BUFFER=constants["MEMPOOL_BLOCK_BUFFER"]
+        )
+    )
+
+    cli = SimClient(sim)
+    new_reward_coins = []
+    spend_coins = []
+    fee_coins = []
+    await farm(sim, puzzle_hash)
+
+    for i in range(1, spends_per_block + 1):
+        await farm(sim, puzzle_hash)
+        new_reward_coins.extend(sim.block_records[i].reward_claims_incorporated)
+        fee_coins.append(sim.block_records[i].reward_claims_incorporated[0])
+        spend_coins.append(sim.block_records[i].reward_claims_incorporated[1])
+    await farm(sim, puzzle_hash)
+
+    assert len(sim.blocks) == spends_per_block + 2
+    assert sim.blocks[-1].height == spends_per_block + 1
+    assert sim.block_records[0].reward_claims_incorporated[0].amount == 18375000000000000000
+    assert sim.block_records[0].reward_claims_incorporated[1].amount == 2625000000000000000
+
+    assert sim.block_records[1].reward_claims_incorporated[0].amount == 1750000000000
+    assert sim.block_records[1].reward_claims_incorporated[1].amount == 250000000000
+
+    estimator: BitcoinFeeEstimator = sim.mempool_manager.mempool.fee_estimator  # type:ignore
+    coin_pairs = [CoinPair(c, f) for c, f in zip(spend_coins, fee_coins)]
+    return sim, cli, estimator, set(coin_pairs)
+
+
+@pytest.mark.asyncio
+async def test_static_fee_rate() -> None:
+    """
+    Test if the fee estimator converges to a set prediction after a certain number
+    of full blocks with a set average fee rate.
+    """
+
+    typical_cost = 2 * 5900283  # Cost for a typical main wallet spend
+    fee = uint64(typical_cost * 2)
+    num_coins_per_block = 2
+    num_rounds = 30
+    sim = None
+
+    def always(mm: MempoolManager, mi: MempoolItem) -> bool:
+        return True
+
+    def wait_5_blocks(mm: MempoolManager, mi: MempoolItem) -> bool:
+        assert mm.peak
+        return mm.peak.height >= mi.height_added_to_mempool + 5
+
+    try:
+        height = 0
+        max_block_cost = int(typical_cost * 1.5)
+        constants = {"MAX_BLOCK_COST_CLVM": max_block_cost, "MEMPOOL_BLOCK_BUFFER": 1}
+        sim, cli, estimator, spend_pairs = await init_test(the_puzzle_hash, num_coins_per_block, constants=constants)
+        phs = [the_puzzle_hash for _ in range(num_coins_per_block)]
+        # coin_values = [x + 1 for x in range(num_coins)]
+
+        for step in range(1, 1 + num_rounds):
+            height = sim.get_height()
+
+            tx_fees = [fee for _ in spend_pairs]
+            new_unspent_pairs, new_pairs = await transfer_coins(
+                sim, cli, spend_pairs, phs, tx_fees, the_puzzle_hash, wait_5_blocks
+            )
+
+            # remove new_unspent_coins from new_spend_coins
+            assert len(new_unspent_pairs) + len(new_pairs) == len(spend_pairs)
+
+            log.warning(f"step {step} DELTA: new_spend_coins={len(new_pairs)}, new_unspent={len(new_unspent_pairs)}")
+
+            spend_pairs = new_pairs | new_unspent_pairs
+            unspent_pairs = new_unspent_pairs
+
+            log.warning(f"step {step} STATE:     spend_coins={len(spend_pairs)},     unspent={len(unspent_pairs)}")
+
+            log.warning(f"mempool size: {len(sim.mempool_manager.mempool.spends)}")
+            log.warning(f"{sim.mempool_manager.mempool.spends.keys()}")
+            log.warning(f"{sim.mempool_manager.mempool.spends.values()}")
+            fees_in_mempool = 0
+            for m in sim.mempool_manager.mempool.spends.values():
+                fees_in_mempool += m.spend_bundle.fees()
+            log.warning(f"fees_in_mempool={fees_in_mempool}")
+
+        log.warning(estimator.get_tracker().short_horizon.max_confirms)
+        log.warning(estimator.get_tracker().short_horizon.max_periods)
+
+        rate = FeeRate.create(Mojos(fee), CLVMCost(uint64(typical_cost)))
+        est = estimator.estimate_fee_rate(time_offset_seconds=240)
+        log.warning(f"height: {height}  estimate: {est}  rate: {rate}")
+        fee_stats: FeeStat = estimator.get_tracker().short_horizon
+        log.warning(fee_stats)
+        assert est.mojos_per_clvm_cost > rate.mojos_per_clvm_cost
+
+    finally:
+        if sim:
+            await sim.close()


### PR DESCRIPTION

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->

Fix issue in fee estimator: Don't re-create fee estimator on each new block when Mempool is recreated

<!-- What is the current behavior?** (You can also link to an open issue here) -->


<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->

Testing Notes: Try `chia show -f` while blocks are full

<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
