### PR TITLE
optimize offers

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -520,7 +520,7 @@ async def print_trade_record(record, wallet_client: WalletRpcClient, summaries: 
         offer = Offer.from_bytes(record.offer)
         offered, requested, _ = offer.summary()
         outbound_balances: Dict[str, int] = offer.get_pending_amounts()
-        fees: Decimal = Decimal(offer.bundle.fees())
+        fees: Decimal = Decimal(offer.fees())
         cat_name_resolver = wallet_client.cat_asset_id_to_name
         print("  OFFERED:")
         await print_offer_summary(cat_name_resolver, offered)
@@ -678,7 +678,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
                 converted_amount = Decimal(amount) / divisor
                 print(f"  - {converted_amount} {asset} ({amount} mojos)")
 
-    print(f"Included Fees: {Decimal(offer.bundle.fees()) / units['chia']} XCH, {offer.bundle.fees()} mojos")
+    print(f"Included Fees: {Decimal(offer.fees()) / units['chia']} XCH, {offer.fees()} mojos")
 
     if not examine_only:
         print()

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -1216,8 +1216,8 @@ class DataLayerWallet:
         # Build a mapping of launcher IDs to their new innerpuz
         singleton_to_innerpuzhash: Dict[bytes32, bytes32] = {}
         singleton_to_root: Dict[bytes32, bytes32] = {}
-        all_parent_ids: List[bytes32] = [cs.coin.parent_coin_info for cs in offer.bundle.coin_spends]
-        for spend in offer.bundle.coin_spends:
+        all_parent_ids: List[bytes32] = [cs.coin.parent_coin_info for cs in offer.coin_spends()]
+        for spend in offer.coin_spends():
             matched, curried_args = match_dl_singleton(spend.puzzle_reveal.to_program())
             if matched and spend.coin.name() not in all_parent_ids:
                 innerpuz, root, launcher_id = curried_args
@@ -1227,7 +1227,7 @@ class DataLayerWallet:
 
         # Create all of the new solutions
         new_spends: List[CoinSpend] = []
-        for spend in offer.bundle.coin_spends:
+        for spend in offer.coin_spends():
             solution = spend.solution.to_program()
             if match_dl_singleton(spend.puzzle_reveal.to_program())[0]:
                 try:
@@ -1283,12 +1283,12 @@ class DataLayerWallet:
                     spend = new_spend
             new_spends.append(spend)
 
-        return Offer({}, SpendBundle(new_spends, offer.bundle.aggregated_signature), offer.driver_dict, offer.old)
+        return Offer({}, SpendBundle(new_spends, offer.aggregated_signature()), offer.driver_dict, offer.old)
 
     @staticmethod
     async def get_offer_summary(offer: Offer) -> Dict[str, Any]:
         summary: Dict[str, Any] = {"offered": []}
-        for spend in offer.bundle.coin_spends:
+        for spend in offer.coin_spends():
             solution = spend.solution.to_program()
             matched, curried_args = match_dl_singleton(spend.puzzle_reveal.to_program())
             if matched:
@@ -1299,7 +1299,7 @@ class DataLayerWallet:
                 mod, graftroot_curried_args = graftroot.uncurry()
                 if mod == GRAFTROOT_DL_OFFERS:
                     child_spend: CoinSpend = next(
-                        cs for cs in offer.bundle.coin_spends if cs.coin.parent_coin_info == spend.coin.name()
+                        cs for cs in offer.coin_spends() if cs.coin.parent_coin_info == spend.coin.name()
                     )
                     _, child_curried_args = match_dl_singleton(child_spend.puzzle_reveal.to_program())
                     singleton_summary = {

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1615,7 +1615,7 @@ class WalletRpcApi:
 
         if request.get("advanced", False):
             return {
-                "summary": {"offered": offered, "requested": requested, "fees": offer.bundle.fees(), "infos": infos},
+                "summary": {"offered": offered, "requested": requested, "fees": offer.fees(), "infos": infos},
                 "id": offer.name(),
             }
         else:

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -52,6 +52,7 @@ class SpendBundle(Streamable):
     def removals(self) -> List[Coin]:
         return [_.coin for _ in self.coin_spends]
 
+    # TODO: this should be removed
     def fees(self) -> int:
         """Unsafe to use for fees validation!!!"""
         amount_in = sum(_.amount for _ in self.removals())
@@ -65,6 +66,7 @@ class SpendBundle(Streamable):
     def debug(self, agg_sig_additional_data=DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA):
         debug_spend_bundle(self, agg_sig_additional_data)
 
+    # TODO: this should be removed
     def not_ephemeral_additions(self) -> List[Coin]:
         all_removals = self.removals()
         all_additions = self.additions()

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -138,13 +138,13 @@ class TradeManager:
 
         # Then let's filter the offer into coins that WE offered
         offer = Offer.from_bytes(trade.offer)
-        primary_coin_ids = [c.name() for c in offer.bundle.removals()]
+        primary_coin_ids = [c.name() for c in offer.removals()]
         our_coin_records: List[WalletCoinRecord] = await self.wallet_state_manager.coin_store.get_multiple_coin_records(
             primary_coin_ids
         )
         our_primary_coins: List[Coin] = [cr.coin for cr in our_coin_records]
         our_additions: List[Coin] = list(
-            filter(lambda c: offer.get_root_removal(c) in our_primary_coins, offer.bundle.additions())
+            filter(lambda c: offer.get_root_removal(c) in our_primary_coins, offer.additions())
         )
         our_addition_ids: List[bytes32] = [c.name() for c in our_additions]
 
@@ -596,7 +596,7 @@ class TradeManager:
                 await wsm.create_wallet_for_puzzle_info(offer.driver_dict[key])
 
     async def check_offer_validity(self, offer: Offer, peer: WSChiaConnection) -> bool:
-        all_removals: List[Coin] = offer.bundle.removals()
+        all_removals: List[Coin] = offer.removals()
         all_removal_names: List[bytes32] = [c.name() for c in all_removals]
         non_ephemeral_removals: List[Coin] = list(
             filter(lambda c: c.parent_coin_info not in all_removal_names, all_removals)
@@ -610,7 +610,7 @@ class TradeManager:
         if validate:
             final_spend_bundle: SpendBundle = offer.to_valid_spend()
         else:
-            final_spend_bundle = offer.bundle
+            final_spend_bundle = offer._bundle
 
         settlement_coins: List[Coin] = [c for coins in offer.get_offered_coins().values() for c in coins]
         settlement_coin_ids: List[bytes32] = [c.name() for c in settlement_coins]
@@ -860,7 +860,7 @@ class TradeManager:
                 return await DataLayerWallet.get_offer_summary(offer)
         # Otherwise just return the same thing as the RPC normally does
         offered, requested, infos = offer.summary()
-        return {"offered": offered, "requested": requested, "fees": offer.bundle.fees(), "infos": infos}
+        return {"offered": offered, "requested": requested, "fees": offer.fees(), "infos": infos}
 
     async def check_for_final_modifications(self, offer: Offer, solver: Solver) -> Offer:
         for puzzle_info in offer.driver_dict.values():

--- a/chia/wallet/trade_record.py
+++ b/chia/wallet/trade_record.py
@@ -40,7 +40,7 @@ class TradeRecord(Streamable):
             "offered": offered,
             "requested": requested,
             "infos": infos,
-            "fees": offer.bundle.fees(),
+            "fees": offer.fees(),
         }
         formatted["pending"] = offer.get_pending_amounts()
         del formatted["offer"]


### PR DESCRIPTION
Currently we recompute `additions()` quite a lot of times in offers. Every time `additions()` is called, we execute the CLVM puzzle program. This patch aims to reduce the time and energy we waste on repeatedly executing the puzzle program by caching the additions (as well as the coin spends that failed for some reason).

To fully realize the benefits of these caches, the `bundle` member was made private (i.e. renamed to `_bundle`) so that users of it has to go through the offer object to ask for additions (for example).