### PR TITLE
tests: Merge some fixtures and drop other redundant ones

### DIFF
--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -134,45 +134,6 @@ async def setup_n_nodes(
         keyring.cleanup()
 
 
-async def setup_node_and_wallet(
-    consensus_constants: ConsensusConstants,
-    self_hostname: str,
-    key_seed: Optional[bytes32] = None,
-    db_version: int = 1,
-    disable_capabilities: Optional[List[Capability]] = None,
-) -> AsyncGenerator[Tuple[FullNodeAPI, WalletNode, ChiaServer, ChiaServer, BlockTools], None]:
-    with TempKeyring(populate=True) as keychain:
-        btools = await create_block_tools_async(constants=test_constants, keychain=keychain)
-        full_node_iter = setup_full_node(
-            consensus_constants,
-            "blockchain_test.db",
-            self_hostname,
-            btools,
-            simulator=False,
-            db_version=db_version,
-            disable_capabilities=disable_capabilities,
-        )
-
-        wallet_node_iter = setup_wallet_node(
-            btools.config["self_hostname"],
-            consensus_constants,
-            btools,
-            None,
-            key_seed=key_seed,
-        )
-
-        full_node_service = await full_node_iter.__anext__()
-        full_node_api = full_node_service._api
-        wallet_node_service = await wallet_node_iter.__anext__()
-        wallet = wallet_node_service._node
-        s2 = wallet_node_service._node.server
-
-        yield full_node_api, wallet, full_node_api.full_node.server, s2, btools
-
-        await _teardown_nodes([full_node_iter])
-        await _teardown_nodes([wallet_node_iter])
-
-
 async def setup_simulators_and_wallets(
     simulator_count: int,
     wallet_count: int,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,12 +475,6 @@ async def three_nodes_two_wallets():
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_and_node():
-    async for _ in setup_simulators_and_wallets(1, 1, {}):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
 async def one_node() -> AsyncIterator[Tuple[List[Service], List[FullNodeSimulator], BlockTools]]:
     async for _ in setup_simulators_and_wallets_service(1, 0, {}):
         yield _

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ from chia.simulator.setup_nodes import (
     SimulatorsAndWallets,
     setup_full_system_connect_to_deamon,
     setup_n_nodes,
-    setup_node_and_wallet,
     setup_simulators_and_wallets,
     setup_simulators_and_wallets_service,
     setup_two_nodes,
@@ -251,15 +250,6 @@ if os.getenv("_PYTEST_RAISE", "0") != "0":
     @pytest.hookimpl(tryfirst=True)
     def pytest_internalerror(excinfo):
         raise excinfo.value
-
-
-@pytest_asyncio.fixture(scope="function")
-async def wallet_node(self_hostname, request):
-    params = {}
-    if request and request.param_index > 0:
-        params = request.param
-    async for _ in setup_node_and_wallet(test_constants, self_hostname, **params):
-        yield _
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,14 +326,6 @@ async def two_nodes_sim_and_wallets_services():
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_node_sim_and_wallet() -> AsyncIterator[
-    Tuple[List[Union[FullNodeAPI, FullNodeSimulator]], List[Tuple[Wallet, ChiaServer]], BlockTools],
-]:
-    async for _ in setup_simulators_and_wallets(1, 1, {}):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
 async def one_wallet_and_one_simulator_services():
     async for _ in setup_simulators_and_wallets_service(1, 1, {}):
         yield _

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -395,12 +395,6 @@ async def three_wallet_nodes():
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_node_simulator():
-    async for _ in setup_simulators_and_wallets(1, 1, {}):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
 async def wallet_two_node_simulator():
     async for _ in setup_simulators_and_wallets(2, 1, {}):
         yield _

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -413,12 +413,6 @@ async def three_wallet_nodes():
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_wallet_nodes_five_freeze():
-    async for _ in setup_simulators_and_wallets(1, 2, {}):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
 async def wallet_node_simulator():
     async for _ in setup_simulators_and_wallets(1, 1, {}):
         yield _

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -18,9 +18,9 @@ from chia.util.ints import uint16, uint32
 
 class TestTransactions:
     @pytest.mark.asyncio
-    async def test_wallet_coinbase(self, wallet_node_sim_and_wallet, self_hostname):
+    async def test_wallet_coinbase(self, simulator_and_wallet, self_hostname):
         num_blocks = 5
-        full_nodes, wallets, _ = wallet_node_sim_and_wallet
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node, server_2 = wallets[0]

--- a/tests/core/mempool/test_mempool_fee_protocol.py
+++ b/tests/core/mempool/test_mempool_fee_protocol.py
@@ -20,11 +20,11 @@ from tests.core.node_height import node_height_at_least
 
 @pytest.mark.asyncio
 async def test_protocol_messages(
-    wallet_node_sim_and_wallet: Tuple[
+    simulator_and_wallet: Tuple[
         List[Union[FullNodeAPI, FullNodeSimulator]], List[Tuple[Wallet, ChiaServer]], BlockTools
     ]
 ) -> None:
-    full_nodes, wallets, bt = wallet_node_sim_and_wallet
+    full_nodes, wallets, bt = simulator_and_wallet
     a_wallet = bt.get_pool_wallet_tool()
     reward_ph = a_wallet.get_new_puzzlehash()
     blocks = bt.get_consecutive_blocks(

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -41,8 +41,8 @@ async def establish_connection(server: ChiaServer, self_hostname: str, ssl_conte
 
 class TestSSL:
     @pytest.mark.asyncio
-    async def test_public_connections(self, wallet_node_sim_and_wallet, self_hostname):
-        full_nodes, wallets, _ = wallet_node_sim_and_wallet
+    async def test_public_connections(self, simulator_and_wallet, self_hostname):
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         server_1: ChiaServer = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]
@@ -82,8 +82,8 @@ class TestSSL:
             await establish_connection(farmer_server, self_hostname, ssl_context)
 
     @pytest.mark.asyncio
-    async def test_full_node(self, wallet_node_sim_and_wallet, self_hostname):
-        full_nodes, wallets, bt = wallet_node_sim_and_wallet
+    async def test_full_node(self, simulator_and_wallet, self_hostname):
+        full_nodes, wallets, bt = simulator_and_wallet
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
         chia_ca_crt_path, chia_ca_key_path = chia_ssl_ca_paths(bt.root_path, bt.config)
@@ -101,8 +101,8 @@ class TestSSL:
         await establish_connection(full_node_server, self_hostname, ssl_context)
 
     @pytest.mark.asyncio
-    async def test_wallet(self, wallet_node_sim_and_wallet, self_hostname):
-        full_nodes, wallets, bt = wallet_node_sim_and_wallet
+    async def test_wallet(self, simulator_and_wallet, self_hostname):
+        full_nodes, wallets, bt = simulator_and_wallet
         wallet_node, wallet_server = wallets[0]
         ca_private_crt_path, ca_private_key_path = private_ssl_ca_paths(bt.root_path, bt.config)
         chia_ca_crt_path, chia_ca_key_path = chia_ssl_ca_paths(bt.root_path, bt.config)

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -8,8 +8,8 @@ from chiabip158 import PyBIP158
 
 class TestFilter:
     @pytest.mark.asyncio
-    async def test_basic_filter_test(self, wallet_and_node):
-        full_nodes, wallets, bt = wallet_and_node
+    async def test_basic_filter_test(self, simulator_and_wallet):
+        full_nodes, wallets, bt = simulator_and_wallet
         wallet_node, server_2 = wallets[0]
         wallet = wallet_node.wallet_state_manager.main_wallet
 

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import AsyncIterator, List, Tuple
+from typing import List, Tuple
 
 import pytest
 import pytest_asyncio
@@ -15,7 +15,7 @@ from chia.server.start_service import Service
 from chia.simulator.block_tools import BlockTools, create_block_tools_async, test_constants
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.keyring import TempKeyring
-from chia.simulator.setup_nodes import SimulatorsAndWallets, setup_full_system, setup_simulators_and_wallets
+from chia.simulator.setup_nodes import SimulatorsAndWallets, setup_full_system
 from chia.simulator.setup_services import setup_full_node
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, GetAllCoinsProtocol, ReorgProtocol
 from chia.simulator.time_out_assert import time_out_assert
@@ -61,12 +61,6 @@ async def extra_node(self_hostname):
 @pytest_asyncio.fixture(scope="function")
 async def simulation(bt):
     async for _ in setup_full_system(test_constants_modified, bt, db_version=1):
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
-async def one_wallet_node() -> AsyncIterator[SimulatorsAndWallets]:
-    async for _ in setup_simulators_and_wallets(simulator_count=1, wallet_count=1, dic={}):
         yield _
 
 
@@ -214,9 +208,9 @@ class TestSimulation:
     async def test_simulation_farm_blocks_to_puzzlehash(
         self,
         count,
-        one_wallet_node: SimulatorsAndWallets,
+        simulator_and_wallet: SimulatorsAndWallets,
     ):
-        [[full_node_api], _, _] = one_wallet_node
+        [[full_node_api], _, _] = simulator_and_wallet
 
         # Starting at the beginning.
         assert full_node_api.full_node.blockchain.get_peak_height() is None
@@ -233,9 +227,9 @@ class TestSimulation:
         self,
         self_hostname: str,
         count,
-        one_wallet_node: SimulatorsAndWallets,
+        simulator_and_wallet: SimulatorsAndWallets,
     ):
-        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
 
@@ -299,9 +293,9 @@ class TestSimulation:
         self_hostname: str,
         amount: int,
         coin_count: int,
-        one_wallet_node: SimulatorsAndWallets,
+        simulator_and_wallet: SimulatorsAndWallets,
     ):
-        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
 
@@ -328,11 +322,11 @@ class TestSimulation:
     async def test_wait_transaction_records_entered_mempool(
         self,
         self_hostname: str,
-        one_wallet_node: SimulatorsAndWallets,
+        simulator_and_wallet: SimulatorsAndWallets,
     ) -> None:
         repeats = 50
         tx_amount = uint64(1)
-        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
 
@@ -366,13 +360,13 @@ class TestSimulation:
     async def test_process_transactions(
         self,
         self_hostname: str,
-        one_wallet_node: SimulatorsAndWallets,
+        simulator_and_wallet: SimulatorsAndWallets,
         records_or_bundles_or_coins: str,
     ) -> None:
         repeats = 20
         tx_amount = uint64(1)
         tx_per_repeat = 2
-        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
 
@@ -440,9 +434,9 @@ class TestSimulation:
         self,
         self_hostname: str,
         amounts: List[uint64],
-        one_wallet_node: SimulatorsAndWallets,
+        simulator_and_wallet: SimulatorsAndWallets,
     ) -> None:
-        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
 
@@ -474,9 +468,9 @@ class TestSimulation:
         self,
         self_hostname: str,
         amounts: List[uint64],
-        one_wallet_node: SimulatorsAndWallets,
+        simulator_and_wallet: SimulatorsAndWallets,
     ) -> None:
-        [[full_node_api], [[wallet_node, wallet_server]], _] = one_wallet_node
+        [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
 
         await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
 

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -44,26 +44,6 @@ class TestDLWallet:
         async for _ in setup_simulators_and_wallets(1, 1, {}):
             yield _
 
-    @pytest_asyncio.fixture(scope="function")
-    async def two_wallet_nodes(self) -> AsyncIterator[SimulatorsAndWallets]:
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
-            yield _
-
-    @pytest_asyncio.fixture(scope="function")
-    async def three_wallet_nodes(self) -> AsyncIterator[SimulatorsAndWallets]:
-        async for _ in setup_simulators_and_wallets(1, 3, {}):
-            yield _
-
-    @pytest_asyncio.fixture(scope="function")
-    async def two_wallet_nodes_five_freeze(self) -> AsyncIterator[SimulatorsAndWallets]:
-        async for _ in setup_simulators_and_wallets(1, 2, {}):
-            yield _
-
-    @pytest_asyncio.fixture(scope="function")
-    async def three_sim_two_wallets(self) -> AsyncIterator[SimulatorsAndWallets]:
-        async for _ in setup_simulators_and_wallets(3, 2, {}):
-            yield _
-
     @pytest.mark.parametrize(
         "trusted",
         [True, False],

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-from typing import Any, AsyncIterator, Iterator, List
+from typing import Any, Iterator, List
 
 import pytest
-import pytest_asyncio
 
 from chia.data_layer.data_layer_wallet import DataLayerWallet, Mirror
-from chia.simulator.setup_nodes import SimulatorsAndWallets, setup_simulators_and_wallets
+from chia.simulator.setup_nodes import SimulatorsAndWallets
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import adjusted_timeout, time_out_assert
 from chia.types.blockchain_format.coin import Coin
@@ -39,18 +38,15 @@ async def is_singleton_confirmed(dl_wallet: DataLayerWallet, lid: bytes32) -> bo
 
 
 class TestDLWallet:
-    @pytest_asyncio.fixture(scope="function")
-    async def wallet_node(self) -> AsyncIterator[SimulatorsAndWallets]:
-        async for _ in setup_simulators_and_wallets(1, 1, {}):
-            yield _
-
     @pytest.mark.parametrize(
         "trusted",
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_initial_creation(self, self_hostname: str, wallet_node: SimulatorsAndWallets, trusted: bool) -> None:
-        full_nodes, wallets, _ = wallet_node
+    async def test_initial_creation(
+        self, self_hostname: str, simulator_and_wallet: SimulatorsAndWallets, trusted: bool
+    ) -> None:
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]
@@ -98,9 +94,9 @@ class TestDLWallet:
     )
     @pytest.mark.asyncio
     async def test_get_owned_singletons(
-        self, self_hostname: str, wallet_node: SimulatorsAndWallets, trusted: bool
+        self, self_hostname: str, simulator_and_wallet: SimulatorsAndWallets, trusted: bool
     ) -> None:
-        full_nodes, wallets, _ = wallet_node
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]
@@ -233,8 +229,10 @@ class TestDLWallet:
         [True, False],
     )
     @pytest.mark.asyncio
