### PR TITLE
Test DID Wallet creation by blockchain singleton update

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from chia.server.server import ChiaServer
 from chia.server.start_service import Service
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.setup_nodes import (
+    SimulatorsAndWallets,
     setup_full_system_connect_to_deamon,
     setup_n_nodes,
     setup_node_and_wallet,
@@ -433,6 +434,13 @@ async def wallet_two_node_simulator():
 async def wallet_nodes_mempool_perf(bt):
     key_seed = bt.farmer_master_sk_entropy
     async for _ in setup_simulators_and_wallets(2, 1, {}, key_seed=key_seed):
+        yield _
+
+
+@pytest_asyncio.fixture(scope="function")
+async def two_nodes_two_wallets_with_same_keys(bt) -> AsyncIterator[SimulatorsAndWallets]:
+    key_seed = bt.farmer_master_sk_entropy
+    async for _ in setup_simulators_and_wallets(2, 2, {}, key_seed=key_seed):
         yield _
 
 

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -9,6 +9,7 @@ from blspy import AugSchemeMPL, G1Element, G2Element
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.rpc.wallet_rpc_api import WalletRpcApi
+from chia.simulator.setup_nodes import SimulatorsAndWallets
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_not_none
 from chia.types.blockchain_format.program import Program
@@ -36,6 +37,103 @@ def get_parent_num(did_wallet: DIDWallet):
 
 
 class TestDIDWallet:
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
+    @pytest.mark.asyncio
+    async def test_creation_from_coin_spend(
+        self, self_hostname, two_nodes_two_wallets_with_same_keys: SimulatorsAndWallets, trusted
+    ):
+        """
+        Verify that DIDWallet.create_new_did_wallet_from_coin_spend() is called after Singleton creation on
+        the blockchain, and that the wallet is created in the second wallet node.
+        """
+        num_blocks = 5
+        full_nodes, wallets, _ = two_nodes_two_wallets_with_same_keys
+        full_node_api = full_nodes[0]
+        full_node_server = full_node_api.server
+        wallet_node_0, server_0 = wallets[0]
+        wallet_node_1, server_1 = wallets[1]
+
+        wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
+        wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
+
+        ph0 = await wallet_0.get_new_puzzlehash()
+        ph1 = await wallet_1.get_new_puzzlehash()
+
+        keys0 = await wallet_node_0.wallet_state_manager.get_keys(ph0)
+        keys1 = await wallet_node_1.wallet_state_manager.get_keys(ph1)
+        assert keys0
+        assert keys1
+        pk0, sk0 = keys0
+        pk1, sk1 = keys1
+        assert pk0 == pk1
+        assert sk0 == sk1
+
+        if trusted:
+            wallet_node_0.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+            wallet_node_1.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+
+        else:
+            wallet_node_0.config["trusted_peers"] = {}
+            wallet_node_1.config["trusted_peers"] = {}
+        await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+
+        for i in range(1, num_blocks):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph0))
+
+        funds = sum(
+            [
+                calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i))
+                for i in range(1, num_blocks - 1)
+            ]
+        )
+
+        await time_out_assert(10, wallet_0.get_unconfirmed_balance, funds)
+        await time_out_assert(10, wallet_0.get_confirmed_balance, funds)
+        for i in range(1, num_blocks):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
+
+        # Wallet1 sets up DIDWallet1 without any backup set
+        async with wallet_node_0.wallet_state_manager.lock:
+            did_wallet_0: DIDWallet = await DIDWallet.create_new_did_wallet(
+                wallet_node_0.wallet_state_manager, wallet_0, uint64(101)
+            )
+
+        spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
+            did_wallet_0.id()
+        )
+
+        spend_bundle = spend_bundle_list[0].spend_bundle
+        assert spend_bundle
+        await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
+
+        for i in range(1, num_blocks):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph0))
+
+        await time_out_assert(15, did_wallet_0.get_confirmed_balance, 101)
+        await time_out_assert(15, did_wallet_0.get_unconfirmed_balance, 101)
+        await time_out_assert(15, did_wallet_0.get_pending_change_balance, 0)
+
+        for i in range(1, num_blocks):
+            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph0))
+
+        #######################
+        all_node_0_wallets = await wallet_node_0.wallet_state_manager.user_store.get_all_wallet_info_entries()
+        print(f"Node 0: {all_node_0_wallets}")
+        all_node_1_wallets = await wallet_node_1.wallet_state_manager.user_store.get_all_wallet_info_entries()
+        print(f"Node 1: {all_node_1_wallets}")
+        assert (
+            json.loads(all_node_0_wallets[1].data)["current_inner"]
+            == json.loads(all_node_1_wallets[1].data)["current_inner"]
+        )
+
     @pytest.mark.parametrize(
         "trusted",
         [True, False],


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This PR one in a series that aims to recreate conditions that cause wallet DB corruption. The next PR in this series will cause an exception in WalletStateManager while processing a DID Wallet Spend, simulating the issue.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

No test for create_new_did_wallet_from_coin_spend

### New Behavior:

Test `create_new_did_wallet_from_coin_spend` by simulating a DID spend on the blockchain.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

This test, although created in the process of tracking down a wallet DB bug, is not a test for that issue. It is just a test that `create_new_did_wallet_from_coin_spend` behaves as intended.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
