### PR TITLE
Remove wallet coins subcommand including list/split/combine

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import click
 
 from chia.cmds.cmds_util import execute_with_wallet
-from chia.cmds.coins import coins_cmd
+
+# from chia.cmds.coins import coins_cmd
 from chia.cmds.plotnft import validate_fee
 from chia.wallet.transaction_sorting import SortKey
 from chia.wallet.util.address_type import AddressType
@@ -924,7 +925,8 @@ def nft_get_info_cmd(
 
 
 # Keep at bottom.
-wallet_cmd.add_command(coins_cmd)
+# Remove coins subcommand from wallet for now pending further testing
+# wallet_cmd.add_command(coins_cmd)
 
 
 @wallet_cmd.group("notifications", short_help="Send/Manage notifications")


### PR DESCRIPTION
Remove the `chia wallet coins` command. This removes the CLI options `chia wallet coins {list/combine/split}`


