### PR TITLE
Add a height timestamp for wallet notifications

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1196,7 +1196,12 @@ class WalletRpcApi:
 
         return {
             "notifications": [
-                {"id": notification.coin_id.hex(), "message": notification.message.hex(), "amount": notification.amount}
+                {
+                    "id": notification.coin_id.hex(),
+                    "message": notification.message.hex(),
+                    "amount": notification.amount,
+                    "height": notification.height,
+                }
                 for notification in notifications
             ]
         }

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -998,6 +998,7 @@ class WalletRpcClient(RpcClient):
                 bytes32.from_hexstr(notification["id"]),
                 bytes.fromhex(notification["message"]),
                 uint64(notification["amount"]),
+                uint32(notification["height"]),
             )
             for notification in response["notifications"]
         ]

--- a/chia/wallet/notification_manager.py
+++ b/chia/wallet/notification_manager.py
@@ -14,7 +14,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.db_wrapper import DBWrapper2
-from chia.util.ints import uint64
+from chia.util.ints import uint32, uint64
 from chia.wallet.notification_store import Notification, NotificationStore
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_memos import compute_memos_for_spend
@@ -64,7 +64,7 @@ class NotificationManager:
                         coin_state.coin.name(),
                         coin_memos[1],
                         uint64(coin_state.coin.amount),
-                        coin_state.spent_height,
+                        uint32(coin_state.spent_height),
                     )
                 )
                 self.wallet_state_manager.state_changed("new_on_chain_notification")

--- a/chia/wallet/notification_manager.py
+++ b/chia/wallet/notification_manager.py
@@ -64,6 +64,7 @@ class NotificationManager:
                         coin_state.coin.name(),
                         coin_memos[1],
                         uint64(coin_state.coin.amount),
+                        coin_state.spent_height,
                     )
                 )
                 self.wallet_state_manager.state_changed("new_on_chain_notification")

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import sqlite3
 import logging
 from typing import List, Optional, Tuple
 

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -48,8 +48,11 @@ class NotificationStore:
 
             try:
                 await conn.execute("ALTER TABLE notifications ADD COLUMN height bigint DEFAULT 0")
-            except sqlite3.OperationalError:
-                pass  # ignore what is likely Duplicate column error
+            except sqlite3.OperationalError as e:
+                if "duplicate column" in e.args[0]:
+                    pass  # ignore what is likely Duplicate column error
+                else:
+                    raise e
 
             # This used to be an accidentally created redundant index on coin_id which is already a primary key
             # We can remove this at some point in the future when it's unlikely this index still exists

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
-import sqlite3
 import logging
+import sqlite3
 from typing import List, Optional, Tuple
 
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -47,9 +47,7 @@ class NotificationStore:
             )
 
             try:
-                await conn.execute(
-                    "ALTER TABLE notifications ADD COLUMN height bigint DEFAULT 0"
-                )
+                await conn.execute("ALTER TABLE notifications ADD COLUMN height bigint DEFAULT 0")
             except sqlite3.OperationalError:
                 pass  # ignore what is likely Duplicate column error
 

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -113,10 +113,12 @@ async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted:
             else:
                 AMOUNT = uint64(750000000000)
             FEE = uint64(1)
+        peak = full_node_api.full_node.blockchain.get_peak()
+        assert peak is not None
         if case == "allow":
-            allow_height = full_node_api.full_node.blockchain.get_peak().height + 1
+            allow_height = peak.height + 1
         if case == "allow_larger":
-            allow_larger_height = full_node_api.full_node.blockchain.get_peak().height + 1
+            allow_larger_height = peak.height + 1
         tx = await notification_manager_1.send_new_notification(ph_2, bytes(case, "utf8"), AMOUNT, fee=FEE)
         await wsm_1.add_pending_transaction(tx)
         await time_out_assert_not_none(

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -113,6 +113,10 @@ async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted:
             else:
                 AMOUNT = uint64(750000000000)
             FEE = uint64(1)
+        if case == "allow":
+            allow_height = full_node_api.full_node.blockchain.get_peak().height + 1
+        if case == "allow_larger":
+            allow_larger_height = full_node_api.full_node.blockchain.get_peak().height + 1
         tx = await notification_manager_1.send_new_notification(ph_2, bytes(case, "utf8"), AMOUNT, fee=FEE)
         await wsm_1.add_pending_transaction(tx)
         await time_out_assert_not_none(
@@ -133,9 +137,11 @@ async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted:
     notifications = await notification_manager_2.notification_store.get_all_notifications(pagination=(0, 2))
     assert len(notifications) == 2
     assert notifications[0].message == b"allow_larger"
+    assert notifications[0].height == allow_larger_height
     notifications = await notification_manager_2.notification_store.get_all_notifications(pagination=(1, None))
     assert len(notifications) == 1
     assert notifications[0].message == b"allow"
+    assert notifications[0].height == allow_height
     notifications = await notification_manager_2.notification_store.get_all_notifications(pagination=(0, 1))
     assert len(notifications) == 1
     assert notifications[0].message == b"allow_larger"

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
 from secrets import token_bytes
 from typing import Any
 
@@ -11,10 +13,40 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_not_none
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
+from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint16, uint32, uint64
-
-# from clvm_tools.binutils import disassemble
+from chia.wallet.notification_store import NotificationStore
 from tests.util.wallet_is_synced import wallets_are_synced
+
+
+# For testing backwards compatibility with a DB change to add height
+@pytest.mark.asyncio
+async def test_notification_store_backwards_compat() -> None:
+    # First create the DB the way it would have otheriwse been created
+    db_name = Path(tempfile.TemporaryDirectory().name).joinpath("test.sqlite")
+    db_name.parent.mkdir(parents=True, exist_ok=True)
+    db_wrapper = await DBWrapper2.create(
+        database=db_name,
+    )
+    try:
+        async with db_wrapper.writer_maybe_transaction() as conn:
+            await conn.execute(
+                "CREATE TABLE IF NOT EXISTS notifications(" "coin_id blob PRIMARY KEY," "msg blob," "amount blob" ")"
+            )
+            cursor = await conn.execute(
+                "INSERT OR REPLACE INTO notifications " "(coin_id, msg, amount) " "VALUES(?, ?, ?)",
+                (
+                    bytes32([0] * 32),
+                    bytes([0] * 10),
+                    bytes([0]),
+                ),
+            )
+            await cursor.close()
+
+        await NotificationStore.create(db_wrapper)
+        await NotificationStore.create(db_wrapper)
+    finally:
+        await db_wrapper.close()
 
 
 @pytest.mark.parametrize(
@@ -22,7 +54,6 @@ from tests.util.wallet_is_synced import wallets_are_synced
     [True, False],
 )
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted: Any) -> None:
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]


### PR DESCRIPTION
<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->
Probably good to test a wallet that already has notifications before this patch starts up correctly with the patch.  I would write a unit test for it, but I'm not sure how to restart the wallet in the middle of a test (suggestions welcome)