### PR TITLE
use .get("testing", False) to avoid errors when missing

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -683,7 +683,7 @@ class ChiaServer:
     def is_trusted_peer(self, peer: WSChiaConnection, trusted_peers: Dict[str, Any]) -> bool:
         if trusted_peers is None:
             return False
-        if not self.config["testing"] and peer.peer_host == "127.0.0.1":
+        if not self.config.get("testing", False) and peer.peer_host == "127.0.0.1":
             return True
         if peer.peer_node_id.hex() not in trusted_peers:
             return False

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -94,7 +94,7 @@ async def async_main() -> int:
     config[SERVICE_NAME] = service_config
 
     # This is simulator
-    local_test = service_config["testing"]
+    local_test = service_config.get("testing", False)
     if local_test is True:
         from chia.simulator.block_tools import test_constants
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -864,7 +864,11 @@ class WalletNode:
             latest_timestamp = last_tx.foliage_transaction_block.timestamp
 
         # Return None if not synced
-        if latest_timestamp is None or self.config["testing"] is False and latest_timestamp < request_time - 600:
+        if (
+            latest_timestamp is None
+            or self.config.get("testing", False) is False
+            and latest_timestamp < request_time - 600
+        ):
             return None
         return latest_timestamp
 


### PR DESCRIPTION

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:

Fix sync issues triggered by assumption that a config value is present.  Reported in https://github.com/Chia-Network/chia-blockchain/issues/14239.

<!-- Does this PR introduce a breaking change? -->
Current Behavior:
New Behavior:


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
