### PR TITLE
server: Cleanup after `peer_info` holds the full `peername` data

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -261,7 +261,7 @@ class Farmer:
         )
 
     def on_disconnect(self, connection: WSChiaConnection) -> None:
-        self.log.info(f"peer disconnected {connection.get_peer_logging()}")
+        self.log.info(f"peer disconnected {connection.get_peer_info()}")
         self.state_changed("close_connection", {})
         if connection.connection_type is NodeType.HARVESTER:
             del self.plot_sync_receivers[connection.peer_node_id]

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -534,7 +534,7 @@ class FarmerAPI:
 
     @api_request(peer_required=True)
     async def respond_plots(self, _: harvester_protocol.RespondPlots, peer: WSChiaConnection):
-        self.farmer.log.warning(f"Respond plots came too late from: {peer.get_peer_logging()}")
+        self.farmer.log.warning(f"Respond plots came too late from: {peer.get_peer_info()}")
 
     @api_request(peer_required=True)
     async def plot_sync_start(self, message: PlotSyncStart, peer: WSChiaConnection):

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -639,10 +639,10 @@ class FullNode:
                     FullNodeAPI.request_block, full_node_protocol.RequestBlock(uint32(curr_height), fetch_tx)
                 )
                 if curr is None:
-                    raise ValueError(f"Failed to fetch block {curr_height} from {peer.get_peer_logging()}, timed out")
+                    raise ValueError(f"Failed to fetch block {curr_height} from {peer.get_peer_info()}, timed out")
                 if curr is None or not isinstance(curr, full_node_protocol.RespondBlock):
                     raise ValueError(
-                        f"Failed to fetch block {curr_height} from {peer.get_peer_logging()}, wrong type {type(curr)}"
+                        f"Failed to fetch block {curr_height} from {peer.get_peer_info()}, wrong type {type(curr)}"
                     )
                 blocks.append(curr.block)
                 if self.blockchain.contains_block(curr.block.prev_header_hash) or curr_height == 0:
@@ -869,7 +869,7 @@ class FullNode:
                 await self.send_peak_to_timelords()
 
     def on_disconnect(self, connection: WSChiaConnection) -> None:
-        self.log.info(f"peer disconnected {connection.get_peer_logging()}")
+        self.log.info(f"peer disconnected {connection.get_peer_info()}")
         self._state_changed("close_connection")
         self._state_changed("sync_mode")
         if self.sync_store is not None:
@@ -1244,7 +1244,7 @@ class FullNode:
         for i, block in enumerate(blocks_to_validate):
             if pre_validation_results[i].error is not None:
                 self.log.error(
-                    f"Invalid block from peer: {peer.get_peer_logging()} {Err(pre_validation_results[i].error)}"
+                    f"Invalid block from peer: {peer.get_peer_info()} {Err(pre_validation_results[i].error)}"
                 )
                 return False, None
 
@@ -1275,7 +1275,7 @@ class FullNode:
                     )
             elif result == AddBlockResult.INVALID_BLOCK or result == AddBlockResult.DISCONNECTED_BLOCK:
                 if error is not None:
-                    self.log.error(f"Error: {error}, Invalid block from peer: {peer.get_peer_logging()} ")
+                    self.log.error(f"Error: {error}, Invalid block from peer: {peer.get_peer_info()} ")
                 return False, agg_state_change_summary
             block_record = self.blockchain.block_record(block.header_hash)
             if block_record.sub_epoch_summary_included is not None:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -132,7 +132,7 @@ class FullNodeAPI:
             async with self.full_node.new_peak_sem.acquire():
                 await self.full_node.new_peak(request, peer)
         except LimitedSemaphoreFullError:
-            self.log.debug("Ignoring NewPeak, limited semaphore full: %s %s", peer.get_peer_logging(), request)
+            self.log.debug("Ignoring NewPeak, limited semaphore full: %s %s", peer.get_peer_info(), request)
             return None
 
         return None
