### PR TITLE
remove additions() and reserved_fee() from CoinSpend

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -18,7 +18,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint8, uint32, uint64, uint128
@@ -294,7 +294,8 @@ class DataLayerWallet:
             )
             await self.singleton_removed(parent_spend, new_singleton_coin_record.spent_block_height)
             try:
-                new_singleton = next(coin for coin in parent_spend.additions() if coin.amount % 2 != 0)
+                additions = compute_additions(parent_spend)
+                new_singleton = next(coin for coin in additions if coin.amount % 2 != 0)
                 new_singleton_coin_record = await self.wallet_state_manager.coin_store.get_coin_record(
                     new_singleton.name()
                 )

--- a/chia/pools/pool_puzzles.py
+++ b/chia/pools/pool_puzzles.py
@@ -13,7 +13,7 @@ from chia.pools.pool_wallet_info import LEAVING_POOL, SELF_POOLING, PoolState
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.util.ints import uint32, uint64
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
 from chia.wallet.puzzles.singleton_top_layer import puzzle_for_singleton
@@ -282,7 +282,7 @@ def create_absorb_spend(
 
 
 def get_most_recent_singleton_coin_from_coin_spend(coin_sol: CoinSpend) -> Optional[Coin]:
-    additions: List[Coin] = coin_sol.additions()
+    additions: List[Coin] = compute_additions(coin_sol)
     for coin in additions:
         if coin.amount % 2 == 1:
             return coin

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -42,7 +42,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.wallet.derive_keys import find_owner_sk
@@ -550,7 +550,7 @@ class PoolWallet:
 
         tip = (await self.get_tip())[1]
         tip_coin = tip.coin
-        singleton = tip.additions()[0]
+        singleton = compute_additions(tip)[0]
         singleton_id = singleton.name()
         assert outgoing_coin_spend.coin.parent_coin_info == tip_coin.name()
         assert outgoing_coin_spend.coin.name() == singleton_id

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import INFINITE_COST, SerializedProgram
+from chia.types.blockchain_format.program import SerializedProgram
 from chia.util.chain_utils import additions_for_solution, fee_for_solution
 from chia.util.streamable import Streamable, streamable
 
@@ -22,12 +23,10 @@ class CoinSpend(Streamable):
     puzzle_reveal: SerializedProgram
     solution: SerializedProgram
 
-    # TODO: this function should be moved out of the full node. It cannot be
-    # called on untrusted input
-    def additions(self) -> List[Coin]:
-        return additions_for_solution(self.coin.name(), self.puzzle_reveal, self.solution, INFINITE_COST)
 
-    # TODO: this function should be moved out of the full node. It cannot be
-    # called on untrusted input
-    def reserved_fee(self) -> int:
-        return fee_for_solution(self.puzzle_reveal, self.solution, INFINITE_COST)
+def compute_additions(cs: CoinSpend, *, max_cost: int = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM) -> List[Coin]:
+    return additions_for_solution(cs.coin.name(), cs.puzzle_reveal, cs.solution, max_cost)
+
+
+def compute_reserved_fee(cs: CoinSpend, *, max_cost: int = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM) -> int:
+    return fee_for_solution(cs.puzzle_reveal, cs.solution, max_cost)

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -12,7 +12,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.streamable import Streamable, recurse_jsonify, streamable, streamable_from_dict
 from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
-from .coin_spend import CoinSpend
+from .coin_spend import CoinSpend, compute_additions
 
 
 @streamable
@@ -42,14 +42,14 @@ class SpendBundle(Streamable):
         aggregated_signature = AugSchemeMPL.aggregate(sigs)
         return cls(coin_spends, aggregated_signature)
 
+    # TODO: this should be removed
     def additions(self) -> List[Coin]:
         items: List[Coin] = []
-        for coin_spend in self.coin_spends:
-            items.extend(coin_spend.additions())
+        for cs in self.coin_spends:
+            items.extend(compute_additions(cs))
         return items
 
     def removals(self) -> List[Coin]:
-        """This should be used only by wallet"""
         return [_.coin for _ in self.coin_spends]
 
     def fees(self) -> int:

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -16,7 +16,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.hash import std_hash
@@ -221,7 +221,7 @@ class NFTWallet:
             nft_puzzles.create_full_puzzle_with_nft_puzzle(singleton_id, uncurried_nft.inner_puzzle),
         )
         child_puzzle_hash = child_puzzle.get_tree_hash()