-    async def test_lifecycle(self, self_hostname: str, wallet_node: SimulatorsAndWallets, trusted: bool) -> None:
-        full_nodes, wallets, _ = wallet_node
+    async def test_lifecycle(
+        self, self_hostname: str, simulator_and_wallet: SimulatorsAndWallets, trusted: bool
+    ) -> None:
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.server
         wallet_node_0, server_0 = wallets[0]

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -50,9 +50,9 @@ async def get_all_messages_in_queue(queue):
 
 class TestSimpleSyncProtocol:
     @pytest.mark.asyncio
-    async def test_subscribe_for_ph(self, wallet_node_simulator, self_hostname):
+    async def test_subscribe_for_ph(self, simulator_and_wallet, self_hostname):
         num_blocks = 4
-        full_nodes, wallets, _ = wallet_node_simulator
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
         fn_server = full_node_api.full_node.server
@@ -227,9 +227,9 @@ class TestSimpleSyncProtocol:
         assert notified_state.spent_height is not None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_coin_id(self, wallet_node_simulator, self_hostname):
+    async def test_subscribe_for_coin_id(self, simulator_and_wallet, self_hostname):
         num_blocks = 4
-        full_nodes, wallets, _ = wallet_node_simulator
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
         fn_server = full_node_api.full_node.server
