### PR TITLE
infrastructure for upcoming soft-fork

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -318,6 +318,7 @@ async def validate_block_body(
                     min(constants.MAX_BLOCK_COST_CLVM, curr.transactions_info.cost),
                     cost_per_byte=constants.COST_PER_BYTE,
                     mempool_mode=False,
+                    height=curr.height,
                 )
                 removals_in_curr, additions_in_curr = tx_removals_and_additions(curr_npc_result.conds)
             else:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -443,6 +443,7 @@ class Blockchain(BlockchainInterface):
                 self.constants.MAX_BLOCK_COST_CLVM,
                 cost_per_byte=self.constants.COST_PER_BYTE,
                 mempool_mode=False,
+                height=block.height,
             )
         tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
         return tx_removals, tx_additions, npc_result
@@ -646,13 +647,14 @@ class Blockchain(BlockchainInterface):
             validate_signatures=validate_signatures,
         )
 
-    async def run_generator(self, unfinished_block: bytes, generator: BlockGenerator) -> NPCResult:
+    async def run_generator(self, unfinished_block: bytes, generator: BlockGenerator, height: uint32) -> NPCResult:
         task = asyncio.get_running_loop().run_in_executor(
             self.pool,
             _run_generator,
             self.constants,
             unfinished_block,
             bytes(generator),
+            height,
         )
         npc_result_bytes = await task
         if npc_result_bytes is None:

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -61,6 +61,7 @@ class ConsensusConstants:
     MAX_GENERATOR_SIZE: uint32
     MAX_GENERATOR_REF_LIST_SIZE: uint32
     POOL_SUB_SLOT_ITERS: uint64
+    SOFT_FORK_HEIGHT: uint32
 
     def replace(self, **changes: object) -> "ConsensusConstants":
         return dataclasses.replace(self, **changes)

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -55,6 +55,7 @@ default_kwargs = {
     "MAX_GENERATOR_SIZE": 1000000,
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
+    "SOFT_FORK_HEIGHT": 3630000,
 }
 
 

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -93,6 +93,7 @@ def batch_pre_validate_blocks(
                         min(constants.MAX_BLOCK_COST_CLVM, block.transactions_info.cost),
                         cost_per_byte=constants.COST_PER_BYTE,
                         mempool_mode=False,
+                        height=block.height,
                     )
                     removals, tx_additions = tx_removals_and_additions(npc_result.conds)
                 if npc_result is not None and npc_result.error is not None:
