### PR TITLE
optimize mempool's potential cache

### DIFF
--- a/chia/full_node/pending_tx_cache.py
+++ b/chia/full_node/pending_tx_cache.py
@@ -1,33 +1,40 @@
 from __future__ import annotations
 
-from typing import Dict
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from sortedcontainers import SortedDict
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_item import MempoolItem
+from chia.util.ints import uint32
 
 
-class PendingTxCache:
+@dataclass
+class ConflictTxCache:
     _cache_max_total_cost: int
-    _cache_cost: int
-    _txs: Dict[bytes32, MempoolItem]
+    _cache_max_size: int = 1000
+    _cache_cost: int = field(default=0, init=False)
+    _txs: Dict[bytes32, MempoolItem] = field(default_factory=dict, init=False)
 
-    def __init__(self, cost_limit: int):
-        self._cache_max_total_cost = cost_limit
-        self._cache_cost = 0
-        self._txs = {}
+    def get(self, bundle_name: bytes32) -> Optional[MempoolItem]:
+        return self._txs.get(bundle_name, None)
 
     def add(self, item: MempoolItem) -> None:
         """
         Adds SpendBundles that have failed to be added to the pool in potential tx set.
         This is later used to retry to add them.
         """
-        if item.spend_bundle_name in self._txs:
+        name = item.name
+
+        if name in self._txs:
             return None
 
-        self._txs[item.spend_bundle_name] = item
+        self._txs[name] = item
         self._cache_cost += item.cost
 
-        while self._cache_cost > self._cache_max_total_cost:
+        while self._cache_cost > self._cache_max_total_cost or len(self._txs) > self._cache_max_size:
+
             first_in = list(self._txs.keys())[0]
             self._cache_cost -= self._txs[first_in].cost
             self._txs.pop(first_in)
@@ -36,6 +43,71 @@ class PendingTxCache:
         ret = self._txs
         self._txs = {}
         self._cache_cost = 0
+        return ret
+
+    def cost(self) -> int:
+        return self._cache_cost
+
+
+@dataclass
+class PendingTxCache:
+    _cache_max_total_cost: int
+    _cache_max_size: int = 3000
+    _cache_cost: int = field(default=0, init=False)
+    _txs: Dict[bytes32, MempoolItem] = field(default_factory=dict, init=False)
+    _by_height: SortedDict[uint32, Dict[bytes32, MempoolItem]] = field(default_factory=SortedDict, init=False)
+
+    def get(self, bundle_name: bytes32) -> Optional[MempoolItem]:
+        return self._txs.get(bundle_name, None)
+
+    def add(self, item: MempoolItem) -> None:
+        """
+        Adds SpendBundles that are not yet valid because of a height assertion.
+        They will be re-tried once their height requirement is satisfied
+        """
+        assert item.assert_height is not None
+
+        name = item.name
+
+        if name in self._txs:
+            return None
+
+        self._txs[name] = item
+        self._cache_cost += item.cost
+        self._by_height.setdefault(item.assert_height, {})[name] = item
+
+        while self._cache_cost > self._cache_max_total_cost or len(self._txs) > self._cache_max_size:
+
+            # we start removing items with the highest assert_height first
+            to_evict = self._by_height.items()[-1]
+            if to_evict[1] == {}:
+                self._txs.pop(to_evict[0])
+                continue
+
+            first_in = list(to_evict[1].keys())[0]
+            removed_item = self._txs.pop(first_in)
+            self._cache_cost -= removed_item.cost
+            to_evict[1].pop(first_in)
+            if to_evict[1] == {}:
+                self._by_height.pop()
+
+    def drain(self, up_to_height: uint32) -> Dict[bytes32, MempoolItem]:
+        ret: Dict[bytes32, MempoolItem] = {}
+
+        if self._txs == {}:
+            return ret
+
+        height_line = self._by_height.items()[0]
+        while height_line[0] < up_to_height:
+            ret.update(height_line[1])
+            for name, item in height_line[1].items():
+                self._cache_cost -= item.cost
+                self._txs.pop(name)
+            self._by_height.popitem(0)
+            if len(self._by_height) == 0:
+                break
+            height_line = self._by_height.items()[0]
+
         return ret
 
     def cost(self) -> int:

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from chia.consensus.cost_calculator import NPCResult
 from chia.types.blockchain_format.coin import Coin
@@ -21,6 +21,9 @@ class MempoolItem(Streamable):
     spend_bundle_name: bytes32
     additions: List[Coin]
     height_added_to_mempool: uint32
