### PR TITLE
Add current block height member to FeeMempoolInfo

### DIFF
--- a/chia/full_node/fee_estimation.py
+++ b/chia/full_node/fee_estimation.py
@@ -44,6 +44,7 @@ class FeeMempoolInfo:
     mempool_info: MempoolInfo
     current_mempool_cost: CLVMCost  # Current sum of CLVM cost of all SpendBundles in mempool (mempool "size")
     time: datetime  # Local time this sample was taken
+    height: uint32  # Current blockchain height
 
 
 EmptyMempoolInfo = MempoolInfo(
@@ -51,11 +52,7 @@ EmptyMempoolInfo = MempoolInfo(
 )
 
 
-EmptyFeeMempoolInfo = FeeMempoolInfo(
-    EmptyMempoolInfo,
-    CLVMCost(uint64(0)),
-    datetime.min,
-)
+EmptyFeeMempoolInfo = FeeMempoolInfo(EmptyMempoolInfo, CLVMCost(uint64(0)), datetime.min, uint32(0))
 
 
 @dataclass(frozen=True)

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -22,12 +22,6 @@ class MempoolRemoveReason(Enum):
     POOL_FULL = 3
 
 
-class MempoolRemoveReason(Enum):
-    CONFLICT = 1
-    BLOCK_INCLUSION = 2
-    POOL_FULL = 3
-
-
 class Mempool:
     def __init__(self, mempool_info: MempoolInfo, fee_estimator: FeeEstimatorInterface):
         self.log: logging.Logger = logging.getLogger(__name__)

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -95,7 +95,7 @@ def test_mempool_fee_estimator_add_item() -> None:
     fee_estimator = FeeEstimatorInterfaceIntegrationVerificationObject()
     mempool = Mempool(test_mempool_info, fee_estimator)
     item = make_mempoolitem()
-    mempool.add_to_pool(item)
+    mempool.add_to_pool(item, block_height=uint32(1))
     assert mempool.fee_estimator.add_mempool_item_called_count == 1  # type: ignore[attr-defined]
 
 

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -104,7 +104,7 @@ def test_item_not_removed_if_not_added() -> None:
         fee_estimator = FeeEstimatorInterfaceIntegrationVerificationObject()
         mempool = Mempool(test_mempool_info, fee_estimator)
         item = make_mempoolitem()
-        mempool.remove_from_pool([item.name], reason)
+        mempool.remove_from_pool([item.name], reason, block_height=uint32(1))
         assert mempool.fee_estimator.remove_mempool_item_called_count == 0  # type: ignore[attr-defined]
 
 
@@ -118,8 +118,8 @@ def test_mempool_fee_estimator_remove_item() -> None:
         fee_estimator = FeeEstimatorInterfaceIntegrationVerificationObject()
         mempool = Mempool(test_mempool_info, fee_estimator)
         item = make_mempoolitem()
-        mempool.add_to_pool(item)
-        mempool.remove_from_pool([item.name], reason)
+        mempool.add_to_pool(item, block_height=uint32(1))
+        mempool.remove_from_pool([item.name], reason, block_height=uint32(1))
         assert mempool.fee_estimator.remove_mempool_item_called_count == call_count  # type: ignore[attr-defined]
 
 

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -12,7 +12,7 @@ from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from chia.types.peer_info import PeerInfo
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint16, uint64
+from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_node import WalletNode
 from tests.pools.test_pool_rpc import farm_blocks
@@ -30,7 +30,10 @@ def assert_sb_not_in_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
 
 def evict_from_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
     mempool_item = node.full_node.mempool_manager.mempool.spends[sb.name()]
-    node.full_node.mempool_manager.mempool.remove_from_pool([mempool_item.name], MempoolRemoveReason.CONFLICT)
+    block_height = node.full_node.mempool_manager.peak.height if node.full_node.mempool_manager.peak else uint32(0)
+    node.full_node.mempool_manager.mempool.remove_from_pool(
+        [mempool_item.name], MempoolRemoveReason.CONFLICT, block_height
+    )
     node.full_node.mempool_manager.remove_seen(sb.name())
 
 


### PR DESCRIPTION
No user visible changes. We add the concept of current block height to `FeeMempoolInfo`, a struct which holds information about the current state of the Mempool. This can be used by the Fee Estimator to gauge the passing "blockchain time" as the methods in its interface are called.