### PR TITLE
Add a wallet rpc endpoint to get in-use addresses for a particular wallet ID

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -886,6 +886,14 @@ class WalletRpcApi:
 
     async def get_used_addresses(self, request: Dict) -> EndpointResult:
         """Returns addresses that have actually been used, as determined by looking at the puzzle hash of coins"""
+        syncing = self.service.wallet_state_manager.sync_mode
+        if syncing:
+            return {
+                "success": False,
+                "syncing": syncing,
+                "addresses": [],
+            }
+
         wallet_id = int(request.get("wallet_id", 1))
 
         async with self.service.wallet_state_manager.db_wrapper.reader_no_transaction() as conn:
@@ -898,6 +906,7 @@ class WalletRpcApi:
             )
 
         return {
+            "syncing": syncing,
             "addresses": [
                 {
                     "puzzle_hash": row[0],


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Adds the ability to get in-use addresses for a particular wallet ID via the RPC.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Currently, there is not a straight forward way to get this, aside from iterating through all of the coins in the wallet and finding the unique puzzlehashes. Its another step to then determine if the address is observer or non-observer.


### New Behavior:

New behavior adds an endpoint with a relatively simple query to get this data directly.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

`chia rpc wallet get_used_addresses` - Returns addresses for the (default) wallet_id 1

`chia rpc wallet get_used_addresses '{"wallet_id":3}'` - Returns addresses for wallet_id 3

**Example Response**

```{
    "addresses": [
        {
            "address": "xch...",
            "observer": true,
            "puzzle_hash": "xxxxx"
        },
        {
            "address": "xch...",
            "observer": false,
            "puzzle_hash": "xxxxx"
        },
        ...
    ],
    "success": true
}
```

Note that when testing, this worked fine for the normal XCH wallet and all my CAT wallets, but did not seem to work for NFT wallets. It doesn't appear that we store any data in `derivation_paths` for NFTs which is the joined table utilized to determine hardened or unhardened, so that would explain why no results come back for NFT wallets.