### PR TITLE
Don't rely on noticing self.limit_factor, instead do the block limit calculation once.

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -520,7 +520,7 @@ class MempoolManager:
         log.log(
             logging.DEBUG if duration < 2 else logging.WARNING,
             f"add_spendbundle {spend_name} took {duration:0.2f} seconds. "
-            f"Cost: {cost} ({round(100.0 * cost/self.max_block_clvm_cost, 3)}% of max block cost)",
+            f"Cost: {cost} ({round(100.0 * cost/self.constants.MAX_BLOCK_COST_CLVM, 3)}% of max block cost)",
         )
 
         return None, potential, list(conflicting_pool_items.keys())

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -86,7 +86,6 @@ class MempoolManager:
     seen_bundle_hashes: Dict[bytes32, bytes32]
     get_coin_record: Callable[[bytes32], Awaitable[Optional[CoinRecord]]]
     nonzero_fee_minimum_fpc: int
-    limit_factor: float
     mempool_max_total_cost: int
     potential_cache: PendingTxCache
     seen_cache_size: int
@@ -113,7 +112,8 @@ class MempoolManager:
         # spends.
         self.nonzero_fee_minimum_fpc = 5
 
-        self.limit_factor = 0.5
+        BLOCK_SIZE_LIMIT_FACTOR = 0.5
+        self.max_block_clvm_cost = int(self.constants.MAX_BLOCK_COST_CLVM * BLOCK_SIZE_LIMIT_FACTOR)
         self.mempool_max_total_cost = int(self.constants.MAX_BLOCK_COST_CLVM * self.constants.MEMPOOL_BLOCK_BUFFER)
 
         # Transactions that were unable to enter mempool, used for retry. (they were invalid)
@@ -134,7 +134,7 @@ class MempoolManager:
         self.mempool: Mempool = Mempool(
             self.mempool_max_total_cost,
             uint64(self.nonzero_fee_minimum_fpc),
-            uint64(self.constants.MAX_BLOCK_COST_CLVM),
+            uint64(self.max_block_clvm_cost),
         )
 
     def shut_down(self) -> None:
@@ -154,7 +154,7 @@ class MempoolManager:
                     continue
                 log.info(f"Cumulative cost: {cost_sum}, fee per cost: {item.fee / item.cost}")
                 if (
-                    item.cost + cost_sum > self.limit_factor * self.constants.MAX_BLOCK_COST_CLVM
+                    item.cost + cost_sum > self.max_block_clvm_cost
                     or item.fee + fee_sum > self.constants.MAX_COIN_AMOUNT
                 ):
                     return (spend_bundles, uint64(cost_sum), additions, removals)
@@ -184,13 +184,13 @@ class MempoolManager:
 
             item_inclusion_filter = always
 
-        log.info(f"Starting to make block, max cost: {self.constants.MAX_BLOCK_COST_CLVM}")
+        log.info(f"Starting to make block, max cost: {self.max_block_clvm_cost}")
         spend_bundles, cost_sum, additions, removals = self.process_mempool_items(item_inclusion_filter)
         if len(spend_bundles) == 0:
             return None
         log.info(
             f"Cumulative cost of block (real cost should be less) {cost_sum}. Proportion "
-            f"full: {cost_sum / self.constants.MAX_BLOCK_COST_CLVM}"
+            f"full: {cost_sum / self.max_block_clvm_cost}"
         )
         agg = SpendBundle.aggregate(spend_bundles)
         return agg, additions, removals
@@ -295,7 +295,7 @@ class MempoolManager:
             self.pool,
             validate_clvm_and_signature,
             new_spend_bytes,
-            int(self.limit_factor * self.constants.MAX_BLOCK_COST_CLVM),
+            self.max_block_clvm_cost,
             self.constants.COST_PER_BYTE,
             self.constants.AGG_SIG_ME_ADDITIONAL_DATA,
         )
@@ -392,7 +392,7 @@ class MempoolManager:
 
         log.debug(f"Cost: {cost}")
 
-        if cost > int(self.limit_factor * self.constants.MAX_BLOCK_COST_CLVM):
+        if cost > self.max_block_clvm_cost:
             # we shouldn't ever end up here, since the cost is limited when we
             # execute the CLVM program.
             return Err.BLOCK_COST_EXCEEDS_MAX, None, []
@@ -520,7 +520,7 @@ class MempoolManager:
         log.log(
             logging.DEBUG if duration < 2 else logging.WARNING,
             f"add_spendbundle {spend_name} took {duration:0.2f} seconds. "
-            f"Cost: {cost} ({round(100.0 * cost/self.constants.MAX_BLOCK_COST_CLVM, 3)}% of max block cost)",
+            f"Cost: {cost} ({round(100.0 * cost/self.max_block_clvm_cost, 3)}% of max block cost)",
         )
 
         return None, potential, list(conflicting_pool_items.keys())
@@ -600,7 +600,7 @@ class MempoolManager:
             self.mempool = Mempool(
                 self.mempool_max_total_cost,
                 uint64(self.nonzero_fee_minimum_fpc),
-                uint64(self.constants.MAX_BLOCK_COST_CLVM),
+                uint64(self.max_block_clvm_cost),
             )
             self.seen_bundle_hashes = {}
             for item in old_pool.spends.values():
@@ -660,5 +660,5 @@ class MempoolManager:
             FeeRate(uint64(self.nonzero_fee_minimum_fpc)),
             CLVMCost(uint64(self.mempool.total_mempool_cost)),
             datetime.datetime.now(),
-            CLVMCost(uint64(self.constants.MAX_BLOCK_COST_CLVM)),
+            CLVMCost(uint64(self.max_block_clvm_cost)),
         )


### PR DESCRIPTION
Correct some non-essential block size calculations by computing the value once.

This is a required part of the Fee Estimator backend.