### PR TITLE
Add additional state_changed events to metrics destination

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -98,7 +98,7 @@ class Harvester:
         return default_get_connections(server=self.server, request_node_type=request_node_type)
 
     async def on_connect(self, connection: WSChiaConnection):
-        pass
+        self.state_changed("add_connection")
 
     def _set_state_changed_callback(self, callback: Callable):
         self.state_changed_callback = callback

--- a/chia/rpc/farmer_rpc_api.py
+++ b/chia/rpc/farmer_rpc_api.py
@@ -118,6 +118,14 @@ class FarmerRpcApi:
                     "wallet_ui",
                 )
             )
+            payloads.append(
+                create_payload_dict(
+                    "new_signage_point",
+                    data,
+                    self.service_name,
+                    "metrics",
+                )
+            )
         elif change == "new_farming_info":
             payloads.append(
                 create_payload_dict(
@@ -125,6 +133,14 @@ class FarmerRpcApi:
                     change_data,
                     self.service_name,
                     "wallet_ui",
+                )
+            )
+            payloads.append(
+                create_payload_dict(
+                    "new_farming_info",
+                    change_data,
+                    self.service_name,
+                    "metrics",
                 )
             )
         elif change == "harvester_update":
@@ -136,6 +152,14 @@ class FarmerRpcApi:
                     "wallet_ui",
                 )
             )
+            payloads.append(
+                create_payload_dict(
+                    "harvester_update",
+                    change_data,
+                    self.service_name,
+                    "metrics",
+                )
+            )
         elif change == "harvester_removed":
             payloads.append(
                 create_payload_dict(
@@ -143,6 +167,14 @@ class FarmerRpcApi:
                     change_data,
                     self.service_name,
                     "wallet_ui",
+                )
+            )
+            payloads.append(
+                create_payload_dict(
+                    "harvester_removed",
+                    change_data,
+                    self.service_name,
+                    "metrics",
                 )
             )
         elif change == "submitted_partial":
@@ -158,6 +190,24 @@ class FarmerRpcApi:
             payloads.append(
                 create_payload_dict(
                     "proof",
+                    change_data,
+                    self.service_name,
+                    "metrics",
+                )
+            )
+        elif change == "add_connection":
+            payloads.append(
+                create_payload_dict(
+                    "add_connection",
+                    change_data,
+                    self.service_name,
+                    "metrics",
+                )
+            )
+        elif change == "close_connection":
+            payloads.append(
+                create_payload_dict(
+                    "close_connection",
                     change_data,
                     self.service_name,
                     "metrics",

--- a/chia/rpc/harvester_rpc_api.py
+++ b/chia/rpc/harvester_rpc_api.py
@@ -36,6 +36,12 @@ class HarvesterRpcApi:
         if change == "farming_info":
             payloads.append(create_payload_dict("farming_info", change_data, self.service_name, "metrics"))
 
+        if change == "add_connection":
+            payloads.append(create_payload_dict("add_connection", change_data, self.service_name, "metrics"))
+
+        if change == "close_connection":
+            payloads.append(create_payload_dict("close_connection", change_data, self.service_name, "metrics"))
+
         return payloads
 
     async def get_plots(self, request: Dict) -> EndpointResult:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -219,7 +219,7 @@ class WalletRpcApi:
         gives us an opportunity to send notifications to all connected clients via WebSocket.
         """
         payloads = []
-        if change in {"sync_changed", "coin_added"}:
+        if change in {"sync_changed", "coin_added", "add_connection", "close_connection"}:
             # Metrics is the only current consumer for this event
             payloads.append(create_payload_dict(change, change_data, self.service_name, "metrics"))
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -555,6 +555,8 @@ class WalletNode:
         if peer.peer_node_id in self.node_peaks:
             self.node_peaks.pop(peer.peer_node_id)
 
+        self.wallet_state_manager.state_changed("close_connection")
+
     async def on_connect(self, peer: WSChiaConnection):
         if self._wallet_state_manager is None:
             return None


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Adds additional metrics events so chia-exporter can reliably report additional data related to connections for each service as well as know when to update harvester info for remote harvesters (from the farmer)


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Some events not passed to metrics


### New Behavior:
* Additional events passed to metrics destination. 
* `add_connection` event added to harvester on_connect method
* `close_connection` event added to wallet_node
