### PR TITLE
rpc endpoint to count nfts per wallet or all wallets

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -174,6 +174,7 @@ class WalletRpcApi:
             "/did_find_lost_did": self.did_find_lost_did,
             # NFT Wallet
             "/nft_mint_nft": self.nft_mint_nft,
+            "/nft_count_nfts": self.nft_count_nfts,
             "/nft_get_nfts": self.nft_get_nfts,
             "/nft_get_by_did": self.nft_get_by_did,
             "/nft_set_nft_did": self.nft_set_nft_did,
@@ -2247,6 +2248,20 @@ class WalletRpcApi:
             if cs.coin.puzzle_hash == nft_puzzles.LAUNCHER_PUZZLE_HASH:
                 nft_id = encode_puzzle_hash(cs.coin.name(), AddressType.NFT.hrp(self.service.config))
         return {"wallet_id": wallet_id, "success": True, "spend_bundle": spend_bundle, "nft_id": nft_id}
+
+    async def nft_count_nfts(self, request) -> EndpointResult:
+        wallet_id = request.get("wallet_id", None)
+        count = 0
+        if wallet_id is not None:
+            try:
+                nft_wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=NFTWallet)
+            except KeyError:
+                # wallet not found
+                return {"success": False, "error": f"Wallet {wallet_id} not found."}
+            count = await nft_wallet.get_nft_count()
+        else:
+            count = await self.service.wallet_state_manager.nft_store.count()
+        return {"wallet_id": wallet_id, "success": True, "count": count}
 
     async def nft_get_nfts(self, request) -> EndpointResult:
         wallet_id = request.get("wallet_id", None)

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -848,6 +848,11 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_transfer_nft", request)
         return response
 
+    async def count_nfts(self, wallet_id: Optional[int]):
+        request: Dict[str, Any] = {"wallet_id": wallet_id}
+        response = await self.fetch("nft_count_nfts", request)
+        return response
+
     async def list_nfts(self, wallet_id):
         request: Dict[str, Any] = {"wallet_id": wallet_id}
         response = await self.fetch("nft_get_nfts", request)

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -436,6 +436,19 @@ async def test_nft_wallet_rpc_creation_and_list(self_hostname: str, two_wallet_n
     assert len(coins) == 1
     assert coins[0].data_hash.hex() == "0xD4584AD463139FA8C0D9F68F4B59F184"[2:].lower()
 
+    # test counts
+
+    resp = await wait_rpc_state_condition(
+        10, api_0.nft_count_nfts, [{"wallet_id": nft_wallet_0_id}], lambda x: x["success"]
+    )
+    assert resp["count"] == 2
+    resp = await wait_rpc_state_condition(10, api_0.nft_count_nfts, [{}], lambda x: x["success"])
+    assert resp["count"] == 2
+    resp = await wait_rpc_state_condition(
+        10, api_0.nft_count_nfts, [{"wallet_id": 50}], lambda x: x["success"] is False
+    )
+    assert resp.get("count") is None
+
 
 @pytest.mark.parametrize(
     "trusted",


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Add RPC endpoint to count how many NFTs a wallet has so frontend can prepare when loading 


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
No RPC to count.

