### PR TITLE
bump default bladebit version to 2.0.1 in install-plotter.sh

### DIFF
--- a/install-plotter.sh
+++ b/install-plotter.sh
@@ -75,7 +75,7 @@ if [ "$1" = "-h" ] || [ -z "$1" ]; then
   exit 0
 fi
 
-DEFAULT_BLADEBIT_VERSION="v2.0.0"
+DEFAULT_BLADEBIT_VERSION="v2.0.1"
 DEFAULT_MADMAX_VERSION="0.0.2"
 VERSION=
 PLOTTER=$1


### PR DESCRIPTION
It appears the current default version (`v2.0.0`) does not exist.

```
$ ./install-plotter.sh bladebit
Detected Debian/Ubuntu like OS
Installing bladebit v2.0.0
Fetching binary from: https://github.com/Chia-Network/bladebit/releases/download/v2.0.0/bladebit-v2.0.0-ubuntu-x86-64.tar.gz
ERROR: Download failed. Maybe specified version of the binary does not exist.
```

adding `-v v2.0.1` makes it work