### PR TITLE
put lock to prevent race aliasing IDs

### DIFF
--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -56,7 +56,7 @@ class WalletUserStore:
         id: Optional[int] = None,
     ) -> WalletInfo:
 
-        async with self.lock
+        async with self.lock:
             async with self.db_wrapper.writer_maybe_transaction() as conn:
                 cursor = await conn.execute(
                     "INSERT INTO users_wallets VALUES(?, ?, ?, ?)",

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -56,7 +56,7 @@ class WalletUserStore:
         id: Optional[int] = None,
     ) -> WalletInfo:
 
-        with self.lock
+        async with self.lock
             async with self.db_wrapper.writer_maybe_transaction() as conn:
                 cursor = await conn.execute(
                     "INSERT INTO users_wallets VALUES(?, ?, ?, ?)",

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from typing import List, Optional
 import asyncio
+from typing import List, Optional
 
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List, Optional
+from asyncio import Lock
 
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import List, Optional
-from asyncio import Lock
+import asyncio
 
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32


### PR DESCRIPTION
### Purpose:

So ID is enforced using AUTOINCREMENT. Hard to see that failing.  For create_wallet, id is never passed in AFAICT. Rather, the wallet is created and depends on sqlite autoincrementing the ID. Then the wallet is read back out again to retrieve the id. There is no lock around this so under the right circumstances two wallets could get the same ID.  especially with all the sqlite io it would be pretty likely to have a task switch

### Current Behavior:

IDs could be aliased

### New Behavior:

lock prevents aliasing

### Testing Notes:

This is a race condition when multiple wallets are added at the same time