@@ -324,10 +324,10 @@ class TestSimpleSyncProtocol:
         assert notified_state.spent_height is None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_ph_reorg(self, wallet_node_simulator, self_hostname):
+    async def test_subscribe_for_ph_reorg(self, simulator_and_wallet, self_hostname):
         num_blocks = 4
         long_blocks = 20
-        full_nodes, wallets, _ = wallet_node_simulator
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
         fn_server = full_node_api.full_node.server
@@ -399,10 +399,10 @@ class TestSimpleSyncProtocol:
         assert second_state_coin_2.created_height is None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_coin_id_reorg(self, wallet_node_simulator, self_hostname):
+    async def test_subscribe_for_coin_id_reorg(self, simulator_and_wallet, self_hostname):
         num_blocks = 4
         long_blocks = 20
-        full_nodes, wallets, _ = wallet_node_simulator
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
         fn_server = full_node_api.full_node.server
@@ -466,9 +466,9 @@ class TestSimpleSyncProtocol:
         assert second_coin.created_height is None
 
     @pytest.mark.asyncio
-    async def test_subscribe_for_hint(self, wallet_node_simulator, self_hostname):
+    async def test_subscribe_for_hint(self, simulator_and_wallet, self_hostname):
         num_blocks = 4
-        full_nodes, wallets, bt = wallet_node_simulator
+        full_nodes, wallets, bt = simulator_and_wallet
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
         fn_server = full_node_api.full_node.server
