### PR TITLE
Remove redundant check for duplicate inputs

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections
 import logging
 import time
 from concurrent.futures import Executor
@@ -408,11 +407,6 @@ class MempoolManager:
         for add in additions:
             additions_dict[add.name()] = add
             addition_amount = addition_amount + add.amount
-        # Check for duplicate inputs
-        removal_counter = collections.Counter(name for name in removal_names)
-        for k, v in removal_counter.items():
-            if v > 1:
-                return Err.DOUBLE_SPEND, None, []
 
         removal_record_dict: Dict[bytes32, CoinRecord] = {}
         removal_amount: int = 0

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -126,3 +126,13 @@ async def test_block_cost_exceeds_max() -> None:
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="Err.BLOCK_COST_EXCEEDS_MAX"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+
+
+@pytest.mark.asyncio
+async def test_double_spend_prevalidation() -> None:
+    mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
+    conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
+    sb = spend_bundle_from_conditions(conditions)
+    sb_twice: SpendBundle = SpendBundle.aggregate([sb, sb])
+    with pytest.raises(ValidationError, match="Err.DOUBLE_SPEND"):
+        await mempool_manager.pre_validate_spendbundle(sb_twice, None, sb_twice.name())


### PR DESCRIPTION
This simplifies the mempool by removing a DOUBLE_SPEND check that is already performed on the Rust side.
The added test passes before and after introducing the code changes.