### PR TITLE
Remove redundant checks in validate_spend_bundle()

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -394,19 +394,11 @@ class MempoolManager:
             return Err.INVALID_SPEND_BUNDLE, None, []
 
         additions: List[Coin] = additions_for_npc(npc_result)
-
         additions_dict: Dict[bytes32, Coin] = {}
+        addition_amount: int = 0
         for add in additions:
             additions_dict[add.name()] = add
-
-        addition_amount: int = 0
-        # Check additions for max coin amount
-        for coin in additions:
-            if coin.amount < 0:
-                return Err.COIN_AMOUNT_NEGATIVE, None, []
-            if coin.amount > self.constants.MAX_COIN_AMOUNT:
-                return Err.COIN_AMOUNT_EXCEEDS_MAXIMUM, None, []
-            addition_amount = addition_amount + coin.amount
+            addition_amount = addition_amount + add.amount
         # Check for duplicate outputs
         addition_counter = collections.Counter(_.name() for _ in additions)
         for k, v in addition_counter.items():

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import asyncio
-from typing import Any, Iterator, List, Optional
+from typing import Any, List, Optional
 
 import pytest
 import pytest_asyncio
@@ -30,49 +29,43 @@ TEST_COIN_ID = TEST_COIN.name()
 TEST_COIN_RECORD = CoinRecord(TEST_COIN, uint32(0), uint32(0), False, TEST_TIMESTAMP)
 TEST_COIN_RECORDS = {TEST_COIN_ID: TEST_COIN_RECORD}
 TEST_HEIGHT = uint32(1)
-TEST_BLOCK_RECORD = BlockRecord(
-    IDENTITY_PUZZLE_HASH,
-    IDENTITY_PUZZLE_HASH,
-    TEST_HEIGHT,
-    uint128(0),
-    uint128(0),
-    uint8(0),
-    ClassgroupElement(bytes100(b"0" * 100)),
-    None,
-    IDENTITY_PUZZLE_HASH,
-    IDENTITY_PUZZLE_HASH,
-    uint64(0),
-    IDENTITY_PUZZLE_HASH,
-    IDENTITY_PUZZLE_HASH,
-    uint64(0),
-    uint8(0),
-    False,
-    uint32(TEST_HEIGHT - 1),
-    TEST_TIMESTAMP,
-    None,
-    uint64(0),
-    None,
-    None,
-    None,
-    None,
-    None,
-)
 
 
 async def get_coin_record(coin_id: bytes32) -> Optional[CoinRecord]:
     return TEST_COIN_RECORDS.get(coin_id)
 
 
-@pytest.fixture(scope="module")
-def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    loop = asyncio.get_event_loop()
-    yield loop
-
-
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture(scope="function")
 async def mempool_manager() -> MempoolManager:
     mempool_manager = MempoolManager(get_coin_record, DEFAULT_CONSTANTS)
