### PR TITLE
simplify fee estimator by not leaking MempoolItem into its interface

### DIFF
--- a/chia/full_node/bitcoin_fee_estimator.py
+++ b/chia/full_node/bitcoin_fee_estimator.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from chia.full_node.fee_estimate_store import FeeStore
-from chia.full_node.fee_estimation import EmptyFeeMempoolInfo, FeeBlockInfo, FeeMempoolInfo
+from chia.full_node.fee_estimation import EmptyFeeMempoolInfo, FeeBlockInfo, FeeMempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator import SmartFeeEstimator
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.full_node.fee_tracker import FeeTracker
 from chia.types.clvm_cost import CLVMCost
 from chia.types.fee_rate import FeeRateV2
-from chia.types.mempool_item import MempoolItem
 from chia.util.ints import uint32, uint64
 
 
@@ -35,11 +34,11 @@ class BitcoinFeeEstimator(FeeEstimatorInterface):
         self.block_height = block_info.block_height
         self.tracker.process_block(block_info.block_height, block_info.included_items)
 
-    def add_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
+    def add_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItemInfo) -> None:
         self.last_mempool_info = mempool_info
         self.tracker.add_tx(mempool_item)
 
-    def remove_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
+    def remove_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItemInfo) -> None:
         self.last_mempool_info = mempool_info
         self.tracker.remove_tx(mempool_item)
 

--- a/chia/full_node/fee_estimation.py
+++ b/chia/full_node/fee_estimation.py
@@ -6,9 +6,24 @@ from typing import List
 
 from chia.types.clvm_cost import CLVMCost
 from chia.types.fee_rate import FeeRate
-from chia.types.mempool_item import MempoolItem
 from chia.types.mojos import Mojos
 from chia.util.ints import uint32, uint64
+
+
+@dataclass(frozen=True)
+class MempoolItemInfo:
+    """
+    The information the fee estimator is passed for each mempool item that's
+    added, removed from the mempool and included in blocks
+    """
+
+    cost: int
+    fee: int
+    height_added_to_mempool: uint32
+
+    @property
+    def fee_per_cost(self) -> float:
+        return self.fee / self.cost
 
 
 @dataclass(frozen=True)
