### PR TITLE
util: Rework `get_host_addr`

### DIFF
--- a/chia/server/reconnect_task.py
+++ b/chia/server/reconnect_task.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from logging import Logger
-from typing import Optional
 
 from chia.server.server import ChiaServer
 from chia.types.peer_info import PeerInfo
@@ -10,7 +9,7 @@ from chia.util.network import get_host_addr
 
 
 def start_reconnect_task(
-    server: ChiaServer, peer_info_arg: PeerInfo, log: Logger, prefer_ipv6: Optional[bool]
+    server: ChiaServer, peer_info_arg: PeerInfo, log: Logger, prefer_ipv6: bool
 ) -> asyncio.Task[None]:
     """
     Start a background task that checks connection and reconnects periodically to a peer.
@@ -19,7 +18,7 @@ def start_reconnect_task(
     if peer_info_arg.is_valid():
         peer_info = peer_info_arg
     else:
-        peer_info = PeerInfo(get_host_addr(peer_info_arg, prefer_ipv6), peer_info_arg.port)
+        peer_info = PeerInfo(str(get_host_addr(peer_info_arg.host, prefer_ipv6)), peer_info_arg.port)
 
     async def connection_check() -> None:
         while True:

--- a/chia/server/reconnect_task.py
+++ b/chia/server/reconnect_task.py
@@ -18,7 +18,7 @@ def start_reconnect_task(
     if peer_info_arg.is_valid():
         peer_info = peer_info_arg
     else:
-        peer_info = PeerInfo(str(get_host_addr(peer_info_arg.host, prefer_ipv6)), peer_info_arg.port)
+        peer_info = PeerInfo(str(get_host_addr(peer_info_arg.host, prefer_ipv6=prefer_ipv6)), peer_info_arg.port)
 
     async def connection_check() -> None:
         while True:

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -193,7 +193,7 @@ class Service(Generic[_T_RpcServiceProtocol]):
             raise ServiceException(f"Peer {peer} already added")
 
         self._reconnect_tasks[peer] = start_reconnect_task(
-            self._server, peer, self._log, self.config.get("prefer_ipv6")
+            self._server, peer, self._log, self.config.get("prefer_ipv6", False)
         )
 
     async def setup_process_global_state(self) -> None:

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -321,7 +321,9 @@ async def setup_introducer(bt: BlockTools, port: int) -> AsyncGenerator[Service[
 
 async def setup_vdf_client(bt: BlockTools, self_hostname: str, port: int) -> AsyncGenerator[asyncio.Task[Any], None]:
     lock = asyncio.Lock()
-    vdf_task_1 = asyncio.create_task(spawn_process(self_hostname, port, 1, lock, bt.config.get("prefer_ipv6", False)))
+    vdf_task_1 = asyncio.create_task(
+        spawn_process(self_hostname, port, 1, lock, prefer_ipv6=bt.config.get("prefer_ipv6", False))
+    )
 
     def stop() -> None:
         asyncio.create_task(kill_processes(lock))
@@ -337,9 +339,15 @@ async def setup_vdf_clients(
     bt: BlockTools, self_hostname: str, port: int
 ) -> AsyncGenerator[Tuple[asyncio.Task[Any], asyncio.Task[Any], asyncio.Task[Any]], None]:
     lock = asyncio.Lock()
-    vdf_task_1 = asyncio.create_task(spawn_process(self_hostname, port, 1, lock, bt.config.get("prefer_ipv6", False)))
-    vdf_task_2 = asyncio.create_task(spawn_process(self_hostname, port, 2, lock, bt.config.get("prefer_ipv6", False)))
-    vdf_task_3 = asyncio.create_task(spawn_process(self_hostname, port, 3, lock, bt.config.get("prefer_ipv6", False)))
+    vdf_task_1 = asyncio.create_task(
+        spawn_process(self_hostname, port, 1, lock, prefer_ipv6=bt.config.get("prefer_ipv6", False))
+    )
+    vdf_task_2 = asyncio.create_task(
+        spawn_process(self_hostname, port, 2, lock, prefer_ipv6=bt.config.get("prefer_ipv6", False))
+    )
+    vdf_task_3 = asyncio.create_task(
+        spawn_process(self_hostname, port, 3, lock, prefer_ipv6=bt.config.get("prefer_ipv6", False))
+    )
 
     def stop() -> None:
         asyncio.create_task(kill_processes(lock))

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -321,7 +321,7 @@ async def setup_introducer(bt: BlockTools, port: int) -> AsyncGenerator[Service[
 
 async def setup_vdf_client(bt: BlockTools, self_hostname: str, port: int) -> AsyncGenerator[asyncio.Task[Any], None]:
     lock = asyncio.Lock()
-    vdf_task_1 = asyncio.create_task(spawn_process(self_hostname, port, 1, lock, bt.config.get("prefer_ipv6")))
+    vdf_task_1 = asyncio.create_task(spawn_process(self_hostname, port, 1, lock, bt.config.get("prefer_ipv6", False)))
 
     def stop() -> None:
         asyncio.create_task(kill_processes(lock))
@@ -337,9 +337,9 @@ async def setup_vdf_clients(
     bt: BlockTools, self_hostname: str, port: int
 ) -> AsyncGenerator[Tuple[asyncio.Task[Any], asyncio.Task[Any], asyncio.Task[Any]], None]:
     lock = asyncio.Lock()
-    vdf_task_1 = asyncio.create_task(spawn_process(self_hostname, port, 1, lock, bt.config.get("prefer_ipv6")))
-    vdf_task_2 = asyncio.create_task(spawn_process(self_hostname, port, 2, lock, bt.config.get("prefer_ipv6")))
-    vdf_task_3 = asyncio.create_task(spawn_process(self_hostname, port, 3, lock, bt.config.get("prefer_ipv6")))
+    vdf_task_1 = asyncio.create_task(spawn_process(self_hostname, port, 1, lock, bt.config.get("prefer_ipv6", False)))
+    vdf_task_2 = asyncio.create_task(spawn_process(self_hostname, port, 2, lock, bt.config.get("prefer_ipv6", False)))
+    vdf_task_3 = asyncio.create_task(spawn_process(self_hostname, port, 3, lock, bt.config.get("prefer_ipv6", False)))
 
     def stop() -> None:
         asyncio.create_task(kill_processes(lock))

--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -4,7 +4,7 @@ import pathlib
 import signal
 import time
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import pkg_resources
 
@@ -39,7 +39,7 @@ def find_vdf_client() -> pathlib.Path:
     raise FileNotFoundError("can't find vdf_client binary")
 
 
-async def spawn_process(host: str, port: int, counter: int, lock: asyncio.Lock, prefer_ipv6: Optional[bool]):
+async def spawn_process(host: str, port: int, counter: int, lock: asyncio.Lock, prefer_ipv6: bool):
     global stopped
     global active_processes
     path_to_vdf_client = find_vdf_client()
@@ -85,7 +85,9 @@ async def spawn_all_processes(config: Dict, net_config: Dict, lock: asyncio.Lock
     if process_count == 0:
         log.info("Process_count set to 0, stopping TLauncher.")
         return
-    awaitables = [spawn_process(hostname, port, i, lock, net_config.get("prefer_ipv6")) for i in range(process_count)]
+    awaitables = [
+        spawn_process(hostname, port, i, lock, net_config.get("prefer_ipv6", False)) for i in range(process_count)
+    ]
     await asyncio.gather(*awaitables)
 
 

--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -39,7 +39,7 @@ def find_vdf_client() -> pathlib.Path:
     raise FileNotFoundError("can't find vdf_client binary")
 
 
-async def spawn_process(host: str, port: int, counter: int, lock: asyncio.Lock, prefer_ipv6: bool):
+async def spawn_process(host: str, port: int, counter: int, lock: asyncio.Lock, *, prefer_ipv6: bool):
     global stopped
     global active_processes
     path_to_vdf_client = find_vdf_client()
@@ -49,7 +49,7 @@ async def spawn_process(host: str, port: int, counter: int, lock: asyncio.Lock, 
         try:
             dirname = path_to_vdf_client.parent
             basename = path_to_vdf_client.name
-            resolved = get_host_addr(host, prefer_ipv6)
+            resolved = get_host_addr(host, prefer_ipv6=prefer_ipv6)
             proc = await asyncio.create_subprocess_shell(
                 f"{basename} {resolved} {port} {counter}",
                 stdout=asyncio.subprocess.PIPE,
@@ -86,7 +86,8 @@ async def spawn_all_processes(config: Dict, net_config: Dict, lock: asyncio.Lock
         log.info("Process_count set to 0, stopping TLauncher.")
         return
     awaitables = [
-        spawn_process(hostname, port, i, lock, net_config.get("prefer_ipv6", False)) for i in range(process_count)
+        spawn_process(hostname, port, i, lock, prefer_ipv6=net_config.get("prefer_ipv6", False))
+        for i in range(process_count)
     ]
     await asyncio.gather(*awaitables)
 

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -109,7 +109,7 @@ def class_for_type(type: NodeType) -> Any:
     raise ValueError("No class for type")
 
 
-def get_host_addr(host: str, prefer_ipv6: bool = False) -> IPAddress:
+def get_host_addr(host: str, *, prefer_ipv6: bool = False) -> IPAddress:
     # If there was no preference passed in (from config), set the system-wide
     # default here.  Not a great place to locate a default value, and we should
     # probably do something to write it into the config, but.  For now...

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -110,9 +110,6 @@ def class_for_type(type: NodeType) -> Any:
 
 
 def get_host_addr(host: str, *, prefer_ipv6: bool = False) -> IPAddress:
-    # If there was no preference passed in (from config), set the system-wide
-    # default here.  Not a great place to locate a default value, and we should
-    # probably do something to write it into the config, but.  For now...
     try:
         return ip_address(host)
     except ValueError:

--- a/tests/util/test_network.py
+++ b/tests/util/test_network.py
@@ -14,10 +14,10 @@ class TestNetwork:
     async def test_get_host_addr4(self):
         # Run these tests forcing IPv4 resolution
         prefer_ipv6 = False
-        assert get_host_addr("127.0.0.1", prefer_ipv6) == ip_address("127.0.0.1")
-        assert get_host_addr("10.11.12.13", prefer_ipv6) == ip_address("10.11.12.13")
-        assert get_host_addr("localhost", prefer_ipv6) == ip_address("127.0.0.1")
-        assert get_host_addr("example.net", prefer_ipv6) == ip_address("93.184.216.34")
+        assert get_host_addr("127.0.0.1", prefer_ipv6=prefer_ipv6) == ip_address("127.0.0.1")
+        assert get_host_addr("10.11.12.13", prefer_ipv6=prefer_ipv6) == ip_address("10.11.12.13")
+        assert get_host_addr("localhost", prefer_ipv6=prefer_ipv6) == ip_address("127.0.0.1")
+        assert get_host_addr("example.net", prefer_ipv6=prefer_ipv6) == ip_address("93.184.216.34")
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -27,10 +27,10 @@ class TestNetwork:
     async def test_get_host_addr6(self):
         # Run these tests forcing IPv6 resolution
         prefer_ipv6 = True
-        assert get_host_addr("::1", prefer_ipv6) == ip_address("::1")
-        assert get_host_addr("2000:1000::1234:abcd", prefer_ipv6) == ip_address("2000:1000::1234:abcd")
+        assert get_host_addr("::1", prefer_ipv6=prefer_ipv6) == ip_address("::1")
+        assert get_host_addr("2000:1000::1234:abcd", prefer_ipv6=prefer_ipv6) == ip_address("2000:1000::1234:abcd")
         # ip6-localhost is not always available, and localhost is IPv4 only
         # on some systems.  Just test neither here.
-        # assert get_host_addr("ip6-localhost", prefer_ipv6) == ip_address("::1")
-        # assert get_host_addr("localhost", prefer_ipv6) == ip_address("::1")
-        assert get_host_addr("example.net", prefer_ipv6) == ip_address("2606:2800:220:1:248:1893:25c8:1946")
+        # assert get_host_addr("ip6-localhost", prefer_ipv6=prefer_ipv6) == ip_address("::1")
+        # assert get_host_addr("localhost", prefer_ipv6=prefer_ipv6) == ip_address("::1")
+        assert get_host_addr("example.net", prefer_ipv6=prefer_ipv6) == ip_address("2606:2800:220:1:248:1893:25c8:1946")

--- a/tests/util/test_network.py
+++ b/tests/util/test_network.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from ipaddress import ip_address
 
 import pytest
 
@@ -13,10 +14,10 @@ class TestNetwork:
     async def test_get_host_addr4(self):
         # Run these tests forcing IPv4 resolution
         prefer_ipv6 = False
-        assert get_host_addr("127.0.0.1", prefer_ipv6) == "127.0.0.1"
-        assert get_host_addr("10.11.12.13", prefer_ipv6) == "10.11.12.13"
-        assert get_host_addr("localhost", prefer_ipv6) == "127.0.0.1"
-        assert get_host_addr("example.net", prefer_ipv6) == "93.184.216.34"
+        assert get_host_addr("127.0.0.1", prefer_ipv6) == ip_address("127.0.0.1")
+        assert get_host_addr("10.11.12.13", prefer_ipv6) == ip_address("10.11.12.13")
+        assert get_host_addr("localhost", prefer_ipv6) == ip_address("127.0.0.1")
+        assert get_host_addr("example.net", prefer_ipv6) == ip_address("93.184.216.34")
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -26,10 +27,10 @@ class TestNetwork:
     async def test_get_host_addr6(self):
         # Run these tests forcing IPv6 resolution
         prefer_ipv6 = True
-        assert get_host_addr("::1", prefer_ipv6) == "::1"
-        assert get_host_addr("2000:1000::1234:abcd", prefer_ipv6) == "2000:1000::1234:abcd"
+        assert get_host_addr("::1", prefer_ipv6) == ip_address("::1")
+        assert get_host_addr("2000:1000::1234:abcd", prefer_ipv6) == ip_address("2000:1000::1234:abcd")
         # ip6-localhost is not always available, and localhost is IPv4 only
         # on some systems.  Just test neither here.
-        # assert get_host_addr("ip6-localhost", prefer_ipv6) == "::1"
-        # assert get_host_addr("localhost", prefer_ipv6) == "::1"
-        assert get_host_addr("example.net", prefer_ipv6) == "2606:2800:220:1:248:1893:25c8:1946"
+        # assert get_host_addr("ip6-localhost", prefer_ipv6) == ip_address("::1")
+        # assert get_host_addr("localhost", prefer_ipv6) == ip_address("::1")
+        assert get_host_addr("example.net", prefer_ipv6) == ip_address("2606:2800:220:1:248:1893:25c8:1946")


### PR DESCRIPTION
Start of a series of PR's working towards using

```
IPAddress = Union[IPv4Address, IPv6Address]
```

wherever we use string hosts except in some places where they are needed because it can be a domain also. One example would be in `PeerInfo` to use `address: IPAddress` instead of `host: str` which is a big example since it will require a bunch of other changes and will also be done in few steps but i think at the end if this is all done things will be much cleaner.