### PR TITLE
Soft fork2 tests

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -319,6 +319,7 @@ async def validate_block_body(
                     cost_per_byte=constants.COST_PER_BYTE,
                     mempool_mode=False,
                     height=curr.height,
+                    constants=constants,
                 )
                 removals_in_curr, additions_in_curr = tx_removals_and_additions(curr_npc_result.conds)
             else:

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -94,6 +94,7 @@ def batch_pre_validate_blocks(
                         cost_per_byte=constants.COST_PER_BYTE,
                         mempool_mode=False,
                         height=block.height,
+                        constants=constants,
                     )
                     removals, tx_additions = tx_removals_and_additions(npc_result.conds)
                 if npc_result is not None and npc_result.error is not None:

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -8,6 +8,7 @@ from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_
 from chia_rs import run_block_generator, run_chia_program
 from clvm.casts import int_from_bytes
 
+from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
@@ -33,7 +34,13 @@ log = logging.getLogger(__name__)
 
 
 def get_name_puzzle_conditions(
-    generator: BlockGenerator, max_cost: int, *, cost_per_byte: int, mempool_mode: bool, height: Optional[uint32] = None
+    generator: BlockGenerator,
+    max_cost: int,
+    *,
+    cost_per_byte: int,
+    mempool_mode: bool,
+    height: Optional[uint32] = None,
+    constants: ConsensusConstants = DEFAULT_CONSTANTS,
 ) -> NPCResult:
     # in mempool mode, the height doesn't matter, because it's always strict.
     # But otherwise, height must be specified to know which rules to apply
@@ -41,9 +48,9 @@ def get_name_puzzle_conditions(
 
     if mempool_mode:
         flags = MEMPOOL_MODE
-    elif height is not None and height >= DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT:
+    elif height is not None and height >= constants.SOFT_FORK2_HEIGHT:
         flags = LIMIT_STACK | ENABLE_ASSERT_BEFORE
-    elif height is not None and height >= DEFAULT_CONSTANTS.SOFT_FORK_HEIGHT:
+    elif height is not None and height >= constants.SOFT_FORK_HEIGHT:
         flags = LIMIT_STACK
     else:
         flags = 0

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1680,6 +1680,10 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
 
+co = ConditionOpcode
+rbr = ReceiveBlockResult
+
+
 class TestPreValidation:
     @pytest.mark.asyncio
     async def test_pre_validation_fails_bad_blocks(self, empty_blockchain, bt):
@@ -1871,27 +1875,27 @@ class TestBodyValidation:
     @pytest.mark.parametrize(
         "opcode,lock_value,expected,with_garbage",
         [
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -2, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -1, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 1, ReceiveBlockResult.INVALID_BLOCK, False),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -2, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -1, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0, ReceiveBlockResult.INVALID_BLOCK, False),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 1, ReceiveBlockResult.INVALID_BLOCK, False),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 2, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 3, ReceiveBlockResult.INVALID_BLOCK, False),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 4, ReceiveBlockResult.INVALID_BLOCK, False),
+            (co.ASSERT_SECONDS_RELATIVE, -2, rbr.NEW_PEAK, False),
+            (co.ASSERT_SECONDS_RELATIVE, -1, rbr.NEW_PEAK, False),
+            (co.ASSERT_SECONDS_RELATIVE, 0, rbr.NEW_PEAK, False),
+            (co.ASSERT_SECONDS_RELATIVE, 1, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_HEIGHT_RELATIVE, -2, rbr.NEW_PEAK, False),
+            (co.ASSERT_HEIGHT_RELATIVE, -1, rbr.NEW_PEAK, False),
+            (co.ASSERT_HEIGHT_RELATIVE, 0, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_HEIGHT_RELATIVE, 1, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 2, rbr.NEW_PEAK, False),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 3, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 4, rbr.INVALID_BLOCK, False),
             # genesis timestamp is 10000 and each block is 10 seconds
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10029, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10030, ReceiveBlockResult.NEW_PEAK, False),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10031, ReceiveBlockResult.INVALID_BLOCK, False),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10032, ReceiveBlockResult.INVALID_BLOCK, False),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10029, rbr.NEW_PEAK, False),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10030, rbr.NEW_PEAK, False),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10031, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10032, rbr.INVALID_BLOCK, False),
             # additional garbage at the end of parameters
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0, ReceiveBlockResult.NEW_PEAK, True),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -1, ReceiveBlockResult.NEW_PEAK, True),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 2, ReceiveBlockResult.NEW_PEAK, True),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10029, ReceiveBlockResult.NEW_PEAK, True),
+            (co.ASSERT_SECONDS_RELATIVE, 0, rbr.NEW_PEAK, True),
+            (co.ASSERT_HEIGHT_RELATIVE, -1, rbr.NEW_PEAK, True),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 2, rbr.NEW_PEAK, True),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10029, rbr.NEW_PEAK, True),
         ],
     )
     async def test_ephemeral_timelock(self, empty_blockchain, opcode, lock_value, expected, with_garbage, bt):

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import multiprocessing
 import time
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from secrets import token_bytes
 from typing import List
