### PR TITLE
Add MempoolRemoveReason, which represents why we are removing a MempoolItem

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -19,7 +19,7 @@ from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.fee_estimation import FeeBlockInfo, MempoolInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
-from chia.full_node.mempool import Mempool
+from chia.full_node.mempool import Mempool, MempoolRemoveReason
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
 from chia.full_node.pending_tx_cache import PendingTxCache
 from chia.types.blockchain_format.coin import Coin
@@ -350,7 +350,7 @@ class MempoolManager:
             # No error, immediately add to mempool, after removing conflicting TXs.
             assert item is not None
             self.mempool.add_to_pool(item)
-            self.mempool.remove_from_pool(remove_items)
+            self.mempool.remove_from_pool(remove_items, MempoolRemoveReason.CONFLICT)
             return item.cost, MempoolInclusionStatus.SUCCESS, None
         elif item is not None:
             # There is an error,  but we still returned a mempool item, this means we should add to the pending pool.
@@ -586,7 +586,7 @@ class MempoolManager:
                         spendbundle_ids: List[bytes32] = self.mempool.removal_coin_id_to_spendbundle_ids[
                             bytes32(spend.coin_id)
                         ]
-                        self.mempool.remove_from_pool(spendbundle_ids)
+                        self.mempool.remove_from_pool(spendbundle_ids, MempoolRemoveReason.BLOCK_INCLUSION)
                         for spendbundle_id in spendbundle_ids:
                             self.remove_seen(spendbundle_id)
         else:

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Tuple
 import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
+from chia.full_node.mempool import MempoolRemoveReason
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_custom_interval
@@ -29,7 +30,7 @@ def assert_sb_not_in_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
 
 def evict_from_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
     mempool_item = node.full_node.mempool_manager.mempool.spends[sb.name()]
-    node.full_node.mempool_manager.mempool.remove_from_pool([mempool_item.name])
+    node.full_node.mempool_manager.mempool.remove_from_pool([mempool_item.name], MempoolRemoveReason.CONFLICT)
     node.full_node.mempool_manager.remove_seen(sb.name())
 
 


### PR DESCRIPTION
The Mempool interface did not have the concept of why an item was being removed from the Mempool (e.g. Mempool Full, Replace by Fee, etc). This patch adds that. We can now use this information in lower layers. This patch also declines to call `FeeEstimatorInterface.remove_mempool_item` when the reason is `MempoolRemoveReason.BLOCK_INCLUSION`. The semantics of the FeeEstimatorInterface dictate that that case be handled by `FeeEstimatorInterface.new_block`.