### PR TITLE
remove some redundant fields from MempoolItem

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -512,9 +512,7 @@ class MempoolManager:
         if tl_error:
             assert_height = compute_assert_height(removal_record_dict, npc_result.conds)
 
-        potential = MempoolItem(
-            new_spend, uint64(fees), npc_result, cost, spend_name, additions, first_added_height, assert_height
-        )
+        potential = MempoolItem(new_spend, uint64(fees), npc_result, spend_name, first_added_height, assert_height)
 
         if tl_error:
             if tl_error is Err.ASSERT_HEIGHT_ABSOLUTE_FAILED or tl_error is Err.ASSERT_HEIGHT_RELATIVE_FAILED:

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -7,6 +7,7 @@ from chia.consensus.cost_calculator import NPCResult
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
+from chia.util.generator_tools import additions_for_npc
 from chia.util.ints import uint32, uint64
 from chia.util.streamable import Streamable, streamable
 
@@ -17,9 +18,7 @@ class MempoolItem(Streamable):
     spend_bundle: SpendBundle
     fee: uint64
     npc_result: NPCResult
-    cost: uint64
     spend_bundle_name: bytes32
-    additions: List[Coin]
     height_added_to_mempool: uint32
 
     # If present, this SpendBundle is not valid at or before this height
@@ -35,6 +34,15 @@ class MempoolItem(Streamable):
     @property
     def name(self) -> bytes32:
         return self.spend_bundle_name
+
+    @property
+    def cost(self) -> uint64:
+        assert self.npc_result.conds is not None
+        return uint64(self.npc_result.conds.cost)
+
+    @property
+    def additions(self) -> List[Coin]:
+        return additions_for_npc(self.npc_result)
 
     @property
     def removals(self) -> List[Coin]:

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -94,10 +94,8 @@ def make_item(idx: int, cost: uint64 = uint64(80), assert_height=100) -> Mempool
     return MempoolItem(
         SpendBundle([], G2Element()),
         uint64(0),
-        NPCResult(None, None, cost),
-        cost,
+        NPCResult(None, SpendBundleConditions([], 0, 0, 0, None, None, [], cost), cost),
         spend_bundle_name,
-        [],
         uint32(0),
         assert_height,
     )

--- a/tests/core/mempool/test_mempool_fee_estimator.py
+++ b/tests/core/mempool/test_mempool_fee_estimator.py
@@ -19,6 +19,7 @@ from chia.types.coin_record import CoinRecord
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import MempoolItem
+from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.ints import uint32, uint64
 from tests.core.consensus.test_pot_iterations import test_constants
 from tests.core.mempool.test_mempool_manager import (
@@ -47,10 +48,8 @@ async def test_basics() -> None:
             mempool_item = MempoolItem(
                 spend_bundle,
                 fee,
-                NPCResult(None, None, cost),
-                cost,
+                NPCResult(None, SpendBundleConditions([], 0, 0, 0, None, None, [], cost), cost),
                 spend_bundle.name(),
-                [],
                 uint32(i - 1),
             )
             items.append(mempool_item)
@@ -59,10 +58,8 @@ async def test_basics() -> None:
             mempool_item1 = MempoolItem(
                 spend_bundle,
                 fee1,
-                NPCResult(None, None, cost),
-                cost,
+                NPCResult(None, SpendBundleConditions([], 0, 0, 0, None, None, [], cost), cost),
                 spend_bundle.name(),
-                [],
                 uint32(i - 40),
             )
             items.append(mempool_item1)
@@ -71,10 +68,8 @@ async def test_basics() -> None:
             mempool_item2 = MempoolItem(
                 spend_bundle,
                 fee2,
-                NPCResult(None, None, cost),
-                cost,
+                NPCResult(None, SpendBundleConditions([], 0, 0, 0, None, None, [], cost), cost),
                 spend_bundle.name(),
-                [],
                 uint32(i - 270),
             )
             items.append(mempool_item2)
@@ -113,10 +108,8 @@ async def test_fee_increase() -> None:
                 mempool_item = MempoolItem(
                     spend_bundle,
                     fee,
-                    NPCResult(None, None, cost),
-                    cost,
+                    NPCResult(None, SpendBundleConditions([], 0, 0, 0, None, None, [], cost), cost),
                     spend_bundle.name(),
-                    [],
                     included_height,
                 )
                 items.append(mempool_item)

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -42,14 +42,12 @@ def make_mempoolitem() -> MempoolItem:
 
     fee = uint64(10000000)
     spends: List[Spend] = []
-    conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], 0)
+    conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], cost)
     mempool_item = MempoolItem(
         spend_bundle,
         fee,
         NPCResult(None, conds, cost),
-        cost,
         spend_bundle.name(),
-        [],
         uint32(block_height),
     )
     return mempool_item

--- a/tests/fee_estimation/test_fee_estimation_unit_tests.py
+++ b/tests/fee_estimation/test_fee_estimation_unit_tests.py
@@ -16,6 +16,7 @@ from chia.simulator.block_tools import test_constants
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.fee_rate import FeeRateV2
 from chia.types.mempool_item import MempoolItem
+from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.ints import uint32, uint64
 from chia.util.math import make_monotonically_decreasing
 
@@ -60,9 +61,8 @@ def make_block(
 
     for n in range(num_tx):
         block_included = uint32(height - num_blocks_wait_in_mempool)
-        mempool_item = MempoolItem(
-            spend_bundle, fee, NPCResult(None, None, cost), cost, spend_bundle.name(), [], block_included
-        )
+        conds = SpendBundleConditions([], 0, 0, 0, None, None, [], cost)
+        mempool_item = MempoolItem(spend_bundle, fee, NPCResult(None, conds, cost), spend_bundle.name(), block_included)
         items.append(mempool_item)
     return items
 


### PR DESCRIPTION
Apart from lowering memory footprint of the mempool, the main objective of this change is to (slightly) improve the performance of serializing and deserialializing `MempoolItem`s. A forthcoming PR storing these in a sqlite database rely in serializing and deserializing these.

This change shaves off a small amount of time deserializing:

| before | after | after / before |
| --- | --- | --- |
| 131.7 | 120.68 | 91.6 % |

before:
```
Profiling create_bundle_from_mempool()
  output written to: mempool-create-mt.png
  time: 65.8534s
  per call: 131.71ms
```

after:
```
Profiling create_bundle_from_mempool()
  output written to: mempool-create-mt.png
  time: 60.3389s
  per call: 120.68ms
```