@@ -15,6 +16,7 @@ from chia.consensus.block_header_validation import validate_finished_header_bloc
 from chia.consensus.block_rewards import calculate_base_farmer_reward
 from chia.consensus.blockchain import ReceiveBlockResult
 from chia.consensus.coinbase import create_farmer_coin
+from chia.consensus.constants import ConsensusConstants
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.bundle_tools import detect_potential_template_generator
@@ -57,6 +59,20 @@ from tests.util.blockchain import create_blockchain
 
 log = logging.getLogger(__name__)
 bad_element = ClassgroupElement.from_bytes(b"\x00")
+
+
+@asynccontextmanager
+async def make_empty_blockchain(constants: ConsensusConstants = test_constants):
+    """
+    Provides a list of 10 valid blocks, as well as a blockchain with 9 blocks added to it.
+    """
+
+    bc, db_wrapper, db_path = await create_blockchain(constants, 2)
+    yield bc
+
+    await db_wrapper.close()
+    bc.shut_down()
+    db_path.unlink()
 
 
 class TestGenesisBlock:
@@ -1872,6 +1888,7 @@ class TestBodyValidation:
         assert (res, error, state_change.fork_height if state_change else None) == expected
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("with_softfork2", [False, True])
     @pytest.mark.parametrize(
         "opcode,lock_value,expected,with_garbage",
         [
@@ -1898,56 +1915,65 @@ class TestBodyValidation:
             (co.ASSERT_SECONDS_ABSOLUTE, 10029, rbr.NEW_PEAK, True),
         ],
     )
-    async def test_ephemeral_timelock(self, empty_blockchain, opcode, lock_value, expected, with_garbage, bt):
-        b = empty_blockchain
-        blocks = bt.get_consecutive_blocks(
-            3,
-            guarantee_transaction_block=True,
-            farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
-            genesis_timestamp=10000,
-            time_per_block=10,
-        )
-        await _validate_and_add_block(empty_blockchain, blocks[0])
-        await _validate_and_add_block(empty_blockchain, blocks[1])
-        await _validate_and_add_block(empty_blockchain, blocks[2])
+    async def test_ephemeral_timelock(self, opcode, lock_value, expected, with_garbage, with_softfork2, bt):
+        if with_softfork2:
+            # enable softfork2 at height 0, to make it apply to this test
+            constants = test_constants.replace(SOFT_FORK2_HEIGHT=0)
+        else:
+            constants = test_constants
 
-        wt: WalletTool = bt.get_pool_wallet_tool()
+        async with make_empty_blockchain(constants) as b:
 
-        conditions = {
-            opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)] + ([b"garbage"] if with_garbage else []))]
-        }
+            blocks = bt.get_consecutive_blocks(
+                3,
+                guarantee_transaction_block=True,
+                farmer_reward_puzzle_hash=bt.pool_ph,
+                pool_reward_puzzle_hash=bt.pool_ph,
+                genesis_timestamp=10000,
+                time_per_block=10,
+            )
+            await _validate_and_add_block(b, blocks[0])
+            await _validate_and_add_block(b, blocks[1])
+            await _validate_and_add_block(b, blocks[2])
 
