### PR TITLE
let sqlite count NFTs on removal

### DIFF
--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -280,8 +280,8 @@ class NFTWallet:
         if nft_coin_info:
             await self.nft_store.delete_nft_by_coin_id(coin.name(), height)
             self.wallet_state_manager.state_changed("nft_coin_removed", self.wallet_info.id)
-            num = await self.get_current_nfts()
-            if len(num) == 0 and self.did_id is not None:
+            num = await self.get_nft_count()
+            if num == 0 and self.did_id is not None:
                 # Check if the wallet owns the DID
                 for did_wallet in await self.wallet_state_manager.get_all_wallet_info_entries(
                     wallet_type=WalletType.DECENTRALIZED_ID


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
improve performance when removing NFTs 


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
we load all NFTs into memory to count them


### New Behavior:
we ask the db to count them, which is going to be much faster for wallets with large number of NFTs


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
have a lot of NFTs in your wallet 


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