-        for new_coin in coin_spend.additions():
+        for new_coin in compute_additions(coin_spend):
             self.log.debug(
                 "Comparing addition: %s with %s, amount: %s ",
                 new_coin.puzzle_hash,
@@ -1038,7 +1038,9 @@ class NFTWallet:
 
                         if duplicate_payments != []:
                             payments = duplicate_payments
-                            royalty_coin = next(c for c in new_coin_spend.additions() if c.puzzle_hash == royalty_ph)
+                            royalty_coin = next(
+                                c for c in compute_additions(new_coin_spend) if c.puzzle_hash == royalty_ph
+                            )
                             parent_spend = new_coin_spend
                             continue
                         else:

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -10,7 +10,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import bech32_decode, bech32_encode, convertbits
 from chia.util.ints import uint64
@@ -130,7 +130,7 @@ class Offer:
         final_list: List[Coin] = []
         for cs in self.bundle.coin_spends:
             try:
-                final_list.extend(cs.additions())
+                final_list.extend(compute_additions(cs))
             except Exception:
                 pass
         return final_list
@@ -142,7 +142,7 @@ class Offer:
         final_list: List[CoinSpend] = []
         for cs in self.bundle.coin_spends:
             try:
-                cs.additions()
+                compute_additions(cs)
             except Exception:
                 final_list.append(cs)
         return final_list
@@ -157,7 +157,7 @@ class Offer:
 
             parent_puzzle: UncurriedPuzzle = uncurry_puzzle(parent_spend.puzzle_reveal.to_program())
             parent_solution: Program = parent_spend.solution.to_program()
-            additions: List[Coin] = parent_spend.additions()
+            additions: List[Coin] = compute_additions(parent_spend)
 
             puzzle_driver = match_puzzle(parent_puzzle)
             if puzzle_driver is not None:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -29,7 +29,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.full_block import FullBlock
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.bech32m import encode_puzzle_hash
@@ -1341,7 +1341,7 @@ class WalletStateManager:
                                 uint32(child.spent_height),
                                 name="pool_wallet",
                             )
-                            launcher_spend_additions = launcher_spend.additions()
+                            launcher_spend_additions = compute_additions(launcher_spend)
                             assert len(launcher_spend_additions) == 1
                             coin_added = launcher_spend_additions[0]
                             coin_name = coin_added.name()

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -16,6 +16,7 @@ from chia.simulator.block_tools import get_signage_point, test_constants
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
 from chia.simulator.time_out_assert import time_out_assert
 from chia.simulator.wallet_tools import WalletTool
+from chia.types.coin_spend import compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.full_block import FullBlock
@@ -185,11 +186,8 @@ class TestRpc:
 
             coin_record = await client.get_coin_record_by_name(coin.name())
             assert coin_record.coin == coin
-            assert (
-                coin
-                in (
-                    await client.get_puzzle_and_solution(coin.parent_coin_info, coin_record.confirmed_block_index)
-                ).additions()
+            assert coin in compute_additions(
+                await client.get_puzzle_and_solution(coin.parent_coin_info, coin_record.confirmed_block_index)
             )
 
             assert len(await client.get_coin_records_by_puzzle_hash(ph_receiver)) == 1

--- a/tests/pools/test_wallet_pool_store.py
+++ b/tests/pools/test_wallet_pool_store.py
@@ -9,7 +9,7 @@ from clvm_tools import binutils
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.util.ints import uint64
 from chia.wallet.wallet_pool_store import WalletPoolStore
 from tests.util.db_connection import DBConnection
@@ -22,7 +22,7 @@ def make_child_solution(coin_spend: CoinSpend, new_coin: Optional[Coin] = None) 
     puzzle_prog = Program.to(binutils.assemble(puzzle))
     solution_prog = Program.to(binutils.assemble(solution))
     if new_coin is None:
-        new_coin = coin_spend.additions()[0]
+        new_coin = compute_additions(coin_spend)[0]
     sol: CoinSpend = CoinSpend(
         new_coin,
         SerializedProgram.from_program(puzzle_prog),

--- a/tests/wallet/test_singleton_lifecycle_fast.py
+++ b/tests/wallet/test_singleton_lifecycle_fast.py
@@ -10,7 +10,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program, SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
@@ -228,7 +228,7 @@ class SingletonWallet:
         current_coin_name = self.current_state.name()
         for coin_spend in removals:
             if coin_spend.coin.name() == current_coin_name:
-                for coin in coin_spend.additions():
+                for coin in compute_additions(coin_spend):
                     if coin.amount & 1 == 1:
                         parent_puzzle_hash = coin_spend.coin.puzzle_hash
                         parent_puzzle = puzzle_db.puzzle_for_hash(parent_puzzle_hash)
@@ -442,7 +442,7 @@ def find_interesting_singletons(puzzle_db: PuzzleDB, removals: List[CoinSpend]) 
             r = Program.from_bytes(bytes(coin_spend.solution))
             key_value_list = r.rest().rest().first()
 
-            eve_coin = coin_spend.additions()[0]
+            eve_coin = compute_additions(coin_spend)[0]
 
             lineage_proof = lineage_proof_for_coin_spend(coin_spend)
             launcher_id = coin_spend.coin.name()

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -17,6 +17,7 @@ from chia.simulator.simulator_protocol import ReorgProtocol
 from chia.simulator.time_out_assert import time_out_assert
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_spend import compute_additions
 from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint16, uint32, uint64
@@ -533,7 +534,7 @@ class TestWalletSimulator:
 
         # extract coin_spend from generated spend_bundle
         for cs in tx.spend_bundle.coin_spends:
-            if cs.additions() == []:
+            if compute_additions(cs) == []:
                 stolen_cs = cs
         # get a legit signature
         stolen_sb = await wallet.sign_transaction([stolen_cs])


### PR DESCRIPTION
### Purpose:

These functions are potentially expensive and must not be called on untrusted CoinSpends. We only use them in wallets, where we do trust the puzzles. Having them be members and not have a name indicating that they are potentially expensive is a risk that they will be incorrectly used in the future.

This patch:

1. moves these functions to be free functions rather than members.
2. renames them to have the word `compute_` in them, indicating that they shouldn't be called willy nilly or redundantly.
3. improves their safety by capping the max allowed CLVM cost to the max of one block

This also enables future patches to transition the `CoinSpend` type to use the one implemented in rust.