### PR TITLE
factor out coin- and PH subscription handling in order to add unit tests

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -170,7 +170,6 @@ class FullNode:
 
         db_path_replaced: str = config["database_path"].replace("CHALLENGE", config["selected_network"])
         self.db_path = path_from_root(root_path, db_path_replaced)
-
         self.subscriptions = PeerSubscriptions()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._transaction_queue_task = None
@@ -1134,8 +1133,8 @@ class FullNode:
                     # Hints must be added to the DB. The other post-processing tasks are not required when syncing
                     hints_to_add, lookup_coin_ids = get_hints_and_subscription_coin_ids(
                         state_change_summary,
-                        self.subscriptions.has_coin_sub,
-                        self.subscriptions.has_ph_sub,
+                        self.subscriptions.has_coin_subscription,
+                        self.subscriptions.has_ph_subscription,
                     )
                     await self.hint_store.add_hints(hints_to_add)
                     await self.update_wallets(state_change_summary, hints_to_add, lookup_coin_ids)
@@ -1440,8 +1439,8 @@ class FullNode:
 
         hints_to_add, lookup_coin_ids = get_hints_and_subscription_coin_ids(
             state_change_summary,
-            self.subscriptions.has_coin_sub,
-            self.subscriptions.has_ph_sub,
+            self.subscriptions.has_coin_subscription,
+            self.subscriptions.has_ph_subscription,
         )
         await self.hint_store.add_hints(hints_to_add)
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1452,33 +1452,18 @@ class FullNodeAPI:
     async def register_interest_in_puzzle_hash(
         self, request: wallet_protocol.RegisterForPhUpdates, peer: WSChiaConnection
     ) -> Message:
-        if peer.peer_node_id not in self.full_node.peer_puzzle_hash:
-            self.full_node.peer_puzzle_hash[peer.peer_node_id] = set()
 
-        if peer.peer_node_id not in self.full_node.peer_sub_counter:
-            self.full_node.peer_sub_counter[peer.peer_node_id] = 0
-
-        hint_coin_ids = []
-        # Add peer to the "Subscribed" dictionary
         if self.is_trusted(peer):
             max_items = self.full_node.config.get("trusted_max_subscribe_items", 2000000)
         else:
             max_items = self.full_node.config.get("max_subscribe_items", 200000)
+
+        self.full_node.subscriptions.add_ph_subscriptions(peer.peer_node_id, request.puzzle_hashes, max_items)
+
+        hint_coin_ids = []
         for puzzle_hash in request.puzzle_hashes:
