### PR TITLE
server: Fix invalid attribute accesses in `WSChiaConnection`

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -408,7 +408,7 @@ class ChiaServer:
             self.log.debug(f"Not connecting to {target_node}")
             return True
         for connection in self.all_connections.values():
-            if connection.host == target_node.host and connection.peer_server_port == target_node.port:
+            if connection.peer_host == target_node.host and connection.peer_server_port == target_node.port:
                 self.log.debug(f"Not connecting to {target_node}, duplicate connection")
                 return True
         return False

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -364,7 +364,7 @@ class WSChiaConnection:
                 # peer protocol violation
                 error_message = f"WSConnection.invoke sent message {sent_message_type.name} "
                 f"but received {recv_message_type.name}"
-                await self.ban_peer_bad_protocol(self.error_message)
+                await self.ban_peer_bad_protocol(error_message)
                 raise ProtocolError(Err.INVALID_PROTOCOL_MESSAGE, [error_message])
 
             recv_method = getattr(class_for_type(self.local_type), recv_message_type.name)

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import pytest
+
+from chia.full_node.full_node_api import FullNodeAPI
+from chia.server.server import ChiaServer
+from chia.simulator.block_tools import BlockTools
+from chia.types.peer_info import PeerInfo
+from chia.util.ints import uint16
+
+
+@pytest.mark.asyncio
+async def test_duplicate_client_connection(
+    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    _, _, server_1, server_2, _ = two_nodes
+    assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
+    assert not await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->


They are not yet discovered by `mypy` because we override `__getattr__` here https://github.com/Chia-Network/chia-blockchain/blob/b916275540451ff38b1c2456c294924eea306ac2/chia/server/ws_connection.py#L340

which just returns a coroutine (`Any` by hint) for whatever attribute you request.

This will be fixed in #14052. 

