### PR TITLE
Fix Offer.to_spend_bundle to create dummy coin spends with old offer_mod

### DIFF
--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -531,7 +531,8 @@ class Offer:
         # Before we serialze this as a SpendBundle, we need to serialze the `requested_payments` as dummy CoinSpends
         additional_coin_spends: List[CoinSpend] = []
         for asset_id, payments in self.requested_payments.items():
-            puzzle_reveal: Program = construct_puzzle(self.driver_dict[asset_id], OFFER_MOD) if asset_id else OFFER_MOD
+            offer_mod = OFFER_MOD_OLD if self.old else OFFER_MOD
+            puzzle_reveal: Program = construct_puzzle(self.driver_dict[asset_id], offer_mod) if asset_id else offer_mod
             inner_solutions = []
             nonces: List[bytes32] = [p.nonce for p in payments]
             for nonce in list(dict.fromkeys(nonces)):  # dedup without messing with order


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
With the update settlement puzzle [PR](https://github.com/Chia-Network/chia-blockchain/commit/9cc25cc820accad778bf626500aedd299f62a825#diff-a64c3114c9aa8feff3e93d93c9a673eca47eaee549f1559c929141b8fb78d3f2), an property [`Offer.old`](https://github.com/Chia-Network/chia-blockchain/blob/2e34cc5fe86ee7697ae7eadd0b0d9dde70d298b1/chia/wallet/trading/offer.py#L74) is checked to select either the old or new settlement puzzle. However, [`Offer.to_spend_bundle`](https://github.com/Chia-Network/chia-blockchain/blob/2e34cc5fe86ee7697ae7eadd0b0d9dde70d298b1/chia/wallet/trading/offer.py#L530) has not been updated.

### Current Behavior:
 `Offer.to_spend_bundle` always create dummy coin spends with new offer mod. 

### New Behavior:
Fix Offer.to_spend_bundle to create dummy coin spends with old offer_mod when the `old` is true.

### Testing Notes:
I can add tests, but I am not sure where I should put it. Maybe in [tests/wallet/cat_wallet/test_trades.py](https://github.com/Chia-Network/chia-blockchain/blob/9cc25cc820accad778bf626500aedd299f62a825/tests/wallet/cat_wallet/test_trades.py)?