### PR TITLE
Add the expected offer ID to some RPCs that take offer blobs

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1534,7 +1534,10 @@ class WalletRpcApi:
                 "summary": {"offered": offered, "requested": requested, "fees": offer.bundle.fees(), "infos": infos}
             }
         else:
-            return {"summary": await self.service.wallet_state_manager.trade_manager.get_offer_summary(offer)}
+            return {
+                "summary": await self.service.wallet_state_manager.trade_manager.get_offer_summary(offer),
+                "id": offer.name(),
+            }
 
     async def check_offer_validity(self, request) -> EndpointResult:
         offer_hex: str = request["offer"]
@@ -1542,7 +1545,10 @@ class WalletRpcApi:
         peer: Optional[WSChiaConnection] = self.service.get_full_node_peer()
         if peer is None:
             raise ValueError("No peer connected")
-        return {"valid": (await self.service.wallet_state_manager.trade_manager.check_offer_validity(offer, peer))}
+        return {
+            "valid": (await self.service.wallet_state_manager.trade_manager.check_offer_validity(offer, peer)),
+            "id": offer.name(),
+        }
 
     async def take_offer(self, request) -> EndpointResult:
         offer_hex: str = request["offer"]

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1531,7 +1531,8 @@ class WalletRpcApi:
 
         if request.get("advanced", False):
             return {
-                "summary": {"offered": offered, "requested": requested, "fees": offer.bundle.fees(), "infos": infos}
+                "summary": {"offered": offered, "requested": requested, "fees": offer.bundle.fees(), "infos": infos},
+                "id": offer.name(),
             }
         else:
             return {

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -689,7 +689,9 @@ class WalletRpcClient(RpcClient):
         offer_str: str = "" if offer is None else bytes(offer).hex()
         return offer, TradeRecord.from_json_dict_convenience(res["trade_record"], offer_str)
 
-    async def get_offer_summary(self, offer: Offer, advanced: bool = False) -> Tuple[bytes32, Dict[str, Dict[str, int]]]:
+    async def get_offer_summary(
+        self, offer: Offer, advanced: bool = False
+    ) -> Tuple[bytes32, Dict[str, Dict[str, int]]]:
         res = await self.fetch("get_offer_summary", {"offer": offer.to_bech32(), "advanced": advanced})
         return bytes32.from_hexstr(res["id"]), res["summary"]
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -689,13 +689,13 @@ class WalletRpcClient(RpcClient):
         offer_str: str = "" if offer is None else bytes(offer).hex()
         return offer, TradeRecord.from_json_dict_convenience(res["trade_record"], offer_str)
 
-    async def get_offer_summary(self, offer: Offer, advanced: bool = False) -> Dict[str, Dict[str, int]]:
+    async def get_offer_summary(self, offer: Offer, advanced: bool = False) -> Tuple[bytes32, Dict[str, Dict[str, int]]]:
         res = await self.fetch("get_offer_summary", {"offer": offer.to_bech32(), "advanced": advanced})
-        return res["summary"]
+        return bytes32.from_hexstr(res["id"]), res["summary"]
 
-    async def check_offer_validity(self, offer: Offer) -> bool:
+    async def check_offer_validity(self, offer: Offer) -> Tuple[bytes32, bool]:
         res = await self.fetch("check_offer_validity", {"offer": offer.to_bech32()})
-        return res["valid"]
+        return bytes32.from_hexstr(res["id"]), res["valid"]
 
     async def take_offer(
         self, offer: Offer, solver: Dict[str, Any] = None, fee=uint64(0), min_coin_amount: uint64 = uint64(0)

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -126,7 +126,7 @@ async def check_singleton_confirmed(dl: DataLayer, tree_id: bytes32) -> bool:
 
 async def process_block_and_check_offer_validity(offer: TradingOffer, offer_setup: OfferSetup) -> bool:
     await offer_setup.full_node_api.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
-    return await offer_setup.maker.data_layer.wallet_rpc.check_offer_validity(offer=offer)
+    return (await offer_setup.maker.data_layer.wallet_rpc.check_offer_validity(offer=offer))[1]
 
 
 @pytest.mark.asyncio
@@ -1609,9 +1609,9 @@ async def test_make_and_cancel_offer(offer_setup: OfferSetup, reference: MakeAnd
     await offer_setup.maker.api.cancel_offer(request=cancel_request)
 
     for _ in range(10):
-        if not await offer_setup.maker.data_layer.wallet_rpc.check_offer_validity(
+        if not (await offer_setup.maker.data_layer.wallet_rpc.check_offer_validity(
             offer=TradingOffer.from_bytes(hexstr_to_bytes(reference.make_offer_response["offer"])),
-        ):
+        ))[1]:
             break
         await offer_setup.full_node_api.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
         await asyncio.sleep(0.5)

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -1609,9 +1609,11 @@ async def test_make_and_cancel_offer(offer_setup: OfferSetup, reference: MakeAnd
     await offer_setup.maker.api.cancel_offer(request=cancel_request)
 
     for _ in range(10):
-        if not (await offer_setup.maker.data_layer.wallet_rpc.check_offer_validity(
-            offer=TradingOffer.from_bytes(hexstr_to_bytes(reference.make_offer_response["offer"])),
-        ))[1]:
+        if not (
+            await offer_setup.maker.data_layer.wallet_rpc.check_offer_validity(
+                offer=TradingOffer.from_bytes(hexstr_to_bytes(reference.make_offer_response["offer"])),
+            )
+        )[1]:
             break
         await offer_setup.full_node_api.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
         await asyncio.sleep(0.5)

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -779,12 +779,15 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     )
     assert offer is not None
 
-    summary = await wallet_1_rpc.get_offer_summary(offer)
-    advanced_summary = await wallet_1_rpc.get_offer_summary(offer, advanced=True)
+    id, summary = await wallet_1_rpc.get_offer_summary(offer)
+    assert id == offer.name()
+    id, advanced_summary = await wallet_1_rpc.get_offer_summary(offer, advanced=True)
+    assert id == offer.name()
     assert summary == {"offered": {"xch": 5}, "requested": {cat_asset_id.hex(): 1}, "infos": driver_dict, "fees": 1}
     assert advanced_summary == summary
 
-    assert await wallet_1_rpc.check_offer_validity(offer)
+    id, valid = await wallet_1_rpc.check_offer_validity(offer)
+    assert id == offer.name()
 
     all_offers = await wallet_1_rpc.get_all_offers(file_contents=True)
     assert len(all_offers) == 1


### PR DESCRIPTION
Requested for front end purposes so there is a hook to check if the offer is already in the wallet and what it's state may be.