### PR TITLE
wallet: Avoid duplicates in `get_puzzle_hashes_to_subscribe`

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1261,13 +1261,13 @@ class WalletNode:
         return weight_proof, summaries, block_records
 
     async def get_puzzle_hashes_to_subscribe(self) -> List[bytes32]:
-        all_puzzle_hashes = list(await self.wallet_state_manager.puzzle_store.get_all_puzzle_hashes())
+        all_puzzle_hashes = await self.wallet_state_manager.puzzle_store.get_all_puzzle_hashes()
         # Get all phs from interested store
         interested_puzzle_hashes = [
             t[0] for t in await self.wallet_state_manager.interested_store.get_interested_puzzle_hashes()
         ]
-        all_puzzle_hashes.extend(interested_puzzle_hashes)
-        return all_puzzle_hashes
+        all_puzzle_hashes.update(interested_puzzle_hashes)
+        return list(all_puzzle_hashes)
 
     async def get_coin_ids_to_subscribe(self, min_height: int) -> List[bytes32]:
         all_coin_names: Set[bytes32] = await self.wallet_state_manager.coin_store.get_coin_names_to_check(min_height)

--- a/tests/wallet/test_wallet_node.py
+++ b/tests/wallet/test_wallet_node.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import pytest
 from blspy import PrivateKey
 
-from chia.simulator.block_tools import test_constants
+from chia.full_node.full_node_api import FullNodeAPI
+from chia.server.server import ChiaServer
+from chia.simulator.block_tools import BlockTools, test_constants
 from chia.util.config import load_config
 from chia.util.keychain import Keychain, generate_mnemonic
 from chia.wallet.wallet_node import WalletNode
@@ -293,3 +295,13 @@ def test_update_last_used_fingerprint(root_path_populated_with_config: Path) -> 
 
     assert path.exists() is True
     assert path.read_text() == "9876543210"
+
+
+@pytest.mark.asyncio
+async def test_unique_puzzle_hash_subscriptions(
+    wallet_node: Tuple[FullNodeAPI, WalletNode, ChiaServer, ChiaServer, BlockTools]
+) -> None:
+    _, node, _, _, _ = wallet_node
+    puzzle_hashes = await node.get_puzzle_hashes_to_subscribe()
+    assert len(puzzle_hashes) > 1
+    assert len(set(puzzle_hashes)) == len(puzzle_hashes)


### PR DESCRIPTION
We currently store the derived puzzle hashes in both, puzzle store and  interested store and here we combine them as list. There is some code to  mitigate duplicate subscriptions but its based on chunks here  https://github.com/Chia-Network/chia-blockchain/blob/39d733599d170b340b0ae4c13ada8896a78a0d29/chia/wallet/wallet_node.py#L662  so if there are less than 1000 puzzle hashes it obviously still can lead to duplicated entries in the subscription calls?

Based on:
- https://github.com/Chia-Network/chia-blockchain/pull/14187