### PR TITLE
coverage use [run] source_pkgs= instead of source=

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch=True
 relative_files=True
-source=
+source_pkgs=
   chia
   tests
 concurrency=multiprocessing


### PR DESCRIPTION
This avoids some collisions in some coverage reports between files in `chia/` and `tests/`.  Minimal example in https://github.com/altendky/example001 and "real" trouble observed in https://github.com/Chia-Network/chia-blockchain/pull/14141/files.

Reported to coverage at https://github.com/nedbat/coveragepy/issues/1508.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
