### PR TITLE
 fix for short option collision

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -174,7 +174,7 @@ def get_transactions_cmd(
 )
 @click.option(
     "--exclude-coin",
-    "exclude_coins",
+    "coins_to_exclude",
     multiple=True,
     help="Exclude this coin from being spent.",
 )

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -189,7 +189,7 @@ def send_cmd(
     override: bool,
     min_coin_amount: str,
     max_coin_amount: str,
-    exclude_coins: Tuple[str],
+    coins_to_exclude: Tuple[str],
 ) -> None:
     extra_params = {
         "id": id,
@@ -200,7 +200,7 @@ def send_cmd(
         "override": override,
         "min_coin_amount": min_coin_amount,
         "max_coin_amount": max_coin_amount,
-        "exclude_coin_ids": list(exclude_coins),
+        "exclude_coin_ids": list(coins_to_exclude),
     }
     import asyncio
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -173,8 +173,8 @@ def get_transactions_cmd(
     default="0",
 )
 @click.option(
-    "-e",
-    "--exclude-coin-ids",
+    "--exclude-coin",
+    "exclude_coins",
     multiple=True,
     help="Exclude this coin from being spent.",
 )
@@ -189,7 +189,7 @@ def send_cmd(
     override: bool,
     min_coin_amount: str,
     max_coin_amount: str,
-    exclude_coin_ids: Tuple[str],
+    exclude_coins: Tuple[str],
 ) -> None:
     extra_params = {
         "id": id,
@@ -200,7 +200,7 @@ def send_cmd(
         "override": override,
         "min_coin_amount": min_coin_amount,
         "max_coin_amount": max_coin_amount,
-        "exclude_coin_ids": list(exclude_coin_ids),
+        "exclude_coin_ids": list(exclude_coins),
     }
     import asyncio
 


### PR DESCRIPTION
Newly added option for --exclude-coin-ids had conflicting short option with --memo. This caused a variety of issues.

Resolution: Remove short option for --exclude-coin-ids - also small cleanup to long option