### PR TITLE
Don't print entire TransactionRecord to log file

### DIFF
--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -141,7 +141,10 @@ class Wallet:
         for record in unconfirmed_tx:
             if not record.is_in_mempool():
                 if record.spend_bundle is not None:
-                    self.log.warning(f"Record: {record} not in mempool, {record.sent_to}")
+                    self.log.warning(
+                        f"TransactionRecord SpendBundle ID: {record.spend_bundle.name()} not in mempool. "
+                        f"(peer, included, error) list: {record.sent_to}"
+                    )
                 continue
             our_spend = False
             for coin in record.removals:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Cleanup log file.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

See https://github.com/Chia-Network/chia-blockchain/issues/14452

### New Behavior:

Log line will look like:

`TransactionRecord SpendBundle ID: {record.spend_bundle.name()} not in mempool. (peer, included, error) list: {record.sent_to}`

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

See https://github.com/Chia-Network/chia-blockchain/issues/14452

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
