### PR TITLE
Remove ability for client code to specify wallet_id during wallet creation.

### DIFF
--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -51,13 +51,12 @@ class WalletUserStore:
         name: str,
         wallet_type: int,
         data: str,
-        id: Optional[int] = None,
     ) -> WalletInfo:
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             cursor = await conn.execute(
-                "INSERT INTO users_wallets VALUES(?, ?, ?, ?)",
-                (id, name, wallet_type, data),
+                "INSERT INTO users_wallets (name, wallet_type, data) VALUES(?, ?, ?)",
+                (name, wallet_type, data),
             )
             await cursor.close()
             wallet = await self.get_last_wallet()


### PR DESCRIPTION
Remove ability for client code to specify wallet_id during wallet creation. wallet_id is used as an external long-lived identifier in the wallet RPCs, and they must be unique.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This reduces code complexity, and removes a dangerous internal interface. No externally visible changes.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Allows specifying wallet_id during wallet creation.

### New Behavior:

Disallows specifying wallet_id during wallet creation.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
