### PR TITLE
Add py310 to the black target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 120
-target-version =  ['py37', 'py38', 'py39']
+target-version =  ['py37', 'py38', 'py39', 'py310']
 include = '''
 ^/(
     [^/]*.py


### PR DESCRIPTION
Black is configurable around what Python versions you support.  I forgot to add 3.10 https://github.com/Chia-Network/chia-blockchain/pull/9930 when I added 3.10 support.  I need to add 3.11 in https://github.com/Chia-Network/chia-blockchain/pull/11407 as well.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
