### PR TITLE
Adding Community seeders/dns introducers

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -411,6 +411,9 @@ full_node:
   # If you modify this, please change the hardcode as well from FullNode.set_server()
   dns_servers:
     - "dns-introducer.chia.net"
+    - "chia.hoffmang.com"
+    - "seeder.xchpool.org"
+    - "chia.ctrlaltdel.ch"
   farmer_peer:
       host: *self_hostname
       port: 8447
@@ -495,6 +498,9 @@ wallet:
 
   dns_servers:
     - "dns-introducer.chia.net"
+    - "chia.hoffmang.com"
+    - "seeder.xchpool.org"
+    - "chia.ctrlaltdel.ch"
 
   full_node_peer:
     host: *self_hostname

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -411,9 +411,10 @@ full_node:
   # If you modify this, please change the hardcode as well from FullNode.set_server()
   dns_servers:
     - "dns-introducer.chia.net"
+    - "chia.ctrlaltdel.ch"
+    - "chia-seeder.h9.com"
     - "chia.hoffmang.com"
     - "seeder.xchpool.org"
-    - "chia.ctrlaltdel.ch"
   farmer_peer:
       host: *self_hostname
       port: 8447
@@ -498,9 +499,10 @@ wallet:
 
   dns_servers:
     - "dns-introducer.chia.net"
+    - "chia.ctrlaltdel.ch"
+    - "chia-seeder.h9.com"
     - "chia.hoffmang.com"
     - "seeder.xchpool.org"
-    - "chia.ctrlaltdel.ch"
 
   full_node_peer:
     host: *self_hostname

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -409,7 +409,7 @@ full_node:
 
   # List of trusted DNS seeders to bootstrap from.
   # If you modify this, please change the hardcode as well from FullNode.set_server()
-  dns_servers:
+  dns_servers: &dns_servers
     - "dns-introducer.chia.net"
     - "chia.ctrlaltdel.ch"
     - "chia-seeder.h9.com"
@@ -497,12 +497,7 @@ wallet:
 
   initial_num_public_keys: 425
 
-  dns_servers:
-    - "dns-introducer.chia.net"
-    - "chia.ctrlaltdel.ch"
-    - "chia-seeder.h9.com"
-    - "chia.hoffmang.com"
-    - "seeder.xchpool.org"
+  dns_servers: *dns_servers
 
   full_node_peer:
     host: *self_hostname


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Currently wallet and node use only `dns-introducer.chia.net` when searching in the primary manner for nodes with open ports. This adds an initial batch of dns introducer/seeders run by various individuals and entities around the world. After fixes in 1.6.2, this list is randomly selected from to spread this traffic. If one seeder doesn't reply, wallet and node will pick a next one to try from the random order. If others wish to be included the can follow the [Chia Seeder User's Guide](https://github.com/Chia-Network/chia-blockchain/wiki/Chia-Seeder-User-Guide) and make a pull request against initial-config.yaml. Note that the list is sorted by primary domain name alphabetical order (e.g h9 before hoffmang.) This removes one centralizing point from this software.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
All dns/seeder requests go to `dns-introducer.chia.net`.


### New Behavior:
Requests to dns/seeder will now pick randomly from a list of community and CNI run seeders which increases decentralization.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Each community seeder was hand tested before inclusion with both `dig chia.hoffmang.com` and `dig -t AAAA chia.hoffmang.com`.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
