### PR TITLE
No need to test install scripts on Mint

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -112,41 +112,6 @@ jobs:
           type: ubuntu
           # https://packages.ubuntu.com/jammy/python3 (22.04, 3.10)
           url: "docker://ubuntu:jammy"
-        - name: linuxmintd/mint19.1-amd64 (Tessa)
-          type: mint
-          # 3.6 default with an option for 3.7
-          url: "docker://linuxmintd/mint19.1-amd64"
-        - name: linuxmintd/mint19.2-amd64 (Tina)
-          type: mint
-          # 3.6 default with an option for 3.7
-          url: "docker://linuxmintd/mint19.2-amd64"
-        - name: linuxmintd/mint19.3-amd64 (Tricia)
-          type: mint
-          # 3.6 default with an option for 3.7
-          url: "docker://linuxmintd/mint19.3-amd64"
-        - name: linuxmintd/mint20-amd64 (Ulyana)
-          type: mint
-          # 3.8
-          url: "docker://linuxmintd/mint20-amd64"
-        - name: linuxmintd/mint20.1-amd64 (Ulyssa)
-          type: mint
-          # 3.8
-          url: "docker://linuxmintd/mint20.1-amd64"
-        - name: linuxmintd/mint20.2-amd64 (Uma)
-          type: mint
-          # 3.8
-          url: "docker://linuxmintd/mint20.2-amd64"
-        - name: linuxmintd/mint20.3-amd64 (Una)
-          type: mint
-          # 3.8
-          url: "docker://linuxmintd/mint20.3-amd64"
-#        The Linux Mint 21 docker image reports as 20.3 but has different Python.
-#        Uncomment after adapting to handle this or upstream fixing it.
-#        Also, Linux Mint 21 is not released as of this change.
-#        - name: linuxmintd/mint21-amd64
-#          type: linuxmint
-#          # 3.10 default with an option for 3.9
-#          url: "docker://linuxmintd/mint21-amd64"
 
     steps:
     - name: Prepare Amazon Linux
@@ -208,25 +173,6 @@ jobs:
       run: |
         # for bionic
         apt-get --yes update
-        apt-get install --yes software-properties-common
-        add-apt-repository --yes ppa:git-core/ppa
-        apt-get --yes update
-        apt-get install --yes git lsb-release sudo
-
-    - name: Prepare Linux Mint
-      if: ${{ matrix.distribution.type == 'mint' }}
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: |
-        # for 19.*
-        apt-get --yes update
-        # for 19.3 to avoid
-        # Setting up software-properties-common (2.0.0.2) ...
-        # Traceback (most recent call last):
-        #   File "/usr/lib/linuxmint/mintSources/mintSources.py", line 11, in <module>
-        #     import requests
-        # ModuleNotFoundError: No module named 'requests'
-        apt-get install --yes python3-requests
         apt-get install --yes software-properties-common
         add-apt-repository --yes ppa:git-core/ppa
         apt-get --yes update


### PR DESCRIPTION
Testing the install scripts on Linux Mint has very little value and simply causes longer CI times along with more chances of flaky failure due to network issues during OS setup.

We are transitioning away from users running the install manually to more and more encouraging users to use the binary packages and Mint users can use the Ubuntu DEB package.

This distro is only minimally popular and there is no rationale for specific testing on Mint as opposed to other distros (Gentoo, etc)