### PR TITLE
Cleanup: Add specific error if derivation missing

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -432,7 +432,8 @@ class WalletStateManager:
             record: Optional[DerivationRecord] = await self.puzzle_store.get_derivation_record(
                 unused, wallet_id, hardened
             )
-            assert record is not None
+            if record is None:
+                raise ValueError(f"Missing derivation '{unused}' for wallet id '{wallet_id}' (hardened={hardened})")
 
             # Set this key to used so we never use it again
             await self.puzzle_store.set_used_up_to(record.index)


### PR DESCRIPTION
Purpose: To add a little better logging output when a particular exception happens

Currently, if the derivation is missing, a generic AssertionError is raised (see #13500) 
`File "chia\wallet\wallet_state_manager.py", line 446, in get_unused_derivation_record AssertionError`

This change will instead raise a ValueError with a more helpful string "Missing derivation '{unused}' for wallet id '{wallet_id}' (hardened={hardened})" - this is a debugging aid.

Note, that the cause of #13500 continues to be investigated