### PR TITLE
Fixed: remove duplicates in puzzle hash and interested puzzle hash

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1279,7 +1279,6 @@ class WalletNode:
 
     async def get_puzzle_hashes_to_subscribe(self) -> List[bytes32]:
         all_puzzle_hashes = list(await self.wallet_state_manager.puzzle_store.get_all_puzzle_hashes())
-        puzzle_store_count = len(all_puzzle_hashes)
         # Get all phs from interested store
         interested_puzzle_hashes = [
             t[0] for t in await self.wallet_state_manager.interested_store.get_interested_puzzle_hashes()

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1285,8 +1285,7 @@ class WalletNode:
             t[0] for t in await self.wallet_state_manager.interested_store.get_interested_puzzle_hashes()
         ]
         all_puzzle_hashes.extend(interested_puzzle_hashes)
-        assert puzzle_store_count + len(interested_puzzle_hashes) == len(set(all_puzzle_hashes))
-        return all_puzzle_hashes
+        return list(set(all_puzzle_hashes))  # Remove duplicates
 
     async def get_coin_ids_to_subscribe(self, min_height: int) -> List[bytes32]:
         all_coin_names: Set[bytes32] = await self.wallet_state_manager.coin_store.get_coin_names_to_check(min_height)


### PR DESCRIPTION
Purpose:

This removes the assertion when dupes were found and returns a list without duplicates

Current Behavior:

Assert out if dupes found

New Behavior:

Remove dupes and return list without dupes

Testing Notes: