### PR TITLE
consensus: Rename add block method/enum

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -56,7 +56,7 @@ log = logging.getLogger(__name__)
 
 class AddBlockResult(Enum):
     """
-    When Blockchain.receive_block(b) is called, one of these results is returned,
+    When Blockchain.add_block(b) is called, one of these results is returned,
     showing whether the block was added to the chain (extending the peak),
     and if not, why it was not added.
     """
@@ -193,7 +193,7 @@ class Blockchain(BlockchainInterface):
     async def get_full_block(self, header_hash: bytes32) -> Optional[FullBlock]:
         return await self.block_store.get_full_block(header_hash)
 
-    async def receive_block(
+    async def add_block(
         self,
         block: FullBlock,
         pre_validation_result: PreValidationResult,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -118,7 +118,7 @@ def batch_pre_validate_blocks(
                 if error_int is None:
                     # If this is False, it means either we don't have a signature (not a tx block) or we have an invalid
                     # signature (which also puts in an error) or we didn't validate the signature because we want to
-                    # validate it later. receive_block will attempt to validate the signature later.
+                    # validate it later. add_block will attempt to validate the signature later.
                     if validate_signatures:
                         if npc_result is not None and block.transactions_info is not None:
                             assert npc_result.conds

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -17,7 +17,7 @@ from blspy import AugSchemeMPL
 
 from chia.consensus.block_creation import unfinished_block_to_full_block
 from chia.consensus.block_record import BlockRecord
-from chia.consensus.blockchain import Blockchain, ReceiveBlockResult, StateChangeSummary
+from chia.consensus.blockchain import AddBlockResult, Blockchain, StateChangeSummary
 from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
@@ -1260,7 +1260,7 @@ class FullNode:
                 block, pre_validation_results[i], None if advanced_peak else fork_point
             )
 
-            if result == ReceiveBlockResult.NEW_PEAK:
+            if result == AddBlockResult.NEW_PEAK:
                 assert state_change_summary is not None
                 # Since all blocks are contiguous, we can simply append the rollback changes and npc results
                 if agg_state_change_summary is None:
@@ -1275,7 +1275,7 @@ class FullNode:
                         agg_state_change_summary.new_npc_results + state_change_summary.new_npc_results,
                         agg_state_change_summary.new_rewards + state_change_summary.new_rewards,
                     )
-            elif result == ReceiveBlockResult.INVALID_BLOCK or result == ReceiveBlockResult.DISCONNECTED_BLOCK:
+            elif result == AddBlockResult.INVALID_BLOCK or result == AddBlockResult.DISCONNECTED_BLOCK:
                 if error is not None:
                     self.log.error(f"Error: {error}, Invalid block from peer: {peer.get_peer_logging()} ")
                 return False, agg_state_change_summary
@@ -1666,14 +1666,14 @@ class FullNode:
             pre_validation_results = await self.blockchain.pre_validate_blocks_multiprocessing(
                 [block], npc_results, validate_signatures=False
             )
-            added: Optional[ReceiveBlockResult] = None
+            added: Optional[AddBlockResult] = None
             pre_validation_time = time.time() - validation_start
             try:
                 if len(pre_validation_results) < 1:
                     raise ValueError(f"Failed to validate block {header_hash} height {block.height}")
                 if pre_validation_results[0].error is not None:
                     if Err(pre_validation_results[0].error) == Err.INVALID_PREV_BLOCK_HASH:
-                        added = ReceiveBlockResult.DISCONNECTED_BLOCK
+                        added = AddBlockResult.DISCONNECTED_BLOCK
                         error_code: Optional[Err] = Err.INVALID_PREV_BLOCK_HASH
                     else:
                         raise ValueError(
@@ -1688,23 +1688,23 @@ class FullNode:
                     (added, error_code, state_change_summary) = await self.blockchain.receive_block(
                         block, result_to_validate, None
                     )
-                if added == ReceiveBlockResult.ALREADY_HAVE_BLOCK:
+                if added == AddBlockResult.ALREADY_HAVE_BLOCK:
                     return None
-                elif added == ReceiveBlockResult.INVALID_BLOCK:
+                elif added == AddBlockResult.INVALID_BLOCK:
                     assert error_code is not None
                     self.log.error(f"Block {header_hash} at height {block.height} is invalid with code {error_code}.")
                     raise ConsensusError(error_code, [header_hash])
-                elif added == ReceiveBlockResult.DISCONNECTED_BLOCK:
+                elif added == AddBlockResult.DISCONNECTED_BLOCK:
                     self.log.info(f"Disconnected block {header_hash} at height {block.height}")
                     if raise_on_disconnected:
                         raise RuntimeError("Expected block to be added, received disconnected block.")
                     return None
-                elif added == ReceiveBlockResult.NEW_PEAK:
+                elif added == AddBlockResult.NEW_PEAK:
                     # Only propagate blocks which extend the blockchain (becomes one of the heads)
                     assert state_change_summary is not None
                     ppp_result = await self.peak_post_processing(block, state_change_summary, peer)
 
-                elif added == ReceiveBlockResult.ADDED_AS_ORPHAN:
+                elif added == AddBlockResult.ADDED_AS_ORPHAN:
                     self.log.info(
                         f"Received orphan block of height {block.height} rh {block.reward_chain_block.get_hash()}"
                     )
@@ -1714,7 +1714,7 @@ class FullNode:
             except asyncio.CancelledError:
                 # We need to make sure to always call this method even when we get a cancel exception, to make sure
                 # the node stays in sync
-                if added == ReceiveBlockResult.NEW_PEAK:
+                if added == AddBlockResult.NEW_PEAK:
                     assert state_change_summary is not None
                     await self.peak_post_processing(block, state_change_summary, peer)
                 raise

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1256,7 +1256,7 @@ class FullNode:
             assert pre_validation_results[i].required_iters is not None
             state_change_summary: Optional[StateChangeSummary]
             advanced_peak = agg_state_change_summary is not None
-            result, error, state_change_summary = await self.blockchain.receive_block(
+            result, error, state_change_summary = await self.blockchain.add_block(
                 block, pre_validation_results[i], None if advanced_peak else fork_point
             )
 
@@ -1685,7 +1685,7 @@ class FullNode:
                         pre_validation_results[0] if pre_validation_result is None else pre_validation_result
                     )
                     assert result_to_validate.required_iters == pre_validation_results[0].required_iters
-                    (added, error_code, state_change_summary) = await self.blockchain.receive_block(
+                    (added, error_code, state_change_summary) = await self.blockchain.add_block(
                         block, result_to_validate, None
                     )
                 if added == AddBlockResult.ALREADY_HAVE_BLOCK:
@@ -1710,7 +1710,7 @@ class FullNode:
                     )
                 else:
                     # Should never reach here, all the cases are covered
-                    raise RuntimeError(f"Invalid result from receive_block {added}")
+                    raise RuntimeError(f"Invalid result from add_block {added}")
             except asyncio.CancelledError:
                 # We need to make sure to always call this method even when we get a cancel exception, to make sure
                 # the node stays in sync

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -190,7 +190,7 @@ class FullNodeSimulator(FullNodeAPI):
                     [genesis], {}, validate_signatures=True
                 )
                 assert pre_validation_results is not None
-                await self.full_node.blockchain.receive_block(genesis, pre_validation_results[0])
+                await self.full_node.blockchain.add_block(genesis, pre_validation_results[0])
 
             peak = self.full_node.blockchain.get_peak()
             assert peak is not None
@@ -239,7 +239,7 @@ class FullNodeSimulator(FullNodeAPI):
                     [genesis], {}, validate_signatures=True
                 )
                 assert pre_validation_results is not None
