### PR TITLE
full_node: Rename some `receive`/`respond` prefixes to `add`

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2438,7 +2438,7 @@ class FullNode:
             )
             response = await peer.call_api(FullNodeAPI.request_compact_vdf, peer_request, timeout=10)
             if response is not None and isinstance(response, full_node_protocol.RespondCompactVDF):
-                await self.respond_compact_vdf(response, peer)
+                await self.add_compact_vdf(response, peer)
 
     async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection) -> None:
         header_block = await self.blockchain.get_header_block_by_height(
@@ -2484,7 +2484,7 @@ class FullNode:
         msg = make_msg(ProtocolMessageTypes.respond_compact_vdf, compact_vdf)
         await peer.send_message(msg)
 
-    async def respond_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:
+    async def add_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:
         field_vdf = CompressibleVDFField(int(request.field_vdf))
         if not await self._can_accept_compact_proof(
             request.vdf_info, request.vdf_proof, request.height, request.header_hash, field_vdf

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -442,7 +442,7 @@ class FullNode:
     async def _handle_one_transaction(self, entry: TransactionQueueEntry) -> None:
         peer = entry.peer
         try:
-            inc_status, err = await self.respond_transaction(entry.transaction, entry.spend_name, peer, entry.test)
+            inc_status, err = await self.add_transaction(entry.transaction, entry.spend_name, peer, entry.test)
             self.transaction_responses.append((entry.spend_name, inc_status, err))
             if len(self.transaction_responses) > 50:
                 self.transaction_responses = self.transaction_responses[1:]
@@ -2190,7 +2190,7 @@ class FullNode:
                 )
         return None, False
 
-    async def respond_transaction(
+    async def add_transaction(
         self,
         transaction: SpendBundle,
         spend_name: bytes32,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -578,7 +578,7 @@ class FullNode:
                     raise ValueError(f"Error short batch syncing, invalid/no response for {height}-{end_height}")
                 async with self._blockchain_lock_high_priority:
                     state_change_summary: Optional[StateChangeSummary]
-                    success, state_change_summary = await self.receive_block_batch(response.blocks, peer, None)
+                    success, state_change_summary = await self.add_block_batch(response.blocks, peer, None)
                     if not success:
                         raise ValueError(f"Error short batch syncing, failed to validate blocks {height}-{end_height}")
                     if state_change_summary is not None:
@@ -1110,7 +1110,7 @@ class FullNode:
                 peer, blocks = res
                 start_height = blocks[0].height
                 end_height = blocks[-1].height
-                success, state_change_summary = await self.receive_block_batch(
+                success, state_change_summary = await self.add_block_batch(
                     blocks, peer, None if advanced_peak else uint32(fork_point_height), summaries
                 )
                 if success is False:
@@ -1211,7 +1211,7 @@ class FullNode:
             msg = make_msg(ProtocolMessageTypes.coin_state_update, state)
             await ws_peer.send_message(msg)
 
-    async def receive_block_batch(
+    async def add_block_batch(
         self,
         all_blocks: List[FullBlock],
         peer: WSChiaConnection,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2403,7 +2403,7 @@ class FullNode:
                 )
                 raise
 
-    async def respond_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
+    async def add_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
         field_vdf = CompressibleVDFField(int(request.field_vdf))
         if not await self._can_accept_compact_proof(
             request.vdf_info, request.vdf_proof, request.height, request.header_hash, field_vdf

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1785,19 +1785,18 @@ class FullNode:
                 self._segment_task = asyncio.create_task(self.weight_proof_handler.create_prev_sub_epoch_segments())
         return None
 
-    async def respond_unfinished_block(
+    async def add_unfinished_block(
         self,
-        respond_unfinished_block: full_node_protocol.RespondUnfinishedBlock,
+        block: UnfinishedBlock,
         peer: Optional[WSChiaConnection],
         farmed_block: bool = False,
         block_bytes: Optional[bytes] = None,
     ) -> None:
         """
         We have received an unfinished block, either created by us, or from another peer.
-        We can validate it and if it's a good block, propagate it to other peers and
+        We can validate and add it and if it's a good block, propagate it to other peers and
         timelords.
         """
-        block = respond_unfinished_block.unfinished_block
         receive_time = time.time()
 
         if block.prev_header_hash != self.constants.GENESIS_CHALLENGE and not self.blockchain.contains_block(

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1450,7 +1450,7 @@ class FullNodeAPI:
     async def respond_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:
         if self.full_node.sync_store.get_sync_mode():
             return None
-        await self.full_node.respond_compact_vdf(request, peer)
+        await self.full_node.add_compact_vdf(request, peer)
         return None
 
     @api_request(peer_required=True)

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -465,8 +465,8 @@ class FullNodeAPI:
     ) -> Optional[Message]:
         if self.full_node.sync_store.get_sync_mode():
             return None
-        await self.full_node.respond_unfinished_block(
-            respond_unfinished_block, peer, block_bytes=respond_unfinished_block_bytes
+        await self.full_node.add_unfinished_block(
+            respond_unfinished_block.unfinished_block, peer, block_bytes=respond_unfinished_block_bytes
         )
         return None
 
@@ -1008,12 +1008,11 @@ class FullNodeAPI:
             return None
 
         # Propagate to ourselves (which validates and does further propagations)
-        request = full_node_protocol.RespondUnfinishedBlock(new_candidate)
         try:
-            await self.full_node.respond_unfinished_block(request, None, True)
+            await self.full_node.add_unfinished_block(new_candidate, None, True)
         except Exception as e:
             # If we have an error with this block, try making an empty block
-            self.full_node.log.error(f"Error farming block {e} {request}")
+            self.full_node.log.error(f"Error farming block {e} {new_candidate}")
             candidate_tuple = self.full_node.full_node_store.get_candidate_block(
                 farmer_request.quality_string, backup=True
             )

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1409,7 +1409,7 @@ class FullNodeAPI:
     async def respond_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
         if self.full_node.sync_store.get_sync_mode():
             return None
-        await self.full_node.respond_compact_proof_of_time(request)
+        await self.full_node.add_compact_proof_of_time(request)
         return None
 
     @api_request(peer_required=True, bytes_required=True, execute_task=True)

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -658,7 +658,7 @@ class FullNodeAPI:
     ) -> Optional[Message]:
         if self.full_node.sync_store.get_sync_mode():
             return None
-        msg, _ = await self.full_node.respond_end_of_sub_slot(request, peer)
+        msg, _ = await self.full_node.add_end_of_sub_slot(request.end_of_slot_bundle, peer)
         return msg
 
     @api_request(peer_required=True)
@@ -1070,8 +1070,7 @@ class FullNodeAPI:
         ):
             return None
         # Calls our own internal message to handle the end of sub slot, and potentially broadcasts to other peers.
-        full_node_message = full_node_protocol.RespondEndOfSubSlot(request.end_of_sub_slot_bundle)
-        msg, added = await self.full_node.respond_end_of_sub_slot(full_node_message, peer)
+        msg, added = await self.full_node.add_end_of_sub_slot(request.end_of_sub_slot_bundle, peer)
         if not added:
             self.log.error(
                 f"Was not able to add end of sub-slot: "

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -665,7 +665,7 @@ class FullNodeRpcApi:
             status = MempoolInclusionStatus.SUCCESS
             error = None
         else:
-            status, error = await self.service.respond_transaction(spend_bundle, spend_name)
+            status, error = await self.service.add_transaction(spend_bundle, spend_name)
             if status != MempoolInclusionStatus.SUCCESS:
                 if self.service.mempool_manager.get_spendbundle(spend_name) is not None:
                     # Already in mempool

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -12,7 +12,6 @@ from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.protocols.full_node_protocol import RespondBlock
 from chia.rpc.rpc_server import default_get_connections
 from chia.server.outbound_message import NodeType
 from chia.simulator.block_tools import BlockTools
@@ -225,8 +224,7 @@ class FullNodeSimulator(FullNodeAPI):
                 current_time=current_time,
                 previous_generator=self.full_node.full_node_store.previous_generator,
             )
-            rr = RespondBlock(more[-1])
-        await self.full_node.respond_block(rr)
+        await self.full_node.add_block(more[-1])
         return more[-1]
 
     async def farm_new_block(self, request: FarmNewBlockProtocol, force_wait_for_timestamp: bool = False):
@@ -272,8 +270,7 @@ class FullNodeSimulator(FullNodeAPI):
                 current_time=current_time,
                 time_per_block=time_per_block,
             )
-            rr: RespondBlock = RespondBlock(more[-1])
-        await self.full_node.respond_block(rr)
+        await self.full_node.add_block(more[-1])
 
     async def reorg_from_index_to_new_index(self, request: ReorgProtocol):
         new_index = request.new_index
@@ -297,7 +294,7 @@ class FullNodeSimulator(FullNodeAPI):
         )
 
         for block in more_blocks:
-            await self.full_node.respond_block(RespondBlock(block))
+            await self.full_node.add_block(block)
 
     async def farm_blocks_to_puzzlehash(
         self,

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 from clvm.casts import int_to_bytes
 
-from chia.protocols import full_node_protocol, wallet_protocol
+from chia.protocols import wallet_protocol
 from chia.simulator.block_tools import test_constants
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.announcement import Announcement
@@ -39,7 +39,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block), None)
+            await full_node_api_1.full_node.add_block(block, None)
 
         spend_block = blocks[2]
         spend_coin = None
@@ -72,7 +72,7 @@ class TestBlockchainTransactions:
         )
 
         next_block = new_blocks[-1]
-        await full_node_1.respond_block(full_node_protocol.RespondBlock(next_block))
+        await full_node_1.add_block(next_block)
 
         assert next_block.header_hash == full_node_1.blockchain.get_peak().header_hash
 
@@ -99,7 +99,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         spend_block = blocks[2]
         spend_coin = None
@@ -136,7 +136,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         spend_block = blocks[2]
 
@@ -172,7 +172,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         spend_block = blocks[2]
 
@@ -191,7 +191,7 @@ class TestBlockchainTransactions:
         )
         # Move chain to height 10, with a spend at height 10
         for block in blocks_spend:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Reorg at height 5, add up to and including height 12
         new_blocks = bt.get_consecutive_blocks(
@@ -203,7 +203,7 @@ class TestBlockchainTransactions:
         )
 
         for block in new_blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Spend the same coin in the new reorg chain at height 13
         new_blocks = bt.get_consecutive_blocks(
@@ -239,7 +239,7 @@ class TestBlockchainTransactions:
             seed=b"spend at 12 is ok",
         )
         for block in new_blocks_reorg:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Spend at height 13 is also OK (same height)
         new_blocks_reorg = bt.get_consecutive_blocks(
@@ -251,7 +251,7 @@ class TestBlockchainTransactions:
             seed=b"spend at 13 is ok",
         )
         for block in new_blocks_reorg:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Spend at height 14 is not OK (already spend)
         new_blocks_reorg = bt.get_consecutive_blocks(
@@ -264,7 +264,7 @@ class TestBlockchainTransactions:
         )
         with pytest.raises(ConsensusError):
             for block in new_blocks_reorg:
-                await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api_1.full_node.add_block(block)
 
     @pytest.mark.asyncio
     async def test_validate_blockchain_spend_reorg_coin(self, two_nodes, softfork_height):
@@ -280,7 +280,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         spend_block = blocks[2]
 
@@ -301,7 +301,7 @@ class TestBlockchainTransactions:
             guarantee_transaction_block=True,
         )
 
