### PR TITLE
Separate JSON and formatted output for fee estimates

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -11,6 +11,7 @@ from chia.cmds.configure import configure_cmd
 from chia.cmds.data import data_cmd
 from chia.cmds.db import db_cmd
 from chia.cmds.farm import farm_cmd
+from chia.cmds.fees import fees_cmd
 from chia.cmds.init import init_cmd
 from chia.cmds.keys import keys_cmd
 from chia.cmds.netspace import netspace_cmd
@@ -125,6 +126,7 @@ cli.add_command(peer_cmd)
 cli.add_command(data_cmd)
 cli.add_command(passphrase_cmd)
 cli.add_command(beta_cmd)
+cli.add_command(fees_cmd)
 
 
 def main() -> None:

--- a/chia/cmds/fees.py
+++ b/chia/cmds/fees.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Optional
 
 import click
@@ -12,7 +13,7 @@ async def print_fee_info(node_client: FullNodeRpcClient, json_flag: bool) -> Non
     target_times_names = ["1  minute", "2 minutes", "5 minutes"]
     res = await node_client.get_fee_estimate(target_times=target_times, cost=1)
     if json_flag:
-        print(res)
+        print(json.dumps(res))
         return
 
     print("\n")

--- a/chia/cmds/fees.py
+++ b/chia/cmds/fees.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from chia.rpc.full_node_rpc_client import FullNodeRpcClient
+
+
+async def print_fee_info(node_client: FullNodeRpcClient, json_flag: bool) -> None:
+    target_times = [60, 120, 300]
+    target_times_names = ["1  minute", "2 minutes", "5 minutes"]
+    res = await node_client.get_fee_estimate(target_times=target_times, cost=1)
+    if json_flag:
+        print(res)
+        return
+
+    print("\n")
+    print(f"  Mempool max cost: {res['mempool_max_size']:>12} CLVM cost")
+    print(f"      Mempool cost: {res['mempool_size']:>12} CLVM cost")
+    print(f"     Mempool count: {res['num_spends']:>12} spends")
+    print(f"   Fees in Mempool: {res['mempool_fees']:>12} mojos")
+    print()
+
+    print("Stats for last transaction block:")
+    print(f"      Block height: {res['last_tx_block_height']:>12}")
+    print(f"        Block fees: {res['fees_last_block']:>12} mojos")
+    print(f"        Block cost: {res['last_block_cost']:>12} CLVM cost")
+    print(f"          Fee rate: {res['fee_rate_last_block']:>12.5} mojos per CLVM cost")
+
+    print("\nFee Rate Estimates:")
+    max_name_len = max(len(name) for name in target_times_names)
+    for (n, e) in zip(target_times_names, res["estimates"]):
+        print(f"    {n:>{max_name_len}}: {e} mojo per CLVM cost")
+    print("")
+
+
+@click.command("fees", short_help="Show network fee estimates")
+@click.option(
+    "-p",
+    "--rpc-port",
+    help=(
+        "Set the port where the Full Node is hosting the RPC interface. "
+        "See the rpc_port under full_node in config.yaml"
+    ),
+    type=int,
+    default=None,
+)
+@click.option(
+    "-j",
+    "--json",
+    is_flag=True,
+    help="print json",
+)
+@click.pass_context
+async def fees_cmd(rpc_port: Optional[int], root_path: Path, json_flag: bool) -> None:
+    from chia.cmds.cmds_util import get_any_service_client
+
+    node_client: Optional[FullNodeRpcClient]
+    async with get_any_service_client("full_node", rpc_port, root_path) as node_config_fp:
+        node_client, config, _ = node_config_fp
+        if node_client is not None:
+            await print_fee_info(node_client, json_flag)

--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -25,7 +25,6 @@ from chia.cmds.show_funcs import show_async
     type=int,
     default=None,
 )
