### PR TITLE
simplify create_bundle_from_mempool() interface

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -254,13 +254,13 @@ class SpendSim:
                 result = self.mempool_manager.create_bundle_from_mempool(peak.header_hash, item_inclusion_filter)
 
                 if result is not None:
-                    bundle, additions, removals = result
+                    bundle, additions = result
                     generator_bundle = bundle
                     return_additions = additions
-                    return_removals = removals
+                    return_removals = bundle.removals()
 
                     await self.coin_store._add_coin_records([self.new_coin_record(addition) for addition in additions])
-                    await self.coin_store._set_spent([r.name() for r in removals], uint32(self.block_height + 1))
+                    await self.coin_store._set_spent([r.name() for r in return_removals], uint32(self.block_height + 1))
 
         # SimBlockRecord is created
         generator: Optional[BlockGenerator] = await self.generate_transaction_generator(generator_bundle)

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -756,7 +756,7 @@ class FullNodeAPI:
                     if mempool_bundle is not None:
                         spend_bundle = mempool_bundle[0]
                         additions = mempool_bundle[1]
-                        removals = mempool_bundle[2]
+                        removals = spend_bundle.removals()
                         self.full_node.log.info(f"Add rem: {len(additions)} {len(removals)}")
                         aggregate_signature = spend_bundle.aggregated_signature
                         if self.full_node.full_node_store.previous_generator is not None:

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -58,10 +58,9 @@ class TestBlockchainTransactions:
         assert sb == spend_bundle
 
         last_block = blocks[-1]
-        next_spendbundle, additions, removals = full_node_1.mempool_manager.create_bundle_from_mempool(
+        next_spendbundle, _ = full_node_1.mempool_manager.create_bundle_from_mempool(
             last_block.header_hash
         )
-        assert next_spendbundle is not None
 
         new_blocks = bt.get_consecutive_blocks(
             1,


### PR DESCRIPTION
Currently `create_bundle_from_mempool()` returns 3 values, the spend bundle, additions and removals. removals are available in the SpendBundle and so do not provide great benefits of returning.

This removes the `removals` return value to just return the SpendBundle and additions. Note that additions would still be expensive to re-compute from the SpendBundle, so they make sense to return