### PR TITLE
return failure if mempool manager has no peak

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2259,10 +2259,11 @@ class FullNode:
                 if self.mempool_manager.get_spendbundle(spend_name) is not None:
                     self.mempool_manager.remove_seen(spend_name)
                     return MempoolInclusionStatus.SUCCESS, None
-                if self.mempool_manager.peak is not None:
-                    cost, status, error = await self.mempool_manager.add_spend_bundle(
-                        transaction, cost_result, spend_name, self.mempool_manager.peak.height
-                    )
+                if self.mempool_manager.peak is None:
+                    return MempoolInclusionStatus.FAILED, Err.MEMPOOL_NOT_INITIALIZED
+                cost, status, error = await self.mempool_manager.add_spend_bundle(
+                    transaction, cost_result, spend_name, self.mempool_manager.peak.height
+                )
             if status == MempoolInclusionStatus.SUCCESS:
                 self.log.debug(
                     f"Added transaction to mempool: {spend_name} mempool size: "

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2259,10 +2259,10 @@ class FullNode:
                 if self.mempool_manager.get_spendbundle(spend_name) is not None:
                     self.mempool_manager.remove_seen(spend_name)
                     return MempoolInclusionStatus.SUCCESS, None
-                assert self.mempool_manager.peak
-                cost, status, error = await self.mempool_manager.add_spend_bundle(
-                    transaction, cost_result, spend_name, self.mempool_manager.peak.height
-                )
+                if self.mempool_manager.peak is not None:
+                    cost, status, error = await self.mempool_manager.add_spend_bundle(
+                        transaction, cost_result, spend_name, self.mempool_manager.peak.height
+                    )
             if status == MempoolInclusionStatus.SUCCESS:
                 self.log.debug(
                     f"Added transaction to mempool: {spend_name} mempool size: "


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:

This avoids an exception that seems to block ... well, general functioning anyways.  I made a trivial "fix" and Adam thought it was ok.  Anyone else have opinions?

<!-- Does this PR introduce a breaking change? -->
Current Behavior:

```python-traceback
Jan 04 15:18:54 fullnode chia_full_node[3315992]: 2023-01-04T15:18:54.301 full_node chia.full_node.full_node: ERROR    Error in _handle_one_transaction, closing: Traceback (most recent call last):
Jan 04 15:18:54 fullnode chia_full_node[3315992]:   File "/farm/chia-blockchain/chia/full_node/full_node.py", line 458, in _handle_one_transaction
Jan 04 15:18:54 fullnode chia_full_node[3315992]:     inc_status, err = await self.respond_transaction(entry.transaction, entry.spend_name, peer, entry.test)
Jan 04 15:18:54 fullnode chia_full_node[3315992]:   File "/farm/chia-blockchain/chia/full_node/full_node.py", line 2262, in respond_transaction
Jan 04 15:18:54 fullnode chia_full_node[3315992]:     assert self.mempool_manager.peak
Jan 04 15:18:54 fullnode chia_full_node[3315992]: AssertionError
```

New Behavior:


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
