### PR TITLE
Improve the help text for the peer command

### DIFF
--- a/chia/cmds/peer.py
+++ b/chia/cmds/peer.py
@@ -20,9 +20,9 @@ from chia.cmds.peer_funcs import peer_async
     default=None,
 )
 @click.option(
-    "-c", "--connections", help="List nodes connected to this Full Node", is_flag=True, type=bool, default=False
+    "-c", "--connections", help="List connections to the specified service", is_flag=True, type=bool, default=False
 )
-@click.option("-a", "--add-connection", help="Connect to another Full Node by ip:port", type=str, default="")
+@click.option("-a", "--add-connection", help="Connect to another remote Chia service by ip:port", type=str, default="")
 @click.option(
     "-r", "--remove-connection", help="Remove a Node by the first 8 characters of NodeID", type=str, default=""
 )


### PR DESCRIPTION
Improve the help text for the `chia peer` command to more accurately reflect how it actually works. 

### Purpose:
The `chia peer` command can manage connections for all Chia services, but the help text suggests all it can do is show Full Node connections or add connections to a Full Node.  This updates the help language shown with `-h` to more accurately reflect what this command can do.  

### Current Behavior:
```
$ chia peer -h
Usage: chia peer [OPTIONS] {farmer|wallet|full_node|harvester|data_layer}

Options:
  -p, --rpc-port INTEGER        Set the port where the farmer, wallet, full
                                node or harvester is hosting the RPC
                                interface. See the rpc_port in config.yaml
  -c, --connections             List nodes connected to this Full Node
  -a, --add-connection TEXT     Connect to another Full Node by ip:port
  -r, --remove-connection TEXT  Remove a Node by the first 8 characters of
                                NodeID
  -h, --help                    Show this message and exit.
```

### New Behavior:
```
$ chia peer -h
Usage: chia peer [OPTIONS] {farmer|wallet|full_node|harvester|data_layer}

Options:
  -p, --rpc-port INTEGER        Set the port where the farmer, wallet, full
                                node or harvester is hosting the RPC
                                interface. See the rpc_port in config.yaml
  -c, --connections             List connections to the specified service
  -a, --add-connection TEXT     Connect to another remote Chia service by ip:port
  -r, --remove-connection TEXT  Remove a Node by the first 8 characters of
                                NodeID
  -h, --help                    Show this message and exit.
```

### Testing Notes:
Not performed - simple help text update, no functional code changed. 


Thanks to Keybase user sharktan for reporting this issue. 