-
-            hint_coin_ids.extend(await self.full_node.hint_store.get_coin_ids(puzzle_hash))
-
-            # check subscription limit
-            if self.full_node.peer_sub_counter[peer.peer_node_id] >= max_items:
-                self.log.warning(f"wallet {peer.peer_node_id} exceeded max puzzle_hash subscription limit")
-                continue
-
-            if puzzle_hash not in self.full_node.ph_subscriptions:
-                self.full_node.ph_subscriptions[puzzle_hash] = set()
-            if peer.peer_node_id not in self.full_node.ph_subscriptions[puzzle_hash]:
-                self.full_node.ph_subscriptions[puzzle_hash].add(peer.peer_node_id)
-                self.full_node.peer_puzzle_hash[peer.peer_node_id].add(puzzle_hash)
-                self.full_node.peer_sub_counter[peer.peer_node_id] += 1
+            ph_hint_coins = await self.full_node.hint_store.get_coin_ids(puzzle_hash)
+            hint_coin_ids.extend(ph_hint_coins)
 
         # Send all coins with requested puzzle hash that have been created after the specified height
         states: List[CoinState] = await self.full_node.coin_store.get_coin_states_by_puzzle_hashes(
@@ -1499,28 +1484,12 @@ class FullNodeAPI:
     async def register_interest_in_coin(
         self, request: wallet_protocol.RegisterForCoinUpdates, peer: WSChiaConnection
     ) -> Message:
-        if peer.peer_node_id not in self.full_node.peer_coin_ids:
-            self.full_node.peer_coin_ids[peer.peer_node_id] = set()
 
-        if peer.peer_node_id not in self.full_node.peer_sub_counter:
-            self.full_node.peer_sub_counter[peer.peer_node_id] = 0
         if self.is_trusted(peer):
             max_items = self.full_node.config.get("trusted_max_subscribe_items", 2000000)
         else:
             max_items = self.full_node.config.get("max_subscribe_items", 200000)
-        for coin_id in request.coin_ids:
-
-            # check subscription limit
-            if self.full_node.peer_sub_counter[peer.peer_node_id] >= max_items:
-                self.log.warning(f"wallet {peer.peer_node_id} exceeded max coin subscription limit")
-                break
-
-            if coin_id not in self.full_node.coin_subscriptions:
-                self.full_node.coin_subscriptions[coin_id] = set()
-            if peer.peer_node_id not in self.full_node.coin_subscriptions[coin_id]:
-                self.full_node.coin_subscriptions[coin_id].add(peer.peer_node_id)
-                self.full_node.peer_coin_ids[peer.peer_node_id].add(coin_id)
-                self.full_node.peer_sub_counter[peer.peer_node_id] += 1
+        self.full_node.subscriptions.add_coin_subscriptions(peer.peer_node_id, request.coin_ids, max_items)
 
         states: List[CoinState] = await self.full_node.coin_store.get_coin_states_by_ids(
             include_spent_coins=True, coin_ids=request.coin_ids, min_height=request.min_height

--- a/chia/full_node/hint_management.py
+++ b/chia/full_node/hint_management.py
@@ -10,8 +10,8 @@ from chia.util.ints import uint64
 
 def get_hints_and_subscription_coin_ids(
     state_change_summary: StateChangeSummary,
-    has_coin_sub: Callable[[bytes32], bool],
-    has_ph_sub: Callable[[bytes32], bool],
+    has_coin_subscription: Callable[[bytes32], bool],
+    has_ph_subscription: Callable[[bytes32], bool],
 ) -> Tuple[List[Tuple[bytes32, bytes]], List[bytes32]]:
     # Precondition: all hints passed in are max 32 bytes long
     # Returns the hints that we need to add to the DB, and the coin ids that need to be looked up
@@ -24,11 +24,11 @@ def get_hints_and_subscription_coin_ids(
     lookup_coin_ids: Set[bytes32] = set()
 
     def add_if_coin_subscription(coin_id: bytes32) -> None:
-        if has_coin_sub(coin_id):
+        if has_coin_subscription(coin_id):
             lookup_coin_ids.add(coin_id)
 
     def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
-        if has_ph_sub(puzzle_hash):
+        if has_ph_subscription(puzzle_hash):
             lookup_coin_ids.add(coin_id)
 
     for npc_result in state_change_summary.new_npc_results:

--- a/chia/full_node/hint_management.py
+++ b/chia/full_node/hint_management.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Callable, List, Optional, Set, Tuple
 
 from chia.consensus.blockchain import StateChangeSummary
 from chia.types.blockchain_format.coin import Coin
@@ -10,8 +10,8 @@ from chia.util.ints import uint64
 
 def get_hints_and_subscription_coin_ids(
     state_change_summary: StateChangeSummary,
-    coin_subscriptions: Dict[bytes32, Set[bytes32]],
-    ph_subscriptions: Dict[bytes32, Set[bytes32]],
+    has_coin_sub: Callable[[bytes32], bool],
+    has_ph_sub: Callable[[bytes32], bool],
 ) -> Tuple[List[Tuple[bytes32, bytes]], List[bytes32]]:
     # Precondition: all hints passed in are max 32 bytes long
     # Returns the hints that we need to add to the DB, and the coin ids that need to be looked up
@@ -24,33 +24,34 @@ def get_hints_and_subscription_coin_ids(
     lookup_coin_ids: Set[bytes32] = set()
 
     def add_if_coin_subscription(coin_id: bytes32) -> None:
-        if coin_id in coin_subscriptions:
+        if has_coin_sub(coin_id):
             lookup_coin_ids.add(coin_id)
 
     def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
-        if puzzle_hash in ph_subscriptions:
+        if has_ph_sub(puzzle_hash):
             lookup_coin_ids.add(coin_id)
 
     for npc_result in state_change_summary.new_npc_results:
-        if npc_result.conds is not None:
-            for spend in npc_result.conds.spends:
-                # Record all coin_ids that we are interested in, that had changes
-                add_if_coin_subscription(bytes32(spend.coin_id))
-                add_if_ph_subscription(bytes32(spend.puzzle_hash), bytes32(spend.coin_id))
+        if npc_result.conds is None:
+            continue
+        for spend in npc_result.conds.spends:
+            # Record all coin_ids that we are interested in, that had changes
+            add_if_coin_subscription(bytes32(spend.coin_id))
+            add_if_ph_subscription(bytes32(spend.puzzle_hash), bytes32(spend.coin_id))
 
-                for new_ph, new_am, hint in spend.create_coin:
-                    addition_coin: Coin = Coin(bytes32(spend.coin_id), bytes32(new_ph), uint64(new_am))
-                    addition_coin_name = addition_coin.name()
-                    add_if_coin_subscription(addition_coin_name)
-                    add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
-                    if hint is None:
-                        continue
-                    if len(hint) == 32:
-                        add_if_ph_subscription(bytes32(hint), addition_coin_name)
+            for new_ph, new_am, hint in spend.create_coin:
+                addition_coin: Coin = Coin(bytes32(spend.coin_id), bytes32(new_ph), uint64(new_am))
+                addition_coin_name = addition_coin.name()
+                add_if_coin_subscription(addition_coin_name)
+                add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
+                if hint is None:
+                    continue
+                if len(hint) == 32:
+                    add_if_ph_subscription(bytes32(hint), addition_coin_name)
 
-                    if len(hint) > 0:
-                        assert len(hint) <= 32
-                        hints_to_add.append((addition_coin_name, hint))
+                if len(hint) > 0:
+                    assert len(hint) <= 32
+                    hints_to_add.append((addition_coin_name, hint))
 
     # Goes through all new reward coins
     for reward_coin in state_change_summary.new_rewards:

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+
+
+def _get_or_add_set(c: Dict[bytes32, Set[bytes32]], key: bytes32) -> Set[bytes32]:
+    ret: Optional[Set[bytes32]] = c.get(key)
+    if ret is not None:
+        return ret
+
+    ret2: Set[bytes32] = set()
+    c[key] = ret2
+    return ret2
+
+
+# The PeerSubscriptions class is essentially a multi-index container. It can be
+# indexed by peer_id, coin_id and puzzle_hash.
+@dataclass
+class PeerSubscriptions:
+    # TODO: use NewType all over to describe these various uses of the same types
+    # Puzzle Hash : Set[Peer ID]
+    _coin_subscriptions: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
+    # Puzzle Hash : Set[Peer ID]
+    _ph_subscriptions: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
+    # Peer ID: Set[Coin ids]
+    _peer_coin_ids: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
+    # Peer ID: Set[puzzle_hash]
+    _peer_puzzle_hash: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
+    # Peer ID: subscription count
+    _peer_sub_counter: Dict[bytes32, int] = field(default_factory=dict, init=False)
+
+    def has_ph_sub(self, ph: bytes32) -> bool:
+        return ph in self._ph_subscriptions
+
+    def has_coin_sub(self, coin_id: bytes32) -> bool:
+        return coin_id in self._coin_subscriptions
+
+    def add_ph_subscriptions(self, peer_id: bytes32, phs: List[bytes32], max_items: int) -> None:
+        puzzle_hash_peers = _get_or_add_set(self._peer_puzzle_hash, peer_id)
+
+        existing_sub_count = self._peer_sub_counter.get(peer_id)
+        if existing_sub_count is None:
+            self._peer_sub_counter[peer_id] = 0
+            existing_sub_count = 0
+
+        # if we've reached the limit on number of subscriptions, just bail
+        if existing_sub_count >= max_items:
+            return
+
+        # decrement this counter as we go, to know if we've hit the limit of
+        # number of subscriptions
+        subscriptions_left = max_items - existing_sub_count
+
+        for ph in phs:
+            ph_sub: Optional[Set[bytes32]] = self._ph_subscriptions.get(ph)
+            if ph_sub is None:
+                ph_sub = set()
+                self._ph_subscriptions[ph] = ph_sub
+            elif peer_id in ph_sub:
+                continue
+
+            ph_sub.add(peer_id)
+            puzzle_hash_peers.add(ph)
+            self._peer_sub_counter[peer_id] += 1
+            subscriptions_left -= 1
+
+            if subscriptions_left == 0:
+                break
+
+    def add_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32], max_items: int) -> None:
+
+        coin_id_peers = _get_or_add_set(self._peer_coin_ids, peer_id)
+
+        existing_sub_count = self._peer_sub_counter.get(peer_id)
+        if existing_sub_count is None:
+            self._peer_sub_counter[peer_id] = 0
+            existing_sub_count = 0
+
+        # if we've reached the limit on number of subscriptions, just bail
+        if existing_sub_count >= max_items:
+            return
+
+        # decrement this counter as we go, to know if we've hit the limit of
+        # number of subscriptions
+        subscriptions_left = max_items - existing_sub_count
+
+        for coin_id in coin_ids:
+            coin_sub: Optional[Set[bytes32]] = self._coin_subscriptions.get(coin_id)
+            if coin_sub is None:
+                coin_sub = set()
+                self._coin_subscriptions[coin_id] = coin_sub
+            elif peer_id in coin_sub:
+                continue
+
+            coin_sub.add(peer_id)
+            coin_id_peers.add(coin_id)
+            self._peer_sub_counter[peer_id] += 1
+            subscriptions_left -= 1
+
+            if subscriptions_left == 0:
+                break
+
+    def remove_peer(self, peer_id: bytes32) -> None:
+
+        counter = 0
+        puzzle_hashes = self._peer_puzzle_hash.get(peer_id)
+        if puzzle_hashes is not None:
+            for ph in puzzle_hashes:
+                subs = self._ph_subscriptions[ph]
+                subs.remove(peer_id)
+                counter += 1
+                if subs == set():
+                    self._ph_subscriptions.pop(ph)
+            self._peer_puzzle_hash.pop(peer_id)
+
+        coin_ids = self._peer_coin_ids.get(peer_id)
+        if coin_ids is not None:
+            for coin_id in coin_ids:
+                subs = self._coin_subscriptions[coin_id]
+                subs.remove(peer_id)
+                counter += 1
+                if subs == set():
+                    self._coin_subscriptions.pop(coin_id)
+            self._peer_coin_ids.pop(peer_id)
+
+        if peer_id in self._peer_sub_counter:
+            num_subs = self._peer_sub_counter.pop(peer_id)
+            assert num_subs == counter
+
+    def peers_for_coin_id(self, coin_id: bytes32) -> Set[bytes32]:
+        return self._coin_subscriptions.get(coin_id, set())
+
+    def peers_for_puzzle_hash(self, puzzle_hash: bytes32) -> Set[bytes32]:
+        return self._ph_subscriptions.get(puzzle_hash, set())

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -1,24 +1,17 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 
-
-def _get_or_add_set(c: Dict[bytes32, Set[bytes32]], key: bytes32) -> Set[bytes32]:
-    ret: Optional[Set[bytes32]] = c.get(key)
-    if ret is not None:
-        return ret
-
-    ret2: Set[bytes32] = set()
-    c[key] = ret2
-    return ret2
+log = logging.getLogger(__name__)
 
 
 # The PeerSubscriptions class is essentially a multi-index container. It can be
 # indexed by peer_id, coin_id and puzzle_hash.
-@dataclass
+@dataclass(frozen=True)
 class PeerSubscriptions:
     # TODO: use NewType all over to describe these various uses of the same types
     # Puzzle Hash : Set[Peer ID]
@@ -32,22 +25,23 @@ class PeerSubscriptions:
     # Peer ID: subscription count
     _peer_sub_counter: Dict[bytes32, int] = field(default_factory=dict, init=False)
 
-    def has_ph_sub(self, ph: bytes32) -> bool:
+    def has_ph_subscription(self, ph: bytes32) -> bool:
         return ph in self._ph_subscriptions
 
-    def has_coin_sub(self, coin_id: bytes32) -> bool:
+    def has_coin_subscription(self, coin_id: bytes32) -> bool:
         return coin_id in self._coin_subscriptions
 
     def add_ph_subscriptions(self, peer_id: bytes32, phs: List[bytes32], max_items: int) -> None:
-        puzzle_hash_peers = _get_or_add_set(self._peer_puzzle_hash, peer_id)
-
-        existing_sub_count = self._peer_sub_counter.get(peer_id)
-        if existing_sub_count is None:
-            self._peer_sub_counter[peer_id] = 0
-            existing_sub_count = 0
+        puzzle_hash_peers = self._peer_puzzle_hash.setdefault(peer_id, set())
+        existing_sub_count = self._peer_sub_counter.setdefault(peer_id, 0)
 
         # if we've reached the limit on number of subscriptions, just bail
         if existing_sub_count >= max_items:
+            log.info(
+                "peer_id: %s reached max number of puzzle-hash subscriptions. "
+                "Not all its coin states will be reported",
+                peer_id,
+            )
             return
 
         # decrement this counter as we go, to know if we've hit the limit of
@@ -55,11 +49,8 @@ class PeerSubscriptions:
         subscriptions_left = max_items - existing_sub_count
 
         for ph in phs:
-            ph_sub: Optional[Set[bytes32]] = self._ph_subscriptions.get(ph)
-            if ph_sub is None:
-                ph_sub = set()
-                self._ph_subscriptions[ph] = ph_sub
-            elif peer_id in ph_sub:
+            ph_sub = self._ph_subscriptions.setdefault(ph, set())
+            if peer_id in ph_sub:
                 continue
 
             ph_sub.add(peer_id)
@@ -68,19 +59,23 @@ class PeerSubscriptions:
             subscriptions_left -= 1
 
             if subscriptions_left == 0:
+                log.info(
+                    "peer_id: %s reached max number of puzzle-hash subscriptions. "
+                    "Not all its coin states will be reported",
+                    peer_id,
+                )
                 break
 
     def add_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32], max_items: int) -> None:
