### PR TITLE
add cache to speed up manage_clvm/clvm_hex pre-commit check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -72,4 +72,6 @@ jobs:
 
     - uses: chia-network/actions/activate-venv@main
 
-    - run: pre-commit run --all-files --verbose
+    - env:
+        CHIA_MANAGE_CLVM_CHECK_USE_CACHE: "false"
+      run: pre-commit run --all-files --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,8 @@ build/
 # https://pytest-monitor.readthedocs.io/en/latest/operating.html?highlight=.pymon#storage
 .pymon
 
+# cache for tooling such as tools/manage_clvm.py
+.chia_cache/
 
 #       =====                       =====
 #     DO NOT EDIT BELOW - GENERATED

--- a/tools/manage_clvm.py
+++ b/tools/manage_clvm.py
@@ -43,8 +43,6 @@ class CacheEntry(typing.TypedDict):
     hash: str
 
 
-# PathString = typing.NewType(str)
-# HashString = typing.NewType(str)
 CacheEntries = typing.Dict[str, CacheEntry]
 
 


### PR DESCRIPTION
Runs were taking +/- 10 seconds.  When the cache is fully hit runs are less than one second.

Draft for:
- [x] cache version

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->



<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
