### PR TITLE
server: Resolve config peers earlier

### DIFF
--- a/chia/server/reconnect_task.py
+++ b/chia/server/reconnect_task.py
@@ -5,26 +5,18 @@ from logging import Logger
 
 from chia.server.server import ChiaServer
 from chia.types.peer_info import PeerInfo
-from chia.util.network import get_host_addr
 
 
-def start_reconnect_task(
-    server: ChiaServer, peer_info_arg: PeerInfo, log: Logger, prefer_ipv6: bool
-) -> asyncio.Task[None]:
+def start_reconnect_task(server: ChiaServer, peer_info: PeerInfo, log: Logger) -> asyncio.Task[None]:
     """
     Start a background task that checks connection and reconnects periodically to a peer.
     """
-    # If peer_info_arg is already an address, use it, otherwise resolve it here.
-    if peer_info_arg.is_valid():
-        peer_info = peer_info_arg
-    else:
-        peer_info = PeerInfo(str(get_host_addr(peer_info_arg.host, prefer_ipv6=prefer_ipv6)), peer_info_arg.port)
 
     async def connection_check() -> None:
         while True:
             peer_retry = True
             for _, connection in server.all_connections.items():
-                if connection.get_peer_info() == peer_info or connection.get_peer_info() == peer_info_arg:
+                if connection.get_peer_info() == peer_info:
                     peer_retry = False
             if peer_retry:
                 log.info(f"Reconnecting to peer {peer_info}")

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -16,6 +16,7 @@ from chia.util.chia_logging import initialize_service_logging
 from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.keychain import Keychain
+from chia.util.network import get_host_addr
 
 # See: https://bugs.python.org/issue29288
 "".encode("idna")
@@ -36,7 +37,9 @@ def create_farmer_service(
     connect_peers = []
     fnp = service_config.get("full_node_peer")
     if fnp is not None:
-        connect_peers.append(PeerInfo(fnp["host"], fnp["port"]))
+        connect_peers.append(
+            PeerInfo(str(get_host_addr(fnp["host"], prefer_ipv6=config.get("prefer_ipv6", False))), fnp["port"])
+        )
 
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -192,9 +192,7 @@ class Service(Generic[_T_RpcServiceProtocol]):
         if self._reconnect_tasks.get(peer) is not None:
             raise ServiceException(f"Peer {peer} already added")
 
-        self._reconnect_tasks[peer] = start_reconnect_task(
-            self._server, peer, self._log, self.config.get("prefer_ipv6", False)
-        )
+        self._reconnect_tasks[peer] = start_reconnect_task(self._server, peer, self._log)
 
     async def setup_process_global_state(self) -> None:
         # Being async forces this to be run from within an active event loop as is

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -16,6 +16,7 @@ from chia.util.chia_logging import initialize_service_logging
 from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.keychain import Keychain
+from chia.util.network import get_host_addr
 from chia.util.task_timing import maybe_manage_task_instrumentation
 from chia.wallet.wallet_node import WalletNode
 
@@ -56,8 +57,10 @@ def create_wallet_service(
     fnp = service_config.get("full_node_peer")
 
     if fnp:
-        connect_peers = [PeerInfo(fnp["host"], fnp["port"])]
-        node.full_node_peer = PeerInfo(fnp["host"], fnp["port"])
+        node.full_node_peer = PeerInfo(
+            str(get_host_addr(fnp["host"], prefer_ipv6=config.get("prefer_ipv6", False))), fnp["port"]
+        )
+        connect_peers = [node.full_node_peer]
     else:
         connect_peers = []
         node.full_node_peer = None


### PR DESCRIPTION
Don't pass around `PeerInfo` objects with a non-IP host.

Based on:
- #14068 