### PR TITLE
use adjusted_timeout() for simulator helpers

### DIFF
--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -17,6 +17,7 @@ from chia.rpc.rpc_server import default_get_connections
 from chia.server.outbound_message import NodeType
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, GetAllCoinsProtocol, ReorgProtocol
+from chia.simulator.time_out_assert import adjusted_timeout
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
@@ -64,7 +65,7 @@ async def wait_for_coins_in_wallet(coins: Set[Coin], wallet: Wallet, timeout: Op
         coins: The coins expected to be received.
         wallet: The wallet expected to receive the coins.
     """
-    with anyio.fail_after(delay=timeout):
+    with anyio.fail_after(delay=adjusted_timeout(timeout)):
         for backoff in backoff_times():
             spendable_wallet_coin_records = await wallet.wallet_state_manager.get_spendable_coins_for_wallet(
                 wallet_id=wallet.id()
@@ -321,7 +322,7 @@ class FullNodeSimulator(FullNodeAPI):
             timeout = count * timeout_per_block
             timeout += 1
 
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             rewards = 0
 
             if count == 0:
@@ -360,7 +361,7 @@ class FullNodeSimulator(FullNodeAPI):
             timeout = (count + 1) * timeout_per_block
             timeout += 15
 
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             if count == 0:
                 return 0
 
@@ -443,7 +444,7 @@ class FullNodeSimulator(FullNodeAPI):
         if isinstance(timeout, _Default):
             timeout = (count + 1) * timeout_per_block
 
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             await self.farm_blocks_to_wallet(count=count, wallet=wallet, timeout=None)
             return rewards
 
@@ -458,7 +459,7 @@ class FullNodeSimulator(FullNodeAPI):
         Arguments:
             records: The transaction records to wait for.
         """
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             ids_to_check: Set[bytes32] = set()
             for record in records:
                 if record.spend_bundle is None:
@@ -490,7 +491,7 @@ class FullNodeSimulator(FullNodeAPI):
         Arguments:
             records: The transaction records to process.
         """
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             coins_to_wait_for: Set[Coin] = set()
             for record in records:
                 if record.spend_bundle is None:
@@ -514,7 +515,7 @@ class FullNodeSimulator(FullNodeAPI):
             bundles: The spend bundles to process.
         """
 
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             coins_to_wait_for: Set[Coin] = {addition for bundle in bundles for addition in bundle.additions()}
             return await self.process_coin_spends(coins=coins_to_wait_for, timeout=None)
 
@@ -530,7 +531,7 @@ class FullNodeSimulator(FullNodeAPI):
             coin_names: The coin names to process.
         """
 
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             coin_set = set(coins)
             coin_store = self.full_node.coin_store
 
@@ -569,7 +570,7 @@ class FullNodeSimulator(FullNodeAPI):
             A set of the generated coins.  Note that this does not include any change
             coins that were created.
         """
-        with anyio.fail_after(delay=timeout):
+        with anyio.fail_after(delay=adjusted_timeout(timeout)):
             invalid_amounts = [amount for amount in amounts if amount <= 0]
             if len(invalid_amounts) > 0:
                 invalid_amounts_string = ", ".join(str(amount) for amount in invalid_amounts)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:

The adjusted timeout and simulator helpers PRs crossed last week.  This applies the timeout adjustments that account for the runners arbitrary hang times to the new simulator helper timeouts.

<!-- Does this PR introduce a breaking change? -->
Current Behavior:
New Behavior:


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