-        tx1: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
-        )
-        coin1: Coin = tx1.additions()[0]
-        tx2: SpendBundle = wt.generate_signed_transaction(10, wt.get_new_puzzlehash(), coin1, condition_dic=conditions)
-        assert coin1 in tx2.removals()
-        coin2: Coin = tx2.additions()[0]
+            wt: WalletTool = bt.get_pool_wallet_tool()
 
-        bundles = SpendBundle.aggregate([tx1, tx2])
-        blocks = bt.get_consecutive_blocks(
-            1,
-            block_list_input=blocks,
-            guarantee_transaction_block=True,
-            transaction_data=bundles,
-            time_per_block=10,
-        )
+            conditions = {
+                opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)] + ([b"garbage"] if with_garbage else []))]
+            }
 
-        pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-            [blocks[-1]], {}, validate_signatures=True
-        )
-        assert pre_validation_results is not None
-        assert (await b.receive_block(blocks[-1], pre_validation_results[0]))[0] == expected
+            tx1: SpendBundle = wt.generate_signed_transaction(
+                10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            )
+            coin1: Coin = tx1.additions()[0]
+            tx2: SpendBundle = wt.generate_signed_transaction(
+                10, wt.get_new_puzzlehash(), coin1, condition_dic=conditions
+            )
+            assert coin1 in tx2.removals()
+            coin2: Coin = tx2.additions()[0]
 
-        if expected == ReceiveBlockResult.NEW_PEAK:
-            # ensure coin1 was in fact spent
-            c = await b.coin_store.get_coin_record(coin1.name())
-            assert c is not None and c.spent
-            # ensure coin2 was NOT spent
-            c = await b.coin_store.get_coin_record(coin2.name())
-            assert c is not None and not c.spent
+            bundles = SpendBundle.aggregate([tx1, tx2])
+            blocks = bt.get_consecutive_blocks(
+                1,
+                block_list_input=blocks,
+                guarantee_transaction_block=True,
+                transaction_data=bundles,
+                time_per_block=10,
+            )
+
+            pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
+                [blocks[-1]], {}, validate_signatures=True
+            )
+            assert pre_validation_results is not None
+            assert (await b.receive_block(blocks[-1], pre_validation_results[0]))[0] == expected
+
+            if expected == ReceiveBlockResult.NEW_PEAK:
+                # ensure coin1 was in fact spent
+                c = await b.coin_store.get_coin_record(coin1.name())
+                assert c is not None and c.spent
+                # ensure coin2 was NOT spent
+                c = await b.coin_store.get_coin_record(coin2.name())
+                assert c is not None and not c.spent
 
     @pytest.mark.asyncio
     async def test_not_tx_block_but_has_data(self, empty_blockchain, bt):

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -59,13 +59,18 @@ async def check_spend_bundle_validity(
     blocks: List[FullBlock],
     spend_bundle: SpendBundle,
     expected_err: Optional[Err] = None,
+    softfork2: bool = False,
 ) -> Tuple[List[CoinRecord], List[CoinRecord]]:
     """
     This test helper create an extra block after the given blocks that contains the given
     `SpendBundle`, and then invokes `receive_block` to ensure that it's accepted (if `expected_err=None`)
     or fails with the correct error code.
     """
-    constants = bt.constants
+    if softfork2:
+        constants = bt.constants.replace(SOFT_FORK2_HEIGHT=0)
+    else:
+        constants = bt.constants
+
     db_wrapper, blockchain = await create_ram_blockchain(constants)
     try:
         for block in blocks:
