### PR TITLE
server: Resolve peers in harvester and timelord startup also

### DIFF
--- a/chia/server/start_harvester.py
+++ b/chia/server/start_harvester.py
@@ -15,6 +15,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.chia_logging import initialize_service_logging
 from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.network import get_host_addr
 
 # See: https://bugs.python.org/issue29288
 "".encode("idna")
@@ -62,7 +63,9 @@ async def async_main() -> int:
     service_config = load_config_cli(DEFAULT_ROOT_PATH, "config.yaml", SERVICE_NAME)
     config[SERVICE_NAME] = service_config
     initialize_service_logging(service_name=SERVICE_NAME, config=config)
-    farmer_peer = PeerInfo(service_config["farmer_peer"]["host"], service_config["farmer_peer"]["port"])
+    farmer_peer = PeerInfo(
+        str(get_host_addr(service_config["farmer_peer"]["host"])), service_config["farmer_peer"]["port"]
+    )
     service = create_harvester_service(DEFAULT_ROOT_PATH, config, DEFAULT_CONSTANTS, farmer_peer)
     await service.setup_process_global_state()
     await service.run()

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -16,6 +16,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.chia_logging import initialize_service_logging
 from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.network import get_host_addr
 
 # See: https://bugs.python.org/issue29288
 "".encode("idna")
@@ -34,7 +35,9 @@ def create_timelord_service(
 ) -> Service[Timelord]:
     service_config = config[SERVICE_NAME]
 
-    connect_peers = [PeerInfo(service_config["full_node_peer"]["host"], service_config["full_node_peer"]["port"])]
+    connect_peers = [
+        PeerInfo(str(get_host_addr(service_config["full_node_peer"]["host"])), service_config["full_node_peer"]["port"])
+    ]
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = constants.replace_str_to_bytes(**overrides)
 


### PR DESCRIPTION
Fix missing host resolving in harvester and timelord startup process  after https://github.com/Chia-Network/chia-blockchain/pull/14069.

Fixes https://github.com/Chia-Network/chia-blockchain/issues/14158.