### PR TITLE
Add get_new_puzzlehash to WalletProtocol

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -978,6 +978,9 @@ class PoolWallet:
     def get_name(self) -> str:
         return self.wallet_info.name
 
+    async def get_new_puzzlehash(self) -> bytes32:
+        return await self.standard_wallet.get_new_puzzlehash()
+
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1471,6 +1471,9 @@ class DIDWallet:
     def require_derivation_paths(self) -> bool:
         return True
 
+    async def get_new_puzzlehash(self) -> bytes32:
+        return await self.standard_wallet.get_new_puzzlehash()
+
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -1655,6 +1655,9 @@ class NFTWallet:
     def get_name(self) -> str:
         return self.wallet_info.name
 
+    async def get_new_puzzlehash(self) -> bytes32:
+        return await self.standard_wallet.get_new_puzzlehash()
+
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -64,6 +64,9 @@ class WalletProtocol(Protocol):
     def get_name(self) -> str:
         ...
 
+    async def get_new_puzzlehash(self) -> bytes32:
+        ...
+
     # WalletStateManager is only imported for type hinting thus leaving pylint
     # unable to process this
     wallet_state_manager: WalletStateManager  # pylint: disable=used-before-assignment


### PR DESCRIPTION
Part of a series of PRs to add type checking to WalletStateManager

Add `get_new_puzzlehash()` to WalletProtocol - this is used primarily by trade_manager code.

The specific implementation for Pool, DID, and NFT wallets was taken from the existing CAT wallet implementation