-
-        coin_id_peers = _get_or_add_set(self._peer_coin_ids, peer_id)
-
-        existing_sub_count = self._peer_sub_counter.get(peer_id)
-        if existing_sub_count is None:
-            self._peer_sub_counter[peer_id] = 0
-            existing_sub_count = 0
+        coin_id_peers = self._peer_coin_ids.setdefault(peer_id, set())
+        existing_sub_count = self._peer_sub_counter.setdefault(peer_id, 0)
 
         # if we've reached the limit on number of subscriptions, just bail
         if existing_sub_count >= max_items:
+            log.info(
+                "peer_id: %s reached max number of coin subscriptions. Not all its coin states will be reported",
+                peer_id,
+            )
             return
 
         # decrement this counter as we go, to know if we've hit the limit of
@@ -88,11 +83,8 @@ class PeerSubscriptions:
         subscriptions_left = max_items - existing_sub_count
 
         for coin_id in coin_ids:
-            coin_sub: Optional[Set[bytes32]] = self._coin_subscriptions.get(coin_id)
-            if coin_sub is None:
-                coin_sub = set()
-                self._coin_subscriptions[coin_id] = coin_sub
-            elif peer_id in coin_sub:
+            coin_sub = self._coin_subscriptions.setdefault(coin_id, set())
+            if peer_id in coin_sub:
                 continue
 
             coin_sub.add(peer_id)
@@ -101,6 +93,10 @@ class PeerSubscriptions:
             subscriptions_left -= 1
 
             if subscriptions_left == 0:
+                log.info(
+                    "peer_id: %s reached max number of coin subscriptions. Not all its coin states will be reported",
+                    peer_id,
+                )
                 break
 
     def remove_peer(self, peer_id: bytes32) -> None:

--- a/tests/core/full_node/test_hint_management.py
+++ b/tests/core/full_node/test_hint_management.py
@@ -101,8 +101,8 @@ async def test_lookup_coin_ids(bt: BlockTools, empty_blockchain: Blockchain) -> 
     scs = StateChangeSummary(br, uint32(0), [], npc_res, rewards)
 
     # Removal ID and addition PH