@@ -622,8 +622,8 @@ class TestSimpleSyncProtocol:
         check_messages_for_hint(all_messages_1)
 
     @pytest.mark.asyncio
-    async def test_ph_subscribe_limits(self, wallet_node_simulator, self_hostname):
-        full_nodes, wallets, _ = wallet_node_simulator
+    async def test_ph_subscribe_limits(self, simulator_and_wallet, self_hostname):
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
         fn_server = full_node_api.full_node.server
@@ -663,8 +663,8 @@ class TestSimpleSyncProtocol:
         assert not s.has_ph_subscription(phs[5])
 
     @pytest.mark.asyncio
-    async def test_coin_subscribe_limits(self, wallet_node_simulator, self_hostname):
-        full_nodes, wallets, _ = wallet_node_simulator
+    async def test_coin_subscribe_limits(self, simulator_and_wallet, self_hostname):
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         wallet_node, server_2 = wallets[0]
         fn_server = full_node_api.full_node.server

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -452,8 +452,8 @@ class TestWalletSync:
             await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
     @pytest.mark.asyncio
-    async def test_request_additions_errors(self, wallet_node_sim_and_wallet, self_hostname):
-        full_nodes, wallets, _ = wallet_node_sim_and_wallet
+    async def test_request_additions_errors(self, simulator_and_wallet, self_hostname):
+        full_nodes, wallets, _ = simulator_and_wallet
         wallet_node, wallet_server = wallets[0]
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
@@ -493,8 +493,8 @@ class TestWalletSync:
         assert response.proofs[0][2] is None
 
     @pytest.mark.asyncio
