### PR TITLE
wallet: Handle some peer closed cases better

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1292,6 +1292,8 @@ class WalletNode:
         Returns all state that is valid and included in the blockchain proved by the weight proof. If return_old_states
         is False, only new states that are not in the coin_store are returned.
         """
+        if peer.closed:
+            return False
         # Only use the cache if we are talking about states before the fork point. If we are evaluating something
         # in a reorg, we cannot use the cache, since we don't know if it's actually in the new chain after the reorg.
         if can_use_peer_request_cache(coin_state, peer_request_cache, fork_height):

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -875,10 +875,8 @@ class WalletNode:
 
             except Exception as e:
                 tb = traceback.format_exc()
-                if self._shut_down:
-                    self.log.debug(f"Shutting down while adding state : {e} {tb}")
-                else:
-                    self.log.error(f"Exception while adding state: {e} {tb}")
+                log_level = logging.DEBUG if peer.closed or self._shut_down else logging.ERROR
+                self.log.log(log_level, f"receive_and_validate failed - exception: {e}, traceback: {tb}")
 
         idx = 1
         # Keep chunk size below 1000 just in case, windows has sqlite limits of 999 per query
@@ -1519,10 +1517,8 @@ class WalletNode:
             start, end, peer_request_cache, all_peers
         )
         if blocks is None:
-            if self._shut_down:
-                self.log.debug(f"Shutting down, block fetching from: {start} to {end} canceled.")
-            else:
-                self.log.error(f"Error fetching blocks {start} {end}")
+            log_level = logging.DEBUG if self._shut_down or peer.closed else logging.ERROR
+            self.log.log(log_level, f"Error fetching blocks {start} {end}")
             return False
 
         if compare_to_recent and weight_proof.recent_chain_data[0].header_hash != blocks[-1].header_hash:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -864,7 +864,7 @@ class WalletNode:
             except Exception as e:
                 tb = traceback.format_exc()
                 log_level = logging.DEBUG if peer.closed or self._shut_down else logging.ERROR
-                self.log.log(log_level, f"receive_and_validate failed - exception: {e}, traceback: {tb}")
+                self.log.log(log_level, f"validate_and_add failed - exception: {e}, traceback: {tb}")
 
         idx = 1
         # Keep chunk size below 1000 just in case, windows has sqlite limits of 999 per query

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1013,6 +1013,8 @@ class WalletStateManager:
         local_records = await self.coin_store.get_coin_records(coin_names)
 
         for coin_name, coin_state in zip(coin_names, coin_states):
+            if peer.closed:
+                raise ConnectionError("Connection closed")
             self.log.debug("Add coin state: %s: %s", coin_name, coin_state)
             local_record = local_records.get(coin_name)
             rollback_wallets = None


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

If a peer connection was closed during sync by either the client or the server we end up with a bunch of scary error logs in the debug log. This PR changes some log levels to `DEBUG` (should it maybe be `WARNING` instead?) based on the connection state and returns early in few places for disconnected peers to avoid running into code which will anyway fail.  

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

`ERROR` logs for disconnected peer failures.

### New Behavior:

`DEBUG` logs for disconnected peer failures.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

 Just disconnect a peer which is in a long sync and watch the debug logs.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