@@ -75,4 +90,4 @@ class FeeBlockInfo:  # See BlockRecord
     """
 
     block_height: uint32
-    included_items: List[MempoolItem]
+    included_items: List[MempoolItemInfo]

--- a/chia/full_node/fee_estimator_example.py
+++ b/chia/full_node/fee_estimator_example.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from chia.full_node.fee_estimate import FeeEstimateV2
-from chia.full_node.fee_estimation import FeeBlockInfo, FeeMempoolInfo
+from chia.full_node.fee_estimation import FeeBlockInfo, FeeMempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.types.clvm_cost import CLVMCost
 from chia.types.fee_rate import FeeRateV2
-from chia.types.mempool_item import MempoolItem
 from chia.util.ints import uint64
 
 MIN_MOJO_PER_COST = 5
@@ -31,10 +30,10 @@ class FeeEstimatorExample(FeeEstimatorInterface):
     def new_block(self, block_info: FeeBlockInfo) -> None:
         pass
 
-    def add_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
+    def add_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItemInfo) -> None:
         pass
 
-    def remove_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
+    def remove_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItemInfo) -> None:
         pass
 
     def estimate_fee_rate(self, *, time_offset_seconds: int) -> FeeRateV2:

--- a/chia/full_node/fee_estimator_interface.py
+++ b/chia/full_node/fee_estimator_interface.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing_extensions import Protocol
 
-from chia.full_node.fee_estimation import FeeBlockInfo, FeeMempoolInfo
+from chia.full_node.fee_estimation import FeeBlockInfo, FeeMempoolInfo, MempoolItemInfo
 from chia.types.clvm_cost import CLVMCost
 from chia.types.fee_rate import FeeRateV2
-from chia.types.mempool_item import MempoolItem
 from chia.util.ints import uint32
 
 
@@ -18,11 +17,11 @@ class FeeEstimatorInterface(Protocol):
         """A new transaction block has been added to the blockchain"""
         pass
 
-    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
+    def add_mempool_item(self, mempool_item_info: FeeMempoolInfo, mempool_item: MempoolItemInfo) -> None:
         """A MempoolItem (transaction and associated info) has been added to the mempool"""
         pass
 
-    def remove_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItem) -> None:
+    def remove_mempool_item(self, mempool_info: FeeMempoolInfo, mempool_item: MempoolItemInfo) -> None:
         """A MempoolItem (transaction and associated info) has been removed from the mempool"""
         pass
 

--- a/chia/full_node/fee_tracker.py
+++ b/chia/full_node/fee_tracker.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 from chia.full_node.fee_estimate_store import FeeStore
+from chia.full_node.fee_estimation import MempoolItemInfo
 from chia.full_node.fee_estimator_constants import (
     FEE_ESTIMATOR_VERSION,
     INFINITE_FEE_RATE,
@@ -26,7 +27,6 @@ from chia.full_node.fee_estimator_constants import (
     SUFFICIENT_FEE_TXS,
 )
 from chia.full_node.fee_history import FeeStatBackup, FeeTrackerBackup
-from chia.types.mempool_item import MempoolItem
 from chia.util.ints import uint8, uint32, uint64
 
 
@@ -129,7 +129,7 @@ class FeeStat:  # TxConfirmStats
 
         self.old_unconfirmed_txs = [0 for _ in range(0, len(buckets))]
 
-    def tx_confirmed(self, blocks_to_confirm: int, item: MempoolItem) -> None:
+    def tx_confirmed(self, blocks_to_confirm: int, item: MempoolItemInfo) -> None:
         if blocks_to_confirm < 1:
             raise ValueError("tx_confirmed called with < 1 block to confirm")
 
@@ -164,7 +164,7 @@ class FeeStat:  # TxConfirmStats
         self.unconfirmed_txs[block_index][bucket_index] += 1
         return bucket_index
 
-    def remove_tx(self, latest_seen_height: uint32, item: MempoolItem, bucket_index: int) -> None:
+    def remove_tx(self, latest_seen_height: uint32, item: MempoolItemInfo, bucket_index: int) -> None:
         if item.height_added_to_mempool is None:
             return
         block_ago = latest_seen_height - item.height_added_to_mempool
@@ -475,7 +475,7 @@ class FeeTracker:
         )
         self.fee_store.store_fee_data(backup)
 
-    def process_block(self, block_height: uint32, items: List[MempoolItem]) -> None:
+    def process_block(self, block_height: uint32, items: List[MempoolItemInfo]) -> None:
         """A new block has been farmed and these transactions have been included in that block"""
         if block_height <= self.latest_seen_height:
             # Ignore reorgs
@@ -498,7 +498,7 @@ class FeeTracker:
             self.first_recorded_height = block_height
             self.log.info(f"Fee Estimator first recorded height: {self.first_recorded_height}")
 
-    def process_block_tx(self, current_height: uint32, item: MempoolItem) -> None:
+    def process_block_tx(self, current_height: uint32, item: MempoolItemInfo) -> None:
         if item.height_added_to_mempool is None:
             raise ValueError("process_block_tx called with item.height_added_to_mempool=None")
 
@@ -510,7 +510,7 @@ class FeeTracker:
         self.med_horizon.tx_confirmed(blocks_to_confirm, item)
         self.long_horizon.tx_confirmed(blocks_to_confirm, item)
 
-    def add_tx(self, item: MempoolItem) -> None:
+    def add_tx(self, item: MempoolItemInfo) -> None:
         if item.height_added_to_mempool < self.latest_seen_height:
             self.log.info(f"Processing Item from pending pool: cost={item.cost} fee={item.fee}")
 
@@ -521,7 +521,7 @@ class FeeTracker:
         self.med_horizon.new_mempool_tx(self.latest_seen_height, bucket_index)
         self.long_horizon.new_mempool_tx(self.latest_seen_height, bucket_index)
 
-    def remove_tx(self, item: MempoolItem) -> None:
+    def remove_tx(self, item: MempoolItemInfo) -> None:
         bucket_index = get_bucket_index(self.buckets, item.fee_per_cost * 1000)
         self.short_horizon.remove_tx(self.latest_seen_height, item, bucket_index)
         self.med_horizon.remove_tx(self.latest_seen_height, item, bucket_index)

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 
 from sortedcontainers import SortedDict
 
-from chia.full_node.fee_estimation import FeeMempoolInfo, MempoolInfo
+from chia.full_node.fee_estimation import FeeMempoolInfo, MempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -111,7 +111,9 @@ class Mempool:
             assert self._total_mempool_cost >= 0
             info = FeeMempoolInfo(self.mempool_info, self._total_mempool_cost, self._total_mempool_fees, datetime.now())
             if reason != MempoolRemoveReason.BLOCK_INCLUSION:
-                self.fee_estimator.remove_mempool_item(info, item)
+                self.fee_estimator.remove_mempool_item(
+                    info, MempoolItemInfo(item.cost, item.fee, item.height_added_to_mempool)
+                )
 
     def add_to_pool(self, item: MempoolItem) -> None:
         """
@@ -143,7 +145,7 @@ class Mempool:
         self._total_mempool_cost = CLVMCost(uint64(self._total_mempool_cost + item.cost))
         self._total_mempool_fees = self._total_mempool_fees + item.fee
         info = FeeMempoolInfo(self.mempool_info, self._total_mempool_cost, self._total_mempool_fees, datetime.now())
-        self.fee_estimator.add_mempool_item(info, item)
+        self.fee_estimator.add_mempool_item(info, MempoolItemInfo(item.cost, item.fee, item.height_added_to_mempool))
 
     def at_full_capacity(self, cost: int) -> bool:
         """


### PR DESCRIPTION
This is a step towards isolating the `Mempool` implementation by preventing `MempoolItem` "leak" out of it. It simplifies the sqlite mempool patch I'm working on as well as making it cheaper to interact with the fee estimator.