### PR TITLE
Add Arch Linux to install-gui.sh script

### DIFF
--- a/install-gui.sh
+++ b/install-gui.sh
@@ -152,7 +152,7 @@ if [ "$(uname)" = "Linux" ]; then
     #Arch Linux
     if ! nodejs_is_installed; then
       echo "Installing nodejs on Arch Linux"
-      sudo pacman -Sy nodejs npm
+      sudo pacman -S nodejs npm
     fi
     do_install_npm_locally
   fi

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -148,6 +148,13 @@ if [ "$(uname)" = "Linux" ]; then
       sudo dnf install -y nodejs
     fi
     do_install_npm_locally
+  elif type pacman >/dev/null 2>&1 && [ -f /etc/arch-release ]; then
+    #Arch Linux
+    if ! nodejs_is_installed; then
+      echo "Installing nodejs on Arch Linux"
+      sudo pacman -Sy nodejs npm
+    fi
+    do_install_npm_locally
   fi
 elif [ "$(uname)" = "Darwin" ] && type brew >/dev/null 2>&1; then
   # MacOS


### PR DESCRIPTION
Install-gui.sh will now install nodejs and npm on Arch Linux

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
To Allow Arch Linux to use the install-gui script when npm or nodejs is not installed


<!-- What is the current behavior?** (You can also link to an open issue here) -->
The script will exit and the gui will not install
https://github.com/Chia-Network/chia-blockchain/issues/13719

<!-- What is the new behavior (if this is a feature change)? -->
Npm and NodeJS Will install, allowing the GUI install to continue


<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->
No


<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->
Tested manually on Arch linux


<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
