### PR TITLE
Add get_asset_id to WalletProtocol

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -1105,6 +1105,9 @@ class DataLayerWallet:
     def get_name(self) -> str:
         return self.wallet_info.name
 
+    def get_asset_id(self) -> str:
+        raise RuntimeError("DL wallet does not have an asset id")
+
     ##########
     # OFFERS #
     ##########

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -978,6 +978,9 @@ class PoolWallet:
     def get_name(self) -> str:
         return self.wallet_info.name
 
+    def get_asset_id(self) -> str:
+        raise RuntimeError("Pool wallet does not have an asset id")
+
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1471,6 +1471,9 @@ class DIDWallet:
     def require_derivation_paths(self) -> bool:
         return True
 
+    def get_asset_id(self) -> str:
+        raise RuntimeError("DID wallet does not have an asset id")
+
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -1655,6 +1655,9 @@ class NFTWallet:
     def get_name(self) -> str:
         return self.wallet_info.name
 
+    def get_asset_id(self) -> str:
+        raise RuntimeError("NFT wallet does not have an asset id")
+
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -460,12 +460,13 @@ class TradeManager:
                         wallet = self.wallet_state_manager.wallets[wallet_id]
                         p2_ph: bytes32 = await wallet.get_new_puzzlehash()
                         if wallet.type() != WalletType.STANDARD_WALLET:
-                            if callable(getattr(wallet, "get_asset_id", None)):  # ATTENTION: new wallets
+                            try:
                                 asset_id = bytes32(bytes.fromhex(wallet.get_asset_id()))
                                 memos = [p2_ph]
-                            else:
+                            except RuntimeError as e:
                                 raise ValueError(
                                     f"Cannot request assets from wallet id {wallet.id()} without more information"
+                                    f" - {str(e)}"
                                 )
                     else:
                         p2_ph = await self.wallet_state_manager.main_wallet.get_new_puzzlehash()

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -605,6 +605,9 @@ class Wallet:
     def get_name(self) -> str:
         return "Standard Wallet"
 
+    def get_asset_id(self) -> str:
+        raise RuntimeError("Standard wallet does not have an asset id")
+
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_protocol import WalletProtocol

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -64,6 +64,9 @@ class WalletProtocol(Protocol):
     def get_name(self) -> str:
         ...
 
+    def get_asset_id(self) -> str:
+        ...
+
     # WalletStateManager is only imported for type hinting thus leaving pylint
     # unable to process this
     wallet_state_manager: WalletStateManager  # pylint: disable=used-before-assignment


### PR DESCRIPTION
Another PR in the type hint WalletStateManager series.

Add `get_asset_id` to WalletProtocol. The only implementation is the CAT wallet
Other wallets will raise an exception
Used by the TradeManager