### PR TITLE
add dust warning message to chia coins commands & cleanup code

### DIFF
--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -252,3 +252,12 @@ async def async_split(
         tx_id = transaction.name.hex()
         print(f"Transaction sent: {tx_id}")
         print(f"To get status, use command: chia wallet get_transaction -f {fingerprint} -tx 0x{tx_id}")
+        dust_threshold = config.get("xch_spam_amount", 1000000)  # min amount per coin in mojo
+        spam_filter_after_n_txs = config.get("spam_filter_after_n_txs", 200)  # how many txs to wait before filtering
+        if final_amount_per_coin < dust_threshold and wallet_type == WalletType.STANDARD_WALLET:
+            print(
+                f"WARNING: The amount per coin: {amount_per_coin} is less than the dust threshold: "
+                f"{dust_threshold / mojo_per_unit}. Some or all of the Coins "
+                f"{'will' if number_of_coins > spam_filter_after_n_txs else 'may'} not show up in your wallet unless "
+                f"you decrease the dust limit to below {final_amount_per_coin} mojos or disable it by setting it to 0."
+            )


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
Purpose:
This adds a warning to the user letting them know that the dust filter might prevent them from seeing their coins.

<!-- Does this PR introduce a breaking change? -->
Current Behavior:
No warning when making coins below the dust limit, user might be confused as wallet ignores coins.
New Behavior:
A warning was added to stop possible user confusion.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Testing Notes:
CLI Testing will be added in the coming weeks.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
