### PR TITLE
Add cost logging to CLVM tests as fixture

### DIFF
--- a/tests/clvm/test_singletons.py
+++ b/tests/clvm/test_singletons.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple
 import pytest
 from blspy import AugSchemeMPL, G1Element, G2Element, PrivateKey
 
-from chia.clvm.spend_sim import SimClient, SpendSim, sim_and_client
+from chia.clvm.spend_sim import CostLogger, SimClient, SpendSim, sim_and_client
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -59,12 +59,16 @@ class TestSingleton:
         coinsols: List[CoinSpend],
         ex_error: Optional[Err] = None,
         fail_msg: str = "",
+        cost_logger: Optional[CostLogger] = None,
+        cost_log_msg: str = "",
     ):
         signature: G2Element = self.sign_delegated_puz(delegated_puzzle, coin)
         spend_bundle = SpendBundle(
             coinsols,
             signature,
         )
+        if cost_logger is not None:
+            spend_bundle = cost_logger.add_cost(cost_log_msg, spend_bundle)
 
         try:
             result, error = await sim_client.push_tx(spend_bundle)
@@ -79,7 +83,7 @@ class TestSingleton:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("version", [0, 1])
-    async def test_singleton_top_layer(self, version):
+    async def test_singleton_top_layer(self, version, cost_logger):
         async with sim_and_client() as (sim, sim_client):
             # START TESTS
             # Generate starting info
@@ -133,6 +137,8 @@ class TestSingleton:
                 starting_coin,
                 delegated_puzzle,
                 [starting_coinsol, launcher_coinsol],
+                cost_logger=cost_logger,
+                cost_log_msg="Singleton Launch + Standard TX",
             )
 
             # EVE
@@ -180,6 +186,8 @@ class TestSingleton:
                 singleton_eve,
                 delegated_puzzle,
                 [singleton_eve_coinsol],
+                cost_logger=cost_logger,
+                cost_log_msg="Singleton Eve Spend w/ Standard TX",
             )
 
             # POST-EVE
@@ -205,6 +213,8 @@ class TestSingleton:
                 singleton,
                 delegated_puzzle,
                 [singleton_coinsol],
+                cost_logger=cost_logger,
+                cost_log_msg="Singleton Spend + Standard TX",
             )
 
             # CLAIM A P2_SINGLETON
@@ -247,7 +257,13 @@ class TestSingleton:
             )
 
             await self.make_and_spend_bundle(
-                sim, sim_client, singleton_child, delegated_puzzle, [singleton_claim_coinsol, claim_coinsol]
+                sim,
+                sim_client,
+                singleton_child,
+                delegated_puzzle,
+                [singleton_claim_coinsol, claim_coinsol],
+                cost_logger=cost_logger,
+                cost_log_msg="Singleton w/ Standard TX claim p2_singleton",
             )
 
             # CLAIM A P2_SINGLETON_OR_DELAYED
@@ -303,7 +319,13 @@ class TestSingleton:
                 sim.get_height()
             )  # The last coin solution before this point is singleton_claim_coinsol
             await self.make_and_spend_bundle(
-                sim, sim_client, singleton_child, delegated_puzzle, [delay_claim_coinsol, claim_coinsol]
+                sim,
+                sim_client,
+                singleton_child,
+                delegated_puzzle,
+                [delay_claim_coinsol, claim_coinsol],
+                cost_logger=cost_logger,
+                cost_log_msg="Singleton w/ Standard TX claim p2_singleton_or_delayed",
             )
 
             # TRY TO SPEND AWAY TOO SOON (Negative Test)
@@ -513,6 +535,8 @@ class TestSingleton:
                 singleton_child,
                 delegated_puzzle,
                 [melt_coinsol],
+                cost_logger=cost_logger,
+                cost_log_msg="Singleton w/ Standard TX melt",
             )
 
             melted_coin: Coin = (await sim.all_non_reward_coins())[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ import pytest_asyncio
 from _pytest.fixtures import SubRequest
 
 # Set spawn after stdlib imports, but before other imports
+from chia.clvm.spend_sim import CostLogger
 from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol
@@ -748,3 +749,12 @@ def chia_root_fixture(tmp_path: Path, scripts_path: Path) -> ChiaRoot:
     root.run(args=["configure", "--set-log-level", "INFO"])
 
     return root
+
+
+@pytest.fixture(name="cost_logger", scope="session")
+def cost_logger_fixture() -> Iterator[CostLogger]:
+    cost_logger = CostLogger()
+    yield cost_logger
+    print()
+    print()
+    print(cost_logger.log_cost_statistics())

--- a/tests/wallet/db_wallet/test_db_graftroot.py
+++ b/tests/wallet/db_wallet/test_db_graftroot.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 import pytest
 from blspy import G2Element
 
-from chia.clvm.spend_sim import sim_and_client
+from chia.clvm.spend_sim import CostLogger, sim_and_client
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -39,7 +39,7 @@ NIL_PH = Program.to(None).get_tree_hash()
 
 
 @pytest.mark.asyncio
-async def test_graftroot() -> None:
+async def test_graftroot(cost_logger: CostLogger) -> None:
     async with sim_and_client() as (sim, sim_client):
         # Create the coin we're testing
         all_values: List[bytes32] = [bytes32([x] * 32) for x in range(0, 100)]
@@ -117,6 +117,10 @@ async def test_graftroot() -> None:
 
             # If this is the satisfactory merkle tree
             if filtered_values == all_values:
+                cost_logger.add_cost(
+                    "DL Graftroot - fake singleton w/ announce + prove two rows in a DL merkle tree + create one child",
+                    final_bundle,
+                )
                 assert result == (MempoolInclusionStatus.SUCCESS, None)
                 # clear the mempool
                 same_height = sim.block_height


### PR DESCRIPTION
### Purpose:
This PR adds an easy way for tests to bring in a fixture that they can pass spendbundles to in order for the cost of those spendbundles to be printed at the end of tests.  Useful for optimizing Chialisp.