### PR TITLE
Make `--number-of-coins` required for the `chia coins split` CLI

### DIFF
--- a/chia/cmds/coins.py
+++ b/chia/cmds/coins.py
@@ -198,6 +198,7 @@ def combine_cmd(
     "--number-of-coins",
     type=int,
     help="The number of coins we are creating.",
+    required=True,
 )
 @click.option(
     "-m",


### PR DESCRIPTION
```python-traceback
chia wallet coins split -f 353135768 -a 1 -t 0xd34ab3bec670fc473acda616bcab1f05665ced504c7c058d18ddb836ff7e6b12
Exception from 'wallet' '>' not supported between instances of 'NoneType' and 'int':
Traceback (most recent call last):
  File "/home/william/chia-blockchain/chia/cmds/cmds_util.py", line 100, in get_any_service_client
    yield node_client, config, fingerprint
  File "/home/william/chia-blockchain/chia/cmds/cmds_util.py", line 211, in execute_with_wallet
    await function(extra_params, wallet_client, new_fp)
  File "/home/william/chia-blockchain/chia/cmds/coin_funcs.py", line 184, in async_split
    if number_of_coins > 500:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

I think that this command doesn't make sense without a number of coins to create.  There is probably no sensible default so the option should just be required.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
