### PR TITLE
Simplify request_mempool_transactions() and get_items_not_in_filter()

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -49,8 +49,8 @@ from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
 from chia.types.generator_types import BlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.mempool_item import MempoolItem
 from chia.types.peer_info import PeerInfo
+from chia.types.spend_bundle import SpendBundle
 from chia.types.transaction_queue_entry import TransactionQueueEntry
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.api_decorators import api_request
@@ -669,10 +669,10 @@ class FullNodeAPI:
     ) -> Optional[Message]:
         received_filter = PyBIP158(bytearray(request.filter))
 
-        items: List[MempoolItem] = await self.full_node.mempool_manager.get_items_not_in_filter(received_filter)
+        items: List[SpendBundle] = await self.full_node.mempool_manager.get_items_not_in_filter(received_filter)
 
         for item in items:
-            transaction = full_node_protocol.RespondTransaction(item.spend_bundle)
+            transaction = full_node_protocol.RespondTransaction(item)
             msg = make_msg(ProtocolMessageTypes.respond_transaction, transaction)
             await peer.send_message(msg)
         return None

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -669,7 +669,7 @@ class FullNodeAPI:
     ) -> Optional[Message]:
         received_filter = PyBIP158(bytearray(request.filter))
 
-        items: List[SpendBundle] = await self.full_node.mempool_manager.get_items_not_in_filter(received_filter)
+        items: List[SpendBundle] = self.full_node.mempool_manager.get_items_not_in_filter(received_filter)
 
         for item in items:
             transaction = full_node_protocol.RespondTransaction(item)

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -669,17 +669,15 @@ class MempoolManager:
 
     def get_items_not_in_filter(self, mempool_filter: PyBIP158, limit: int = 100) -> List[SpendBundle]:
         items: List[SpendBundle] = []
-        counter = 0
 
         assert limit > 0
 
         # Send 100 with the highest fee per cost
         for dic in reversed(self.mempool.sorted_spends.values()):
             for item in dic.values():
-                if counter == limit:
+                if len(items) == limit:
                     return items
                 if mempool_filter.Match(bytearray(item.spend_bundle_name)):
                     continue
                 items.append(item.spend_bundle)
-                counter += 1
         return items

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -667,7 +667,7 @@ class MempoolManager:
         self.mempool.fee_estimator.new_block(FeeBlockInfo(new_peak.height, included_items))
         return txs_added
 
-    async def get_items_not_in_filter(self, mempool_filter: PyBIP158, limit: int = 100) -> List[SpendBundle]:
+    def get_items_not_in_filter(self, mempool_filter: PyBIP158, limit: int = 100) -> List[SpendBundle]:
         items: List[SpendBundle] = []
         counter = 0
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -667,24 +667,19 @@ class MempoolManager:
         self.mempool.fee_estimator.new_block(FeeBlockInfo(new_peak.height, included_items))
         return txs_added
 
-    async def get_items_not_in_filter(self, mempool_filter: PyBIP158, limit: int = 100) -> List[MempoolItem]:
-        items: List[MempoolItem] = []
+    async def get_items_not_in_filter(self, mempool_filter: PyBIP158, limit: int = 100) -> List[SpendBundle]:
+        items: List[SpendBundle] = []
         counter = 0
-        broke_from_inner_loop = False
 
         assert limit > 0
 
         # Send 100 with the highest fee per cost
         for dic in reversed(self.mempool.sorted_spends.values()):
-            if broke_from_inner_loop:
-                break
             for item in dic.values():
                 if counter == limit:
-                    broke_from_inner_loop = True
-                    break
+                    return items
                 if mempool_filter.Match(bytearray(item.spend_bundle_name)):
                     continue
-                items.append(item)
+                items.append(item.spend_bundle)
                 counter += 1
-
         return items

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -510,45 +510,42 @@ async def test_ephemeral_timelock(
 async def test_get_items_not_in_filter() -> None:
     mempool_manager = await instantiate_mempool_manager(get_coin_record_for_test_coins)
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
-    _, sb1_name, _ = await generate_and_add_spendbundle(mempool_manager, conditions)
-    mempool_item1 = mempool_manager.get_mempool_item(sb1_name)
+    sb1, sb1_name, _ = await generate_and_add_spendbundle(mempool_manager, conditions)
     conditions2 = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 2]]
-    _, sb2_name, _ = await generate_and_add_spendbundle(mempool_manager, conditions2, TEST_COIN2)
-    mempool_item2 = mempool_manager.get_mempool_item(sb2_name)
+    sb2, sb2_name, _ = await generate_and_add_spendbundle(mempool_manager, conditions2, TEST_COIN2)
     conditions3 = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 3]]
-    _, sb3_name, _ = await generate_and_add_spendbundle(mempool_manager, conditions3, TEST_COIN3)
-    mempool_item3 = mempool_manager.get_mempool_item(sb3_name)
+    sb3, sb3_name, _ = await generate_and_add_spendbundle(mempool_manager, conditions3, TEST_COIN3)
 
     # Don't filter anything
     empty_filter = PyBIP158([])
-    result = await mempool_manager.get_items_not_in_filter(empty_filter)
-    assert result == [mempool_item3, mempool_item2, mempool_item1]
+    result = mempool_manager.get_items_not_in_filter(empty_filter)
+    assert result == [sb3, sb2, sb1]
 
     # Filter everything
     full_filter = PyBIP158([bytearray(sb1_name), bytearray(sb2_name), bytearray(sb3_name)])
-    result = await mempool_manager.get_items_not_in_filter(full_filter)
+    result = mempool_manager.get_items_not_in_filter(full_filter)
     assert result == []
 
     # Negative limit
     with pytest.raises(AssertionError):
-        await mempool_manager.get_items_not_in_filter(empty_filter, limit=-1)
+        mempool_manager.get_items_not_in_filter(empty_filter, limit=-1)
 
     # Zero limit
     with pytest.raises(AssertionError):
-        await mempool_manager.get_items_not_in_filter(empty_filter, limit=0)
+        mempool_manager.get_items_not_in_filter(empty_filter, limit=0)
 
     # Filter only one of the spend bundles
     sb3_filter = PyBIP158([bytearray(sb3_name)])
 
     # With a limit of one, sb2 has the highest FPC
-    result = await mempool_manager.get_items_not_in_filter(sb3_filter, limit=1)
-    assert result == [mempool_item2]
+    result = mempool_manager.get_items_not_in_filter(sb3_filter, limit=1)
+    assert result == [sb2]
 
     # With a higher limit, all bundles aside from sb3 get included
-    result = await mempool_manager.get_items_not_in_filter(sb3_filter, limit=5)
-    assert result == [mempool_item2, mempool_item1]
+    result = mempool_manager.get_items_not_in_filter(sb3_filter, limit=5)
+    assert result == [sb2, sb1]
 
     # Filter two of the spend bundles
     sb2_and_3_filter = PyBIP158([bytearray(sb2_name), bytearray(sb3_name)])
-    result = await mempool_manager.get_items_not_in_filter(sb2_and_3_filter)
-    assert result == [mempool_item1]
+    result = mempool_manager.get_items_not_in_filter(sb2_and_3_filter)
+    assert result == [sb1]


### PR DESCRIPTION
* Only deal with the relevant subset of the `MempoolItem` (which is `SpendBundle` here).
* `get_items_not_in_filter()` doesn't need to be async.
* Use len(items) instead of counter for the limit check.
* Update tests to reflect the improvements.