### PR TITLE
move SerializedProgram to its own file

### DIFF
--- a/benchmarks/block_ref.py
+++ b/benchmarks/block_ref.py
@@ -15,7 +15,7 @@ from chia.consensus.blockchain import Blockchain
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.db_version import lookup_db_version
 from chia.util.db_wrapper import DBWrapper2

--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -24,9 +24,9 @@ from chia.consensus.block_record import BlockRecord
 from chia.full_node.block_store import BlockStore
 from chia.types.blockchain_format.foliage import Foliage, FoliageBlockData, FoliageTransactionBlock, TransactionsInfo
 from chia.types.blockchain_format.pool_target import PoolTarget
-from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.full_block import FullBlock

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -18,9 +18,9 @@ from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import Foliage, FoliageBlockData, FoliageTransactionBlock, TransactionsInfo
 from chia.types.blockchain_format.pool_target import PoolTarget
-from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes100
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
 from chia.types.full_block import FullBlock

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -32,7 +32,7 @@ from chia.full_node.coin_store import CoinStore
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.blockchain_format.vdf import VDFInfo

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -16,7 +16,8 @@ from chia.protocols.wallet_protocol import CoinState
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
@@ -499,7 +500,7 @@ class DataLayerWallet:
             )
             second_coin_spend = CoinSpend(
                 second_coin,
-                second_full_puz.to_serialized_program(),
+                SerializedProgram.from_program(second_full_puz),
                 Program.to(
                     [
                         LineageProof(
@@ -778,7 +779,7 @@ class DataLayerWallet:
         )
         mirror_spend = CoinSpend(
             mirror_coin,
-            create_mirror_puzzle().to_serialized_program(),
+            SerializedProgram.from_program(create_mirror_puzzle()),
             Program.to(
                 [
                     parent_coin.parent_coin_info,
@@ -1192,7 +1193,7 @@ class DataLayerWallet:
             new_solution: Program = dl_solution.replace(rrffrf=new_graftroot, rrffrrf=Program.to([None] * 5))
             new_spend: CoinSpend = dataclasses.replace(
                 dl_spend,
-                solution=new_solution.to_serialized_program(),
+                solution=SerializedProgram.from_program(new_solution),
             )
             signed_bundle = await dl_wallet.sign(new_spend)
             new_bundle: SpendBundle = dataclasses.replace(
@@ -1276,7 +1277,7 @@ class DataLayerWallet:
                     )
                     new_spend: CoinSpend = dataclasses.replace(
                         spend,
-                        solution=new_solution.to_serialized_program(),
+                        solution=SerializedProgram.from_program(new_solution),
                     )
                     spend = new_spend
             new_spends.append(spend)

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -9,7 +9,7 @@ import typing_extensions
 import zstd
 
 from chia.consensus.block_record import BlockRecord
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.weight_proof import SubEpochChallengeSegment, SubEpochSegments

--- a/chia/full_node/bundle_tools.py
+++ b/chia/full_node/bundle_tools.py
@@ -6,7 +6,8 @@ from typing import List, Optional, Tuple, Union
 from clvm.casts import int_to_bytes
 
 from chia.full_node.generator import create_compressed_generator
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.coin_spend import CoinSpend
 from chia.types.generator_types import BlockGenerator, CompressorArg
 from chia.types.spend_bundle import SpendBundle

--- a/chia/full_node/generator.py
+++ b/chia/full_node/generator.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 from typing import List, Optional, Tuple, Union
 
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.generator_types import BlockGenerator, CompressorArg, GeneratorBlockCacheInterface
 from chia.util.ints import uint32
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -10,7 +10,8 @@ from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.generator import setup_generator_args
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.generator_types import BlockGenerator

--- a/chia/pools/pool_puzzles.py
+++ b/chia/pools/pool_puzzles.py
@@ -11,7 +11,8 @@ from chia.consensus.block_rewards import calculate_pool_reward
 from chia.consensus.coinbase import pool_parent_id
 from chia.pools.pool_wallet_info import LEAVING_POOL, SELF_POOLING, PoolState
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.util.ints import uint32, uint64

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -39,7 +39,8 @@ from chia.protocols.pool_protocol import POOL_PROTOCOL_VERSION
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, compute_additions

--- a/chia/protocols/wallet_protocol.py
+++ b/chia/protocols/wallet_protocol.py
@@ -7,7 +7,7 @@ from chia_rs import CoinState, RespondToPhUpdates
 
 from chia.full_node.fee_estimate import FeeEstimateGroup
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
 from chia.types.spend_bundle import SpendBundle

--- a/chia/simulator/wallet_tools.py
+++ b/chia/simulator/wallet_tools.py
@@ -8,7 +8,8 @@ from clvm.casts import int_from_bytes, int_to_bytes
 from chia.consensus.constants import ConsensusConstants
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode

--- a/chia/types/block_protocol.py
+++ b/chia/types/block_protocol.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from typing_extensions import Protocol
 
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32
 

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -48,9 +48,6 @@ class Program(SExp):
     def fromhex(cls, hexstr: str) -> "Program":
         return cls.from_bytes(hexstr_to_bytes(hexstr))
 
-    def to_serialized_program(self) -> "SerializedProgram":
-        return SerializedProgram.from_bytes(bytes(self))
-
     def __bytes__(self) -> bytes:
         f = io.BytesIO()
         self.stream(f)  # noqa
@@ -220,12 +217,6 @@ def _tree_hash(node: SExp, precalculated: Set[bytes32]) -> bytes32:
         s = b"\1" + atom
     return bytes32(std_hash(s))
 
-
-# this has to be here to avoid the issue with circular import.
-# TODO: update all import statements
-from .serialized_program import SerializedProgram  # noqa: E402
-
-__all__ = ["SerializedProgram", "Program", "NIL"]
 
 NIL = Program.from_bytes(b"\x80")
 

--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from chia_rs import MEMPOOL_MODE, run_chia_program, run_generator, serialized_length, tree_hash
+from clvm import SExp
+
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.spend_bundle_conditions import SpendBundleConditions
+from chia.util.byte_types import hexstr_to_bytes
+
+
+def _serialize(node) -> bytes:
+    if type(node) == SerializedProgram:
+        return bytes(node)
+    else:
+        return SExp.to(node).as_bin()
+
+
+class SerializedProgram:
+    """
+    An opaque representation of a clvm program. It has a more limited interface than a full SExp
+    """
+
+    _buf: bytes = b""
+
+    @classmethod
+    def parse(cls, f) -> "SerializedProgram":
+        length = serialized_length(f.getvalue()[f.tell() :])
+        return SerializedProgram.from_bytes(f.read(length))
+
+    def stream(self, f):
+        f.write(self._buf)
+
+    @classmethod
+    def from_bytes(cls, blob: bytes) -> "SerializedProgram":
+        ret = SerializedProgram()
+        ret._buf = bytes(blob)
+        return ret
+
+    @classmethod
+    def fromhex(cls, hexstr: str) -> "SerializedProgram":
+        return cls.from_bytes(hexstr_to_bytes(hexstr))
+
+    @classmethod
+    def from_program(cls, p: Program) -> "SerializedProgram":
+        ret = SerializedProgram()
+        ret._buf = bytes(p)
+        return ret
+
+    def to_program(self) -> Program:
+        return Program.from_bytes(self._buf)
+
+    def uncurry(self) -> Tuple["Program", "Program"]:
+        return self.to_program().uncurry()
+
+    def __bytes__(self) -> bytes:
+        return self._buf
+
+    def __str__(self) -> str:
+        return bytes(self).hex()
+
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, str(self))
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, SerializedProgram):
+            return False
+        return self._buf == other._buf
+
+    def __ne__(self, other) -> bool:
+        if not isinstance(other, SerializedProgram):
+            return True
+        return self._buf != other._buf
+
+    def get_tree_hash(self) -> bytes32:
+        return bytes32(tree_hash(self._buf))
+
+    def run_mempool_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
+        return self._run(max_cost, MEMPOOL_MODE, *args)
+
+    def run_with_cost(self, max_cost: int, *args) -> Tuple[int, Program]:
+        return self._run(max_cost, 0, *args)
+
+    # returns an optional error code and an optional SpendBundleConditions (from chia_rs)
+    # exactly one of those will hold a value
+    def run_as_generator(
+        self, max_cost: int, flags: int, *args
+    ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]:
+
+        serialized_args = bytearray()
+        if len(args) > 1:
+            # when we have more than one argument, serialize them into a list
+            for a in args:
+                serialized_args += b"\xff"
+                serialized_args += _serialize(a)
+            serialized_args += b"\x80"
+        else:
+            serialized_args += _serialize(args[0])
+
+        err, ret = run_generator(
+            self._buf,
+            bytes(serialized_args),
+            max_cost,
+            flags,
+        )
+        if err is not None:
+            assert err != 0
+            return err, None
+
+        assert ret is not None
+        return None, ret
+
+    def _run(self, max_cost: int, flags, *args) -> Tuple[int, Program]:
+        # when multiple arguments are passed, concatenate them into a serialized
+        # buffer. Some arguments may already be in serialized form (e.g.
+        # SerializedProgram) so we don't want to de-serialize those just to
+        # serialize them back again. This is handled by _serialize()
+        serialized_args = bytearray()
+        if len(args) > 1:
+            # when we have more than one argument, serialize them into a list
+            for a in args:
+                serialized_args += b"\xff"
+                serialized_args += _serialize(a)
+            serialized_args += b"\x80"
+        else:
+            serialized_args += _serialize(args[0])
+
+        cost, ret = run_chia_program(
+            self._buf,
+            bytes(serialized_args),
+            max_cost,
+            flags,
+        )
+        return cost, Program.to(ret)

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -5,7 +5,7 @@ from typing import List
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.util.chain_utils import additions_for_solution, fee_for_solution
 from chia.util.streamable import Streamable, streamable
 

--- a/chia/types/full_block.py
+++ b/chia/types/full_block.py
@@ -5,8 +5,8 @@ from typing import List, Optional, Set
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import Foliage, FoliageTransactionBlock, TransactionsInfo
-from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle

--- a/chia/types/generator_types.py
+++ b/chia/types/generator_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.util.ints import uint32
 from chia.util.streamable import Streamable, streamable
 

--- a/chia/types/unfinished_block.py
+++ b/chia/types/unfinished_block.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from chia.types.blockchain_format.foliage import Foliage, FoliageTransactionBlock, TransactionsInfo
-from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlockUnfinished
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.util.ints import uint32

--- a/chia/util/chain_utils.py
+++ b/chia/util/chain_utils.py
@@ -5,7 +5,7 @@ from typing import List
 from clvm.casts import int_from_bytes
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.condition_tools import conditions_dict_for_solution, created_outputs_for_conditions_dict

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -5,7 +5,8 @@ from typing import Dict, List, Optional, Tuple
 from clvm.casts import int_from_bytes
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs

--- a/chia/util/full_block_utils.py
+++ b/chia/util/full_block_utils.py
@@ -10,7 +10,7 @@ from chiabip158 import PyBIP158
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import TransactionsInfo
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32
 

--- a/chia/wallet/nft_wallet/nft_puzzles.py
+++ b/chia/wallet/nft_wallet/nft_puzzles.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from clvm.casts import int_from_bytes
 from clvm_tools.binutils import disassemble
 
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint16, uint64
 from chia.wallet.nft_wallet.nft_info import NFTCoinInfo, NFTInfo

--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -11,7 +11,8 @@ from typing import List
 import pkg_resources
 from clvm_tools_rs import compile_clvm as compile_clvm_rust
 
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.util.lock import Lockfile
 
 compile_clvm_py = None

--- a/chia/wallet/puzzles/rom_bootstrap_generator.py
+++ b/chia/wallet/puzzles/rom_bootstrap_generator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 
 from .load_clvm import load_serialized_clvm_maybe_recompile
 

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -11,7 +11,8 @@ from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.generator_types import BlockGenerator

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -25,7 +25,7 @@ from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import TransactionsInfo
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import InfusedChallengeChainSubSlot
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof

--- a/tests/clvm/test_serialized_program.py
+++ b/tests/clvm/test_serialized_program.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from unittest import TestCase
 
-from chia.types.blockchain_format.program import INFINITE_COST, Program, SerializedProgram
+from chia.types.blockchain_format.program import INFINITE_COST, Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.wallet.puzzles.load_clvm import load_clvm
 
 SHA256TREE_MOD = load_clvm("sha256tree_module.clvm")

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -15,7 +15,7 @@ from chia.consensus.full_block_to_block_record import header_block_to_sub_block_
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.simulator.block_tools import test_constants
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.full_block import FullBlock

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -30,9 +30,10 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.foliage import Foliage, FoliageTransactionBlock, TransactionsInfo
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace, calculate_plot_id_pk, calculate_pos_challenge
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlockUnfinished
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFProof
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -26,7 +26,8 @@ from chia.simulator.time_out_assert import time_out_assert
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import INFINITE_COST, Program, SerializedProgram
+from chia.types.blockchain_format.program import INFINITE_COST, Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
 from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_spend import CoinSpend

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -15,7 +15,8 @@ from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, get_puzzle_and_solution_for_coin
 from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.generator_types import BlockGenerator
 from chia.wallet.puzzles import p2_delegated_puzzle_or_hidden_puzzle

--- a/tests/generator/test_compression.py
+++ b/tests/generator/test_compression.py
@@ -20,7 +20,8 @@ from chia.full_node.bundle_tools import (
 )
 from chia.full_node.generator import create_generator_args, run_generator_unsafe
 from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
-from chia.types.blockchain_format.program import INFINITE_COST, Program, SerializedProgram
+from chia.types.blockchain_format.program import INFINITE_COST, Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.generator_types import BlockGenerator, CompressorArg
 from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes

--- a/tests/generator/test_generator_types.py
+++ b/tests/generator/test_generator_types.py
@@ -4,7 +4,8 @@ from typing import Dict
 from unittest import TestCase
 
 from chia.full_node.generator import create_block_generator, create_generator_args
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.generator_types import GeneratorBlockCacheInterface
 from chia.util.ints import uint32
 

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -6,7 +6,8 @@ from clvm_tools.clvmc import compile_clvm_text
 from chia.consensus.condition_costs import ConditionCost
 from chia.full_node.generator import run_generator_unsafe
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle_conditions import ELIGIBLE_FOR_DEDUP, Spend

--- a/tests/pools/test_wallet_pool_store.py
+++ b/tests/pools/test_wallet_pool_store.py
@@ -7,7 +7,8 @@ import pytest
 from clvm_tools import binutils
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.util.ints import uint64

--- a/tests/util/network_protocol_data.py
+++ b/tests/util/network_protocol_data.py
@@ -17,9 +17,10 @@ from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import Foliage, FoliageBlockData, FoliageTransactionBlock, TransactionsInfo
 from chia.types.blockchain_format.pool_target import PoolTarget
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import (
     ChallengeChainSubSlot,

--- a/tests/util/test_full_block_utils.py
+++ b/tests/util/test_full_block_utils.py
@@ -9,9 +9,9 @@ from blspy import G1Element, G2Element
 from benchmarks.utils import rand_bytes, rand_g1, rand_g2, rand_hash, rand_vdf, rand_vdf_proof, rewards
 from chia.types.blockchain_format.foliage import Foliage, FoliageBlockData, FoliageTransactionBlock, TransactionsInfo
 from chia.types.blockchain_format.pool_target import PoolTarget
-from chia.types.blockchain_format.program import SerializedProgram
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import (
     ChallengeChainSubSlot,

--- a/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
+++ b/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
@@ -7,6 +7,7 @@ from clvm_tools.binutils import disassemble
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.util.ints import uint64
@@ -38,7 +39,7 @@ def test_cat_outer_puzzle() -> None:
     # Set up for solve
     parent_coin = Coin(tail, double_cat_puzzle.get_tree_hash(), uint64(100))
     child_coin = Coin(parent_coin.name(), double_cat_puzzle.get_tree_hash(), uint64(100))
-    parent_spend = CoinSpend(parent_coin, double_cat_puzzle.to_serialized_program(), Program.to([]))
+    parent_spend = CoinSpend(parent_coin, SerializedProgram.from_program(double_cat_puzzle), Program.to([]))
     child_coin_as_hex: str = (
         "0x" + child_coin.parent_coin_info.hex() + child_coin.puzzle_hash.hex() + bytes(uint64(child_coin.amount)).hex()
     )

--- a/tests/wallet/test_singleton_lifecycle_fast.py
+++ b/tests/wallet/test_singleton_lifecycle_fast.py
@@ -8,7 +8,8 @@ from clvm_tools import binutils
 
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program, SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
@@ -354,7 +355,7 @@ def claim_p2_singleton(
     )
     p2_singleton_coin_spend = CoinSpend(
         p2_singleton_coin,
-        p2_singleton_puzzle.to_serialized_program(),
+        SerializedProgram.from_program(p2_singleton_puzzle),
         p2_singleton_solution,
     )
     expected_p2_singleton_announcement = Announcement(p2_singleton_coin_name, bytes(b"$")).name()

--- a/tools/manage_clvm.py
+++ b/tools/manage_clvm.py
@@ -27,7 +27,7 @@ sys.path = [path for path in sys.path if path != os.fspath(here)]
 
 from clvm_tools_rs import compile_clvm  # noqa: E402
 
-from chia.types.blockchain_format.program import SerializedProgram  # noqa: E402
+from chia.types.blockchain_format.serialized_program import SerializedProgram  # noqa: E402
 
 clvm_suffix = ".clvm"
 hex_suffix = ".clvm.hex"

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -48,7 +48,7 @@ from clvm.casts import int_from_bytes
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs


### PR DESCRIPTION
The new file is no longer exempt from full mypy checks, so those are fixed.

This patch clarifies the dependency relationship between `Program` and `SerializedProgram`. the latter depends on the former, and not the other way around. This is required to avoid cyclical imports. This also has the consequence that `Program` cannot have the `to_serialized_program()` member.

This patch is split into 3 commits:

1. move `SerializedProgram` into its own file
2. fix mypy annotations in the new file
3. update all module imports to refer to the new file

It's advised to review each commit independently.

My long-term vision is to transition `SerializedProgram` into being the `chia_rs` rust implementation (currently called `chia_rs.Program`). That, in turn, would enable transitioning `CoinSpend` into using the rust implementation, which in-turn enabled transitioning `SpendBundle` into using the rust implementation.

`SpendBundle` contains a `G2Element` however, which is not solved how to transition yet. 