### PR TITLE
wallet: Drop `async` for `can_use_peer_request_cache`

### DIFF
--- a/chia/wallet/util/peer_request_cache.py
+++ b/chia/wallet/util/peer_request_cache.py
@@ -132,7 +132,7 @@ class PeerRequestCache:
         self._additions_in_block = new_additions_in_block
 
 
-async def can_use_peer_request_cache(
+def can_use_peer_request_cache(
     coin_state: CoinState, peer_request_cache: PeerRequestCache, fork_height: Optional[uint32]
 ) -> bool:
     if not peer_request_cache.in_states_validated(coin_state.get_hash()):

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1291,7 +1291,7 @@ class WalletNode:
         """
         # Only use the cache if we are talking about states before the fork point. If we are evaluating something
         # in a reorg, we cannot use the cache, since we don't know if it's actually in the new chain after the reorg.
-        if await can_use_peer_request_cache(coin_state, peer_request_cache, fork_height):
+        if can_use_peer_request_cache(coin_state, peer_request_cache, fork_height):
             return True
 
         spent_height: Optional[uint32] = None if coin_state.spent_height is None else uint32(coin_state.spent_height)


### PR DESCRIPTION
There is not need for it to be `async`.
