### PR TITLE
fix crossed parameters for setup_simulators_and_wallets_inner() calling setup_full_node()

### DIFF
--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -283,10 +283,10 @@ async def setup_simulators_and_wallets_inner(
             )
         )  # block tools modifies constants
         sim = setup_full_node(
-            bt_tools[index].constants,
-            bt_tools[index].config["self_hostname"],
-            db_name,
-            bt_tools[index],
+            consensus_constants=bt_tools[index].constants,
+            db_name=db_name,
+            self_hostname=bt_tools[index].config["self_hostname"],
+            local_bt=bt_tools[index],
             simulator=True,
             db_version=db_version,
             disable_capabilities=disable_capabilities,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Correct the test code.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The self hostname is passed as the db name while the db name is used as the self hostname.

### New Behavior:

Parameters go to the proper places.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
