### PR TITLE
require npc_result to be set in mempool items added to the mempool

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -87,6 +87,8 @@ class Mempool:
         Adds an item to the mempool by kicking out transactions (if it doesn't fit), in order of increasing fee per cost
         """
 
+        assert item.npc_result.conds is not None
+
         while self.at_full_capacity(item.cost):
             # Val is Dict[hash, MempoolItem]
             fee_per_cost, val = self.sorted_spends.peekitem(index=0)

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -23,6 +23,7 @@ from chia.simulator.wallet_tools import WalletTool
 from chia.types.clvm_cost import CLVMCost
 from chia.types.fee_rate import FeeRate, FeeRateV2
 from chia.types.mempool_item import MempoolItem
+from chia.types.spend_bundle_conditions import Spend, SpendBundleConditions
 from chia.util.ints import uint32, uint64
 from tests.core.mempool.test_mempool_manager import (
     create_test_block_record,
@@ -40,10 +41,12 @@ def make_mempoolitem() -> MempoolItem:
     block_height = 1
 
     fee = uint64(10000000)
+    spends: List[Spend] = []
+    conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], 0)
     mempool_item = MempoolItem(
         spend_bundle,
         fee,
-        NPCResult(None, None, cost),
+        NPCResult(None, conds, cost),
         cost,
         spend_bundle.name(),
         [],


### PR DESCRIPTION
This has always technically been a requirement. The assert makes sure all tests honor this requirement.

In a future patch I will use the `npc_results.conds.spends` for the removal coin IDs rather than `spend_bundle.removals()`. There are various reasons, one is that the coin IDs are already computed.