-    has_coin_sub = lambda c: c == coin_ids[1]  # noqa
-    has_ph_sub = lambda ph: ph == phs[4]  # noqa
+    has_coin_sub = lambda c: c == coin_ids[1]  # noqa: E731
+    has_ph_sub = lambda ph: ph == phs[4]  # noqa: E731
 
     _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
 
@@ -111,8 +111,8 @@ async def test_lookup_coin_ids(bt: BlockTools, empty_blockchain: Blockchain) -> 
     assert set(lookup_coin_ids) == {coin_ids[1], first_coin_id, second_coin_id}
 
     # Removal PH and addition ID
-    has_coin_sub = lambda c: c == first_coin_id  # noqa
-    has_ph_sub = lambda ph: ph == phs[0]  # noqa
+    has_coin_sub = lambda c: c == first_coin_id  # noqa: E731
+    has_ph_sub = lambda ph: ph == phs[0]  # noqa: E731
 
     _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {first_coin_id, coin_ids[0], coin_ids[2]}
@@ -120,19 +120,19 @@ async def test_lookup_coin_ids(bt: BlockTools, empty_blockchain: Blockchain) -> 
     # Subscribe to hint
     third_coin_id: bytes32 = Coin(bytes32(spends[1].coin_id), phs[9], uint64(123)).name()
 
-    has_ph_sub = lambda ph: ph == bytes32(b"1" * 32)  # noqa
+    has_ph_sub = lambda ph: ph == bytes32(b"1" * 32)  # noqa: E731
 
     _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, no_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {first_coin_id, third_coin_id}
 
     # Reward PH
-    has_ph_sub = lambda ph: ph == rewards[0].puzzle_hash  # noqa
+    has_ph_sub = lambda ph: ph == rewards[0].puzzle_hash  # noqa: E731
 
     _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, no_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {rewards[0].name(), rewards[2].name()}
 
     # Reward coin id + reward ph
-    has_coin_sub = lambda c: c == rewards[1].name()  # noqa
+    has_coin_sub = lambda c: c == rewards[1].name()  # noqa: E731
 
     _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {rewards[1].name(), rewards[0].name(), rewards[2].name()}

--- a/tests/core/full_node/test_hint_management.py
+++ b/tests/core/full_node/test_hint_management.py
@@ -59,6 +59,10 @@ spends: List[Spend] = [
 ]
 
 
+def no_sub(c: bytes32) -> bool:
+    return False
+
+
 @pytest.mark.asyncio
 async def test_hints_to_add(bt: BlockTools, empty_blockchain: Blockchain) -> None:
     blocks = bt.get_consecutive_blocks(2)
@@ -70,7 +74,7 @@ async def test_hints_to_add(bt: BlockTools, empty_blockchain: Blockchain) -> Non
     npc_res = [NPCResult(None, None, uint64(0)), NPCResult(None, sbc, uint64(0))]
 
     scs = StateChangeSummary(br, uint32(0), [], npc_res, [])
-    hints_to_add, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, {}, {})
+    hints_to_add, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, no_sub, no_sub)
     assert len(lookup_coin_ids) == 0
 
     first_coin_id: bytes32 = Coin(bytes32(spends[0].coin_id), bytes32(phs[4]), uint64(3)).name()
@@ -97,33 +101,38 @@ async def test_lookup_coin_ids(bt: BlockTools, empty_blockchain: Blockchain) -> 
     scs = StateChangeSummary(br, uint32(0), [], npc_res, rewards)
 
     # Removal ID and addition PH
-    coin_subscriptions = {coin_ids[1]: {bytes32(b"2" * 32)}}
-    ph_subscriptions = {phs[4]: {bytes32(b"3" * 32)}}
+    has_coin_sub = lambda c: c == coin_ids[1]  # noqa
+    has_ph_sub = lambda ph: ph == phs[4]  # noqa
 
-    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, coin_subscriptions, ph_subscriptions)
+    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
 
     first_coin_id: bytes32 = Coin(bytes32(spends[0].coin_id), bytes32(phs[4]), uint64(3)).name()
     second_coin_id: bytes32 = Coin(bytes32(spends[1].coin_id), bytes32(phs[4]), uint64(6)).name()
     assert set(lookup_coin_ids) == {coin_ids[1], first_coin_id, second_coin_id}
 
     # Removal PH and addition ID
-    coin_subscriptions = {first_coin_id: {bytes32(b"5" * 32)}}
-    ph_subscriptions = {phs[0]: {bytes32(b"6" * 32)}}
-    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, coin_subscriptions, ph_subscriptions)
+    has_coin_sub = lambda c: c == first_coin_id  # noqa
+    has_ph_sub = lambda ph: ph == phs[0]  # noqa
+
+    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {first_coin_id, coin_ids[0], coin_ids[2]}
 
     # Subscribe to hint
     third_coin_id: bytes32 = Coin(bytes32(spends[1].coin_id), phs[9], uint64(123)).name()
-    ph_subscriptions = {bytes32(b"1" * 32): {bytes32(b"7" * 32)}}
-    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, {}, ph_subscriptions)
+
+    has_ph_sub = lambda ph: ph == bytes32(b"1" * 32)  # noqa
+
+    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, no_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {first_coin_id, third_coin_id}
 
     # Reward PH
-    ph_subscriptions = {rewards[0].puzzle_hash: {bytes32(b"8" * 32)}}
-    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, {}, ph_subscriptions)
+    has_ph_sub = lambda ph: ph == rewards[0].puzzle_hash  # noqa
+
+    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, no_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {rewards[0].name(), rewards[2].name()}
 
     # Reward coin id + reward ph
-    coin_subscriptions = {rewards[1].name(): {bytes32(b"9" * 32)}}
-    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, coin_subscriptions, ph_subscriptions)
+    has_coin_sub = lambda c: c == rewards[1].name()  # noqa
+
+    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {rewards[1].name(), rewards[0].name(), rewards[2].name()}

--- a/tests/core/full_node/test_subscriptions.py
+++ b/tests/core/full_node/test_subscriptions.py
@@ -20,62 +20,62 @@ ph4 = bytes32(b"h" * 32)
 def test_has_ph_sub() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_ph_sub(ph1) is False
-    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_subscription(ph1) is False
+    assert sub.has_ph_subscription(ph2) is False
 
     sub.add_ph_subscriptions(peer1, [ph1], 100)
 
-    assert sub.has_ph_sub(ph1) is True
-    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_subscription(ph1) is True
+    assert sub.has_ph_subscription(ph2) is False
 
     sub.add_ph_subscriptions(peer1, [ph1, ph2], 100)
 
