### PR TITLE
nft paging at sqlite level

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2253,25 +2253,28 @@ class WalletRpcApi:
         nfts: List[NFTCoinInfo] = []
         if wallet_id is not None:
             nft_wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=NFTWallet)
-            nfts = await nft_wallet.get_current_nfts()
         else:
-            for wallet in self.service.wallet_state_manager.wallets.values():
-                if wallet.type() == WalletType.NFT.value:
-                    assert isinstance(wallet, NFTWallet)
-                    nfts.extend(await wallet.get_current_nfts())
-        start_index = request.get("start_index", 0)
-        num = request.get("num", len(nfts))
+            nft_wallet = None
+        try:
+            start_index = int(request.get("start_index"))
+        except (TypeError, ValueError):
+            start_index = 0
+        try:
+            count = int(request.get("num"))
+        except (TypeError, ValueError):
+            count = 50
         nft_info_list = []
-        count = 0
+        if nft_wallet is not None:
+            nfts = await nft_wallet.get_current_nfts(start_index=start_index, count=count)
+        else:
+            nfts = await self.service.wallet_state_manager.nft_store.get_nft_list(start_index=start_index, count=count)
         for nft in nfts:
-            if count >= start_index and count - start_index < num:
-                nft_info = await nft_puzzles.get_nft_info_from_puzzle(
-                    nft,
-                    self.service.wallet_state_manager.config,
-                    request.get("ignore_size_limit", False),
-                )
-                nft_info_list.append(nft_info)
-            count += 1
+            nft_info = await nft_puzzles.get_nft_info_from_puzzle(
+                nft,
+                self.service.wallet_state_manager.config,
+                request.get("ignore_size_limit", False),
+            )
+            nft_info_list.append(nft_info)
         return {"wallet_id": wallet_id, "success": True, "nft_list": nft_info_list}
 
     async def nft_set_nft_did(self, request):

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -501,8 +501,8 @@ class NFTWallet:
         self.wallet_state_manager.state_changed("nft_coin_updated", self.wallet_info.id)
         return SpendBundle.aggregate([x.spend_bundle for x in txs if x.spend_bundle is not None])
 
-    async def get_current_nfts(self) -> List[NFTCoinInfo]:
-        return await self.nft_store.get_nft_list(wallet_id=self.id())
+    async def get_current_nfts(self, start_index: int = 0, count: int = 50) -> List[NFTCoinInfo]:
+        return await self.nft_store.get_nft_list(wallet_id=self.id(), start_index=start_index, count=count)
 
     async def get_nft_count(self) -> int:
         return await self.nft_store.count(wallet_id=self.id())

--- a/chia/wallet/wallet_nft_store.py
+++ b/chia/wallet/wallet_nft_store.py
@@ -196,9 +196,9 @@ class WalletNftStore:
         if wallet_id is not None or did_id is not None:
             sql += " and"
         sql += " removed_height is NULL"
-        sql += " LIMIT %s OFFSET %s " % (count, start_index)
+        sql += " LIMIT ? OFFSET ?"
         async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(sql)
+            rows = await conn.execute_fetchall(sql, (count, start_index))
 
         return [
             NFTCoinInfo(

--- a/chia/wallet/wallet_nft_store.py
+++ b/chia/wallet/wallet_nft_store.py
@@ -171,8 +171,21 @@ class WalletNftStore:
         return True
 
     async def get_nft_list(
-        self, wallet_id: Optional[uint32] = None, did_id: Optional[bytes32] = None
+        self,
+        wallet_id: Optional[uint32] = None,
+        did_id: Optional[bytes32] = None,
+        start_index: int = 0,
+        count: int = 50,
     ) -> List[NFTCoinInfo]:
+        try:
+            start_index = int(start_index)
+        except ValueError:
+            start_index = 0
+        try:
+            count = int(count)
+        except ValueError:
+            count = 50
+
         sql: str = f"SELECT {NFT_COIN_INFO_COLUMNS}" " from users_nfts WHERE"
         if wallet_id is not None and did_id is None:
             sql += f" wallet_id={wallet_id}"
@@ -183,6 +196,7 @@ class WalletNftStore:
         if wallet_id is not None or did_id is not None:
             sql += " and"
         sql += " removed_height is NULL"
+        sql += " LIMIT %s OFFSET %s " % (count, start_index)
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(sql)
 

--- a/tests/wallet/test_nft_store.py
+++ b/tests/wallet/test_nft_store.py
@@ -52,6 +52,15 @@ class TestNftStore:
             assert nft == (await db.get_nft_list(wallet_id=uint32(1), did_id=a_bytes32))[0]
             assert nft == await db.get_nft_by_id(a_bytes32)
 
+            # test get nft list pagination
+            assert not (await db.get_nft_list(wallet_id=uint32(1), start_index=0, count=0))
+            assert nft == (await db.get_nft_list(wallet_id=uint32(1), start_index=0, count=1))[0]
+            assert 1 == len(await db.get_nft_list(wallet_id=uint32(1), start_index=0, count=1))
+            assert 2 == len(await db.get_nft_list(wallet_id=uint32(1), start_index=0, count=5))
+            assert nft2 == (await db.get_nft_list(wallet_id=uint32(1), start_index=0, count=2))[1]
+            assert nft2 == (await db.get_nft_list(wallet_id=uint32(1), start_index=1, count=1))[0]
+            assert 0 == len(await db.get_nft_list(wallet_id=uint32(1), start_index=2, count=1))
+
             assert nft == (await db.get_nft_by_coin_id(nft.coin.name()))
             assert await db.exists(nft.coin.name())
             # negative tests


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
`nft_get_nfts` is very slow on large NFT wallets as pagination is applied only after we load all NFTs from the database. This patch moves pagination to sqlite level. 


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Load all NFTs from db, then paginate.


### New Behavior:
Load only one page from sqlite.

