### PR TITLE
add node-level API metadata

### DIFF
--- a/chia/data_layer/data_layer_api.py
+++ b/chia/data_layer/data_layer_api.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from chia.data_layer.data_layer import DataLayer
+from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer
+from chia.util.api_decorators import ApiNodeMetadata
 
 
 class DataLayerAPI:
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.DATA_LAYER)
     data_layer: DataLayer
 
     def __init__(self, data_layer: DataLayer) -> None:

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -50,7 +50,7 @@ def strip_old_entries(pairs: List[Tuple[float, Any]], before: float) -> List[Tup
     return []
 
 
-_api_node_metadata = ApiNodeMetadata()
+_api_node_metadata = ApiNodeMetadata(type=NodeType.FARMER)
 
 
 class FarmerAPI:

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -50,11 +50,8 @@ def strip_old_entries(pairs: List[Tuple[float, Any]], before: float) -> List[Tup
     return []
 
 
-_api_node_metadata = ApiNodeMetadata(type=NodeType.FARMER)
-
-
 class FarmerAPI:
-    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.FARMER)
     farmer: Farmer
 
     def __init__(self, farmer) -> None:

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 import aiohttp
 from blspy import AugSchemeMPL, G2Element, PrivateKey
@@ -36,7 +36,7 @@ from chia.types.blockchain_format.proof_of_space import (
     generate_taproot_sk,
     verify_and_get_quality_string,
 )
-from chia.util.api_decorators import api_request
+from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint32, uint64
 
 
@@ -50,13 +50,17 @@ def strip_old_entries(pairs: List[Tuple[float, Any]], before: float) -> List[Tup
     return []
 
 
+_api_node_metadata = ApiNodeMetadata()
+
+
 class FarmerAPI:
+    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     farmer: Farmer
 
     def __init__(self, farmer) -> None:
         self.farmer = farmer
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_proof_of_space(self, new_proof_of_space: harvester_protocol.NewProofOfSpace, peer: WSChiaConnection):
         """
         This is a response from the harvester, for a NewChallenge. Here we check if the proof
@@ -286,7 +290,7 @@ class FarmerAPI:
 
                 return
 
-    @api_request()
+    @metadata.request()
     async def respond_signatures(self, response: harvester_protocol.RespondSignatures):
         """
         There are two cases: receiving signatures for sps, or receiving signatures for the block.
@@ -441,7 +445,7 @@ class FarmerAPI:
     FARMER PROTOCOL (FARMER <-> FULL NODE)
     """
 
-    @api_request()
+    @metadata.request()
     async def new_signage_point(self, new_signage_point: farmer_protocol.NewSignagePoint):
         try:
             pool_difficulties: List[PoolDifficulty] = []
@@ -497,7 +501,7 @@ class FarmerAPI:
         self.farmer.cache_add_time[new_signage_point.challenge_chain_sp] = uint64(int(time.time()))
         self.farmer.state_changed("new_signage_point", {"sp_hash": new_signage_point.challenge_chain_sp})
 
-    @api_request()
+    @metadata.request()
     async def request_signed_values(self, full_node_request: farmer_protocol.RequestSignedValues):
         if full_node_request.quality_string not in self.farmer.quality_str_to_identifiers:
             self.farmer.log.error(f"Do not have quality string {full_node_request.quality_string}")
@@ -516,7 +520,7 @@ class FarmerAPI:
         msg = make_msg(ProtocolMessageTypes.request_signatures, request)
         await self.farmer.server.send_to_specific([msg], node_id)
 
-    @api_request()
+    @metadata.request()
     async def farming_info(self, request: farmer_protocol.FarmingInfo):
         self.farmer.state_changed(
             "new_farming_info",
@@ -532,34 +536,34 @@ class FarmerAPI:
             },
         )
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_plots(self, _: harvester_protocol.RespondPlots, peer: WSChiaConnection):
         self.farmer.log.warning(f"Respond plots came too late from: {peer.get_peer_logging()}")
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def plot_sync_start(self, message: PlotSyncStart, peer: WSChiaConnection):
         await self.farmer.plot_sync_receivers[peer.peer_node_id].sync_started(message)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def plot_sync_loaded(self, message: PlotSyncPlotList, peer: WSChiaConnection):
         await self.farmer.plot_sync_receivers[peer.peer_node_id].process_loaded(message)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def plot_sync_removed(self, message: PlotSyncPathList, peer: WSChiaConnection):
         await self.farmer.plot_sync_receivers[peer.peer_node_id].process_removed(message)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def plot_sync_invalid(self, message: PlotSyncPathList, peer: WSChiaConnection):
         await self.farmer.plot_sync_receivers[peer.peer_node_id].process_invalid(message)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def plot_sync_keys_missing(self, message: PlotSyncPathList, peer: WSChiaConnection):
         await self.farmer.plot_sync_receivers[peer.peer_node_id].process_keys_missing(message)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def plot_sync_duplicates(self, message: PlotSyncPathList, peer: WSChiaConnection):
         await self.farmer.plot_sync_receivers[peer.peer_node_id].process_duplicates(message)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def plot_sync_done(self, message: PlotSyncDone, peer: WSChiaConnection):
         await self.farmer.plot_sync_receivers[peer.peer_node_id].sync_done(message)

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -35,7 +35,7 @@ from chia.protocols.wallet_protocol import (
     RespondFeeEstimates,
     RespondSESInfo,
 )
-from chia.server.outbound_message import Message, make_msg
+from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.block_protocol import BlockInfo
@@ -67,7 +67,7 @@ else:
     FullNode = object
 
 
-_api_node_metadata = ApiNodeMetadata()
+_api_node_metadata = ApiNodeMetadata(type=NodeType.FULL_NODE)
 
 
 class FullNodeAPI:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -70,7 +70,6 @@ else:
 _api_node_metadata = ApiNodeMetadata()
 
 
-@_api_node_metadata.node()
 class FullNodeAPI:
     metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     full_node: FullNode

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -9,7 +9,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from secrets import token_bytes
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Set, Tuple
 
 from blspy import AugSchemeMPL, G1Element, G2Element
 from chiabip158 import PyBIP158
@@ -53,7 +53,7 @@ from chia.types.mempool_item import MempoolItem
 from chia.types.peer_info import PeerInfo
 from chia.types.transaction_queue_entry import TransactionQueueEntry
 from chia.types.unfinished_block import UnfinishedBlock
-from chia.util.api_decorators import api_request
+from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.full_block_utils import header_block_from_block
 from chia.util.generator_tools import get_block_header, tx_removals_and_additions
 from chia.util.hash import std_hash
@@ -67,7 +67,12 @@ else:
     FullNode = object
 
 
+_api_node_metadata = ApiNodeMetadata()
+
+
+@_api_node_metadata.node()
 class FullNodeAPI:
+    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     full_node: FullNode
     executor: ThreadPoolExecutor
 
@@ -88,7 +93,7 @@ class FullNodeAPI:
     def api_ready(self) -> bool:
         return self.full_node.initialized
 
-    @api_request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_peers])
+    @metadata.request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_peers])
     async def request_peers(
         self, _request: full_node_protocol.RequestPeers, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -100,7 +105,7 @@ class FullNodeAPI:
             return msg
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_peers(
         self, request: full_node_protocol.RespondPeers, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -109,7 +114,7 @@ class FullNodeAPI:
             await self.full_node.full_node_peers.respond_peers(request, peer.get_peer_info(), True)
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_peers_introducer(
         self, request: introducer_protocol.RespondPeersIntroducer, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -120,7 +125,7 @@ class FullNodeAPI:
         await peer.close()
         return None
 
-    @api_request(peer_required=True, execute_task=True)
+    @metadata.request(peer_required=True, execute_task=True)
     async def new_peak(self, request: full_node_protocol.NewPeak, peer: WSChiaConnection) -> None:
         """
         A peer notifies us that they have added a new peak to their blockchain. If we don't have it,
@@ -136,7 +141,7 @@ class FullNodeAPI:
 
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_transaction(
         self, transaction: full_node_protocol.NewTransaction, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -219,7 +224,7 @@ class FullNodeAPI:
             return None
         return None
 
-    @api_request(reply_types=[ProtocolMessageTypes.respond_transaction])
+    @metadata.request(reply_types=[ProtocolMessageTypes.respond_transaction])
     async def request_transaction(self, request: full_node_protocol.RequestTransaction) -> Optional[Message]:
         """Peer has requested a full transaction from us."""
         # Ignore if syncing
@@ -234,7 +239,7 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_transaction, transaction)
         return msg
 
-    @api_request(peer_required=True, bytes_required=True)
+    @metadata.request(peer_required=True, bytes_required=True)
     async def respond_transaction(
         self,
         tx: full_node_protocol.RespondTransaction,
@@ -262,7 +267,7 @@ class FullNodeAPI:
             pass  # we can't do anything here, the tx will be dropped. We might do something in the future.
         return None
 
-    @api_request(reply_types=[ProtocolMessageTypes.respond_proof_of_weight])
+    @metadata.request(reply_types=[ProtocolMessageTypes.respond_proof_of_weight])
     async def request_proof_of_weight(self, request: full_node_protocol.RequestProofOfWeight) -> Optional[Message]:
         if self.full_node.weight_proof_handler is None:
             return None
@@ -302,12 +307,12 @@ class FullNodeAPI:
         self.full_node.full_node_store.serialized_wp_message = message
         return message
 
-    @api_request()
+    @metadata.request()
     async def respond_proof_of_weight(self, request: full_node_protocol.RespondProofOfWeight) -> Optional[Message]:
         self.log.warning("Received proof of weight too late.")
         return None
 
-    @api_request(reply_types=[ProtocolMessageTypes.respond_block, ProtocolMessageTypes.reject_block])
+    @metadata.request(reply_types=[ProtocolMessageTypes.respond_block, ProtocolMessageTypes.reject_block])
     async def request_block(self, request: full_node_protocol.RequestBlock) -> Optional[Message]:
         if not self.full_node.blockchain.contains_height(request.height):
             reject = RejectBlock(request.height)
@@ -324,7 +329,7 @@ class FullNodeAPI:
             return make_msg(ProtocolMessageTypes.respond_block, full_node_protocol.RespondBlock(block))
         return make_msg(ProtocolMessageTypes.reject_block, RejectBlock(request.height))
 
-    @api_request(reply_types=[ProtocolMessageTypes.respond_blocks, ProtocolMessageTypes.reject_blocks])
+    @metadata.request(reply_types=[ProtocolMessageTypes.respond_blocks, ProtocolMessageTypes.reject_blocks])
     async def request_blocks(self, request: full_node_protocol.RequestBlocks) -> Optional[Message]:
         if request.end_height < request.start_height or request.end_height - request.start_height > 32:
             reject = RejectBlocks(request.start_height, request.end_height)
@@ -380,20 +385,20 @@ class FullNodeAPI:
 
         return msg
 
-    @api_request()
+    @metadata.request()
     async def reject_block(self, request: full_node_protocol.RejectBlock) -> None:
         self.log.debug(f"reject_block {request.height}")
 
-    @api_request()
+    @metadata.request()
     async def reject_blocks(self, request: full_node_protocol.RejectBlocks) -> None:
         self.log.debug(f"reject_blocks {request.start_height} {request.end_height}")
 
-    @api_request()
+    @metadata.request()
     async def respond_blocks(self, request: full_node_protocol.RespondBlocks) -> None:
         self.log.warning("Received unsolicited/late blocks")
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_block(
         self,
         respond_block: full_node_protocol.RespondBlock,
@@ -406,7 +411,7 @@ class FullNodeAPI:
         self.log.warning(f"Received unsolicited/late block from peer {peer.get_peer_logging()}")
         return None
 
-    @api_request()
+    @metadata.request()
     async def new_unfinished_block(
         self, new_unfinished_block: full_node_protocol.NewUnfinishedBlock
     ) -> Optional[Message]:
@@ -438,7 +443,7 @@ class FullNodeAPI:
 
         return msg
 
-    @api_request(reply_types=[ProtocolMessageTypes.respond_unfinished_block])
+    @metadata.request(reply_types=[ProtocolMessageTypes.respond_unfinished_block])
     async def request_unfinished_block(
         self, request_unfinished_block: full_node_protocol.RequestUnfinishedBlock
     ) -> Optional[Message]:
@@ -453,7 +458,7 @@ class FullNodeAPI:
             return msg
         return None
 
-    @api_request(peer_required=True, bytes_required=True)
+    @metadata.request(peer_required=True, bytes_required=True)
     async def respond_unfinished_block(
         self,
         respond_unfinished_block: full_node_protocol.RespondUnfinishedBlock,
@@ -467,7 +472,7 @@ class FullNodeAPI:
         )
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_signage_point_or_end_of_sub_slot(
         self, new_sp: full_node_protocol.NewSignagePointOrEndOfSubSlot, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -551,7 +556,9 @@ class FullNodeAPI:
 
         return make_msg(ProtocolMessageTypes.request_signage_point_or_end_of_sub_slot, full_node_request)
 
-    @api_request(reply_types=[ProtocolMessageTypes.respond_signage_point, ProtocolMessageTypes.respond_end_of_sub_slot])
+    @metadata.request(
+        reply_types=[ProtocolMessageTypes.respond_signage_point, ProtocolMessageTypes.respond_end_of_sub_slot]
+    )
     async def request_signage_point_or_end_of_sub_slot(
         self, request: full_node_protocol.RequestSignagePointOrEndOfSubSlot
     ) -> Optional[Message]:
@@ -594,7 +601,7 @@ class FullNodeAPI:
                 self.log.info(f"Don't have signage point {request}")
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_signage_point(
         self, request: full_node_protocol.RespondSignagePoint, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -649,7 +656,7 @@ class FullNodeAPI:
 
             return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_end_of_sub_slot(
         self, request: full_node_protocol.RespondEndOfSubSlot, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -658,7 +665,7 @@ class FullNodeAPI:
         msg, _ = await self.full_node.respond_end_of_sub_slot(request, peer)
         return msg
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def request_mempool_transactions(
         self,
         request: full_node_protocol.RequestMempoolTransactions,
@@ -675,7 +682,7 @@ class FullNodeAPI:
         return None
 
     # FARMER PROTOCOL
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def declare_proof_of_space(
         self, request: farmer_protocol.DeclareProofOfSpace, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -964,7 +971,7 @@ class FullNodeAPI:
                 )
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def signed_values(
         self, farmer_request: farmer_protocol.SignedValues, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -1030,7 +1037,7 @@ class FullNodeAPI:
         return None
 
     # TIMELORD PROTOCOL
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_infusion_point_vdf(
         self, request: timelord_protocol.NewInfusionPointVDF, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -1040,7 +1047,7 @@ class FullNodeAPI:
         async with self.full_node.timelord_lock:
             return await self.full_node.new_infusion_point_vdf(request, peer)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_signage_point_vdf(
         self, request: timelord_protocol.NewSignagePointVDF, peer: WSChiaConnection
     ) -> None:
@@ -1056,7 +1063,7 @@ class FullNodeAPI:
         )
         await self.respond_signage_point(full_node_message, peer)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_end_of_sub_slot_vdf(
         self, request: timelord_protocol.NewEndOfSubSlotVDF, peer: WSChiaConnection
     ) -> Optional[Message]:
@@ -1081,7 +1088,7 @@ class FullNodeAPI:
         else:
             return msg
 
-    @api_request()
+    @metadata.request()
     async def request_block_header(self, request: wallet_protocol.RequestBlockHeader) -> Optional[Message]:
         header_hash = self.full_node.blockchain.height_to_hash(request.height)
         if header_hash is None:
@@ -1122,7 +1129,7 @@ class FullNodeAPI:
         )
         return msg
 
-    @api_request()
+    @metadata.request()
     async def request_additions(self, request: wallet_protocol.RequestAdditions) -> Optional[Message]:
         if request.header_hash is None:
             header_hash: Optional[bytes32] = self.full_node.blockchain.height_to_hash(request.height)
@@ -1177,7 +1184,7 @@ class FullNodeAPI:
             response = wallet_protocol.RespondAdditions(request.height, header_hash, coins_map, proofs_map)
         return make_msg(ProtocolMessageTypes.respond_additions, response)
 
-    @api_request()
+    @metadata.request()
     async def request_removals(self, request: wallet_protocol.RequestRemovals) -> Optional[Message]:
         block: Optional[FullBlock] = await self.full_node.block_store.get_full_block(request.header_hash)
 
@@ -1242,7 +1249,7 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_removals, response)
         return msg
 
-    @api_request()
+    @metadata.request()
     async def send_transaction(
         self, request: wallet_protocol.SendTransaction, *, test: bool = False
     ) -> Optional[Message]:
@@ -1283,7 +1290,7 @@ class FullNodeAPI:
                     response = wallet_protocol.TransactionAck(spend_name, uint8(status.value), error_name)
         return make_msg(ProtocolMessageTypes.transaction_ack, response)
 
-    @api_request()
+    @metadata.request()
     async def request_puzzle_solution(self, request: wallet_protocol.RequestPuzzleSolution) -> Optional[Message]:
         coin_name = request.coin_name
         height = request.height
@@ -1319,7 +1326,7 @@ class FullNodeAPI:
         response_msg = make_msg(ProtocolMessageTypes.respond_puzzle_solution, response)
         return response_msg
 
-    @api_request()
+    @metadata.request()
     async def request_block_headers(self, request: wallet_protocol.RequestBlockHeaders) -> Optional[Message]:
         """Returns header blocks by directly streaming bytes into Message
 
@@ -1366,7 +1373,7 @@ class FullNodeAPI:
         respond_header_blocks_manually_streamed += b"".join(header_blocks_bytes)
         return make_msg(ProtocolMessageTypes.respond_block_headers, respond_header_blocks_manually_streamed)
 
-    @api_request()
+    @metadata.request()
     async def request_header_blocks(self, request: wallet_protocol.RequestHeaderBlocks) -> Optional[Message]:
         """DEPRECATED: please use RequestBlockHeaders"""
         if request.end_height < request.start_height or request.end_height - request.start_height > 32:
@@ -1400,14 +1407,14 @@ class FullNodeAPI:
         )
         return msg
 
-    @api_request()
+    @metadata.request()
     async def respond_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
         if self.full_node.sync_store.get_sync_mode():
             return None
         await self.full_node.respond_compact_proof_of_time(request)
         return None
 
-    @api_request(peer_required=True, bytes_required=True, execute_task=True)
+    @metadata.request(peer_required=True, bytes_required=True, execute_task=True)
     async def new_compact_vdf(
         self, request: full_node_protocol.NewCompactVDF, peer: WSChiaConnection, request_bytes: bytes = b""
     ) -> None:
@@ -1434,21 +1441,21 @@ class FullNodeAPI:
 
         return None
 
-    @api_request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_compact_vdf])
+    @metadata.request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_compact_vdf])
     async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection) -> None:
         if self.full_node.sync_store.get_sync_mode():
             return None
         await self.full_node.request_compact_vdf(request, peer)
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:
         if self.full_node.sync_store.get_sync_mode():
             return None
         await self.full_node.respond_compact_vdf(request, peer)
         return None
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def register_interest_in_puzzle_hash(
         self, request: wallet_protocol.RegisterForPhUpdates, peer: WSChiaConnection
     ) -> Message:
@@ -1489,7 +1496,7 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_to_ph_update, response)
         return msg
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def register_interest_in_coin(
         self, request: wallet_protocol.RegisterForCoinUpdates, peer: WSChiaConnection
     ) -> Message:
@@ -1518,7 +1525,7 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_to_coin_update, response)
         return msg
 
-    @api_request()
+    @metadata.request()
     async def request_children(self, request: wallet_protocol.RequestChildren) -> Optional[Message]:
         coin_records: List[CoinRecord] = await self.full_node.coin_store.get_coin_records_by_parent_ids(
             True, [request.coin_name]
@@ -1528,7 +1535,7 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_children, response)
         return msg
 
-    @api_request()
+    @metadata.request()
     async def request_ses_hashes(self, request: wallet_protocol.RequestSESInfo) -> Message:
         """Returns the start and end height of a sub-epoch for the height specified in request"""
 
@@ -1564,7 +1571,7 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_ses_hashes, response)
         return msg
 
-    @api_request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_fee_estimates])
+    @metadata.request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_fee_estimates])
     async def request_fee_estimates(self, request: wallet_protocol.RequestFeeEstimates) -> Message:
         def get_fee_estimates(est: FeeEstimatorInterface, req_times: List[uint64]) -> List[FeeEstimate]:
             now = datetime.now(timezone.utc)

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -67,11 +67,8 @@ else:
     FullNode = object
 
 
-_api_node_metadata = ApiNodeMetadata(type=NodeType.FULL_NODE)
-
-
 class FullNodeAPI:
-    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.FULL_NODE)
     full_node: FullNode
     executor: ThreadPoolExecutor
 

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -14,7 +14,7 @@ from chia.protocols import harvester_protocol
 from chia.protocols.farmer_protocol import FarmingInfo
 from chia.protocols.harvester_protocol import Plot, PlotSyncResponse
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.server.outbound_message import make_msg
+from chia.server.outbound_message import NodeType, make_msg
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.proof_of_space import (
     ProofOfSpace,
@@ -27,7 +27,7 @@ from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint8, uint32, uint64
 from chia.wallet.derive_keys import master_sk_to_local_sk
 
-_api_node_metadata = ApiNodeMetadata()
+_api_node_metadata = ApiNodeMetadata(type=NodeType.HARVESTER)
 
 
 class HarvesterAPI:

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -27,11 +27,9 @@ from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint8, uint32, uint64
 from chia.wallet.derive_keys import master_sk_to_local_sk
 
-_api_node_metadata = ApiNodeMetadata(type=NodeType.HARVESTER)
-
 
 class HarvesterAPI:
-    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.HARVESTER)
     harvester: Harvester
 
     def __init__(self, harvester: Harvester):

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
-from typing import List, Tuple
+from typing import ClassVar, List, Tuple
 
 from blspy import AugSchemeMPL, G1Element, G2Element
 
@@ -23,18 +23,21 @@ from chia.types.blockchain_format.proof_of_space import (
     passes_plot_filter,
 )
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.api_decorators import api_request
+from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint8, uint32, uint64
 from chia.wallet.derive_keys import master_sk_to_local_sk
 
+_api_node_metadata = ApiNodeMetadata()
+
 
 class HarvesterAPI:
+    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     harvester: Harvester
 
     def __init__(self, harvester: Harvester):
         self.harvester = harvester
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def harvester_handshake(
         self, harvester_handshake: harvester_protocol.HarvesterHandshake, peer: WSChiaConnection
     ):
@@ -50,7 +53,7 @@ class HarvesterAPI:
         await self.harvester.plot_sync_sender.start()
         self.harvester.plot_manager.start_refreshing()
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_signage_point_harvester(
         self, new_challenge: harvester_protocol.NewSignagePointHarvester, peer: WSChiaConnection
     ):
@@ -245,7 +248,7 @@ class HarvesterAPI:
             },
         )
 
-    @api_request()
+    @metadata.request()
     async def request_signatures(self, request: harvester_protocol.RequestSignatures):
         """
         The farmer requests a signature on the header hash, for one of the proofs that we found.
@@ -294,7 +297,7 @@ class HarvesterAPI:
 
         return make_msg(ProtocolMessageTypes.respond_signatures, response)
 
-    @api_request()
+    @metadata.request()
     async def request_plots(self, _: harvester_protocol.RequestPlots):
         plots_response = []
         plots, failed_to_open_filenames, no_key_filenames = self.harvester.get_plots()
@@ -315,6 +318,6 @@ class HarvesterAPI:
         response = harvester_protocol.RespondPlots(plots_response, failed_to_open_filenames, no_key_filenames)
         return make_msg(ProtocolMessageTypes.respond_plots, response)
 
-    @api_request()
+    @metadata.request()
     async def plot_sync_response(self, response: PlotSyncResponse):
         self.harvester.plot_sync_sender.set_response(response)

--- a/chia/introducer/introducer_api.py
+++ b/chia/introducer/introducer_api.py
@@ -5,13 +5,13 @@ from typing import Callable, ClassVar, Optional
 from chia.introducer.introducer import Introducer
 from chia.protocols.introducer_protocol import RequestPeersIntroducer, RespondPeersIntroducer
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.server.outbound_message import Message, make_msg
+from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import TimestampedPeerInfo
 from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint64
 
-_api_node_metadata = ApiNodeMetadata()
+_api_node_metadata = ApiNodeMetadata(type=NodeType.INTRODUCER)
 
 
 class IntroducerAPI:

--- a/chia/introducer/introducer_api.py
+++ b/chia/introducer/introducer_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable, ClassVar, Optional
 
 from chia.introducer.introducer import Introducer
 from chia.protocols.introducer_protocol import RequestPeersIntroducer, RespondPeersIntroducer
@@ -8,11 +8,14 @@ from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.server.outbound_message import Message, make_msg
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import TimestampedPeerInfo
-from chia.util.api_decorators import api_request
+from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint64
+
+_api_node_metadata = ApiNodeMetadata()
 
 
 class IntroducerAPI:
+    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     introducer: Introducer
 
     def __init__(self, introducer) -> None:
@@ -21,7 +24,7 @@ class IntroducerAPI:
     def _set_state_changed_callback(self, callback: Callable):
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def request_peers_introducer(
         self,
         request: RequestPeersIntroducer,

--- a/chia/introducer/introducer_api.py
+++ b/chia/introducer/introducer_api.py
@@ -11,11 +11,9 @@ from chia.types.peer_info import TimestampedPeerInfo
 from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint64
 
-_api_node_metadata = ApiNodeMetadata(type=NodeType.INTRODUCER)
-
 
 class IntroducerAPI:
-    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.INTRODUCER)
     introducer: Introducer
 
     def __init__(self, introducer) -> None:

--- a/chia/seeder/crawler_api.py
+++ b/chia/seeder/crawler_api.py
@@ -9,12 +9,10 @@ from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.util.api_decorators import ApiNodeMetadata
 
-# TODO: full node.  'ish
-_api_node_metadata = ApiNodeMetadata(type=NodeType.FULL_NODE)
-
 
 class CrawlerAPI:
-    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
+    # TODO: full node.  'ish
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.FULL_NODE)
     crawler: Crawler
 
     def __init__(self, crawler):

--- a/chia/seeder/crawler_api.py
+++ b/chia/seeder/crawler_api.py
@@ -4,12 +4,13 @@ from typing import ClassVar, Optional
 
 from chia.protocols import full_node_protocol, wallet_protocol
 from chia.seeder.crawler import Crawler
-from chia.server.outbound_message import Message
+from chia.server.outbound_message import Message, NodeType
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.util.api_decorators import ApiNodeMetadata
 
-_api_node_metadata = ApiNodeMetadata()
+# TODO: full node.  'ish
+_api_node_metadata = ApiNodeMetadata(type=NodeType.FULL_NODE)
 
 
 class CrawlerAPI:

--- a/chia/seeder/crawler_api.py
+++ b/chia/seeder/crawler_api.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import ClassVar, Optional
 
 from chia.protocols import full_node_protocol, wallet_protocol
 from chia.seeder.crawler import Crawler
 from chia.server.outbound_message import Message
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
-from chia.util.api_decorators import api_request
+from chia.util.api_decorators import ApiNodeMetadata
+
+_api_node_metadata = ApiNodeMetadata()
 
 
 class CrawlerAPI:
+    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     crawler: Crawler
 
     def __init__(self, crawler):
@@ -31,70 +34,70 @@ class CrawlerAPI:
     def log(self):
         return self.crawler.log
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def request_peers(self, _request: full_node_protocol.RequestPeers, peer: WSChiaConnection):
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_peers(
         self, request: full_node_protocol.RespondPeers, peer: WSChiaConnection
     ) -> Optional[Message]:
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_peak(self, request: full_node_protocol.NewPeak, peer: WSChiaConnection) -> Optional[Message]:
         await self.crawler.new_peak(request, peer)
         return None
 
-    @api_request()
+    @metadata.request()
     async def new_transaction(self, transaction: full_node_protocol.NewTransaction) -> Optional[Message]:
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_signage_point_or_end_of_sub_slot(
         self, new_sp: full_node_protocol.NewSignagePointOrEndOfSubSlot, peer: WSChiaConnection
     ) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def new_unfinished_block(
         self, new_unfinished_block: full_node_protocol.NewUnfinishedBlock
     ) -> Optional[Message]:
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def new_compact_vdf(self, request: full_node_protocol.NewCompactVDF, peer: WSChiaConnection):
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_transaction(self, request: full_node_protocol.RequestTransaction) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_proof_of_weight(self, request: full_node_protocol.RequestProofOfWeight) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_block(self, request: full_node_protocol.RequestBlock) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_blocks(self, request: full_node_protocol.RequestBlocks) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_unfinished_block(
         self, request_unfinished_block: full_node_protocol.RequestUnfinishedBlock
     ) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_signage_point_or_end_of_sub_slot(
         self, request: full_node_protocol.RequestSignagePointOrEndOfSubSlot
     ) -> Optional[Message]:
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def request_mempool_transactions(
         self,
         request: full_node_protocol.RequestMempoolTransactions,
@@ -102,22 +105,22 @@ class CrawlerAPI:
     ) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_block_header(self, request: wallet_protocol.RequestBlockHeader) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_additions(self, request: wallet_protocol.RequestAdditions) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_removals(self, request: wallet_protocol.RequestRemovals) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_puzzle_solution(self, request: wallet_protocol.RequestPuzzleSolution) -> Optional[Message]:
         pass
 
-    @api_request()
+    @metadata.request()
     async def request_header_blocks(self, request: wallet_protocol.RequestHeaderBlocks) -> Optional[Message]:
         pass

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -458,7 +458,7 @@ class WSChiaConnection:
         if self.connection_type is None:
             raise ValueError("handshake not done yet")
         request_metadata = get_metadata(request_method)
-        assert request_metadata is not None, f"ApiMetadata unavailable for {request_method}"
+        assert request_metadata is not None, f"ApiEndpointMetadata unavailable for {request_method}"
         attribute = getattr(class_for_type(self.connection_type), request_metadata.request_type.name, None)
         if attribute is None:
             raise AttributeError(
@@ -485,7 +485,7 @@ class WSChiaConnection:
 
         recv_method = getattr(class_for_type(self.local_type), recv_message_type.name)
         receive_metadata = get_metadata(recv_method)
-        assert receive_metadata is not None, f"ApiMetadata unavailable for {recv_method}"
+        assert receive_metadata is not None, f"ApiEndpointMetadata unavailable for {recv_method}"
         return receive_metadata.message_class.from_bytes(response.data)
 
     async def send_request(self, message_no_id: Message, timeout: int) -> Optional[Message]:

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -13,11 +13,8 @@ from chia.util.ints import uint64
 log = logging.getLogger(__name__)
 
 
-_api_node_metadata = ApiNodeMetadata(type=NodeType.TIMELORD)
-
-
 class TimelordAPI:
-    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.TIMELORD)
     timelord: Timelord
 
     def __init__(self, timelord) -> None:

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 _api_node_metadata = ApiNodeMetadata()
 
 
-@_api_node_metadata.node()
 class TimelordAPI:
     metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     timelord: Timelord

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -5,6 +5,7 @@ import time
 from typing import Callable, ClassVar, Optional
 
 from chia.protocols import timelord_protocol
+from chia.server.outbound_message import NodeType
 from chia.timelord.timelord import Chain, IterationType, Timelord, iters_from_block
 from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.ints import uint64
@@ -12,7 +13,7 @@ from chia.util.ints import uint64
 log = logging.getLogger(__name__)
 
 
-_api_node_metadata = ApiNodeMetadata()
+_api_node_metadata = ApiNodeMetadata(type=NodeType.TIMELORD)
 
 
 class TimelordAPI:

--- a/chia/util/api_decorators.py
+++ b/chia/util/api_decorators.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, List, Optional, Type, TypeVar, Union, get_typ
 from typing_extensions import Concatenate, ParamSpec
 
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.server.outbound_message import NodeType
 from chia.util.streamable import Streamable
 
 log = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ def _set_metadata(function: Callable[..., object], metadata: ApiEndpointMetadata
 
 @dataclass
 class ApiNodeMetadata:
+    type: NodeType
     name_to_endpoint: Dict[str, ApiEndpointMetadata] = field(default_factory=dict)
 
     # TODO: This hinting does not express that the returned callable *_bytes parameter

--- a/chia/util/api_decorators.py
+++ b/chia/util/api_decorators.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional, Type, TypeVar, Union, get_type_hints
+from typing import Callable, Dict, List, Optional, Type, TypeVar, Union, get_type_hints
 
 from typing_extensions import Concatenate, ParamSpec
 
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 P = ParamSpec("P")
 R = TypeVar("R")
 S = TypeVar("S", bound=Streamable)
+T = TypeVar("T")
 Self = TypeVar("Self")
 
 
@@ -21,7 +22,72 @@ metadata_attribute_name = "_chia_api_metadata"
 
 
 @dataclass
-class ApiMetadata:
+class ApiNodeMetadata:
+    name_to_endpoint: Dict[str, ApiEndpointMetadata] = field(default_factory=dict)
+
+    def node(self) -> Callable[[Type[T]], Type[T]]:
+        def decorator(cls: Type[T]) -> Type[T]:
+            return cls
+
+        return decorator
+
+    # TODO: This hinting does not express that the returned callable *_bytes parameter
+    #       corresponding to the first parameter name will be filled in by the wrapper.
+    def request(
+        self,
+        peer_required: bool = False,
+        bytes_required: bool = False,
+        execute_task: bool = False,
+        reply_types: Optional[List[ProtocolMessageTypes]] = None,
+    ) -> Callable[[Callable[Concatenate[Self, S, P], R]], Callable[Concatenate[Self, Union[bytes, S], P], R]]:
+        non_optional_reply_types: List[ProtocolMessageTypes]
+        if reply_types is None:
+            non_optional_reply_types = []
+        else:
+            non_optional_reply_types = reply_types
+
+        def inner(f: Callable[Concatenate[Self, S, P], R]) -> Callable[Concatenate[Self, Union[bytes, S], P], R]:
+            name = f.__name__
+            if name in self.name_to_endpoint:
+                raise Exception(f"endpoint name already registered: {name}")
+
+            def wrapper(self: Self, original: Union[bytes, S], *args: P.args, **kwargs: P.kwargs) -> R:
+                arg: S
+                if isinstance(original, bytes):
+                    if metadata.bytes_required:
+                        kwargs[message_name_bytes] = original
+                    arg = message_class.from_bytes(original)
+                else:
+                    arg = original
+                    if metadata.bytes_required:
+                        kwargs[message_name_bytes] = bytes(original)
+
+                return f(self, arg, *args, **kwargs)
+
+            message_name, message_class = next(
+                (name, hint) for name, hint in get_type_hints(f).items() if name not in {"self", "peer", "return"}
+            )
+            message_name_bytes = f"{message_name}_bytes"
+
+            metadata = ApiEndpointMetadata(
+                request_type=getattr(ProtocolMessageTypes, f.__name__),
+                peer_required=peer_required,
+                bytes_required=bytes_required,
+                execute_task=execute_task,
+                reply_types=non_optional_reply_types,
+                message_class=message_class,
+            )
+
+            self.name_to_endpoint[name] = metadata
+            _set_metadata(function=wrapper, metadata=metadata)
+
+            return wrapper
+
+        return inner
+
+
+@dataclass
+class ApiEndpointMetadata:
     request_type: ProtocolMessageTypes
     message_class: Type[Streamable]
     peer_required: bool = False
@@ -30,58 +96,9 @@ class ApiMetadata:
     reply_types: List[ProtocolMessageTypes] = field(default_factory=list)
 
 
-def get_metadata(function: Callable[..., object]) -> Optional[ApiMetadata]:
+def get_metadata(function: Callable[..., object]) -> Optional[ApiEndpointMetadata]:
     return getattr(function, metadata_attribute_name, None)
 
 
-def _set_metadata(function: Callable[..., object], metadata: ApiMetadata) -> None:
+def _set_metadata(function: Callable[..., object], metadata: ApiEndpointMetadata) -> None:
     setattr(function, metadata_attribute_name, metadata)
-
-
-# TODO: This hinting does not express that the returned callable *_bytes parameter
-#       corresponding to the first parameter name will be filled in by the wrapper.
-def api_request(
-    peer_required: bool = False,
-    bytes_required: bool = False,
-    execute_task: bool = False,
-    reply_types: Optional[List[ProtocolMessageTypes]] = None,
-) -> Callable[[Callable[Concatenate[Self, S, P], R]], Callable[Concatenate[Self, Union[bytes, S], P], R]]:
-    non_optional_reply_types: List[ProtocolMessageTypes]
-    if reply_types is None:
-        non_optional_reply_types = []
-    else:
-        non_optional_reply_types = reply_types
-
-    def inner(f: Callable[Concatenate[Self, S, P], R]) -> Callable[Concatenate[Self, Union[bytes, S], P], R]:
-        def wrapper(self: Self, original: Union[bytes, S], *args: P.args, **kwargs: P.kwargs) -> R:
-            arg: S
-            if isinstance(original, bytes):
-                if metadata.bytes_required:
-                    kwargs[message_name_bytes] = original
-                arg = message_class.from_bytes(original)
-            else:
-                arg = original
-                if metadata.bytes_required:
-                    kwargs[message_name_bytes] = bytes(original)
-
-            return f(self, arg, *args, **kwargs)
-
-        message_name, message_class = next(
-            (name, hint) for name, hint in get_type_hints(f).items() if name not in {"self", "peer", "return"}
-        )
-        message_name_bytes = f"{message_name}_bytes"
-
-        metadata = ApiMetadata(
-            request_type=getattr(ProtocolMessageTypes, f.__name__),
-            peer_required=peer_required,
-            bytes_required=bytes_required,
-            execute_task=execute_task,
-            reply_types=non_optional_reply_types,
-            message_class=message_class,
-        )
-
-        _set_metadata(function=wrapper, metadata=metadata)
-
-        return wrapper
-
-    return inner

--- a/chia/util/api_decorators.py
+++ b/chia/util/api_decorators.py
@@ -43,12 +43,6 @@ def _set_metadata(function: Callable[..., object], metadata: ApiEndpointMetadata
 class ApiNodeMetadata:
     name_to_endpoint: Dict[str, ApiEndpointMetadata] = field(default_factory=dict)
 
-    def node(self) -> Callable[[Type[T]], Type[T]]:
-        def decorator(cls: Type[T]) -> Type[T]:
-            return cls
-
-        return decorator
-
     # TODO: This hinting does not express that the returned callable *_bytes parameter
     #       corresponding to the first parameter name will be filled in by the wrapper.
     def request(

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+from typing import ClassVar
+
 from chia.protocols import full_node_protocol, introducer_protocol, wallet_protocol
 from chia.server.outbound_message import NodeType
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.util.api_decorators import api_request
+from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.errors import Err
 from chia.wallet.wallet_node import WalletNode
 
+_api_node_metadata = ApiNodeMetadata()
+
 
 class WalletNodeAPI:
+    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
     wallet_node: WalletNode
 
     def __init__(self, wallet_node) -> None:
@@ -23,7 +28,7 @@ class WalletNodeAPI:
     def api_ready(self):
         return self.wallet_node.logged_in
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_removals(self, response: wallet_protocol.RespondRemovals, peer: WSChiaConnection):
         pass
 
@@ -33,14 +38,14 @@ class WalletNodeAPI:
         """
         pass
 
-    @api_request()
+    @metadata.request()
     async def reject_additions_request(self, response: wallet_protocol.RejectAdditionsRequest):
         """
         The full node has rejected our request for additions.
         """
         pass
 
-    @api_request(peer_required=True, execute_task=True)
+    @metadata.request(peer_required=True, execute_task=True)
     async def new_peak_wallet(self, peak: wallet_protocol.NewPeakWallet, peer: WSChiaConnection):
         """
         The full node sent as a new peak
@@ -48,26 +53,26 @@ class WalletNodeAPI:
         self.wallet_node.node_peaks[peer.peer_node_id] = (peak.height, peak.header_hash)
         await self.wallet_node.new_peak_queue.new_peak_wallet(peak, peer)
 
-    @api_request()
+    @metadata.request()
     async def reject_header_request(self, response: wallet_protocol.RejectHeaderRequest):
         """
         The full node has rejected our request for a header.
         """
         pass
 
-    @api_request()
+    @metadata.request()
     async def respond_block_header(self, response: wallet_protocol.RespondBlockHeader):
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_additions(self, response: wallet_protocol.RespondAdditions, peer: WSChiaConnection):
         pass
 
-    @api_request()
+    @metadata.request()
     async def respond_proof_of_weight(self, response: full_node_protocol.RespondProofOfWeight):
         pass
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def transaction_ack(self, ack: wallet_protocol.TransactionAck, peer: WSChiaConnection):
         """
         This is an ack for our previous SendTransaction call. This removes the transaction from
@@ -101,7 +106,7 @@ class WalletNodeAPI:
             else:
                 await wallet_state_manager.remove_from_queue(ack.txid, name, status, None)
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_peers_introducer(
         self, request: introducer_protocol.RespondPeersIntroducer, peer: WSChiaConnection
     ):
@@ -111,7 +116,7 @@ class WalletNodeAPI:
         if peer is not None and peer.connection_type is NodeType.INTRODUCER:
             await peer.close()
 
-    @api_request(peer_required=True)
+    @metadata.request(peer_required=True)
     async def respond_peers(self, request: full_node_protocol.RespondPeers, peer: WSChiaConnection):
         if self.wallet_node.wallet_peers is None:
             return None
@@ -121,54 +126,54 @@ class WalletNodeAPI:
 
         return None
 
-    @api_request()
+    @metadata.request()
     async def respond_puzzle_solution(self, request: wallet_protocol.RespondPuzzleSolution):
         self.log.error("Unexpected message `respond_puzzle_solution`. Peer might be slow to respond")
         return None
 
-    @api_request()
+    @metadata.request()
     async def reject_puzzle_solution(self, request: wallet_protocol.RejectPuzzleSolution):
         self.log.warning(f"Reject puzzle solution: {request}")
 
-    @api_request()
+    @metadata.request()
     async def respond_header_blocks(self, request: wallet_protocol.RespondHeaderBlocks):
         pass
 
-    @api_request()
+    @metadata.request()
     async def respond_block_headers(self, request: wallet_protocol.RespondBlockHeaders):
         pass
 
-    @api_request()
+    @metadata.request()
     async def reject_header_blocks(self, request: wallet_protocol.RejectHeaderBlocks):
         self.log.warning(f"Reject header blocks: {request}")
 
-    @api_request()
+    @metadata.request()
     async def reject_block_headers(self, request: wallet_protocol.RejectBlockHeaders):
         pass
 
-    @api_request(peer_required=True, execute_task=True)
+    @metadata.request(peer_required=True, execute_task=True)
     async def coin_state_update(self, request: wallet_protocol.CoinStateUpdate, peer: WSChiaConnection):
         await self.wallet_node.new_peak_queue.full_node_state_updated(request, peer)
 
     # TODO: Review this hinting issue around this rust type not being a Streamable
     #       subclass, as you might expect it wouldn't be.  Maybe we can get the
     #       protocol working right back at the api_request definition.
-    @api_request()  # type: ignore[type-var]
+    @metadata.request()  # type: ignore[type-var]
     async def respond_to_ph_update(self, request: wallet_protocol.RespondToPhUpdates):
         pass
 
-    @api_request()
+    @metadata.request()
     async def respond_to_coin_update(self, request: wallet_protocol.RespondToCoinUpdates):
         pass
 
-    @api_request()
+    @metadata.request()
     async def respond_children(self, request: wallet_protocol.RespondChildren):
         pass
 
-    @api_request()
+    @metadata.request()
     async def respond_ses_hashes(self, request: wallet_protocol.RespondSESInfo):
         pass
 
-    @api_request()
+    @metadata.request()
     async def respond_blocks(self, request: full_node_protocol.RespondBlocks) -> None:
         pass

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -10,11 +10,9 @@ from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.errors import Err
 from chia.wallet.wallet_node import WalletNode
 
-_api_node_metadata = ApiNodeMetadata(type=NodeType.WALLET)
-
 
 class WalletNodeAPI:
-    metadata: ClassVar[ApiNodeMetadata] = _api_node_metadata
+    metadata: ClassVar[ApiNodeMetadata] = ApiNodeMetadata(type=NodeType.WALLET)
     wallet_node: WalletNode
 
     def __init__(self, wallet_node) -> None:

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -10,7 +10,7 @@ from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.errors import Err
 from chia.wallet.wallet_node import WalletNode
 
-_api_node_metadata = ApiNodeMetadata()
+_api_node_metadata = ApiNodeMetadata(type=NodeType.WALLET)
 
 
 class WalletNodeAPI:

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -17,7 +17,7 @@ from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.full_node.pending_tx_cache import PendingTxCache
 from chia.protocols import full_node_protocol, wallet_protocol
 from chia.protocols.wallet_protocol import TransactionAck
-from chia.server.outbound_message import Message
+from chia.server.outbound_message import Message, NodeType
 from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert
@@ -159,7 +159,8 @@ class TestMempool:
         assert spend_bundle is not None
 
 
-_api_node_metadata = ApiNodeMetadata()
+# TODO: full node.  'ish
+_api_node_metadata = ApiNodeMetadata(type=NodeType.FULL_NODE)
 
 
 @_api_node_metadata.request(peer_required=True, bytes_required=True)

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -34,7 +34,7 @@ from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import MempoolItem
 from chia.types.spend_bundle import SpendBundle
 from chia.types.spend_bundle_conditions import Spend, SpendBundleConditions
-from chia.util.api_decorators import api_request
+from chia.util.api_decorators import ApiNodeMetadata
 from chia.util.condition_tools import conditions_for_solution, pkm_pairs
 from chia.util.errors import Err
 from chia.util.hash import std_hash
@@ -159,7 +159,10 @@ class TestMempool:
         assert spend_bundle is not None
 
 
-@api_request(peer_required=True, bytes_required=True)
+_api_node_metadata = ApiNodeMetadata()
+
+
+@_api_node_metadata.request(peer_required=True, bytes_required=True)
 async def respond_transaction(
     self: FullNodeAPI,
     tx: full_node_protocol.RespondTransaction,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

The data defining our peer API is spread around across various places.  This is one step towards collecting the implementation information into a single, well-defined, and easily accessible structure.  Next steps would include create a whole API definition that is aware of all of the nodes, implementing checks of this information against the static API definitions, and increasing the automation of the API double-check tests.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Each API endpoint stands alone and any attempt to get all of them must collect all the information themselves

### New Behavior:

Each API node type has already collected the relevant implementation metadata into a fully hinted class instance.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Hiding the whitespace when reading the diff of `ApiNodeMetadata.request()` can help highlight the content changes.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

### Draft for:
- [ ] review `TODO`s