### PR TITLE
Make sure to await properly during Daemon shutdown

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -213,7 +213,7 @@ class WebSocketServer:
         if stop_service_jobs:
             await asyncio.wait(stop_service_jobs)
         self.services.clear()
-        asyncio.create_task(self.exit())
+        await self.exit()
         log.info(f"Daemon Server stopping, Services stopped: {service_names}")
         return {"success": True, "services_stopped": service_names}
 

--- a/tests/core/test_daemon_rpc.py
+++ b/tests/core/test_daemon_rpc.py
@@ -22,4 +22,6 @@ class TestDaemonRpc:
 
         assert response["data"]["success"]
         assert response["data"]["version"] == __version__
+
+        client.close()
         ws_server.stop()


### PR DESCRIPTION
Running a simple test like `test_daemon_rpc` with `pytest -n 0 tests/core/test_daemon_rpc.py` results in various not awaited errors and task destroyed messages like :
```
sys:1: RuntimeWarning: coroutine 'WebServer._close' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Task was destroyed but it is pending!
task: <Task pending name='Task-16' coro=<WebServer._close() running at /Users/elowe/source/chia-blockchain/chia/util/network.py:91> cb=[Task.task_wakeup()]>
```

This PR attempts to make all the ways the daemon can be stopped work cleanly. The following have been tested to work without errors in logs or console. There are still tasks created that are not awaited, so there may still be edges cases

Testing scenarios - testing limited to macOS
- running pytest. daemon service stop method properly stops and awaits and tests exit clean
- using `chia stop -d`. Daemon stops all started services and cleanly exits with no errors in the log
- HUP'ing the service (`kill -HUP`). Daemon stops all started services and cleanly exits with no errors in the log
- running daemon in foreground `chia run_daemon` and using `ctrl-c`. Daemon stops all started services and cleanly exits with no errors in the log.
