### PR TITLE
wallet: Drop leaking weight proof validation cache

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -48,7 +48,6 @@ from chia.util.db_wrapper import manage_connection
 from chia.util.errors import KeychainIsEmpty, KeychainIsLocked, KeychainKeyNotFound, KeychainProxyConnectionFailure
 from chia.util.ints import uint32, uint64
 from chia.util.keychain import Keychain
-from chia.util.lru_cache import LRUCache
 from chia.util.path import path_from_root
 from chia.util.profiler import mem_profile_task, profile_task
 from chia.wallet.transaction_record import TransactionRecord
@@ -107,7 +106,6 @@ class WalletNode:
     # Peers that we have long synced to
     synced_peers: Set[bytes32] = dataclasses.field(default_factory=set)
     wallet_peers: Optional[WalletPeers] = None
-    valid_wp_cache: LRUCache[bytes32, Any] = dataclasses.field(default_factory=lambda: LRUCache(2))
     peer_caches: Dict[bytes32, PeerRequestCache] = dataclasses.field(default_factory=dict)
     # in Untrusted mode wallet might get the state update before receiving the block
     race_cache: Dict[bytes32, Set[CoinState]] = dataclasses.field(default_factory=dict)
@@ -1244,7 +1242,6 @@ class WalletNode:
         if weight_proof_response is None:
             raise Exception("weight proof response was none")
 
-        start_validation = time.time()
         weight_proof = weight_proof_response.wp
 
         if weight_proof.recent_chain_data[-1].height != peak.height:
@@ -1254,21 +1251,15 @@ class WalletNode:
         if weight_proof.recent_chain_data[-1].header_hash != peak.header_hash:
             raise Exception("weight proof peak hash does not match peak")
 
-        cache = self.valid_wp_cache.get(weight_proof.get_hash())
-        if cache is not None:
-            valid, fork_point, summaries, block_records = cache
-        else:
-            old_proof = self.wallet_state_manager.blockchain.synced_weight_proof
-            fork_point = get_wp_fork_point(self.constants, old_proof, weight_proof)
-            start_validation = time.time()
-            (
-                valid,
-                summaries,
-                block_records,
-            ) = await self._weight_proof_handler.validate_weight_proof(weight_proof, False, old_proof)
-            if not valid:
-                raise Exception("weight proof failed validation")
-            self.valid_wp_cache.put(weight_proof.get_hash(), (valid, fork_point, summaries, block_records))
+        old_proof = self.wallet_state_manager.blockchain.synced_weight_proof
+        start_validation = time.time()
+        (
+            valid,
+            summaries,
+            block_records,
+        ) = await self._weight_proof_handler.validate_weight_proof(weight_proof, False, old_proof)
+        if not valid:
+            raise Exception("weight proof failed validation")
 
         end_validation = time.time()
         self.log.info(f"It took {end_validation - start_validation} time to validate the weight proof")


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fix memory leak by dropping the leaking weight proof validation cache `WalletNode.valid_wp_cache`. 

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

We currently add 2 new cache entries (~2MB per entry) every time we long sync to untrusted peers (primary + secondary) which might happen whenever depending on the setup/network because we always long sync from new connections if we lost connection to synced untrusted peers. Currently we don't remove those entries anywhere so the weight proof validation cache may just keep growing without limit.

### New Behavior:

Initially i thought about making it an LRU with a limit of 2 entries, see 0784dc8e5c35208523e20e987aa674beabdfb229. But then after thinking more about it.. it seems to me that we never even would get a cache hit here because we never end up requesting the weight proof for the same peak twice and each peak leads to a different weight proof because of the `recent_chain_data`? Let me know if i miss something, i can drop 93df1f81b099fabe1dc23dc1d1a6dd7e8a1e83c5 and maybe even adjust the size if we still need the cache for some reason.
