### PR TITLE
fix reporting of deprecation of plotter install and bladebit2 commands

### DIFF
--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -452,12 +452,19 @@ def call_plotters(root_path: Path, args):
     deprecation_warning = (
         "[DEPRECATED] 'chia plotters install' is no longer available. Use install-plotter.sh/ps1 instead."
     )
-    install_parser = subparsers.add_parser("install", help=deprecation_warning)
-    install_parser.add_argument("install_plotter", type=str, nargs="*")
+    subparsers.add_parser("install", help=deprecation_warning, add_help=False)
 
     deprecation_warning_bb2 = "[DEPRECATED] 'chia plotters bladebit2' was integrated to 'chia plotters bladebit'"
-    bladebit2_parser = subparsers.add_parser("bladebit2", help=deprecation_warning_bb2)
-    bladebit2_parser.add_argument("bladebit2_plotter", type=str, nargs="*")
+    subparsers.add_parser("bladebit2", help=deprecation_warning_bb2, add_help=False)
+
+    known_args = plotters.parse_known_args(args)
+    maybe_plotter = vars(known_args[0]).get("plotter")
+    if maybe_plotter == "install":
+        print(deprecation_warning)
+        return
+    elif maybe_plotter == "bladebit2":
+        print(deprecation_warning_bb2)
+        return
 
     args = plotters.parse_args(args)
 
@@ -471,10 +478,6 @@ def call_plotters(root_path: Path, args):
         plot_bladebit(args, chia_root_path, root_path)
     elif args.plotter == "version":
         show_plotters_version(chia_root_path)
-    elif args.plotter == "install":
-        print(deprecation_warning)
-    elif args.plotter == "bladebit2":
-        print(deprecation_warning_bb2)
 
 
 def get_available_plotters(root_path) -> Dict[str, Any]:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Make sure that the ~deprecation~ removal messages for `chia plotters install` and `chia plotters bladebit2` are presented even when arguments such as `-h` are passed.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Presently you just get an empty help output for `-h`.

### New Behavior:

You get the message regardless of anything following `chia plotters bladebit2`

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Make sure to test out other commands as well since this fix injects a pre-parsing of the arguments.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
