### PR TITLE
Install Python 3.10 for Debian Bookworm install script test

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -191,6 +191,13 @@ jobs:
         apt-get --yes update
         apt-get install --yes git lsb-release sudo
 
+    - name: Prepare Debian Bookworm with Python 3.10
+      if: ${{ matrix.distribution.name == 'debian:bookworm' }}
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get install --yes python3.10
+
     - name: Prepare Fedora
       if: ${{ matrix.distribution.type == 'fedora' }}
       run: |


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fix build failures on the Python 3.7-3.10 compatible `release/1.7.0` branch such as https://github.com/Chia-Network/chia-blockchain/actions/runs/4049779693/jobs/6966809985.

NOTE: We do not want this change retained for `main`.  Either we do a special checkpoint that ignores the change while tracking the history or we do a regular checkpoint and then revert it after it is merged to `main`.  I _think_ that both will work.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The Debian Bookworm install script test uses Python 3.11 after a recent upstream change.

### New Behavior:

The Debian Bookworm install script test installs Python 3.10 so it is available for use by our install script.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Check CI.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