-    assert sub.has_ph_sub(ph1) is True
-    assert sub.has_ph_sub(ph2) is True
+    assert sub.has_ph_subscription(ph1) is True
+    assert sub.has_ph_subscription(ph2) is True
 
     # note that this is technically a type error as well.
     # we can remove these asserts once we have type checking
-    assert sub.has_coin_sub(coin1) is False
-    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_subscription(coin1) is False
+    assert sub.has_coin_subscription(coin2) is False
 
     sub.remove_peer(peer1)
 
-    assert sub.has_ph_sub(ph1) is False
-    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_subscription(ph1) is False
+    assert sub.has_ph_subscription(ph2) is False
 
 
 def test_has_coin_sub() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_coin_sub(coin1) is False
-    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_subscription(coin1) is False
+    assert sub.has_coin_subscription(coin2) is False
 
     sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-    assert sub.has_coin_sub(coin1) is True
-    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_subscription(coin1) is True
+    assert sub.has_coin_subscription(coin2) is False
 
     sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
 
-    assert sub.has_coin_sub(coin1) is True
-    assert sub.has_coin_sub(coin2) is True
+    assert sub.has_coin_subscription(coin1) is True
+    assert sub.has_coin_subscription(coin2) is True
 
     # note that this is technically a type error as well.
     # we can remove these asserts once we have type checking
-    assert sub.has_ph_sub(coin1) is False
-    assert sub.has_ph_sub(coin2) is False
+    assert sub.has_ph_subscription(coin1) is False
+    assert sub.has_ph_subscription(coin2) is False
 
     sub.remove_peer(peer1)
 
-    assert sub.has_coin_sub(coin1) is False
-    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_subscription(coin1) is False
+    assert sub.has_coin_subscription(coin2) is False
 
 
 def test_overlapping_coin_subscriptions() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_coin_sub(coin1) is False
-    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_subscription(coin1) is False
+    assert sub.has_coin_subscription(coin2) is False
 
     assert sub.peers_for_coin_id(coin1) == set()
     assert sub.peers_for_coin_id(coin2) == set()
@@ -88,8 +88,8 @@ def test_overlapping_coin_subscriptions() -> None:
 
     sub.add_coin_subscriptions(peer2, [coin2], 100)
 
-    assert sub.has_coin_sub(coin1) is True
-    assert sub.has_coin_sub(coin2) is True
+    assert sub.has_coin_subscription(coin1) is True
+    assert sub.has_coin_subscription(coin2) is True
 
     assert sub.peers_for_coin_id(coin1) == set([peer1])
     assert sub.peers_for_coin_id(coin2) == set([peer2])
@@ -97,8 +97,8 @@ def test_overlapping_coin_subscriptions() -> None:
     # peer1 is now subscribing to both coins
     sub.add_coin_subscriptions(peer1, [coin2], 100)
 
-    assert sub.has_coin_sub(coin1) is True
-    assert sub.has_coin_sub(coin2) is True
+    assert sub.has_coin_subscription(coin1) is True
+    assert sub.has_coin_subscription(coin2) is True
 
     assert sub.peers_for_coin_id(coin1) == set([peer1])
     assert sub.peers_for_coin_id(coin2) == set([peer1, peer2])
@@ -106,8 +106,8 @@ def test_overlapping_coin_subscriptions() -> None:
     # removing peer1 still leaves the subscription to coin2
     sub.remove_peer(peer1)
 
-    assert sub.has_coin_sub(coin1) is False
-    assert sub.has_coin_sub(coin2) is True
+    assert sub.has_coin_subscription(coin1) is False
+    assert sub.has_coin_subscription(coin2) is True
 
     assert sub.peers_for_coin_id(coin1) == set()
     assert sub.peers_for_coin_id(coin2) == set([peer2])
@@ -116,8 +116,8 @@ def test_overlapping_coin_subscriptions() -> None:
 def test_overlapping_ph_subscriptions() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_ph_sub(ph1) is False
-    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_subscription(ph1) is False
+    assert sub.has_ph_subscription(ph2) is False
 
     assert sub.peers_for_puzzle_hash(ph1) == set()
     assert sub.peers_for_puzzle_hash(ph2) == set()
@@ -130,8 +130,8 @@ def test_overlapping_ph_subscriptions() -> None:
 
     sub.add_ph_subscriptions(peer2, [ph2], 100)
 
-    assert sub.has_ph_sub(ph1) is True
-    assert sub.has_ph_sub(ph2) is True
+    assert sub.has_ph_subscription(ph1) is True
+    assert sub.has_ph_subscription(ph2) is True
 
     assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
     assert sub.peers_for_puzzle_hash(ph2) == set([peer2])
@@ -139,8 +139,8 @@ def test_overlapping_ph_subscriptions() -> None:
     # peer1 is now subscribing to both phs
     sub.add_ph_subscriptions(peer1, [ph2], 100)
 
-    assert sub.has_ph_sub(ph1) is True
-    assert sub.has_ph_sub(ph2) is True
+    assert sub.has_ph_subscription(ph1) is True
+    assert sub.has_ph_subscription(ph2) is True
 
     assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
     assert sub.peers_for_puzzle_hash(ph2) == set([peer1, peer2])
@@ -148,8 +148,8 @@ def test_overlapping_ph_subscriptions() -> None:
     # removing peer1 still leaves the subscription to ph2
     sub.remove_peer(peer1)
 
-    assert sub.has_ph_sub(ph1) is False
-    assert sub.has_ph_sub(ph2) is True
+    assert sub.has_ph_subscription(ph1) is False
+    assert sub.has_ph_subscription(ph2) is True
 
     assert sub.peers_for_puzzle_hash(ph1) == set()
     assert sub.peers_for_puzzle_hash(ph2) == set([peer2])
@@ -158,17 +158,17 @@ def test_overlapping_ph_subscriptions() -> None:
 def test_ph_sub_limit() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_ph_sub(ph1) is False
-    assert sub.has_ph_sub(ph2) is False
-    assert sub.has_ph_sub(ph2) is False
-    assert sub.has_ph_sub(ph3) is False
+    assert sub.has_ph_subscription(ph1) is False
+    assert sub.has_ph_subscription(ph2) is False
+    assert sub.has_ph_subscription(ph2) is False
+    assert sub.has_ph_subscription(ph3) is False
 
     sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
 
-    assert sub.has_ph_sub(ph1) is True
-    assert sub.has_ph_sub(ph2) is True
-    assert sub.has_ph_sub(ph3) is True
-    assert sub.has_ph_sub(ph4) is False
+    assert sub.has_ph_subscription(ph1) is True
+    assert sub.has_ph_subscription(ph2) is True
+    assert sub.has_ph_subscription(ph3) is True
+    assert sub.has_ph_subscription(ph4) is False
 
     assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
     assert sub.peers_for_puzzle_hash(ph2) == set([peer1])
