### PR TITLE
Fixing snyk secret check

### DIFF
--- a/.github/workflows/snyk-python-scan.yml
+++ b/.github/workflows/snyk-python-scan.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         unset HAS_SNYK_SECRET
         if [ -n "$SNYK_TOKEN" ]; then HAS_SNYK_SECRET='true' ; fi
-        echo HAS_SNYK_SECRET=${HAS_SNYK_SECRET} >> GITHUB_OUTPUT
+        echo HAS_SNYK_SECRET=${HAS_SNYK_SECRET} >> $GITHUB_OUTPUT
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
https://github.com/Chia-Network/chia-blockchain/actions/runs/3955259292/workflow#L37 was not writing to the environment variable


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
`echo HAS_SNYK_SECRET=${HAS_SNYK_SECRET} >> GITHUB_OUTPUT`


### New Behavior:
`echo HAS_SNYK_SECRET=${HAS_SNYK_SECRET} >> $GITHUB_OUTPUT`


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Ran locally with `act` to verify functionality


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
