### PR TITLE
feat: make recurse_jsonify support for float

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -328,6 +328,8 @@ def recurse_jsonify(d: Any) -> Any:
         return d
     elif isinstance(d, int):
         return int(d)
+    elif isinstance(d, float):
+        return float(d)
     elif d is None or type(d) == str:
         return d
     elif hasattr(d, "to_json_dict"):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
To extend the type of number support in recurse_jsonify.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
for numbers, currently recurse_jsonify only supports for int


### New Behavior:
make recurse_jsonify also supports for float numbers


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
