### PR TITLE
add rate limits numbers to none response type

### DIFF
--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -178,6 +178,7 @@ rate_limits = {
             ProtocolMessageTypes.request_puzzle_solution: RLSettings(5000, 100),
             ProtocolMessageTypes.respond_puzzle_solution: RLSettings(5000, 1024 * 1024),
             ProtocolMessageTypes.reject_puzzle_solution: RLSettings(5000, 100),
+            ProtocolMessageTypes.none_response: RLSettings(500, 100),
         },
         "rate_limits_other": {  # These will have a lower cap since they don't scale with high TPS (NON_TX_FREQ)
             ProtocolMessageTypes.request_header_blocks: RLSettings(5000, 100),


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
- Use the prompts below to provide information wherever applicable
-->
<!-- What is the purpose of the changes in this PR? -->

added rate limit numbers to the new none_response message type, doesn't change behavior 
https://github.com/Chia-Network/chia-blockchain/issues/14162
<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
