### PR TITLE
use config.get("trusted_peers", {}) for wallet

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1594,4 +1594,4 @@ class FullNodeAPI:
         return msg
 
     def is_trusted(self, peer: WSChiaConnection) -> bool:
-        return self.server.is_trusted_peer(peer, self.full_node.config["trusted_peers"])
+        return self.server.is_trusted_peer(peer, self.full_node.config.get("trusted_peers", {}))


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:

Avoid problems when the wallet trusted peers configuration is not present.

<!-- Does this PR introduce a breaking change? -->
Current Behavior:

https://gist.github.com/altendky/d604f3fe260cc6056032a93c9034765c#file-gistfile1-txt-L71
```
Jan 04 13:22:09 fullnode chia_wallet[3244452]:   File "/farm/chia-blockchain/chia/wallet/wallet_node.py", line 467, in _process_new_subscriptions
Jan 04 13:22:09 fullnode chia_wallet[3244452]:     await self.new_peak_wallet(request, peer)
Jan 04 13:22:09 fullnode chia_wallet[3244452]:   File "/farm/chia-blockchain/chia/wallet/wallet_node.py", line 1038, in new_peak_wallet
Jan 04 13:22:09 fullnode chia_wallet[3244452]:     await self.new_peak_from_trusted(new_peak_hb, latest_timestamp, peer)
Jan 04 13:22:09 fullnode chia_wallet[3244452]:   File "/farm/chia-blockchain/chia/wallet/wallet_node.py", line 1064, in new_peak_from_trusted
Jan 04 13:22:09 fullnode chia_wallet[3244452]:     await self._primary_peer_sync_task
Jan 04 13:22:09 fullnode chia_wallet[3244452]:   File "/farm/chia-blockchain/chia/wallet/wallet_node.py", line 655, in long_sync
Jan 04 13:22:09 fullnode chia_wallet[3244452]:     ph_update_res: List[CoinState] = await subscribe_to_phs(
Jan 04 13:22:09 fullnode chia_wallet[3244452]:   File "/farm/chia-blockchain/chia/wallet/util/wallet_sync_utils.py", line 78, in subscribe_to_phs
Jan 04 13:22:09 fullnode chia_wallet[3244452]:     raise ValueError(f"None response from peer {peer.peer_host} for register_interest_in_puzzle_hash")
Jan 04 13:22:09 fullnode chia_wallet[3244452]: ValueError: None response from peer 127.0.0.1 for register_interest_in_puzzle_hash
```

New Behavior:

No such tracebacks.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