-        await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
+        await full_node_api_1.full_node.add_block(new_blocks[-1])
 
         coin_2 = None
         for coin in run_and_get_removals_and_additions(
@@ -325,7 +325,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             guarantee_transaction_block=True,
         )
-        await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
+        await full_node_api_1.full_node.add_block(new_blocks[-1])
 
         coin_3 = None
         for coin in run_and_get_removals_and_additions(
@@ -350,7 +350,7 @@ class TestBlockchainTransactions:
             guarantee_transaction_block=True,
         )
 
-        await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
+        await full_node_api_1.full_node.add_block(new_blocks[-1])
 
     @pytest.mark.asyncio
     async def test_validate_blockchain_spend_reorg_cb_coin(self, two_nodes):
@@ -362,7 +362,7 @@ class TestBlockchainTransactions:
         blocks = bt.get_consecutive_blocks(num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash)
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Spends a coinbase created in reorg
         new_blocks = bt.get_consecutive_blocks(
@@ -374,7 +374,7 @@ class TestBlockchainTransactions:
         )
 
         for block in new_blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         spend_block = new_blocks[-1]
         spend_coin = None
@@ -392,7 +392,7 @@ class TestBlockchainTransactions:
             guarantee_transaction_block=True,
         )
 
-        await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
+        await full_node_api_1.full_node.add_block(new_blocks[-1])
 
     @pytest.mark.asyncio
     async def test_validate_blockchain_spend_reorg_since_genesis(self, two_nodes):
@@ -406,7 +406,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         spend_block = blocks[-1]
         spend_coin = None
@@ -418,7 +418,7 @@ class TestBlockchainTransactions:
         new_blocks = bt.get_consecutive_blocks(
             1, blocks, seed=b"", farmer_reward_puzzle_hash=coinbase_puzzlehash, transaction_data=spend_bundle
         )
-        await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
+        await full_node_api_1.full_node.add_block(new_blocks[-1])
 
         # Spends a coin in a genesis reorg, that was already spent
         new_blocks = bt.get_consecutive_blocks(
@@ -430,7 +430,7 @@ class TestBlockchainTransactions:
         )
 
         for block in new_blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         new_blocks = bt.get_consecutive_blocks(
             1,
@@ -440,7 +440,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
         )
 
-        await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[-1]))
+        await full_node_api_1.full_node.add_block(new_blocks[-1])
 
     @pytest.mark.asyncio
     async def test_assert_my_coin_id(self, two_nodes):
@@ -456,7 +456,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
 
