### PR TITLE
fix sending of the `new_on_chain_notification` state change message

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -234,6 +234,7 @@ class WalletRpcApi:
             "added_stray_cat",
             "pending_transaction",
             "tx_update",
+            "new_on_chain_notification",
         }:
             payloads.append(create_payload_dict("state_changed", change_data, self.service_name, "wallet_ui"))
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

The `new_on_chain_notification` state change message is intended to notify the UI that new notifications are available for processing. Wallet state change messages need to be handled by wallet_rpc_api.py's `_state_changed` method to ensure that the payload is properly constructed to ensure delivery to the UI.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Without this fix, the state change message is never sent to the UI.

### New Behavior:

With this fix, the state change message is sent and seen by the UI.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Manually tested by watching RPC messages in the UI.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
