### PR TITLE
sqlite-backed mempool

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -1,18 +1,26 @@
 from __future__ import annotations
 
+import sqlite3
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, Iterator, List, Optional
 
-from sortedcontainers import SortedDict
-
+from chia.consensus.cost_calculator import NPCResult
 from chia.full_node.fee_estimation import FeeMempoolInfo, MempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
-from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.clvm_cost import CLVMCost
 from chia.types.mempool_item import MempoolItem
-from chia.util.ints import uint64
+from chia.types.spend_bundle import SpendBundle
+from chia.util.chunks import chunks
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
+from chia.util.ints import uint32, uint64
+
+# We impose a limit on the fee a single transaction can pay in order to have the
+# sum of all fees in the mempool be less than 2^63. That's the limit of sqlite's
+# integers, which we rely on for computing fee per cost as well as the fee sum
+MEMPOOL_ITEM_FEE_LIMIT = 2**50
 
 
 class MempoolRemoveReason(Enum):
@@ -21,48 +29,117 @@ class MempoolRemoveReason(Enum):
     POOL_FULL = 3
 
 
+@dataclass(frozen=True)
+class InternalMempoolItem:
+    spend_bundle: SpendBundle
+    npc_result: NPCResult
+    height_added_to_mempool: uint32
+
+
 class Mempool:
+    _db_conn: sqlite3.Connection
+    # it's expensive to serialize and deserialize G2Element, so we keep those in
+    # this separate dictionary
+    _items: Dict[bytes32, InternalMempoolItem]
+
     def __init__(self, mempool_info: MempoolInfo, fee_estimator: FeeEstimatorInterface):
-        self._spends: Dict[bytes32, MempoolItem] = {}
-        self._sorted_spends: SortedDict = SortedDict()
+        self._db_conn = sqlite3.connect(":memory:")
+        self._items = {}
+
+        with self._db_conn:
+            # name means SpendBundle hash
+            # assert_height may be NIL
+            self._db_conn.execute(
+                """CREATE TABLE tx(
+                name BLOB PRIMARY KEY,
+                cost INT NOT NULL,
+                fee INT NOT NULL,
+                assert_height INT,
+                fee_per_cost REAL GENERATED ALWAYS AS (fee / cost) VIRTUAL)
+                """
+            )
+            self._db_conn.execute("CREATE INDEX fee_sum ON tx(fee)")
+            self._db_conn.execute("CREATE INDEX cost_sum ON tx(cost)")
+            self._db_conn.execute("CREATE INDEX feerate ON tx(fee_per_cost)")
+
+            # This table maps coin IDs to spend bundles hashes
+            self._db_conn.execute(
+                """CREATE TABLE spends(
+                coin_id BLOB NOT NULL,
+                tx BLOB NOT NULL,
+                UNIQUE(coin_id, tx))
+                """
+            )
+            self._db_conn.execute("CREATE INDEX spend_by_coin ON spends(coin_id)")
+            self._db_conn.execute("CREATE INDEX spend_by_bundle ON spends(tx)")
+
         self.mempool_info: MempoolInfo = mempool_info
         self.fee_estimator: FeeEstimatorInterface = fee_estimator
-        self._removal_coin_id_to_spendbundle_ids: Dict[bytes32, List[bytes32]] = {}
-        self._total_mempool_cost: CLVMCost = CLVMCost(uint64(0))
-        self._total_mempool_fees: int = 0
+
+    def __del__(self) -> None:
+        self._db_conn.close()
+
+    def _row_to_item(self, row: sqlite3.Row) -> MempoolItem:
+        name = bytes32(row[0])
+        fee = int(row[1])
+        assert_height = row[2]
+        item = self._items[name]
+
+        return MempoolItem(
+            item.spend_bundle, uint64(fee), item.npc_result, name, uint32(item.height_added_to_mempool), assert_height
+        )
 
     def total_mempool_fees(self) -> int:
-        return self._total_mempool_fees
+        with self._db_conn:
+            cursor = self._db_conn.execute("SELECT SUM(fee) FROM tx")
+            val = cursor.fetchone()[0]
+            return uint64(0) if val is None else uint64(val)
 
     def total_mempool_cost(self) -> CLVMCost:
