### PR TITLE
exit softly from unhandled keyboard interrupt

### DIFF
--- a/chia/__init__.py
+++ b/chia/__init__.py
@@ -1,6 +1,34 @@
 from __future__ import annotations
 
-from pkg_resources import DistributionNotFound, get_distribution, resource_filename
+import inspect
+import os
+import pathlib
+import sys
+import sysconfig
+from types import TracebackType
+from typing import Optional, Type
+
+_original_excepthook = sys.excepthook
+
+
+def _excepthook_handle_ctrl_c(
+    type: Type[BaseException],
+    value: BaseException,
+    traceback: Optional[TracebackType],
+) -> None:
+    if issubclass(type, KeyboardInterrupt):
+        print("process terminated by user")
+    else:
+        _original_excepthook(type, value, traceback)
+
+
+frames = inspect.stack()
+
+expected = os.fspath(pathlib.Path(sysconfig.get_path("scripts"), "chia"))
+if pathlib.Path(inspect.stack()[-1].filename).with_suffix("") == expected:
+    sys.excepthook = _excepthook_handle_ctrl_c
+
+from pkg_resources import DistributionNotFound, get_distribution, resource_filename  # noqa E402
 
 try:
     __version__ = get_distribution("chia-blockchain").version


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Tracebacks when exiting via ctrl+c are pretty loud.  Since it takes awhile to import everything, that leaves more time to get tracebacks before you get to a 'normal' place to put an exception handler.  This quiets that down for otherwise unhandled ctrl+c termination.

This relates to the import-time case mentioned in https://github.com/Chia-Network/chia-blockchain/issues/14389.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Loud `KeyboardInterrupt` tracebacks when the user pressed ctrl+c.

### New Behavior:

A quieter `process terminated by user` message is printed when the user presses ctrl+c.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

### Draft for:

- [ ] Handling Windows
- [ ] Handling when it is pyinstallered
- [ ] Consideration of the message text
- [ ] Consideration of stdout vs. stderr
- [ ] Check for proper exit code
