### PR TITLE
Update version of clvm_tools_rs to 0.1.30

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ dependencies = [
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
     "chia_rs==0.2.0",
-    "clvm-tools-rs==0.1.25",  # Rust implementation of clvm_tools' compiler
+    "clvm-tools-rs==0.1.30",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.3",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks
     "bitstring==3.1.9",  # Binary data management library


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
This bumps chia-blockchain to use clvm_tools_rs 0.1.30, which contains bug fixes from bugs detected by me and others.

<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Memory leak fix
Fix for modern chialisp when parsing improper lists
Avoid a panic when compiling code that doesn't give enough arguments to an inline function.
Purpose:
Pulls in a version of the chialisp compiler with some bug fixes, which will lead to more freedom for chialisp devs.

<!-- Does this PR introduce a breaking change? -->
Not a breaking change.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
See tests:
https://github.com/Chia-Network/clvm_tools_rs/blob/283f38af052fab4373920a29634eaef32186b791/src/tests/compiler/compiler.rs#L1138
https://github.com/Chia-Network/clvm_tools_rs/blob/283f38af052fab4373920a29634eaef32186b791/src/tests/compiler/compiler.rs#L1151