-        return self._total_mempool_cost
+        with self._db_conn:
+            cursor = self._db_conn.execute("SELECT SUM(cost) FROM tx")
+            val = cursor.fetchone()[0]
+            return CLVMCost(uint64(0) if val is None else uint64(val))
 
-    def all_spends(self) -> List[MempoolItem]:
-        return list(self._spends.values())
+    def all_spends(self) -> Iterator[MempoolItem]:
+        with self._db_conn:
+            cursor = self._db_conn.execute("SELECT name, fee, assert_height FROM tx")
+            for row in cursor:
+                yield self._row_to_item(row)
 
     def all_spend_ids(self) -> List[bytes32]:
-        return list(self._spends.keys())
+        with self._db_conn:
+            cursor = self._db_conn.execute("SELECT name FROM tx")
+            return [bytes32(row[0]) for row in cursor]
 
-    def spends_by_feerate(self) -> List[MempoolItem]:
-        ret: List[MempoolItem] = []
-        for spends_with_fpc in reversed(self._sorted_spends.values()):
-            ret.extend(spends_with_fpc.values())
-        return ret
+    # TODO: move "process_mempool_items()" into this class in order to do this a
+    # bit more efficiently
+    def spends_by_feerate(self) -> Iterator[MempoolItem]:
+        with self._db_conn:
+            cursor = self._db_conn.execute("SELECT name, fee, assert_height FROM tx ORDER BY fee_per_cost DESC")
+            for row in cursor:
+                yield self._row_to_item(row)
 
     def size(self) -> int:
-        return len(self._spends)
+        with self._db_conn:
+            cursor = self._db_conn.execute("SELECT Count(name) FROM tx")
+            val = cursor.fetchone()
+            return 0 if val is None else int(val[0])
 
     def get_spend_by_id(self, spend_bundle_id: bytes32) -> Optional[MempoolItem]:
-        return self._spends.get(spend_bundle_id, None)
+        with self._db_conn:
+            cursor = self._db_conn.execute("SELECT name, fee, assert_height FROM tx WHERE name=?", (spend_bundle_id,))
+            row = cursor.fetchone()
+            return None if row is None else self._row_to_item(row)
 
+    # TODO: we need a bulk lookup function like this too
     def get_spends_by_coin_id(self, spent_coin_id: bytes32) -> List[MempoolItem]:
-        spend_bundle_ids = self._removal_coin_id_to_spendbundle_ids.get(spent_coin_id)
-        if spend_bundle_ids is None:
-            return []
-        ret: List[MempoolItem] = []
-        for spend_bundle_id in spend_bundle_ids:
-            ret.append(self._spends[spend_bundle_id])
-        return ret
+        with self._db_conn:
+            cursor = self._db_conn.execute(
+                "SELECT name, fee, assert_height FROM tx WHERE name in (SELECT tx FROM spends WHERE coin_id=?)",
+                (spent_coin_id,),
+            )
+            return [self._row_to_item(row) for row in cursor]
 
     def get_min_fee_rate(self, cost: int) -> float:
         """
@@ -70,16 +147,21 @@ class Mempool:
         """
 
         if self.at_full_capacity(cost):
-            current_cost = self._total_mempool_cost
+            # TODO: make MempoolItem.cost be CLVMCost
+            current_cost = int(self.total_mempool_cost())
 
             # Iterates through all spends in increasing fee per cost
-            fee_per_cost: float
-            for fee_per_cost, spends_with_fpc in self._sorted_spends.items():
-                for spend_name, item in spends_with_fpc.items():
-                    current_cost -= item.cost
+            with self._db_conn:
+                cursor = self._db_conn.execute("SELECT cost,fee_per_cost FROM tx ORDER BY fee_per_cost ASC")
+
+                item_cost: int
+                fee_per_cost: float
+                for item_cost, fee_per_cost in cursor:
+                    current_cost -= item_cost
                     # Removing one at a time, until our transaction of size cost fits
                     if current_cost + cost <= self.mempool_info.max_size_in_cost:
                         return fee_per_cost
