### PR TITLE
Softfork2 infrastructure

### DIFF
--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -61,7 +61,11 @@ class ConsensusConstants:
     MAX_GENERATOR_SIZE: uint32
     MAX_GENERATOR_REF_LIST_SIZE: uint32
     POOL_SUB_SLOT_ITERS: uint64
+    # soft fork initiated in 1.7.0 release
     SOFT_FORK_HEIGHT: uint32
+
+    # soft fork initiated in 1.8.0 release
+    SOFT_FORK2_HEIGHT: uint32
 
     def replace(self, **changes: object) -> "ConsensusConstants":
         return dataclasses.replace(self, **changes)

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -56,6 +56,7 @@ default_kwargs = {
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
     "SOFT_FORK_HEIGHT": 3630000,
+    "SOFT_FORK2_HEIGHT": 3830000,
 }
 
 

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from chia_rs import LIMIT_STACK, MEMPOOL_MODE, ENABLE_ASSERT_BEFORE
+from chia_rs import ENABLE_ASSERT_BEFORE, LIMIT_STACK, MEMPOOL_MODE
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_chia_program
 from clvm.casts import int_from_bytes

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from chia_rs import LIMIT_STACK, MEMPOOL_MODE
+from chia_rs import LIMIT_STACK, MEMPOOL_MODE, ENABLE_ASSERT_BEFORE
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_chia_program
 from clvm.casts import int_from_bytes
@@ -41,6 +41,8 @@ def get_name_puzzle_conditions(
 
     if mempool_mode:
         flags = MEMPOOL_MODE
+    elif height is not None and height >= DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT:
+        flags = LIMIT_STACK | ENABLE_ASSERT_BEFORE
     elif height is not None and height >= DEFAULT_CONSTANTS.SOFT_FORK_HEIGHT:
         flags = LIMIT_STACK
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def db_version(request):
     return request.param
 
 
-@pytest.fixture(scope="function", params=[1000000, 3630000])
+@pytest.fixture(scope="function", params=[1000000, 3630000, 3830000])
 def softfork_height(request):
     return request.param
 

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2224,6 +2224,7 @@ class TestGeneratorConditions:
             (True, None),
             (False, 2300000),
             (False, 3630000),
+            (False, 3830000),
         ],
     )
     def test_unknown_condition(self, mempool: bool, height: uint32):

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -141,7 +141,7 @@ class TestCostCalculation:
         program = SerializedProgram.from_bytes(
             binutils.assemble(
                 f"(q ((0x3d2331635a58c0d49912bc1427d7db51afe3f20a7b4bcaffa17ee250dcbcbfaa {disassembly} 300"
-                f"  (() (q . ((65 '00000000000000000000000000000000' 0x0cbba106e000))) ()))))"
+                f"  (() (q . ((48 '00000000000000000000000000000000' 0x0cbba106e000))) ()))))"
             ).as_bin()
         )
         generator = BlockGenerator(program, [], [])


### PR DESCRIPTION
introduce the new constant for the new upcoming soft-fork (for 1.8.0). Also enable parsing the `ASSERT_BEFORE_*` conditions after that height.

This flag also enables the other new conditions like `ASSERT_CONCURRENT_SPEND` and `ASSERT_CONCURRENT_PUZZLE`.

Note that these are already enabled in `MEMPOOL_MODE` unconditionally.