### PR TITLE
Add SigningMode and update verify_signature RPC to work with sign_message_by_* RPCs

### DIFF
--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -266,7 +266,7 @@ def parse_signature_json(json_str: str):
     type=str,
 )
 def verify_cmd(message: str, public_key: str, signature: str, as_bytes: bool, json: str):
-    from .keys_funcs import verify, as_bytes_from_signing_mode
+    from .keys_funcs import as_bytes_from_signing_mode, verify
 
     if json is not None:
         parsed_message, parsed_pubkey, parsed_sig, parsed_signing_mode_str = parse_signature_json(json)

--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -210,21 +210,70 @@ def generate_and_print_cmd():
     show_default=True,
     is_flag=True,
 )
-def sign_cmd(message: str, fingerprint: Optional[int], filename: Optional[str], hd_path: str, as_bytes: bool):
+@click.option(
+    "--json",
+    "-j",
+    help=("Write the signature output in JSON format"),
+    default=False,
+    show_default=True,
+    is_flag=True,
+)
+def sign_cmd(
+    message: str, fingerprint: Optional[int], filename: Optional[str], hd_path: str, as_bytes: bool, json: bool
+):
     from .keys_funcs import resolve_derivation_master_key, sign
 
     private_key = resolve_derivation_master_key(filename if filename is not None else fingerprint)
-    sign(message, private_key, hd_path, as_bytes)
+    sign(message, private_key, hd_path, as_bytes, json)
+
+
+def parse_signature_json(json_str: str):
+    import json
+
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError:
+        raise click.BadParameter("Invalid JSON string")
+    if "message" not in data:
+        raise click.BadParameter("Missing 'message' field")
+    if "pubkey" not in data:
+        raise click.BadParameter("Missing 'pubkey' field")
+    if "signature" not in data:
+        raise click.BadParameter("Missing 'signature' field")
+    if "signing_mode" not in data:
+        raise click.BadParameter("Missing 'signing_mode' field")
+
+    return data["message"], data["pubkey"], data["signature"], data["signing_mode"]
 
 
 @keys_cmd.command("verify", short_help="Verify a signature with a pk")
-@click.option("--message", "-d", default=None, help="Enter the message to sign in UTF-8", type=str, required=True)
-@click.option("--public_key", "-p", default=None, help="Enter the pk in hex", type=str, required=True)
-@click.option("--signature", "-s", default=None, help="Enter the signature in hex", type=str, required=True)
-def verify_cmd(message: str, public_key: str, signature: str):
-    from .keys_funcs import verify
+@click.option("--message", "-d", default=None, help="Enter the signed message in UTF-8", type=str)
+@click.option("--public_key", "-p", default=None, help="Enter the pk in hex", type=str)
+@click.option("--signature", "-s", default=None, help="Enter the signature in hex", type=str)
+@click.option(
+    "--as-bytes",
+    "-b",
+    help="Verify the signed message as sequence of bytes rather than UTF-8 string. Ignored if --json is used.",
+    default=False,
+    show_default=True,
+    is_flag=True,
+)
+@click.option(
+    "--json",
+    "-j",
+    help=("Read the signature data from a JSON string. Overrides --message, --public_key, and --signature."),
+    show_default=True,
+    type=str,
+)
+def verify_cmd(message: str, public_key: str, signature: str, as_bytes: bool, json: str):
+    from .keys_funcs import verify, as_bytes_from_signing_mode
 
-    verify(message, public_key, signature)
+    if json is not None:
+        parsed_message, parsed_pubkey, parsed_sig, parsed_signing_mode_str = parse_signature_json(json)
+
+        verify(parsed_message, parsed_pubkey, parsed_sig, as_bytes_from_signing_mode(parsed_signing_mode_str))
+    else:
+        verify(message, public_key, signature, as_bytes)
 
 
 @keys_cmd.group("derive", short_help="Derive child keys or wallet addresses")

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -11,6 +11,7 @@ from blspy import AugSchemeMPL, G1Element, G2Element, PrivateKey
 
 from chia.cmds.passphrase_funcs import obtain_current_passphrase
 from chia.consensus.coinbase import create_puzzlehash_for_pk