@@ -99,7 +104,11 @@ async def check_spend_bundle_validity(
 
 
 async def check_conditions(
-    bt: BlockTools, condition_solution: Program, expected_err: Optional[Err] = None, spend_reward_index: int = -2
+    bt: BlockTools,
+    condition_solution: Program,
+    expected_err: Optional[Err] = None,
+    spend_reward_index: int = -2,
+    softfork2: bool = False,
 ):
     blocks = await initial_blocks(bt)
     coin = list(blocks[spend_reward_index].get_included_reward_coins())[0]
@@ -109,7 +118,7 @@ async def check_conditions(
 
     # now let's try to create a block with the spend bundle and ensure that it doesn't validate
 
-    await check_spend_bundle_validity(bt, blocks, spend_bundle, expected_err=expected_err)
+    await check_spend_bundle_validity(bt, blocks, spend_bundle, expected_err=expected_err, softfork2=softfork2)
 
 
 co = ConditionOpcode
@@ -117,6 +126,7 @@ co = ConditionOpcode
 
 class TestConditions:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("softfork2", [True, False])
     @pytest.mark.parametrize(
         "opcode,value,expected",
         [
@@ -148,9 +158,9 @@ class TestConditions:
             (co.ASSERT_SECONDS_RELATIVE, 0, None),
         ],
     )
-    async def test_condition(self, opcode, value, expected, bt):
+    async def test_condition(self, opcode, value, expected, bt, softfork2):
         conditions = Program.to(assemble(f"(({opcode[0]} {value}))"))
-        await check_conditions(bt, conditions, expected_err=expected)
+        await check_conditions(bt, conditions, expected_err=expected, softfork2=softfork2)
 
     @pytest.mark.asyncio
     async def test_invalid_my_id(self, bt):

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -112,6 +112,9 @@ async def check_conditions(
     await check_spend_bundle_validity(bt, blocks, spend_bundle, expected_err=expected_err)
 
 
+co = ConditionOpcode
+
+
 class TestConditions:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -121,28 +124,28 @@ class TestConditions:
             # the coin being spent was created in the 3rd block
             # ensure invalid heights fail and pass correctly, depending on
             # which end of the range they exceed
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -1, None),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0, None),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0x100000000, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, -1, None),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 0, None),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 0x100000000, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -1, None),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0, None),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0x10000000000000000, Err.ASSERT_SECONDS_RELATIVE_FAILED),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, -1, None),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 0, None),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 0x10000000000000000, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
+            (co.ASSERT_HEIGHT_RELATIVE, -1, None),
+            (co.ASSERT_HEIGHT_RELATIVE, 0, None),
+            (co.ASSERT_HEIGHT_RELATIVE, 0x100000000, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+            (co.ASSERT_HEIGHT_ABSOLUTE, -1, None),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 0, None),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 0x100000000, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
+            (co.ASSERT_SECONDS_RELATIVE, -1, None),
+            (co.ASSERT_SECONDS_RELATIVE, 0, None),
+            (co.ASSERT_SECONDS_RELATIVE, 0x10000000000000000, Err.ASSERT_SECONDS_RELATIVE_FAILED),
+            (co.ASSERT_SECONDS_ABSOLUTE, -1, None),
+            (co.ASSERT_SECONDS_ABSOLUTE, 0, None),
+            (co.ASSERT_SECONDS_ABSOLUTE, 0x10000000000000000, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
             # test boundary values
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 2, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 1, None),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 4, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 3, None),
+            (co.ASSERT_HEIGHT_RELATIVE, 2, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+            (co.ASSERT_HEIGHT_RELATIVE, 1, None),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 4, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 3, None),
             # genesis timestamp is 10000 and each block is 10 seconds
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10049, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10000, None),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 30, Err.ASSERT_SECONDS_RELATIVE_FAILED),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0, None),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10049, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10000, None),
+            (co.ASSERT_SECONDS_RELATIVE, 30, Err.ASSERT_SECONDS_RELATIVE_FAILED),
+            (co.ASSERT_SECONDS_RELATIVE, 0, None),
         ],
     )
     async def test_condition(self, opcode, value, expected, bt):

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -431,41 +431,35 @@ async def test_sb_twice_with_eligible_coin_and_different_spends_order() -> None:
     assert mempool_manager.get_spendbundle(reordered_sb_name) is None
 
 