-                await self.full_node.blockchain.receive_block(genesis, pre_validation_results[0])
+                await self.full_node.blockchain.add_block(genesis, pre_validation_results[0])
 
             peak = self.full_node.blockchain.get_peak()
             assert peak is not None

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple
 
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.block_record import BlockRecord
-from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.blockchain import AddBlockResult
 from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.find_fork_point import find_fork_point_in_chain
@@ -89,11 +89,11 @@ class WalletBlockchain(BlockchainInterface):
             await self.set_peak_block(weight_proof.recent_chain_data[-1], latest_timestamp)
             await self.clean_block_records()
 
-    async def receive_block(self, block: HeaderBlock) -> Tuple[ReceiveBlockResult, Optional[Err]]:
+    async def receive_block(self, block: HeaderBlock) -> Tuple[AddBlockResult, Optional[Err]]:
         if self.contains_block(block.header_hash):
-            return ReceiveBlockResult.ALREADY_HAVE_BLOCK, None
+            return AddBlockResult.ALREADY_HAVE_BLOCK, None
         if not self.contains_block(block.prev_header_hash) and block.height > 0:
-            return ReceiveBlockResult.DISCONNECTED_BLOCK, None
+            return AddBlockResult.DISCONNECTED_BLOCK, None
         if (
             len(block.finished_sub_slots) > 0
             and block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None
@@ -110,9 +110,9 @@ class WalletBlockchain(BlockchainInterface):
             self.constants, self, block, False, difficulty, sub_slot_iters, False
         )
         if error is not None:
-            return ReceiveBlockResult.INVALID_BLOCK, error.code
+            return AddBlockResult.INVALID_BLOCK, error.code
         if required_iters is None:
-            return ReceiveBlockResult.INVALID_BLOCK, Err.INVALID_POSPACE
+            return AddBlockResult.INVALID_BLOCK, Err.INVALID_POSPACE
 
         # We are passing in sub_slot_iters here so we don't need to backtrack until the start of the epoch to find
         # the sub slot iters and difficulty. This allows us to keep the cache small.
@@ -127,7 +127,7 @@ class WalletBlockchain(BlockchainInterface):
                 latest_timestamp = None
             self._height_to_hash[block_record.height] = block_record.header_hash
             await self.set_peak_block(block, latest_timestamp)
-            return ReceiveBlockResult.NEW_PEAK, None
+            return AddBlockResult.NEW_PEAK, None
         elif block_record.weight > self._peak.weight:
             if block_record.prev_hash == self._peak.header_hash:
                 fork_height: int = self._peak.height
