### PR TITLE
remove test aimed at the inital soft-fork to enable transactions

### DIFF
--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -1551,65 +1551,6 @@ class TestFullNodeProtocol:
 
         await time_out_assert(20, caught_up_slots)
 
-    @pytest.mark.skip("a timebomb causes mainnet to stop after transactions start, so this test doesn't work yet")
-    @pytest.mark.asyncio
-    async def test_mainnet_softfork(self, wallet_nodes_mainnet):
-        full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver, bt = wallet_nodes_mainnet
-        blocks = await full_node_1.get_all_full_blocks()
-
-        wallet_ph = wallet_a.get_new_puzzlehash()
-        blocks = bt.get_consecutive_blocks(
-            3,
-            block_list_input=blocks,
-            guarantee_transaction_block=True,
-            farmer_reward_puzzle_hash=wallet_ph,
-            pool_reward_puzzle_hash=wallet_ph,
-        )
-        for block in blocks[-3:]:
-            await full_node_1.full_node.respond_block(fnp.RespondBlock(block))
-
-        conditions_dict: Dict = {ConditionOpcode.CREATE_COIN: []}
-
-        receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
-        output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [receiver_puzzlehash, int_to_bytes(1000)])
-        conditions_dict[ConditionOpcode.CREATE_COIN].append(output)
-
-        spend_bundle: SpendBundle = wallet_a.generate_signed_transaction(
-            100,
-            32 * b"0",
-            get_future_reward_coins(blocks[1])[0],
-            condition_dic=conditions_dict,
-        )
-        assert spend_bundle is not None
-        max_size = test_constants.MAX_GENERATOR_SIZE
-        large_puzzle_reveal = (max_size + 1) * b"0"
-        under_sized = max_size * b"0"
-        blocks_new = bt.get_consecutive_blocks(
-            1,
-            block_list_input=blocks,
-            guarantee_transaction_block=True,
-            transaction_data=spend_bundle,
-        )
-
-        invalid_block: FullBlock = blocks_new[-1]
-        invalid_program = SerializedProgram.from_bytes(large_puzzle_reveal)
-        invalid_block = dataclasses.replace(invalid_block, transactions_generator=invalid_program)
-
-        await _validate_and_add_block(
-            full_node_1.full_node.blockchain, invalid_block, expected_error=Err.PRE_SOFT_FORK_MAX_GENERATOR_SIZE
-        )
-
-        blocks_new = bt.get_consecutive_blocks(
-            1,
-            block_list_input=blocks,
-            guarantee_transaction_block=True,
-            transaction_data=spend_bundle,
-        )
-        valid_block = blocks_new[-1]
-        valid_program = SerializedProgram.from_bytes(under_sized)
-        valid_block = dataclasses.replace(valid_block, transactions_generator=valid_program)
-        await _validate_and_add_block(full_node_1.full_node.blockchain, valid_block)
-
     @pytest.mark.asyncio
     async def test_compact_protocol(self, setup_two_nodes_fixture):
         nodes, _, bt = setup_two_nodes_fixture


### PR DESCRIPTION
When chia was first launched, we were not done supporting transactions. We had a pre-defined block height for introducing support. All this special case code has now been removed, and the historic chain is treated as-if transactions were supported during that time, there just weren't any.

This is a left-over test from that time, to ensure the soft-fork logic worked. It's marked as skipped since we not longer have that special case logic. We might as well remove it.