### PR TITLE
Add dexie DNS seeder

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -412,6 +412,7 @@ full_node:
   dns_servers: &dns_servers
     - "dns-introducer.chia.net"
     - "chia.ctrlaltdel.ch"
+    - "seeder.dexie.space"
     - "chia-seeder.h9.com"
     - "chia.hoffmang.com"
     - "seeder.xchpool.org"


### PR DESCRIPTION
### Purpose

Add `seeder.dexie.space` to the list of default DNS seeders. 

Server-Location: `EU`

### Notes

For questions, contact @denisu on Keybase.