+from chia.types.signing_mode import SigningMode
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import load_config
 from chia.util.errors import KeychainException
@@ -18,7 +19,6 @@ from chia.util.file_keyring import MAX_LABEL_LENGTH
 from chia.util.ints import uint32
 from chia.util.keychain import Keychain, bytes_to_mnemonic, generate_mnemonic, mnemonic_to_seed
 from chia.util.keyring_wrapper import KeyringWrapper
-from chia.types.signing_mode import SigningMode
 from chia.wallet.derive_keys import (
     master_sk_to_farmer_sk,
     master_sk_to_pool_sk,

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -18,6 +18,7 @@ from chia.util.file_keyring import MAX_LABEL_LENGTH
 from chia.util.ints import uint32
 from chia.util.keychain import Keychain, bytes_to_mnemonic, generate_mnemonic, mnemonic_to_seed
 from chia.util.keyring_wrapper import KeyringWrapper
+from chia.types.signing_mode import SigningMode
 from chia.wallet.derive_keys import (
     master_sk_to_farmer_sk,
     master_sk_to_pool_sk,
@@ -256,18 +257,44 @@ def derive_sk_from_hd_path(master_sk: PrivateKey, hd_path_root: str) -> Tuple[Pr
     return (current_sk, "m/" + "/".join(path) + "/")
 
 
-def sign(message: str, private_key: PrivateKey, hd_path: str, as_bytes: bool):
+def sign(message: str, private_key: PrivateKey, hd_path: str, as_bytes: bool, json_output: bool):
     sk: PrivateKey = derive_sk_from_hd_path(private_key, hd_path)[0]
     data = bytes.fromhex(message) if as_bytes else bytes(message, "utf-8")
-    print("Public key:", sk.get_g1())
-    print("Signature:", AugSchemeMPL.sign(sk, data))
+    signing_mode: SigningMode = (
+        SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT if as_bytes else SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT
+    )
+    pubkey_hex: str = bytes(sk.get_g1()).hex()
+    signature_hex: str = bytes(AugSchemeMPL.sign(sk, data)).hex()
+    if json_output:
+        print(
+            json.dumps(
+                {
+                    "message": message,
+                    "pubkey": pubkey_hex,
+                    "signature": signature_hex,
+                    "signing_mode": signing_mode.value,
+                }
+            )
+        )
+    else:
+        print(f"Message: {message}")
+        print(f"Public Key: {pubkey_hex}")
+        print(f"Signature: {signature_hex}")
+        print(f"Signing Mode: {signing_mode.value}")
 
 
-def verify(message: str, public_key: str, signature: str):
-    messageBytes = bytes(message, "utf-8")
+def verify(message: str, public_key: str, signature: str, as_bytes: bool):
+    data = bytes.fromhex(message) if as_bytes else bytes(message, "utf-8")
     public_key = G1Element.from_bytes(bytes.fromhex(public_key))
     signature = G2Element.from_bytes(bytes.fromhex(signature))
-    print(AugSchemeMPL.verify(public_key, messageBytes, signature))
+    print(AugSchemeMPL.verify(public_key, data, signature))
+
+
+def as_bytes_from_signing_mode(signing_mode_str: str) -> bool:
+    if signing_mode_str == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT.value:
+        return True
+    else:
+        return False
 
 
 def _clear_line_part(n: int):

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1104,11 +1104,11 @@ async def delete_notifications(args: Dict, wallet_client: WalletRpcClient, finge
 
 async def sign_message(args: Dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     if args["type"] == AddressType.XCH:
-        pubkey, signature = await wallet_client.sign_message_by_address(args["address"], args["message"])
+        pubkey, signature, signing_mode = await wallet_client.sign_message_by_address(args["address"], args["message"])
     elif args["type"] == AddressType.DID:
-        pubkey, signature = await wallet_client.sign_message_by_id(args["did_id"], args["message"])
+        pubkey, signature, signing_mode = await wallet_client.sign_message_by_id(args["did_id"], args["message"])
     elif args["type"] == AddressType.NFT:
-        pubkey, signature = await wallet_client.sign_message_by_id(args["nft_id"], args["message"])
+        pubkey, signature, signing_mode = await wallet_client.sign_message_by_id(args["nft_id"], args["message"])
     else:
         print("Invalid wallet type.")
         return
@@ -1116,3 +1116,4 @@ async def sign_message(args: Dict, wallet_client: WalletRpcClient, fingerprint: 
     print(f'Message: {args["message"]}')
     print(f"Public Key: {pubkey}")
     print(f"Signature: {signature}")
+    print(f"Signing Mode: {signing_mode}")

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1257,7 +1257,7 @@ class WalletRpcApi:
             # Message is expected to be a UTF-8 string
             message_to_verify = bytes(input_message, "utf-8")
         else:
-            raise ValueError(f"Unsupported signing mode: {signing_mode_str}")
+            raise ValueError(f"Unsupported signing mode: {signing_mode_str!r}")
 
         # Verify using the BLS message augmentation scheme
         is_valid = AugSchemeMPL.verify(

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1244,7 +1244,7 @@ class WalletRpcApi:
             try:
                 signing_mode = SigningMode(signing_mode_str)
             except ValueError:
-                raise ValueError(f"Invalid signing mode: {signing_mode_str}")
+                raise ValueError(f"Invalid signing mode: {signing_mode_str!r}")
 
         if signing_mode == SigningMode.CHIP_0002:
             # CHIP-0002 message signatures are made over the tree hash of:

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1026,8 +1026,8 @@ class WalletRpcClient(RpcClient):
 
     async def sign_message_by_address(self, address: str, message: str) -> Tuple[str, str]:
         response = await self.fetch("sign_message_by_address", {"address": address, "message": message})
-        return response["pubkey"], response["signature"]
+        return response["pubkey"], response["signature"], response["signing_mode"]
 
     async def sign_message_by_id(self, id: str, message: str) -> Tuple[str, str]:
         response = await self.fetch("sign_message_by_id", {"id": id, "message": message})
-        return response["pubkey"], response["signature"]
+        return response["pubkey"], response["signature"], response["signing_mode"]

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1024,10 +1024,10 @@ class WalletRpcClient(RpcClient):
         )
         return TransactionRecord.from_json_dict_convenience(response["tx"])
 
-    async def sign_message_by_address(self, address: str, message: str) -> Tuple[str, str]:
+    async def sign_message_by_address(self, address: str, message: str) -> Tuple[str, str, str]:
         response = await self.fetch("sign_message_by_address", {"address": address, "message": message})
         return response["pubkey"], response["signature"], response["signing_mode"]
 
-    async def sign_message_by_id(self, id: str, message: str) -> Tuple[str, str]:
+    async def sign_message_by_id(self, id: str, message: str) -> Tuple[str, str, str]:
         response = await self.fetch("sign_message_by_id", {"id": id, "message": message})
         return response["pubkey"], response["signature"], response["signing_mode"]

--- a/chia/types/signing_mode.py
+++ b/chia/types/signing_mode.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/chia/types/signing_mode.py
+++ b/chia/types/signing_mode.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class SigningMode(Enum):
+    # Cipher suites used for BLS signatures defined at:
+    # https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-ciphersuites
+
+    # CHIP-0002 signs the result of sha256tree(cons("Chia Signed Message", message)) using the
+    # BLS message augmentation scheme
+    CHIP_0002 = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:CHIP-0002_"
+
+    # Standard BLS signatures used by Chia use the BLS message augmentation scheme
+    # https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-sign
+    BLS_MESSAGE_AUGMENTATION_UTF8_INPUT = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:utf8input_"
+
+    # Same as above but with the message specified as a string of hex characters
+    BLS_MESSAGE_AUGMENTATION_HEX_INPUT = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:hexinput_"

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -39,7 +39,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
-from chia.wallet.wallet import Wallet
+from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 
@@ -1182,7 +1182,7 @@ class DIDWallet:
             pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
             synthetic_pk = synthetic_secret_key.get_g1()
-            puzzle: Program = Program.to(("Chia Signed Message", message))
+            puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
             return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, puzzle.get_tree_hash())
         else:
             raise ValueError("Invalid inner DID puzzle.")

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -44,7 +44,7 @@ from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.debug_spend_bundle import disassemble
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
-from chia.wallet.wallet import Wallet
+from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_nft_store import WalletNftStore
@@ -537,7 +537,7 @@ class NFTWallet:
             pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
             synthetic_pk = synthetic_secret_key.get_g1()
-            puzzle: Program = Program.to(("Chia Signed Message", message))
+            puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
             return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, puzzle.get_tree_hash())
         else:
             raise ValueError("Invalid NFT puzzle.")

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -452,7 +452,7 @@ class Wallet:
 
     async def sign_message(self, message: str, puzzle_hash: bytes32) -> Tuple[G1Element, G2Element]:
         # CHIP-0002 message signing as documented at:
-        # https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0002.md#signmessage
+        # https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md#signmessage
         pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
         synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
         synthetic_pk = synthetic_secret_key.get_g1()

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from chia.server.ws_connection import WSChiaConnection
 
 
-# https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0002.md#signmessage
+# https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md#signmessage
 CHIP_0002_SIGN_MESSAGE_PREFIX = "Chia Signed Message"
 
 

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:
     from chia.server.ws_connection import WSChiaConnection
 
 
+# https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0002.md#signmessage
+CHIP_0002_SIGN_MESSAGE_PREFIX = "Chia Signed Message"
+
+
 class Wallet:
     wallet_state_manager: Any
     log: logging.Logger
@@ -447,10 +451,12 @@ class Wallet:
         )
 
     async def sign_message(self, message: str, puzzle_hash: bytes32) -> Tuple[G1Element, G2Element]:
+        # CHIP-0002 message signing as documented at:
+        # https://github.com/Chia-Network/chips/blob/main/CHIPs/chip-0002.md#signmessage
         pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
         synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
         synthetic_pk = synthetic_secret_key.get_g1()
-        puzzle: Program = Program.to(("Chia Signed Message", message))
+        puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
         return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, puzzle.get_tree_hash())
 
     async def generate_signed_transaction(

--- a/tests/core/cmds/test_keys.py
+++ b/tests/core/cmds/test_keys.py
@@ -597,7 +597,7 @@ class TestKeysCommands:
         assert (
             result.output.find(
                 (
-                    "Public key: 92f15caed8a5495faa7ec25a8af3f223438ef73c974b0aa81e788057b1154870f149739b2c2d0e"
+                    "Public Key: 92f15caed8a5495faa7ec25a8af3f223438ef73c974b0aa81e788057b1154870f149739b2c2d0e"
                     "736234baf9386f7f83"
                 )
             )
@@ -630,7 +630,7 @@ class TestKeysCommands:
         assert (
             result.output.find(
                 (
-                    "Public key: b5e383b8192dacff662455bdb3bbfc433f678f0d7ff7f118149e0d2ad39aa6d59ac4cb3662acf8"
+                    "Public Key: b5e383b8192dacff662455bdb3bbfc433f678f0d7ff7f118149e0d2ad39aa6d59ac4cb3662acf8"
                     "e8307e66069d3a13cc"
                 )
             )
@@ -669,7 +669,7 @@ class TestKeysCommands:
         assert (
             result.output.find(
                 (
-                    "Public key: "
+                    "Public Key: "
                     "92f15caed8a5495faa7ec25a8af3f223438ef73c974b0aa81e788057b1154870f149739b2c2d0e736234baf9386f7f83"
                 )
             )

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -23,6 +23,7 @@ from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import create_fullpuz
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX
 from tests.util.wallet_is_synced import wallet_is_synced
 
 
@@ -1166,7 +1167,7 @@ class TestDIDWallet:
                 "message": message,
             }
         )
-        puzzle: Program = Program.to(("Chia Signed Message", message))
+        puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
         assert AugSchemeMPL.verify(
             G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
             puzzle.get_tree_hash(),

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -25,6 +25,7 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX
 from chia.wallet.wallet_state_manager import WalletStateManager
 from tests.util.wallet_is_synced import wallet_is_synced
 
@@ -1636,7 +1637,7 @@ async def test_nft_sign_message(self_hostname: str, two_wallet_nodes: Any, trust
     response = await api_0.sign_message_by_id(
         {"id": encode_puzzle_hash(coins[0].launcher_id, AddressType.NFT.value), "message": message}
     )
-    puzzle: Program = Program.to(("Chia Signed Message", message))
+    puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
     assert AugSchemeMPL.verify(
         G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
         puzzle.get_tree_hash(),

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1308,6 +1308,20 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     assert [] == (await client_2.get_notifications([notification.coin_id]))
 
 
+# The signatures below were made from an ephemeral key pair that isn't included in the test code.
+# When modifying this test, any key can be used to generate signatures. Only the pubkey needs to
+# be included in the test code.
+#
+# Example 1:
+# $ chia keys generate
+# $ chia keys sign -d 'hello world' -t 'm/12381/8444/1/1'
+#
+# Example 2:
+# $ chia wallet get_address
+# xch1vk0dj7cx7d638h80mcuw70xqlnr56pmuhzajemn5ym02vhl3mzyqrrd4wp
+# $ chia wallet sign_message -m $(echo -n 'hello world' | xxd -p)
+# -a xch1vk0dj7cx7d638h80mcuw70xqlnr56pmuhzajemn5ym02vhl3mzyqrrd4wp
+#
 @pytest.mark.parametrize(
     ["rpc_request", "rpc_response"],
     [

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -28,6 +28,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
 from chia.types.peer_info import PeerInfo
+from chia.types.signing_mode import SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.config import lock_and_load_config, save_config
@@ -1308,7 +1309,7 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
 
 
 @pytest.mark.parametrize(
-    "rpc_request, rpc_response",
+    ["rpc_request", "rpc_response"],
     [
         # Valid signatures
         (
@@ -1341,7 +1342,7 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
                     "5218bbe0e17677c9a23a9f18dbe488b7026be59d476161f5e6f0eea109cd7be22b1f74fda9c80c6b845ecc6"
                     "91246eb1c7f1b66a6a"
                 ),
-                "signing_mode": "chip_0002",
+                "signing_mode": SigningMode.CHIP_0002.value,
             },
             {"isValid": True},
         ),
@@ -1359,7 +1360,7 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
                     "5218bbe0e17677c9a23a9f18dbe488b7026be59d476161f5e6f0eea109cd7be22b1f74fda9c80c6b845ecc6"
                     "91246eb1c7f1b66a6a"
                 ),
-                "signing_mode": "chip_0002",
+                "signing_mode": SigningMode.CHIP_0002.value,
                 "address": "xch1e2pcue5q7t4sg8gygz3aht369sk78rzzs92zx65ktn9a9qurw35saajvkh",
             },
             {"isValid": True},
@@ -1394,14 +1395,14 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
                     "5218bbe0e17677c9a23a9f18dbe488b7026be59d476161f5e6f0eea109cd7be22b1f74fda9c80c6b845ecc6"
                     "91246eb1c7f1b66a6a"
                 ),
-                "signing_mode": "chip_0002",
+                "signing_mode": SigningMode.CHIP_0002.value,
                 "address": "xch1d0rekc2javy5gpruzmcnk4e4qq834jzlvxt5tcgl2ylt49t26gdsjen7t0",
             },
             {"isValid": False, "error": "Public key doesn't match the address"},
         ),
     ],
 )
-@pytest.mark.parametrize("prefix_hex_strings", [True, False])
+@pytest.mark.parametrize("prefix_hex_strings", [True, False], ids=["with 0x", "no 0x"])
 @pytest.mark.asyncio
 async def test_verify_signature(
     wallet_rpc_environment: WalletRpcTestEnvironment,

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -4,7 +4,7 @@ import dataclasses
 import json
 import logging
 from operator import attrgetter
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import pytest
 import pytest_asyncio
@@ -13,8 +13,11 @@ from blspy import G2Element
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.coinbase import create_puzzlehash_for_pk
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
+from chia.rpc.rpc_server import RpcServer
+from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.server.server import ChiaServer
+from chia.server.start_service import Service
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert
@@ -53,6 +56,7 @@ log = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class WalletBundle:
+    service: Service
     node: WalletNode
     rpc_client: WalletRpcClient
     wallet: Wallet
@@ -148,8 +152,8 @@ async def wallet_rpc_environment(two_wallet_nodes_services, request, self_hostna
         hostname, full_node_service.rpc_server.listen_port, full_node_service.root_path, full_node_service.config
     )
 
-    wallet_bundle_1: WalletBundle = WalletBundle(wallet_node, client, wallet)
-    wallet_bundle_2: WalletBundle = WalletBundle(wallet_node_2, client_2, wallet_2)
+    wallet_bundle_1: WalletBundle = WalletBundle(wallet_service, wallet_node, client, wallet)
+    wallet_bundle_2: WalletBundle = WalletBundle(wallet_service_2, wallet_node_2, client_2, wallet_2)
     node_bundle: FullNodeBundle = FullNodeBundle(full_node_server, full_node_api, client_node)
 
     yield WalletRpcTestEnvironment(wallet_bundle_1, wallet_bundle_2, node_bundle)
@@ -228,6 +232,13 @@ async def get_confirmed_balance(client: WalletRpcClient, wallet_id: int):
 
 async def get_unconfirmed_balance(client: WalletRpcClient, wallet_id: int):
     return (await client.get_wallet_balance(wallet_id))["unconfirmed_wallet_balance"]
+
+
+def update_verify_signature_request(request: Dict[str, Any], prefix_hex_values: bool):
+    updated_request = request.copy()
+    updated_request["pubkey"] = ("0x" if prefix_hex_values else "") + updated_request["pubkey"]
+    updated_request["signature"] = ("0x" if prefix_hex_values else "") + updated_request["signature"]
+    return updated_request
 
 
 @pytest.mark.asyncio
@@ -1294,3 +1305,113 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     notification = (await client_2.get_notifications())[0]
     assert await client_2.delete_notifications([notification.coin_id])
     assert [] == (await client_2.get_notifications([notification.coin_id]))
+
+
+@pytest.mark.parametrize(
+    "rpc_request, rpc_response",
+    [
+        # Valid signatures
+        (
+            # chia keys sign -d "Let's eat, Grandma" -t "m/12381/8444/1/1"
+            {
+                "message": "4c65742773206561742c204772616e646d61",  # Let's eat, Grandma
+                "pubkey": (
+                    "89d8e2a225c2ff543222bd0f2ba457a44acbdd147e4dfa02"
+                    "eadaef73eae49450dc708fd7c86800b60e8bc456e77563e4"
+                ),
+                "signature": (
+                    "8006f63537563f038321eeda25f3838613d8f938e95f19d1d19ccbe634e9ee4d69552536aab08b4fe961305"
+                    "e534ffddf096199ae936b272dac88c936e8774bfc7a6f24025085026db3b7c3c41b472db3daf99b5e6cabf2"
+                    "6034d8782d10ef148d"
+                ),
+            },
+            {"isValid": True},
+        ),
+        (
+            # chia wallet sign_message -m $(echo -n 'Happy happy joy joy' | xxd -p)
+            # -a xch1e2pcue5q7t4sg8gygz3aht369sk78rzzs92zx65ktn9a9qurw35saajvkh
+            {
+                "message": "4861707079206861707079206a6f79206a6f79",  # Happy happy joy joy
+                "pubkey": (
+                    "8e156d106f1b0ff0ebbe5ab27b1797a19cf3e895a7a435b0"
+                    "03a1df2dd477d622be928379625b759ef3b388b286ee8658"
+                ),
+                "signature": (
+                    "a804111f80be2ed0d4d3fdd139c8fe20cd506b99b03592563d85292abcbb9cd6ff6df2e7a13093e330d66aa"
+                    "5218bbe0e17677c9a23a9f18dbe488b7026be59d476161f5e6f0eea109cd7be22b1f74fda9c80c6b845ecc6"
+                    "91246eb1c7f1b66a6a"
+                ),
+                "signing_mode": "chip_0002",
+            },
+            {"isValid": True},
+        ),
+        (
+            # chia wallet sign_message -m $(echo -n 'Happy happy joy joy' | xxd -p)
+            # -a xch1e2pcue5q7t4sg8gygz3aht369sk78rzzs92zx65ktn9a9qurw35saajvkh
+            {
+                "message": "4861707079206861707079206a6f79206a6f79",  # Happy happy joy joy
+                "pubkey": (
+                    "8e156d106f1b0ff0ebbe5ab27b1797a19cf3e895a7a435b0"
+                    "03a1df2dd477d622be928379625b759ef3b388b286ee8658"
+                ),
+                "signature": (
+                    "a804111f80be2ed0d4d3fdd139c8fe20cd506b99b03592563d85292abcbb9cd6ff6df2e7a13093e330d66aa"
+                    "5218bbe0e17677c9a23a9f18dbe488b7026be59d476161f5e6f0eea109cd7be22b1f74fda9c80c6b845ecc6"
+                    "91246eb1c7f1b66a6a"
+                ),
+                "signing_mode": "chip_0002",
+                "address": "xch1e2pcue5q7t4sg8gygz3aht369sk78rzzs92zx65ktn9a9qurw35saajvkh",
+            },
+            {"isValid": True},
+        ),
+        # Negative tests
+        (
+            # Message was modified
+            {
+                "message": "4c6574277320656174204772616e646d61",  # Let's eat Grandma
+                "pubkey": (
+                    "89d8e2a225c2ff543222bd0f2ba457a44acbdd147e4dfa02"
+                    "eadaef73eae49450dc708fd7c86800b60e8bc456e77563e4"
+                ),
+                "signature": (
+                    "8006f63537563f038321eeda25f3838613d8f938e95f19d1d19ccbe634e9ee4d69552536aab08b4fe961305"
+                    "e534ffddf096199ae936b272dac88c936e8774bfc7a6f24025085026db3b7c3c41b472db3daf99b5e6cabf2"
+                    "6034d8782d10ef148d"
+                ),
+            },
+            {"isValid": False, "error": "Signature is invalid."},
+        ),
+        (
+            # Valid signature but address doesn't match pubkey
+            {
+                "message": "4861707079206861707079206a6f79206a6f79",  # Happy happy joy joy
+                "pubkey": (
+                    "8e156d106f1b0ff0ebbe5ab27b1797a19cf3e895a7a435b0"
+                    "03a1df2dd477d622be928379625b759ef3b388b286ee8658"
+                ),
+                "signature": (
+                    "a804111f80be2ed0d4d3fdd139c8fe20cd506b99b03592563d85292abcbb9cd6ff6df2e7a13093e330d66aa"
+                    "5218bbe0e17677c9a23a9f18dbe488b7026be59d476161f5e6f0eea109cd7be22b1f74fda9c80c6b845ecc6"
+                    "91246eb1c7f1b66a6a"
+                ),
+                "signing_mode": "chip_0002",
+                "address": "xch1d0rekc2javy5gpruzmcnk4e4qq834jzlvxt5tcgl2ylt49t26gdsjen7t0",
+            },
+            {"isValid": False, "error": "Public key doesn't match the address"},
+        ),
+    ],
+)
+@pytest.mark.parametrize("prefix_hex_strings", [True, False])
+@pytest.mark.asyncio
+async def test_verify_signature(
+    wallet_rpc_environment: WalletRpcTestEnvironment,
+    rpc_request: Dict[str, Any],
+    rpc_response: Dict[str, Any],
+    prefix_hex_strings: bool,
+):
+    rpc_server: Optional[RpcServer] = wallet_rpc_environment.wallet_1.service.rpc_server
+    assert rpc_server is not None
+    api: WalletRpcApi = cast(WalletRpcApi, rpc_server.rpc_api)
+    req = update_verify_signature_request(rpc_request, prefix_hex_strings)
+    res = await api.verify_signature(req)
+    assert res == rpc_response

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -25,6 +25,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import AmountWithPuzzlehash
+from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX
 from chia.wallet.wallet_node import WalletNode, get_wallet_db_path
 from chia.wallet.wallet_state_manager import WalletStateManager
 from tests.util.wallet_is_synced import wallet_is_synced, wallets_are_synced
@@ -772,7 +773,7 @@ class TestWalletSimulator:
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         message = "Hello World"
         response = await api_0.sign_message_by_address({"address": encode_puzzle_hash(ph, "xch"), "message": message})
-        puzzle: Program = Program.to(("Chia Signed Message", message))
+        puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
 
         assert AugSchemeMPL.verify(
             G1Element.from_bytes(bytes.fromhex(response["pubkey"])),


### PR DESCRIPTION
<!-- What is the purpose of the changes in this PR? -->
The `verify_signature` RPC currently doesn't verify signatures made by the `sign_message_by_address`/`sign_message_by_id` RPCs, which follow the CHIP-0002 signing method. The signatures made by those RPCs calculate a tree hash of ("Chia Signed Message", message), and then sign that hash. This change adds support for verifying those signatures by computing the same tree hash and verifying the signature over that hash.

The `verify_signature` RPC was originally written to complement the `chia keys sign` CLI, which directly signs the message content (as a hex string) using the BLS message augmentation mode.

A new RPC request param, `signing_mode`, can be set to `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:CHIP-0002_` to indicate that the signature should be validated as a CHIP-0002 signature. In this signing mode, the tree hash of ("Chia Signed Message", message) should be computed the signature should be verified against that hash.

The `sign_message_by_*` RPCs now return the `signing_mode` that was used (CHIP-0002 in both cases) to assist with verification.

A new SigningMode enum has been added to `chia/types` to indicate how a particular message was signed, and similarly how it should be verified. Enum values are provided for signing in the CHIP-0002 method, as well as values for direct signing of the content using BLS message augmentation mode, where the message is either a hex string or UTF-8 string.

The`chia keys sign` and `chia keys verify` CLIs has been updated to output and accept JSON data respectively. The signing CLI output now also includes the original message and the signing mode that was used. The verification CLI now accepts the `-b as_bytes` option to match the same option on the signing side.

Testing notes:
`verify_signature` wasn't previously covered by any tests, nor is it exposed to the CLI. This change includes tests to cover both behaviors (`signing_mode = chip_0002|None`) as well as some negative tests.
<!-- What is the current behavior?** (You can also link to an open issue here) -->



<!-- What is the new behavior (if this is a feature change)? -->



<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->



<!-- Testing notes (is this code covered by tests, or equivalent manual testing?) -->



<!-- Are there any visual examples to help explain this PR? (attach any .gif/movie/console output below) -->