@@ -524,7 +524,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -606,7 +606,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -687,7 +687,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -751,7 +751,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -818,7 +818,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -876,7 +876,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -935,7 +935,7 @@ class TestBlockchainTransactions:
         )
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         # Coinbase that gets spent
         block1 = blocks[2]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -476,7 +476,7 @@ async def one_node_one_block() -> AsyncIterator[Tuple[Union[FullNodeAPI, FullNod
     assert blocks[0].height == 0
 
     for block in blocks:
-        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+        await full_node_1.full_node.add_block(block)
 
     await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
 
@@ -508,7 +508,7 @@ async def two_nodes_one_block():
     assert blocks[0].height == 0
 
     for block in blocks:
-        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+        await full_node_1.full_node.add_block(block)
 
     await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
 

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -42,7 +42,7 @@ class TestFullSync:
 
         # Syncs up less than recent blocks
         for block in blocks[: test_constants.WEIGHT_PROOF_RECENT_BLOCKS - 5]:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await server_2.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)), on_connect=full_node_2.full_node.on_connect
@@ -58,7 +58,7 @@ class TestFullSync:
         for block in blocks[
             test_constants.WEIGHT_PROOF_RECENT_BLOCKS - 5 : test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 5
         ]:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await server_3.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)), on_connect=full_node_3.full_node.on_connect
@@ -76,7 +76,7 @@ class TestFullSync:
         for con in cons:
             await con.close()
         for block in blocks[test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 5 :]:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await server_2.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)), on_connect=full_node_2.full_node.on_connect
@@ -106,7 +106,7 @@ class TestFullSync:
         # Deep reorg, fall back from batch sync to long sync
         blocks_node_5 = bt.get_consecutive_blocks(60, block_list_input=blocks[:350], seed=b"node5")
         for block in blocks_node_5:
-            await full_node_5.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_5.full_node.add_block(block)
         await server_5.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)), on_connect=full_node_5.full_node.on_connect
         )
@@ -129,15 +129,15 @@ class TestFullSync:
         server_3 = full_node_3.full_node.server
 
         for block in blocks_950:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         # Node 2 syncs from halfway
         for i in range(int(len(default_1000_blocks) / 2)):
-            await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(default_1000_blocks[i]))
+            await full_node_2.full_node.add_block(default_1000_blocks[i])
 
         # Node 3 syncs from a different blockchain
         for block in blocks_400:
-            await full_node_3.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_3.full_node.add_block(block)
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), full_node_2.full_node.on_connect)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), full_node_3.full_node.on_connect)
@@ -172,7 +172,7 @@ class TestFullSync:
         for con in cons:
             await con.close()
         for block in blocks_rest:
-            await full_node_3.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_3.full_node.add_block(block)
             assert full_node_3.full_node.blockchain.get_peak().height >= block.height
 
         log.warning(f"FN3 height {full_node_3.full_node.blockchain.get_peak().height}")
@@ -197,11 +197,11 @@ class TestFullSync:
 
         # 12 blocks to node_1
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         # 9 different blocks to node_2
         for block in blocks_2:
-            await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_2.full_node.add_block(block)
 
         await server_2.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)),
@@ -218,7 +218,7 @@ class TestFullSync:
 
         # 3 blocks to node_1 in different sub slots
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await server_2.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)),
@@ -234,7 +234,7 @@ class TestFullSync:
 
         # 3 blocks to node_1 in different sub slots
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await server_2.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)),
@@ -253,11 +253,11 @@ class TestFullSync:
         server_3 = full_node_3.full_node.server
 
         for block in blocks_a:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
         for block in blocks_b:
-            await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_2.full_node.add_block(block)
         for block in blocks_c:
-            await full_node_3.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_3.full_node.add_block(block)
 
         await server_2.start_client(
             PeerInfo(self_hostname, uint16(server_1._port)),
@@ -293,11 +293,11 @@ class TestFullSync:
         server_3 = full_node_3.full_node.server
         full_node_3.full_node.weight_proof_handler = None
         for block in blocks_750:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
         # Node 3 syncs from a different blockchain
 
         for block in default_1500_blocks[:1100]:
-            await full_node_3.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_3.full_node.add_block(block)
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), full_node_2.full_node.on_connect)
 
@@ -322,7 +322,7 @@ class TestFullSync:
         await asyncio.sleep(2)
         assert not full_node_2.full_node.sync_store.get_sync_mode()
         for block in default_1000_blocks[1000 - num_blocks_initial :]:
-            await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_2.full_node.add_block(block)
 
         assert node_height_exactly(full_node_2, 999)
 
@@ -339,7 +339,7 @@ class TestFullSync:
 
         # load blocks into node 1
         for block in blocks[:501]:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         peak1 = full_node_1.full_node.blockchain.get_peak()
         assert peak1 is not None
@@ -390,7 +390,7 @@ class TestFullSync:
         )
 
         for block in blocks_950:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), full_node_2.full_node.on_connect)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), full_node_3.full_node.on_connect)

--- a/tests/core/full_node/stores/test_hint_store.py
+++ b/tests/core/full_node/stores/test_hint_store.py
@@ -6,7 +6,6 @@ import pytest
 from clvm.casts import int_to_bytes
 
 from chia.full_node.hint_store import HintStore
-from chia.protocols.full_node_protocol import RespondBlock
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -118,7 +117,7 @@ class TestHintStore:
             pool_reward_puzzle_hash=bt.pool_ph,
         )
         for block in blocks:
-            await full_node_1.full_node.respond_block(RespondBlock(block), None)
+            await full_node_1.full_node.add_block(block, None)
 
         wt: WalletTool = bt.get_pool_wallet_tool()
         puzzle_hash = bytes32(32 * b"\0")
@@ -140,7 +139,7 @@ class TestHintStore:
         )
 
         for block in blocks[-10:]:
-            await full_node_1.full_node.respond_block(RespondBlock(block), None)
+            await full_node_1.full_node.add_block(block, None)
 
         get_hint = await full_node_1.full_node.hint_store.get_coin_ids(hint)
 

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -917,7 +917,7 @@ class TestFullNodeProtocol:
         await time_out_assert(10, new_transaction_not_requested, True, incoming_queue, new_transaction)
 
         # Idempotence in resubmission
-        status, err = await full_node_1.full_node.respond_transaction(
+        status, err = await full_node_1.full_node.add_transaction(
             successful_bundle, successful_bundle.name(), peer, test=True
         )
         assert status == MempoolInclusionStatus.SUCCESS
@@ -935,7 +935,7 @@ class TestFullNodeProtocol:
         await full_node_1.new_transaction(new_transaction, fake_peer)
 
         # Cannot resubmit transaction, but not because of ALREADY_INCLUDING
-        status, err = await full_node_1.full_node.respond_transaction(
+        status, err = await full_node_1.full_node.add_transaction(
             successful_bundle, successful_bundle.name(), peer, test=True
         )
         assert status == MempoolInclusionStatus.FAILED
@@ -954,7 +954,7 @@ class TestFullNodeProtocol:
             await full_node_1.full_node.add_block(block, peer)
 
         # Can now resubmit a transaction after the reorg
-        status, err = await full_node_1.full_node.respond_transaction(
+        status, err = await full_node_1.full_node.add_transaction(
             successful_bundle, successful_bundle.name(), peer, test=True
         )
         assert err is None

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -614,7 +614,7 @@ class TestFullNodeProtocol:
         for slot in blocks[-1].finished_sub_slots:
             await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
 
-        await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), None)
+        await full_node_1.full_node.add_unfinished_block(unf, None)
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
 
         # Do the same thing but with non-genesis
@@ -643,7 +643,7 @@ class TestFullNodeProtocol:
         for slot in blocks[-1].finished_sub_slots:
             await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
 
-        await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), None)
+        await full_node_1.full_node.add_unfinished_block(unf, None)
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
 
         # Do the same thing one more time, with overflow
