### PR TITLE
Force coverage==7.0.1 (#14255)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ upnp_dependencies = [
 
 dev_dependencies = [
     "build",
-    "coverage",
+    "coverage==7.0.1",
     "diff-cover",
     "pre-commit",
     "py3createtorrent",


### PR DESCRIPTION
Lots of failures in coverage processing.

https://github.com/Chia-Network/chia-blockchain/actions/runs/3825220672/jobs/6508036405#step:16:558
```python-traceback
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/_pytest/main.py", line 270, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/_pytest/main.py", line 324, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/pluggy/_hooks.py", line 265, in __call__
INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/pluggy/_callers.py", line 55, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/pytest_cov/plugin.py", line 297, in pytest_runtestloop
INTERNALERROR>     self.cov_controller.finish()
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/pytest_cov/engine.py", line 44, in ensure_topdir_wrapper
INTERNALERROR>     return meth(self, *args, **kwargs)
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/pytest_cov/engine.py", line 338, in finish
INTERNALERROR>     self.cov.stop()
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/coverage/control.py", line 797, in combine
INTERNALERROR>     message=self._message,
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/coverage/data.py", line 158, in combine_parallel_data
INTERNALERROR>     new_data.read()
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/coverage/sqldata.py", line 815, in read
INTERNALERROR>     with self._connect():
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/coverage/sqldata.py", line 342, in _connect
INTERNALERROR>     self._open_db()
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/coverage/sqldata.py", line 285, in _open_db
INTERNALERROR>     self._read_db()
INTERNALERROR>   File "/home/runner/work/chia-blockchain/chia-blockchain/venv/lib/python3.7/site-packages/coverage/sqldata.py", line 302, in _read_db
INTERNALERROR>     assert row is not None
INTERNALERROR> AssertionError
```

(cherry picked from commit 5fe05bd3a9b8ae361628bba6a68d87979efef3d6)

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:


<!-- Does this PR introduce a breaking change? -->
Current Behavior:
New Behavior:


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
