### PR TITLE
Add gzip support to Data Layer download client

### DIFF
--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -145,7 +145,10 @@ async def insert_from_delta_file(
 
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get(server_info.url + "/" + filename, timeout=timeout, proxy=proxy_url) as resp:
+                headers = {"accept-encoding": "gzip"}
+                async with session.get(
+                    server_info.url + "/" + filename, headers=headers, timeout=timeout, proxy=proxy_url
+                ) as resp:
                     resp.raise_for_status()
                     size = int(resp.headers.get("content-length", 0))
                     log.debug(f"Downloading delta file {filename}. Size {size} bytes.")


### PR DESCRIPTION
### Purpose: 
Add a possibility to use gzip encoding when download Data Layer files. Gzip reduce the data, typicaly reduce your data to somewhere between 1/3 and 1/2 of its original size.

### Current Behavior: 
No gzip Encoding

### New Behavior: 
If the server allows it, The content is possible encoding gzip.

### Testing Notes: 
If you use a proxy like Fiddler, you can force gzip encoding

Before 
![image](https://user-images.githubusercontent.com/6495665/211379548-38eac173-7f0c-4403-bcee-16434f707155.png)

after 
![image](https://user-images.githubusercontent.com/6495665/211379605-992addac-61a9-4910-9615-85b7bddc3ff4.png)

from 4823 KB to 1878 KB 

![image](https://user-images.githubusercontent.com/6495665/211379794-888f978d-50ab-4bef-be6c-a82306a660c2.png)

 
In the request now have in the header "accept-encoding: gzip" and the code manages the response with "Content-Encoding: gzip"