@@ -668,7 +668,7 @@ class TestFullNodeProtocol:
         for slot in blocks[-1].finished_sub_slots:
             await full_node_1.respond_end_of_sub_slot(fnp.RespondEndOfSubSlot(slot), peer)
 
-        await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), None)
+        await full_node_1.full_node.add_unfinished_block(unf, None)
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
 
         # This next section tests making unfinished block with transactions, and then submitting the finished block
@@ -709,7 +709,7 @@ class TestFullNodeProtocol:
             [],
         )
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is None
-        await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), None)
+        await full_node_1.full_node.add_unfinished_block(unf, None)
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
         result = full_node_1.full_node.full_node_store.get_unfinished_block_result(unf.partial_hash)
         assert result is not None
@@ -1183,7 +1183,7 @@ class TestFullNodeProtocol:
         # Don't have
         res = await full_node_1.new_unfinished_block(fnp.NewUnfinishedBlock(unf.partial_hash))
         assert res is not None
-        await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), peer)
+        await full_node_1.full_node.add_unfinished_block(unf, peer)
 
         # Have
         res = await full_node_1.new_unfinished_block(fnp.NewUnfinishedBlock(unf.partial_hash))
@@ -1334,7 +1334,7 @@ class TestFullNodeProtocol:
         res = await full_node_1.new_unfinished_block(fnp.NewUnfinishedBlock(unf.partial_hash))
         assert res is not None
         with pytest.raises(ConsensusError, match=f"{str(expected).split('.')[1]}"):
-            await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), peer)
+            await full_node_1.full_node.add_unfinished_block(unf, peer)
 
     @pytest.mark.asyncio
     async def test_double_blocks_same_pospace(self, wallet_nodes, self_hostname):
@@ -1370,7 +1370,7 @@ class TestFullNodeProtocol:
             block.transactions_generator,
             [],
         )
-        await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), dummy_peer)
+        await full_node_1.full_node.add_unfinished_block(unf, dummy_peer)
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash)
 
         block_2 = recursive_replace(
@@ -1411,7 +1411,7 @@ class TestFullNodeProtocol:
         # Don't have
         res = await full_node_1.request_unfinished_block(fnp.RequestUnfinishedBlock(unf.partial_hash))
         assert res is None
-        await full_node_1.full_node.respond_unfinished_block(fnp.RespondUnfinishedBlock(unf), peer)
+        await full_node_1.full_node.add_unfinished_block(unf, peer)
         # Have
         res = await full_node_1.request_unfinished_block(fnp.RequestUnfinishedBlock(unf.partial_hash))
         assert res is not None

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1887,7 +1887,7 @@ class TestFullNodeProtocol:
         for invalid_compact_proof in timelord_protocol_invalid_messages:
             await full_node_1.full_node.respond_compact_proof_of_time(invalid_compact_proof)
         for invalid_compact_proof in full_node_protocol_invalid_messaages:
-            await full_node_1.full_node.respond_compact_vdf(invalid_compact_proof, peer)
+            await full_node_1.full_node.add_compact_vdf(invalid_compact_proof, peer)
         stored_blocks = await full_node_1.get_all_full_blocks()
         for block in stored_blocks:
             for sub_slot in block.finished_sub_slots:

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -383,7 +383,7 @@ class TestFullNodeBlockCompression:
 
             # Test revert previous_generator
             for block in reog_blocks:
-                await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_1.full_node.add_block(block)
             assert full_node_1.full_node.full_node_store.previous_generator is None
 
 
@@ -439,14 +439,14 @@ class TestFullNodeProtocol:
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         blocks = bt.get_consecutive_blocks(1)
         for block in blocks[:1]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
+            await full_node_1.full_node.add_block(block, peer)
 
         await time_out_assert(10, time_out_messages(incoming_queue, "new_peak", 1))
 
         assert full_node_1.full_node.blockchain.get_peak().height == 0
 
         for block in bt.get_consecutive_blocks(30):
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
+            await full_node_1.full_node.add_block(block, peer)
 
         assert full_node_1.full_node.blockchain.get_peak().height == 29
 
@@ -491,7 +491,7 @@ class TestFullNodeProtocol:
         # Add some blocks
         blocks = bt.get_consecutive_blocks(4, block_list_input=blocks)
         for block in blocks[-5:]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
+            await full_node_1.full_node.add_block(block, peer)
         await time_out_assert(10, time_out_messages(incoming_queue, "new_peak", 5))
         blocks = bt.get_consecutive_blocks(1, skip_slots=2, block_list_input=blocks)
 
@@ -535,7 +535,7 @@ class TestFullNodeProtocol:
 
         # Add all blocks
         for block in blocks:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
+            await full_node_1.full_node.add_block(block, peer)
 
         original_ss = full_node_1.full_node.full_node_store.finished_sub_slots[:]
 
@@ -561,13 +561,13 @@ class TestFullNodeProtocol:
         blocks = await full_node_1.get_all_full_blocks()
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
 
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), peer)
+        await full_node_1.full_node.add_block(blocks[-1], peer)
 
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1)
 
         original_ss = full_node_1.full_node.full_node_store.finished_sub_slots[:].copy()
         # Add the block
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), peer)
+        await full_node_1.full_node.add_block(blocks[-1], peer)
 
         # Replace with original SS in order to imitate race condition (block added but subslot not yet added)
         full_node_1.full_node.full_node_store.finished_sub_slots = original_ss
@@ -618,7 +618,7 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
 
         # Do the same thing but with non-genesis
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+        await full_node_1.full_node.add_block(block)
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=3)
 
         block = blocks[-1]
@@ -647,7 +647,7 @@ class TestFullNodeProtocol:
         assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
 
         # Do the same thing one more time, with overflow
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+        await full_node_1.full_node.add_block(block)
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=3, force_overflow=True)
 
         block = blocks[-1]
@@ -682,8 +682,8 @@ class TestFullNodeProtocol:
             farmer_reward_puzzle_hash=ph,
             pool_reward_puzzle_hash=ph,
         )
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-2]))
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]))
+        await full_node_1.full_node.add_block(blocks[-2])
+        await full_node_1.full_node.add_block(blocks[-1])
         coin_to_spend = list(blocks[-1].get_included_reward_coins())[0]
 
         spend_bundle = wallet_a.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend)
@@ -720,7 +720,7 @@ class TestFullNodeProtocol:
         block_no_transactions = dataclasses.replace(block, transactions_generator=None)
         assert block_no_transactions.transactions_generator is None
 
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(block_no_transactions))
+        await full_node_1.full_node.add_block(block_no_transactions)
         assert full_node_1.full_node.blockchain.contains_block(block.header_hash)
 
     @pytest.mark.asyncio
@@ -751,7 +751,7 @@ class TestFullNodeProtocol:
             await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 1))
             task_1.cancel()
 
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
+            await full_node_1.full_node.add_block(block, peer)
             # Ignores, already have
             task_2 = asyncio.create_task(full_node_1.new_peak(new_peak, dummy_peer))
             await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 0))
@@ -790,7 +790,7 @@ class TestFullNodeProtocol:
             pool_reward_puzzle_hash=wallet_ph,
         )
         for block in blocks:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         start_height = (
             full_node_1.full_node.blockchain.get_peak().height
@@ -833,7 +833,7 @@ class TestFullNodeProtocol:
             guarantee_transaction_block=True,
             transaction_data=spend_bundle,
         )
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), None)
+        await full_node_1.full_node.add_block(blocks[-1], None)
 
         # Already seen
         await full_node_1.new_transaction(new_transaction, fake_peer)
