### PR TITLE
[DO NOT MERGE] Review DAO chialisp

### DIFF
--- a/chia/wallet/puzzles/dao_lockup.clvm
+++ b/chia/wallet/puzzles/dao_lockup.clvm
@@ -41,9 +41,11 @@
     (if conditions
       (if (= (f (f conditions)) CREATE_COIN)  ; this guarantees that the new coin is obeying the rules - other coins are banned to avoid re-voting
         (if (= (f (r (f conditions))) vote_added_puzhash)
+          ; COMMENT: do we care? We're enforcing the amount is correct so what do we care if they make 0 CAT or use some value from a non voted CAT to make this?
           (if seen_vote  ; assert we haven't already made a coin with the new vote included
             (x)
             (if (= (f (r (r (f conditions)))) my_amount)  ; we vote with all our value
+              ; COMMENT: If I'm not mistaken this should be called "seen_any_vote", yeah?
               (if seen_no_vote  ; assert that we haven't already recreated ourself in some fashion
                 (x)
                 (c (f conditions) (check_conditions (r conditions) vote_added_puzhash my_amount message vote_amount my_puzhash 1 1))
@@ -59,6 +61,7 @@
           (x)
          )
         )
+        ; COMMENT: Should we do this within a namespace like CATs so that other announcements not in that namespace are allowed through?
         (if (= (f (f conditions)) CREATE_PUZZLE_ANNOUNCEMENT)  ; this secures the values used to generate message - other messages are banned in case of LIES
           (if (= (f (r (f conditions))) message)
             (c (f conditions) (check_conditions (r conditions) vote_added_puzhash my_amount message vote_amount my_puzhash seen_vote seen_no_vote))

--- a/chia/wallet/puzzles/dao_proposal.clvm
+++ b/chia/wallet/puzzles/dao_proposal.clvm
@@ -14,6 +14,7 @@
 
 
 (mod (
+  ; COMMENT: When using the modern compiler, you can destructure this like so (@ SINGLETON_STRUCT (SINGLETON_MOD_HASH SINGLETON_ID . LAUNCHER_PUZZLE_HASH))
   SINGLETON_STRUCT  ; (SINGLETON_MOD_HASH, (SINGLETON_ID, LAUNCHER_PUZZLE_HASH))
   PROPOSAL_MOD_HASH
   PROPOSAL_TIMER_MOD_HASH ; proposal timer needs to know which proposal created it, AND
@@ -45,6 +46,7 @@
   (defconstant dao_finished_state 0xfb015415f2e6a09c1141f880fc2135beec6adf2a19e4d02a191432846db16559)
 
   (defun-inline calculate_win_percentage (CURRENT_CAT_ISSUANCE PROPOSAL_PASS_PERCENTAGE)
+    ; COMMENT: this code would be clearer if the divmod was performed on the proposal_pass_percente/ten_thousand first, then multiplied to current_cat_issuance (maybe more optimal too not sure)
     (f (divmod (* CURRENT_CAT_ISSUANCE PROPOSAL_PASS_PERCENTAGE) TEN_THOUSAND))
   )
 
@@ -262,6 +264,7 @@
     (c
       (list CREATE_COIN dao_finished_state ONE (c (f (r SINGLETON_STRUCT)) 0))  ; move to announce finished mode. See previous comment about proposal amounts
       (c
+        ; COMMENT: should this number 5 be configurable?
         (list ASSERT_HEIGHT_RELATIVE 5)  ; soft close so all votes can get in
         (c
           (list ASSERT_PUZZLE_ANNOUNCEMENT  ; make sure that we actually have a matching treasury spend
@@ -307,10 +310,12 @@
               )
               (if
                 (all
+                  ; COMMENT: If this is used for both things, the function could use a different name probably
                   (> TOTAL_VOTES (calculate_win_percentage vote_coin_id_or_current_cat_issuance lockup_innerpuzhash_or_attendance_required))
                   (> YES_VOTES (calculate_win_percentage TOTAL_VOTES previous_votes_or_pass_margin))
                 )
                 (a INNERPUZ vote_amount_or_solution)  ; run_chialisp: run proposed chialisp ; XXX Matt, Geoff: should we also re-create ourself with previous_votes=0 in this case?
+                ; COMMENT: Is there even a reason to ping the treasury in this case? Nothing happens on it, it can just stay the same right?
                 (list (list CREATE_PUZZLE_ANNOUNCEMENT (sha256tree (list "u" 0))))  ; dont_run_chialisp: we dont run the chialisp, but we still move to the finished state
                                                                                     ;    and let the treasury know to remain the same
               )

--- a/chia/wallet/puzzles/dao_proposal_timer.clvm
+++ b/chia/wallet/puzzles/dao_proposal_timer.clvm
@@ -7,6 +7,7 @@
   PROPOSAL_TIMER_MOD_HASH
   CAT_MOD_HASH
   CAT_TAIL_HASH
+  ; COMMENT: When using the modern compiler, you can destructure this like so (@ MY_PARENT_SINGLETON_STRUCT (SINGLETON_MOD_HASH SINGLETON_ID . LAUNCHER_PUZZLE_HASH))
   MY_PARENT_SINGLETON_STRUCT  ; ((SINGLETON_MOD_HASH, (PROPOSAL_SINGLETON_ID, LAUNCHER_PUZZLE_HASH)))
   TREASURY_ID
   proposal_yes_votes
@@ -51,6 +52,7 @@
     )
   )
 
+  ; COMMENT: this function is unused
   ; saves the calculated proposal puzzlehash to use in two conditions rather than calculating it twice
   (defun generate_proposal_conditions (TREASURY_ID proposal_puzzlehash proposal_parent_id proposal_amount)
     (list
@@ -84,6 +86,7 @@
     )
     (list
         ASSERT_MY_PARENT_ID
+        ; COMMENT: this is ASSERT_MY_PARENT_ID but we're passing it a puzzle hash
         (calculate_singleton_puzzle_hash
           MY_PARENT_SINGLETON_STRUCT
           (calculate_proposal_puzzlehash

--- a/chia/wallet/puzzles/dao_treasury.clvm
+++ b/chia/wallet/puzzles/dao_treasury.clvm
@@ -3,6 +3,7 @@
 
 (mod (
   (
+    ; COMMENT: When using the modern compiler, you can destructure this like so (@ SINGLETON_STRUCT (SINGLETON_MOD_HASH SINGLETON_ID . LAUNCHER_PUZZLE_HASH))
     SINGLETON_STRUCT  ; ((SINGLETON_MOD_HASH, (SINGLETON_ID, LAUNCHER_PUZZLE_HASH)))
     TREASURY_MOD_HASH
     PROPOSAL_MOD_HASH
@@ -100,6 +101,7 @@
     announcement_messages_list
     type
   )
+    ; COMMENT: The two ASSERT_PUZZLE_ANNOUNCEMENTs here should probably just be combined into one yeah?
     (c
       (list ASSERT_PUZZLE_ANNOUNCEMENT (sha256 proposal_puzhash (sha256tree (list my_singleton_id PROPOSAL_TIMELOCK))))  ; the proposal format will make this
       (c
@@ -112,6 +114,7 @@
 
   (defun-inline recurry_self (TREASURY_MOD_HASH index_value_pairs_list CURRENT_PARAMS)
     (puzzle-hash-of-curried-function
+      ; COMMENT: We could change the treasury mod hash, but it would take two spends right? I think this should check index_value_pairs_list for a TREASURY_MOD change and use it if it exists.
       TREASURY_MOD_HASH
       (sha256tree
         (recurry_by_index_ordered
@@ -134,9 +137,11 @@
     my_amount
     my_singleton_id
   )
+    ; COMMENT: this whole if tree can be on just the CREATE_COIN's puzhash since the amount and hint are the same in every case
     (if (= type 'u')  ; unchanged
       (list
         (list CREATE_COIN new_puzhash (+ my_amount new_amount_change) (c my_singleton_id 0))
+        ; COMMENT: this ends up double wrapping the singleton right? You need to recreate with the current inner puzzle not full puzzle.
         (list ASSERT_MY_PUZZLEHASH new_puzhash)
       )
       (if (= type 'r')  ; recurry by index
@@ -208,14 +213,19 @@
         )
       )
       ; this is the add money spend case
+      ; COMMENT: This should probably be 0 or something configurable to prevent spaming the add money case a DOS
       (if (> new_amount_change -1)
         (merge_list
+          ; COMMENT: maybe this should be a loop so you can do more than one p2_singleton at once
           (if proposal_innerpuz_or_optional_p2_singleton_coin_id
+            ; COMMENT: An attacker here could give you a p2_singleton to this DAO, then specify an amount increase of 0 or 1 and melt the p2_singleton's value without actually giving it to the DAO
             (list
               (list CREATE_PUZZLE_ANNOUNCEMENT proposal_innerpuz_or_optional_p2_singleton_coin_id)
+              ; COMMENT: Using the existing p2_singleton here pretty much eliminates support for CATs or NFTs being sent to the DAO
               (list ASSERT_COIN_ANNOUNCEMENT (sha256 proposal_innerpuz_or_optional_p2_singleton_coin_id '$'))
             )
             (list
+              ; COMMENT: should this be a coin announcement? Is it possible that you might not want to do this spend if someone else increases the amount before you?
               (list
                 CREATE_PUZZLE_ANNOUNCEMENT  ; by creating this announcement the payer can assert and make sure its their payment that's being taken
                 (sha256tree (list new_amount_change announcement_messages_list_or_payment_nonce))


### PR DESCRIPTION
A few high level thoughts as well:
* **DAO treasury**: I'm fairly confident this can be implemented as the standard puzzle, except instead of a signature, it takes an announcement from specifically a proposal coin telling it what delegated puzzle it should run.  It seems like this is sort of the behavior it is exhibiting now, except there's a lot of different spend paths for everything you might possibly want the treasury to do.  This could be simplified/generalized by telling the treasury just a puzzle to run.

* **DAO proposal**: I don't think this has to be a singleton.  The singleton layer's job is to make sure that its unknown inner puzzle isn't trying to duplicate the singleton, but the proposal does not have an inner puzzle.  It just takes CAT votes and recreates itself.  There's nothing malicious that could be attempting to duplicate or melt the proposal.

* **DAO Lockup**: Not being able to trade these CATs while they're voting is pretty unfortunate.  I think it may be possible to have this lockup layer travel with the CAT without letting it double vote.  Assuming the stack (CAT -> Lockup -> innerpuz), then Lockup _should_ only have to do three things:
  * enforce that all child coins also get wrapped in Lockup
  * enforce that the sum of all child coins >= the current amount of the coin
  * allow adding/removal from a list of proposal IDs, announcing the ones that get added as they get added
this negates you from being able to melt this CAT for amount as part of a larger spend, but does still at least allow you to trade/rekey it while it has already voted on a proposal.  The lockup could keep track of multiple proposals that it has voted on too just like it does now.  And a proposal would only let CATs with Lockup wrappers vote on them (that way they could check whether or not they had their ID in the Lockup's list).