### PR TITLE
Supply a reason when removing an item from the mempool

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -80,8 +80,7 @@ class Mempool:
             self.total_mempool_cost -= item.cost
             assert self.total_mempool_cost >= 0
             mempool_info = self.get_mempool_info()
-            if reason != MempoolRemoveReason.BLOCK_INCLUSION:
-                self.fee_estimator.remove_mempool_item(mempool_info, item)
+            self.fee_estimator.remove_mempool_item(mempool_info, item)
 
     def add_to_pool(self, item: MempoolItem) -> None:
         """

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from enum import IntEnum
+from enum import Enum
 from typing import Dict, List, Optional
 
 from sortedcontainers import SortedDict
@@ -18,16 +18,10 @@ from chia.types.mempool_item import MempoolItem
 from chia.util.ints import uint64
 
 
-class MempoolRemoveReason(IntEnum):
+class MempoolRemoveReason(Enum):
     CONFLICT = 1
     BLOCK_INCLUSION = 2
     POOL_FULL = 3
-
-    def __repr__(self) -> str:
-        return str(f"{self.__class__.__name__}.{self.name}")
-
-    def __str__(self) -> str:
-        return self.__repr__()
 
 
 class Mempool:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -590,7 +590,7 @@ class MempoolManager:
                 for spend in last_npc_result.conds.spends:
                     if spend.coin_id in self.mempool.removals:
                         spendbundle_ids: List[bytes32] = self.mempool.removals[bytes32(spend.coin_id)]
-                        self.mempool.remove_from_pool(spendbundle_ids)
+                        self.mempool.remove_from_pool(spendbundle_ids, MempoolRemoveReason.BLOCK_INCLUSION)
                         for spendbundle_id in spendbundle_ids:
                             self.remove_seen(spendbundle_id)
         else:

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Tuple
 import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
+from chia.full_node.mempool import MempoolRemoveReason
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_custom_interval
@@ -29,7 +30,7 @@ def assert_sb_not_in_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
 
 def evict_from_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
     mempool_item = node.full_node.mempool_manager.mempool.spends[sb.name()]
-    node.full_node.mempool_manager.mempool.remove_from_pool([mempool_item.name])
+    node.full_node.mempool_manager.mempool.remove_from_pool([mempool_item.name], MempoolRemoveReason.CONFLICT)
     node.full_node.mempool_manager.remove_seen(sb.name())
 
 


### PR DESCRIPTION
No user visible changes. This change will let the mempool know why a caller is removing a SpendBundle.

This is a required part of the Fee Estimator backend