### PR TITLE
tests: Some refactoring of `poll_directory` and keyring sync tests

### DIFF
--- a/tests/core/util/test_file_keyring_synchronization.py
+++ b/tests/core/util/test_file_keyring_synchronization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from multiprocessing import Pool
 from pathlib import Path
 from sys import platform
@@ -18,7 +19,7 @@ log = logging.getLogger(__name__)
 DUMMY_SLEEP_VALUE = 2
 
 
-def dummy_set_passphrase(service, user, passphrase, keyring_path, index, num_workers):
+def dummy_set_passphrase(service, user, passphrase, keyring_path, index):
     with TempKeyring(existing_keyring_path=keyring_path, delete_on_cleanup=False):
         if platform == "linux" or platform == "win32" or platform == "cygwin":
             # FileKeyring's setup_keyring_file_watcher needs to be called explicitly here,
@@ -30,17 +31,13 @@ def dummy_set_passphrase(service, user, passphrase, keyring_path, index, num_wor
         with open(ready_file_path, "w") as f:
             f.write(f"{os.getpid()}\n")
 
-        # Wait up to 30 seconds for all processes to indicate readiness
+        # Wait up to 120 seconds for all processes to indicate readiness
         start_file_path: Path = Path(ready_file_path.parent) / "start"
-        remaining_attempts = 120
-        while remaining_attempts > 0:
-            if start_file_path.exists():
-                break
-            else:
-                sleep(0.25)
-                remaining_attempts -= 1
+        start = time.time()
+        while not start_file_path.exists() and time.time() - start < 120:
+            sleep(0.1)
 
-        assert remaining_attempts >= 0
+        assert start_file_path.exists()
 
         KeyringWrapper.get_shared_instance().set_passphrase(service=service, user=user, passphrase=passphrase)
 
@@ -64,11 +61,11 @@ class TestFileKeyringSynchronization:
     # When: using a new empty keyring
     @using_temp_file_keyring()
     def test_multiple_writers(self):
-        num_workers = 20
+        num_workers = 10
         keyring_path = str(KeyringWrapper.get_shared_instance().keyring.keyring_path)
         passphrase_list = list(
             map(
-                lambda x: ("test-service", f"test-user-{x}", f"passphrase {x}", keyring_path, x, num_workers),
+                lambda x: ("test-service", f"test-user-{x}", f"passphrase {x}", keyring_path, x),
                 range(num_workers),
             )
         )
@@ -84,8 +81,8 @@ class TestFileKeyringSynchronization:
         with Pool(processes=num_workers) as pool:
             res = pool.starmap_async(dummy_set_passphrase, passphrase_list)
 
-            # Wait up to 30 seconds for all processes to indicate readiness
-            assert poll_directory(ready_dir, num_workers, 30) is True
+            # Wait for all processes to indicate readiness
+            assert poll_directory(ready_dir, num_workers)
 
             log.warning(f"Test setup complete: {num_workers} workers ready")
 
@@ -94,8 +91,8 @@ class TestFileKeyringSynchronization:
             with open(start_file_path, "w") as f:
                 f.write(f"{os.getpid()}\n")
 
-            # Wait up to 30 seconds for all processes to indicate completion
-            assert poll_directory(finished_dir, num_workers, 30) is True
+            # Wait for all processes to indicate completion
+            assert poll_directory(finished_dir, num_workers)
 
             log.warning(f"Finished: {num_workers} workers finished")
 

--- a/tests/core/util/test_file_keyring_synchronization.py
+++ b/tests/core/util/test_file_keyring_synchronization.py
@@ -33,8 +33,8 @@ def dummy_set_passphrase(service, user, passphrase, keyring_path, index):
 
         # Wait up to 120 seconds for all processes to indicate readiness
         start_file_path: Path = Path(ready_file_path.parent) / "start"
-        start = time.time()
-        while not start_file_path.exists() and time.time() - start < 120:
+        end = time.monotonic() + 120
+        while not start_file_path.exists() and time.monotonic() < end:
             sleep(0.1)
 
         assert start_file_path.exists()
@@ -63,12 +63,10 @@ class TestFileKeyringSynchronization:
     def test_multiple_writers(self):
         num_workers = 10
         keyring_path = str(KeyringWrapper.get_shared_instance().keyring.keyring_path)
-        passphrase_list = list(
-            map(
-                lambda x: ("test-service", f"test-user-{x}", f"passphrase {x}", keyring_path, x),
-                range(num_workers),
-            )
-        )
+        passphrase_list = [
+            ("test-service", f"test-user-{index}", f"passphrase {index}", keyring_path, index)
+            for index in range(num_workers)
+        ]
 
         # Create a directory for each process to indicate readiness
         ready_dir: Path = Path(keyring_path).parent / "ready"

--- a/tests/core/util/test_lockfile.py
+++ b/tests/core/util/test_lockfile.py
@@ -63,6 +63,7 @@ def child_writer_dispatch_with_readiness_check(
     while not started and time.monotonic() < end:
         started = start_file_path.exists()
         sleep(0.1)
+    assert started
 
     try:
         while attempts > 0:

--- a/tests/core/util/test_lockfile.py
+++ b/tests/core/util/test_lockfile.py
@@ -58,8 +58,8 @@ def child_writer_dispatch_with_readiness_check(
 
     # Wait for all processes to indicate readiness
     start_file_path: Path = ready_dir / "start"
-    start = time.time()
-    while not start_file_path.exists() and time.time() - start < 120:
+    end = time.monotonic() + 120
+    while not start_file_path.exists() and time.monotonic() < end:
         sleep(0.1)
 
     try:
@@ -88,8 +88,8 @@ def child_writer_dispatch_with_readiness_check(
 
 def poll_directory(dir: Path, expected_entries: int) -> bool:
     found_all: bool = False
-    start = time.time()
-    while time.time() - start < 120:
+    end = time.monotonic() + 120
+    while time.monotonic() < end:
         entries = list(os.scandir(dir))
         if len(entries) < expected_entries:  # Expecting num_workers of dir entries
             log.warning(f"Polling not complete: {len(entries)} of {expected_entries} entries found")


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

I wanted to add more tests to `core.util` in #14591 which ended up making `test_multiple_writers` super flaky.. i assume because of the number of processes/files there/ in `core.util` tests.. so this PR makes `test_multiple_writers` a little less heavy and more reliable by reducing the number of processes and increase the timeouts which is not a final solution i guess but probably still reasonable to do for now?

Also includes some refactoring of the polling and drops an unused parameter. 

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The multiple writers test runs with 20 workers and has a timeout of 30s for polling the directories. 

### New Behavior:

The multiple writers test runs only with 10 workers and has a timeout of 120s for polling the directories. 