### PR TITLE
Rate limit 'Rate limiting' message

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -28,6 +28,7 @@ from chia.util.api_decorators import get_metadata
 from chia.util.errors import Err, ProtocolError
 from chia.util.ints import uint8, uint16
 from chia.util.log_exceptions import log_exceptions
+from chia.util.logging import TimedDuplicateFilter
 
 # Each message is prepended with LENGTH_BYTES bytes specifying the length
 from chia.util.network import class_for_type, is_localhost
@@ -549,10 +550,10 @@ class WSChiaConnection:
             message, self.local_capabilities, self.peer_capabilities
         ):
             if not is_localhost(self.peer_host):
-                self.log.debug(
-                    f"Rate limiting ourselves. message type: {ProtocolMessageTypes(message.type).name}, "
-                    f"peer: {self.peer_host}"
-                )
+                msg = f"Rate limiting ourselves. message type: {ProtocolMessageTypes(message.type).name}, "
+                f"peer: {self.peer_host}"
+                self.log.debug(msg)
+                self.log.addFilter(TimedDuplicateFilter(msg, 60))
 
                 # TODO: fix this special case. This function has rate limits which are too low.
                 if ProtocolMessageTypes(message.type) != ProtocolMessageTypes.respond_peers:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This change reduces `Rate Limit` log message spam when rate limiting Chia protocol messages.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Currently, we can easily log 1000 messages per minute to the log. e.g.
"Rate limiting ourselves. message type: respond_transaction, peer: x.y.z.z"


### New Behavior:
Only log one message per minute for the exact same message.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
See `tests/util/test_logging_filter.py`


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
