### PR TITLE
enable memos in transactions

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -58,6 +58,10 @@ def print_transaction(tx: TransactionRecord, verbose: bool, name, address_prefix
         print(f"Amount {description}: {chia_amount} {name}")
         print(f"To address: {to_address}")
         print("Created at:", datetime.fromtimestamp(tx.created_at_time).strftime("%Y-%m-%d %H:%M:%S"))
+        memos = "n/a"
+        if tx.memos and tx.memos[0][1:]:
+            memos = ", ".join([x.decode("utf-8") for x in tx.memos[0][1]])
+        print(f"Memos: {memos}")
         print("")
 
 
@@ -429,7 +433,8 @@ async def make_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
                         total_amounts_requested.setdefault(summary["asset"], fungible_asset_dict[summary["asset"]])
                         total_amounts_requested[summary["asset"]] += summary["amount"]
                         print(
-                            f"    - {converted_amount} {summary['asset']} ({summary['amount']} mojos) to {summary['address']}"  # noqa
+                            f"    - {converted_amount} {summary['asset']} ({summary['amount']} mojos)"
+                            " to {summary['address']}"
                         )
 
                 print()
@@ -662,7 +667,8 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
                     total_amounts_requested.setdefault(summary["asset"], fungible_asset_dict[summary["asset"]])
                     total_amounts_requested[summary["asset"]] += summary["amount"]
                     print(
-                        f"    - {converted_amount} {summary['asset']} ({summary['amount']} mojos) to {summary['address']}"  # noqa
+                        f"    - {converted_amount} {summary['asset']} ({summary['amount']} mojos)"
+                        " to {summary['address']}"
                     )
 
             print()

--- a/chia/wallet/util/compute_memos.py
+++ b/chia/wallet/util/compute_memos.py
@@ -14,11 +14,12 @@ from chia.types.spend_bundle import SpendBundle
 
 def compute_memos_for_spend(coin_spend: CoinSpend) -> Dict[bytes32, List[bytes]]:
     _, result = coin_spend.puzzle_reveal.run_with_cost(INFINITE_COST, coin_spend.solution)
+    coin_name = coin_spend.coin.name()
     memos: Dict[bytes32, List[bytes]] = {}
     for condition in result.as_python():
         if condition[0] == ConditionOpcode.CREATE_COIN and len(condition) >= 4:
             # If only 3 elements (opcode + 2 args), there is no memo, this is ph, amount
-            coin_added = Coin(coin_spend.coin.name(), bytes32(condition[1]), int_from_bytes(condition[2]))
+            coin_added = Coin(coin_name, bytes32(condition[1]), int_from_bytes(condition[2]))
             if type(condition[3]) != list:
                 # If it's not a list, it's not the correct format
                 continue

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1501,6 +1501,7 @@ class WalletStateManager:
                         await self.tx_store.set_confirmed(record.name, height)
             elif not change:
                 timestamp = await self.wallet_node.get_timestamp_for_height(height)
+                memos = []
                 # only calculate memos for standard transactions
                 if wallet_type == WalletType.STANDARD_WALLET:
                     # we're trying to avoid fetching parent coin, so directly calling fetch p/s


### PR DESCRIPTION
**What is the purpose of the changes in this PR?**
To populate transactions with memos that were sent with coins. 


**What is the current behavior?**
The memos are not read from the blockchain so no memos are present in `Transaction` object.


**What is the new behavior (if this is a feature change)?**
Memos will appear when printing transactions in CLI and `Transaction` object will have memos filled. 

**Testing notes**
We should test if this has significant impact on performance and if there are cases where we could miss filling memos.


_I tested toilet wallet (on testnet) and memos make syncing about **3X SLOWER**_
