### PR TITLE
disallow empty SpendBundles in the mempool

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -295,7 +295,7 @@ class MempoolManager:
             new_spend_bytes = bytes(new_spend)
 
         if new_spend.coin_spends == []:
-            raise ValidationError(Err.INVALID_SPEND_BUNDLE)
+            raise ValidationError(Err.INVALID_SPEND_BUNDLE, "Empty SpendBundle")
 
         err, cached_result_bytes, new_cache_entries = await asyncio.get_running_loop().run_in_executor(
             self.pool,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -294,6 +294,9 @@ class MempoolManager:
         if new_spend_bytes is None:
             new_spend_bytes = bytes(new_spend)
 
+        if new_spend.coin_spends == []:
+            raise ValidationError(Err.INVALID_SPEND_BUNDLE)
+
         err, cached_result_bytes, new_cache_entries = await asyncio.get_running_loop().run_in_executor(
             self.pool,
             validate_clvm_and_signature,

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -77,6 +77,14 @@ def spend_bundle_from_conditions(conditions: List[List[Any]]) -> SpendBundle:
 
 
 @pytest.mark.asyncio
+async def test_empty_spend_bundle() -> None:
+    mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
+    sb = SpendBundle([], G2Element())
+    with pytest.raises(ValidationError, match="Err.INVALID_SPEND_BUNDLE"):
+        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+
+
+@pytest.mark.asyncio
 async def test_negative_addition_amount() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_record)
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, -1]]


### PR DESCRIPTION
sebastian discovered that he had empty spend bundles in his mempool. That's a waste of space and compute resources.

This patch checks whether the SpendBundle is empty when validating the transaction.