### PR TITLE
Add a persitent id table to notification store

### DIFF
--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -46,6 +46,8 @@ class NotificationStore:
                 "CREATE TABLE IF NOT EXISTS notifications(" "coin_id blob PRIMARY KEY," "msg blob," "amount blob" ")"
             )
 
+            await conn.execute("CREATE TABLE IF NOT EXISTS all_ids(coin_id blob PRIMARY KEY)")
+
             try:
                 await conn.execute("ALTER TABLE notifications ADD COLUMN height bigint DEFAULT 0")
             except sqlite3.OperationalError as e:
@@ -73,6 +75,10 @@ class NotificationStore:
                     bytes(notification.amount),
                     notification.height,
                 ),
+            )
+            cursor = await conn.execute(
+                "INSERT OR REPLACE INTO all_ids (coin_id) VALUES(?)",
+                (notification.coin_id,),
             )
             await cursor.close()
 
@@ -155,7 +161,7 @@ class NotificationStore:
 
     async def notification_exists(self, id: bytes32) -> bool:
         async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute("SELECT EXISTS (SELECT 1 from notifications WHERE coin_id=?)", (id,)) as cursor:
+            async with conn.execute("SELECT EXISTS (SELECT 1 from all_ids WHERE coin_id=?)", (id,)) as cursor:
                 row = await cursor.fetchone()
                 assert row is not None
                 exists: bool = row[0] > 0

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -161,7 +161,9 @@ class NotificationStore:
 
     async def notification_exists(self, id: bytes32) -> bool:
         async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute("SELECT EXISTS (SELECT 1 from all_notification_ids WHERE coin_id=?)", (id,)) as cursor:
+            async with conn.execute(
+                "SELECT EXISTS (SELECT 1 from all_notification_ids WHERE coin_id=?)", (id,)
+            ) as cursor:
                 row = await cursor.fetchone()
                 assert row is not None
                 exists: bool = row[0] > 0

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -46,7 +46,7 @@ class NotificationStore:
                 "CREATE TABLE IF NOT EXISTS notifications(" "coin_id blob PRIMARY KEY," "msg blob," "amount blob" ")"
             )
 
-            await conn.execute("CREATE TABLE IF NOT EXISTS all_ids(coin_id blob PRIMARY KEY)")
+            await conn.execute("CREATE TABLE IF NOT EXISTS all_notification_ids(coin_id blob PRIMARY KEY)")
 
             try:
                 await conn.execute("ALTER TABLE notifications ADD COLUMN height bigint DEFAULT 0")
@@ -77,7 +77,7 @@ class NotificationStore:
                 ),
             )
             cursor = await conn.execute(
-                "INSERT OR REPLACE INTO all_ids (coin_id) VALUES(?)",
+                "INSERT OR REPLACE INTO all_notification_ids (coin_id) VALUES(?)",
                 (notification.coin_id,),
             )
             await cursor.close()
@@ -161,7 +161,7 @@ class NotificationStore:
 
     async def notification_exists(self, id: bytes32) -> bool:
         async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute("SELECT EXISTS (SELECT 1 from all_ids WHERE coin_id=?)", (id,)) as cursor:
+            async with conn.execute("SELECT EXISTS (SELECT 1 from all_notification_ids WHERE coin_id=?)", (id,)) as cursor:
                 row = await cursor.fetchone()
                 assert row is not None
                 exists: bool = row[0] > 0

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -99,9 +99,12 @@ async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted:
 
     func = notification_manager_2.potentially_add_new_notification
     notification_manager_2.most_recent_args = tuple()
-    async def track_coin_state(*args):
+
+    async def track_coin_state(*args: Any) -> bool:
         notification_manager_2.most_recent_args = args
-        return await func(*args)
+        result: bool = await func(*args)
+        return result
+
     notification_manager_2.potentially_add_new_notification = track_coin_state
 
     for case in ("block all", "block too low", "allow", "allow_larger", "block_too_large"):

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -97,6 +97,13 @@ async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted:
     notification_manager_1 = wsm_1.notification_manager
     notification_manager_2 = wsm_2.notification_manager
 
+    func = notification_manager_2.potentially_add_new_notification
+    notification_manager_2.most_recent_args = tuple()
+    async def track_coin_state(*args):
+        notification_manager_2.most_recent_args = args
+        return await func(*args)
+    notification_manager_2.potentially_add_new_notification = track_coin_state
+
     for case in ("block all", "block too low", "allow", "allow_larger", "block_too_large"):
         msg: bytes = bytes(case, "utf8")
         if case == "block all":
@@ -165,3 +172,7 @@ async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted:
     await notification_manager_2.notification_store.add_notification(notifications[0])
     await notification_manager_2.notification_store.delete_notifications([n.coin_id for n in notifications])
     assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
+
+    assert not await func(*notification_manager_2.most_recent_args)
+    await notification_manager_2.notification_store.delete_all_notifications()
+    assert not await func(*notification_manager_2.most_recent_args)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Add a list of IDs for notification we've synced separate from the main notifications table.  This means that even if a notification is deleted, we don't forget that we've already synced it previously.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Reproduce this issue and see if it exists: https://github.com/Chia-Network/chia-blockchain/issues/14411