+co = ConditionOpcode
+mis = MempoolInclusionStatus
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "opcode,lock_value,expected_status,expected_error",
     [
-        (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -2, MempoolInclusionStatus.SUCCESS, None),
-        (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -1, MempoolInclusionStatus.SUCCESS, None),
+        (co.ASSERT_SECONDS_RELATIVE, -2, mis.SUCCESS, None),
+        (co.ASSERT_SECONDS_RELATIVE, -1, mis.SUCCESS, None),
         # The rules allow spending an ephemeral coin with an ASSERT_SECONDS_RELATIVE 0 condition
-        (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0, MempoolInclusionStatus.SUCCESS, None),
-        (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 1, MempoolInclusionStatus.FAILED, Err.ASSERT_SECONDS_RELATIVE_FAILED),
-        (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -2, MempoolInclusionStatus.SUCCESS, None),
-        (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -1, MempoolInclusionStatus.SUCCESS, None),
+        (co.ASSERT_SECONDS_RELATIVE, 0, mis.SUCCESS, None),
+        (co.ASSERT_SECONDS_RELATIVE, 1, mis.FAILED, Err.ASSERT_SECONDS_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, -2, mis.SUCCESS, None),
+        (co.ASSERT_HEIGHT_RELATIVE, -1, mis.SUCCESS, None),
         # Unlike ASSERT_SECONDS_RELATIVE, for ASSERT_HEIGHT_RELATIVE the block height
         # must be greater than the coin creation height + the argument, which means
         # the coin cannot be spent in the same block (where the height would be the same)
-        (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0, MempoolInclusionStatus.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
-        (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 1, MempoolInclusionStatus.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
-        (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 4, MempoolInclusionStatus.SUCCESS, None),
-        (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 5, MempoolInclusionStatus.SUCCESS, None),
-        (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 6, MempoolInclusionStatus.PENDING, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
-        (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 7, MempoolInclusionStatus.PENDING, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, 0, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, 1, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_ABSOLUTE, 4, mis.SUCCESS, None),
+        (co.ASSERT_HEIGHT_ABSOLUTE, 5, mis.SUCCESS, None),
+        (co.ASSERT_HEIGHT_ABSOLUTE, 6, mis.PENDING, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
+        (co.ASSERT_HEIGHT_ABSOLUTE, 7, mis.PENDING, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
         # Current block timestamp is 10050
-        (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10049, MempoolInclusionStatus.SUCCESS, None),
-        (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10050, MempoolInclusionStatus.SUCCESS, None),
-        (
-            ConditionOpcode.ASSERT_SECONDS_ABSOLUTE,
-            10051,
-            MempoolInclusionStatus.FAILED,
-            Err.ASSERT_SECONDS_ABSOLUTE_FAILED,
-        ),
-        (
-            ConditionOpcode.ASSERT_SECONDS_ABSOLUTE,
-            10052,
-            MempoolInclusionStatus.FAILED,
-            Err.ASSERT_SECONDS_ABSOLUTE_FAILED,
-        ),
+        (co.ASSERT_SECONDS_ABSOLUTE, 10049, mis.SUCCESS, None),
+        (co.ASSERT_SECONDS_ABSOLUTE, 10050, mis.SUCCESS, None),
+        (co.ASSERT_SECONDS_ABSOLUTE, 10051, mis.FAILED, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
+        (co.ASSERT_SECONDS_ABSOLUTE, 10052, mis.FAILED, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
     ],
 )
 async def test_ephemeral_timelock(


### PR DESCRIPTION
This patch makes two categories of changes:
1. it introduces aliases for `MempoolInclusionStatus`, `ConditionOpcode` and `ReceivedBlockResult` in tests. This reduces noise in the test parameters. In the upcoming assert-before patch, these test will see a doubling in the number of test cases, so this makes that a bit more palatable.
2. It makes some tests cover both with and without soft-fork 2 activated. Since we can't reasonably make a test chain reach all the way up to the soft-fork 2 cut-off, this means changing the constants instead, which means passing them down to `get_name_puzzle_condition()`. Since there aren't any test cases that depend on soft-fork2 (yet), all the existing tests still pass without change. This is preparing for additional test cases for assert-before conditions.

These commits are best reviewed one at a time. The change to `test_blockchain.py` that fall into category (2) introduce an extra level of indentation, and are hence best reviewed ignoring white space.