@@ -178,19 +178,19 @@ def test_ph_sub_limit() -> None:
     # peer1 should still be limited
     sub.add_ph_subscriptions(peer1, [ph4], 3)
 
-    assert sub.has_ph_sub(ph4) is False
+    assert sub.has_ph_subscription(ph4) is False
     assert sub.peers_for_puzzle_hash(ph4) == set()
 
     # peer1 is also limied on coin subscriptions
     sub.add_ph_subscriptions(peer1, [coin1], 3)
 
-    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_subscription(coin1) is False
     assert sub.peers_for_coin_id(coin1) == set()
 
     # peer2 is has its own limit
     sub.add_ph_subscriptions(peer2, [ph4], 3)
 
-    assert sub.has_ph_sub(ph4) is True
+    assert sub.has_ph_subscription(ph4) is True
     assert sub.peers_for_puzzle_hash(ph4) == set([peer2])
 
     sub.remove_peer(peer1)
@@ -200,17 +200,17 @@ def test_ph_sub_limit() -> None:
 def test_ph_sub_limit_incremental() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_ph_sub(ph1) is False
-    assert sub.has_ph_sub(ph2) is False
-    assert sub.has_ph_sub(ph2) is False
-    assert sub.has_ph_sub(ph3) is False
+    assert sub.has_ph_subscription(ph1) is False
+    assert sub.has_ph_subscription(ph2) is False
+    assert sub.has_ph_subscription(ph2) is False
+    assert sub.has_ph_subscription(ph3) is False
 
     sub.add_ph_subscriptions(peer1, [ph1], 2)
 
-    assert sub.has_ph_sub(ph1) is True
-    assert sub.has_ph_sub(ph2) is False
-    assert sub.has_ph_sub(ph3) is False
-    assert sub.has_ph_sub(ph4) is False
+    assert sub.has_ph_subscription(ph1) is True
+    assert sub.has_ph_subscription(ph2) is False
+    assert sub.has_ph_subscription(ph3) is False
+    assert sub.has_ph_subscription(ph4) is False
 
     assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
     assert sub.peers_for_puzzle_hash(ph2) == set()
@@ -220,10 +220,10 @@ def test_ph_sub_limit_incremental() -> None:
     # this will cross the limit. Only ph2 will be added
     sub.add_ph_subscriptions(peer1, [ph2, ph3], 2)
 
-    assert sub.has_ph_sub(ph1) is True
-    assert sub.has_ph_sub(ph2) is True
-    assert sub.has_ph_sub(ph3) is False
-    assert sub.has_ph_sub(ph4) is False
+    assert sub.has_ph_subscription(ph1) is True
+    assert sub.has_ph_subscription(ph2) is True
+    assert sub.has_ph_subscription(ph3) is False
+    assert sub.has_ph_subscription(ph4) is False
 
     assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
     assert sub.peers_for_puzzle_hash(ph2) == set([peer1])
@@ -236,17 +236,17 @@ def test_ph_sub_limit_incremental() -> None:
 def test_coin_sub_limit() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_coin_sub(coin1) is False
-    assert sub.has_coin_sub(coin2) is False
-    assert sub.has_coin_sub(coin2) is False
-    assert sub.has_coin_sub(coin3) is False
+    assert sub.has_coin_subscription(coin1) is False
+    assert sub.has_coin_subscription(coin2) is False
+    assert sub.has_coin_subscription(coin2) is False
+    assert sub.has_coin_subscription(coin3) is False
 
     sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
 
-    assert sub.has_coin_sub(coin1) is True
-    assert sub.has_coin_sub(coin2) is True
-    assert sub.has_coin_sub(coin3) is True
-    assert sub.has_coin_sub(coin4) is False
+    assert sub.has_coin_subscription(coin1) is True
+    assert sub.has_coin_subscription(coin2) is True
+    assert sub.has_coin_subscription(coin3) is True
+    assert sub.has_coin_subscription(coin4) is False
 
     assert sub.peers_for_coin_id(coin1) == set([peer1])
     assert sub.peers_for_coin_id(coin2) == set([peer1])
@@ -256,19 +256,19 @@ def test_coin_sub_limit() -> None:
     # peer1 should still be limited
     sub.add_coin_subscriptions(peer1, [coin4], 3)
 
-    assert sub.has_coin_sub(coin4) is False
+    assert sub.has_coin_subscription(coin4) is False
     assert sub.peers_for_coin_id(coin4) == set()
 
     # peer1 is also limied on ph subscriptions
     sub.add_ph_subscriptions(peer1, [ph1], 3)
 
-    assert sub.has_ph_sub(ph1) is False
+    assert sub.has_ph_subscription(ph1) is False
     assert sub.peers_for_puzzle_hash(ph1) == set()
 
     # peer2 is has its own limit
     sub.add_coin_subscriptions(peer2, [coin4], 3)
 
-    assert sub.has_coin_sub(coin4) is True
+    assert sub.has_coin_subscription(coin4) is True
     assert sub.peers_for_coin_id(coin4) == set([peer2])
 
     sub.remove_peer(peer1)
@@ -278,17 +278,17 @@ def test_coin_sub_limit() -> None:
 def test_coin_sub_limit_incremental() -> None:
     sub = PeerSubscriptions()
 
-    assert sub.has_coin_sub(coin1) is False
-    assert sub.has_coin_sub(coin2) is False
-    assert sub.has_coin_sub(coin2) is False
-    assert sub.has_coin_sub(coin3) is False
+    assert sub.has_coin_subscription(coin1) is False
+    assert sub.has_coin_subscription(coin2) is False
+    assert sub.has_coin_subscription(coin2) is False
+    assert sub.has_coin_subscription(coin3) is False
 
     sub.add_coin_subscriptions(peer1, [coin1], 2)
 
-    assert sub.has_coin_sub(coin1) is True
-    assert sub.has_coin_sub(coin2) is False
-    assert sub.has_coin_sub(coin3) is False
-    assert sub.has_coin_sub(coin4) is False
+    assert sub.has_coin_subscription(coin1) is True
+    assert sub.has_coin_subscription(coin2) is False
+    assert sub.has_coin_subscription(coin3) is False
+    assert sub.has_coin_subscription(coin4) is False
 
     assert sub.peers_for_coin_id(coin1) == set([peer1])
     assert sub.peers_for_coin_id(coin2) == set()
@@ -298,10 +298,10 @@ def test_coin_sub_limit_incremental() -> None:
     # this will cross the limit. Only coin2 will be added
     sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
 
