### PR TITLE
Refine help text for chia peer -a

### DIFF
--- a/chia/cmds/peer.py
+++ b/chia/cmds/peer.py
@@ -22,7 +22,7 @@ from chia.cmds.peer_funcs import peer_async
 @click.option(
     "-c", "--connections", help="List connections to the specified service", is_flag=True, type=bool, default=False
 )
-@click.option("-a", "--add-connection", help="Connect to another remote Chia service by ip:port", type=str, default="")
+@click.option("-a", "--add-connection", help="Connect to another Chia service (local or remote) by ip:port", type=str, default="")
 @click.option(
     "-r", "--remove-connection", help="Remove a Node by the first 8 characters of NodeID", type=str, default=""
 )

--- a/chia/cmds/peer.py
+++ b/chia/cmds/peer.py
@@ -22,7 +22,7 @@ from chia.cmds.peer_funcs import peer_async
 @click.option(
     "-c", "--connections", help="List connections to the specified service", is_flag=True, type=bool, default=False
 )
-@click.option("-a", "--add-connection", help="Connect to another Chia service (local or remote) by ip:port", type=str, default="")
+@click.option("-a", "--add-connection", help="Connect specified Chia service to ip:port", type=str, default="")
 @click.option(
     "-r", "--remove-connection", help="Remove a Node by the first 8 characters of NodeID", type=str, default=""
 )


### PR DESCRIPTION
### Purpose:
Refine the text for `chia peer -a` to make it more clear what the `node_type` refers to, and remove the language that specifies a "remote" service since this command can be used locally as well. 

No breaking change. 

### Current Behavior:
```
$ chia peer -h
Usage: chia peer [OPTIONS] {farmer|wallet|full_node|harvester|data_layer}

Options:
  -p, --rpc-port INTEGER        Set the port where the farmer, wallet, full
                                node or harvester is hosting the RPC
                                interface. See the rpc_port in config.yaml
  -c, --connections             List nodes connected to this Full Node
  -a, --add-connection TEXT     Connect to another Full Node by ip:port
  -r, --remove-connection TEXT  Remove a Node by the first 8 characters of
                                NodeID
  -h, --help                    Show this message and exit.
```


### New Behavior:
```
$ chia peer -h
Usage: chia peer [OPTIONS] {farmer|wallet|full_node|harvester|data_layer}

Options:
  -p, --rpc-port INTEGER        Set the port where the farmer, wallet, full
                                node or harvester is hosting the RPC
                                interface. See the rpc_port in config.yaml
  -c, --connections             List nodes connected to this Full Node
  -a, --add-connection TEXT     Connect specified Chia service to ip:port
  -r, --remove-connection TEXT  Remove a Node by the first 8 characters of
                                NodeID
  -h, --help                    Show this message and exit.
```

