### PR TITLE
Allow sending of zero coins

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -186,7 +186,7 @@ async def get_transactions(args: dict, wallet_client: WalletRpcClient, fingerpri
 
 
 def check_unusual_transaction(amount: Decimal, fee: Decimal):
-    return fee >= amount
+    return fee >= amount or amount == 0
 
 
 async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
@@ -209,9 +209,6 @@ async def send(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> 
             f"A transaction of amount {amount} and fee {fee} is unusual.\n"
             f"Pass in --override if you are sure you mean to do this."
         )
-        return
-    if amount == 0:
-        print("You can not send an empty transaction")
         return
 
     try:

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -390,10 +390,7 @@ class Wallet:
             if origin_id in (None, coin.name()):
                 origin_id = coin.name()
                 if primaries is None:
-                    if amount > 0:
-                        primaries = [{"puzzlehash": newpuzzlehash, "amount": uint64(amount), "memos": memos}]
-                    else:
-                        primaries = []
+                    primaries = [{"puzzlehash": newpuzzlehash, "amount": uint64(amount), "memos": memos}]
                 else:
                     primaries.append({"puzzlehash": newpuzzlehash, "amount": uint64(amount), "memos": memos})
                 if change > 0:

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -231,7 +231,8 @@ async def get_unconfirmed_balance(client: WalletRpcClient, wallet_id: int):
 
 
 @pytest.mark.asyncio
-async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment):
+@pytest.mark.parametrize("tx_amount", [uint64(15600000), uint64(0)])
+async def test_send_transaction(tx_amount: uint64, wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
 
     wallet_2: Wallet = env.wallet_2.wallet
@@ -242,7 +243,6 @@ async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment
     generated_funds = await generate_funds(full_node_api, env.wallet_1)
 
     addr = encode_puzzle_hash(await wallet_2.get_new_puzzlehash(), "txch")
-    tx_amount = uint64(15600000)
     with pytest.raises(ValueError):
         await client.send_transaction(1, uint64(100000000000000001), addr)
 


### PR DESCRIPTION
### Purpose:
0 coins currently cannot be sent from the standard wallet. There isn't really a reason for this that I can see, so this removes that restriction.

### New Behavior:
Calls to the `/send_transaction` RPC will now create a 0 coin if `"amount": 0` is specified.
`chia wallet send` now guards zero-amount spends behind the `--override` flag