@@ -951,7 +951,7 @@ class TestFullNodeProtocol:
             guarantee_transaction_block=True,
         )
         for block in blocks[-2:]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
+            await full_node_1.full_node.add_block(block, peer)
 
         # Can now resubmit a transaction after the reorg
         status, err = await full_node_1.full_node.respond_transaction(
@@ -979,8 +979,8 @@ class TestFullNodeProtocol:
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         for block in blocks[-3:]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block), peer)
-            await full_node_2.full_node.respond_block(fnp.RespondBlock(block), peer)
+            await full_node_1.full_node.add_block(block, peer)
+            await full_node_2.full_node.add_block(block, peer)
 
         # Farm another block to clear mempool
         await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(wallet_ph))
@@ -1035,9 +1035,9 @@ class TestFullNodeProtocol:
         while incoming_queue.qsize() > 0:
             await incoming_queue.get()
 
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks_new[-3]), peer)
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks_new[-2]), peer)
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks_new[-1]), peer)
+        await full_node_1.full_node.add_block(blocks_new[-3], peer)
+        await full_node_1.full_node.add_block(blocks_new[-2], peer)
+        await full_node_1.full_node.add_block(blocks_new[-1], peer)
 
         await time_out_assert(10, time_out_messages(incoming_queue, "new_peak", 3))
         # Invalid transaction does not propagate
@@ -1077,7 +1077,7 @@ class TestFullNodeProtocol:
         )
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         # Don't have height
         res = await full_node_1.request_block(fnp.RequestBlock(uint32(1248921), False))
@@ -1121,7 +1121,7 @@ class TestFullNodeProtocol:
         )
 
         for block in blocks_t:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         peak_height = blocks_t[-1].height
 
@@ -1381,7 +1381,7 @@ class TestFullNodeProtocol:
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fbh_sig)
         block_2 = recursive_replace(block_2, "transactions_generator", None)
 
-        rb_task = asyncio.create_task(full_node_2.full_node.respond_block(fnp.RespondBlock(block_2), dummy_peer))
+        rb_task = asyncio.create_task(full_node_2.full_node.add_block(block_2, dummy_peer))
 
         await time_out_assert(10, time_out_messages(incoming_queue, "request_block", 1))
         rb_task.cancel()
@@ -1393,7 +1393,7 @@ class TestFullNodeProtocol:
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         blocks = bt.get_consecutive_blocks(10, block_list_input=blocks, seed=b"12345")
         for block in blocks[:-1]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
         block: FullBlock = blocks[-1]
         overflow = is_overflow_block(test_constants, block.reward_chain_block.signage_point_index)
         unf = UnfinishedBlock(
@@ -1422,9 +1422,9 @@ class TestFullNodeProtocol:
         blocks = await full_node_1.get_all_full_blocks()
 
         blocks = bt.get_consecutive_blocks(3, block_list_input=blocks, skip_slots=2)
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-3]))
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-2]))
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]))
+        await full_node_1.full_node.add_block(blocks[-3])
+        await full_node_1.full_node.add_block(blocks[-2])
+        await full_node_1.full_node.add_block(blocks[-1])
 
         blockchain = full_node_1.full_node.blockchain
         peak = blockchain.get_peak()
@@ -1447,7 +1447,7 @@ class TestFullNodeProtocol:
         assert fnp.RequestSignagePointOrEndOfSubSlot.from_bytes(res.data).index_from_challenge == uint8(11)
 
         for block in blocks:
-            await full_node_2.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_2.full_node.add_block(block)
 
         num_slots = 20
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=num_slots)
@@ -1478,9 +1478,9 @@ class TestFullNodeProtocol:
 
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         blocks = bt.get_consecutive_blocks(3, block_list_input=blocks, skip_slots=2)
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-3]))
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-2]))
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]))
+        await full_node_1.full_node.add_block(blocks[-3])
+        await full_node_1.full_node.add_block(blocks[-2])
+        await full_node_1.full_node.add_block(blocks[-1])
 
         blockchain = full_node_1.full_node.blockchain
 
@@ -1517,7 +1517,7 @@ class TestFullNodeProtocol:
         assert len(full_node_1.full_node.full_node_store.future_sp_cache[sp.rc_vdf.challenge]) == 1
 
         # Add block
-        await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), peer)
+        await full_node_1.full_node.add_block(blocks[-1], peer)
 
         # Now signage point should be added
         assert full_node_1.full_node.full_node_store.get_signage_point(sp.cc_vdf.output.get_hash()) is not None
@@ -1561,7 +1561,7 @@ class TestFullNodeProtocol:
         blocks = bt.get_consecutive_blocks(num_blocks=10, skip_slots=3)
         block = blocks[0]
         for b in blocks:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(b))
+            await full_node_1.full_node.add_block(b)
         timelord_protocol_finished = []
         cc_eos_count = 0
         for sub_slot in block.finished_sub_slots:
@@ -1585,7 +1585,7 @@ class TestFullNodeProtocol:
         blocks_2 = bt.get_consecutive_blocks(num_blocks=10, block_list_input=blocks, skip_slots=3)
         block = blocks_2[-10]
         for b in blocks_2[-11:]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(b))
+            await full_node_1.full_node.add_block(b)
         icc_eos_count = 0
         for sub_slot in block.finished_sub_slots:
             if sub_slot.infused_challenge_chain is not None:
@@ -1668,7 +1668,7 @@ class TestFullNodeProtocol:
         assert has_compact_cc_sp_vdf
         assert has_compact_cc_ip_vdf
         for height, block in enumerate(stored_blocks):
-            await full_node_2.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_2.full_node.add_block(block)
             assert full_node_2.full_node.blockchain.get_peak().height == height
 
     @pytest.mark.asyncio
@@ -1679,7 +1679,7 @@ class TestFullNodeProtocol:
         blocks = bt.get_consecutive_blocks(num_blocks=1, skip_slots=3)
         blocks_2 = bt.get_consecutive_blocks(num_blocks=3, block_list_input=blocks, skip_slots=3)
         for block in blocks_2[:2]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
         assert full_node_1.full_node.blockchain.get_peak().height == 1
         # (wrong_vdf_info, wrong_vdf_proof) pair verifies, but it's not present in the blockchain at all.
         block = blocks_2[2]

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1643,7 +1643,7 @@ class TestFullNodeProtocol:
         # Note: the below numbers depend on the block cache, so might need to be updated
         assert cc_eos_count == 3 and icc_eos_count == 3
         for compact_proof in timelord_protocol_finished:
-            await full_node_1.full_node.respond_compact_proof_of_time(compact_proof)
+            await full_node_1.full_node.add_compact_proof_of_time(compact_proof)
         stored_blocks = await full_node_1.get_all_full_blocks()
         cc_eos_compact_count = 0
         icc_eos_compact_count = 0
@@ -1885,7 +1885,7 @@ class TestFullNodeProtocol:
         server_2 = full_node_2.full_node.server
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         for invalid_compact_proof in timelord_protocol_invalid_messages:
-            await full_node_1.full_node.respond_compact_proof_of_time(invalid_compact_proof)
+            await full_node_1.full_node.add_compact_proof_of_time(invalid_compact_proof)
         for invalid_compact_proof in full_node_protocol_invalid_messaages:
             await full_node_1.full_node.add_compact_vdf(invalid_compact_proof, peer)
         stored_blocks = await full_node_1.get_all_full_blocks()