@@ -147,8 +147,8 @@ class WalletBlockchain(BlockchainInterface):
             self._difficulty = uint64(block_record.weight - self.block_record(block_record.prev_hash).weight)
             await self.set_peak_block(block, latest_timestamp)
             await self.clean_block_records()
-            return ReceiveBlockResult.NEW_PEAK, None
-        return ReceiveBlockResult.ADDED_AS_ORPHAN, None
+            return AddBlockResult.NEW_PEAK, None
+        return AddBlockResult.ADDED_AS_ORPHAN, None
 
     async def _rollback_to_height(self, height: int) -> None:
         if self._peak is None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -16,7 +16,7 @@ from blspy import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from packaging.version import Version
 
 from chia.consensus.block_record import BlockRecord
-from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.blockchain import AddBlockResult
 from chia.consensus.constants import ConsensusConstants
 from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate, wrap_local_keychain
 from chia.full_node.full_node_api import FullNodeAPI
@@ -1219,7 +1219,7 @@ class WalletNode:
         for block in blocks:
             # Set blockchain to the latest peak
             res, err = await self.wallet_state_manager.blockchain.receive_block(block)
-            if res == ReceiveBlockResult.INVALID_BLOCK:
+            if res == AddBlockResult.INVALID_BLOCK:
                 raise ValueError(err)
 
         return fork_height

--- a/tests/blockchain/blockchain_test_utils.py
+++ b/tests/blockchain/blockchain_test_utils.py
@@ -48,7 +48,7 @@ async def _validate_and_add_block(
     # block is added to the peak.
     # If expected_result is not None, that result will be enforced.
     # If expected_error is not None, that error will be enforced. If expected_error is not None,
-    # receive_block must return Err.INVALID_BLOCK.
+    # add_block must return Err.INVALID_BLOCK.
     # If expected_result == INVALID_BLOCK but expected_error is None, we will allow for errors to happen
 
     await check_block_store_invariant(blockchain)
@@ -79,7 +79,7 @@ async def _validate_and_add_block(
         result,
         err,
         _,
-    ) = await blockchain.receive_block(block, results, fork_point_with_peak=fork_point_with_peak)
+    ) = await blockchain.add_block(block, results, fork_point_with_peak=fork_point_with_peak)
     await check_block_store_invariant(blockchain)
 
     if expected_error is None and expected_result != AddBlockResult.INVALID_BLOCK:

--- a/tests/blockchain/blockchain_test_utils.py
+++ b/tests/blockchain/blockchain_test_utils.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from chia.consensus.blockchain import Blockchain, ReceiveBlockResult
+from chia.consensus.blockchain import Blockchain, AddBlockResult
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.types.full_block import FullBlock
 from chia.util.errors import Err
