### PR TITLE
remove args passed to super() calls

### DIFF
--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -161,20 +161,20 @@ class Err(Enum):
 
 class ValidationError(Exception):
     def __init__(self, code: Err, error_msg: str = ""):
-        super(ValidationError, self).__init__(f"Error code: {code.name} {error_msg}")
+        super().__init__(f"Error code: {code.name} {error_msg}")
         self.code = code
         self.error_msg = error_msg
 
 
 class ConsensusError(Exception):
     def __init__(self, code: Err, errors: List[Any] = []):
-        super(ConsensusError, self).__init__(f"Error code: {code.name} {errors}")
+        super().__init__(f"Error code: {code.name} {errors}")
         self.errors = errors
 
 
 class ProtocolError(Exception):
     def __init__(self, code: Err, errors: List[Any] = []):
-        super(ProtocolError, self).__init__(f"Error code: {code.name} {errors}")
+        super().__init__(f"Error code: {code.name} {errors}")
         self.code = code
         self.errors = errors
 

--- a/chia/util/logging.py
+++ b/chia/util/logging.py
@@ -12,13 +12,13 @@ class TimedDuplicateFilter(logging.Filter):
     min_time_wait_secs: int
 
     def __init__(self, regex_str: str, min_time_wait_secs: int, name: str = ""):
-        super(TimedDuplicateFilter, self).__init__(name)
+        super().__init__(name)
         self.last_log_time = time.monotonic()
         self.regex = re.compile(regex_str)
         self.min_time_wait_secs = min_time_wait_secs
 
     def filter(self, record: logging.LogRecord) -> bool:
-        _ = super(TimedDuplicateFilter, self).filter(record)
+        _ = super().filter(record)
         if not _:
             return False
 

--- a/tests/generator/test_compression.py
+++ b/tests/generator/test_compression.py
@@ -168,7 +168,7 @@ class TestCompression(TestCase):
 
 class TestDecompression(TestCase):
     def __init__(self, *args, **kwargs):
-        super(TestDecompression, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.maxDiff = None
 
     def test_deserialization(self):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Cleanup calls to `super()` that are passing arguments.  The arguments are only needed in Python 2, not Python 3, and passing them opens the opportunity to pass the wrong thing.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Using Python 2 style `super()` calls with arguments in a few places.

### New Behavior:

Use only Python 3 style `super()` calls without arguments.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
