### PR TITLE
improve test_loop to not hard-code a listen port

### DIFF
--- a/tests/core/server/serve.py
+++ b/tests/core/server/serve.py
@@ -35,7 +35,7 @@ class EchoServer(asyncio.Protocol):
 
 async def async_main(
     ip: str = "127.0.0.1",
-    port: int = 8444,
+    port: int = 0,
     thread_end_event: Optional[threading.Event] = None,
     port_holder: Optional[List[int]] = None,
 ) -> None:


### PR DESCRIPTION
Since I run a chia full node on my computer, running `test_loop.py` locally always fails with:
```
Using selector: EpollSelector
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/arvid/dev/2/chia-blockchain/tests/core/server/serve.py", line 76, in <module>
    main()
  File "/home/arvid/dev/2/chia-blockchain/tests/core/server/serve.py", line 72, in main
    async_run(async_main(), connection_limit=connection_limit - 100)
  File "/home/arvid/dev/2/chia-blockchain/chia/server/start_service.py", line 283, in async_run
    return asyncio.run(coro)
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/arvid/dev/2/chia-blockchain/tests/core/server/serve.py", line 43, in async_main
    server = await loop.create_server(EchoServer, ip, port)
  File "/home/arvid/dev/2/chia-blockchain/chia/server/chia_policy.py", line 245, in create_server
    return await _chia_create_server(super(), *args, **kwargs)
  File "/home/arvid/dev/2/chia-blockchain/chia/server/chia_policy.py", line 208, in _chia_create_server
    server: BaseEventsServer = await cls.create_server(
  File "/usr/lib/python3.10/asyncio/base_events.py", line 1505, in create_server
    raise OSError(err.errno, 'error while attempting '
OSError: [Errno 98] error while attempting to bind on address ('127.0.0.1', 8444): address already in use
```

This patch makes the test use any available listen port instead of the hard coded 8444.

This makes the test pass that first part, but still fails later with:

```
tests/core/server/test_loop.py:217: in test_loop
    assert "paused accepting connections" in output
E   assert 'paused accepting connections' in "Using selector: EpollSelector\nserving on ('127.0.0.1', 33171)\nclosing server\nserver closed\n"
```

This seems to be a step in the right direction though