### PR TITLE
Output proper json

### DIFF
--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -164,7 +165,7 @@ async def print_fee_info(node_client: FullNodeRpcClient) -> None:
     target_times = [60, 120, 300]
     target_times_names = ["1  minute", "2 minutes", "5 minutes"]
     res = await node_client.get_fee_estimate(target_times=target_times, cost=1)
-    print(res)
+    print(json.dumps(res))
     print("\n")
     print(f"  Mempool max cost: {res['mempool_max_size']:>12} CLVM cost")
     print(f"      Mempool cost: {res['mempool_size']:>12} CLVM cost")


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Make command line output more useful.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
```
chia show -f

{'current_fee_rate': 454, 'estimates': [454, 454, 0], 'fee_rate_last_block': 1.0029639450087947e-08, 'fees_last_block': 5, 'full_node_synced': True, 'last_block_cost': 498522407, 'last_peak_timestamp': 1675196587, 'last_tx_block_height': 3185271, 'mempool_fees': 0, 'mempool_max_size': 550000000000, 'mempool_size': 269563905, 'node_time_utc': 1675196654, 'num_spends': 5, 'peak_height': 3185273, 'success': True, 'target_times': [60, 120, 300]}
```


### New Behavior:

```
chia show -f

{"current_fee_rate": 454, "estimates": [454, 454, 0], "fee_rate_last_block": 0.0, "fees_last_block": 0, "full_node_synced": true, "last_block_cost": 114210342, "last_peak_timestamp": 1675198056, "last_tx_block_height": 3185347, "mempool_fees": 3, "mempool_max_size": 550000000000, "mempool_size": 551006798, "node_time_utc": 1675198088, "num_spends": 4, "peak_height": 3185348, "success": true, "target_times": [60, 120, 300]}
```


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
