### PR TITLE
Fees should always be in XCH mojos units

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -219,7 +219,7 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
         print(f"Wallet id: {wallet_id} not found.")
         return
 
-    final_fee = uint64(int(fee * mojo_per_unit))
+    final_fee: uint64 = uint64(int(fee * units["chia"]))  # fees are always in XCH mojos
     final_amount: uint64 = uint64(int(amount * mojo_per_unit))
     final_min_coin_amount: uint64 = uint64(int(min_coin_amount * mojo_per_unit))
     final_max_coin_amount: uint64 = uint64(int(max_coin_amount * mojo_per_unit))


### PR DESCRIPTION
Fixes bug introduced in #13325 where the CLI would use CAT units for fee calculations instead of XCH mojos.
Fees should always be in XCH mojos

Currently, when sending CATs using the CLI, the fee will be calculated incorrectly and is multiplied by the incorrect multiplier

This fix puts back the proper behaviour.

This resolves #14118 

This is a fix to a bug introduced in not-yet-released code.