### PR TITLE
Fixed condition to check for wallet_id

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2215,7 +2215,7 @@ class WalletRpcApi:
         nft_ids = []
         fee = uint64(request.get("fee", 0))
         for nft_coin in request["nft_coin_list"]:
-            if "nft_coin_id" not in nft_coin or "nft_coin_id" not in nft_coin:
+            if "nft_coin_id" not in nft_coin or "wallet_id" not in nft_coin:
                 log.error(f"Cannot set DID for NFT :{nft_coin}, missing nft_coin_id or wallet_id.")
                 continue
             wallet_id = uint32(nft_coin["wallet_id"])


### PR DESCRIPTION
The second condition for the OR statement was the same as the first. It should be verifying that a wallet_id was passed in.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
The nft bulk set did is looping through each coin_id/nft_id. The first action is to check if both the coin/nft id AND a wallet id were passed in. The check was looking for coin/nft id twice and not check for a wallet id. This will update the second condition to ensure a wallet id is given.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
wallet_id **_is not_** checked to ensure it is passed into the RPC.


### New Behavior:
wallet_id **_is_** checked to ensure it is passed into the RPC.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
