### PR TITLE
fixup ephemeral coin test in test_mempool

### DIFF
--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -342,6 +342,10 @@ async def next_block(full_node_1, wallet_a, bt) -> Coin:
     return list(blocks[-1].get_included_reward_coins())[0]
 
 
+co = ConditionOpcode
+mis = MempoolInclusionStatus
+
+
 class TestMempoolManager:
     @pytest.mark.asyncio
     async def test_basic_mempool_manager(self, two_nodes_one_block, wallet_a, self_hostname):
@@ -367,26 +371,26 @@ class TestMempoolManager:
     @pytest.mark.parametrize(
         "opcode,lock_value,expected",
         [
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -2, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, -1, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 0, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_SECONDS_RELATIVE, 1, MempoolInclusionStatus.FAILED),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -2, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, -1, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 0, MempoolInclusionStatus.PENDING),
-            (ConditionOpcode.ASSERT_HEIGHT_RELATIVE, 1, MempoolInclusionStatus.PENDING),
+            (co.ASSERT_SECONDS_RELATIVE, -2, mis.SUCCESS),
+            (co.ASSERT_SECONDS_RELATIVE, -1, mis.SUCCESS),
+            (co.ASSERT_SECONDS_RELATIVE, 0, mis.SUCCESS),
+            (co.ASSERT_SECONDS_RELATIVE, 1, mis.FAILED),
+            (co.ASSERT_HEIGHT_RELATIVE, -2, mis.SUCCESS),
+            (co.ASSERT_HEIGHT_RELATIVE, -1, mis.SUCCESS),
+            (co.ASSERT_HEIGHT_RELATIVE, 0, mis.PENDING),
+            (co.ASSERT_HEIGHT_RELATIVE, 1, mis.PENDING),
             # the absolute height and seconds tests require fresh full nodes to
             # run the test on. The fixture (one_node_one_block) creates a block,
             # then condition_tester2 creates another 3 blocks
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 4, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 5, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 6, MempoolInclusionStatus.PENDING),
-            (ConditionOpcode.ASSERT_HEIGHT_ABSOLUTE, 7, MempoolInclusionStatus.PENDING),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 4, mis.SUCCESS),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 5, mis.SUCCESS),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 6, mis.PENDING),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 7, mis.PENDING),
             # genesis timestamp is 10000 and each block is 10 seconds
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10049, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10050, MempoolInclusionStatus.SUCCESS),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10051, MempoolInclusionStatus.FAILED),
-            (ConditionOpcode.ASSERT_SECONDS_ABSOLUTE, 10052, MempoolInclusionStatus.FAILED),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10049, mis.SUCCESS),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10050, mis.SUCCESS),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10051, mis.FAILED),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10052, mis.FAILED),
         ],
     )
     async def test_ephemeral_timelock(self, one_node_one_block, wallet_a, opcode, lock_value, expected):

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -396,9 +396,7 @@ class TestMempoolManager:
     async def test_ephemeral_timelock(self, one_node_one_block, wallet_a, opcode, lock_value, expected):
         def test_fun(coin_1: Coin, coin_2: Coin) -> SpendBundle:
             conditions = {opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)])]}
-            tx1 = wallet_a.generate_signed_transaction(
-                uint64(1000000), wallet_a.get_new_puzzlehash(), coin_2, conditions.copy(), uint64(0)
-            )
+            tx1 = wallet_a.generate_signed_transaction(uint64(1000000), wallet_a.get_new_puzzlehash(), coin_2)
 
             ephemeral_coin: Coin = tx1.additions()[0]
             tx2 = wallet_a.generate_signed_transaction(


### PR DESCRIPTION
This patch does 2 things:
1. uses shorter names for the constants in the test parameters for `test_ephemeral_timelock` (to make it easier to read)
2. fixes an old typo where the condition to test was applied both to the ephemeral coin *and* the coin creating it. It's meant to just test the ephemeral coin