### PR TITLE
run the connection DoS tests on the benchmark CI infrastructure

### DIFF
--- a/tests/core/server/test_event_loop.py
+++ b/tests/core/server/test_event_loop.py
@@ -11,6 +11,7 @@ from chia.server.chia_policy import ChiaSelectorEventLoop, PausableServer, _chia
 
 
 @pytest.mark.asyncio
+@pytest.mark.benchmark
 async def test_base_event_loop_has_methods() -> None:
     """
     `ChiaPolicy` overrides `create_server` to create and return the custom `PausableServer`

--- a/tests/core/server/test_loop.py
+++ b/tests/core/server/test_loop.py
@@ -145,6 +145,7 @@ class ServeInThread:
 
 
 @pytest.mark.asyncio
+@pytest.mark.benchmark
 async def test_loop() -> None:
     print(" ==== launching serve.py")
     with subprocess.Popen(
@@ -237,6 +238,7 @@ async def test_loop() -> None:
     ids=lambda cycles: f"{cycles} cycle{'s' if cycles != 1 else ''}",
 )
 @pytest.mark.asyncio
+@pytest.mark.benchmark
 async def test_limits_connections(repetition: int, cycles: int) -> None:
     ip = "127.0.0.1"
     connection_limit = 25


### PR DESCRIPTION
This is an attempt to improve the flakiness of the tests by isolating the ones requiring a lot of file descriptors to the benchmark runner, where tests are run one at a time.