### PR TITLE
make SpendBundle.additions() count complete cost

### DIFF
--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Tuple
 
 from clvm.casts import int_from_bytes
 
@@ -29,7 +29,11 @@ class CoinSpend(Streamable):
     solution: SerializedProgram
 
 
-def compute_additions(cs: CoinSpend, *, max_cost: int = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM) -> List[Coin]:
+def compute_additions_with_cost(
+    cs: CoinSpend,
+    *,
+    max_cost: int = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+) -> Tuple[List[Coin], int]:
     """
     Run the puzzle in the specified CoinSpend and return the cost and list of
     coins created by the puzzle, i.e. additions. If the cost (CLVM- and
@@ -55,4 +59,9 @@ def compute_additions(cs: CoinSpend, *, max_cost: int = DEFAULT_CONSTANTS.MAX_BL
         puzzle_hash = next(atoms).atom
         amount = int_from_bytes(next(atoms).atom)
         ret.append(Coin(parent_id, puzzle_hash, amount))
-    return ret
+
+    return ret, cost
+
+
+def compute_additions(cs: CoinSpend, *, max_cost: int = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM) -> List[Coin]:
+    return compute_additions_with_cost(cs, max_cost=max_cost)[0]

--- a/tests/core/custom_types/test_spend_bundle.py
+++ b/tests/core/custom_types/test_spend_bundle.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import json
+import random
 import unittest
+from typing import List, Tuple
 
+import pytest
 from blspy import G2Element
 
+from chia.types.blockchain_format.coin import Coin
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_spend import CoinSpend
+from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
+from chia.util.errors import ValidationError
 
 BLANK_SPEND_BUNDLE = SpendBundle(coin_spends=[], aggregated_signature=G2Element())
 NULL_SIGNATURE = "0xc" + "0" * 191
@@ -75,3 +84,45 @@ def round_trip(spend_bundle: SpendBundle, **kwargs):
     sb = SpendBundle.from_json_dict(json_dict_2)
     json_dict_3 = sb.to_json_dict()
     assert json_dict_2 == json_dict_3
+
+
+def rand_hash(rng: random.Random) -> bytes32:
+    ret = bytearray(32)
+    for i in range(32):
+        ret[i] = rng.getrandbits(8)
+    return bytes32(ret)
+
+
+def create_spends(num: int) -> Tuple[List[CoinSpend], List[Coin]]:
+    spends: List[CoinSpend] = []
+    create_coin: List[Coin] = []
+    rng = random.Random()
+
+    puzzle = Program.to(1)
+    puzzle_hash = puzzle.get_tree_hash()
+
+    for i in range(num):
+        target_ph = rand_hash(rng)
+        conditions = [[ConditionOpcode.CREATE_COIN, target_ph, 1]]
+        coin = Coin(rand_hash(rng), puzzle_hash, 1000)
+        new_coin = Coin(coin.name(), target_ph, 1)
+        create_coin.append(new_coin)
+        spends.append(CoinSpend(coin, puzzle, Program.to(conditions)))
+
+    return spends, create_coin
+
+
+def test_compute_additions_create_coin() -> None:
+    # make a large number of CoinSpends
+    spends, create_coin = create_spends(2000)
+    sb = SpendBundle(spends, G2Element())
+    coins = sb.additions()
+    assert coins == create_coin
+
+
+def test_compute_additions_create_coin_max_cost() -> None:
+    # make a large number of CoinSpends
+    spends, _ = create_spends(6111)
+    sb = SpendBundle(spends, G2Element())
+    with pytest.raises(ValidationError, match="BLOCK_COST_EXCEEDS_MAX"):
+        sb.additions()


### PR DESCRIPTION
apply the cost limit across all `CoinSpend`s whose additions are computed.