@@ -39,7 +39,7 @@ async def check_block_store_invariant(bc: Blockchain):
 async def _validate_and_add_block(
     blockchain: Blockchain,
     block: FullBlock,
-    expected_result: Optional[ReceiveBlockResult] = None,
+    expected_result: Optional[AddBlockResult] = None,
     expected_error: Optional[Err] = None,
     skip_prevalidation: bool = False,
     fork_point_with_peak: Optional[uint32] = None,
@@ -62,7 +62,7 @@ async def _validate_and_add_block(
         assert pre_validation_results is not None
         results = pre_validation_results[0]
     if results.error is not None:
-        if expected_result == ReceiveBlockResult.INVALID_BLOCK and expected_error is None:
+        if expected_result == AddBlockResult.INVALID_BLOCK and expected_error is None:
             # We expected an error but didn't specify which one
             await check_block_store_invariant(blockchain)
             return None
@@ -82,7 +82,7 @@ async def _validate_and_add_block(
     ) = await blockchain.receive_block(block, results, fork_point_with_peak=fork_point_with_peak)
     await check_block_store_invariant(blockchain)
 
-    if expected_error is None and expected_result != ReceiveBlockResult.INVALID_BLOCK:
+    if expected_error is None and expected_result != AddBlockResult.INVALID_BLOCK:
         # Expecting an error here (but didn't specify which), let's check if we actually got an error
         if err is not None:
             # Got an error
@@ -97,10 +97,10 @@ async def _validate_and_add_block(
         raise AssertionError(f"Expected {expected_result} but got {result}")
     elif expected_result is None:
         # If we expected an error assume that expected_result = INVALID_BLOCK
-        if expected_error is not None and result != ReceiveBlockResult.INVALID_BLOCK:
+        if expected_error is not None and result != AddBlockResult.INVALID_BLOCK:
             raise AssertionError(f"Block should be invalid, but received: {result}")
         # Otherwise, assume that expected_result = NEW_PEAK
-        if expected_error is None and result != ReceiveBlockResult.NEW_PEAK:
+        if expected_error is None and result != AddBlockResult.NEW_PEAK:
             raise AssertionError(f"Block was not added: {result}")
 
 
@@ -121,7 +121,7 @@ async def _validate_and_add_block_multi_error(
 async def _validate_and_add_block_multi_result(
     blockchain: Blockchain,
     block: FullBlock,
-    expected_result: List[ReceiveBlockResult],
+    expected_result: List[AddBlockResult],
     skip_prevalidation: Optional[bool] = None,
 ) -> None:
     try:
@@ -146,9 +146,9 @@ async def _validate_and_add_block_no_error(
         blockchain,
         block,
         expected_result=[
-            ReceiveBlockResult.ALREADY_HAVE_BLOCK,
-            ReceiveBlockResult.NEW_PEAK,
-            ReceiveBlockResult.ADDED_AS_ORPHAN,
+            AddBlockResult.ALREADY_HAVE_BLOCK,
+            AddBlockResult.NEW_PEAK,
+            AddBlockResult.ADDED_AS_ORPHAN,
         ],
         skip_prevalidation=skip_prevalidation,
     )

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -14,7 +14,7 @@ from clvm.casts import int_to_bytes
 
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.block_rewards import calculate_base_farmer_reward
-from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.blockchain import AddBlockResult
 from chia.consensus.coinbase import create_farmer_coin
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.multiprocess_validation import PreValidationResult
@@ -160,9 +160,7 @@ class TestBlockHeaderValidation:
                 assert error.code == Err.INVALID_NEW_SUB_SLOT_ITERS
 
                 # Also fails calling the outer methods, but potentially with a different error
-                await _validate_and_add_block(
-                    empty_blockchain, block_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK
-                )
+                await _validate_and_add_block(empty_blockchain, block_bad, expected_result=AddBlockResult.INVALID_BLOCK)
 
                 new_finished_ss_2 = recursive_replace(
                     block.finished_sub_slots[0],
@@ -186,7 +184,7 @@ class TestBlockHeaderValidation:
 
                 # Also fails calling the outer methods, but potentially with a different error
                 await _validate_and_add_block(
-                    empty_blockchain, block_bad_2, expected_result=ReceiveBlockResult.INVALID_BLOCK
+                    empty_blockchain, block_bad_2, expected_result=AddBlockResult.INVALID_BLOCK
                 )
 
                 # 3c
@@ -218,7 +216,7 @@ class TestBlockHeaderValidation:
 
                 # Also fails calling the outer methods, but potentially with a different error
                 await _validate_and_add_block(
-                    empty_blockchain, block_bad_3, expected_result=ReceiveBlockResult.INVALID_BLOCK
+                    empty_blockchain, block_bad_3, expected_result=AddBlockResult.INVALID_BLOCK
                 )
 
                 # 3d
@@ -249,7 +247,7 @@ class TestBlockHeaderValidation:
 
                 # Also fails calling the outer methods, but potentially with a different error
                 await _validate_and_add_block(
-                    empty_blockchain, block_bad_4, expected_result=ReceiveBlockResult.INVALID_BLOCK
+                    empty_blockchain, block_bad_4, expected_result=AddBlockResult.INVALID_BLOCK
                 )
             await _validate_and_add_block(empty_blockchain, block)
             log.info(
@@ -471,7 +469,7 @@ class TestBlockHeaderValidation:
         )
 
         assert error.code == Err.INVALID_PREV_CHALLENGE_SLOT_HASH
-        await _validate_and_add_block(empty_blockchain, block_0_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
+        await _validate_and_add_block(empty_blockchain, block_0_bad, expected_result=AddBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
     async def test_invalid_sub_slot_challenge_hash_non_genesis(self, empty_blockchain, bt):
@@ -498,7 +496,7 @@ class TestBlockHeaderValidation:
             blocks[1].finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
         )
         assert error.code == Err.INVALID_PREV_CHALLENGE_SLOT_HASH
-        await _validate_and_add_block(empty_blockchain, block_1_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
+        await _validate_and_add_block(empty_blockchain, block_1_bad, expected_result=AddBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
     async def test_invalid_sub_slot_challenge_hash_empty_ss(self, empty_blockchain, bt):
@@ -525,7 +523,7 @@ class TestBlockHeaderValidation:
             blocks[1].finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
         )
         assert error.code == Err.INVALID_PREV_CHALLENGE_SLOT_HASH
-        await _validate_and_add_block(empty_blockchain, block_1_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
+        await _validate_and_add_block(empty_blockchain, block_1_bad, expected_result=AddBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
     async def test_genesis_no_icc(self, empty_blockchain, bt):
@@ -681,7 +679,7 @@ class TestBlockHeaderValidation:
                     block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
                 )
                 assert error.code == Err.INVALID_ICC_HASH_CC
-                await _validate_and_add_block(blockchain, block_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
+                await _validate_and_add_block(blockchain, block_bad, expected_result=AddBlockResult.INVALID_BLOCK)
 
                 # 2i
                 new_finished_ss_bad_rc = recursive_replace(
@@ -751,7 +749,7 @@ class TestBlockHeaderValidation:
             empty_blockchain.constants.SUB_SLOT_ITERS_STARTING,
         )
         assert error.code == Err.INVALID_SUB_EPOCH_SUMMARY_HASH
-        await _validate_and_add_block(blockchain, block_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK)
+        await _validate_and_add_block(blockchain, block_bad, expected_result=AddBlockResult.INVALID_BLOCK)
 
     @pytest.mark.asyncio
     async def test_empty_sub_slots_epoch(self, empty_blockchain, default_400_blocks, bt):
@@ -765,10 +763,10 @@ class TestBlockHeaderValidation:
         for block in blocks_base:
             await _validate_and_add_block(empty_blockchain, block, skip_prevalidation=True)
         await _validate_and_add_block(
-            empty_blockchain, blocks_1[-1], expected_result=ReceiveBlockResult.NEW_PEAK, skip_prevalidation=True
+            empty_blockchain, blocks_1[-1], expected_result=AddBlockResult.NEW_PEAK, skip_prevalidation=True
         )
         await _validate_and_add_block(
-            empty_blockchain, blocks_2[-1], expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN, skip_prevalidation=True
+            empty_blockchain, blocks_2[-1], expected_result=AddBlockResult.ADDED_AS_ORPHAN, skip_prevalidation=True
         )
 
     @pytest.mark.asyncio
@@ -1233,25 +1231,19 @@ class TestBlockHeaderValidation:
                 block_bad = recursive_replace(
                     blocks[-1], "reward_chain_block.challenge_chain_sp_vdf.challenge", std_hash(b"1")
                 )
-                await _validate_and_add_block(
-                    empty_blockchain, block_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK
-                )
+                await _validate_and_add_block(empty_blockchain, block_bad, expected_result=AddBlockResult.INVALID_BLOCK)
                 block_bad = recursive_replace(
                     blocks[-1],
                     "reward_chain_block.challenge_chain_sp_vdf.output",
                     bad_element,
                 )
-                await _validate_and_add_block(
-                    empty_blockchain, block_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK
-                )
+                await _validate_and_add_block(empty_blockchain, block_bad, expected_result=AddBlockResult.INVALID_BLOCK)
                 block_bad = recursive_replace(
                     blocks[-1],
                     "reward_chain_block.challenge_chain_sp_vdf.number_of_iterations",
                     uint64(1111111111111),
                 )
-                await _validate_and_add_block(
-                    empty_blockchain, block_bad, expected_result=ReceiveBlockResult.INVALID_BLOCK
-                )
+                await _validate_and_add_block(empty_blockchain, block_bad, expected_result=AddBlockResult.INVALID_BLOCK)
                 block_bad = recursive_replace(
                     blocks[-1],
                     "challenge_chain_sp_proof",
@@ -1697,7 +1689,7 @@ class TestBlockHeaderValidation:
 
 
 co = ConditionOpcode
-rbr = ReceiveBlockResult
+rbr = AddBlockResult
 
 
 class TestPreValidation:
@@ -1741,7 +1733,7 @@ class TestPreValidation:
                 end_rb = time.time()
                 times_rb.append(end_rb - start_rb)
                 assert err is None
-                assert result == ReceiveBlockResult.NEW_PEAK
+                assert result == AddBlockResult.NEW_PEAK
                 log.info(
                     f"Added block {block.height} total iters {block.total_iters} "
                     f"new slot? {len(block.finished_sub_slots)}, time {end_rb - start_rb}"
@@ -1827,7 +1819,7 @@ class TestBodyValidation:
         # Ignore errors from pre-validation, we are testing block_body_validation
         repl_preval_results = replace(pre_validation_results[0], error=None, required_iters=uint64(1))
         code, err, state_change = await b.receive_block(blocks[-1], repl_preval_results)
-        assert code == ReceiveBlockResult.NEW_PEAK
+        assert code == AddBlockResult.NEW_PEAK
         assert err is None
         assert state_change.fork_height == 2
 
@@ -1923,16 +1915,16 @@ class TestBodyValidation:
                 ConditionOpcode.ASSERT_BEFORE_HEIGHT_RELATIVE,
                 ConditionOpcode.ASSERT_BEFORE_HEIGHT_ABSOLUTE,
             ]:
-                expected = ReceiveBlockResult.NEW_PEAK
+                expected = AddBlockResult.NEW_PEAK
 
             # before soft-fork 2, the timestamp we compared against was the
             # current block's timestamp as opposed to the previous tx-block's
             # timestamp. These conditions used to be valid, before the soft-fork
             if opcode == ConditionOpcode.ASSERT_SECONDS_RELATIVE and lock_value > 0 and lock_value <= 10:
-                expected = ReceiveBlockResult.NEW_PEAK
+                expected = AddBlockResult.NEW_PEAK
 
             if opcode == ConditionOpcode.ASSERT_SECONDS_ABSOLUTE and lock_value > 10020 and lock_value <= 10030:
-                expected = ReceiveBlockResult.NEW_PEAK
+                expected = AddBlockResult.NEW_PEAK
 
         async with make_empty_blockchain(constants) as b:
 
@@ -1970,7 +1962,7 @@ class TestBodyValidation:
             assert pre_validation_results is not None
             assert (await b.receive_block(blocks[-1], pre_validation_results[0]))[0] == expected
 
-            if expected == ReceiveBlockResult.NEW_PEAK:
+            if expected == AddBlockResult.NEW_PEAK:
                 # ensure coin was in fact spent
                 c = await b.coin_store.get_coin_record(coin.name())
                 assert c is not None and c.spent
@@ -1980,8 +1972,8 @@ class TestBodyValidation:
     @pytest.mark.parametrize(
         "with_garbage,expected",
         [
-            (True, (ReceiveBlockResult.INVALID_BLOCK, Err.INVALID_CONDITION, None)),
-            (False, (ReceiveBlockResult.NEW_PEAK, None, 2)),
+            (True, (AddBlockResult.INVALID_BLOCK, Err.INVALID_CONDITION, None)),
+            (False, (AddBlockResult.NEW_PEAK, None, 2)),
         ],
     )
     async def test_aggsig_garbage(self, empty_blockchain, opcode, with_garbage, expected, bt):
@@ -2111,7 +2103,7 @@ class TestBodyValidation:
                 ConditionOpcode.ASSERT_SECONDS_RELATIVE,
                 ConditionOpcode.ASSERT_HEIGHT_RELATIVE,
             ]:
-                expected = ReceiveBlockResult.INVALID_BLOCK
+                expected = AddBlockResult.INVALID_BLOCK
 
         else:
             constants = test_constants
@@ -2126,7 +2118,7 @@ class TestBodyValidation:
                 ConditionOpcode.ASSERT_BEFORE_SECONDS_RELATIVE,
                 ConditionOpcode.ASSERT_BEFORE_SECONDS_ABSOLUTE,
             ]:
-                expected = ReceiveBlockResult.NEW_PEAK
+                expected = AddBlockResult.NEW_PEAK
 
             # before the softfork, we compared ASSERT_SECONDS_* conditions
             # against the current block's timestamp, so we need to
@@ -2182,7 +2174,7 @@ class TestBodyValidation:
             assert pre_validation_results is not None
             assert (await b.receive_block(blocks[-1], pre_validation_results[0]))[0] == expected
 
-            if expected == ReceiveBlockResult.NEW_PEAK:
+            if expected == AddBlockResult.NEW_PEAK:
                 # ensure coin1 was in fact spent
                 c = await b.coin_store.get_coin_record(coin1.name())
                 assert c is not None and c.spent
@@ -2675,9 +2667,9 @@ class TestBodyValidation:
         #         farmer_reward_puzzle_hash=bt.pool_ph,
         #         pool_reward_puzzle_hash=bt.pool_ph,
         #     )
-        #     assert (await b.receive_block(blocks[0]))[0] == ReceiveBlockResult.NEW_PEAK
-        #     assert (await b.receive_block(blocks[1]))[0] == ReceiveBlockResult.NEW_PEAK
-        #     assert (await b.receive_block(blocks[2]))[0] == ReceiveBlockResult.NEW_PEAK
+        #     assert (await b.receive_block(blocks[0]))[0] == AddBlockResult.NEW_PEAK
+        #     assert (await b.receive_block(blocks[1]))[0] == AddBlockResult.NEW_PEAK
+        #     assert (await b.receive_block(blocks[2]))[0] == AddBlockResult.NEW_PEAK
 
         #     wt: WalletTool = bt_2.get_pool_wallet_tool()
 
@@ -2913,8 +2905,8 @@ class TestBodyValidation:
             await _validate_and_add_block(b, block)
 
         blocks_reorg = bt.get_consecutive_blocks(2, block_list_input=blocks[:-7], guarantee_transaction_block=True)
-        await _validate_and_add_block(b, blocks_reorg[-2], expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN)
-        await _validate_and_add_block(b, blocks_reorg[-1], expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN)
+        await _validate_and_add_block(b, blocks_reorg[-2], expected_result=AddBlockResult.ADDED_AS_ORPHAN)
+        await _validate_and_add_block(b, blocks_reorg[-1], expected_result=AddBlockResult.ADDED_AS_ORPHAN)
 
         # Coin does not exist in reorg
         blocks_reorg = bt.get_consecutive_blocks(
@@ -2928,7 +2920,7 @@ class TestBodyValidation:
         blocks_reorg = bt.get_consecutive_blocks(
             1, block_list_input=blocks_reorg[:-1], guarantee_transaction_block=True, transaction_data=agg
         )
-        await _validate_and_add_block(b, blocks_reorg[-1], expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN)
+        await _validate_and_add_block(b, blocks_reorg[-1], expected_result=AddBlockResult.ADDED_AS_ORPHAN)
 
         blocks_reorg = bt.get_consecutive_blocks(
             1, block_list_input=blocks_reorg, guarantee_transaction_block=True, transaction_data=tx_2
@@ -2944,7 +2936,7 @@ class TestBodyValidation:
         )
         for block in blocks_reorg[-10:]:
             await _validate_and_add_block_multi_result(
-                b, block, expected_result=[ReceiveBlockResult.ADDED_AS_ORPHAN, ReceiveBlockResult.NEW_PEAK]
+                b, block, expected_result=[AddBlockResult.ADDED_AS_ORPHAN, AddBlockResult.NEW_PEAK]
             )
 
         # ephemeral coin is spent
@@ -3106,9 +3098,9 @@ class TestReorgs:
         blocks_reorg_chain = bt.get_consecutive_blocks(7, blocks[:10], seed=b"2")
         for reorg_block in blocks_reorg_chain:
             if reorg_block.height < 10:
-                await _validate_and_add_block(b, reorg_block, expected_result=ReceiveBlockResult.ALREADY_HAVE_BLOCK)
+                await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK)
             elif reorg_block.height < 15:
-                await _validate_and_add_block(b, reorg_block, expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN)
+                await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ADDED_AS_ORPHAN)
             elif reorg_block.height >= 15:
                 await _validate_and_add_block(b, reorg_block)
         assert b.get_peak().height == 16
@@ -3141,13 +3133,13 @@ class TestReorgs:
         for reorg_block in test_long_reorg_blocks:
             if reorg_block.height < num_blocks_chain_2_start:
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=ReceiveBlockResult.ALREADY_HAVE_BLOCK, skip_prevalidation=True
+                    b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK, skip_prevalidation=True
                 )
             elif reorg_block.weight <= chain_1_weight:
                 await _validate_and_add_block_multi_result(
                     b,
                     reorg_block,
-                    [ReceiveBlockResult.ADDED_AS_ORPHAN, ReceiveBlockResult.ALREADY_HAVE_BLOCK],
+                    [AddBlockResult.ADDED_AS_ORPHAN, AddBlockResult.ALREADY_HAVE_BLOCK],
                     skip_prevalidation=True,
                 )
             elif reorg_block.weight > chain_1_weight:
@@ -3181,7 +3173,7 @@ class TestReorgs:
                 await _validate_and_add_block_multi_result(
                     b,
                     reorg_block,
-                    expected_result=[ReceiveBlockResult.ADDED_AS_ORPHAN, ReceiveBlockResult.ALREADY_HAVE_BLOCK],
+                    expected_result=[AddBlockResult.ADDED_AS_ORPHAN, AddBlockResult.ALREADY_HAVE_BLOCK],
                 )
             elif reorg_block.height >= 15:
                 await _validate_and_add_block(b, reorg_block)
@@ -3189,7 +3181,7 @@ class TestReorgs:
         # Back to original chain
         blocks_reorg_chain_2 = bt.get_consecutive_blocks(3, blocks, seed=b"3")
 
-        await _validate_and_add_block(b, blocks_reorg_chain_2[-3], expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN)
+        await _validate_and_add_block(b, blocks_reorg_chain_2[-3], expected_result=AddBlockResult.ADDED_AS_ORPHAN)
         await _validate_and_add_block(b, blocks_reorg_chain_2[-2])
         await _validate_and_add_block(b, blocks_reorg_chain_2[-1])
 
@@ -3353,11 +3345,11 @@ async def test_reorg_new_ref(empty_blockchain, bt):
     for i, block in enumerate(blocks_reorg_chain):
         fork_point_with_peak = None
         if i < 10:
-            expected = ReceiveBlockResult.ALREADY_HAVE_BLOCK
+            expected = AddBlockResult.ALREADY_HAVE_BLOCK
         elif i < 20:
-            expected = ReceiveBlockResult.ADDED_AS_ORPHAN
+            expected = AddBlockResult.ADDED_AS_ORPHAN
         else:
-            expected = ReceiveBlockResult.NEW_PEAK
+            expected = AddBlockResult.NEW_PEAK
             fork_point_with_peak = uint32(1)
         await _validate_and_add_block(b, block, expected_result=expected, fork_point_with_peak=fork_point_with_peak)
     assert b.get_peak().height == 20
@@ -3405,11 +3397,11 @@ async def test_reorg_stale_fork_height(empty_blockchain, bt):
     blocks = bt.get_consecutive_blocks(4, blocks, previous_generator=[uint32(5)], transaction_data=spend_bundle2)
 
     for block in blocks[:5]:
-        await _validate_and_add_block(b, block, expected_result=ReceiveBlockResult.NEW_PEAK)
+        await _validate_and_add_block(b, block, expected_result=AddBlockResult.NEW_PEAK)
 
     # fake the fork_height to make every new block look like a reorg
     for block in blocks[5:]:
-        await _validate_and_add_block(b, block, expected_result=ReceiveBlockResult.NEW_PEAK, fork_point_with_peak=2)
+        await _validate_and_add_block(b, block, expected_result=AddBlockResult.NEW_PEAK, fork_point_with_peak=2)
     assert b.get_peak().height == 13
 
 
@@ -3454,7 +3446,7 @@ async def test_chain_failed_rollback(empty_blockchain, bt):
     )
 
     for block in blocks_reorg_chain[10:-1]:
-        await _validate_and_add_block(b, block, expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN)
+        await _validate_and_add_block(b, block, expected_result=AddBlockResult.ADDED_AS_ORPHAN)
 
     # Incorrectly set the height as spent in DB to trigger an error
     print(f"{await b.coin_store.get_coin_record(spend_bundle.coin_spends[0].coin.name())}")

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Set, Tuple
 import pytest
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
-from chia.consensus.blockchain import Blockchain, ReceiveBlockResult
+from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
@@ -346,15 +346,11 @@ class TestCoinStoreWithBlocks:
 
                 for reorg_block in blocks_reorg_chain:
                     if reorg_block.height < initial_block_count - 10:
-                        await _validate_and_add_block(
-                            b, reorg_block, expected_result=ReceiveBlockResult.ALREADY_HAVE_BLOCK
-                        )
+                        await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK)
                     elif reorg_block.height < initial_block_count:
-                        await _validate_and_add_block(
-                            b, reorg_block, expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN
-                        )
+                        await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ADDED_AS_ORPHAN)
                     elif reorg_block.height >= initial_block_count:
-                        await _validate_and_add_block(b, reorg_block, expected_result=ReceiveBlockResult.NEW_PEAK)
+                        await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.NEW_PEAK)
                         if reorg_block.is_transaction_block():
                             coins = reorg_block.get_included_reward_coins()
                             records = [await coin_store.get_coin_record(coin.name()) for coin in coins]

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import pytest
 import pytest_asyncio
 
-from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.blockchain import AddBlockResult
 from chia.consensus.find_fork_point import find_fork_point_in_chain
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.consensus.pot_iterations import is_overflow_block
@@ -486,7 +486,7 @@ class TestFullNodeStore:
             blocks_4[-1].reward_chain_block.signage_point_index
             < test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA
         )
-        await _validate_and_add_block(blockchain, blocks_4[-1], expected_result=ReceiveBlockResult.ADDED_AS_ORPHAN)
+        await _validate_and_add_block(blockchain, blocks_4[-1], expected_result=AddBlockResult.ADDED_AS_ORPHAN)
 
         sb = blockchain.block_record(blocks_4[-1].header_hash)
         store.new_peak(sb, blocks_4[-1], None, None, None, blockchain)

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -63,7 +63,7 @@ async def check_spend_bundle_validity(
 ) -> Tuple[List[CoinRecord], List[CoinRecord]]:
     """
     This test helper create an extra block after the given blocks that contains the given
-    `SpendBundle`, and then invokes `receive_block` to ensure that it's accepted (if `expected_err=None`)
+    `SpendBundle`, and then invokes `add_block` to ensure that it's accepted (if `expected_err=None`)
     or fails with the correct error code.
     """
     if softfork2:

--- a/tests/core/test_db_conversion.py
+++ b/tests/core/test_db_conversion.py
@@ -77,7 +77,7 @@ class TestDbUpgrade:
                 for block in blocks:
                     # await _validate_and_add_block(bc, block)
                     results = PreValidationResult(None, uint64(1), None, False)
-                    result, err, _ = await bc.receive_block(block, results)
+                    result, err, _ = await bc.add_block(block, results)
                     assert err is None
             finally:
                 await db_wrapper1.close()

--- a/tests/core/test_db_validation.py
+++ b/tests/core/test_db_validation.py
@@ -143,7 +143,7 @@ async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
 
         for block in blocks:
             results = PreValidationResult(None, uint64(1), None, False)
-            result, err, _ = await bc.receive_block(block, results)
+            result, err, _ = await bc.add_block(block, results)
             assert err is None
     finally:
         await db_wrapper.close()

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -4,7 +4,7 @@ import dataclasses
 
 import pytest
 
-from chia.consensus.blockchain import ReceiveBlockResult
+from chia.consensus.blockchain import AddBlockResult
 from chia.protocols import full_node_protocol
 from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.vdf import VDFProof
@@ -75,26 +75,26 @@ class TestWalletBlockchain:
 
             res, err = await chain.receive_block(header_blocks[50])
             print(res, err)
-            assert res == ReceiveBlockResult.DISCONNECTED_BLOCK
+            assert res == AddBlockResult.DISCONNECTED_BLOCK
 
             res, err = await chain.receive_block(header_blocks[400])
             print(res, err)
-            assert res == ReceiveBlockResult.ALREADY_HAVE_BLOCK
+            assert res == AddBlockResult.ALREADY_HAVE_BLOCK
 
             res, err = await chain.receive_block(header_blocks[507])
             print(res, err)
-            assert res == ReceiveBlockResult.DISCONNECTED_BLOCK
+            assert res == AddBlockResult.DISCONNECTED_BLOCK
 
             res, err = await chain.receive_block(
                 dataclasses.replace(header_blocks[506], challenge_chain_ip_proof=VDFProof(2, b"123", True))
             )
-            assert res == ReceiveBlockResult.INVALID_BLOCK
+            assert res == AddBlockResult.INVALID_BLOCK
 
             assert (await chain.get_peak_block()).height == 505
 
             for block in header_blocks[506:]:
                 res, err = await chain.receive_block(block)
-                assert res == ReceiveBlockResult.NEW_PEAK
+                assert res == AddBlockResult.NEW_PEAK
                 assert (await chain.get_peak_block()).height == block.height
 
             assert (await chain.get_peak_block()).height == 999


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Same idea like in #14458 - Renaming `receive` to `add`.. maybe it's only me but i was confused many times until i internalized all the `receive`'s which are there to add.. i feel like `add` is just much clearer in this context when reading the code.

### New Behavior:

No change in behaviour.