### PR TITLE
Fixed wallet state if db is rolled back

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1011,9 +1011,10 @@ class WalletStateManager:
 
         assert len(local_records) == len(coin_states)
         for coin_state, local_record in zip(coin_states, local_records):
-            rollback_wallets = self.wallets.copy()  # Shallow copy of wallets in case writer rolls back the db
+            rollback_wallets = None
             try:
                 async with self.db_wrapper.writer():
+                    rollback_wallets = self.wallets.copy()  # Shallow copy of wallets if writer rolls back the db
                     # This only succeeds if we don't raise out of the transaction
                     await self.retry_store.remove_state(coin_state)
 
@@ -1363,7 +1364,8 @@ class WalletStateManager:
                         raise RuntimeError("All cases already handled")  # Logic error, all cases handled
             except Exception as e:
                 self.log.exception(f"Error adding state... {e}")
-                self.wallets = rollback_wallets  # Restore since DB will be rolled back by writer
+                if rollback_wallets is not None:
+                    self.wallets = rollback_wallets  # Restore since DB will be rolled back by writer
                 if isinstance(e, PeerRequestException) or isinstance(e, aiosqlite.Error):
                     await self.retry_store.add_state(coin_state, peer.peer_node_id, fork_height)
                 else:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1011,7 +1011,7 @@ class WalletStateManager:
 
         assert len(local_records) == len(coin_states)
         for coin_state, local_record in zip(coin_states, local_records):
-            rollback_wallets=self.wallets.copy()  # Shallow copy of wallets in case writer rolls back the db
+            rollback_wallets = self.wallets.copy()  # Shallow copy of wallets in case writer rolls back the db
             try:
                 async with self.db_wrapper.writer():
                     # This only succeeds if we don't raise out of the transaction


### PR DESCRIPTION
### Purpose:

Problem is sqlite rollbacks because of exceptions thrown during writer() in new_coin_state. that would explain the aliasing of wallet IDs as well as the missing derivation_paths. if you look through logs there are lots of "Error adding state..." exceptions thrown in new_coin_state. that may roll back the db but i don't think it handles wallets that may have been created by new_coin_state in the interim with erroneous ids

### Current Behavior:

2023-01-19T10:26:38.295 wallet chia.wallet.wallet_state_manager: ERROR    Error adding state... 
Traceback (most recent call last):
  File "chia/wallet/wallet_state_manager.py", line 1065, in new_coin_state
  File "chia/wallet/wallet_state_manager.py", line 1519, in coin_added
  File "chia/wallet/did_wallet/did_wallet.py", line 389, in coin_added
AssertionError
assert full_puzzle.get_tree_hash() == coin.puzzle_hash

this assertion happens after the did wallet is created so easy to see why wallet disappears from the db due to rollback but is probably still hanging around in memory causing wallet aliasing as long as the running instance is around. 

### New Behavior:

if we nuke these wallets during the exception, i think this will be fixed. but there are still probably issues with why the exceptions happen in the first place

### Testing Notes:

Try to force exceptions in new_coin_state