### PR TITLE
Return a better error message when the 'coin_id' argument for nft_get_info cannot be decoded into a 32 byte hex string

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2530,7 +2530,10 @@ class WalletRpcApi:
         if coin_id.startswith(AddressType.NFT.hrp(self.service.config)):
             coin_id = decode_puzzle_hash(coin_id)
         else:
-            coin_id = bytes32.from_hexstr(coin_id)
+            try:
+                coin_id = bytes32.from_hexstr(coin_id)
+            except ValueError:
+                return {"success": False, "error": f"Invalid Coin ID format for 'coin_id' {request['coin_id']}"}
         # Get coin state
         peer: Optional[WSChiaConnection] = self.service.get_full_node_peer()
         assert peer is not None

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2533,7 +2533,7 @@ class WalletRpcApi:
             try:
                 coin_id = bytes32.from_hexstr(coin_id)
             except ValueError:
-                return {"success": False, "error": f"Invalid Coin ID format for 'coin_id' {request['coin_id']}"}
+                return {"success": False, "error": f"Invalid Coin ID format for 'coin_id': {request['coin_id']!r}"}
         # Get coin state
         peer: Optional[WSChiaConnection] = self.service.get_full_node_peer()
         assert peer is not None


### PR DESCRIPTION
Return a better error message when the 'coin_id' argument for nft_get_info cannot be decoded into a 32 byte hex string.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fix error reporting.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Leave an exception in the log when interpreting 'coin_id' as a hex encoded bytes32

### New Behavior:

Return error message `Invalid Coin ID format for 'coin_id': <<contents>>`

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

See https://github.com/Chia-Network/chia-blockchain/pull/new/ak.fix-14453

Reporter: @esaung 

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
