### PR TITLE
server: Introduce `ChiaServer.trusted_peers`

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1611,4 +1611,4 @@ class FullNodeAPI:
         return msg
 
     def is_trusted(self, peer: WSChiaConnection) -> bool:
-        return self.server.is_trusted_peer(peer, self.full_node.config.get("trusted_peers", {}))
+        return self.server.is_trusted_peer(peer)

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -937,7 +937,7 @@ class WalletNode:
         return latest_timestamp
 
     def is_trusted(self, peer) -> bool:
-        return self.server.is_trusted_peer(peer, self.config.get("trusted_peers", {}))
+        return self.server.is_trusted_peer(peer)
 
     def add_state_to_race_cache(self, header_hash: bytes32, height: uint32, coin_state: CoinState) -> None:
         # Clears old state that is no longer relevant

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -627,11 +627,8 @@ async def wallets_prefarm(two_wallet_nodes, self_hostname, trusted):
     wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        wallet_node_1.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_server.node_id}
 
     await wallet_server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await wallet_server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/core/util/test_file_keyring_synchronization.py
+++ b/tests/core/util/test_file_keyring_synchronization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from multiprocessing import Pool
 from pathlib import Path
 from sys import platform
@@ -10,7 +11,7 @@ from time import sleep
 from chia.simulator.keyring import TempKeyring, using_temp_file_keyring
 from chia.simulator.time_out_assert import adjusted_timeout
 from chia.util.keyring_wrapper import KeyringWrapper
-from tests.core.util.test_lockfile import poll_directory
+from tests.core.util.test_lockfile import wait_for_enough_files_in_directory
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ log = logging.getLogger(__name__)
 DUMMY_SLEEP_VALUE = 2
 
 
-def dummy_set_passphrase(service, user, passphrase, keyring_path, index, num_workers):
+def dummy_set_passphrase(service, user, passphrase, keyring_path, index):
     with TempKeyring(existing_keyring_path=keyring_path, delete_on_cleanup=False):
         if platform == "linux" or platform == "win32" or platform == "cygwin":
             # FileKeyring's setup_keyring_file_watcher needs to be called explicitly here,
