### PR TITLE
Remove redundant check for maximum block CLVM cost

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -389,13 +389,7 @@ class MempoolManager:
             return Err(npc_result.error), None, []
 
         cost = npc_result.cost
-
         log.debug(f"Cost: {cost}")
-
-        if cost > self.max_block_clvm_cost:
-            # we shouldn't ever end up here, since the cost is limited when we
-            # execute the CLVM program.
-            return Err.BLOCK_COST_EXCEEDS_MAX, None, []
 
         assert npc_result.conds is not None
         # build removal list

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -115,3 +115,14 @@ async def test_duplicate_output() -> None:
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="Err.DUPLICATE_OUTPUT"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+
+
+@pytest.mark.asyncio
+async def test_block_cost_exceeds_max() -> None:
+    mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
+    conditions = []
+    for i in range(2400):
+        conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, i])
+    sb = spend_bundle_from_conditions(conditions)
+    with pytest.raises(ValidationError, match="Err.BLOCK_COST_EXCEEDS_MAX"):
+        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())


### PR DESCRIPTION
This simplifies the mempool by removing a BLOCK_COST_EXCEEDS_MAX check that is already performed on the Rust side.
The added test passes before and after introducing the code changes.