### PR TITLE
types: Use `IPAddress` instead of `str` in `PeerInfo`

### DIFF
--- a/chia/server/address_manager.py
+++ b/chia/server/address_manager.py
@@ -300,7 +300,7 @@ class AddressManager:
     def mark_good_(self, addr: PeerInfo, test_before_evict: bool, timestamp: int) -> None:
         self.last_good = timestamp
         (info, node_id) = self.find_(addr)
-        if not addr.is_valid(self.allow_private_subnets):
+        if addr.ip.is_private and not self.allow_private_subnets:
             return None
         if info is None:
             return None
@@ -365,7 +365,7 @@ class AddressManager:
             addr.host,
             addr.port,
         )
-        if not peer_info.is_valid(self.allow_private_subnets):
+        if peer_info.ip.is_private and not self.allow_private_subnets:
             return False
         (info, node_id) = self.find_(peer_info)
         if info is not None and info.peer_info == peer_info:
@@ -554,7 +554,7 @@ class AddressManager:
             rand_pos = randrange(len(self.random_pos) - n) + n
             self.swap_random_(n, rand_pos)
             info = self.map_info[self.random_pos[n]]
-            if not info.peer_info.is_valid(self.allow_private_subnets):
+            if info.peer_info.ip.is_private and not self.allow_private_subnets:
                 continue
             if not info.is_terrible():
                 cur_peer_info = TimestampedPeerInfo(

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -25,6 +25,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import PeerInfo, TimestampedPeerInfo
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint64
+from chia.util.network import IPAddress, get_host_addr
 
 MAX_PEERS_RECEIVED_PER_REQUEST = 1000
 MAX_TOTAL_PEERS_RECEIVED = 3000
@@ -62,7 +63,7 @@ class FullNodeDiscovery:
         random.shuffle(dns_servers)  # Don't always start with the same DNS server
         if introducer_info is not None:
             self.introducer_info: Optional[PeerInfo] = PeerInfo(
-                introducer_info["host"],
+                str(get_host_addr(introducer_info["host"], prefer_ipv6=False)),
                 introducer_info["port"],
             )
         else:
@@ -390,9 +391,6 @@ class FullNodeDiscovery:
                     addr = info.peer_info
                     if has_collision:
                         break
-                    if addr is not None and not addr.is_valid():
-                        addr = None
-                        continue
                     if not is_feeler and addr.get_group() in groups:
                         addr = None
                         continue
@@ -647,8 +645,9 @@ class FullNodePeers(FullNodeDiscovery):
                     relay_peer, num_peers = await self.relay_queue.get()
                 except asyncio.CancelledError:
                     return None
-                relay_peer_info = PeerInfo(relay_peer.host, relay_peer.port)
-                if not relay_peer_info.is_valid():
+                try:
+                    IPAddress.create(relay_peer.host)
+                except ValueError:
                     continue
                 # https://en.bitcoin.it/wiki/Satoshi_Client_Node_Discovery#Address_Relay
                 connections = self.server.get_connections(NodeType.FULL_NODE)

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -62,6 +62,8 @@ class FullNodeDiscovery:
         self.dns_servers = dns_servers
         random.shuffle(dns_servers)  # Don't always start with the same DNS server
         if introducer_info is not None:
+            # get_host_addr is blocking but this only gets called on startup or in the wallet after disconnecting from
+            # all trusted peers.
             self.introducer_info: Optional[PeerInfo] = PeerInfo(
                 str(get_host_addr(introducer_info["host"], prefer_ipv6=False)),
                 introducer_info["port"],

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -6,7 +6,7 @@ import ssl
 import time
 import traceback
 from dataclasses import dataclass, field
-from ipaddress import IPv4Network, IPv6Address, IPv6Network, ip_address, ip_network
+from ipaddress import IPv4Network, IPv6Network, ip_network
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
@@ -419,14 +419,8 @@ class ChiaServer:
             timeout_value = float(self.config.get("peer_connect_timeout", 30))
             timeout = ClientTimeout(total=timeout_value)
             session = ClientSession(timeout=timeout)
-
-            try:
-                if type(ip_address(target_node.host)) is IPv6Address:
-                    target_node = PeerInfo(f"[{target_node.host}]", target_node.port)
-            except ValueError:
-                pass
-
-            url = f"wss://{target_node.host}:{target_node.port}/ws"
+            ip = f"[{target_node.ip}]" if target_node.ip.is_v6 else f"{target_node.ip}"
+            url = f"wss://{ip}:{target_node.port}/ws"
             self.log.debug(f"Connecting: {url}, Peer info: {target_node}")
             try:
                 ws = await session.ws_connect(
@@ -656,10 +650,10 @@ class ChiaServer:
                 ip = None
         if ip is None:
             return None
-        peer = PeerInfo(ip, uint16(port))
-        if not peer.is_valid():
+        try:
+            return PeerInfo(ip, uint16(port))
+        except ValueError:
             return None
-        return peer
 
     def get_port(self) -> uint16:
         return uint16(self._port)

--- a/chia/types/peer_info.py
+++ b/chia/types/peer_info.py
@@ -2,64 +2,52 @@ from __future__ import annotations
 
 import ipaddress
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Union
 
 from chia.util.ints import uint16, uint64
+from chia.util.network import IPAddress
 from chia.util.streamable import Streamable, streamable
 
 
-@dataclass(frozen=True)
+# TODO, Replace unsafe_hash with frozen and drop the __init__ as soon as all PeerInfo call sites pass in an IPAddress.
+@dataclass(unsafe_hash=True)
 class PeerInfo:
-    host: str
-    port: uint16
+    _ip: IPAddress
+    _port: uint16
 
-    def is_valid(self, allow_private_subnets: bool = False) -> bool:
-        ip: Optional[Union[ipaddress.IPv6Address, ipaddress.IPv4Address]] = None
-        try:
-            ip = ipaddress.IPv6Address(self.host)
-        except ValueError:
-            ip = None
-        if ip is not None:
-            if ip.is_private and not allow_private_subnets:
-                return False
-            return True
+    # TODO, Drop this as soon as all call PeerInfo calls pass in an IPAddress
+    def __init__(self, host: Union[IPAddress, str], port: int):
+        self._ip = host if isinstance(host, IPAddress) else IPAddress.create(host)
+        self._port = uint16(port)
 
-        try:
-            ip = ipaddress.IPv4Address(self.host)
-        except ValueError:
-            ip = None
-        if ip is not None:
-            if ip.is_private and not allow_private_subnets:
-                return False
-            return True
-        return False
+    # Kept here for compatibility until all places where its used transitioned to IPAddress instead of str.
+    @property
+    def host(self) -> str:
+        return str(self._ip)
+
+    @property
+    def ip(self) -> IPAddress:
+        return self._ip
+
+    @property
+    def port(self) -> uint16:
+        return self._port
 
     # Functions related to peer bucketing in new/tried tables.
     def get_key(self) -> bytes:
-        try:
-            ip = ipaddress.IPv6Address(self.host)
-        except ValueError:
-            ip_v4 = ipaddress.IPv4Address(self.host)
-            ip = ipaddress.IPv6Address(int(ipaddress.IPv6Address("2002::")) | (int(ip_v4) << 80))
-        key = ip.packed
+        if self.ip.is_v4:
+            key = ipaddress.IPv6Address(int(ipaddress.IPv6Address("2002::")) | (int(self.ip) << 80)).packed
+        else:
+            key = self.ip.packed
         key += bytes([self.port // 0x100, self.port & 0x0FF])
         return key
 
     def get_group(self) -> bytes:
         # TODO: Port everything from Bitcoin.
-        ip_v4: Optional[ipaddress.IPv4Address] = None
-        ip_v6: Optional[ipaddress.IPv6Address] = None
-        try:
-            ip_v4 = ipaddress.IPv4Address(self.host)
-        except ValueError:
-            ip_v6 = ipaddress.IPv6Address(self.host)
-        if ip_v4 is not None:
-            group = bytes([1]) + ip_v4.packed[:2]
-        elif ip_v6 is not None:
-            group = bytes([0]) + ip_v6.packed[:4]
+        if self.ip.is_v4:
+            return bytes([1]) + self.ip.packed[:2]
         else:
-            raise ValueError("PeerInfo.host is not an ip address")
-        return group
+            return bytes([0]) + self.ip.packed[:4]
 
 
 @streamable

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -417,7 +417,7 @@ class TestFullNodeProtocol:
                 [TimestampedPeerInfo("127.0.0.1", uint16(1000), uint64(int(time.time())) - 1000)],
                 None,
             )
-            msg_bytes = await full_node_2.full_node.full_node_peers.request_peers(PeerInfo("[::1]", server_2._port))
+            msg_bytes = await full_node_2.full_node.full_node_peers.request_peers(PeerInfo("::1", server_2._port))
             msg = fnp.RespondPeers.from_bytes(msg_bytes.data)
             if msg is not None and not (len(msg.peer_list) == 1):
                 return False

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -75,7 +75,7 @@ async def test_simulation_farm_blocks_to_wallet(
 ) -> None:
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
-    await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
+    await wallet_server.start_client(PeerInfo("127.0.0.1", uint16(full_node_api.server._port)), None)
 
     # Avoiding an attribute error below.
     assert wallet_node.wallet_state_manager is not None
@@ -113,7 +113,7 @@ async def test_simulation_farm_rewards_to_wallet(
 ) -> None:
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
-    await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
+    await wallet_server.start_client(PeerInfo("127.0.0.1", uint16(full_node_api.server._port)), None)
 
     # Avoiding an attribute error below.
     assert wallet_node.wallet_state_manager is not None
@@ -143,7 +143,7 @@ async def test_wait_transaction_records_entered_mempool(
     tx_amount = 1
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
-    await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
+    await wallet_server.start_client(PeerInfo("127.0.0.1", uint16(full_node_api.server._port)), None)
 
     # Avoiding an attribute hint issue below.
     assert wallet_node.wallet_state_manager is not None
@@ -177,7 +177,7 @@ async def test_process_transaction_records(
     tx_amount = 1
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
-    await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
+    await wallet_server.start_client(PeerInfo("127.0.0.1", uint16(full_node_api.server._port)), None)
 
     # Avoiding an attribute hint issue below.
     assert wallet_node.wallet_state_manager is not None
@@ -219,7 +219,7 @@ async def test_create_coins_with_amounts(
 ) -> None:
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
-    await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
+    await wallet_server.start_client(PeerInfo("127.0.0.1", uint16(full_node_api.server._port)), None)
 
     # Avoiding an attribute hint issue below.
     assert wallet_node.wallet_state_manager is not None
@@ -251,7 +251,7 @@ async def test_create_coins_with_invalid_amounts_raises(
 ) -> None:
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
-    await wallet_server.start_client(PeerInfo("localhost", uint16(full_node_api.server._port)), None)
+    await wallet_server.start_client(PeerInfo("127.0.0.1", uint16(full_node_api.server._port)), None)
 
     # Avoiding an attribute hint issue below.backoff_times
     assert wallet_node.wallet_state_manager is not None

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1351,8 +1351,8 @@ async def test_nft_bulk_transfer(two_wallet_nodes: Any, trusted: Any) -> None:
         wallet_node_0.config["trusted_peers"] = {}
         wallet_node_1.config["trusted_peers"] = {}
 
-    await server_0.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
-    await server_1.start_client(PeerInfo("localhost", uint16(full_node_server._port)), None)
+    await server_0.start_client(PeerInfo("127.0.0.1", uint16(full_node_server._port)), None)
+    await server_1.start_client(PeerInfo("127.0.0.1", uint16(full_node_server._port)), None)
 
     for _ in range(1, num_blocks + 1):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))


### PR DESCRIPTION
Working towards using `IPAddress` instead of `str` all over / where it makes sense.

Based on:

- #14166 