### PR TITLE
full_node: Drop unused `FullNode._num_needed_peers`

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -877,11 +877,6 @@ class FullNode:
         # Remove all ph | coin id subscription for this peer
         self.subscriptions.remove_peer(connection.peer_node_id)
 
-    def _num_needed_peers(self) -> int:
-        assert self.server.all_connections is not None
-        diff: int = int(self.config["target_peer_count"]) - len(self.server.all_connections)
-        return diff if diff >= 0 else 0
-
     def _close(self) -> None:
         self._shut_down = True
         if self._init_weight_proof is not None:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Remove the broken (because it also includes wallet/farmers in the calculation) and unused (probably leftover from when the node discovery stuff was moved into `node_discovery.py`) method `FullNode._num_needed_peers`.


### New Behavior:

No change in behaviour.