+
             raise ValueError(
                 f"Transaction with cost {cost} does not fit in mempool of max cost {self.mempool_info.max_size_in_cost}"
             )
@@ -90,61 +172,67 @@ class Mempool:
         """
         Removes an item from the mempool.
         """
-        for spend_bundle_id in items:
-            item: Optional[MempoolItem] = self._spends.get(spend_bundle_id)
-            if item is None:
-                continue
-            assert item.name == spend_bundle_id
-            removals: List[Coin] = item.removals
-            for rem in removals:
-                rem_name: bytes32 = rem.name()
-                self._removal_coin_id_to_spendbundle_ids[rem_name].remove(spend_bundle_id)
-                if len(self._removal_coin_id_to_spendbundle_ids[rem_name]) == 0:
-                    del self._removal_coin_id_to_spendbundle_ids[rem_name]
-            del self._spends[item.name]
-            del self._sorted_spends[item.fee_per_cost][item.name]
-            dic = self._sorted_spends[item.fee_per_cost]
-            if len(dic.values()) == 0:
-                del self._sorted_spends[item.fee_per_cost]
-            self._total_mempool_cost = CLVMCost(uint64(self._total_mempool_cost - item.cost))
-            self._total_mempool_fees = self._total_mempool_fees - item.fee
-            assert self._total_mempool_cost >= 0
-            info = FeeMempoolInfo(self.mempool_info, self._total_mempool_cost, self._total_mempool_fees, datetime.now())
-            if reason != MempoolRemoveReason.BLOCK_INCLUSION:
-                self.fee_estimator.remove_mempool_item(
-                    info, MempoolItemInfo(item.cost, item.fee, item.height_added_to_mempool)
-                )
+        removed_items: List[MempoolItemInfo] = []
+        if reason != MempoolRemoveReason.BLOCK_INCLUSION:
+
+            for spend_bundle_ids in chunks(items, SQLITE_MAX_VARIABLE_NUMBER):
+                args = ",".join(["?"] * len(spend_bundle_ids))
+                with self._db_conn:
+                    cursor = self._db_conn.execute(
+                        f"SELECT name, cost, fee FROM tx WHERE name in ({args})", spend_bundle_ids
+                    )
+                    for row in cursor:
+                        name = bytes32(row[0])
+                        internal_item = self._items[name]
+                        item = MempoolItemInfo(int(row[1]), int(row[2]), internal_item.height_added_to_mempool)
+                        removed_items.append(item)
+
+        for name in items:
+            self._items.pop(name)
+
+        for spend_bundle_ids in chunks(items, SQLITE_MAX_VARIABLE_NUMBER):
+            args = ",".join(["?"] * len(spend_bundle_ids))
+            with self._db_conn:
+                self._db_conn.execute(f"DELETE FROM tx WHERE name in ({args})", spend_bundle_ids)
+                self._db_conn.execute(f"DELETE FROM spends WHERE tx in ({args})", spend_bundle_ids)
+
+        if reason != MempoolRemoveReason.BLOCK_INCLUSION:
+            info = FeeMempoolInfo(
+                self.mempool_info, self.total_mempool_cost(), self.total_mempool_fees(), datetime.now()
+            )
+            for iteminfo in removed_items:
+                self.fee_estimator.remove_mempool_item(info, iteminfo)
 
     def add_to_pool(self, item: MempoolItem) -> None:
         """
         Adds an item to the mempool by kicking out transactions (if it doesn't fit), in order of increasing fee per cost
         """
 
+        assert item.fee < MEMPOOL_ITEM_FEE_LIMIT
         assert item.npc_result.conds is not None
 
-        while self.at_full_capacity(item.cost):
-            # Val is Dict[hash, MempoolItem]
-            fee_per_cost, val = self._sorted_spends.peekitem(index=0)
-            to_remove: MempoolItem = list(val.values())[0]
-            self.remove_from_pool([to_remove.name], MempoolRemoveReason.POOL_FULL)
+        # TODO: this block could be simplified by removing all items in a single
+        # SQL query. Or at least figure out which items to remove and then
+        # remove them all in a single call to remove_from_pool()
+        with self._db_conn:
+            while self.at_full_capacity(item.cost):
+                # pick the item with the lowest fee per cost to remove
+                cursor = self._db_conn.execute("SELECT name FROM tx ORDER BY fee_per_cost ASC LIMIT 1")
+                name = bytes32(cursor.fetchone()[0])
+                self.remove_from_pool([name], MempoolRemoveReason.POOL_FULL)
 
