### PR TITLE
Fix display issues when listing coins from a CAT wallet

### DIFF
--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -27,7 +27,7 @@ async def async_list(args: Dict[str, Any], wallet_client: WalletRpcClient, finge
     if paginate is None:
         paginate = sys.stdout.isatty()
     try:
-        wallet_type: WalletType = await get_wallet_type(wallet_id=wallet_id, wallet_client=wallet_client)
+        wallet_type = await get_wallet_type(wallet_id=wallet_id, wallet_client=wallet_client)
         mojo_per_unit = get_mojo_per_unit(wallet_type)
     except LookupError:
         print(f"Wallet id: {wallet_id} not found.")
@@ -45,9 +45,10 @@ async def async_list(args: Dict[str, Any], wallet_client: WalletRpcClient, finge
         excluded_amounts=final_excluded_amounts,
         excluded_coin_ids=excluded_coin_ids,
     )
-    coin_type: str = "XCH" if addr_prefix == "xch" else "TXCH"
     if wallet_type == WalletType.CAT:
-        coin_type = "CAT"  # override XCH/TXCH prefix for CAT wallet
+        coin_ticker = "CAT"
+    else:
+        coin_ticker = "XCH" if addr_prefix == "xch" else "TXCH"
 
     print(f"There are a total of {len(conf_coins) + len(unconfirmed_additions)} coins in wallet {wallet_id}.")
     print(f"{len(conf_coins)} confirmed coins.")
@@ -59,7 +60,7 @@ async def async_list(args: Dict[str, Any], wallet_client: WalletRpcClient, finge
         [(cr.coin, str(cr.confirmed_block_index)) for cr in conf_coins],
         mojo_per_unit,
         addr_prefix,
-        coin_type,
+        coin_ticker,
         paginate,
     )
     if show_unconfirmed:
@@ -69,7 +70,7 @@ async def async_list(args: Dict[str, Any], wallet_client: WalletRpcClient, finge
             [(cr.coin, str(cr.confirmed_block_index)) for cr in unconfirmed_removals],
             mojo_per_unit,
             addr_prefix,
-            coin_type,
+            coin_ticker,
             paginate,
         )
         print("\nUnconfirmed Additions:")
@@ -78,7 +79,7 @@ async def async_list(args: Dict[str, Any], wallet_client: WalletRpcClient, finge
             [(coin, "") for coin in unconfirmed_additions],
             mojo_per_unit,
             addr_prefix,
-            coin_type,
+            coin_ticker,
             paginate,
         )
 
@@ -88,7 +89,7 @@ def print_coins(
     coins: List[Tuple[Coin, str]],
     mojo_per_unit: int,
     addr_prefix: str,
-    coin_type: str,
+    coin_ticker: str,
     paginate: bool,
 ) -> None:
     if len(coins) == 0:
@@ -101,7 +102,7 @@ def print_coins(
                 break
             coin, conf_height = coins[i + j]
             address = encode_puzzle_hash(coin.puzzle_hash, addr_prefix)
-            amount_str = print_balance(coin.amount, mojo_per_unit, coin_type, decimal_only=True)
+            amount_str = print_balance(coin.amount, mojo_per_unit, coin_ticker, decimal_only=True)
             print(f"Coin ID: 0x{coin.name().hex()}")
             print(target_string.format(address, amount_str, conf_height))
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -219,7 +219,7 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
         print(f"Wallet id: {wallet_id} not found.")
         return
 
-    final_fee: uint64 = uint64(int(fee * units["chia"]))  # fees are always in XCH mojos
+    final_fee = uint64(int(fee * mojo_per_unit))
     final_amount: uint64 = uint64(int(amount * mojo_per_unit))
     final_min_coin_amount: uint64 = uint64(int(min_coin_amount * mojo_per_unit))
     final_max_coin_amount: uint64 = uint64(int(max_coin_amount * mojo_per_unit))

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -219,7 +219,7 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
         print(f"Wallet id: {wallet_id} not found.")
         return
 
-    final_fee = uint64(int(fee * mojo_per_unit))
+    final_fee: uint64 = uint64(int(fee * units["chia"]))  # fees are always in XCH mojos
     final_amount: uint64 = uint64(int(amount * mojo_per_unit))
     final_min_coin_amount: uint64 = uint64(int(min_coin_amount * mojo_per_unit))
     final_max_coin_amount: uint64 = uint64(int(max_coin_amount * mojo_per_unit))


### PR DESCRIPTION
When using `chia wallet coins list` on a CAT wallet, the display would indicate the amount of the coins in XCH/TXCH and then apply the CAT conversion to the mojos, so you would get strange output like

```
Coin ID: 0xa7a087b1d3f49937dcada65f343a0797ebc75c39176c58629689e426355a1baa
	Address: txch1fckd972smrl3pxn5z5ekeqp2nzlfnumjk8l7uulen8rc0kaur9gscy9fq8 Amount: 9.000000000000 txch (9000 mojo), Confirmed in block: 1930591
```

Where clearly 9 TXCH does not equal 9000 mojos.

This PR fixes the display to use the word CAT instead of XCH/TXCH

```
Coin ID: 0xa7a087b1d3f49937dcada65f343a0797ebc75c39176c58629689e426355a1baa
	Address: txch1fckd972smrl3pxn5z5ekeqp2nzlfnumjk8l7uulen8rc0kaur9gscy9fq8 Amount: 9.000000000000 CAT (9000 mojo), Confirmed in block: 1930591
```

This is a fix for a new feature not yet released
