### PR TITLE
Purposefully break offer compression for older versions

### DIFF
--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -584,7 +584,7 @@ class Offer:
         as_spend_bundle = self.to_spend_bundle()
         if version is None:
             mods: List[bytes] = [bytes(s.puzzle_reveal.to_program().uncurry()[0]) for s in as_spend_bundle.coin_spends]
-            version = max(lowest_best_version(mods), 5)  # 5 is the version where OFFER_MOD lives
+            version = max(lowest_best_version(mods), 6)  # Clients lower than version 6 should not be able to parse
         return compress_object_with_puzzles(bytes(as_spend_bundle), version)
 
     @classmethod

--- a/chia/wallet/util/puzzle_compression.py
+++ b/chia/wallet/util/puzzle_compression.py
@@ -35,7 +35,7 @@ ZDICT = [
     + bytes(NFT_TRANSFER_PROGRAM_DEFAULT),
     bytes(CAT_MOD),
     bytes(OFFER_MOD),
-    b"break",  # purposefully break compatibility with older versions
+    b"",  # purposefully break compatibility with older versions
     # more dictionaries go here
 ]
 

--- a/chia/wallet/util/puzzle_compression.py
+++ b/chia/wallet/util/puzzle_compression.py
@@ -35,6 +35,7 @@ ZDICT = [
     + bytes(NFT_TRANSFER_PROGRAM_DEFAULT),
     bytes(CAT_MOD),
     bytes(OFFER_MOD),
+    b"break",  # purposefully break compatibility with older versions
     # more dictionaries go here
 ]
 


### PR DESCRIPTION
This results in more desirable behavior when old versions try to take new offers.  Immediate error rather than on chain failure.