### PR TITLE
simplify the mempool filter to only pass in the spend_bundle name

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -220,7 +220,7 @@ class SpendSim:
     async def farm_block(
         self,
         puzzle_hash: bytes32 = bytes32(b"0" * 32),
-        item_inclusion_filter: Optional[Callable[[MempoolManager, MempoolItem], bool]] = None,
+        item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
     ) -> Tuple[List[Coin], List[Coin]]:
         # Fees get calculated
         fees = uint64(0)

--- a/tests/fee_estimation/test_mempoolitem_height_added.py
+++ b/tests/fee_estimation/test_mempoolitem_height_added.py
@@ -11,11 +11,9 @@ from chia.clvm.spend_sim import SimClient, SpendSim, sim_and_client
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bitcoin_fee_estimator import BitcoinFeeEstimator
-from chia.full_node.mempool_manager import MempoolManager
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
-from chia.types.mempool_item import MempoolItem
 from chia.types.spend_bundle import SpendBundle
 
 log = logging.getLogger(__name__)
@@ -32,7 +30,7 @@ NEW_DEFAULT_CONSTANTS: ConsensusConstants = DEFAULT_CONSTANTS.replace(
 async def farm(
     sim: SpendSim,
     puzzle_hash: bytes32,
-    item_inclusion_filter: Optional[Callable[[MempoolManager, MempoolItem], bool]] = None,
+    item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
 ) -> Tuple[List[Coin], List[Coin], List[Coin]]:
     additions, removals = await sim.farm_block(puzzle_hash)  # , item_inclusion_filter)
     height = sim.get_height()
@@ -91,10 +89,10 @@ async def test_mempool_inclusion_filter_basic() -> None:
         mempool_item = sim.mempool_manager.get_mempool_item(spend_bundle.name())
         assert mempool_item
 
-        def include_none(mm: MempoolManager, mi: MempoolItem) -> bool:
+        def include_none(bundle_name: bytes32) -> bool:
             return False
 
-        def include_all(mm: MempoolManager, mi: MempoolItem) -> bool:
+        def include_all(bundle_name: bytes32) -> bool:
             return True
 
         additions, removals = await sim.farm_block(the_puzzle_hash, item_inclusion_filter=include_none)
@@ -123,9 +121,9 @@ async def test_mempoolitem_height_added(db_version: int) -> None:
         assert mempool_item
         heights = {sim.get_height(): mempool_item.height_added_to_mempool}
 
-        def ignore_spend(mm: MempoolManager, mi: MempoolItem) -> bool:
+        def ignore_spend(bundle_name: bytes32) -> bool:
             assert mempool_item
-            return mi.name != mempool_item.name
+            return bundle_name != mempool_item.name
 
         additions, removals = await sim.farm_block(the_puzzle_hash, item_inclusion_filter=ignore_spend)
         removal_ids = [c.name() for c in removals]


### PR DESCRIPTION
the filter function is only used in the fee estimator test, so part of me thinks we really shouldn't have this feature at all, but come up with a better way to test.

However, its current signature passes in more things than the tests using it need. This patch passes in just the information used by any concrete filter function (the spend bundle name). This opens up the possibility to run the filter without parsing the `MempoolItem` from the DB, in this patch: https://github.com/Chia-Network/chia-blockchain/pull/14657