-    async def test_request_additions_success(self, wallet_node_sim_and_wallet, self_hostname):
-        full_nodes, wallets, _ = wallet_node_sim_and_wallet
+    async def test_request_additions_success(self, simulator_and_wallet, self_hostname):
+        full_nodes, wallets, _ = simulator_and_wallet
         wallet_node, wallet_server = wallets[0]
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -10,7 +10,6 @@ from colorlog import getLogger
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
-from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.mempool_manager import MempoolManager
 from chia.full_node.weight_proof import WeightProofHandler
 from chia.protocols import full_node_protocol, wallet_protocol
@@ -54,10 +53,9 @@ log = getLogger(__name__)
 
 class TestWalletSync:
     @pytest.mark.asyncio
-    async def test_request_block_headers(self, wallet_node, default_1000_blocks):
+    async def test_request_block_headers(self, simulator_and_wallet, default_1000_blocks):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
-        full_node_api: FullNodeAPI
-        full_node_api, wallet_node, full_node_server, wallet_server, bt = wallet_node
+        [full_node_api], [(wallet_node, _)], bt = simulator_and_wallet
 
         wallet = wallet_node.wallet_state_manager.main_wallet
         ph = await wallet.get_new_puzzlehash()
@@ -100,10 +98,9 @@ class TestWalletSync:
     #     [(10, 8, False, None)],
     # )
     @pytest.mark.asyncio
-    async def test_request_block_headers_rejected(self, wallet_node, default_1000_blocks):
+    async def test_request_block_headers_rejected(self, simulator_and_wallet, default_1000_blocks):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
-        full_node_api: FullNodeAPI
-        full_node_api, wallet_node, full_node_server, wallet_server, bt = wallet_node
+        [full_node_api], _, bt = simulator_and_wallet
 
         # start_height, end_height, return_filter, expected_res = test_case
 

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -40,12 +40,12 @@ class TestWalletSimulator:
     @pytest.mark.asyncio
     async def test_wallet_coinbase(
         self,
-        wallet_node_sim_and_wallet: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools],
+        simulator_and_wallet: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools],
         trusted: bool,
         self_hostname: str,
     ) -> None:
         num_blocks = 10
