### PR TITLE
avoid excessive logging filter registration

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 import time
 import traceback
 from dataclasses import dataclass, field
@@ -28,7 +29,6 @@ from chia.util.api_decorators import get_metadata
 from chia.util.errors import Err, ProtocolError
 from chia.util.ints import uint8, uint16
 from chia.util.log_exceptions import log_exceptions
-from chia.util.logging import TimedDuplicateFilter
 
 # Each message is prepended with LENGTH_BYTES bytes specifying the length
 from chia.util.network import class_for_type, is_localhost
@@ -39,6 +39,10 @@ LENGTH_BYTES: int = 4
 
 WebSocket = Union[WebSocketResponse, ClientWebSocketResponse]
 ConnectionCallback = Callable[["WSChiaConnection"], Awaitable[None]]
+
+
+def create_default_last_message_time_dict() -> Dict[ProtocolMessageTypes, float]:
+    return {message_type: -math.inf for message_type in ProtocolMessageTypes}
 
 
 class ConnectionClosedCallbackProtocol(Protocol):
@@ -109,6 +113,11 @@ class WSChiaConnection:
     # Used by the Chia Seeder.
     version: str = field(default_factory=str)
     protocol_version: str = field(default_factory=str)
+
+    log_rate_limit_last_time: Dict[ProtocolMessageTypes, float] = field(
+        default_factory=create_default_last_message_time_dict,
+        repr=False,
+    )
 
     @classmethod
     def create(
@@ -560,10 +569,12 @@ class WSChiaConnection:
             message, self.local_capabilities, self.peer_capabilities
         ):
             if not is_localhost(self.peer_host):
-                msg = f"Rate limiting ourselves. message type: {ProtocolMessageTypes(message.type).name}, "
-                f"peer: {self.peer_host}"
-                self.log.debug(msg)
-                self.log.addFilter(TimedDuplicateFilter(msg, 60))
+                message_type = ProtocolMessageTypes(message.type)
+                last_time = self.log_rate_limit_last_time[message_type]
+                now = time.monotonic()
+                if now - last_time >= 60:
+                    msg = f"Rate limiting ourselves. message type: {message_type.name}, peer: {self.peer_host}"
+                    self.log.debug(msg)
 
                 # TODO: fix this special case. This function has rate limits which are too low.
                 if ProtocolMessageTypes(message.type) != ProtocolMessageTypes.respond_peers:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Avoid gradually increasing CPU usage in the full node process that eventually causes loss of sync.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

For every message that was maybe to be logged we added a new filter object.  They presumably piled up and resulted in every debug message to that log being regexed against each filter that had ever been registered.

https://github.com/Chia-Network/chia-blockchain/pull/14435

### New Behavior:

Directly track the last logged time for that message being sent to over the connection.  If less than 60 seconds have elapsed, don't log it.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

1. graphana cpu usage data progressively growing over 12+ hours
2. profiling data pointing to debug logging and specifically the filter function
3. running with this and observing no issues with increasing cpu usage (in progess)

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
