### PR TITLE
Add new_block_height to FeeEstimatorInterface

### DIFF
--- a/chia/full_node/bitcoin_fee_estimator.py
+++ b/chia/full_node/bitcoin_fee_estimator.py
@@ -20,13 +20,18 @@ class BitcoinFeeEstimator(FeeEstimatorInterface):
     fee_rate_estimator: SmartFeeEstimator
     tracker: FeeTracker
     last_mempool_info: FeeMempoolInfo
+    block_height: uint32
 
     def __init__(self, fee_tracker: FeeTracker, smart_fee_estimator: SmartFeeEstimator) -> None:
         self.fee_rate_estimator: SmartFeeEstimator = smart_fee_estimator
         self.tracker: FeeTracker = fee_tracker
         self.last_mempool_info: FeeMempoolInfo = EmptyFeeMempoolInfo
 
+    def new_block_height(self, block_height: uint32) -> None:
+        self.block_height = block_height
+
     def new_block(self, block_info: FeeBlockInfo) -> None:
+        self.block_height = block_info.block_height
         self.tracker.process_block(block_info.block_height, block_info.included_items)
 
     def add_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:

--- a/chia/full_node/fee_estimator_interface.py
+++ b/chia/full_node/fee_estimator_interface.py
@@ -6,11 +6,16 @@ from chia.full_node.fee_estimation import FeeBlockInfo, FeeMempoolInfo
 from chia.types.clvm_cost import CLVMCost
 from chia.types.fee_rate import FeeRate
 from chia.types.mempool_item import MempoolItem
+from chia.util.ints import uint32
 
 
 class FeeEstimatorInterface(Protocol):
+    def new_block_height(self, block_height: uint32) -> None:
+        """Called immediately when block height changes. Can be called multiple times before `new_block`"""
+        pass
+
     def new_block(self, block_info: FeeBlockInfo) -> None:
-        """A new block has been added to the blockchain"""
+        """A new transaction block has been added to the blockchain"""
         pass
 
     def add_mempool_item(self, mempool_item_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -567,6 +567,7 @@ class MempoolManager:
         if self.peak == new_peak:
             return []
         assert new_peak.timestamp is not None
+        self.fee_estimator.new_block_height(new_peak.height)
         included_items = []
 
         use_optimization: bool = self.peak is not None and new_peak.prev_transaction_block_hash == self.peak.header_hash

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -31,11 +31,11 @@ async def zero_calls_get_coin_record(_: bytes32) -> Optional[CoinRecord]:
     assert False
 
 
-def create_test_block_record() -> BlockRecord:
+def create_test_block_record(*, height: uint32 = TEST_HEIGHT) -> BlockRecord:
     return BlockRecord(
         IDENTITY_PUZZLE_HASH,
         IDENTITY_PUZZLE_HASH,
-        TEST_HEIGHT,
+        height,
         uint128(0),
         uint128(0),
         uint8(0),
@@ -49,7 +49,7 @@ def create_test_block_record() -> BlockRecord:
         uint64(0),
         uint8(0),
         False,
-        uint32(TEST_HEIGHT - 1),
+        uint32(height - 1),
         TEST_TIMESTAMP,
         None,
         uint64(0),

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -31,11 +31,8 @@ async def zero_calls_get_coin_record(_: bytes32) -> Optional[CoinRecord]:
     assert False
 
 
-async def instantiate_mempool_manager(
-    get_coin_record: Callable[[bytes32], Awaitable[Optional[CoinRecord]]]
-) -> MempoolManager:
-    mempool_manager = MempoolManager(get_coin_record, DEFAULT_CONSTANTS)
-    test_block_record = BlockRecord(
+def create_test_block_record() -> BlockRecord:
+    return BlockRecord(
         IDENTITY_PUZZLE_HASH,
         IDENTITY_PUZZLE_HASH,
         TEST_HEIGHT,
@@ -62,6 +59,13 @@ async def instantiate_mempool_manager(
         None,
         None,
     )
+
+
+async def instantiate_mempool_manager(
+    get_coin_record: Callable[[bytes32], Awaitable[Optional[CoinRecord]]]
+) -> MempoolManager:
+    mempool_manager = MempoolManager(get_coin_record, DEFAULT_CONSTANTS)
+    test_block_record = create_test_block_record()
     await mempool_manager.new_peak(test_block_record, None)
     return mempool_manager
 

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import types
 from typing import Dict, List
 
 import pytest
@@ -216,3 +217,21 @@ async def test_mm_new_peak_changes_fee_estimator_block_height() -> None:
     block2 = create_test_block_record(height=uint32(2))
     await mempool_manager.new_peak(block2, None)
     assert mempool_manager.mempool.fee_estimator.block_height == uint32(2)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_mm_calls_new_block_height() -> None:
+    mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
+    new_block_height_called = False
+
+    def test_new_block_height_called(self: FeeEstimatorInterface, height: uint32) -> None:
+        nonlocal new_block_height_called
+        new_block_height_called = True
+
+    # Replace new_block_height with test function
+    mempool_manager.fee_estimator.new_block_height = types.MethodType(  # type: ignore[assignment]
+        test_new_block_height_called, mempool_manager.fee_estimator
+    )
+    block2 = create_test_block_record(height=uint32(2))
+    await mempool_manager.new_peak(block2, None)
+    assert new_block_height_called

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import Dict, List
 
 import pytest
@@ -212,8 +211,8 @@ def test_current_block_height_new_block_then_new_height() -> None:
 
 
 @pytest.mark.asyncio
-async def test_duplicate_output() -> None:
+async def test_mm_new_peak_changes_fee_estimator_block_height() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
-    block2 = replace(create_test_block_record(), height=uint32(2))
+    block2 = create_test_block_record(height=uint32(2))
     await mempool_manager.new_peak(block2, None)
     assert mempool_manager.mempool.fee_estimator.block_height == uint32(2)  # type: ignore[attr-defined]


### PR DESCRIPTION
No user visible changes. We add the ability to update the current block height via `FeeEstimatorInterface.new_block_height`. This can be used by the Fee Estimator to gauge the passing "blockchain time" at a finer level of detail, rather than only updating it in `FeeEstimatorInterface.new_block`, as was done before.