### PR TITLE
Revert "pin mypy to < 1 (#14504)"

### DIFF
--- a/chia/util/files.py
+++ b/chia/util/files.py
@@ -71,8 +71,8 @@ async def write_file_async(file_path: Path, data: Union[str, bytes], *, file_mod
     mode: Literal["w+", "w+b"] = "w+" if type(data) == str else "w+b"
     temp_file_path: Path
     async with tempfile.NamedTemporaryFile(dir=file_path.parent, mode=mode, delete=False) as f:
-        temp_file_path = f.name
-        await f.write(data)
+        temp_file_path = f.name  # type: ignore[assignment]
+        await f.write(data)  # type: ignore[arg-type]
         await f.flush()
         os.fsync(f.fileno())
 

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,7 @@ dev_dependencies = [
     "twine",
     "isort",
     "flake8",
-    # TODO: remove this pin after fixing the new complaints
-    "mypy<1",
+    "mypy",
     "black==22.10.0",
     "aiohttp_cors",  # For blackd
     "ipython",  # For asyncio debugging


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fixup to account for new complaints from mypy v1.

```
chia/util/files.py:74: error: Incompatible types in assignment (expression has type "Union[str, bytes, PathLike[str], PathLike[bytes], int]", variable has type "PathLike[Any]")  [assignment]
chia/util/files.py:75: error: Argument 1 to "write" of "AsyncTextIOWrapper" has incompatible type "Union[str, bytes]"; expected "str"  [arg-type]
chia/util/files.py:75: error: Argument 1 to "write" of "_UnknownAsyncBinaryIO" has incompatible type "Union[str, bytes]"; expected "Union[bytes, Union[bytearray, memoryview, array[Any], mmap, _CData, PickleBuffer]]"  [arg-type]
chia/util/files.py:80: error: Argument 1 to "move_file_async" has incompatible type "PathLike[Any]"; expected "Path"  [arg-type]
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Pinned to mypy <1.

### New Behavior:

Working with mypy 1.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

### Draft For:
- [ ] Actually dealing with the complaints.