### PR TITLE
Fixed an issue where `label-conflict` action did not run when opening a PR

### DIFF
--- a/.github/workflows/conflict-check.yml
+++ b/.github/workflows/conflict-check.yml
@@ -6,7 +6,7 @@ on:
   # We recommend `pull_request_target` so that github secrets are available.
   # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
-    types: [synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   main:


### PR DESCRIPTION
## What is the purpose of the changes in this PR?
There was an issue where actual conflict status and label did not match.
https://github.com/Chia-Network/chia-blockchain/pull/14052
https://github.com/Chia-Network/chia-blockchain/actions/runs/3631834598/jobs/6126986602#step:2:182
The mismatch seems to be happened because the `label-conflict` action did not run after the conflict resolved.

## What is the current behavior?
`label-conflict` action does not run when PR from forked branch is opened/reopened.

## What is the new behavior (if this is a feature change)?
`label-conflict` action does run when PR from forked branch is opened/reopened.

## Does this PR introduce a breaking change?
No

## Testing notes (is this code covered by tests, or equivalent manual testing?)
In the workflow jobs in this PR, there is not a `label-conflict` action on `pull_request_target` context.
(Only `label-conflict` action of `push` to `main` ran but it seems the action of push context does not run for forked PR)

<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
