### PR TITLE
daemon: Fix server shutdown / wait for it

### DIFF
--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -81,8 +81,7 @@ async def setup_daemon(btools: BlockTools) -> AsyncGenerator[WebSocketServer, No
     ca_crt_path = root_path / config["private_ssl_ca"]["crt"]
     ca_key_path = root_path / config["private_ssl_ca"]["key"]
     with Lockfile.create(daemon_launch_lock_path(root_path)):
-        shutdown_event = asyncio.Event()
-        ws_server = WebSocketServer(root_path, ca_crt_path, ca_key_path, crt_path, key_path, shutdown_event)
+        ws_server = WebSocketServer(root_path, ca_crt_path, ca_key_path, crt_path, key_path)
         await ws_server.start()
 
         yield ws_server

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -82,11 +82,8 @@ async def setup_daemon(btools: BlockTools) -> AsyncGenerator[WebSocketServer, No
     ca_key_path = root_path / config["private_ssl_ca"]["key"]
     with Lockfile.create(daemon_launch_lock_path(root_path)):
         ws_server = WebSocketServer(root_path, ca_crt_path, ca_key_path, crt_path, key_path)
-        await ws_server.start()
-
-        yield ws_server
-
-        await ws_server.stop()
+        async with ws_server.run():
+            yield ws_server
 
 
 async def setup_full_node(

--- a/chia/simulator/simulator_test_tools.py
+++ b/chia/simulator/simulator_test_tools.py
@@ -159,10 +159,6 @@ async def get_full_chia_simulator(
 
         ws_server = WebSocketServer(chia_root, ca_crt_path, ca_key_path, crt_path, key_path)
         await ws_server.setup_process_global_state()
-        await ws_server.start()
-
-        async for simulator in start_simulator(chia_root, automated_testing):
-            yield simulator, chia_root, config, mnemonic, fingerprint, keychain
-
-        await ws_server.stop()
-        await ws_server.shutdown_event.wait()  # wait till shutdown is complete
+        async with ws_server.run():
+            async for simulator in start_simulator(chia_root, automated_testing):
+                yield simulator, chia_root, config, mnemonic, fingerprint, keychain

--- a/chia/simulator/simulator_test_tools.py
+++ b/chia/simulator/simulator_test_tools.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import sys
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, Optional, Tuple
@@ -158,8 +157,7 @@ async def get_full_chia_simulator(
         ca_crt_path = chia_root / config["private_ssl_ca"]["crt"]
         ca_key_path = chia_root / config["private_ssl_ca"]["key"]
 
-        shutdown_event = asyncio.Event()
-        ws_server = WebSocketServer(chia_root, ca_crt_path, ca_key_path, crt_path, key_path, shutdown_event)
+        ws_server = WebSocketServer(chia_root, ca_crt_path, ca_key_path, crt_path, key_path)
         await ws_server.setup_process_global_state()
         await ws_server.start()
 
@@ -167,4 +165,4 @@ async def get_full_chia_simulator(
             yield simulator, chia_root, config, mnemonic, fingerprint, keychain
 
         await ws_server.stop()
-        await shutdown_event.wait()  # wait till shutdown is complete
+        await ws_server.shutdown_event.wait()  # wait till shutdown is complete


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Make sure the daemon server gets always closed properly. 

This is an alternative to #14663.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The daemon server shutdown isn't awaited which leads to spammy logs in some cases.

### New Behavior:

The daemon server shutdown gets awaited properly. 

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I tried all ways to start/stop a daemon (CLI/GUI) and all seemed to work fine. 