-        self._spends[item.name] = item
+            self._db_conn.execute(
+                "INSERT INTO tx VALUES(?, ?, ?, ?)", (item.name, item.cost, item.fee, item.assert_height)
+            )
 
-        # _sorted_spends is Dict[float, Dict[bytes32, MempoolItem]]
-        if item.fee_per_cost not in self._sorted_spends:
-            self._sorted_spends[item.fee_per_cost] = {}
+            all_coin_spends = [(s.coin_id, item.name) for s in item.npc_result.conds.spends]
+            self._db_conn.executemany("INSERT INTO spends VALUES(?, ?)", all_coin_spends)
 
-        self._sorted_spends[item.fee_per_cost][item.name] = item
+            self._items[item.name] = InternalMempoolItem(
+                item.spend_bundle, item.npc_result, item.height_added_to_mempool
+            )
 
-        for coin in item.removals:
-            coin_id = coin.name()
-            if coin_id not in self._removal_coin_id_to_spendbundle_ids:
-                self._removal_coin_id_to_spendbundle_ids[coin_id] = []
-            self._removal_coin_id_to_spendbundle_ids[coin_id].append(item.name)
-
-        self._total_mempool_cost = CLVMCost(uint64(self._total_mempool_cost + item.cost))
-        self._total_mempool_fees = self._total_mempool_fees + item.fee
-        info = FeeMempoolInfo(self.mempool_info, self._total_mempool_cost, self._total_mempool_fees, datetime.now())
+        info = FeeMempoolInfo(self.mempool_info, self.total_mempool_cost(), self.total_mempool_fees(), datetime.now())
         self.fee_estimator.add_mempool_item(info, MempoolItemInfo(item.cost, item.fee, item.height_added_to_mempool))
 
     def at_full_capacity(self, cost: int) -> bool:
