### PR TITLE
Run pre-commit SQL checks as a module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
     -   id: check-sql
         name: Validate SQL statements
-        entry: ./tests/check_sql_statements.py
+        entry: python3 -m tests.check_sql_statements
         language: python
         pass_filenames: false
 -   repo: local


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/actions/runs/3635648615/jobs/6134930513#step:9:45
```python-traceback
Traceback (most recent call last):
  File "/home/runner/work/chia-blockchain/chia-blockchain/tests/build-init-files.py", line 14, in <module>
    import logging
  File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/logging/__init__.py", line 26, in <module>
    import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
  File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/re.py", line 124, in <module>
    import enum
  File "/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/enum.py", line 2, in <module>
    from types import MappingProxyType, DynamicClassAttribute
ImportError: cannot import name 'MappingProxyType' from 'types' (/home/runner/work/chia-blockchain/chia-blockchain/tests/types/__init__.py)
```

Running the file directly by the filesystem path has side effects including adding the containing directory to the beginning of the import search path.  In this case that made `tests/types/` shadow the stdlib module `types` resulting in the import failure.  Running it as a module using `-m` and the Python import path avoids this.


<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
