### PR TITLE
Remove conflicting TXs before adding SpendBundle to Mempool in add_spend_bundle

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -348,8 +348,8 @@ class MempoolManager:
         if err is None:
             # No error, immediately add to mempool, after removing conflicting TXs.
             assert item is not None
-            self.mempool.add_to_pool(item)
             self.mempool.remove_from_pool(remove_items, MempoolRemoveReason.CONFLICT)
+            self.mempool.add_to_pool(item)
             return item.cost, MempoolInclusionStatus.SUCCESS, None
         elif item is not None:
             # There is an error,  but we still returned a mempool item, this means we should add to the pending pool.


### PR DESCRIPTION
No user visible change.
Remove conflicting TXs before adding SpendBundle to Mempool in add_spend_bundle.
