### PR TITLE
patch capabilities for old clients

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -257,11 +257,12 @@ def init(
 
 
 def chia_version_number() -> Tuple[str, str, str, str]:
-    scm_full_version = __version__
+    return get_version_numbers(__version__)
+
+
+def get_version_numbers(scm_full_version: str) -> Tuple[str, str, str, str]:
     left_full_version = scm_full_version.split("+")
-
     version = left_full_version[0].split(".")
-
     scm_major_version = version[0]
     scm_minor_version = version[1]
     if len(version) > 2:
@@ -269,11 +270,9 @@ def chia_version_number() -> Tuple[str, str, str, str]:
         patch_release_number = smc_patch_version
     else:
         smc_patch_version = ""
-
     major_release_number = scm_major_version
     minor_release_number = scm_minor_version
     dev_release_number = ""
-
     # If this is a beta dev release - get which beta it is
     if "0b" in scm_minor_version:
         original_minor_ver_list = scm_minor_version.split("0b")
@@ -294,13 +293,11 @@ def chia_version_number() -> Tuple[str, str, str, str]:
         minor_release_number = scm_minor_version
         patch_release_number = smc_patch_version
         dev_release_number = ""
-
     install_release_number = major_release_number + "." + minor_release_number
     if len(patch_release_number) > 0:
         install_release_number += "." + patch_release_number
     if len(dev_release_number) > 0:
         install_release_number += dev_release_number
-
     return major_release_number, minor_release_number, patch_release_number, dev_release_number
 
 

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -49,3 +49,10 @@ capabilities = [
     (uint16(Capability.RATE_LIMITS_V2.value), "1"),
     (uint16(Capability.NONE_RESPONSE.value), "1"),
 ]
+
+# capabilities to send to nodes prior to 1.7
+limitedcapabilties = [
+    (uint16(Capability.BASE.value), "1"),
+    (uint16(Capability.BLOCK_HEADERS.value), "1"),
+    (uint16(Capability.RATE_LIMITS_V2.value), "1"),
+]

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -50,7 +50,7 @@ capabilities = [
     (uint16(Capability.NONE_RESPONSE.value), "1"),
 ]
 
-# capabilities to send to nodes prior to 1.7
+# capabilities to send to nodes prior to 1.6.2
 limitedcapabilties = [
     (uint16(Capability.BASE.value), "1"),
     (uint16(Capability.BLOCK_HEADERS.value), "1"),

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -693,6 +693,9 @@ class WSChiaConnection:
         version = software_version.split(".")
         major = int(version[0])
         minor = int(version[1])
-        if major == 1 and minor < 7:
+        patch_version = 0
+        if len(version) > 2:
+            patch_version = int(version[2])
+        if major == 1 and minor < 6 and patch_version < 2:
             return limitedcapabilties
         return self.local_capabilities_for_handshake

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -18,7 +18,7 @@ from chia.cmds.init_funcs import chia_full_version_str
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.protocol_state_machine import message_requires_reply, message_response_ok
 from chia.protocols.protocol_timing import API_EXCEPTION_BAN_SECONDS, INTERNAL_PROTOCOL_ERROR_BAN_SECONDS
-from chia.protocols.shared_protocol import Capability, Handshake
+from chia.protocols.shared_protocol import Capability, Handshake, limitedcapabilties
 from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.rate_limits import RateLimiter
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -171,23 +171,23 @@ class WSChiaConnection:
         server_port: int,
         local_type: NodeType,
     ) -> None:
-        outbound_handshake = make_msg(
-            ProtocolMessageTypes.handshake,
-            Handshake(
-                network_id,
-                protocol_version,
-                chia_full_version_str(),
-                uint16(server_port),
-                uint8(local_type.value),
-                self.local_capabilities_for_handshake,
-            ),
-        )
         if self.is_outbound:
+            outbound_handshake = make_msg(
+                ProtocolMessageTypes.handshake,
+                Handshake(
+                    network_id,
+                    protocol_version,
+                    chia_full_version_str(),
+                    uint16(server_port),
+                    uint8(local_type.value),
+                    self.local_capabilities_for_handshake,
+                ),
+            )
             await self._send_message(outbound_handshake)
             inbound_handshake_msg = await self._read_one_message()
             if inbound_handshake_msg is None:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
-            inbound_handshake = Handshake.from_bytes(inbound_handshake_msg.data)
+            inbound_handshake: Handshake = Handshake.from_bytes(inbound_handshake_msg.data)
 
             # Handle case of invalid ProtocolMessageType
             try:
@@ -228,7 +228,22 @@ class WSChiaConnection:
             inbound_handshake = Handshake.from_bytes(message.data)
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
+
+            outbound_handshake = make_msg(
+                ProtocolMessageTypes.handshake,
+                Handshake(
+                    network_id,
+                    protocol_version,
+                    chia_full_version_str(),
+                    uint16(server_port),
+                    uint8(local_type.value),
+                    self.get_capabilties_for_version(inbound_handshake.software_version),
+                ),
+            )
+
             await self._send_message(outbound_handshake)
+            self.version = inbound_handshake.software_version
+            self.protocol_version = inbound_handshake.protocol_version
             self.peer_server_port = inbound_handshake.server_port
             self.connection_type = NodeType(inbound_handshake.node_type)
             # "1" means capability is enabled
@@ -672,3 +687,12 @@ class WSChiaConnection:
 
     def has_capability(self, capability: Capability) -> bool:
         return capability in self.peer_capabilities
+
+    # only send limitedcapabilties to peers before 1.7
+    def get_capabilties_for_version(self, software_version: str) -> list[tuple[uint16, str]]:
+        version = software_version.split(".")
+        major = int(version[0])
+        minor = int(version[1])
+        if major == 1 and minor < 7:
+            return limitedcapabilties
+        return self.local_capabilities_for_handshake

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -693,12 +693,17 @@ class WSChiaConnection:
         return capability in self.peer_capabilities
 
     # only send limitedcapabilties to peers before 1.6.2
+    # see https://github.com/Chia-Network/chia-blockchain/commit/618f93b4c42b176659cc74c02a4dd711adc62052
+    # for why that version was selected
     def get_capabilties_for_version(self, software_version: str) -> list[tuple[uint16, str]]:
         major, minor, patch, _ = get_version_numbers(software_version)
         patch_number = 0
-        path_split = re.findall("[0-9]+", patch)  # extract number from patch string
-        if len(path_split) > 1:
-            patch_number = path_split[0]
-        if (int(major), int(minor), int(patch_number)) < (1, 6, 2):
-            return limitedcapabilties
+        try:
+            path_split = re.findall("[0-9]+", patch)  # extract number from patch string
+            if len(path_split) > 1:
+                patch_number = path_split[0]
+            if (int(major), int(minor), int(patch_number)) < (1, 6, 2):
+                return limitedcapabilties
+        except Exception:
+            self.log.error(f"could not parse incoming version {software_version}, returning limited capabilities")
         return self.local_capabilities_for_handshake

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -699,6 +699,6 @@ class WSChiaConnection:
         path_split = re.findall("[0-9]+", patch)  # extract number from patch string
         if len(path_split) > 1:
             patch_number = path_split[0]
-        if int(major) == 1 and int(minor) <= 6 and int(patch_number) < 2:
+        if (int(major), int(minor), int(patch_number)) < (1, 6, 2):
             return limitedcapabilties
         return self.local_capabilities_for_handshake

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -19,6 +19,7 @@ from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.protocol_state_machine import message_requires_reply, message_response_ok
 from chia.protocols.protocol_timing import API_EXCEPTION_BAN_SECONDS, INTERNAL_PROTOCOL_ERROR_BAN_SECONDS
 from chia.protocols.shared_protocol import Capability, Handshake, limitedcapabilties
+from chia.server.capabilities import known_active_capabilities
 from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.rate_limits import RateLimiter
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import logging
 from typing import Tuple
+
 import pytest
+
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.shared_protocol import Capability
 from chia.server import ws_connection

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import logging
 from typing import Tuple
-from unittest.mock import MagicMock, patch
-
 import pytest
-
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.shared_protocol import Capability, capabilities
+from chia.server import ws_connection
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
@@ -26,22 +24,26 @@ async def test_duplicate_client_connection(
 
 
 @pytest.mark.asyncio
-@patch("chia.server.ws_connection.chia_full_version_str", MagicMock(return_value="1.5.0b657"))
-async def test_capabilities_back_comp_fix(
-    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
+async def test_capabilities_back_comp_before_17(
+    monkeypatch, two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
 ) -> None:
+    def getverold():
+        return "1.6.0b657"
+    monkeypatch.setattr(ws_connection, "chia_full_version_str", getverold)
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]
     assert con.has_capability(Capability.NONE_RESPONSE) is False
 
-
 @pytest.mark.asyncio
-async def test_capabilities_curr_version(
-    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
+async def test_capabilities_back_comp_fix_17_or_above(
+    monkeypatch, two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
 ) -> None:
+    def getver17():
+        return "1.7.0b657"
+    monkeypatch.setattr(ws_connection, "chia_full_version_str", getver17)
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]
-    for cap in capabilities:
-        assert con.has_capability(Capability(cap[0]))
+    assert con.has_capability(Capability.NONE_RESPONSE) is True
+

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -44,4 +44,4 @@ async def test_capabilities_curr_version(
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]
     for cap in capabilities:
-        assert Capability(cap[0]) in con.peer_capabilities
+        assert con.has_capability(Capability(cap[0]))

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -8,7 +8,6 @@ import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.shared_protocol import Capability, capabilities
-from chia.server import ws_connection
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
@@ -27,10 +26,10 @@ async def test_duplicate_client_connection(
 
 
 @pytest.mark.asyncio
+@patch("chia.server.ws_connection.chia_full_version_str", MagicMock(return_value="1.5.0b657"))
 async def test_capabilities_back_comp_fix(
     two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
 ) -> None:
-    ws_connection.chia_full_version_str = MagicMock(return_value="1.5.0b657")
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -8,6 +8,7 @@ import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.shared_protocol import Capability, capabilities
+from chia.server import ws_connection
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
@@ -26,10 +27,10 @@ async def test_duplicate_client_connection(
 
 
 @pytest.mark.asyncio
-@patch("chia.server.ws_connection.chia_full_version_str", MagicMock(return_value="1.5.0b657"))
 async def test_capabilities_back_comp_fix(
     two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
 ) -> None:
+    ws_connection.chia_full_version_str = MagicMock(return_value="1.5.0b657")
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -8,7 +8,6 @@ import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.shared_protocol import Capability, capabilities
-from chia.server import ws_connection
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
@@ -27,14 +26,14 @@ async def test_duplicate_client_connection(
 
 
 @pytest.mark.asyncio
+@patch("chia.server.ws_connection.chia_full_version_str", MagicMock(return_value="1.5.0b657"))
 async def test_capabilities_back_comp_fix(
     two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
 ) -> None:
-    ws_connection.chia_full_version_str = MagicMock(return_value="1.5.0b657")
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]
-    assert Capability.NONE_RESPONSE not in con.peer_capabilities
+    assert con.has_capability(Capability.NONE_RESPONSE) is False
 
 
 @pytest.mark.asyncio

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -26,11 +26,15 @@ async def test_duplicate_client_connection(
 
 
 @pytest.mark.asyncio
-async def test_capabilities_back_comp_before_17(  # type: ignore
-    monkeypatch, two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
+@pytest.mark.parametrize("version", ["1.6.1b657", "1.6.abcb657", "1.6.0abcb657", "1.5.0abcb657"])
+async def test_capabilities_back_comp_before_162(  # type: ignore
+    monkeypatch,
+    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    self_hostname: str,
+    version: str,
 ) -> None:
     def getverold() -> str:
-        return "1.6.0b657"
+        return version
 
     monkeypatch.setattr(ws_connection, "chia_full_version_str", getverold)
     _, _, server_1, server_2, _ = two_nodes
@@ -40,13 +44,17 @@ async def test_capabilities_back_comp_before_17(  # type: ignore
 
 
 @pytest.mark.asyncio
-async def test_capabilities_back_comp_fix_17_or_above(  # type: ignore
-    monkeypatch, two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
+@pytest.mark.parametrize("version", ["1.6.2b657", "1.6.3b657"])
+async def test_capabilities_back_comp_fix_162_or_above(  # type: ignore
+    monkeypatch,
+    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    self_hostname: str,
+    version: str,
 ) -> None:
-    def getver17() -> str:
-        return "1.7.0b657"
+    def getver162() -> str:
+        return version
 
-    monkeypatch.setattr(ws_connection, "chia_full_version_str", getver17)
+    monkeypatch.setattr(ws_connection, "chia_full_version_str", getver162)
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import logging
 from typing import Tuple
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
+from chia.protocols.shared_protocol import Capability, capabilities
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
+
+log = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
@@ -18,3 +23,25 @@ async def test_duplicate_client_connection(
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     assert not await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
+
+
+@pytest.mark.asyncio
+@patch("chia.server.ws_connection.chia_full_version_str", MagicMock(return_value="1.5.0b657"))
+async def test_capabilities_back_comp_fix(
+    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    _, _, server_1, server_2, _ = two_nodes
+    assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
+    con = server_2.get_connections()[0]
+    assert Capability.NONE_RESPONSE not in con.peer_capabilities
+
+
+@pytest.mark.asyncio
+async def test_capabilities_curr_version(
+    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    _, _, server_1, server_2, _ = two_nodes
+    assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
+    con = server_2.get_connections()[0]
+    for cap in capabilities:
+        assert Capability(cap[0]) in con.peer_capabilities

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -4,7 +4,7 @@ import logging
 from typing import Tuple
 import pytest
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.protocols.shared_protocol import Capability, capabilities
+from chia.protocols.shared_protocol import Capability
 from chia.server import ws_connection
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
@@ -24,26 +24,28 @@ async def test_duplicate_client_connection(
 
 
 @pytest.mark.asyncio
-async def test_capabilities_back_comp_before_17(
+async def test_capabilities_back_comp_before_17(  # type: ignore
     monkeypatch, two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
 ) -> None:
-    def getverold():
+    def getverold() -> str:
         return "1.6.0b657"
+
     monkeypatch.setattr(ws_connection, "chia_full_version_str", getverold)
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]
     assert con.has_capability(Capability.NONE_RESPONSE) is False
 
+
 @pytest.mark.asyncio
-async def test_capabilities_back_comp_fix_17_or_above(
+async def test_capabilities_back_comp_fix_17_or_above(  # type: ignore
     monkeypatch, two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str
 ) -> None:
-    def getver17():
+    def getver17() -> str:
         return "1.7.0b657"
+
     monkeypatch.setattr(ws_connection, "chia_full_version_str", getver17)
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     con = server_2.get_connections()[0]
     assert con.has_capability(Capability.NONE_RESPONSE) is True
-


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->
make sure we dont send new capabilities for clients under 1.6.2
no breaking changes, fixes the issue where old clients would disconnect new one but only for the older clients outbound connections 

example:
a 1.5 peer initiates a connection to a 1.6.2 peer, the 1.6.2 knows what 1.5 supports and only sends those to avoid the disconnect

this cant be done the other way because of who sends the first handshake message with the version and supported capabilties 

<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