@@ -407,7 +407,7 @@ class FullNodeAPI:
         Receive a full block from a peer full node (or ourselves).
         """
 
-        self.log.warning(f"Received unsolicited/late block from peer {peer.get_peer_logging()}")
+        self.log.warning(f"Received unsolicited/late block from peer {peer.get_peer_info()}")
         return None
 
     @api_request()
@@ -1417,7 +1417,7 @@ class FullNodeAPI:
 
         name = std_hash(request_bytes)
         if name in self.full_node.compact_vdf_requests:
-            self.log.debug("Ignoring NewCompactVDF, already requested: %s %s", peer.get_peer_logging(), request)
+            self.log.debug("Ignoring NewCompactVDF, already requested: %s %s", peer.get_peer_info(), request)
             return None
         self.full_node.compact_vdf_requests.add(name)
 
@@ -1430,7 +1430,7 @@ class FullNodeAPI:
                 finally:
                     self.full_node.compact_vdf_requests.remove(name)
         except LimitedSemaphoreFullError:
-            self.log.debug("Ignoring NewCompactVDF, limited semaphore full: %s %s", peer.get_peer_logging(), request)
+            self.log.debug("Ignoring NewCompactVDF, limited semaphore full: %s %s", peer.get_peer_info(), request)
             return None
 
         return None

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -124,7 +124,7 @@ class Harvester:
             self.plot_sync_sender.sync_done(update_result.removed, update_result.duration)
 
     def on_disconnect(self, connection: WSChiaConnection) -> None:
-        self.log.info(f"peer disconnected {connection.get_peer_logging()}")
+        self.log.info(f"peer disconnected {connection.get_peer_info()}")
         self.state_changed("close_connection")
         self.plot_sync_sender.stop()
         asyncio.run_coroutine_threadsafe(self.plot_sync_sender.await_closed(), asyncio.get_running_loop())

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -115,13 +115,11 @@ class Crawler:
             got_peak = False
             while tries < 25:
                 tries += 1
-                if peer_info is None:
-                    break
                 if peer_info in self.with_peak:
                     got_peak = True
                     break
                 await asyncio.sleep(0.1)
-            if not got_peak and peer_info is not None and self.crawl_store is not None:
+            if not got_peak and self.crawl_store is not None:
                 await self.crawl_store.peer_connected_hostname(peer_info.host, False)
             await peer.close()
 
@@ -356,8 +354,6 @@ class Crawler:
             tls_version = peer.get_tls_version()
             if tls_version is None:
                 tls_version = "unknown"
-            if peer_info is None:
-                return
             if request.height >= self.minimum_height:
                 if self.crawl_store is not None:
                     await self.crawl_store.peer_connected_hostname(peer_info.host, True, tls_version)

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -173,8 +173,6 @@ class FullNodeDiscovery:
             and self.address_manager is not None
         ):
             peer_info = peer.get_peer_info()
-            if peer_info is None:
-                return None
             if peer_info.host not in self.connection_time_pretest:
                 self.connection_time_pretest[peer_info.host] = time.time()
             if time.time() - self.connection_time_pretest[peer_info.host] > 600:
@@ -325,11 +323,8 @@ class FullNodeDiscovery:
                 groups = set()
                 full_node_connected = self.server.get_connections(NodeType.FULL_NODE, outbound=True)
                 connected = [c.get_peer_info() for c in full_node_connected]
-                connected = [c for c in connected if c is not None]
                 for conn in full_node_connected:
                     peer = conn.get_peer_info()
-                    if peer is None:
-                        continue
                     group = peer.get_group()
                     groups.add(group)
 
@@ -458,7 +453,6 @@ class FullNodeDiscovery:
             # Perform the cleanup only if we have at least 3 connections.
             full_node_connected = self.server.get_connections(NodeType.FULL_NODE)
             connected = [c.get_peer_info() for c in full_node_connected]
-            connected = [c for c in connected if c is not None]
             if self.address_manager is not None and len(connected) >= 3:
                 async with self.address_manager.lock:
                     self.address_manager.cleanup(max_timestamp_difference, max_consecutive_failures)
@@ -652,8 +646,6 @@ class FullNodePeers(FullNodeDiscovery):
                 cur_day = int(time.time()) // (24 * 60 * 60)
                 for connection in connections:
                     peer_info = connection.get_peer_info()
-                    if peer_info is None:
-                        continue
                     cur_hash = int.from_bytes(
                         bytes(
                             std_hash(
@@ -670,8 +662,6 @@ class FullNodePeers(FullNodeDiscovery):
                     if index >= num_peers:
                         break
                     peer_info = connection.get_peer_info()
-                    if peer_info is None:
-                        continue
                     async with self.lock:
                         if peer_info not in self.neighbour_known_peers:
                             self.neighbour_known_peers[peer_info] = set()

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -342,9 +342,7 @@ class ChiaServer:
             if not self.accept_inbound_connections(connection.connection_type) and not is_in_network(
                 connection.peer_info.host, self.exempt_peer_networks
             ):
-                self.log.info(
-                    f"Not accepting inbound connection: {connection.get_peer_logging()}.Inbound limit reached."
-                )
+                self.log.info(f"Not accepting inbound connection: {connection.get_peer_info()}.Inbound limit reached.")
                 await connection.close()
             else:
                 await self.connection_added(connection, self.on_connect)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -395,7 +395,7 @@ class WSChiaConnection:
                     pass
                 except Exception as e:
                     tb = traceback.format_exc()
-                    self.log.error(f"Exception: {e}, {self.get_peer_logging()}. {tb}")
+                    self.log.error(f"Exception: {e}, {self.get_peer_info()}. {tb}")
                     raise
                 return None
 
@@ -421,7 +421,7 @@ class WSChiaConnection:
         except Exception as e:
             if not self.closed:
                 tb = traceback.format_exc()
-                self.log.error(f"Exception: {e} {type(e)}, closing connection {self.get_peer_logging()}. {tb}")
+                self.log.error(f"Exception: {e} {type(e)}, closing connection {self.get_peer_info()}. {tb}")
             else:
                 self.log.debug(f"Exception: {e} while closing connection")
             # TODO: actually throw one of the errors from errors.py and pass this to close
@@ -486,7 +486,7 @@ class WSChiaConnection:
         request_start_t = time.time()
         response = await self.send_request(request, timeout)
         self.log.debug(
-            f"Time for request {request_metadata.request_type.name}: {self.get_peer_logging()} = "
+            f"Time for request {request_metadata.request_type.name}: {self.get_peer_info()} = "
             f"{time.time() - request_start_t}, None? {response is None}"
         )
         # todo or response.type == ProtocolMessageTypes.none_response.value when enabling none response
@@ -681,22 +681,9 @@ class WSChiaConnection:
         else:
             return "unknown"
 
-    def get_peer_info(self) -> Optional[PeerInfo]:
-        result = self._get_extra_info("peername")
-        if result is None:
-            return None
-        connection_host = result[0]
+    def get_peer_info(self) -> PeerInfo:
         port = self.peer_server_port if self.peer_server_port is not None else self.peer_info.port
-        return PeerInfo(connection_host, port)
-
-    def get_peer_logging(self) -> PeerInfo:
-        info: Optional[PeerInfo] = self.get_peer_info()
-        if info is None:
-            # in this case, we will use self.peer_info.host which is friendlier for logging
-            port = self.peer_server_port if self.peer_server_port is not None else self.peer_info.port
-            return PeerInfo(self.peer_info.host, port)
-        else:
-            return info
+        return PeerInfo(self.peer_info.host, port)
 
     def has_capability(self, capability: Capability) -> bool:
         return capability in self.peer_capabilities

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -91,14 +91,11 @@ class FakeServer:
 
 
 class FakePeer:
-    def get_peer_logging(self) -> PeerInfo:
-        return PeerInfo("0.0.0.0", uint16(0))
-
     def __init__(self):
         self.peer_node_id = bytes([0] * 32)
 
-    async def get_peer_info(self) -> Optional[PeerInfo]:
-        return None
+    async def get_peer_info(self) -> PeerInfo:
+        return PeerInfo("0.0.0.0", uint16(0))
 
 
 async def run_sync_test(


### PR DESCRIPTION
With the IP address fetched from the connection data's `peername` tuple now instead of passing it into `WSChiaConnection.create` we can:

- Make `get_peer_info` non-optional
- Drop `get_peer_logging` which was only required because `get_peer_info` was optional?
- Cleanup some places which assume the return of `get_peer_info` is optional

Based on:
- #14152 