### PR TITLE
Enable setting time between blocks in full node sim

### DIFF
--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -204,7 +204,6 @@ class FullNodeSimulator(FullNodeAPI):
                     await asyncio.sleep(1)
                 else:
                     current_time = False
-                    time_per_block = 1
             mempool_bundle = self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
             if mempool_bundle is None:
                 spend_bundle = None
@@ -255,7 +254,6 @@ class FullNodeSimulator(FullNodeAPI):
                     await asyncio.sleep(1)
                 else:
                     current_time = False
-                    time_per_block = 1
             mempool_bundle = self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
             if mempool_bundle is None:
                 spend_bundle = None


### PR DESCRIPTION
### Purpose:
Fix a small bug in the full node sim that was reseting the time_per_block parameter to 1. 

### Current Behavior:
When you set the time_per_block, it resets back to 1 so can't be used for testing cases where we want a certain time to pass between blocks


### New Behavior:
To set a custom number of seconds between sim blocks,  set:
`full_node_api.time_per_block = #seconds`

### Testing Notes:
Added a test in: tests/simulation/test_simulation.py::TestSimulation::test_simulation_farm_blocks
