### PR TITLE
pools: Fix delayed pool config updates

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -314,10 +314,8 @@ class PoolWallet:
         if self._update_pool_config_after_sync_task is None or self._update_pool_config_after_sync_task.done():
 
             async def update_pool_config_after_sync_task():
-                synced = await self.wallet_state_manager.synced()
-                while not synced:
-                    await asyncio.sleep(5)  # we sync pretty quickly, so I think this is ok.
-                    synced = await self.wallet_state_manager.synced()
+                while not await self.wallet_state_manager.synced():
+                    await asyncio.sleep(5)
                 await self.update_pool_config()
                 self.log.info("Updated pool config after syncing finished.")
 

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -306,7 +306,11 @@ class PoolWallet:
                     self.next_transaction_fee = uint64(0)
                 break
 
-        await self.update_pool_config_after_sync()  # Update pool config after we finish syncing.
+        if self.wallet_state_manager.synced():
+            await self.update_pool_config()
+        else:
+            await self.update_pool_config_after_sync()
+
         return True
 
     async def update_pool_config_after_sync(self) -> None:


### PR DESCRIPTION
We are in a DB write transaction when we are inside `apply_state_transition` where we then create a new task which fetches the plotnft state from the database. Now, if the wallet is already synced / if we call the update https://github.com/Chia-Network/chia-blockchain/blob/2dea800491302b06f555cbc545607d184f5ea1e6/chia/pools/pool_wallet.py#L321 before the DB transaction was closed we don't get the latest plotnft state since its not yet committed to the DB.  9771183265df2957cac0baa3dce5cfa9bb29851b fixes this by creating the config dict within the same task which has the write transaction open so that we get the latest data still and then it puts it into the task.

2aced3ca39a9b66c62ed8b5c747e762dd7ce073b adds a test and the other commits are some cleanups while at it. 

Fixes issues like https://github.com/Chia-Network/chia-blockchain/issues/13872