@@ -30,17 +31,14 @@ def dummy_set_passphrase(service, user, passphrase, keyring_path, index, num_wor
         with open(ready_file_path, "w") as f:
             f.write(f"{os.getpid()}\n")
 
-        # Wait up to 30 seconds for all processes to indicate readiness
+        # Wait up to 120 seconds for all processes to indicate readiness
         start_file_path: Path = Path(ready_file_path.parent) / "start"
-        remaining_attempts = 120
-        while remaining_attempts > 0:
-            if start_file_path.exists():
-                break
-            else:
-                sleep(0.25)
-                remaining_attempts -= 1
-
-        assert remaining_attempts >= 0
+        end = time.monotonic() + 120
+        started = False
+        while not started and time.monotonic() < end:
+            started = start_file_path.exists()
+            sleep(0.1)
+        assert started
 
         KeyringWrapper.get_shared_instance().set_passphrase(service=service, user=user, passphrase=passphrase)
 
@@ -64,14 +62,12 @@ class TestFileKeyringSynchronization:
     # When: using a new empty keyring
     @using_temp_file_keyring()
     def test_multiple_writers(self):
-        num_workers = 20
+        num_workers = 10
         keyring_path = str(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        passphrase_list = list(
-            map(
-                lambda x: ("test-service", f"test-user-{x}", f"passphrase {x}", keyring_path, x, num_workers),
-                range(num_workers),
-            )
-        )
+        passphrase_list = [
+            ("test-service", f"test-user-{index}", f"passphrase {index}", keyring_path, index)
+            for index in range(num_workers)
+        ]
 
         # Create a directory for each process to indicate readiness
         ready_dir: Path = Path(keyring_path).parent / "ready"
@@ -84,8 +80,7 @@ class TestFileKeyringSynchronization:
         with Pool(processes=num_workers) as pool:
             res = pool.starmap_async(dummy_set_passphrase, passphrase_list)
 
-            # Wait up to 30 seconds for all processes to indicate readiness
-            assert poll_directory(ready_dir, num_workers, 30) is True
+            assert wait_for_enough_files_in_directory(ready_dir, num_workers)
 
             log.warning(f"Test setup complete: {num_workers} workers ready")
 
@@ -94,8 +89,7 @@ class TestFileKeyringSynchronization:
             with open(start_file_path, "w") as f:
                 f.write(f"{os.getpid()}\n")
 
-            # Wait up to 30 seconds for all processes to indicate completion
-            assert poll_directory(finished_dir, num_workers, 30) is True
+            assert wait_for_enough_files_in_directory(finished_dir, num_workers)
 
             log.warning(f"Finished: {num_workers} workers finished")
 

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -108,11 +108,7 @@ async def one_wallet_node_and_rpc(
         wallet = wallet_node.wallet_state_manager.main_wallet
 
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
         await wallet_node.server.start_client(
             PeerInfo(self_hostname, uint16(full_node_api.full_node.server._port)), None
@@ -156,11 +152,7 @@ async def setup(
     )
 
     if trusted:
-        wallet_node.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node.config["trusted_peers"] = {}
+        wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await wallet_node.server.start_client(PeerInfo(self_hostname, uint16(full_node_api.full_node.server._port)), None)
 

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -154,8 +154,6 @@ class TestSimulation:
         wallet_node_2, server_3 = wallets[1]
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
-        wallet_node.config["trusted_peers"] = {}
-        wallet_node_2.config["trusted_peers"] = {}
 
         # enable auto_farming
         await full_node_api.update_autofarm_config(True)

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -37,9 +37,7 @@ class TestCATWallet:
 
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         for i in range(0, num_blocks):
@@ -101,7 +99,7 @@ class TestCATWallet:
         wallet_node, wallet_server = wallets[0]
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
-        wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
+        wallet_node.server.trusted_peers = {full_node_server.node_id}
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         for i in range(0, num_blocks):
@@ -150,11 +148,8 @@ class TestCATWallet:
         api_1 = WalletRpcApi(wallet_node_2)
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -255,9 +250,7 @@ class TestCATWallet:
 
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
         for i in range(0, num_blocks):
@@ -310,11 +303,8 @@ class TestCATWallet:
 
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -401,13 +391,9 @@ class TestCATWallet:
 
         ph = await wallet_0.get_new_puzzlehash()
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_1.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
-            wallet_node_1.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_1.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_server.node_id}
         await wallet_server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await wallet_server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await wallet_server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -521,11 +507,8 @@ class TestCATWallet:
 
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -631,11 +614,8 @@ class TestCATWallet:
 
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_server.node_id}
         wallet_node.config["automatically_add_unknown_cats"] = autodiscovery
         wallet_node_2.config["automatically_add_unknown_cats"] = autodiscovery
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -53,9 +53,7 @@ class TestDLWallet:
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
 
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_server.node_id}
 
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -103,9 +101,7 @@ class TestDLWallet:
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
 
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_server.node_id}
 
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -159,11 +155,8 @@ class TestDLWallet:
         wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
 
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_1.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
-            wallet_node_1.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_1.server.trusted_peers = {full_node_server.node_id}
 
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -239,9 +232,7 @@ class TestDLWallet:
         wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
 
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_server.node_id}
 
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -336,11 +327,8 @@ class TestDLWallet:
         wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
 
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_1.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
-            wallet_node_1.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_1.server.trusted_peers = {full_node_server.node_id}
 
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -71,16 +71,8 @@ class TestDIDWallet:
         assert sk0 == sk1
 
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_1.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
-            wallet_node_1.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -154,19 +146,9 @@ class TestDIDWallet:
         ph1 = await wallet_1.get_new_puzzlehash()
         ph2 = await wallet_2.get_new_puzzlehash()
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_1.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
-            wallet_node_1.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
         await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -318,15 +300,8 @@ class TestDIDWallet:
 
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
 
