### PR TITLE
wallet: Disconnect untrusted peers if we find a trusted synced one

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -917,9 +917,9 @@ class WalletNode:
         await self.update_ui()
         return still_connected and self._server is not None and peer.peer_node_id in self.server.all_connections
 
-    async def is_peer_synced(self, peer: WSChiaConnection, header_block: HeaderBlock) -> Optional[uint64]:
+    async def is_peer_synced(self, peer: WSChiaConnection, height: uint32) -> Optional[uint64]:
         # Get last timestamp
-        last_tx: Optional[HeaderBlock] = await fetch_last_tx_from_peer(header_block.height, peer)
+        last_tx: Optional[HeaderBlock] = await fetch_last_tx_from_peer(height, peer)
         latest_timestamp: Optional[uint64] = None
         if last_tx is not None:
             assert last_tx.foliage_transaction_block is not None
@@ -1023,7 +1023,7 @@ class WalletNode:
         if self._server is None:
             return False
         for peer in self.server.get_connections(NodeType.FULL_NODE):
-            if self.is_trusted(peer) and await self.is_peer_synced(peer, header_block):
+            if self.is_trusted(peer) and await self.is_peer_synced(peer, header_block.height):
                 return True
         return False
 
@@ -1086,7 +1086,7 @@ class WalletNode:
             # dont disconnect from peer, this might be a reorg
             return
 
-        latest_timestamp: Optional[uint64] = await self.is_peer_synced(peer, new_peak_hb)
+        latest_timestamp: Optional[uint64] = await self.is_peer_synced(peer, new_peak_hb.height)
         if latest_timestamp is None:
             if trusted:
                 self.log.debug(f"Trusted peer {peer.get_peer_info()} is not synced.")

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -50,7 +50,9 @@ class WalletNodeAPI:
         # is synced.
         if self.wallet_node.is_trusted(peer):
             full_node_connections = self.wallet_node.server.get_connections(NodeType.FULL_NODE)
-            untrusted_peers = [peer for peer in full_node_connections if not self.wallet_node.is_trusted(peer)]
+            untrusted_peers = [
+                peer for peer in full_node_connections if not self.wallet_node.is_trusted(peer) and not peer.closed
+            ]
 
             # Check for untrusted peers first to avoid calling is_peer_synced if not required
             if len(untrusted_peers) > 0 and await self.wallet_node.is_peer_synced(peer, peak.height):

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -46,6 +46,23 @@ class WalletNodeAPI:
         The full node sent as a new peak
         """
         self.wallet_node.node_peaks[peer.peer_node_id] = (peak.height, peak.header_hash)
+        # For trusted peers check if there are untrusted peers, if so make sure to disconnect them if the trusted node
+        # is synced.
+        if self.wallet_node.is_trusted(peer):
+            full_node_connections = self.wallet_node.server.get_connections(NodeType.FULL_NODE)
+            untrusted_peers = [peer for peer in full_node_connections if not self.wallet_node.is_trusted(peer)]
+
+            # Check for untrusted peers first to avoid calling is_peer_synced if not required
+            if len(untrusted_peers) > 0 and await self.wallet_node.is_peer_synced(peer, peak.height):
+                self.log.info("Connected to a a synced trusted peer, disconnecting from all untrusted nodes.")
+                # Stop peer discovery/connect tasks first
+                if self.wallet_node.wallet_peers is not None:
+                    await self.wallet_node.wallet_peers.ensure_is_closed()
+                    self.wallet_node.wallet_peers = None
+                # Then disconnect from all untrusted nodes
+                for untrusted_peer in untrusted_peers:
+                    await untrusted_peer.close()
+
         await self.wallet_node.new_peak_queue.new_peak_wallet(peak, peer)
 
     @api_request()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Disconnect untrusted peers as soon as we find a trusted synced peer, to continue with a trusted long sync instead of sticking with the untrusted sync until it's done.

We currently just continue syncing to untrusted peers even if we are already connected to a trusted peer. There is some effort in current `main` to try disconnecting untrusted peers but the logic isn't really working because we process messages from `WalletNode.new_peak_queue` which gets blocked whenever we start a sync, so the trusted peaks are not processed until the sync is done which is why we don't see the wallet switching from untrusted to trusted sync right now.

This PR adds some checking for trusted/synced peers before putting the `new_peak_wallet` messages into the queue and just disconnects the untrusted peers right away if there is a trusted synced one. The actual fix happens in 6048b76fb8f9a4438ba9ba06b9f0f9f678fbb4a5, the others are preparation/tests.

This PR is an alternative to #14430 where the idea is to check in few places during long sync if we are connected to a trusted peer and then bail out early form the sync if there is a trusted peer connected but i think it makes more sense to do it like here, to run this checks before we even put the message to the queue.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The wallet just continues to do an untrusted sync even if its connected to a synced trusted peer.

### New Behavior:

The wallet will switch from the untrusted sync to the trusted sync whenever possible.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

There is a test added in this PR which makes sure the untrusted disconnect works as expected but you can test it manually also by starting a untrusted sync and then connecting to a trusted peer.