### PR TITLE
handle ._get_extra_info() call on a closing connection

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -41,10 +41,6 @@ WebSocket = Union[WebSocketResponse, ClientWebSocketResponse]
 ConnectionCallback = Callable[["WSChiaConnection"], Awaitable[None]]
 
 
-class ConnectionClosingError(Exception):
-    pass
-
-
 class ConnectionClosedCallbackProtocol(Protocol):
     def __call__(
         self,
@@ -171,9 +167,7 @@ class WSChiaConnection:
         assert writer is not None, "websocket's ._writer is None, was .prepare() called?"
         transport = writer.transport
         if transport is None or transport.is_closing():
-            # The meaning of this condition is based on the existing aiohttp check when writing.
-            # https://github.com/aio-libs/aiohttp/blob/v3.8.4/aiohttp/http_websocket.py#L661-L664
-            raise ConnectionClosingError("Unable to get extra info for a closing transport")
+            return None
         return transport.get_extra_info(name)
 
     async def perform_handshake(

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -168,7 +168,13 @@ class WSChiaConnection:
         transport = writer.transport
         if transport is None:
             return None
-        return transport.get_extra_info(name)
+        try:
+            return transport.get_extra_info(name)
+        except AttributeError:
+            # "/usr/lib/python3.11/asyncio/sslproto.py", line 91, in get_extra_info
+            #   return self._ssl_protocol._get_extra_info(name, default)
+            # AttributeError: 'NoneType' object has no attribute '_get_extra_info'
+            return None
 
     async def perform_handshake(
         self,

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -166,7 +166,7 @@ class WSChiaConnection:
         writer = self.ws._writer
         assert writer is not None, "websocket's ._writer is None, was .prepare() called?"
         transport = writer.transport
-        if transport is None or transport.is_closing():
+        if transport is None:
             return None
         return transport.get_extra_info(name)
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -29,7 +29,7 @@ from chia.server.node_discovery import WalletPeers
 from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.peer_store_resolver import PeerStoreResolver
 from chia.server.server import ChiaServer
-from chia.server.ws_connection import WSChiaConnection
+from chia.server.ws_connection import ConnectionClosingError, WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
@@ -567,6 +567,10 @@ class WalletNode:
             except asyncio.CancelledError:
                 self.log.info("Queue task cancelled, exiting.")
                 raise
+            except ConnectionClosingError as e:
+                if peer is None:
+                    self.log.error(f"Failed handling {item}, unexpected None peer, {e} {traceback.format_exc()}")
+                self.log.info(f"Failed handling {type(item)}, connection closing for {peer.get_peer_logging()}")
             except Exception as e:
                 self.log.error(f"Exception handling {item}, {e} {traceback.format_exc()}")
                 if peer is not None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -29,7 +29,7 @@ from chia.server.node_discovery import WalletPeers
 from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.peer_store_resolver import PeerStoreResolver
 from chia.server.server import ChiaServer
-from chia.server.ws_connection import ConnectionClosingError, WSChiaConnection
+from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
@@ -567,10 +567,6 @@ class WalletNode:
             except asyncio.CancelledError:
                 self.log.info("Queue task cancelled, exiting.")
                 raise
-            except ConnectionClosingError as e:
-                if peer is None:
-                    self.log.error(f"Failed handling {item}, unexpected None peer, {e} {traceback.format_exc()}")
-                self.log.info(f"Failed handling {type(item)}, connection closing for {peer.get_peer_logging()}")
             except Exception as e:
                 self.log.error(f"Exception handling {item}, {e} {traceback.format_exc()}")
                 if peer is not None:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Avoid loud error tracebacks in the logs when requesting extra peer info for a peer that is disconnecting.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
