### PR TITLE
use run_block_generator() to run block generators

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -47,7 +47,6 @@ from chia.full_node.bundle_tools import (
     simple_solution_generator,
 )
 from chia.full_node.generator import setup_generator_args
-from chia.full_node.mempool_check_conditions import GENERATOR_MOD
 from chia.full_node.signage_point import SignagePoint
 from chia.plotting.create_plots import PlotKeys, create_plots
 from chia.plotting.manager import PlotManager
@@ -115,6 +114,9 @@ from chia.wallet.derive_keys import (
     master_sk_to_pool_sk,
     master_sk_to_wallet_sk,
 )
+from chia.wallet.puzzles.rom_bootstrap_generator import get_generator
+
+GENERATOR_MOD = get_generator()
 
 test_constants = DEFAULT_CONSTANTS.replace(
     **{

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -94,15 +94,11 @@ class TestCostCalculation:
         assert puzzle == coin_spend.puzzle_reveal
         assert solution == coin_spend.solution
 
-        assert npc_result.conds.cost == ConditionCost.CREATE_COIN.value + ConditionCost.AGG_SIG.value + 404560
-
-        # Create condition + agg_sig_condition + length + cpu_cost
+        clvm_cost = 404560
+        byte_cost = len(bytes(program.program)) * test_constants.COST_PER_BYTE
         assert (
-            npc_result.cost
-            == 404560
-            + ConditionCost.CREATE_COIN.value
-            + ConditionCost.AGG_SIG.value
-            + len(bytes(program.program)) * test_constants.COST_PER_BYTE
+            npc_result.conds.cost
+            == ConditionCost.CREATE_COIN.value + ConditionCost.AGG_SIG.value + clvm_cost + byte_cost
         )
 
         # Create condition + agg_sig_condition + length + cpu_cost
@@ -111,7 +107,7 @@ class TestCostCalculation:
             == ConditionCost.CREATE_COIN.value
             + ConditionCost.AGG_SIG.value
             + len(bytes(program.program)) * test_constants.COST_PER_BYTE
-            + 404560  # clvm cost
+            + clvm_cost
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
the new version of `chia_rs` introduces a new function called `run_block_generator()`. It raises the abstraction level over the existing `run_as_generator()` in these ways:

1. Rather than actually running the GENERATOR_ROM, and building the parameter list of the block_generator and block_refs, it just takes the block generator and a list of block_refs. The logic of the generator ROM is on the rust side.
2. Rather then returning just the cost of executing the CLVM and the conditions, it returns the complete cost, including the byte-cost. This change affects a few tests that ensure the clvm cost model doesn't change.


My long term ambition is to port the generator rom program to rust. This would enable lower memory footprint and possibly higher performance execution of block generators. It would allow to record statistics for each individual puzzle. For example, the cost of a single puzzle is sometimes really handy. (in identical spend deduplication).