### PR TITLE
wallet: Fix sync mode indication

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1111,8 +1111,7 @@ class WalletNode:
             await self.wallet_state_manager.new_peak(new_peak)
 
     async def new_peak_from_trusted(self, new_peak_hb: HeaderBlock, latest_timestamp: uint64, peer: WSChiaConnection):
-        current_height: uint32 = await self.wallet_state_manager.blockchain.get_finished_sync_up_to()
-        async with self.wallet_state_manager.set_sync_mode(new_peak_hb.height):
+        async with self.wallet_state_manager.set_sync_mode(new_peak_hb.height) as current_height:
             await self.wallet_state_manager.blockchain.set_peak_block(new_peak_hb, latest_timestamp)
             # Disconnect from all untrusted peers if our local node is trusted and synced
             await self.disconnect_and_stop_wpeers()

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -382,7 +382,7 @@ class WalletNode:
 
         self.sync_event = asyncio.Event()
         self.log_in(private_key)
-        self.wallet_state_manager.set_sync_mode(False)
+        self.wallet_state_manager.state_changed("sync_changed")
 
         async with self.wallet_state_manager.puzzle_store.lock:
             index = await self.wallet_state_manager.puzzle_store.get_last_derivation_path()
@@ -1112,7 +1112,7 @@ class WalletNode:
 
     async def new_peak_from_trusted(self, new_peak_hb: HeaderBlock, latest_timestamp: uint64, peer: WSChiaConnection):
         current_height: uint32 = await self.wallet_state_manager.blockchain.get_finished_sync_up_to()
-        async with self.wallet_state_manager.lock:
+        async with self.wallet_state_manager.set_sync_mode(new_peak_hb.height):
             await self.wallet_state_manager.blockchain.set_peak_block(new_peak_hb, latest_timestamp)
             # Disconnect from all untrusted peers if our local node is trusted and synced
             await self.disconnect_and_stop_wpeers()
@@ -1120,10 +1120,7 @@ class WalletNode:
             # disconnected), we assume that the full node will continue to give us state updates, so we do
             # not need to resync.
             if peer.peer_node_id not in self.synced_peers:
-                if new_peak_hb.height - current_height > self.LONG_SYNC_THRESHOLD:
-                    self.wallet_state_manager.set_sync_mode(True)
                 await self.long_sync(new_peak_hb.height, peer, uint32(max(0, current_height - 256)), rollback=True)