-        full_nodes, wallets, _ = wallet_node_sim_and_wallet
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         server_1: ChiaServer = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]
@@ -133,11 +133,11 @@ class TestWalletSimulator:
     @pytest.mark.asyncio
     async def test_wallet_coinbase_reorg(
         self,
-        wallet_node_sim_and_wallet: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools],
+        simulator_and_wallet: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools],
         trusted: bool,
         self_hostname: str,
     ) -> None:
-        full_nodes, wallets, _ = wallet_node_sim_and_wallet
+        full_nodes, wallets, _ = simulator_and_wallet
         full_node_api = full_nodes[0]
         fn_server = full_node_api.full_node.server
         wallet_node, server_2 = wallets[0]

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -240,12 +240,12 @@ class TestWalletSimulator:
     @pytest.mark.asyncio
     async def test_wallet_make_transaction_hop(
         self,
-        two_wallet_nodes_five_freeze: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools],
+        two_wallet_nodes: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools],
         trusted: bool,
         self_hostname: str,
     ) -> None:
         num_blocks = 10
-        full_nodes, wallets, _ = two_wallet_nodes_five_freeze
+        full_nodes, wallets, _ = two_wallet_nodes
         full_node_api_0 = full_nodes[0]
         full_node_0 = full_node_api_0.full_node
         server_0 = full_node_0.server

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -17,8 +17,8 @@ from tests.util.db_connection import DBConnection
 
 class TestWalletBlockchain:
     @pytest.mark.asyncio
-    async def test_wallet_blockchain(self, wallet_node, default_1000_blocks):
-        full_node_api, wallet_node, full_node_server, wallet_server, _ = wallet_node
+    async def test_wallet_blockchain(self, simulator_and_wallet, default_1000_blocks):
+        [full_node_api], [(wallet_node, _)], bt = simulator_and_wallet
 
         for block in default_1000_blocks[:600]:
             await full_node_api.full_node.respond_block(full_node_protocol.RespondBlock(block))

--- a/tests/wallet/test_wallet_node.py
+++ b/tests/wallet/test_wallet_node.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import pytest
 from blspy import PrivateKey
 
-from chia.full_node.full_node_api import FullNodeAPI
-from chia.server.server import ChiaServer
-from chia.simulator.block_tools import BlockTools, test_constants
+from chia.simulator.block_tools import test_constants
+from chia.simulator.setup_nodes import SimulatorsAndWallets
 from chia.util.config import load_config
 from chia.util.keychain import Keychain, generate_mnemonic
 from chia.wallet.wallet_node import WalletNode
@@ -298,10 +297,8 @@ def test_update_last_used_fingerprint(root_path_populated_with_config: Path) -> 
 
 
 @pytest.mark.asyncio
-async def test_unique_puzzle_hash_subscriptions(
-    wallet_node: Tuple[FullNodeAPI, WalletNode, ChiaServer, ChiaServer, BlockTools]
-) -> None:
-    _, node, _, _, _ = wallet_node
+async def test_unique_puzzle_hash_subscriptions(simulator_and_wallet: SimulatorsAndWallets) -> None:
+    _, [(node, _)], bt = simulator_and_wallet
     puzzle_hashes = await node.get_puzzle_hashes_to_subscribe()
     assert len(puzzle_hashes) > 1
     assert len(set(puzzle_hashes)) == len(puzzle_hashes)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

- Drop some redundant fixtures in `test_dl_wallet.py`
- Drop `two_wallet_nodes_five_freeze` and use `two_wallet_nodes` instead
- Replace all plain redundant "1 node, 1 wallet" fixtures with `simulator_and_wallet`.
- Drop `one_wallet_node` fixture in `test_simulation.py` and use `simulator_and_wallet`
- Replace `wallet_node` (which is the last usage of `setup_node_and_wallet`, hence it gets dropped here) with `simulator_and_wallet`

### New Behavior:

No change in behaviour.