@@ -475,15 +450,8 @@ class TestDIDWallet:
 
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
 
@@ -545,15 +513,8 @@ class TestDIDWallet:
         api_0 = WalletRpcApi(wallet_node)
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         for i in range(1, num_blocks):
@@ -644,15 +605,8 @@ class TestDIDWallet:
         wallet2 = wallet_node_2.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         for i in range(1, num_blocks):
@@ -827,15 +781,8 @@ class TestDIDWallet:
         ph = await wallet.get_new_puzzlehash()
 
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
@@ -924,15 +871,8 @@ class TestDIDWallet:
         ph = await wallet.get_new_puzzlehash()
 
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
@@ -989,15 +929,8 @@ class TestDIDWallet:
         ph1 = await wallet1.get_new_puzzlehash()
         api_0 = WalletRpcApi(wallet_node)
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
@@ -1075,15 +1008,8 @@ class TestDIDWallet:
         ph1 = await wallet1.get_new_puzzlehash()
         api_0 = WalletRpcApi(wallet_node)
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
@@ -1142,15 +1068,8 @@ class TestDIDWallet:
         wallet_node_2, server_3 = wallets[1]
         wallet = wallet_node.wallet_state_manager.main_wallet
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
@@ -1217,15 +1136,8 @@ class TestDIDWallet:
         ph = await wallet.get_new_puzzlehash()
 
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_api.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -76,15 +76,8 @@ async def test_nft_offer_sell_nft(
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -253,15 +246,8 @@ async def test_nft_offer_request_nft(
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -428,15 +414,8 @@ async def test_nft_offer_sell_did_to_did(
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -626,15 +605,8 @@ async def test_nft_offer_sell_nft_for_cat(
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -834,15 +806,8 @@ async def test_nft_offer_request_nft_for_cat(
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -1047,11 +1012,7 @@ async def test_nft_offer_sell_cancel(self_hostname: str, two_wallet_nodes: Any, 
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -1163,11 +1124,7 @@ async def test_nft_offer_sell_cancel_in_batch(self_hostname: str, two_wallet_nod
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
 
@@ -1297,15 +1254,8 @@ async def test_complex_nft_offer(
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
     wallet_node_maker.config["automatically_add_unknown_cats"] = True
     wallet_node_taker.config["automatically_add_unknown_cats"] = True
 

--- a/tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -50,15 +50,8 @@ async def test_nft_mint_from_did(self_hostname: str, two_wallet_nodes: Any, trus
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -164,15 +157,8 @@ async def test_nft_mint_from_did_rpc(two_wallet_nodes: Any, trusted: Any, self_h
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -368,15 +354,8 @@ async def test_nft_mint_from_did_rpc_no_royalties(two_wallet_nodes: Any, trusted
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -551,15 +530,8 @@ async def test_nft_mint_from_did_multiple_xch(self_hostname: str, two_wallet_nod
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -658,15 +630,8 @@ async def test_nft_mint_from_xch(self_hostname: str, two_wallet_nodes: Any, trus
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -771,15 +736,8 @@ async def test_nft_mint_from_xch_rpc(two_wallet_nodes: Any, trusted: Any, self_h
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
+        wallet_node_maker.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_taker.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -968,15 +926,8 @@ async def test_nft_mint_from_xch_multiple_xch(self_hostname: str, two_wallet_nod
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -54,15 +54,8 @@ async def test_nft_offer_with_fee(
     token_ph = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -247,15 +240,8 @@ async def test_nft_offer_cancellations(self_hostname: str, two_wallet_nodes: Any
     token_ph = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -366,15 +352,8 @@ async def test_nft_offer_with_metadata_update(
     token_ph = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -528,15 +507,8 @@ async def test_nft_offer_nft_for_cat(
     token_ph = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -780,15 +752,8 @@ async def test_nft_offer_nft_for_nft(
     token_ph = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -93,15 +93,8 @@ async def test_nft_wallet_creation_automatically(self_hostname: str, two_wallet_
     ph1 = await wallet_1.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -188,15 +181,8 @@ async def test_nft_wallet_creation_and_transfer(self_hostname: str, two_wallet_n
     ph1 = await wallet_1.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -344,15 +330,8 @@ async def test_nft_wallet_rpc_creation_and_list(self_hostname: str, two_wallet_n
     _ = await wallet_1.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -471,15 +450,8 @@ async def test_nft_wallet_rpc_update_metadata(self_hostname: str, two_wallet_nod
     _ = await wallet_1.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -627,15 +599,8 @@ async def test_nft_with_did_wallet_creation(self_hostname: str, two_wallet_nodes
     ph = await wallet_0.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -796,15 +761,8 @@ async def test_nft_rpc_mint(self_hostname: str, two_wallet_nodes: Any, trusted: 
     ph1 = await wallet_1.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -917,15 +875,8 @@ async def test_nft_transfer_nft_with_did(self_hostname: str, two_wallet_nodes: A
     ph1 = await wallet_1.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -1076,15 +1027,8 @@ async def test_update_metadata_for_nft_did(self_hostname: str, two_wallet_nodes:
     ph1 = await wallet_1.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -1208,15 +1152,8 @@ async def test_nft_bulk_set_did(self_hostname: str, two_wallet_nodes: Any, trust
     ph = await wallet_0.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -1354,15 +1291,8 @@ async def test_nft_bulk_transfer(two_wallet_nodes: Any, trusted: Any) -> None:
     ph1 = await wallet_1.get_new_puzzlehash()
     address = encode_puzzle_hash(ph1, AddressType.XCH.hrp(wallet_node_1.config))
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo("127.0.0.1", uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo("127.0.0.1", uint16(full_node_server._port)), None)
@@ -1486,15 +1416,8 @@ async def test_nft_set_did(self_hostname: str, two_wallet_nodes: Any, trusted: A
     ph = await wallet_0.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -1654,15 +1577,8 @@ async def test_set_nft_status(self_hostname: str, two_wallet_nodes: Any, trusted
     ph = await wallet_0.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -1740,15 +1656,8 @@ async def test_nft_sign_message(self_hostname: str, two_wallet_nodes: Any, trust
     ph = await wallet_0.get_new_puzzlehash()
 
     if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
+        wallet_node_0.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -41,11 +41,8 @@ class TestWalletRpc:
         ph = await wallet.get_new_puzzlehash()
 
         if trusted:
-            wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -135,11 +135,8 @@ async def wallet_rpc_environment(two_wallet_nodes_services, request, self_hostna
     hostname = config["self_hostname"]
 
     if request.param:
-        wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-        wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-    else:
-        wallet_node.config["trusted_peers"] = {}
-        wallet_node_2.config["trusted_peers"] = {}
+        wallet_node.server.trusted_peers = {full_node_server.node_id}
+        wallet_node_2.server.trusted_peers = {full_node_server.node_id}
 
     await wallet_node.server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await wallet_node_2.server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -650,7 +650,7 @@ class TestSimpleSyncProtocol:
         assert not s.has_ph_subscription(phs[2])
         assert not s.has_ph_subscription(phs[3])
         full_node_api.full_node.config["trusted_max_subscribe_items"] = 4
-        full_node_api.full_node.config["trusted_peers"] = {server_2.node_id.hex(): server_2.node_id.hex()}
+        full_node_api.full_node.server.trusted_peers = {server_2.node_id}
         assert full_node_api.is_trusted(con) is True
         msg_response = await full_node_api.register_interest_in_puzzle_hash(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_ph_update.value
@@ -691,7 +691,7 @@ class TestSimpleSyncProtocol:
         assert not s.has_coin_subscription(coins[2])
         assert not s.has_coin_subscription(coins[3])
         full_node_api.full_node.config["trusted_max_subscribe_items"] = 4
-        full_node_api.full_node.config["trusted_peers"] = {server_2.node_id.hex(): server_2.node_id.hex()}
+        full_node_api.full_node.server.trusted_peers = {server_2.node_id}
         assert full_node_api.is_trusted(con) is True
         msg_response = await full_node_api.register_interest_in_coin(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_coin_update.value

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -160,10 +160,7 @@ class TestWalletSync:
         full_node_server = full_node_api.full_node.server
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         for block in default_400_blocks:
             await full_node_api.full_node.add_block(block)
@@ -212,10 +209,7 @@ class TestWalletSync:
         full_node_server = full_node_api.full_node.server
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         base_num_blocks = 400
         for block in default_400_blocks:
@@ -250,10 +244,7 @@ class TestWalletSync:
         full_node_server = full_node_api.full_node.server
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         for block in default_400_blocks[:20]:
             await full_node_api.full_node.add_block(block)
@@ -272,10 +263,7 @@ class TestWalletSync:
         full_node_server = full_node_api.full_node.server
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         for block in default_400_blocks[:200]:
             await full_node_api.full_node.add_block(block)
@@ -293,10 +281,7 @@ class TestWalletSync:
         full_node_server = full_node_api.full_node.server
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         for block in default_400_blocks:
             await full_node_api.full_node.add_block(block)
@@ -341,10 +326,7 @@ class TestWalletSync:
         full_node_server = full_node_api.full_node.server
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         phs = []
         for wallet_node, wallet_server in wallets:
@@ -396,10 +378,7 @@ class TestWalletSync:
         full_node_server = full_node_api.full_node.server
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         for wallet_node, wallet_server in wallets:
             await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
@@ -1169,10 +1148,7 @@ class TestWalletSync:
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32([0] * 32)))
 
         # Trusted node sync
-        wallets[0][0].config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
-
-        # Untrusted node sync
-        wallets[1][0].config["trusted_peers"] = {}
+        wallets[0][0].server.trusted_peers = {full_node_server.node_id}
 
         def flaky_get_coin_state(node, func):
             async def new_func(*args, **kwargs):

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -69,15 +69,8 @@ async def test_notifications(self_hostname: str, two_wallet_nodes: Any, trusted:
     ph_token = bytes32(token_bytes())
 
     if trusted:
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_2.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_1.config["trusted_peers"] = {}
-        wallet_node_2.config["trusted_peers"] = {}
+        wallet_node_1.server.trusted_peers = {full_node_api.full_node.server.node_id}
+        wallet_node_2.server.trusted_peers = {full_node_api.full_node.server.node_id}
 
     await server_0.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -51,9 +51,7 @@ class TestWalletSimulator:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         if trusted:
-            wallet_node.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {server_1.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
@@ -96,11 +94,8 @@ class TestWalletSimulator:
         wallet_node_2, server_3 = wallets[1]
         wallet = wallet_node.wallet_state_manager.main_wallet
         if trusted:
-            wallet_node.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {server_1.node_id}
+            wallet_node_2.server.trusted_peers = {server_1.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
 
@@ -142,9 +137,7 @@ class TestWalletSimulator:
         wallet_node, server_2 = wallets[0]
         wallet = wallet_node.wallet_state_manager.main_wallet
         if trusted:
-            wallet_node.config["trusted_peers"] = {fn_server.node_id.hex(): fn_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {fn_server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
         await asyncio.sleep(5)
 
@@ -195,14 +188,7 @@ class TestWalletSimulator:
         server_2 = full_node_2.server
 
         if trusted:
-            wallet_0.config["trusted_peers"] = {
-                server_0.node_id.hex(): server_0.node_id.hex(),
-                server_1.node_id.hex(): server_1.node_id.hex(),
-                server_2.node_id.hex(): server_2.node_id.hex(),
-            }
-
-        else:
-            wallet_0.config["trusted_peers"] = {}
+            wallet_0.server.trusted_peers = {server_0.node_id, server_1.node_id, server_2.node_id}
 
         # wallet0 <-> sever0
         await wallet_server_0.start_client(PeerInfo(self_hostname, uint16(server_0._port)), None)
@@ -256,11 +242,8 @@ class TestWalletSimulator:
         wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
 
         if trusted:
-            wallet_node_0.config["trusted_peers"] = {server_0.node_id.hex(): server_0.node_id.hex()}
-            wallet_node_1.config["trusted_peers"] = {server_0.node_id.hex(): server_0.node_id.hex()}
-        else:
-            wallet_node_0.config["trusted_peers"] = {}
-            wallet_node_1.config["trusted_peers"] = {}
+            wallet_node_0.server.trusted_peers = {server_0.node_id}
+            wallet_node_1.server.trusted_peers = {server_0.node_id}
         await wallet_0_server.start_client(PeerInfo(self_hostname, uint16(server_0._port)), None)
 
         await wallet_1_server.start_client(PeerInfo(self_hostname, uint16(server_0._port)), None)
@@ -365,15 +348,8 @@ class TestWalletSimulator:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_1.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_1.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_1.full_node.server._port)), None)
 
         expected_confirmed_balance = await full_node_1.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
@@ -431,15 +407,8 @@ class TestWalletSimulator:
         api_0 = WalletRpcApi(wallet_node)
         api_1 = WalletRpcApi(wallet_node_2)
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_1.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_1.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_1.full_node.server._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(full_node_1.full_node.server._port)), None)
 
@@ -499,15 +468,8 @@ class TestWalletSimulator:
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_1.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_1.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_1.full_node.server._port)), None)
 
         expected_confirmed_balance = await full_node_1.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
@@ -573,15 +535,8 @@ class TestWalletSimulator:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         if trusted:
-            wallet_node.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-            wallet_node_2.config["trusted_peers"] = {
-                full_node_1.full_node.server.node_id.hex(): full_node_1.full_node.server.node_id.hex()
-            }
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {full_node_1.full_node.server.node_id}
+            wallet_node_2.server.trusted_peers = {full_node_1.full_node.server.node_id}
         await server_2.start_client(PeerInfo(self_hostname, uint16(full_node_1.full_node.server._port)), None)
 
         expected_confirmed_balance = await full_node_1.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
@@ -663,11 +618,8 @@ class TestWalletSimulator:
 
         ph2 = await wallet_2.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {fn_server.node_id.hex(): fn_server.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {fn_server.node_id.hex(): fn_server.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {fn_server.node_id}
+            wallet_node_2.server.trusted_peers = {fn_server.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(fn_server._port)), None)
@@ -758,9 +710,7 @@ class TestWalletSimulator:
         server_1: ChiaServer = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]
         if trusted:
-            wallet_node.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {server_1.node_id}
         wallet = wallet_node.wallet_state_manager.main_wallet
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
@@ -826,11 +776,8 @@ class TestWalletSimulator:
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
         if trusted:
-            wallet_node.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {server_1.node_id}
+            wallet_node_2.server.trusted_peers = {server_1.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         # Test general string
@@ -889,11 +836,8 @@ class TestWalletSimulator:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         if trusted:
-            wallet_node.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-        else:
-            wallet_node.config["trusted_peers"] = {}
-            wallet_node_2.config["trusted_peers"] = {}
+            wallet_node.server.trusted_peers = {server_1.node_id}
+            wallet_node_2.server.trusted_peers = {server_1.node_id}
 
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

- Improve trusted peers handling by storing the parsed trusted peers in the server vs always pass in the config entry to `ChiaServer.is_trusted_peer`
- Add some tests for trusted peers config handling
- Cleanup a bunch of not required assignments in tests - all the `config["trusted_peers"] = {}`

### New Behavior:

No change in behaviour.