-                self.wallet_state_manager.set_sync_mode(False)
 
     async def new_peak_from_untrusted(
         self, new_peak_hb: HeaderBlock, peer: WSChiaConnection, request_time: uint64
@@ -1146,7 +1143,6 @@ class WalletNode:
         syncing = False
         if far_behind or len(self.synced_peers) == 0:
             syncing = True
-            self.wallet_state_manager.set_sync_mode(True)
 
         secondary_sync_running = (
             self._secondary_peer_sync_task is not None and self._secondary_peer_sync_task.done() is False
@@ -1164,8 +1160,6 @@ class WalletNode:
         except Exception:
             self.log.exception(f"Error syncing to {peer.get_peer_info()}")
             await peer.close()
-            if syncing:
-                self.wallet_state_manager.set_sync_mode(False)
             return False
         return True
 
@@ -1188,10 +1182,8 @@ class WalletNode:
         await self.wallet_state_manager.blockchain.new_valid_weight_proof(weight_proof, block_records)
 
         if syncing:
-            async with self.wallet_state_manager.lock:
-                self.log.info("Primary peer syncing")
+            async with self.wallet_state_manager.set_sync_mode(new_peak_hb.height):
                 await self.long_sync(new_peak_hb.height, peer, fork_point, rollback=True)
-            self.log.info(f"New peak wallet.. {new_peak_hb.height} {peer.get_peer_info()} 12")
             return
 
         # we exit earlier in the case where syncing is False and a Secondary sync is running
@@ -1239,7 +1231,6 @@ class WalletNode:
                     await self.receive_state_from_peer(list(self.race_cache[header_hash]), peer)
 
             self.wallet_state_manager.state_changed("new_block")
-            self.wallet_state_manager.set_sync_mode(False)
             self.log.info(f"Finished processing new peak of {new_peak_hb.height}")
             return True
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -538,7 +538,8 @@ class WalletStateManager:
 
     @asynccontextmanager
     async def set_sync_mode(self, target_height: uint32) -> AsyncIterator[None]:
-        self.log.debug(f"set_sync_mode enter {await self.blockchain.get_finished_sync_up_to()}-{target_height}")
+        if self.log.level == logging.DEBUG:
+            self.log.debug(f"set_sync_mode enter {await self.blockchain.get_finished_sync_up_to()}-{target_height}")
         async with self.lock:
             start_time = time.time()
             start_height = await self.blockchain.get_finished_sync_up_to()
@@ -554,11 +555,12 @@ class WalletStateManager:
             finally:
                 self._sync_target = None
                 self.state_changed("sync_changed")
-                self.log.debug(
-                    f"set_sync_mode exit - range: {start_height}-{target_height}, "
-                    f"get_finished_sync_up_to: {await self.blockchain.get_finished_sync_up_to()}, "
-                    f"seconds: {time.time() - start_time}"
-                )
+                if self.log.level == logging.DEBUG:
+                    self.log.debug(
+                        f"set_sync_mode exit - range: {start_height}-{target_height}, "
+                        f"get_finished_sync_up_to: {await self.blockchain.get_finished_sync_up_to()}, "
+                        f"seconds: {time.time() - start_time}"
+                    )
 
     async def get_confirmed_spendable_balance_for_wallet(self, wallet_id: int, unspent_records=None) -> uint128:
         """

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -6,9 +6,10 @@ import logging
 import multiprocessing.context
 import time
 from collections import defaultdict
+from contextlib import asynccontextmanager
 from pathlib import Path
 from secrets import token_bytes
-from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar
+from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, TypeVar
 
 import aiosqlite
 from blspy import G1Element, PrivateKey
@@ -109,8 +110,7 @@ class WalletStateManager:
     log: logging.Logger
 
     # TODO Don't allow user to send tx until wallet is synced
-    sync_mode: bool
-    sync_target: uint32
+    _sync_target: Optional[uint32]
     genesis: FullBlock
 
     state_changed_callback: Optional[StateChangedProtocol] = None
@@ -195,8 +195,7 @@ class WalletStateManager:
         self.default_cats = DEFAULT_CATS
 
         self.wallet_node = wallet_node
-        self.sync_mode = False
-        self.sync_target = uint32(0)
+        self._sync_target = None
         self.blockchain = await WalletBlockchain.create(self.basic_store, self.constants)
         self.state_changed_callback = None
         self.pending_tx_callback = None
@@ -529,13 +528,37 @@ class WalletStateManager:
             return True
         return False
 
-    def set_sync_mode(self, mode: bool, sync_height: uint32 = uint32(0)):
-        """
-        Sets the sync mode. This changes the behavior of the wallet node.
-        """
-        self.sync_mode = mode
-        self.sync_target = sync_height
-        self.state_changed("sync_changed")
+    @property
+    def sync_mode(self) -> bool:
+        return self._sync_target is not None
+
+    @property
+    def sync_target(self) -> Optional[uint32]:
+        return self._sync_target
+
+    @asynccontextmanager
+    async def set_sync_mode(self, target_height: uint32) -> AsyncIterator[None]:
+        self.log.debug(f"set_sync_mode enter {await self.blockchain.get_finished_sync_up_to()}-{target_height}")
+        async with self.lock:
+            start_time = time.time()
+            start_height = await self.blockchain.get_finished_sync_up_to()
+            self._sync_target = target_height
+            self.log.info(f"set_sync_mode syncing - range: {start_height}-{target_height}")
+            self.state_changed("sync_changed")
+            try:
+                yield
+            except Exception:
+                self.log.exception(
+                    f"set_sync_mode failed - range: {start_height}-{target_height}, seconds: {time.time() - start_time}"
+                )
+            finally:
+                self._sync_target = None
+                self.state_changed("sync_changed")
+                self.log.debug(
+                    f"set_sync_mode exit - range: {start_height}-{target_height}, "
+                    f"get_finished_sync_up_to: {await self.blockchain.get_finished_sync_up_to()}, "
+                    f"seconds: {time.time() - start_time}"
+                )
 
     async def get_confirmed_spendable_balance_for_wallet(self, wallet_id: int, unspent_records=None) -> uint128:
         """

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -537,7 +537,7 @@ class WalletStateManager:
         return self._sync_target
 
     @asynccontextmanager
-    async def set_sync_mode(self, target_height: uint32) -> AsyncIterator[None]:
+    async def set_sync_mode(self, target_height: uint32) -> AsyncIterator[uint32]:
         if self.log.level == logging.DEBUG:
             self.log.debug(f"set_sync_mode enter {await self.blockchain.get_finished_sync_up_to()}-{target_height}")
         async with self.lock:
@@ -547,7 +547,7 @@ class WalletStateManager:
             self.log.info(f"set_sync_mode syncing - range: {start_height}-{target_height}")
             self.state_changed("sync_changed")
             try:
-                yield
+                yield start_height
             except Exception:
                 self.log.exception(
                     f"set_sync_mode failed - range: {start_height}-{target_height}, seconds: {time.time() - start_time}"

--- a/tests/wallet/test_wallet_state_manager.py
+++ b/tests/wallet/test_wallet_state_manager.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Tuple
+from chia.simulator.setup_nodes import SimulatorsAndWallets
+
+import pytest
+
+from chia.server.start_service import Service
+from chia.simulator.block_tools import BlockTools
+from chia.util.ints import uint32
+from chia.wallet.wallet_node import WalletNode
+from chia.wallet.wallet_state_manager import WalletStateManager
+
+
+@asynccontextmanager
+async def assert_sync_mode(wallet_state_manager: WalletStateManager, target_height: uint32) -> AsyncIterator[None]:
+    assert not wallet_state_manager.lock.locked()
+    assert not wallet_state_manager.sync_mode
+    assert wallet_state_manager.sync_target is None
+    async with wallet_state_manager.set_sync_mode(target_height):
+        assert wallet_state_manager.sync_mode
+        assert wallet_state_manager.lock.locked()
+        assert wallet_state_manager.sync_target == target_height
+        yield
+    assert not wallet_state_manager.lock.locked()
+    assert not wallet_state_manager.sync_mode
+    assert wallet_state_manager.sync_target is None
+
+
+@pytest.mark.asyncio
+async def test_set_sync_mode(simulator_and_wallet: SimulatorsAndWallets) -> None:
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    async with assert_sync_mode(wallet_node.wallet_state_manager, uint32(1)):
+        pass
+    async with assert_sync_mode(wallet_node.wallet_state_manager, uint32(22)):
+        pass
+    async with assert_sync_mode(wallet_node.wallet_state_manager, uint32(333)):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_set_sync_mode_exception(simulator_and_wallet: SimulatorsAndWallets) -> None:
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    async with assert_sync_mode(wallet_node.wallet_state_manager, uint32(1)):
+        raise Exception


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Make sure to always have the sync mode set whenever we are long syncing and also make sure to reset the sync flag in any case.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

There are currently a few scenarios where we can end up not properly resetting the flag when we for example bail out from the sync after setting the flag or after the untrusted long sync succeeded. 

The GUI is blocked during trusted catch-up sync.
- The balance view in the GUI shows loading spinners all over the place during the initial sync
- The NFT page only shows a big loading spinner until the initial sync is done
- The connections view just shows a big loading spinner until the initial sync is done

### New Behavior:

The sync flag will always be reset whenever the sync context ends.

The GUI is released during trusted catch-up sync. 
- The balance view shows 0 during the initial sync
- The NFT page shows the existing NFTs during the initial sync with a "loading" indication in the corner
- The connections screen shows the connections properly during the initial sync


### Testing notes:

Just sync your wallet to a trusted node, restart the wallet and let it sync again. Do this on `main` and do the same with this PR to see the differences i described above.