-    assert sub.has_coin_sub(coin1) is True
-    assert sub.has_coin_sub(coin2) is True
-    assert sub.has_coin_sub(coin3) is False
-    assert sub.has_coin_sub(coin4) is False
+    assert sub.has_coin_subscription(coin1) is True
+    assert sub.has_coin_subscription(coin2) is True
+    assert sub.has_coin_subscription(coin3) is False
+    assert sub.has_coin_subscription(coin4) is False
 
     assert sub.peers_for_coin_id(coin1) == set([peer1])
     assert sub.peers_for_coin_id(coin2) == set([peer1])

--- a/tests/core/full_node/test_subscriptions.py
+++ b/tests/core/full_node/test_subscriptions.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from chia.full_node.subscriptions import PeerSubscriptions
+from chia.types.blockchain_format.sized_bytes import bytes32
+
+peer1 = bytes32(b"1" * 32)
+peer2 = bytes32(b"2" * 32)
+
+coin1 = bytes32(b"a" * 32)
+coin2 = bytes32(b"b" * 32)
+coin3 = bytes32(b"c" * 32)
+coin4 = bytes32(b"d" * 32)
+
+ph1 = bytes32(b"e" * 32)
+ph2 = bytes32(b"f" * 32)
+ph3 = bytes32(b"g" * 32)
+ph4 = bytes32(b"h" * 32)
+
+
+def test_has_ph_sub() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_ph_sub(ph1) is False
+    assert sub.has_ph_sub(ph2) is False
+
+    sub.add_ph_subscriptions(peer1, [ph1], 100)
+
+    assert sub.has_ph_sub(ph1) is True
+    assert sub.has_ph_sub(ph2) is False
+
+    sub.add_ph_subscriptions(peer1, [ph1, ph2], 100)
+
+    assert sub.has_ph_sub(ph1) is True
+    assert sub.has_ph_sub(ph2) is True
+
+    # note that this is technically a type error as well.
+    # we can remove these asserts once we have type checking
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_sub(coin2) is False
+
+    sub.remove_peer(peer1)
+
+    assert sub.has_ph_sub(ph1) is False
+    assert sub.has_ph_sub(ph2) is False
+
+
+def test_has_coin_sub() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_sub(coin2) is False
+
+    sub.add_coin_subscriptions(peer1, [coin1], 100)
+
+    assert sub.has_coin_sub(coin1) is True
+    assert sub.has_coin_sub(coin2) is False
+
+    sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
+
+    assert sub.has_coin_sub(coin1) is True
+    assert sub.has_coin_sub(coin2) is True
+
+    # note that this is technically a type error as well.
+    # we can remove these asserts once we have type checking
+    assert sub.has_ph_sub(coin1) is False
+    assert sub.has_ph_sub(coin2) is False
+
+    sub.remove_peer(peer1)
+
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_sub(coin2) is False
+
+
+def test_overlapping_coin_subscriptions() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_sub(coin2) is False
+
+    assert sub.peers_for_coin_id(coin1) == set()
+    assert sub.peers_for_coin_id(coin2) == set()
+
+    # subscribed to different coins
+    sub.add_coin_subscriptions(peer1, [coin1], 100)
+
+    assert sub.peers_for_coin_id(coin1) == set([peer1])
+    assert sub.peers_for_coin_id(coin2) == set()
+
+    sub.add_coin_subscriptions(peer2, [coin2], 100)
+
+    assert sub.has_coin_sub(coin1) is True
+    assert sub.has_coin_sub(coin2) is True
+
+    assert sub.peers_for_coin_id(coin1) == set([peer1])
+    assert sub.peers_for_coin_id(coin2) == set([peer2])
+
+    # peer1 is now subscribing to both coins
+    sub.add_coin_subscriptions(peer1, [coin2], 100)
+
+    assert sub.has_coin_sub(coin1) is True
+    assert sub.has_coin_sub(coin2) is True
+
+    assert sub.peers_for_coin_id(coin1) == set([peer1])
+    assert sub.peers_for_coin_id(coin2) == set([peer1, peer2])
+
+    # removing peer1 still leaves the subscription to coin2
+    sub.remove_peer(peer1)
+
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_sub(coin2) is True
+
+    assert sub.peers_for_coin_id(coin1) == set()
+    assert sub.peers_for_coin_id(coin2) == set([peer2])
+
+
+def test_overlapping_ph_subscriptions() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_ph_sub(ph1) is False
+    assert sub.has_ph_sub(ph2) is False
+
+    assert sub.peers_for_puzzle_hash(ph1) == set()
+    assert sub.peers_for_puzzle_hash(ph2) == set()
+
+    # subscribed to different phs
+    sub.add_ph_subscriptions(peer1, [ph1], 100)
+
+    assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph2) == set()
+
+    sub.add_ph_subscriptions(peer2, [ph2], 100)
+
+    assert sub.has_ph_sub(ph1) is True
+    assert sub.has_ph_sub(ph2) is True
+
+    assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph2) == set([peer2])
+
+    # peer1 is now subscribing to both phs
+    sub.add_ph_subscriptions(peer1, [ph2], 100)
+
+    assert sub.has_ph_sub(ph1) is True
+    assert sub.has_ph_sub(ph2) is True
+
+    assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph2) == set([peer1, peer2])
+
+    # removing peer1 still leaves the subscription to ph2
+    sub.remove_peer(peer1)
+
+    assert sub.has_ph_sub(ph1) is False
+    assert sub.has_ph_sub(ph2) is True
+
+    assert sub.peers_for_puzzle_hash(ph1) == set()
+    assert sub.peers_for_puzzle_hash(ph2) == set([peer2])
+
+
+def test_ph_sub_limit() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_ph_sub(ph1) is False
+    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_sub(ph3) is False
+
+    sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
+
+    assert sub.has_ph_sub(ph1) is True
+    assert sub.has_ph_sub(ph2) is True
+    assert sub.has_ph_sub(ph3) is True
+    assert sub.has_ph_sub(ph4) is False
+
+    assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph2) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph3) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph4) == set()
+
+    # peer1 should still be limited
+    sub.add_ph_subscriptions(peer1, [ph4], 3)
+
+    assert sub.has_ph_sub(ph4) is False
+    assert sub.peers_for_puzzle_hash(ph4) == set()
+
+    # peer1 is also limied on coin subscriptions
+    sub.add_ph_subscriptions(peer1, [coin1], 3)
+
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.peers_for_coin_id(coin1) == set()
+
+    # peer2 is has its own limit
+    sub.add_ph_subscriptions(peer2, [ph4], 3)
+
+    assert sub.has_ph_sub(ph4) is True
+    assert sub.peers_for_puzzle_hash(ph4) == set([peer2])
+
+    sub.remove_peer(peer1)
+    sub.remove_peer(peer2)
+
+
+def test_ph_sub_limit_incremental() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_ph_sub(ph1) is False
+    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_sub(ph3) is False
+
+    sub.add_ph_subscriptions(peer1, [ph1], 2)
+
+    assert sub.has_ph_sub(ph1) is True
+    assert sub.has_ph_sub(ph2) is False
+    assert sub.has_ph_sub(ph3) is False
+    assert sub.has_ph_sub(ph4) is False
+
+    assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph2) == set()
+    assert sub.peers_for_puzzle_hash(ph3) == set()
+    assert sub.peers_for_puzzle_hash(ph4) == set()
+
+    # this will cross the limit. Only ph2 will be added
+    sub.add_ph_subscriptions(peer1, [ph2, ph3], 2)
+
+    assert sub.has_ph_sub(ph1) is True
+    assert sub.has_ph_sub(ph2) is True
+    assert sub.has_ph_sub(ph3) is False
+    assert sub.has_ph_sub(ph4) is False
+
+    assert sub.peers_for_puzzle_hash(ph1) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph2) == set([peer1])
+    assert sub.peers_for_puzzle_hash(ph3) == set()
+    assert sub.peers_for_puzzle_hash(ph4) == set()
+
+    sub.remove_peer(peer1)
+
+
+def test_coin_sub_limit() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_sub(coin3) is False
+
+    sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
+
+    assert sub.has_coin_sub(coin1) is True
+    assert sub.has_coin_sub(coin2) is True
+    assert sub.has_coin_sub(coin3) is True
+    assert sub.has_coin_sub(coin4) is False
+
+    assert sub.peers_for_coin_id(coin1) == set([peer1])
+    assert sub.peers_for_coin_id(coin2) == set([peer1])
+    assert sub.peers_for_coin_id(coin3) == set([peer1])
+    assert sub.peers_for_coin_id(coin4) == set()
+
+    # peer1 should still be limited
+    sub.add_coin_subscriptions(peer1, [coin4], 3)
+
+    assert sub.has_coin_sub(coin4) is False
+    assert sub.peers_for_coin_id(coin4) == set()
+
+    # peer1 is also limied on ph subscriptions
+    sub.add_ph_subscriptions(peer1, [ph1], 3)
+
+    assert sub.has_ph_sub(ph1) is False
+    assert sub.peers_for_puzzle_hash(ph1) == set()
+
+    # peer2 is has its own limit
+    sub.add_coin_subscriptions(peer2, [coin4], 3)
+
+    assert sub.has_coin_sub(coin4) is True
+    assert sub.peers_for_coin_id(coin4) == set([peer2])
+
+    sub.remove_peer(peer1)
+    sub.remove_peer(peer2)
+
+
+def test_coin_sub_limit_incremental() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.has_coin_sub(coin1) is False
+    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_sub(coin3) is False
+
+    sub.add_coin_subscriptions(peer1, [coin1], 2)
+
+    assert sub.has_coin_sub(coin1) is True
+    assert sub.has_coin_sub(coin2) is False
+    assert sub.has_coin_sub(coin3) is False
+    assert sub.has_coin_sub(coin4) is False
+
+    assert sub.peers_for_coin_id(coin1) == set([peer1])
+    assert sub.peers_for_coin_id(coin2) == set()
+    assert sub.peers_for_coin_id(coin3) == set()
+    assert sub.peers_for_coin_id(coin4) == set()
+
+    # this will cross the limit. Only coin2 will be added
+    sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
+
+    assert sub.has_coin_sub(coin1) is True
+    assert sub.has_coin_sub(coin2) is True
+    assert sub.has_coin_sub(coin3) is False
+    assert sub.has_coin_sub(coin4) is False
+
+    assert sub.peers_for_coin_id(coin1) == set([peer1])
+    assert sub.peers_for_coin_id(coin2) == set([peer1])
+    assert sub.peers_for_coin_id(coin3) == set()
+    assert sub.peers_for_coin_id(coin4) == set()
+
+    sub.remove_peer(peer1)

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -640,13 +640,24 @@ class TestSimpleSyncProtocol:
         msg = wallet_protocol.RegisterForPhUpdates(phs, 0)
         msg_response = await full_node_api.register_interest_in_puzzle_hash(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_ph_update.value
-        assert len(full_node_api.full_node.ph_subscriptions) == 2
+        s = full_node_api.full_node.subscriptions
+        assert len(s._ph_subscriptions) == 2
+        assert s.has_ph_subscription(phs[0])
+        assert s.has_ph_subscription(phs[1])
+        assert not s.has_ph_subscription(phs[2])
+        assert not s.has_ph_subscription(phs[3])
         full_node_api.full_node.config["trusted_max_subscribe_items"] = 4
         full_node_api.full_node.config["trusted_peers"] = {server_2.node_id.hex(): server_2.node_id.hex()}
         assert full_node_api.is_trusted(con) is True
         msg_response = await full_node_api.register_interest_in_puzzle_hash(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_ph_update.value
-        assert len(full_node_api.full_node.ph_subscriptions) == 4
+        assert len(s._ph_subscriptions) == 4
+        assert s.has_ph_subscription(phs[0])
+        assert s.has_ph_subscription(phs[1])
+        assert s.has_ph_subscription(phs[2])
+        assert s.has_ph_subscription(phs[3])
+        assert not s.has_ph_subscription(phs[4])
+        assert not s.has_ph_subscription(phs[5])
 
     @pytest.mark.asyncio
     async def test_coin_subscribe_limits(self, wallet_node_simulator, self_hostname):
@@ -670,10 +681,21 @@ class TestSimpleSyncProtocol:
         msg = wallet_protocol.RegisterForCoinUpdates(coins, 0)
         msg_response = await full_node_api.register_interest_in_coin(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_coin_update.value
-        assert len(full_node_api.full_node.coin_subscriptions) == 2
+        s = full_node_api.full_node.subscriptions
+        assert len(s._coin_subscriptions) == 2
+        assert s.has_coin_subscription(coins[0])
+        assert s.has_coin_subscription(coins[1])
+        assert not s.has_coin_subscription(coins[2])
+        assert not s.has_coin_subscription(coins[3])
         full_node_api.full_node.config["trusted_max_subscribe_items"] = 4
         full_node_api.full_node.config["trusted_peers"] = {server_2.node_id.hex(): server_2.node_id.hex()}
         assert full_node_api.is_trusted(con) is True
         msg_response = await full_node_api.register_interest_in_coin(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_coin_update.value
-        assert len(full_node_api.full_node.coin_subscriptions) == 4
+        assert len(s._coin_subscriptions) == 4
+        assert s.has_coin_subscription(coins[0])
+        assert s.has_coin_subscription(coins[1])
+        assert s.has_coin_subscription(coins[2])
+        assert s.has_coin_subscription(coins[3])
+        assert not s.has_coin_subscription(coins[4])
+        assert not s.has_coin_subscription(coins[5])


### PR DESCRIPTION
The data structure we use to track subscriptions to coins and puzzle hashes is complex and deserves to be isolated in its own class and unit tested.