+
+    # If present, this SpendBundle is not valid at or before this height
+    assert_height: Optional[uint32] = None
 
     def __lt__(self, other: MempoolItem) -> bool:
         return self.fee_per_cost < other.fee_per_cost

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -16,7 +16,7 @@ from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.mempool import Mempool
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
-from chia.full_node.pending_tx_cache import PendingTxCache
+from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.protocols import full_node_protocol, wallet_protocol
 from chia.protocols.wallet_protocol import TransactionAck
 from chia.server.outbound_message import Message
@@ -83,23 +83,31 @@ def generate_test_spend_bundle(
     return transaction
 
 
-def make_item(idx: int, cost: uint64 = uint64(80)) -> MempoolItem:
+def make_item(idx: int, cost: uint64 = uint64(80), assert_height=100) -> MempoolItem:
     spend_bundle_name = bytes32([idx] * 32)
     return MempoolItem(
-        SpendBundle([], G2Element()), uint64(0), NPCResult(None, None, cost), cost, spend_bundle_name, [], uint32(0)
+        SpendBundle([], G2Element()),
+        uint64(0),
+        NPCResult(None, None, cost),
+        cost,
+        spend_bundle_name,
+        [],
+        uint32(0),
+        assert_height,
     )
 
 
-class TestPendingTxCache:
+class TestConflictTxCache:
     def test_recall(self):
-        c = PendingTxCache(100)
+        c = ConflictTxCache(100)
         item = make_item(1)
         c.add(item)
+        assert c.get(item.name) == item
         tx = c.drain()
         assert tx == {item.spend_bundle_name: item}
 
     def test_fifo_limit(self):
-        c = PendingTxCache(200)
+        c = ConflictTxCache(200)
         # each item has cost 80
         items = [make_item(i) for i in range(1, 4)]
         for i in items:
@@ -109,8 +117,19 @@ class TestPendingTxCache:
         tx = c.drain()
         assert tx == {items[-2].spend_bundle_name: items[-2], items[-1].spend_bundle_name: items[-1]}
 
+    def test_item_limit(self):
+        c = ConflictTxCache(1000000, 2)
+        # each item has cost 80
+        items = [make_item(i) for i in range(1, 4)]
+        for i in items:
+            c.add(i)
+        # the max size is 2, only two transactions will fit
+        # we evict items FIFO, so the to most recently added will be left
+        tx = c.drain()
+        assert tx == {items[-2].spend_bundle_name: items[-2], items[-1].spend_bundle_name: items[-1]}
+
     def test_drain(self):
-        c = PendingTxCache(100)
+        c = ConflictTxCache(100)
         item = make_item(1)
         c.add(item)
         tx = c.drain()
@@ -121,7 +140,7 @@ class TestPendingTxCache:
         assert tx == {}
 
     def test_cost(self):
-        c = PendingTxCache(200)
+        c = ConflictTxCache(200)
         assert c.cost() == 0
         item1 = make_item(1)
         c.add(item1)
@@ -147,6 +166,109 @@ class TestPendingTxCache:
 
         tx = c.drain()
         assert tx == {item4.spend_bundle_name: item4}
+
+
+class TestPendingTxCache:
+    def test_recall(self):
+        c = PendingTxCache(100)
+        item = make_item(1)
+        c.add(item)
+        assert c.get(item.name) == item
+        tx = c.drain(101)
+        assert tx == {item.spend_bundle_name: item}
+
+    def test_fifo_limit(self):
+        c = PendingTxCache(200)
+        # each item has cost 80
+        items = [make_item(i) for i in range(1, 4)]
+        for i in items:
+            c.add(i)
+        # the max cost is 200, only two transactions will fit
+        # the eviction is FIFO because all items have the same assert_height
+        tx = c.drain(101)
+        assert tx == {items[-2].spend_bundle_name: items[-2], items[-1].spend_bundle_name: items[-1]}
+
+    def test_item_limit(self):
+        c = PendingTxCache(1000000, 2)
+        # each item has cost 80
+        items = [make_item(i) for i in range(1, 4)]
+        for i in items:
+            c.add(i)
+        # the max size is 2, only two transactions will fit
+        # the eviction is FIFO because all items have the same assert_height
+        tx = c.drain(101)
+        assert tx == {items[-2].spend_bundle_name: items[-2], items[-1].spend_bundle_name: items[-1]}
+
+    def test_drain(self):
+        c = PendingTxCache(100)
+        item = make_item(1)
+        c.add(item)
+        tx = c.drain(101)
+        assert tx == {item.spend_bundle_name: item}
+
+        # drain will clear the cache, so a second call will be empty
+        tx = c.drain(101)
+        assert tx == {}
+
+    def test_cost(self):
+        c = PendingTxCache(200)
+        assert c.cost() == 0
+        item1 = make_item(1)
+        c.add(item1)
+        # each item has cost 80
+        assert c.cost() == 80
+
+        item2 = make_item(2)
+        c.add(item2)
+        assert c.cost() == 160
+
+        # the first item is evicted, so the cost stays the same
+        item3 = make_item(3)
+        c.add(item3)
+        assert c.cost() == 160
+
+        tx = c.drain(101)
+        assert tx == {item2.spend_bundle_name: item2, item3.spend_bundle_name: item3}
+
+        assert c.cost() == 0
+        item4 = make_item(4)
+        c.add(item4)
+        assert c.cost() == 80
+
+        tx = c.drain(101)
+        assert tx == {item4.spend_bundle_name: item4}
+
+    def test_drain_height(self):
+        c = PendingTxCache(20000, 1000)
+
+        # each item has cost 80
+        # heights are 100-109
+        items = [make_item(i, 80, 100 + i) for i in range(10)]
+        for i in items:
+            c.add(i)
+
+        tx = c.drain(101)
+        assert tx == {items[0].spend_bundle_name: items[0]}
+
+        tx = c.drain(105)
+        assert tx == {
+            items[1].spend_bundle_name: items[1],
+            items[2].spend_bundle_name: items[2],
+            items[3].spend_bundle_name: items[3],
+            items[4].spend_bundle_name: items[4],
+        }
+
+        tx = c.drain(105)
+        assert tx == {}
+
+        tx = c.drain(110)
+        assert tx == {
+            items[5].spend_bundle_name: items[5],
+            items[6].spend_bundle_name: items[6],
+            items[7].spend_bundle_name: items[7],
+            items[8].spend_bundle_name: items[8],
+            items[9].spend_bundle_name: items[9],
+        }
 
 
 class TestMempool:

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -7,7 +7,7 @@ from blspy import G2Element
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.full_node.mempool_manager import MempoolManager
+from chia.full_node.mempool_manager import MempoolManager, compute_assert_height
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -17,6 +17,7 @@ from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle_conditions import Spend, SpendBundleConditions
 from chia.util.errors import Err, ValidationError
 from chia.util.ints import uint8, uint32, uint64, uint128
 
@@ -72,6 +73,32 @@ async def instantiate_mempool_manager(
     test_block_record = create_test_block_record()
     await mempool_manager.new_peak(test_block_record, None)
     return mempool_manager
+
+
+def test_compute_assert_height() -> None:
+
+    c1 = Coin(bytes32(b"a" * 32), bytes32(b"b" * 32), 1337)
+    coin_id = c1.name()
+    confirmed_height = uint32(12)
+    coin_records = {coin_id: CoinRecord(c1, confirmed_height, uint32(0), False, uint64(10000))}
+
+    # 42 is the absolute height condition
+    conds = SpendBundleConditions([Spend(coin_id, bytes32(b"c" * 32), None, 0, [], [], 0)], 0, 42, 0, [], 0)
+    assert compute_assert_height(coin_records, conds) == 42
+
+    # 1 is a relative height, but that only amounts to 13, so the absolute
+    # height is more restrictive
+    conds = SpendBundleConditions([Spend(coin_id, bytes32(b"c" * 32), 1, 0, [], [], 0)], 0, 42, 0, [], 0)
+    assert compute_assert_height(coin_records, conds) == 42
+
+    # 100 is a relative height, and sinec the coin was confirmed at height 12,
+    # that's 112
+    conds = SpendBundleConditions([Spend(coin_id, bytes32(b"c" * 32), 100, 0, [], [], 0)], 0, 42, 0, [], 0)
+    assert compute_assert_height(coin_records, conds) == 112
+
+    # Same thing but without the absolute height
+    conds = SpendBundleConditions([Spend(coin_id, bytes32(b"c" * 32), 100, 0, [], [], 0)], 0, 0, 0, [], 0)
+    assert compute_assert_height(coin_records, conds) == 112
 
 
 def spend_bundle_from_conditions(conditions: List[List[Any]]) -> SpendBundle:


### PR DESCRIPTION
split potential cache into conflict- and pending cache.
The pending cache can be ordered by height so we only have to consider transactions whose assert-height would make them valid with the new peak. This improves big-O complexity and hence allows the pending cache to have a greater capacity.

That's the rationale to separate the conflict case from the assert-height case.

The existing `PendingTxCache` is preserved but renamed `ConflictTxCache`. The new `PendingTxCache` orders the `MempoolItem`s by assert height, and its `drain()` function only trains up to the peak.