### PR TITLE
Offer CLI command help now shows --fee units as XCH

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -382,7 +382,7 @@ def add_token_cmd(wallet_rpc_port: Optional[int], asset_id: str, token_name: str
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, add_token))
 
 
-@wallet_cmd.command("make_offer", short_help="Create an offer of XCH/CATs for XCH/CATs")
+@wallet_cmd.command("make_offer", short_help="Create an offer of XCH/CATs/NFTs for XCH/CATs/NFTs")
 @click.option(
     "-wp",
     "--wallet-rpc-port",
@@ -406,7 +406,9 @@ def add_token_cmd(wallet_rpc_port: Optional[int], asset_id: str, token_name: str
     multiple=True,
 )
 @click.option("-p", "--filepath", help="The path to write the generated offer file to", required=True)
-@click.option("-m", "--fee", help="A fee to add to the offer when it gets taken", default="0")
+@click.option(
+    "-m", "--fee", help="A fee to add to the offer when it gets taken, in XCH", default="0", show_default=True
+)
 def make_offer_cmd(
     wallet_rpc_port: Optional[int], fingerprint: int, offer: Tuple[str], request: Tuple[str], filepath: str, fee: str
 ) -> None:
@@ -476,7 +478,9 @@ def get_offers_cmd(
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-e", "--examine-only", help="Print the summary of the offer file but do not take it", is_flag=True)
-@click.option("-m", "--fee", help="The fee to use when pushing the completed offer", default="0")
+@click.option(
+    "-m", "--fee", help="The fee to use when pushing the completed offer, in XCH", default="0", show_default=True
+)
 def take_offer_cmd(
     path_or_hex: str, wallet_rpc_port: Optional[int], fingerprint: int, examine_only: bool, fee: str
 ) -> None:
@@ -499,7 +503,9 @@ def take_offer_cmd(
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-id", "--id", help="The offer ID that you wish to cancel", required=True)
 @click.option("--insecure", help="Don't make an on-chain transaction, simply mark the offer as cancelled", is_flag=True)
-@click.option("-m", "--fee", help="The fee to use when cancelling the offer securely", default="0")
+@click.option(
+    "-m", "--fee", help="The fee to use when cancelling the offer securely, in XCH", default="0", show_default=True
+)
 def cancel_offer_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: str, insecure: bool, fee: str) -> None:
     extra_params = {"id": id, "insecure": insecure, "fee": fee}
     import asyncio

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -416,6 +416,10 @@ async def make_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
                 if multiplier > 0:
                     print(f"  - {amount} {name} ({int(Decimal(amount) * unit)} mojos)")
 
+            if fee > 0:
+                print()
+                print(f"Including Fees: {Decimal(fee) / units['chia']} XCH, {fee} mojos")
+
             if royalty_asset_dict != {}:
                 royalty_summary: Dict[Any, List[Dict[str, Any]]] = await wallet_client.nft_calculate_royalties(
                     royalty_asset_dict, fungible_asset_dict
@@ -524,7 +528,7 @@ async def print_trade_record(record, wallet_client: WalletRpcClient, summaries: 
         await print_offer_summary(cat_name_resolver, requested)
         print("Pending Outbound Balances:")
         await print_offer_summary(cat_name_resolver, outbound_balances, has_fee=(fees > 0))
-        print(f"Included Fees: {fees / units['chia']}")
+        print(f"Included Fees: {fees / units['chia']} XCH, {fees} mojos")
     print("---------------")
 
 
@@ -674,7 +678,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
                 converted_amount = Decimal(amount) / divisor
                 print(f"  - {converted_amount} {asset} ({amount} mojos)")
 
-    print(f"Included Fees: {Decimal(offer.bundle.fees()) / units['chia']}")
+    print(f"Included Fees: {Decimal(offer.bundle.fees()) / units['chia']} XCH, {offer.bundle.fees()} mojos")
 
     if not examine_only:
         print()


### PR DESCRIPTION
### Purpose:
Clarify in the CLI help how to specify a fee (as XCH or mojos) when using the offers CLI commands: make_offer, take_offer, cancel_offer.

chia wallet -h will now also indicate that NFTs can be part of offers in the 'offers' subcommand description.

Additionally, including a maker fee when using `chia wallet make_offer` will now include a line item in the offer summary. Previously this line was omitted.

### Current Behavior:
Currently the CLI help just states that --fee is used to attach a fee to the operation, without mentioning whether the fee should be specified in XCH or mojos.

### New Behavior:
The CLI help will now indicate "in XCH" for the fee option.

### Testing Notes:
Manually tested make_offer, take_offer, and cancel_offer with and without a fee specified.
