### PR TITLE
make the tests use the real COST_PER_BYTE constant

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -136,7 +136,6 @@ test_constants = DEFAULT_CONSTANTS.replace(
         "MAX_FUTURE_TIME": 3600
         * 24
         * 10,  # Allows creating blockchains with timestamps up to 10 days in the future, for testing
-        "COST_PER_BYTE": 1337,
         "MEMPOOL_BLOCK_BUFFER": 6,
     }
 )

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -902,8 +902,11 @@ class TestFullNodeProtocol:
                 not_included_tx += 1
         assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(10000000 * group_size)
 
-        assert included_tx > 0
-        assert not_included_tx == 3
+        # these numbers reflect the capacity of the mempool. In these
+        # tests MEMPOOL_BLOCK_BUFFER is 1. The other factors are COST_PER_BYTE
+        # and MAX_BLOCK_COST_CLVM
+        assert included_tx == 23
+        assert not_included_tx == 10
         assert seen_bigger_transaction_has_high_fee
 
         # Mempool is full


### PR DESCRIPTION
Some of our tests use a special set of test constants (rather than the mainnet `DEFAULT_CONSTANTS`). One reason for this is to make it cheap enough to create blocks even with very small plots, for tests.

However, the test constant version of `COST_PER_BYTE` does not serve any important purpose like that. I would like to remove it from the override-set, to always use the actual mainnet constant. This had one small implication on one of the tests.

The reason to harmonize this constant in the tests is to facilitate a future transition to a higher level function to run the block generators, implemented in rust. This constant is also encoded in `chia_rs` as the mainnet constant (of 12000).