-@click.option("-f", "--fee", help="Show the fee information", is_flag=True, type=bool, default=False)
 @click.option("-s", "--state", help="Show the current state of the blockchain", is_flag=True, type=bool, default=False)
 @click.option(
     "-c", "--connections", help="List nodes connected to this Full Node", is_flag=True, type=bool, default=False
@@ -43,7 +42,6 @@ def show_cmd(
     ctx: click.Context,
     rpc_port: Optional[int],
     wallet_rpc_port: Optional[int],
-    fee: bool,
     state: bool,
     connections: bool,
     add_connection: str,
@@ -65,7 +63,6 @@ def show_cmd(
         show_async(
             rpc_port,
             ctx.obj["root_path"],
-            fee,
             state,
             block_header_hash_by_height,
             block_by_header_hash,

--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -160,35 +160,9 @@ async def print_block_from_hash(
         print("Block with header hash", block_by_header_hash, "not found")
 
 
-async def print_fee_info(node_client: FullNodeRpcClient) -> None:
-    target_times = [60, 120, 300]
-    target_times_names = ["1  minute", "2 minutes", "5 minutes"]
-    res = await node_client.get_fee_estimate(target_times=target_times, cost=1)
-    print(res)
-    print("\n")
-    print(f"  Mempool max cost: {res['mempool_max_size']:>12} CLVM cost")
-    print(f"      Mempool cost: {res['mempool_size']:>12} CLVM cost")
-    print(f"     Mempool count: {res['num_spends']:>12} spends")
-    print(f"   Fees in Mempool: {res['mempool_fees']:>12} mojos")
-    print()
-
-    print("Stats for last transaction block:")
-    print(f"      Block height: {res['last_tx_block_height']:>12}")
-    print(f"        Block fees: {res['fees_last_block']:>12} mojos")
-    print(f"        Block cost: {res['last_block_cost']:>12} CLVM cost")
-    print(f"          Fee rate: {res['fee_rate_last_block']:>12.5} mojos per CLVM cost")
-
-    print("\nFee Rate Estimates:")
-    max_name_len = max(len(name) for name in target_times_names)
-    for (n, e) in zip(target_times_names, res["estimates"]):
-        print(f"    {n:>{max_name_len}}: {e} mojo per CLVM cost")
-    print("")
-
-
 async def show_async(
     rpc_port: Optional[int],
     root_path: Path,
-    print_fee_info_flag: bool,
     print_state: bool,
     block_header_hash_by_height: str,
     block_by_header_hash: str,
@@ -203,8 +177,6 @@ async def show_async(
             if print_state:
                 if await print_blockchain_state(node_client, config) is True:
                     return None  # if no blockchain is found
-            if print_fee_info_flag:
-                await print_fee_info(node_client)
             # Get Block Information
             if block_header_hash_by_height != "":
                 block_header = await node_client.get_block_record_by_height(block_header_hash_by_height)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Improve command line fee estimation interface.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
```
chia show -f

{'current_fee_rate': 0, 'estimates': [0, 0, 0], 'fee_rate_last_block': 0.48706430336139517, 'fees_last_block': 534621015, 'full_node_synced': False, 'last_block_cost': 1097639493, 'last_peak_timestamp': 1674568819, 'last_tx_block_height': 3151602, 'mempool_fees': 0, 'mempool_max_size': 0, 'mempool_size': 0, 'node_time_utc': 1675189415, 'num_spends': 0, 'peak_height': 3151602, 'success': True, 'target_times': [60, 120, 300]}


  Mempool max cost:            0 CLVM cost
      Mempool cost:            0 CLVM cost
     Mempool count:            0 spends
   Fees in Mempool:            0 mojos

Stats for last transaction block:
      Block height:      3151602
        Block fees:    534621015 mojos
        Block cost:   1097639493 CLVM cost
          Fee rate:      0.48706 mojos per CLVM cost

Fee Rate Estimates:
    1  minute: 0 mojo per CLVM cost
    2 minutes: 0 mojo per CLVM cost
    5 minutes: 0 mojo per CLVM cost
```


### New Behavior:

```
chia fees -j

{'current_fee_rate': 0, 'estimates': [0, 0, 0], 'fee_rate_last_block': 0.48706430336139517, 'fees_last_block': 534621015, 'full_node_synced': False, 'last_block_cost': 1097639493, 'last_peak_timestamp': 1674568819, 'last_tx_block_height': 3151602, 'mempool_fees': 0, 'mempool_max_size': 0, 'mempool_size': 0, 'node_time_utc': 1675189415, 'num_spends': 0, 'peak_height': 3151602, 'success': True, 'target_times': [60, 120, 300]}
```

```
chia fees

  Mempool max cost:            0 CLVM cost
      Mempool cost:            0 CLVM cost
     Mempool count:            0 spends
   Fees in Mempool:            0 mojos

Stats for last transaction block:
      Block height:      3151602
        Block fees:    534621015 mojos
        Block cost:   1097639493 CLVM cost
          Fee rate:      0.48706 mojos per CLVM cost

Fee Rate Estimates:
    1  minute: 0 mojo per CLVM cost
    2 minutes: 0 mojo per CLVM cost
    5 minutes: 0 mojo per CLVM cost
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
