### PR TITLE
@functools.wraps() for the API request decorators

### DIFF
--- a/chia/util/api_decorators.py
+++ b/chia/util/api_decorators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Type, TypeVar, Union, get_type_hints
@@ -53,6 +54,7 @@ def api_request(
         non_optional_reply_types = reply_types
 
     def inner(f: Callable[Concatenate[Self, S, P], R]) -> Callable[Concatenate[Self, Union[bytes, S], P], R]:
+        @functools.wraps(f)
         def wrapper(self: Self, original: Union[bytes, S], *args: P.args, **kwargs: P.kwargs) -> R:
             arg: S
             if isinstance(original, bytes):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:

Improve the representation of the API request methods after decoration.  This makes it easier to see what is going on when debugging.

<!-- Does this PR introduce a breaking change? -->
Current Behavior:

`<function api_request.<locals>.inner.<locals>.wrapper at 0x7ff7ff655990>`

New Behavior:

`<function FullNodeAPI.request_peers at 0x7fcc85d0d990>`

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