--- a/tests/core/full_node/test_node_load.py
+++ b/tests/core/full_node/test_node_load.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-from chia.protocols import full_node_protocol
 from chia.simulator.time_out_assert import time_out_assert
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
@@ -17,7 +16,7 @@ class TestNodeLoad:
         full_node_1, full_node_2, server_1, server_2, bt = two_nodes
         blocks = bt.get_consecutive_blocks(num_blocks)
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
-        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[0]), peer)
+        await full_node_1.full_node.add_block(blocks[0], peer)
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
 
@@ -28,7 +27,7 @@ class TestNodeLoad:
 
         with assert_runtime(seconds=100, label=request.node.name) as runtime_results_future:
             for i in range(1, num_blocks):
-                await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
-                await full_node_2.full_node.respond_block(full_node_protocol.RespondBlock(blocks[i]))
+                await full_node_1.full_node.add_block(blocks[i])
+                await full_node_2.full_node.add_block(blocks[i])
         runtime_results = runtime_results_future.result(timeout=0)
         print(f"Time taken to process {num_blocks} is {runtime_results.duration}")

--- a/tests/core/full_node/test_performance.py
+++ b/tests/core/full_node/test_performance.py
@@ -54,7 +54,7 @@ class TestPerformance:
             pool_reward_puzzle_hash=wallet_ph,
         )
         for block in blocks:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         start_height = (
             full_node_1.full_node.blockchain.get_peak().height
@@ -94,7 +94,7 @@ class TestPerformance:
                 guarantee_transaction_block=True,
                 transaction_data=spend_bundle,
             )
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(blocks[-1]), fake_peer)
+            await full_node_1.full_node.add_block(blocks[-1], fake_peer)
 
         await time_out_assert(20, node_height_at_least, True, full_node_1, start_height + 20)
 
@@ -189,7 +189,7 @@ class TestPerformance:
         with assert_runtime(seconds=0.1, label=f"{request.node.name} - full block"):
             # No transactions generator, the full node already cached it from the unfinished block
             block_small = dataclasses.replace(block, transactions_generator=None)
-            res = await full_node_1.full_node.respond_block(fnp.RespondBlock(block_small))
+            res = await full_node_1.full_node.add_block(block_small)
 
         log.warning(f"Res: {res}")
 

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -9,7 +9,6 @@ import pytest
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.protocols import full_node_protocol
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert
 from chia.types.peer_info import PeerInfo
@@ -147,7 +146,7 @@ class TestTransactions:
         all_blocks = await full_node_api_0.get_all_full_blocks()
 
         for block in all_blocks:
-            await full_node_api_2.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_2.full_node.add_block(block)
 
         funds = sum(
             [calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)]

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -339,7 +339,7 @@ async def next_block(full_node_1, wallet_a, bt) -> Coin:
     )
 
     for block in blocks:
-        await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+        await full_node_1.full_node.add_block(block)
 
     await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 1)
     return list(blocks[-1].get_included_reward_coins())[0]
@@ -489,7 +489,7 @@ class TestMempoolManager:
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         spend_bundle1 = generate_test_spend_bundle(wallet_a, list(blocks[-1].get_included_reward_coins())[0])
@@ -551,7 +551,7 @@ class TestMempoolManager:
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         coins = iter(blocks[-1].get_included_reward_coins())
@@ -627,7 +627,7 @@ class TestMempoolManager:
         )
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         coins = iter(blocks[-1].get_included_reward_coins())
@@ -671,7 +671,7 @@ class TestMempoolManager:
             raise Exception("dummy peer not found")
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + num_blocks)
 
@@ -709,7 +709,7 @@ class TestMempoolManager:
             raise Exception("dummy peer not found")
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
@@ -1592,7 +1592,7 @@ class TestMempoolManager:
         peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 5)
 
@@ -1646,7 +1646,7 @@ class TestMempoolManager:
         )
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
         # coin = list(blocks[-1].get_included_reward_coins())[0]
@@ -1691,7 +1691,7 @@ class TestMempoolManager:
         )
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
@@ -2534,7 +2534,7 @@ class TestMaliciousGenerators:
         )
 
         for block in blocks:
-            await full_node_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_1.full_node.add_block(block)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
 

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -319,7 +319,7 @@ async def respond_transaction(
         self.full_node.full_node_store.pending_tx_request.pop(spend_name)
     if spend_name in self.full_node.full_node_store.peers_with_tx:
         self.full_node.full_node_store.peers_with_tx.pop(spend_name)
-    return await self.full_node.respond_transaction(tx.transaction, spend_name, peer, test)
+    return await self.full_node.add_transaction(tx.transaction, spend_name, peer, test)
 
 
 async def next_block(full_node_1, wallet_a, bt) -> Coin:
@@ -1719,7 +1719,7 @@ class TestMempoolManager:
         # assert spend_bundle is not None
         #
         # tx: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle)
-        # await full_node_1.respond_transaction(tx, peer, test=True)
+        # await full_node_1.add_transaction(tx, peer, test=True)
         #
         # sb = full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle.name())
         # assert sb is spend_bundle
@@ -2545,7 +2545,7 @@ class TestMaliciousGenerators:
         coin_spend_0 = CoinSpend(coin_0, cs.puzzle_reveal, cs.solution)
         new_bundle = recursive_replace(spend_bundle, "coin_spends", [coin_spend_0] + spend_bundle.coin_spends[1:])
         assert spend_bundle is not None
-        res = await full_node_1.full_node.respond_transaction(new_bundle, new_bundle.name(), test=True)
+        res = await full_node_1.full_node.add_transaction(new_bundle, new_bundle.name(), test=True)
         assert res == (MempoolInclusionStatus.FAILED, Err.INVALID_SPEND_BUNDLE)
 
 

--- a/tests/core/mempool/test_mempool_fee_protocol.py
+++ b/tests/core/mempool/test_mempool_fee_protocol.py
@@ -6,7 +6,7 @@ from typing import List, Tuple, Union
 import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.protocols import full_node_protocol, wallet_protocol
+from chia.protocols import wallet_protocol
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.wallet_protocol import RespondFeeEstimates
 from chia.server.server import ChiaServer
@@ -37,7 +37,7 @@ async def test_protocol_messages(
     full_node_sim: Union[FullNodeAPI, FullNodeSimulator] = full_nodes[0]
 
     for block in blocks:
-        await full_node_sim.full_node.respond_block(full_node_protocol.RespondBlock(block))
+        await full_node_sim.full_node.add_block(block)
 
     await time_out_assert(60, node_height_at_least, True, full_node_sim, blocks[-1].height)
 

--- a/tests/core/mempool/test_mempool_performance.py
+++ b/tests/core/mempool/test_mempool_performance.py
@@ -51,7 +51,7 @@ class TestMempoolPerformance:
         ph = await wallet.get_new_puzzlehash()
 
         for block in blocks:
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api_1.full_node.add_block(block)
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await time_out_assert(60, wallet_height_at_least, True, wallet_node, 399)
@@ -70,7 +70,7 @@ class TestMempoolPerformance:
             await con.close()
 
         blocks = bt.get_consecutive_blocks(3, blocks)
-        await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[-3]))
+        await full_node_api_1.full_node.add_block(blocks[-3])
 
         for idx, block in enumerate(blocks):
             if idx >= len(blocks) - 3:
@@ -79,4 +79,4 @@ class TestMempoolPerformance:
                 duration = 0.001
 
             with assert_runtime(seconds=duration, label=request.node.name):
-                await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api_1.full_node.add_block(block)

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -385,9 +385,7 @@ class TestRpc:
 
             # Properly fetch an EOS
             for eos in blocks[-1].finished_sub_slots:
-                await full_node_api_1.full_node.respond_end_of_sub_slot(
-                    full_node_protocol.RespondEndOfSubSlot(eos), peer
-                )
+                await full_node_api_1.full_node.add_end_of_sub_slot(eos, peer)
 
             res = await client.get_recent_signage_point_or_eos(None, selected_eos.challenge_chain.get_hash())
             assert res is not None

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -78,7 +78,7 @@ class TestRpc:
                 await full_node_api_1.full_node.respond_unfinished_block(
                     full_node_protocol.RespondUnfinishedBlock(unf), None
                 )
-                await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block), None)
+                await full_node_api_1.full_node.add_block(block, None)
 
             assert len(await client.get_unfinished_block_headers()) > 0
             assert len(await client.get_all_block(0, 2)) == 2
@@ -130,7 +130,7 @@ class TestRpc:
                 pool_reward_puzzle_hash=ph,
             )
             for block in blocks[-2:]:
-                await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api_1.full_node.add_block(block)
             assert len(await client.get_coin_records_by_puzzle_hash(ph)) == 2
             assert len(await client.get_coin_records_by_puzzle_hash(ph_receiver)) == 0
 
@@ -336,7 +336,7 @@ class TestRpc:
 
             blocks = bt.get_consecutive_blocks(5)
             for block in blocks:
-                await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api_1.full_node.add_block(block)
 
             blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1, force_overflow=True)
 
@@ -363,7 +363,7 @@ class TestRpc:
             assert res is None
 
             # Add the last block
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[-1]))
+            await full_node_api_1.full_node.add_block(blocks[-1])
             await full_node_api_1.respond_signage_point(
                 full_node_protocol.RespondSignagePoint(uint8(4), sp.cc_vdf, sp.cc_proof, sp.rc_vdf, sp.rc_proof), peer
             )
@@ -398,10 +398,10 @@ class TestRpc:
             assert not res["reverted"]
 
             # Do another one but without sending the slot
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[-1]))
+            await full_node_api_1.full_node.add_block(blocks[-1])
             blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1)
             selected_eos = blocks[-1].finished_sub_slots[-1]
-            await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(blocks[-1]))
+            await full_node_api_1.full_node.add_block(blocks[-1])
 
             res = await client.get_recent_signage_point_or_eos(None, selected_eos.challenge_chain.get_hash())
             assert res is not None
@@ -412,7 +412,7 @@ class TestRpc:
             # Perform a reorg
             blocks = bt.get_consecutive_blocks(12, seed=b"1234")
             for block in blocks:
-                await full_node_api_1.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api_1.full_node.add_block(block)
 
             # Signage point is no longer in the blockchain
             res = await client.get_recent_signage_point_or_eos(sp.cc_vdf.output.get_hash(), None)

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -75,9 +75,7 @@ class TestRpc:
                     block.transactions_generator,
                     [],
                 )
-                await full_node_api_1.full_node.respond_unfinished_block(
-                    full_node_protocol.RespondUnfinishedBlock(unf), None
-                )
+                await full_node_api_1.full_node.add_unfinished_block(unf, None)
                 await full_node_api_1.full_node.add_block(block, None)
 
             assert len(await client.get_unfinished_block_headers()) > 0

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -19,8 +19,6 @@ from blspy import G1Element
 from chia.full_node.full_node import FullNode
 from chia.pools.pool_puzzles import SINGLETON_LAUNCHER_HASH
 from chia.pools.pool_wallet_info import PoolSingletonState, PoolWalletInfo
-from chia.protocols import full_node_protocol
-from chia.protocols.full_node_protocol import RespondBlock
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.server.start_service import Service
 from chia.simulator.block_tools import BlockTools, get_plot_dir
@@ -437,7 +435,7 @@ class TestPoolWalletRpc:
             )
 
             for block in blocks[-3:]:
-                await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api.full_node.add_block(block)
             await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
             bal = await client.get_wallet_balance(2)
@@ -528,7 +526,7 @@ class TestPoolWalletRpc:
 
             block_count = 3
             for block in blocks[-block_count:]:
-                await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api.full_node.add_block(block)
             await full_node_api.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
             await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
@@ -601,7 +599,7 @@ class TestPoolWalletRpc:
 
             block_count = 3
             for block in blocks[-block_count:]:
-                await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                await full_node_api.full_node.add_block(block)
             await full_node_api.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
             await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
             # Pooled plots don't have balance
@@ -660,7 +658,7 @@ class TestPoolWalletRpc:
                         guarantee_transaction_block=True,
                     )
                     for block in blocks[-2:]:
-                        await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+                        await full_node_api.full_node.add_block(block)
                     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
                     # Absorb the farmed reward
@@ -1003,7 +1001,7 @@ class TestPoolWalletRpc:
         )
 
         for block in more_blocks[-3:]:
-            await full_node_api.full_node.respond_block(RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         await time_out_assert(timeout=WAIT_SECS, function=status_is_leaving_no_blocks)
 

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -60,7 +60,7 @@ class TestWalletSync:
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
         for block in default_1000_blocks[:100]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         msg = await full_node_api.request_block_headers(
             wallet_protocol.RequestBlockHeaders(uint32(10), uint32(15), False)
@@ -82,7 +82,7 @@ class TestWalletSync:
             num_blocks, block_list_input=default_1000_blocks, pool_reward_puzzle_hash=ph
         )
         for i in range(0, len(new_blocks)):
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[i]))
+            await full_node_api.full_node.add_block(new_blocks[i])
 
         msg = await full_node_api.request_block_headers(
             wallet_protocol.RequestBlockHeaders(uint32(110), uint32(115), True)
@@ -110,7 +110,7 @@ class TestWalletSync:
         assert msg.type == ProtocolMessageTypes.reject_block_headers.value
 
         for block in default_1000_blocks[:150]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         msg = await full_node_api.request_block_headers(
             wallet_protocol.RequestBlockHeaders(uint32(80), uint32(99), False)
@@ -166,7 +166,7 @@ class TestWalletSync:
         wallets[1][0].config["trusted_peers"] = {}
 
         for block in default_400_blocks:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         for wallet_node, wallet_server in wallets:
             await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -179,7 +179,7 @@ class TestWalletSync:
         blocks_reorg = bt.get_consecutive_blocks(num_blocks - 1, block_list_input=default_400_blocks[:-5])
         blocks_reorg = bt.get_consecutive_blocks(1, blocks_reorg, guarantee_transaction_block=True, current_time=True)
         for i in range(1, len(blocks_reorg)):
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(blocks_reorg[i]))
+            await full_node_api.full_node.add_block(blocks_reorg[i])
 
         for wallet_node, wallet_server in wallets:
             await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
@@ -219,7 +219,7 @@ class TestWalletSync:
 
         base_num_blocks = 400
         for block in default_400_blocks:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
         all_blocks = default_400_blocks
         both_phs = []
         for wallet_node, wallet_server in wallets:
@@ -230,13 +230,13 @@ class TestWalletSync:
             # Tests a reorg with the wallet
             ph = both_phs[i % 2]
             all_blocks = bt.get_consecutive_blocks(1, block_list_input=all_blocks, pool_reward_puzzle_hash=ph)
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(all_blocks[-1]))
+            await full_node_api.full_node.add_block(all_blocks[-1])
 
         new_blocks = bt.get_consecutive_blocks(
             test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 10, block_list_input=all_blocks
         )
         for i in range(base_num_blocks + 20, len(new_blocks)):
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(new_blocks[i]))
+            await full_node_api.full_node.add_block(new_blocks[i])
 
         for wallet_node, wallet_server in wallets:
             wallet = wallet_node.wallet_state_manager.main_wallet
