### PR TITLE
close websocket in ssl tests to avoid event loop closed errors

### DIFF
--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -36,6 +36,7 @@ async def establish_connection(server: ChiaServer, self_hostname: str, ssl_conte
             local_capabilities_for_handshake=capabilities,
         )
         await wsc.perform_handshake(server._network_id, protocol_version, dummy_port, NodeType.FULL_NODE)
+        await wsc.close()
 
 
 class TestSSL:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:

Avoid the `Event loop is closed` annotations in the GitHub Actions summaries based on the errors in the tests.

https://github.com/Chia-Network/chia-blockchain/actions/runs/3767301965

https://github.com/Chia-Network/chia-blockchain/actions/runs/3767301965/jobs/6404841003#step:16:56
```python-traceback
Traceback (most recent call last):
  File "/home/runner/work/chia-blockchain/chia-blockchain/chia/server/ws_connection.py", line 420, in incoming_message_handler
    message = await self.incoming_queue.get()
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/asyncio/queues.py", line 161, in get
    getter.cancel()  # Just in case getter is not done yet.
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/asyncio/base_events.py", line 753, in call_soon
    self._check_closed()
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/asyncio/base_events.py", line 515, in _check_closed
Error:     raise RuntimeError('Event loop is closed')
```

<!-- Does this PR introduce a breaking change? -->
Current Behavior:

Websockets are not closed and we get errors and annotations.

New Behavior:

Websockets are closed and we get no errors.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