@@ -368,6 +369,7 @@ def _run_generator(
     constants: ConsensusConstants,
     unfinished_block_bytes: bytes,
     block_generator_bytes: bytes,
+    height: uint32,
 ) -> Optional[bytes]:
     """
     Runs the CLVM generator from bytes inputs. This is meant to be called under a ProcessPoolExecutor, in order to
@@ -383,6 +385,7 @@ def _run_generator(
             min(constants.MAX_BLOCK_COST_CLVM, unfinished_block.transactions_info.cost),
             cost_per_byte=constants.COST_PER_BYTE,
             mempool_mode=False,
+            height=height,
         )
         return bytes(npc_result)
     except ValidationError as e:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1883,7 +1883,8 @@ class FullNode:
             if block_bytes is None:
                 block_bytes = bytes(block)
 
-            npc_result = await self.blockchain.run_generator(block_bytes, block_generator)
+            height = uint32(0) if prev_b is None else uint32(prev_b.height + 1)
+            npc_result = await self.blockchain.run_generator(block_bytes, block_generator, height)
             pre_validation_time = time.time() - pre_validation_start
 
             # blockchain.run_generator throws on errors, so npc_result is

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1111,6 +1111,7 @@ class FullNodeAPI:
                     self.full_node.constants.MAX_BLOCK_COST_CLVM,
                     cost_per_byte=self.full_node.constants.COST_PER_BYTE,
                     mempool_mode=False,
+                    height=request.height,
                 ),
             )
 

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, Optional, Tuple
 
-from chia_rs import MEMPOOL_MODE, NO_NEG_DIV
+from chia_rs import LIMIT_STACK, MEMPOOL_MODE, NO_NEG_DIV
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 
 from chia.consensus.cost_calculator import NPCResult
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 
 
 def get_name_puzzle_conditions(
-    generator: BlockGenerator, max_cost: int, *, cost_per_byte: int, mempool_mode: bool
+    generator: BlockGenerator, max_cost: int, *, cost_per_byte: int, mempool_mode: bool, height: Optional[uint32] = None
 ) -> NPCResult:
     block_program, block_program_args = setup_generator_args(generator)
     size_cost = len(bytes(generator.program)) * cost_per_byte
@@ -38,11 +38,14 @@ def get_name_puzzle_conditions(
     if max_cost < 0:
         return NPCResult(uint16(Err.INVALID_BLOCK_COST.value), None, uint64(0))
 
-    # mempool mode also has these rules apply
-    assert (MEMPOOL_MODE & NO_NEG_DIV) != 0
+    # in mempool mode, the height doesn't matter, because it's always strict.
+    # But otherwise, height must be specified to know which rules to apply
+    assert mempool_mode or height is not None
 
     if mempool_mode:
         flags = MEMPOOL_MODE
+    elif height is not None and height >= DEFAULT_CONSTANTS.SOFT_FORK_HEIGHT:
+        flags = NO_NEG_DIV | LIMIT_STACK
     else:
         # conditions must use integers in canonical encoding (i.e. no redundant
         # leading zeros)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -243,7 +243,7 @@ class TestBlockHeaderValidation:
         assert empty_blockchain.get_peak().height == len(blocks) - 1
 
     @pytest.mark.asyncio
-    async def test_unfinished_blocks(self, empty_blockchain, bt):
+    async def test_unfinished_blocks(self, empty_blockchain, softfork_height, bt):
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(3)
         for block in blocks[:-1]:
@@ -264,7 +264,7 @@ class TestBlockHeaderValidation:
         if unf.transactions_generator is not None:
             block_generator: BlockGenerator = await blockchain.get_block_generator(unf)
             block_bytes = bytes(unf)
-            npc_result = await blockchain.run_generator(block_bytes, block_generator)
+            npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
 
         validate_res = await blockchain.validate_unfinished_block(unf, npc_result, False)
         err = validate_res.error
@@ -288,7 +288,7 @@ class TestBlockHeaderValidation:
         if unf.transactions_generator is not None:
             block_generator: BlockGenerator = await blockchain.get_block_generator(unf)
             block_bytes = bytes(unf)
-            npc_result = await blockchain.run_generator(block_bytes, block_generator)
+            npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
         validate_res = await blockchain.validate_unfinished_block(unf, npc_result, False)
         assert validate_res.error is None
 
@@ -333,7 +333,7 @@ class TestBlockHeaderValidation:
         assert blockchain.get_peak().height == num_blocks - 1
 
     @pytest.mark.asyncio
-    async def test_unf_block_overflow(self, empty_blockchain, bt):
+    async def test_unf_block_overflow(self, empty_blockchain, softfork_height, bt):
         blockchain = empty_blockchain
 
         blocks = []
@@ -367,7 +367,7 @@ class TestBlockHeaderValidation:
                 if block.transactions_generator is not None:
                     block_generator: BlockGenerator = await blockchain.get_block_generator(unf)
                     block_bytes = bytes(unf)
-                    npc_result = await blockchain.run_generator(block_bytes, block_generator)
+                    npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
                 validate_res = await blockchain.validate_unfinished_block(
                     unf, npc_result, skip_overflow_ss_validation=True
                 )
@@ -2262,7 +2262,7 @@ class TestBodyValidation:
             )
 
     @pytest.mark.asyncio
-    async def test_cost_exceeds_max(self, empty_blockchain, bt):
+    async def test_cost_exceeds_max(self, empty_blockchain, softfork_height, bt):
         # 7
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2296,6 +2296,7 @@ class TestBodyValidation:
             b.constants.MAX_BLOCK_COST_CLVM * 1000,
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
+            height=softfork_height,
         )
         err = (await b.receive_block(blocks[-1], PreValidationResult(None, uint64(1), npc_result, True)))[1]
         assert err in [Err.BLOCK_COST_EXCEEDS_MAX]
@@ -2312,7 +2313,7 @@ class TestBodyValidation:
         pass
 
     @pytest.mark.asyncio
-    async def test_invalid_cost_in_block(self, empty_blockchain, bt):
+    async def test_invalid_cost_in_block(self, empty_blockchain, softfork_height, bt):
         # 9
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(
@@ -2356,6 +2357,7 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
+            height=softfork_height,
         )
         result, err, _ = await b.receive_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))
         assert err == Err.INVALID_BLOCK_COST
@@ -2380,6 +2382,7 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
+            height=softfork_height,
         )
         result, err, _ = await b.receive_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))
         assert err == Err.INVALID_BLOCK_COST
@@ -2404,6 +2407,7 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             cost_per_byte=b.constants.COST_PER_BYTE,
             mempool_mode=False,
+            height=softfork_height,
         )
 
         result, err, _ = await b.receive_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -267,7 +267,7 @@ class TestBlockchainTransactions:
                 await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
 
     @pytest.mark.asyncio
-    async def test_validate_blockchain_spend_reorg_coin(self, two_nodes):
+    async def test_validate_blockchain_spend_reorg_coin(self, two_nodes, softfork_height):
         num_blocks = 10
         wallet_a = WALLET_A
         coinbase_puzzlehash = WALLET_A_PUZZLE_HASHES[0]
@@ -308,6 +308,7 @@ class TestBlockchainTransactions:
             new_blocks[-1],
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
+            height=softfork_height,
         )[1]:
             if coin.puzzle_hash == receiver_1_puzzlehash:
                 coin_2 = coin
@@ -331,6 +332,7 @@ class TestBlockchainTransactions:
             new_blocks[-1],
             test_constants.MAX_BLOCK_COST_CLVM,
             cost_per_byte=test_constants.COST_PER_BYTE,
+            height=softfork_height,
         )[1]:
             if coin.puzzle_hash == receiver_2_puzzlehash:
                 coin_3 = coin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,11 @@ def db_version(request):
     return request.param
 
 
+@pytest.fixture(scope="function", params=[1000000, 3630000])
+def softfork_height(request):
+    return request.param
+
+
 saved_blocks_version = "rc5"
 
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -51,7 +51,7 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 
 class TestCoinStoreWithBlocks:
     @pytest.mark.asyncio
-    async def test_basic_coin_store(self, db_version, bt):
+    async def test_basic_coin_store(self, db_version, softfork_height, bt):
         wallet_a = WALLET_A
         reward_ph = wallet_a.get_new_puzzlehash()
 
@@ -100,6 +100,7 @@ class TestCoinStoreWithBlocks:
                             bt.constants.MAX_BLOCK_COST_CLVM,
                             cost_per_byte=bt.constants.COST_PER_BYTE,
                             mempool_mode=False,
+                            height=softfork_height,
                         )
                         tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
                     else:

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -94,14 +94,16 @@ class TestROM:
         assert cost == EXPECTED_ABBREVIATED_COST
         assert r.as_bin().hex() == EXPECTED_OUTPUT
 
-    def test_get_name_puzzle_conditions(self):
+    def test_get_name_puzzle_conditions(self, softfork_height):
         # this tests that extra block or coin data doesn't confuse `get_name_puzzle_conditions`
 
         gen = block_generator()
         cost, r = run_generator_unsafe(gen, max_cost=MAX_COST)
         print(r)
 
-        npc_result = get_name_puzzle_conditions(gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, mempool_mode=False)
+        npc_result = get_name_puzzle_conditions(
+            gen, max_cost=MAX_COST, cost_per_byte=COST_PER_BYTE, mempool_mode=False, height=softfork_height
+        )
         assert npc_result.error is None
         assert npc_result.cost == EXPECTED_COST + ConditionCost.CREATE_COIN.value + (
             len(bytes(gen.program)) * COST_PER_BYTE

--- a/tests/util/generator_tools_testing.py
+++ b/tests/util/generator_tools_testing.py
@@ -8,10 +8,11 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.generator_types import BlockGenerator
 from chia.util.generator_tools import tx_removals_and_additions
+from chia.util.ints import uint32
 
 
 def run_and_get_removals_and_additions(
-    block: FullBlock, max_cost: int, *, cost_per_byte: int, mempool_mode=False
+    block: FullBlock, max_cost: int, *, cost_per_byte: int, height: uint32, mempool_mode=False
 ) -> Tuple[List[bytes32], List[Coin]]:
     removals: List[bytes32] = []
     additions: List[Coin] = []
@@ -26,6 +27,7 @@ def run_and_get_removals_and_additions(
             max_cost,
             cost_per_byte=cost_per_byte,
             mempool_mode=mempool_mode,
+            height=height,
         )
         assert npc_result.error is None
         rem, add = tx_removals_and_additions(npc_result.conds)


### PR DESCRIPTION
This patch restores and fixes up the soft-fork infrastructure from our previous soft-fork.

It primarily entails passing the block height to various relevant places, but mostly adding a block height test fixture to run some tests twice, once before and once after the soft-fork.