@@ -152,4 +240,4 @@ class Mempool:
         Checks whether the mempool is at full capacity and cannot accept a transaction with size cost.
         """
 
-        return self._total_mempool_cost + cost > self.mempool_info.max_size_in_cost
+        return self.total_mempool_cost() + cost > self.mempool_info.max_size_in_cost

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -172,6 +172,9 @@ class Mempool:
         """
         Removes an item from the mempool.
         """
+        if items == []:
+            return
+
         removed_items: List[MempoolItemInfo] = []
         if reason != MempoolRemoveReason.BLOCK_INCLUSION:
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -18,7 +18,7 @@ from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.fee_estimation import FeeBlockInfo, MempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
-from chia.full_node.mempool import Mempool, MempoolRemoveReason
+from chia.full_node.mempool import MEMPOOL_ITEM_FEE_LIMIT, Mempool, MempoolRemoveReason
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.types.blockchain_format.coin import Coin
@@ -33,6 +33,7 @@ from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util import cached_bls
 from chia.util.cached_bls import LOCAL_CACHE
 from chia.util.condition_tools import pkm_pairs
+from chia.util.db_wrapper import SQLITE_INT_MAX
 from chia.util.errors import Err, ValidationError
 from chia.util.generator_tools import additions_for_npc
 from chia.util.inline_executor import InlineExecutor
@@ -187,7 +188,11 @@ class MempoolManager:
             cost_sum += item.cost
             fee_sum += item.fee
             removals.extend(item.removals)
-            additions.extend(item.additions)
+            if item.npc_result.conds is not None:
+                for spend in item.npc_result.conds.spends:
+                    for puzzle_hash, amount, _ in spend.create_coin:
+                        coin = Coin(spend.coin_id, puzzle_hash, amount)
+                        additions.append(coin)
         return (spend_bundles, uint64(cost_sum), additions, removals)
 
     def create_bundle_from_mempool(
@@ -470,6 +475,13 @@ class MempoolManager:
         if cost == 0:
             return Err.UNKNOWN, None, []
 
+        # this is not very likely to happen, but it's here to ensure SQLite
+        # never runs out of precision in its computation of fees.
+        # sqlite's integers are signed int64, so the max value they can
+        # represent is 2^63-1
+        if fees > MEMPOOL_ITEM_FEE_LIMIT or SQLITE_INT_MAX - self.mempool.total_mempool_fees() <= fees:
+            return Err.INVALID_BLOCK_FEE_AMOUNT, None, []
+
         fees_per_cost: float = fees / cost
         # If pool is at capacity check the fee, if not then accept even without the fee
         if self.mempool.at_full_capacity(cost):
@@ -608,14 +620,18 @@ class MempoolManager:
         if use_optimization and last_npc_result is not None:
             # We don't reinitialize a mempool, just kick removed items
             if last_npc_result.conds is not None:
-                spendbundle_ids_to_remove: List[bytes32] = []
+                # transactions in the mempool may be spending multiple coins,
+                # when looking up transactions by all coin IDs, we're likely to
+                # find the same transaction multiple times. We put them in a set
+                # to deduplicate
+                spendbundle_ids_to_remove: Set[bytes32] = set()
                 for spend in last_npc_result.conds.spends:
                     items: List[MempoolItem] = self.mempool.get_spends_by_coin_id(bytes32(spend.coin_id))
                     for item in items:
                         included_items.append(MempoolItemInfo(item.cost, item.fee, item.height_added_to_mempool))
                         self.remove_seen(item.name)
-                        spendbundle_ids_to_remove.append(item.name)
-                self.mempool.remove_from_pool(spendbundle_ids_to_remove, MempoolRemoveReason.BLOCK_INCLUSION)
+                        spendbundle_ids_to_remove.add(item.name)
+                self.mempool.remove_from_pool(list(spendbundle_ids_to_remove), MempoolRemoveReason.BLOCK_INCLUSION)
         else:
             old_pool = self.mempool
             self.mempool = Mempool(old_pool.mempool_info, old_pool.fee_estimator)

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -181,7 +181,7 @@ class MempoolManager:
         for item in self.mempool.spends_by_feerate():
             if not item_inclusion_filter(item.name):
                 continue
-            log.info(f"Cumulative cost: {cost_sum}, fee per cost: {item.fee / item.cost}")
+            log.info("Cumulative cost: %d, fee per cost: %0.4f", cost_sum, item.fee_per_cost)
             if item.cost + cost_sum > self.max_block_clvm_cost or item.fee + fee_sum > self.constants.MAX_COIN_AMOUNT:
                 return (spend_bundles, uint64(cost_sum), additions, removals)
             spend_bundles.append(item.spend_bundle)

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -9,12 +9,11 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
 from chia.util.generator_tools import additions_for_npc
 from chia.util.ints import uint32, uint64
-from chia.util.streamable import Streamable, recurse_jsonify, streamable
+from chia.util.streamable import recurse_jsonify
 
 
-@streamable
 @dataclass(frozen=True)
-class MempoolItem(Streamable):
+class MempoolItem:
     spend_bundle: SpendBundle
     fee: uint64
     npc_result: NPCResult

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -16,6 +16,9 @@ if aiosqlite.sqlite_version_info < (3, 32, 0):
 else:
     SQLITE_MAX_VARIABLE_NUMBER = 32700
 
+# integers in sqlite are limited by int64
+SQLITE_INT_MAX = 2**63 - 1
+
 
 async def execute_fetchone(
     c: aiosqlite.Connection, sql: str, parameters: Iterable[Any] = None

--- a/tests/core/mempool/test_mempool_fee_estimator.py
+++ b/tests/core/mempool/test_mempool_fee_estimator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from random import Random
-from typing import Optional
 
 import pytest
 
@@ -12,18 +11,8 @@ from chia.full_node.fee_estimation import MempoolItemInfo
 from chia.full_node.fee_estimator import SmartFeeEstimator
 from chia.full_node.fee_tracker import FeeTracker
 from chia.full_node.mempool_manager import MempoolManager
-from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_record import CoinRecord
-from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.ints import uint32, uint64
 from tests.core.consensus.test_pot_iterations import test_constants
-from tests.core.mempool.test_mempool_manager import (
-    IDENTITY_PUZZLE_HASH,
-    generate_and_add_spendbundle,
-    instantiate_mempool_manager,
-)
 from tests.util.db_connection import DBConnection
 
 
@@ -113,26 +102,3 @@ async def test_fee_increase() -> None:
         assert short_estimate.mojos_per_clvm_cost == uint64(fee_tracker.buckets[3] / 1000)
         assert med_estimate.mojos_per_clvm_cost == uint64(fee_tracker.buckets[3] / 1000)
         assert long_estimate.mojos_per_clvm_cost == uint64(0)
-
-
-@pytest.mark.asyncio
-async def test_total_mempool_fees() -> None:
-    coin1 = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, uint64(0xFFFFFFFFFFFFFFFF))
-    coin2 = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, uint64(3))
-
-    async def get_coin_record(coin_id: bytes32) -> Optional[CoinRecord]:
-        test_coin_records = {
-            coin1.name(): CoinRecord(coin1, uint32(0), uint32(0), False, uint64(0)),
-            coin2.name(): CoinRecord(coin2, uint32(0), uint32(0), False, uint64(0)),
-        }
-        return test_coin_records.get(coin_id)
-
-    mempool_manager = await instantiate_mempool_manager(get_coin_record)
-    conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
-    _, _, result = await generate_and_add_spendbundle(mempool_manager, conditions, coin1)
-    assert result[1] == MempoolInclusionStatus.SUCCESS
-    _, _, result = await generate_and_add_spendbundle(mempool_manager, conditions, coin2)
-    assert result[1] == MempoolInclusionStatus.SUCCESS
-    # Total fees should be coin1's amount plus coin2's amount minus two mojos
-    # for the created coins
-    assert mempool_manager.mempool.total_mempool_fees() == 0xFFFFFFFFFFFFFFFF + 3 - 2

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -534,3 +534,36 @@ async def test_get_items_not_in_filter() -> None:
     sb2_and_3_filter = PyBIP158([bytearray(sb2_name), bytearray(sb3_name)])
     result = mempool_manager.get_items_not_in_filter(sb2_and_3_filter)
     assert result == [sb1]
+
+
+@pytest.mark.asyncio
+async def test_total_mempool_fees() -> None:
+
+    coin_records: Dict[bytes32, CoinRecord] = {}
+
+    async def get_coin_record(coin_id: bytes32) -> Optional[CoinRecord]:
+        return coin_records.get(coin_id)
+
+    mempool_manager = await instantiate_mempool_manager(get_coin_record)
+    conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
+
+    # the limit of total fees in the mempool is 2^63
+    # the limit per mempool item is 2^50, that lets us add 8192 items with the
+    # maximum amount of fee before reaching the total mempool limit
+    amount = uint64(2**50)
+    total_fee = 0
+    for i in range(8192):
+        coin = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, amount)
+        coin_records[coin.name()] = CoinRecord(coin, uint32(0), uint32(0), False, uint64(0))
+        amount = uint64(amount - 1)
+        # the fee is 1 less than the amount because we create a coin of 1 mojo
+        total_fee += amount
+        _, _, result = await generate_and_add_spendbundle(mempool_manager, conditions, coin)
+        assert result[1] == MempoolInclusionStatus.SUCCESS
+        assert mempool_manager.mempool.total_mempool_fees() == total_fee
+
+    coin = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, amount)
+    coin_records[coin.name()] = CoinRecord(coin, uint32(0), uint32(0), False, uint64(0))
+    _, _, result = await generate_and_add_spendbundle(mempool_manager, conditions, coin)
+    assert result[1] == MempoolInclusionStatus.FAILED
+    assert result[2] == Err.INVALID_BLOCK_FEE_AMOUNT

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -222,7 +222,7 @@ class TestRpc:
             block_spends = await client.get_block_spends(block.header_hash)
 
             assert len(block_spends) == 3
-            assert block_spends == coin_spends
+            assert sorted(block_spends, key=lambda x: str(x)) == sorted(coin_spends, key=lambda x: str(x))
 
             memo = 32 * b"\f"
 

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -120,7 +120,8 @@ def test_item_not_removed_if_not_added() -> None:
         fee_estimator = FeeEstimatorInterfaceIntegrationVerificationObject()
         mempool = Mempool(test_mempool_info, fee_estimator)
         item = make_mempoolitem()
-        mempool.remove_from_pool([item.name], reason)
+        with pytest.raises(KeyError):
+            mempool.remove_from_pool([item.name], reason)
         assert mempool.fee_estimator.remove_mempool_item_called_count == 0  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
# overview

The objective of this change is to allow to *reliably* add more sophisticated rules to the mempool.

This patch adds an sqlite database as the *index* for mempool items. In order to not repeat values from the index in the items themselves, it uses an `InternalMempoolItem` with fewer fields. the `_items` dictionary (which stores the mempool items) is kept in sync with the sqlite database, referencing items in the dict, by *name* (SpendBundle hash).

# rationale

The immediate features to add are the `assert_before_height` and `assert_before_seconds` fields on mempool items, ensuring they expire once those heights or timestamps have been reached.

I'm also envisioning a future where the "pending_cache" and "conflict_cache" are also folded into the database. That would also simplify the mempool data structure (or really, offload the complex parts to sqlite).

With that, I also imagine it would be easy to add support for `ASSERT_SECONDS`, which currently is not supported by the mempool (presumably to keep complexity in check).

# benefits

Fundamentally, the mempool is a multi-index container. A collection of items that we want efficient access to via different fields and ordering. e.g. we want to be able to iterate by fee rate, look up by spend bundle hash, look up by spent coin ID.

There is no native support for multi index cointainers in python, and implementing one is complex and error prone. Using a sqlite database greatly simplifies the data structure we need to support, by offloading all indices. This is especially significant as we add more indices (as mentioned under rationale). The complexity of the mempool will scale better with the number of indices and logic we add to the mempool.

# drawbacks

The main drawback of using a sqlite database is a slight performance degradation. The least common operation (farming a block) is slowed down and takes about 30% more time. See benchmarks below.

Another noteworthy consequence of this patch is that to total fee (i.e. the sum of all fees of all spend bundles) is not allowed to exceed `INT64_MAX`. This is because sqlite uses signed int64 as its internal representation for integers, so in order for the `fee_per_cost` field to be computed (and implied), sqlite need to be able to interpret the integers. This also allows the total fee and total cost to simply be sqlite queries for `SUM(<field>)`.

This patch, additionally, adds a fee limit of 2^50 mojos for an individual `MempoolItem`.

I don't think this restriction is problematic, since you would need astronomical fees in order to hit this ceiling, and it would only push out other transactions for one block (and then require more astronomical fees to keep it up).

# benchmarks

## Ubuntu AMD64 (CPU)

| function | before | after | after / before
| --- | --- | --- | --- |
| add_spend_bundle() | 6.3161s | 6.4140s | 101.55% |
| add_spend_bundle() replace | 6.2743s | 6.3782s | 101.66 % |
| create_bundle_from_mempool() | 4.5330s | 5.9528s | 131.32 % |
| new_peak() optimized | 16.6200s | 17.2157s | 103.58 % |
| new_peak() reorg | 16.2587s | 16.9127s | 104 % |

## Ubuntu AMD64 (memory)

The RAM pressure is pretty crude, just measuring the heap pressure of the mempool benchmark.
The benchmark logic itself probably contributes half of the memory pressure.

| metric | before | after | after / before |
| --- | --- | --- |--- |
| Max RSS | 78864 | 79908 | 101.32% |

## Raspberry PI (CPU)

| function | before | after | after / before
| --- | --- | --- | --- |
| add_spend_bundle() | 18.99s | 19.09s | 100.5 % |
| add_spend_bundle() replace | 18.99s | 19.09s | 100.54 % |
| create_bundle_from_mempool() | 16.98s | 21.53s | 126.78 % |
| new_peak() optimized | 47.12 s | 46.48s | 98.63 % |
| new_peak() reorg | 45.69 s | 46.42s | 101.6 % |

## Ubuntu amd64 (CPU)

current `main`:
```
Profiling add_spend_bundle()
  output written to: mempool-add-mt.png
  time: 6.3161s
  per call: 3.16ms

Profiling add_spend_bundle() with replace-by-fee
  output written to: mempool-replace-mt.png
  time: 6.2743s
  per call: 3.14ms

Profiling create_bundle_from_mempool()
  output written to: mempool-create-mt.png
  time: 4.5330s
  per call: 9.07ms

Profiling new_peak() (optimized)
  output written to: mempool-new-peak-mt.png
  time: 16.6200s
  per call: 8.31ms

Profiling new_peak() (reorg)
  output written to: mempool-new-peak-reorg-mt.png
  time: 16.2587s
  per call: 8.13ms
```

with sqlite:
```
Profiling add_spend_bundle()
  output written to: mempool-add-mt.png
  time: 6.4140s
  per call: 3.21ms

Profiling add_spend_bundle() with replace-by-fee
  output written to: mempool-replace-mt.png
  time: 6.3782s
  per call: 3.19ms

Profiling create_bundle_from_mempool()
  output written to: mempool-create-mt.png
  time: 5.9528s
  per call: 11.91ms

Profiling new_peak() (optimized)
  output written to: mempool-new-peak-mt.png
  time: 17.2157s
  per call: 8.61ms

Profiling new_peak() (reorg)
  output written to: mempool-new-peak-reorg-mt.png
  time: 16.9127s
  per call: 8.46ms
```

the profile of the most-impacted operation with sqlite backing:
![mempool-create-mt](https://user-images.githubusercontent.com/661450/221732999-e65e89ba-4956-49b7-b319-0c5a4ccbe65b.png)

## Ubuntu AMD64 (memory)

current `main`:
```
        Command being timed: "python mempool.py"
        User time (seconds): 198.14
        System time (seconds): 1.24
        Percent of CPU this job got: 109%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:02.68
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 78864
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 92787
        Voluntary context switches: 34294
        Involuntary context switches: 861
        Swaps: 0
        File system inputs: 0
        File system outputs: 3232
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

with sqlite:
```
        Command being timed: "python mempool.py"
        User time (seconds): 209.45
        System time (seconds): 0.87
        Percent of CPU this job got: 111%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:09.48
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 79908
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 120195
        Voluntary context switches: 37254
        Involuntary context switches: 918
        Swaps: 0
        File system inputs: 0
        File system outputs: 4152
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

## Raspberry PI (CPU)

current `main`:
```
Profiling add_spend_bundle()
  output written to: mempool-add-mt.png
  time: 18.9916s
  per call: 9.50ms

Profiling add_spend_bundle() with replace-by-fee
  output written to: mempool-replace-mt.png
  time: 18.9871s
  per call: 9.49ms

Profiling create_bundle_from_mempool()
  output written to: mempool-create-mt.png
  time: 16.9782s
  per call: 33.96ms

Profiling new_peak() (optimized)
  output written to: mempool-new-peak-mt.png
  time: 47.1240s
  per call: 23.56ms

Profiling new_peak() (reorg)
  output written to: mempool-new-peak-reorg-mt.png
  time: 45.6839s
  per call: 22.84ms
```

with sqlite:
```
Profiling add_spend_bundle()
  output written to: mempool-add-mt.png
  time: 19.0876s
  per call: 9.54ms

Profiling add_spend_bundle() with replace-by-fee
  output written to: mempool-replace-mt.png
  time: 19.0887s
  per call: 9.54ms

Profiling create_bundle_from_mempool()
  output written to: mempool-create-mt.png
  time: 21.5251s
  per call: 43.05ms

Profiling new_peak() (optimized)
  output written to: mempool-new-peak-mt.png
  time: 46.4771s
  per call: 23.24ms

Profiling new_peak() (reorg)
  output written to: mempool-new-peak-reorg-mt.png
  time: 46.4199s
  per call: 23.21ms
```
