### PR TITLE
Improve chia wallet check help and diagnostic messages

### DIFF
--- a/chia/cmds/check_wallet_db.py
+++ b/chia/cmds/check_wallet_db.py
@@ -16,6 +16,27 @@ from chia.wallet.util.wallet_types import WalletType
 # TODO: Check for missing paired wallets (eg. No DID wallet for an NFT)
 # TODO: Check for missing DID Wallets
 
+help_text = """
+\b
+    The purpose of this command is find potential issues in Chia wallet databases.
+    The core chia client currently uses sqlite to store the wallet databases, one database per key.
+\b
+    Guide to warning diagnostics:
+    ----------------------------
+    "Missing Wallet IDs": A wallet was created and later deleted. By itself, this is okay because
+                          the wallet does not reuse wallet IDs. However, this information may be useful
+                          in conjunction with other information.
+\b
+    Guide to error diagnostics:
+    --------------------------
+    Diagnostics in the error section indicate an error in the database structure.
+    In general, this does not indicate an error in on-chain data, nor does it mean that you have lost coins.
+\b
+    An example is "Missing DerivationPath indexes" - a derivation path is a sub-key of your master key. Missing
+    derivation paths could cause your wallet to not "know" about transactions that happened on the blockchain.
+\b
+"""
+
 
 def _validate_args_addresses_used(wallet_id: int, last_index: int, last_hardened: int, dp: DerivationPath) -> None:
     if last_hardened:
@@ -335,7 +356,8 @@ class WalletDBReader:
 
         return errors
 
-    async def scan(self, db_path: Path) -> None:
+    async def scan(self, db_path: Path) -> int:
+        """Returns number of lines of error output (not warnings)"""
         self.db_wrapper = await DBWrapper2.create(
             database=db_path,
             reader_count=self.config.get("db_readers", 4),
@@ -345,27 +367,29 @@ class WalletDBReader:
         # TODO: Pass down db_wrapper
         wallets = await self.get_all_wallets()
         derivation_paths = await self.get_derivation_paths()
+        errors = []
+        warnings = []
         try:
-            errors = []
-
             if self.verbose:
                 await self.show_tables()
                 print_min_max_derivation_for_wallets(derivation_paths)
 
-            errors.extend(await self.check_wallets())
+            warnings.extend(await self.check_wallets())
+
             errors.extend(self.check_wallets_missing_derivations(wallets, derivation_paths))
             errors.extend(self.check_unexpected_derivation_entries(wallets, derivation_paths))
             errors.extend(self.check_derivations_are_compact(wallets, derivation_paths))
             errors.extend(check_addresses_used_contiguous(derivation_paths))
 
+            if len(warnings) > 0:
+                print(f"    ---- Warnings Found for {db_path.name} ----")
+                print("\n".join(warnings))
             if len(errors) > 0:
-                print("\n    ---- Errors Found ----")
+                print(f"    ---- Errors Found for {db_path.name}----")
                 print("\n".join(errors))
-                sys.exit(2)
-            else:
-                print("No errors found.\n")
         finally:
             await self.db_wrapper.close()
+        return len(errors)
 
 
 async def scan(root_path: str, db_path: Optional[str] = None, *, verbose: bool = False) -> None:
@@ -375,11 +399,15 @@ async def scan(root_path: str, db_path: Optional[str] = None, *, verbose: bool =
     else:
         wallet_db_paths = [Path(db_path)]
 
+    num_errors = 0
     for wallet_db_path in wallet_db_paths:
         w = WalletDBReader()
         w.verbose = verbose
         print(f"Reading {wallet_db_path}")
-        await w.scan(Path(wallet_db_path))
+        num_errors += await w.scan(Path(wallet_db_path))
+
+    if num_errors > 0:
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import click
 
+from chia.cmds.check_wallet_db import help_text as check_help_text
 from chia.cmds.cmds_util import execute_with_wallet
 from chia.cmds.coins import coins_cmd
 from chia.cmds.plotnft import validate_fee
@@ -515,7 +516,7 @@ def cancel_offer_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: str, 
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, cancel_offer))
 
 
-@wallet_cmd.command("check", short_help="Check wallet DB integrity")
+@wallet_cmd.command("check", short_help="Check wallet DB integrity", help=check_help_text)
 @click.option("-v", "--verbose", help="Print more information", is_flag=True)
 @click.option("--db-path", help="The path to a wallet DB. Default is to scan all active wallet DBs.")
 @click.pass_context


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
New `chia wallet check` help message has more information.
`chia wallet check` now distinguishes errors and warnings.



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
```bash
chia wallet check -h 

Options:
  -v, --verbose   Print more information
  --db-path TEXT  The path to a wallet DB. Default is to scan all active
                  wallet DBs.
  -h, --help      Show this message and exit.
```


### New Behavior:

```bash
chia wallet check -h
Usage: chia wallet check [OPTIONS]

      The purpose of this command is find potential issues in Chia wallet databases.
      The core chia client currently uses sqlite to store the wallet databases, one database per key.

      Guide to warning diagnostics:
      ----------------------------
      "Missing Wallet IDs": A wallet was created and later deleted. By itself, this is okay because
                            the wallet does not reuse wallet IDs. However, this information may be useful
                            in conjunction with other information.

      Guide to error diagnostics:
      --------------------------
      Diagnostics in the error section indicate an error in the database structure.
      In general, this does not indicate an error in on-chain data, nor does it mean that you have lost coins.

      An example is "Missing DerivationPath indexes" - a derivation path is a sub-key of your master key. Missing
      derivation paths could cause your wallet to not "know" about transactions that happened on the blockchain.


Options:
  -v, --verbose   Print more information
  --db-path TEXT  The path to a wallet DB. Default is to scan all active
                  wallet DBs.
  -h, --help      Show this message and exit.
```


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
