### PR TITLE
introduce run_chia_program()

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -17,7 +17,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.serialized_program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram, run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
@@ -877,9 +877,7 @@ class DataLayerWallet:
             root: bytes32
             inner_puzzle_hash: bytes32
 
-            conditions = puzzle.run_with_cost(self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM, solution)[
-                1
-            ].as_python()
+            conditions = run_chia_program(puzzle, solution)[1].as_python()
             found_singleton: bool = False
             for condition in conditions:
                 if condition[0] == ConditionOpcode.CREATE_COIN and int.from_bytes(condition[2], "big") % 2 == 1:

--- a/chia/full_node/generator.py
+++ b/chia/full_node/generator.py
@@ -69,14 +69,3 @@ def create_compressed_generator(
 def setup_generator_args(self: BlockGenerator) -> Tuple[SerializedProgram, Program]:
     args = create_generator_args(self.generator_refs)
     return self.program, args
-
-
-def run_generator_mempool(self: BlockGenerator, max_cost: int) -> Tuple[int, SerializedProgram]:
-    program, args = setup_generator_args(self)
-    return GENERATOR_MOD.run_mempool_with_cost(max_cost, program, args)
-
-
-def run_generator_unsafe(self: BlockGenerator, max_cost: int) -> Tuple[int, SerializedProgram]:
-    """This mode is meant for accepting possibly soft-forked transactions into the mempool"""
-    program, args = setup_generator_args(self)
-    return GENERATOR_MOD.run_with_cost(max_cost, program, args)

--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import io
-from typing import Optional, Tuple, Type, Union
+from typing import Optional, Tuple, Type
 
-from chia_rs import MEMPOOL_MODE, run_chia_program, run_generator, serialized_length, tree_hash
+from chia_rs import run_chia_program as native_run_chia_program
+from chia_rs import serialized_length, tree_hash
 from clvm import SExp
 
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.byte_types import hexstr_to_bytes
 
 
@@ -81,60 +82,31 @@ class SerializedProgram:
     def get_tree_hash(self) -> bytes32:
         return bytes32(tree_hash(self._buf))
 
-    def run_mempool_with_cost(self, max_cost: int, *args: object) -> Tuple[int, Program]:
-        return self._run(max_cost, MEMPOOL_MODE, *args)
 
-    def run_with_cost(self, max_cost: int, *args: object) -> Tuple[int, Program]:
-        return self._run(max_cost, 0, *args)
+def run_chia_program(
+    prg: SerializedProgram, *args: object, max_cost: Optional[int] = None, flags: int = 0
+) -> Tuple[int, Program]:
+    # when multiple arguments are passed, concatenate them into a serialized
+    # buffer. Some arguments may already be in serialized form (e.g.
+    # SerializedProgram) so we don't want to de-serialize those just to
+    # serialize them back again. This is handled by _serialize()
+    serialized_args = bytearray()
+    if len(args) > 1:
+        # when we have more than one argument, serialize them into a list
+        for a in args:
+            serialized_args += b"\xff"
+            serialized_args += _serialize(a)
+        serialized_args += b"\x80"
+    else:
+        serialized_args += _serialize(args[0])
 
-    # returns an optional error code and an optional SpendBundleConditions (from chia_rs)
-    # exactly one of those will hold a value
-    def run_as_generator(
-        self, max_cost: int, flags: int, *args: Union[Program, SerializedProgram]
-    ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]:
+    if max_cost is None:
+        max_cost = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM
 
-        serialized_args = bytearray()
-        if len(args) > 1:
-            # when we have more than one argument, serialize them into a list
-            for a in args:
-                serialized_args += b"\xff"
-                serialized_args += _serialize(a)
-            serialized_args += b"\x80"
-        else:
-            serialized_args += _serialize(args[0])
-
-        err, ret = run_generator(
-            self._buf,
-            bytes(serialized_args),
-            max_cost,
-            flags,
-        )
-        if err is not None:
-            assert err != 0
-            return err, None
-
-        assert ret is not None
-        return None, ret
-
-    def _run(self, max_cost: int, flags: int, *args: object) -> Tuple[int, Program]:
-        # when multiple arguments are passed, concatenate them into a serialized
-        # buffer. Some arguments may already be in serialized form (e.g.
-        # SerializedProgram) so we don't want to de-serialize those just to
-        # serialize them back again. This is handled by _serialize()
-        serialized_args = bytearray()
-        if len(args) > 1:
-            # when we have more than one argument, serialize them into a list
-            for a in args:
-                serialized_args += b"\xff"
-                serialized_args += _serialize(a)
-            serialized_args += b"\x80"
-        else:
-            serialized_args += _serialize(args[0])
-
-        cost, ret = run_chia_program(
-            self._buf,
-            bytes(serialized_args),
-            max_cost,
-            flags,
-        )
-        return cost, Program.to(ret)
+    cost, ret = native_run_chia_program(
+        bytes(prg),
+        bytes(serialized_args),
+        max_cost,
+        flags,
+    )
+    return cost, Program.to(ret)

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -9,7 +9,7 @@ from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.serialized_program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram, run_chia_program
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.errors import Err, ValidationError
 from chia.util.streamable import Streamable, streamable
@@ -44,7 +44,7 @@ def compute_additions_with_cost(
     """
     parent_id = cs.coin.name()
     ret: List[Coin] = []
-    cost, r = cs.puzzle_reveal.run_with_cost(max_cost, cs.solution)
+    cost, r = run_chia_program(cs.puzzle_reveal, cs.solution, max_cost=max_cost, flags=0)
     for cond in Program.to(r).as_iter():
         if cost > max_cost:
             raise ValidationError(Err.BLOCK_COST_EXCEEDS_MAX, "compute_additions() for CoinSpend")

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -6,7 +6,7 @@ from clvm.casts import int_from_bytes
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.serialized_program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram, run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
@@ -154,7 +154,7 @@ def conditions_for_solution(
 ) -> Tuple[Optional[Err], Optional[List[ConditionWithArgs]], uint64]:
     # get the standard script for a puzzle hash and feed in the solution
     try:
-        cost, r = puzzle_reveal.run_with_cost(max_cost, solution)
+        cost, r = run_chia_program(puzzle_reveal, solution, max_cost=max_cost)
         error, result = parse_sexp_to_conditions(r)
         return error, result, uint64(cost)
     except Program.EvalError:

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -9,7 +9,8 @@ from clvm_tools.binutils import disassemble
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin, coin_as_list
-from chia.types.blockchain_format.program import INFINITE_COST, Program
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions_with_cost
 from chia.types.spend_bundle import SpendBundle
@@ -360,7 +361,7 @@ class Offer:
             coin_names.append(name)
             dependencies[name] = []
             announcements[name] = []
-            conditions: Program = spend.puzzle_reveal.run_with_cost(INFINITE_COST, spend.solution)[1]
+            conditions: Program = run_chia_program(spend.puzzle_reveal, spend.solution)[1]
             for condition in conditions.as_iter():
                 if condition.first() == 60:  # create coin announcement
                     announcements[name].append(Announcement(name, condition.at("rf").as_python()).name())

--- a/chia/wallet/util/compute_hints.py
+++ b/chia/wallet/util/compute_hints.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import List
 
-from chia.types.blockchain_format.program import INFINITE_COST
+from chia.types.blockchain_format.serialized_program import run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
 
 
 def compute_coin_hints(cs: CoinSpend) -> List[bytes32]:
-    _, result_program = cs.puzzle_reveal.run_with_cost(INFINITE_COST, cs.solution)
+    _, result_program = run_chia_program(cs.puzzle_reveal, cs.solution)
 
     h_list: List[bytes32] = []
     for condition_data in result_program.as_python():

--- a/chia/wallet/util/compute_memos.py
+++ b/chia/wallet/util/compute_memos.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 from clvm.casts import int_from_bytes
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import INFINITE_COST
+from chia.types.blockchain_format.serialized_program import run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
@@ -13,7 +13,7 @@ from chia.types.spend_bundle import SpendBundle
 
 
 def compute_memos_for_spend(coin_spend: CoinSpend) -> Dict[bytes32, List[bytes]]:
-    _, result = coin_spend.puzzle_reveal.run_with_cost(INFINITE_COST, coin_spend.solution)
+    _, result = run_chia_program(coin_spend.puzzle_reveal, coin_spend.solution)
     memos: Dict[bytes32, List[bytes]] = {}
     for condition in result.as_python():
         if condition[0] == ConditionOpcode.CREATE_COIN and len(condition) >= 4:

--- a/tests/clvm/test_serialized_program.py
+++ b/tests/clvm/test_serialized_program.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from unittest import TestCase
 
-from chia.types.blockchain_format.program import INFINITE_COST, Program
-from chia.types.blockchain_format.serialized_program import SerializedProgram
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram, run_chia_program
 from chia.wallet.puzzles.load_clvm import load_clvm
 
 SHA256TREE_MOD = load_clvm("sha256tree_module.clvm")
@@ -19,7 +19,7 @@ class TestSerializedProgram(TestCase):
     def test_program_execution(self):
         p_result = SHA256TREE_MOD.run(SHA256TREE_MOD)
         sp = SerializedProgram.from_bytes(bytes(SHA256TREE_MOD))
-        cost, sp_result = sp.run_with_cost(INFINITE_COST, sp)
+        cost, sp_result = run_chia_program(sp, sp)
         self.assertEqual(p_result, sp_result)
 
     def test_serialization(self):

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -10,13 +10,12 @@ from clvm_tools import binutils
 
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.cost_calculator import NPCResult
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, get_puzzle_and_solution_for_coin
 from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.serialized_program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram, run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.generator_types import BlockGenerator
 from chia.wallet.puzzles import p2_delegated_puzzle_or_hidden_puzzle
@@ -273,7 +272,7 @@ class TestCostCalculation:
         with assert_runtime(seconds=0.1, label=request.node.name):
             total_cost = 0
             for i in range(0, 1000):
-                cost, result = puzzle_program.run_with_cost(test_constants.MAX_BLOCK_COST_CLVM, solution_program)
+                cost, result = run_chia_program(puzzle_program, solution_program)
                 total_cost += cost
 
 
@@ -289,9 +288,7 @@ async def test_get_puzzle_and_solution_for_coin_performance():
     spends: List[Coin] = []
 
     # first, list all spent coins in the block
-    cost, result = LARGE_BLOCK.transactions_generator.run_with_cost(
-        DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM, DESERIALIZE_MOD, []
-    )
+    cost, result = run_chia_program(LARGE_BLOCK.transactions_generator, DESERIALIZE_MOD, [])
 
     coin_spends = result.first()
     for spend in coin_spends.as_iter():

--- a/tests/wallet/test_singleton_lifecycle.py
+++ b/tests/wallet/test_singleton_lifecycle.py
@@ -8,7 +8,8 @@ from clvm_tools import binutils
 
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import INFINITE_COST, Program
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
@@ -31,7 +32,7 @@ POOL_REWARD_PREFIX_MAINNET = bytes32.fromhex("ccd5bb71183532bff220ba46c268991a00
 
 def check_coin_spend(coin_spend: CoinSpend):
     try:
-        cost, result = coin_spend.puzzle_reveal.run_with_cost(INFINITE_COST, coin_spend.solution)
+        cost, result = run_chia_program(coin_spend.puzzle_reveal, coin_spend.solution)
     except Exception as ex:
         print(ex)
 

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -48,7 +48,7 @@ from clvm.casts import int_from_bytes
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.serialized_program import SerializedProgram
+from chia.types.blockchain_format.serialized_program import SerializedProgram, run_chia_program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
@@ -105,7 +105,7 @@ def npc_to_dict(npc: NPC):
 def run_generator(block_generator: BlockGenerator, constants: ConsensusConstants, max_cost: int) -> List[CAT]:
 
     block_args = [bytes(a) for a in block_generator.generator_refs]
-    cost, block_result = block_generator.program.run_with_cost(max_cost, DESERIALIZE_MOD, block_args)
+    cost, block_result = run_chia_program(block_generator.program, DESERIALIZE_MOD, block_args, max_cost=max_cost)
 
     coin_spends = block_result.first()
 


### PR DESCRIPTION
and remove the member functions to run a program from SerialiedProgram.
This is preparing to make `SerializedProgram` a rust type as well as cutting down on "middle layer" functions between the underlying rust call and calling it from python.

The main change is in `chia/types/blockchain_format/serialized_program.py`. The other changes is accommodations for the new interface.

The new function takes `flags` and `max_cost` as optional arguments, which covers both the "mempool" and "consensus" cases in the same function.

Making `SerializedProgram` a rust type is a step towards making `CoinSpend` a rust type, which would improve serialization and deserialization performance of a lot of types