### PR TITLE
Redirect stdout to the logger system for the Datalayer service

### DIFF
--- a/chia/server/start_data_layer.py
+++ b/chia/server/start_data_layer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import pathlib
 import sys
@@ -94,18 +95,17 @@ async def async_main() -> int:
         root_path=DEFAULT_ROOT_PATH,
     )
 
-    sys.stdout = StdOutputLogger(log, logging.INFO)
+    with contextlib.redirect_stdout(StdOutputLogger(log, logging.INFO)):
+        create_all_ssl(
+            root_path=DEFAULT_ROOT_PATH,
+            private_node_names=["data_layer"],
+            public_node_names=["data_layer"],
+            overwrite=False,
+        )
 
-    create_all_ssl(
-        root_path=DEFAULT_ROOT_PATH,
-        private_node_names=["data_layer"],
-        public_node_names=["data_layer"],
-        overwrite=False,
-    )
-
-    service = create_data_layer_service(DEFAULT_ROOT_PATH, config)
-    await service.setup_process_global_state()
-    await service.run()
+        service = create_data_layer_service(DEFAULT_ROOT_PATH, config)
+        await service.setup_process_global_state()
+        await service.run()
 
     return 0
 

--- a/chia/server/start_data_layer.py
+++ b/chia/server/start_data_layer.py
@@ -95,7 +95,9 @@ async def async_main() -> int:
         root_path=DEFAULT_ROOT_PATH,
     )
 
-    with contextlib.redirect_stdout(StdOutputLogger(log, logging.INFO)):
+    with contextlib.redirect_stdout(
+        StdOutputLogger(log, logging.INFO)
+    ) if not sys.stdout.isatty() else contextlib.nullcontext():
         create_all_ssl(
             root_path=DEFAULT_ROOT_PATH,
             private_node_names=["data_layer"],

--- a/chia/server/start_data_layer.py
+++ b/chia/server/start_data_layer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import pathlib
 import sys
+from io import TextIOWrapper
 from typing import Any, Dict, Optional, cast
 
 from chia.data_layer.data_layer import DataLayer
@@ -23,6 +24,20 @@ from chia.wallet.wallet_node import WalletNode
 
 SERVICE_NAME = "data_layer"
 log = logging.getLogger(__name__)
+
+
+class StdOutputLogger(TextIOWrapper):
+    def __init__(self, logger: logging.Logger, level: int = logging.INFO) -> None:
+        self.logger = logger
+        self.level = level
+
+    def write(self, message: str) -> int:
+        if message and not message.isspace():
+            self.logger.log(self.level, message)
+        return 0
+
+    def flush(self) -> None:
+        pass
 
 
 # TODO: Review need for config and if retained then hint it properly.
@@ -78,6 +93,8 @@ async def async_main() -> int:
         logging_config=service_config["logging"],
         root_path=DEFAULT_ROOT_PATH,
     )
+
+    sys.stdout = StdOutputLogger(log, logging.INFO)
 
     create_all_ssl(
         root_path=DEFAULT_ROOT_PATH,


### PR DESCRIPTION
When using CLI to stop datalayer, a BrokenPipeError would be displayed on the console.

`chia_data_layer: Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe`

This was caused by some code being run by the process that was `print` ing to stdout, but stdout didn't have anywhere to go.

This code creates a fake stream object to redirect stdout to the log file resolves this. This is done conditionally only if stdout is not a TTY. This means that if you directly run the service (`chia_data_layer / start_data_layer`) you will get some prints to stdout - but if you use `chia start data` those are redirected to the log system

Fixes #13543