### PR TITLE
make conditions_for_solution() support untrusted input

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Callable, Dict, List, Set, Tuple
+from typing import Any, Callable, Dict, Set, Tuple
 
 from chia_rs import run_chia_program, tree_hash
 from clvm import SExp
@@ -173,28 +173,6 @@ class Program(SExp):
 
     def as_int(self) -> int:
         return int_from_bytes(self.as_atom())
-
-    def as_atom_list(self) -> List[bytes]:
-        """
-        Pretend `self` is a list of atoms. Return the corresponding
-        python list of atoms.
-
-        At each step, we always assume a node to be an atom or a pair.
-        If the assumption is wrong, we exit early. This way we never fail
-        and always return SOMETHING.
-        """
-        items = []
-        obj = self
-        while True:
-            pair = obj.pair
-            if pair is None:
-                break
-            atom = pair[0].atom
-            if atom is None:
-                break
-            items.append(atom)
-            obj = pair[1]
-        return items
 
     def __deepcopy__(self, memo):
         return type(self).from_bytes(bytes(self))

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import List
+
 from clvm_tools import binutils
 from clvm_tools.clvmc import compile_clvm_text
 
@@ -84,6 +86,29 @@ EXPECTED_OUTPUT = (
 )
 
 
+def as_atom_list(prg: Program) -> List[bytes]:
+    """
+    Pretend `prg` is a list of atoms. Return the corresponding
+    python list of atoms.
+
+    At each step, we always assume a node to be an atom or a pair.
+    If the assumption is wrong, we exit early. This way we never fail
+    and always return SOMETHING.
+    """
+    items = []
+    obj = prg
+    while True:
+        pair = obj.pair
+        if pair is None:
+            break
+        atom = pair[0].atom
+        if atom is None:
+            break
+        items.append(atom)
+        obj = pair[1]
+    return items
+
+
 class TestROM:
     def test_rom_inputs(self):
         # this test checks that the generator just works
@@ -132,7 +157,7 @@ class TestROM:
         coin_spends = r.first()
         for coin_spend in coin_spends.as_iter():
             extra_data = coin_spend.rest().rest().rest().rest()
-            assert extra_data.as_atom_list() == b"extra data for coin".split()
+            assert as_atom_list(extra_data) == b"extra data for coin".split()
 
     def test_block_extras(self):
         # the ROM supports extra data after the coin spend list. This test checks that it actually gets passed through
@@ -140,4 +165,4 @@ class TestROM:
         gen = block_generator()
         cost, r = run_generator_unsafe(gen, max_cost=MAX_COST)
         extra_block_data = r.rest()
-        assert extra_block_data.as_atom_list() == b"extra data for block".split()
+        assert as_atom_list(extra_block_data) == b"extra data for block".split()


### PR DESCRIPTION
This patch fixes `parse_sexp_to_condition()` to convert to python as it parses, rather than converting the entire tree to python types up-front. This means we can fail parsing and cut argument lists short early.

Without this patch, it's not safe to use these functions on untrusted input, we don't use these in the full node for instance. However, hardening this function against untrusted input protects against future mistakes where it may be assumed to handle it.