@@ -256,7 +256,7 @@ class TestWalletSync:
         wallets[1][0].config["trusted_peers"] = {}
 
         for block in default_400_blocks[:20]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         for wallet_node, wallet_server in wallets:
             await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -278,7 +278,7 @@ class TestWalletSync:
         wallets[1][0].config["trusted_peers"] = {}
 
         for block in default_400_blocks[:200]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         for wallet_node, wallet_server in wallets:
             await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -299,7 +299,7 @@ class TestWalletSync:
         wallets[1][0].config["trusted_peers"] = {}
 
         for block in default_400_blocks:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         for wallet_node, wallet_server in wallets:
             await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -309,7 +309,7 @@ class TestWalletSync:
 
         # Tests a long reorg
         for block in default_1000_blocks:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         for wallet_node, wallet_server in wallets:
             await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
@@ -326,7 +326,7 @@ class TestWalletSync:
         blocks_reorg = bt.get_consecutive_blocks(num_blocks, block_list_input=default_1000_blocks[:-5])
 
         for i in range(len(blocks_reorg) - num_blocks - 10, len(blocks_reorg)):
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(blocks_reorg[i]))
+            await full_node_api.full_node.add_block(blocks_reorg[i])
 
         for wallet_node, wallet_server in wallets:
             await time_out_assert(
@@ -354,7 +354,7 @@ class TestWalletSync:
 
         # Insert 400 blocks
         for block in default_400_blocks:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         # Farm few more with reward
         for i in range(0, num_blocks - 1):
@@ -382,7 +382,7 @@ class TestWalletSync:
         blocks_reorg = bt.get_consecutive_blocks(num_blocks, block_list_input=default_400_blocks[:-5])
 
         for block in blocks_reorg[-30:]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         for wallet_node, wallet_server in wallets:
             wallet = wallet_node.wallet_state_manager.main_wallet
@@ -406,14 +406,14 @@ class TestWalletSync:
 
         # Insert 400 blocks
         for block in default_400_blocks:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         # Reorg blocks that carry reward
         num_blocks_reorg = 30
         blocks_reorg = bt.get_consecutive_blocks(num_blocks_reorg, block_list_input=default_400_blocks[:-5])
 
         for block in blocks_reorg[:-5]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         async def get_tx_count(wsm, wallet_id):
             txs = await wsm.get_all_transactions(wallet_id)
@@ -434,7 +434,7 @@ class TestWalletSync:
         blocks_reorg_2 = bt.get_consecutive_blocks(num_blocks_reorg_1, block_list_input=all_blocks_reorg_2)
 
         for block in blocks_reorg_2[-44:]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         for wallet_node, wallet_server in wallets:
             await disconnect_all_and_reconnect(wallet_server, full_node_server, self_hostname)
@@ -1302,7 +1302,7 @@ class TestWalletSync:
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
         for block in blocks:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Tuple
 import pytest
 from blspy import AugSchemeMPL, G1Element, G2Element
 
-from chia.protocols.full_node_protocol import RespondBlock
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
@@ -213,8 +212,8 @@ class TestWalletSimulator:
         all_blocks = await full_node_api_0.get_all_full_blocks()
 
         for block in all_blocks:
-            await full_node_1.respond_block(RespondBlock(block))
-            await full_node_2.respond_block(RespondBlock(block))
+            await full_node_1.add_block(block)
+            await full_node_2.add_block(block)
 
         tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
             uint64(10),

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -21,7 +21,7 @@ class TestWalletBlockchain:
         [full_node_api], [(wallet_node, _)], bt = simulator_and_wallet
 
         for block in default_1000_blocks[:600]:
-            await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))
+            await full_node_api.full_node.add_block(block)
 
         res = await full_node_api.request_proof_of_weight(
             full_node_protocol.RequestProofOfWeight(

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -195,7 +195,7 @@ async def run_sync_test(
                                 await full_node.respond_unfinished_block(
                                     full_node_protocol.RespondUnfinishedBlock(make_unfinished_block(b, constants)), peer
                                 )
-                                await full_node.respond_block(full_node_protocol.RespondBlock(b))
+                                await full_node.add_block(b)
                         else:
                             success, summary = await full_node.receive_block_batch(block_batch, peer, None)
                             end_height = block_batch[-1].height

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -197,7 +197,7 @@ async def run_sync_test(
                                 )
                                 await full_node.add_block(b)
                         else:
-                            success, summary = await full_node.receive_block_batch(block_batch, peer, None)
+                            success, summary = await full_node.add_block_batch(block_batch, peer, None)
                             end_height = block_batch[-1].height
                             full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
@@ -373,7 +373,7 @@ async def run_sync_checkpoint(
                 if len(block_batch) < 32:
                     continue
 
-                success, _ = await full_node.receive_block_batch(block_batch, peer, None)
+                success, _ = await full_node.add_block_batch(block_batch, peer, None)
                 end_height = block_batch[-1].height
                 full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
@@ -385,7 +385,7 @@ async def run_sync_checkpoint(
                 block_batch = []
 
             if len(block_batch) > 0:
-                success, _ = await full_node.receive_block_batch(block_batch, peer, None)
+                success, _ = await full_node.add_block_batch(block_batch, peer, None)
                 if not success:
                     raise RuntimeError("failed to ingest block batch")
 

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -20,7 +20,6 @@ import zstd
 from chia.cmds.init_funcs import chia_init
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.full_node import FullNode
-from chia.protocols import full_node_protocol
 from chia.server.outbound_message import Message, NodeType
 from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.block_tools import make_unfinished_block
@@ -192,9 +191,7 @@ async def run_sync_test(
 
                         if keep_up:
                             for b in block_batch:
-                                await full_node.respond_unfinished_block(
-                                    full_node_protocol.RespondUnfinishedBlock(make_unfinished_block(b, constants)), peer
-                                )
+                                await full_node.add_unfinished_block(make_unfinished_block(b, constants), peer)
                                 await full_node.add_block(b)
                         else:
                             success, summary = await full_node.add_block_batch(block_batch, peer, None)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

- The prefixes `respond` and `receive` are confusing here imo, we have full node API methods prefixed `respond` but the methods changed here in the `FullNode` class are methods add the received data to the internal data structures so i think `add` prefix is the better choice? Maybe it's only me but when i read `receive` or `respond` it more reads like something where communication with a peer is involved.
- Also drop some parameter wrappings which were there to follow the API Call response naming

### New Behavior:

No change in behaviour.
