### PR TITLE
Fix chia wallet coins cli bugs

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1370,7 +1370,7 @@ class WalletRpcApi:
             puzzle_hashes.append(decode_puzzle_hash(request["inner_address"]))
             if "memos" in request:
                 memos.append([mem.encode("utf-8") for mem in request["memos"]])
-        coins = None
+        coins: Optional[Set[Coin]] = None
         if "coins" in request and len(request["coins"]) > 0:
             coins = set([Coin.from_json_dict(coin_json) for coin_json in request["coins"]])
         fee: uint64 = uint64(request.get("fee", 0))

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -632,6 +632,7 @@ class WalletRpcClient(RpcClient):
         exclude_amounts: Optional[List[uint64]] = None,
         exclude_coin_ids: Optional[List[str]] = None,
         additions: Optional[List[Dict[str, Any]]] = None,
+        removals: Optional[List[Coin]] = None,
     ) -> TransactionRecord:
         send_dict: Dict[str, Any] = {
             "wallet_id": wallet_id,
@@ -654,6 +655,8 @@ class WalletRpcClient(RpcClient):
             send_dict["additions"] = additions_hex
         else:
             raise ValueError("Must specify either amount and inner_address or additions")
+        if removals is not None and len(removals) > 0:
+            send_dict["coins"] = [c.to_json_dict() for c in removals]
         res = await self.fetch("cat_spend", send_dict)
         return TransactionRecord.from_json_dict_convenience(res["transaction"])
 


### PR DESCRIPTION
Purpose:
This adds a warning to the user letting them know that the dust filter might prevent them from seeing their coins.
This PR also makes the most sense when viewed by commit.
This PR also fixes issues where the fee was not properly dealt with & specific coin filtering rules were not respected for CATs.

Current Behavior:
No warning when making coins below the dust limit, user might be confused as wallet ignores coins.
New Behavior:
A warning was added to stop possible user confusion.

Testing Notes:
CLI Testing will be added in the coming weeks & tests were expanded for the RPC's modifed
