### PR TITLE
Only the standard wallet generates derivation paths

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -1059,7 +1059,7 @@ class DataLayerWallet:
     ##########
 
     def require_derivation_paths(self) -> bool:
-        return True
+        return False
 
     def puzzle_hash_for_pk(self, pubkey: G1Element) -> bytes32:
         puzzle: Program = self.puzzle_for_pk(pubkey)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -389,7 +389,7 @@ class CATWallet:
         return await self.standard_wallet.get_new_puzzlehash()
 
     def require_derivation_paths(self) -> bool:
-        return True
+        return False
 
     def puzzle_for_pk(self, pubkey: G1Element) -> Program:
         inner_puzzle = self.standard_wallet.puzzle_for_pk(pubkey)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -137,11 +137,12 @@ class CATWallet:
         # Change and actual CAT coin
         non_ephemeral_coins: List[Coin] = spend_bundle.not_ephemeral_additions()
         cat_coin = None
-        puzzle_store = self.wallet_state_manager.puzzle_store
         for c in non_ephemeral_coins:
-            parent_spend: CoinSpend = next(spend for spend in spend_bundle.coin_spends if spend.coin.name() == c.parent_coin_info)
+            parent_spend: CoinSpend = next(
+                spend for spend in spend_bundle.coin_spends if spend.coin.name() == c.parent_coin_info
+            )
             mod, curried_args = parent_spend.puzzle_reveal.to_program().uncurry()
-            if mod == CAT_MOD and bytes32(curried_args.at("rf")).as_python() == self.cat_info.limitations_program_hash:
+            if mod == CAT_MOD and bytes32(curried_args.at("rf").as_python()) == self.cat_info.limitations_program_hash:
                 cat_coin = c
 
         if cat_coin is None:

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -139,11 +139,9 @@ class CATWallet:
         cat_coin = None
         puzzle_store = self.wallet_state_manager.puzzle_store
         for c in non_ephemeral_coins:
-            info = await puzzle_store.wallet_info_for_puzzle_hash(c.puzzle_hash)
-            if info is None:
-                raise ValueError("Internal Error")
-            id, wallet_type = info
-            if id == self.id():
+            parent_spend: CoinSpend = next(spend for spend in spend_bundle.coin_spends if spend.coin.name() == c.parent_coin_info)
+            mod, curried_args = parent_spend.puzzle_reveal.to_program().uncurry()
+            if mod == CAT_MOD and bytes32(curried_args.at("rf")).as_python() == self.cat_info.limitations_program_hash:
                 cat_coin = c
 
         if cat_coin is None:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -387,7 +387,10 @@ class DIDWallet:
         # Check inner puzzle consistency
         assert self.did_info.origin_coin is not None
         full_puzzle = create_fullpuz(inner_puzzle, self.did_info.origin_coin.name())
-        assert full_puzzle.get_tree_hash() == coin.puzzle_hash
+        try:
+            assert full_puzzle.get_tree_hash() == coin.puzzle_hash
+        except:
+            breakpoint()
         if self.did_info.temp_coin is not None:
             self.wallet_state_manager.state_changed("did_coin_added", self.wallet_info.id)
 
@@ -1469,7 +1472,7 @@ class DIDWallet:
         return did_info
 
     def require_derivation_paths(self) -> bool:
-        return False
+        return True
 
 
 if TYPE_CHECKING:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1469,7 +1469,7 @@ class DIDWallet:
         return did_info
 
     def require_derivation_paths(self) -> bool:
-        return True
+        return False
 
 
 if TYPE_CHECKING:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -387,10 +387,7 @@ class DIDWallet:
         # Check inner puzzle consistency
         assert self.did_info.origin_coin is not None
         full_puzzle = create_fullpuz(inner_puzzle, self.did_info.origin_coin.name())
-        try:
-            assert full_puzzle.get_tree_hash() == coin.puzzle_hash
-        except:
-            breakpoint()
+        assert full_puzzle.get_tree_hash() == coin.puzzle_hash
         if self.did_info.temp_coin is not None:
             self.wallet_state_manager.state_changed("did_coin_added", self.wallet_info.id)
 


### PR DESCRIPTION
### Purpose:
Currently, we will generate full puzzle hashes for each type of asset in the wallet.  I believe this logic is leftover from when we did not have hints.  With hints, every coin will hint to a standard XCH address and will be picked up that way.  Once it's been picked up, it gets sorted to the appropriate wallet.  This means we only need to derive puzzle hashes for innermost puzzles of which we only have one type right now: p2_delegated_or_hidden_puzzle.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Make sure you still receive and sync all CATs, DIDs, DL singletons etc.  This was made in response to an error subscribing to too many puzzle hashes so maybe make a bunch of standard puzzle hashes and then add a bunch of wallets and see if you get that error again.