-    await mempool_manager.new_peak(TEST_BLOCK_RECORD, None)
+    test_block_record = BlockRecord(
+        IDENTITY_PUZZLE_HASH,
+        IDENTITY_PUZZLE_HASH,
+        TEST_HEIGHT,
+        uint128(0),
+        uint128(0),
+        uint8(0),
+        ClassgroupElement(bytes100(b"0" * 100)),
+        None,
+        IDENTITY_PUZZLE_HASH,
+        IDENTITY_PUZZLE_HASH,
+        uint64(0),
+        IDENTITY_PUZZLE_HASH,
+        IDENTITY_PUZZLE_HASH,
+        uint64(0),
+        uint8(0),
+        False,
+        uint32(TEST_HEIGHT - 1),
+        TEST_TIMESTAMP,
+        None,
+        uint64(0),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    await mempool_manager.new_peak(test_block_record, None)
     return mempool_manager
 
 

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -6,10 +6,7 @@ import pytest
 from blspy import G2Element
 
 from chia.consensus.block_record import BlockRecord
-from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.full_node.bundle_tools import simple_solution_generator
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.full_node.mempool_manager import MempoolManager
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.coin import Coin
@@ -19,7 +16,7 @@ from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
-from chia.util.errors import Err, ValidationError
+from chia.util.errors import ValidationError
 from chia.util.ints import uint8, uint32, uint64, uint128
 
 IDENTITY_PUZZLE = Program.to(1)
@@ -75,13 +72,6 @@ def spend_bundle_from_conditions(conditions: List[List[Any]]) -> SpendBundle:
     return SpendBundle([coin_spend], G2Element())
 
 
-def get_name_puzzle_conditions_on_spendbundle(mempool_manager: MempoolManager, sb: SpendBundle) -> NPCResult:
-    program = simple_solution_generator(sb)
-    max_cost = int(mempool_manager.limit_factor * mempool_manager.constants.MAX_BLOCK_COST_CLVM)
-    cost_per_byte = mempool_manager.constants.COST_PER_BYTE
-    return get_name_puzzle_conditions(program, max_cost=max_cost, cost_per_byte=cost_per_byte, mempool_mode=True)
-
-
 @pytest.mark.asyncio
 async def test_negative_addition_amount() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
@@ -91,8 +81,6 @@ async def test_negative_addition_amount() -> None:
     # Addressed in https://github.com/Chia-Network/chia_rs/pull/99
     with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
-    result = get_name_puzzle_conditions_on_spendbundle(mempool_manager, sb)
-    assert result.error == Err.INVALID_CONDITION.value
 
 
 @pytest.mark.asyncio
@@ -103,8 +91,6 @@ async def test_valid_addition_amount() -> None:
     sb = spend_bundle_from_conditions(conditions)
     npc_result = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
     assert npc_result.error is None
-    result = get_name_puzzle_conditions_on_spendbundle(mempool_manager, sb)
-    assert result.error is None
 
 
 @pytest.mark.asyncio
@@ -117,5 +103,3 @@ async def test_too_big_addition_amount() -> None:
     # Addressed in https://github.com/Chia-Network/chia_rs/pull/99
     with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
-    result = get_name_puzzle_conditions_on_spendbundle(mempool_manager, sb)
-    assert result.error == Err.INVALID_CONDITION.value

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Iterator, List, Optional
+
+import pytest
+import pytest_asyncio
+from blspy import G2Element
+
+from chia.consensus.block_record import BlockRecord
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.full_node.mempool_manager import MempoolManager
+from chia.types.blockchain_format.classgroup import ClassgroupElement
+from chia.types.blockchain_format.coin import Coin
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32, bytes100
+from chia.types.coin_record import CoinRecord
+from chia.types.coin_spend import CoinSpend
+from chia.types.condition_opcodes import ConditionOpcode
+from chia.types.spend_bundle import SpendBundle
+from chia.util.errors import ValidationError
+from chia.util.ints import uint8, uint32, uint64, uint128
+
+IDENTITY_PUZZLE = Program.to(1)
+IDENTITY_PUZZLE_HASH = IDENTITY_PUZZLE.get_tree_hash()
+
+TEST_COIN = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, uint64(1000000000))
+TEST_HEIGHT = uint32(1)
+TEST_TIMESTAMP = uint64(1616108400)
+TEST_BLOCK_RECORD = BlockRecord(
+    IDENTITY_PUZZLE_HASH,
+    IDENTITY_PUZZLE_HASH,
+    TEST_HEIGHT,
+    uint128(0),
+    uint128(0),
+    uint8(0),
+    ClassgroupElement(bytes100(b"0" * 100)),
+    None,
+    IDENTITY_PUZZLE_HASH,
+    IDENTITY_PUZZLE_HASH,
+    uint64(0),
+    IDENTITY_PUZZLE_HASH,
+    IDENTITY_PUZZLE_HASH,
+    uint64(0),
+    uint8(0),
+    False,
+    uint32(TEST_HEIGHT - 1),
+    TEST_TIMESTAMP,
+    None,
+    uint64(0),
+    None,
+    None,
+    None,
+    None,
+    None,
+)
+
+
+async def get_coin_record(_: bytes32) -> Optional[CoinRecord]:
+    return None
+
+
+@pytest.fixture(scope="module")
+def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    loop = asyncio.get_event_loop()
+    yield loop
+
+
+@pytest_asyncio.fixture(scope="module")
+async def mempool_manager() -> MempoolManager:
+    mempool_manager = MempoolManager(get_coin_record, DEFAULT_CONSTANTS)
+    await mempool_manager.new_peak(TEST_BLOCK_RECORD, None)
+    return mempool_manager
+
+
+def spend_bundle_from_conditions(conditions: List[List[Any]]) -> SpendBundle:
+    solution = Program.to(conditions)
+    coin_spend = CoinSpend(TEST_COIN, IDENTITY_PUZZLE, solution)
+    return SpendBundle([coin_spend], G2Element())
+
+
+@pytest.mark.asyncio
+async def test_addition_amount(mempool_manager: MempoolManager) -> None:
+    # Negative amount
+    conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, -1]]
+    sb = spend_bundle_from_conditions(conditions)
+    sb_name = sb.name()
+    with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
+        await mempool_manager.pre_validate_spendbundle(sb, None, sb_name)
+    # Big but valid amount
+    max_amount = mempool_manager.constants.MAX_COIN_AMOUNT
+    conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, max_amount]]
+    sb = spend_bundle_from_conditions(conditions)
+    npc_result = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+    assert npc_result.error is None
+    # Too big amount
+    conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, max_amount + 1]]
+    sb = spend_bundle_from_conditions(conditions)
+    with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
+        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -86,6 +86,8 @@ def spend_bundle_from_conditions(conditions: List[List[Any]]) -> SpendBundle:
 async def test_negative_addition_amount(mempool_manager: MempoolManager) -> None:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, -1]]
     sb = spend_bundle_from_conditions(conditions)
+    # chia_rs currently emits this instead of Err.COIN_AMOUNT_NEGATIVE
+    # Addressed in https://github.com/Chia-Network/chia_rs/pull/99
     with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
 
@@ -104,5 +106,7 @@ async def test_too_big_addition_amount(mempool_manager: MempoolManager) -> None:
     max_amount = mempool_manager.constants.MAX_COIN_AMOUNT
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, max_amount + 1]]
     sb = spend_bundle_from_conditions(conditions)
+    # chia_rs currently emits this instead of Err.COIN_AMOUNT_EXCEEDS_MAXIMUM
+    # Addressed in https://github.com/Chia-Network/chia_rs/pull/99
     with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())


### PR DESCRIPTION
This simplifies the mempool by removing `COIN_AMOUNT_NEGATIVE` and `COIN_AMOUNT_EXCEEDS_MAXIMUM` checks that are already performed on the Rust side.
The Rust side currently emits `Err.INVALID_CONDITION` for these checks. An exploration to make it return more appropriate values is in https://github.com/Chia-Network/chia_rs/pull/99
The added tests pass before and after introducing the code changes.