### PR TITLE
Make sure to close the DL WalletRpcClient on DL shutdown

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -119,6 +119,7 @@ class DataLayer:
     def _close(self) -> None:
         # TODO: review for anything else we need to do here
         self._shut_down = True
+        self.wallet_rpc.close()
 
     async def _await_closed(self) -> None:
         if self.connection is not None:
@@ -128,6 +129,7 @@ class DataLayer:
         except asyncio.CancelledError:
             pass
         await self.data_store.close()
+        await self.wallet_rpc.await_closed()
 
     async def create_store(
         self, fee: uint64, root: bytes32 = bytes32([0] * 32)


### PR DESCRIPTION
Code Cleanup

DataLayer services wasn't closing down the WalletRpcClient which was resulting in error messages in the log from asyncio about unclosed connectors like
`2023-01-12T12:46:53.165 data_layer asyncio                : ERROR    Unclosed client session : client_session: <aiohttp.client.ClientSession object at 0x10d4196c0>`

Added code to the DL service shutdown procesdures (`_close` and a`_wait_closed`) to close the WalletRpcClient