### PR TITLE
bump chia_rs dependency to the latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ dependencies = [
     "chiapos==1.0.11",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
-    "chia_rs==0.1.16",
+    "chia_rs==0.2.0",
     "clvm-tools-rs==0.1.25",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.3",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -81,9 +81,7 @@ async def test_negative_addition_amount() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, -1]]
     sb = spend_bundle_from_conditions(conditions)
-    # chia_rs currently emits this instead of Err.COIN_AMOUNT_NEGATIVE
-    # Addressed in https://github.com/Chia-Network/chia_rs/pull/99
-    with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
+    with pytest.raises(ValidationError, match="Err.COIN_AMOUNT_NEGATIVE"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
 
 
@@ -103,9 +101,7 @@ async def test_too_big_addition_amount() -> None:
     max_amount = mempool_manager.constants.MAX_COIN_AMOUNT
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, max_amount + 1]]
     sb = spend_bundle_from_conditions(conditions)
-    # chia_rs currently emits this instead of Err.COIN_AMOUNT_EXCEEDS_MAXIMUM
-    # Addressed in https://github.com/Chia-Network/chia_rs/pull/99
-    with pytest.raises(ValidationError, match="Err.INVALID_CONDITION"):
+    with pytest.raises(ValidationError, match="Err.COIN_AMOUNT_EXCEEDS_MAXIMUM"):
         await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
 
 


### PR DESCRIPTION
Among other things, this improves the error code returned on negative amounts and amounts exceeding max (from checking conditions)