### PR TITLE
Check for valid timeout and log error 

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -629,7 +629,6 @@ class Farmer:
                     self.log.error(f"Could not find authentication sk for {pool_config.p2_singleton_puzzle_hash}")
                     continue
                 authentication_token_timeout = pool_state["authentication_token_timeout"]
-                authentication_token = get_current_authentication_token(authentication_token_timeout)
                 if authentication_token_timeout is None:
                     self.log.warning(
                         f"No pool specific authentication_token_timeout has been set for"
@@ -637,6 +636,7 @@ class Farmer:
                     )
                     return None
 
+                authentication_token = get_current_authentication_token(authentication_token_timeout)
                 message: bytes32 = std_hash(
                     AuthenticationPayload(
                         "get_login", pool_config.launcher_id, pool_config.target_puzzle_hash, authentication_token

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -630,6 +630,13 @@ class Farmer:
                     continue
                 authentication_token_timeout = pool_state["authentication_token_timeout"]
                 authentication_token = get_current_authentication_token(authentication_token_timeout)
+                if authentication_token_timeout is None:
+                    self.log.warning(
+                        f"No pool specific authentication_token_timeout has been set for"
+                        f"{pool_config.p2_singleton_puzzle_hash}, check communication with the pool."
+                    )
+                    return None
+
                 message: bytes32 = std_hash(
                     AuthenticationPayload(
                         "get_login", pool_config.launcher_id, pool_config.target_puzzle_hash, authentication_token

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -630,7 +630,7 @@ class Farmer:
                     continue
                 authentication_token_timeout = pool_state["authentication_token_timeout"]
                 if authentication_token_timeout is None:
-                    self.log.warning(
+                    self.log.error(
                         f"No pool specific authentication_token_timeout has been set for"
                         f"{pool_config.p2_singleton_puzzle_hash}, check communication with the pool."
                     )


### PR DESCRIPTION
This attempts to address the edge case seen in #10741 where the `get_login_link` code will raise an exception trying to divide by a `None` value rather than an actual timeout.

Unclear how one gets into this state, but it clearly involves some various networking issues, but this `None` timeout is handled in a similar way in other code (see `new_proof_of_space`)

Fixes #10741

Based on the following log snippet
```
farmer chia.rpc.util              : WARNING  Error while handling message: Traceback (most recent call last):
  File "/home/eamb/chia-blockchain/chia/rpc/util.py", line 16, in inner
    res_object = await f(request_data)
  File "/home/eamb/chia-blockchain/chia/rpc/farmer_rpc_api.py", line 130, in get_pool_login_link
    login_link: Optional[str] = await self.service.generate_login_link(launcher_id)
  File "/home/eamb/chia-blockchain/chia/farmer/farmer.py", line 625, in generate_login_link
    authentication_token = get_current_authentication_token(authentication_token_timeout)
  File "/home/eamb/chia-blockchain/chia/protocols/pool_protocol.py", line 170, in get_current_authentication_token
    return uint64(int(int(time.time() / 60) / timeout))
TypeError: unsupported operand type(s) for /: 'int' and 'NoneType'
```