### PR TITLE
server: Exclude some attributes from `WSChiaConnection.__repr__`

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -59,18 +59,18 @@ class WSChiaConnection:
     set after the handshake is performed in this connection.
     """
 
-    ws: WebSocket
-    api: Any
+    ws: WebSocket = field(repr=False)
+    api: Any = field(repr=False)
     local_type: NodeType
     local_port: int
-    local_capabilities_for_handshake: List[Tuple[uint16, str]]
+    local_capabilities_for_handshake: List[Tuple[uint16, str]] = field(repr=False)
     local_capabilities: List[Capability]
     peer_host: str
     peer_port: uint16
     peer_node_id: bytes32
-    log: logging.Logger
+    log: logging.Logger = field(repr=False)
 
-    close_callback: Optional[ConnectionClosedCallbackProtocol]
+    close_callback: Optional[ConnectionClosedCallbackProtocol] = field(repr=False)
     outbound_rate_limiter: RateLimiter
     inbound_rate_limiter: RateLimiter
 
@@ -78,12 +78,12 @@ class WSChiaConnection:
     is_outbound: bool
 
     # Messaging
-    received_message_callback: Optional[ConnectionCallback]
-    incoming_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue)
-    outgoing_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue)
-    api_tasks: Dict[bytes32, asyncio.Task[None]] = field(default_factory=dict)
+    received_message_callback: Optional[ConnectionCallback] = field(repr=False)
+    incoming_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue, repr=False)
+    outgoing_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue, repr=False)
+    api_tasks: Dict[bytes32, asyncio.Task[None]] = field(default_factory=dict, repr=False)
     # Contains task ids of api tasks which should not be canceled
-    execute_tasks: Set[bytes32] = field(default_factory=set)
+    execute_tasks: Set[bytes32] = field(default_factory=set, repr=False)
 
     # ChiaConnection metrics
     creation_time: float = field(default_factory=time.time)
@@ -92,15 +92,15 @@ class WSChiaConnection:
     last_message_time: float = 0
 
     peer_server_port: Optional[uint16] = None
-    inbound_task: Optional[asyncio.Task[None]] = None
-    incoming_message_task: Optional[asyncio.Task[None]] = None
-    outbound_task: Optional[asyncio.Task[None]] = None
+    inbound_task: Optional[asyncio.Task[None]] = field(default=None, repr=False)
+    incoming_message_task: Optional[asyncio.Task[None]] = field(default=None, repr=False)
+    outbound_task: Optional[asyncio.Task[None]] = field(default=None, repr=False)
     active: bool = False  # once handshake is successful this will be changed to True
-    _close_event: asyncio.Event = field(default_factory=asyncio.Event)
-    session: Optional[ClientSession] = None
+    _close_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+    session: Optional[ClientSession] = field(default=None, repr=False)
 
-    pending_requests: Dict[uint16, asyncio.Event] = field(default_factory=dict)
-    request_results: Dict[uint16, Message] = field(default_factory=dict)
+    pending_requests: Dict[uint16, asyncio.Event] = field(default_factory=dict, repr=False)
+    request_results: Dict[uint16, Message] = field(default_factory=dict, repr=False)
     closed: bool = False
     connection_type: Optional[NodeType] = None
     request_nonce: uint16 = uint16(0)

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Callable, Tuple
 
 import pytest
 
@@ -9,6 +9,7 @@ from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
+from tests.connection_utils import connect_and_get_peer
 
 
 @pytest.mark.asyncio
@@ -18,3 +19,19 @@ async def test_duplicate_client_connection(
     _, _, server_1, server_2, _ = two_nodes
     assert await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
     assert not await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", [repr, str])
+async def test_connection_string_conversion(
+    two_nodes_one_block: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    self_hostname: str,
+    method: Callable[[object], str],
+) -> None:
+    _, _, server_1, server_2, _ = two_nodes_one_block
+    peer = await connect_and_get_peer(server_1, server_2, self_hostname)
+    # 1000 is based on the current implementation (example below), should be reconsidered/adjusted if this test fails
+    # WSChiaConnection(local_type=<NodeType.FULL_NODE: 1>, local_port=50632, local_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>], peer_host='127.0.0.1', peer_port=50640, peer_node_id=<bytes32: 566a318f0f656125b4fef0e85fbddcf9bc77f8003d35293c392479fc5d067f4d>, outbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13f50>, inbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13e90>, is_outbound=False, creation_time=1675271096.275591, bytes_read=68, bytes_written=162, last_message_time=1675271096.276271, peer_server_port=50636, active=False, closed=False, connection_type=<NodeType.FULL_NODE: 1>, request_nonce=32768, peer_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>], version='', protocol_version='') # noqa
+    converted = method(peer)
+    print(converted)
+    assert len(converted) < 1000


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Right now the string representation of `WSChiaConnection` can be *huge* and can totally blow up the logs, mostly but not only because `WSChiaConnection.close_callback` leads to a print of the full `ChiaServer` which contains tons of data. There are some cases where we log `WSChiaConnection` objects, search for `{peer}`, and there might be more so this PR reduces the size of the string representation by excluding attributes to avoid this spam and potentially sensitive data in the log.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

`WSChiaConnection`'s string representation contains all available attributes.

### New Behavior:

`WSChiaConnection`'s string representation has some attributes excluded.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

There is a test added to ensure the representation doesn't blow up again.