### PR TITLE
wallet: Don't add derived puzzle hashes to the `WalletInterestedStore`

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1289,11 +1289,13 @@ class WalletNode:
 
     async def get_puzzle_hashes_to_subscribe(self) -> List[bytes32]:
         all_puzzle_hashes = list(await self.wallet_state_manager.puzzle_store.get_all_puzzle_hashes())
+        puzzle_store_count = len(all_puzzle_hashes)
         # Get all phs from interested store
         interested_puzzle_hashes = [
             t[0] for t in await self.wallet_state_manager.interested_store.get_interested_puzzle_hashes()
         ]
         all_puzzle_hashes.extend(interested_puzzle_hashes)
+        assert puzzle_store_count + len(interested_puzzle_hashes) == len(set(all_puzzle_hashes))
         return all_puzzle_hashes
 
     async def get_coin_ids_to_subscribe(self, min_height: int) -> List[bytes32]:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -383,11 +383,10 @@ class WalletStateManager:
                     )
                 self.log.info(f"Done: {creating_msg} Time: {time.time() - start_t} seconds")
             await self.puzzle_store.add_derivation_paths(derivation_paths)
-            await self.add_interested_puzzle_hashes(
-                [record.puzzle_hash for record in derivation_paths],
-                [record.wallet_id for record in derivation_paths],
-            )
             if len(derivation_paths) > 0:
+                await self.wallet_node.new_peak_queue.subscribe_to_puzzle_hashes(
+                    [record.puzzle_hash for record in derivation_paths]
+                )
                 self.state_changed("new_derivation_index", data_object={"index": derivation_paths[-1].index})
         # By default, we'll mark previously generated unused puzzle hashes as used if we have new paths
         if mark_existing_as_used and unused > 0 and new_paths:


### PR DESCRIPTION
We already use the derived puzzle hashes when we subscribe to the node  here 
https://github.com/Chia-Network/chia-blockchain/blob/39d733599d170b340b0ae4c13ada8896a78a0d29/chia/wallet/wallet_node.py#L1291  I assume this was done to make sure we subscribe to new puzzle hashes  but at the end it leads to redundant entries in `derivation_paths` vs  `interested_puzzle_hashes` so we can just subscribe here instead? If we  want to keep them in both tables for some reason we may at least get rid  of `get_puzzle_hashes_to_subscribe` (where we currently create a list with duplicated entries form both tables) and use the ones from the interest  store only and maybe adjust the other related methods?