### PR TITLE
Remove redundant check for duplicate outputs

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -410,11 +410,6 @@ class MempoolManager:
         for add in additions:
             additions_dict[add.name()] = add
             addition_amount = addition_amount + add.amount
-        # Check for duplicate outputs
-        addition_counter = collections.Counter(_.name() for _ in additions)
-        for k, v in addition_counter.items():
-            if v > 1:
-                return Err.DUPLICATE_OUTPUT, None, []
         # Check for duplicate inputs
         removal_counter = collections.Counter(name for name in removal_names)
         for k, v in removal_counter.items():

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -103,3 +103,15 @@ async def test_too_big_addition_amount() -> None:
     # Addressed in https://github.com/Chia-Network/chia_rs/pull/99
     with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+
+
+@pytest.mark.asyncio
+async def test_duplicate_output() -> None:
+    mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
+    conditions = [
+        [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1],
+        [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1],
+    ]
+    sb = spend_bundle_from_conditions(conditions)
+    with pytest.raises(ValidationError, match="Err.DUPLICATE_OUTPUT"):
+        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())


### PR DESCRIPTION
This simplifies the mempool by removing a DUPLICATE_OUTPUT check is already performed on the Rust side.
The added tests pass before and after introducing the code changes.