### PR TITLE
Bump chia_rs to 0.2.3. and ASSERT_MY_BIRTH_*

### DIFF
--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -201,7 +201,16 @@ async def run_mempool_benchmark() -> None:
             npc_result = NPCResult(
                 None,
                 SpendBundleConditions(
-                    [Spend(coin_id, bytes32(b" " * 32), None, 0, None, None, [], [], 0)], 0, 0, 0, None, None, [], 0
+                    [Spend(coin_id, bytes32(b" " * 32), None, 0, None, None, None, None, [], [], 0)],
+                    0,
+                    0,
+                    0,
+                    None,
+                    None,
+                    [],
+                    0,
+                    0,
+                    0,
                 ),
                 uint64(1000000000),
             )
@@ -224,7 +233,16 @@ async def run_mempool_benchmark() -> None:
             npc_result = NPCResult(
                 None,
                 SpendBundleConditions(
-                    [Spend(coin_id, bytes32(b" " * 32), None, 0, None, None, [], [], 0)], 0, 0, 0, None, None, [], 0
+                    [Spend(coin_id, bytes32(b" " * 32), None, 0, None, None, None, None, [], [], 0)],
+                    0,
+                    0,
+                    0,
+                    None,
+                    None,
+                    [],
+                    0,
+                    0,
+                    0,
                 ),
                 uint64(1000000000),
             )

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -135,6 +135,12 @@ def mempool_check_time_locks(
 
     for spend in bundle_conds.spends:
         unspent = removal_coin_records[bytes32(spend.coin_id)]
+        if spend.birth_height is not None:
+            if spend.birth_height != unspent.confirmed_block_index:
+                return Err.ASSERT_MY_BIRTH_HEIGHT_FAILED
+        if spend.birth_seconds is not None:
+            if spend.birth_seconds != unspent.timestamp:
+                return Err.ASSERT_MY_BIRTH_SECONDS_FAILED
         if spend.height_relative is not None:
             if prev_transaction_block_height < unspent.confirmed_block_index + spend.height_relative:
                 return Err.ASSERT_HEIGHT_RELATIVE_FAILED

--- a/chia/types/condition_opcodes.py
+++ b/chia/types/condition_opcodes.py
@@ -33,6 +33,8 @@ class ConditionOpcode(bytes, enum.Enum):
     ASSERT_MY_PARENT_ID = bytes([71])
     ASSERT_MY_PUZZLEHASH = bytes([72])
     ASSERT_MY_AMOUNT = bytes([73])
+    ASSERT_MY_BIRTH_SECONDS = bytes([74])
+    ASSERT_MY_BIRTH_HEIGHT = bytes([75])
 
     # the conditions below ensure that we're "far enough" in the future
 

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -170,6 +170,9 @@ class Err(Enum):
     IMPOSSIBLE_HEIGHT_RELATIVE_CONSTRAINTS = 136
     IMPOSSIBLE_HEIGHT_ABSOLUTE_CONSTRAINTS = 137
 
+    ASSERT_MY_BIRTH_SECONDS_FAILED = 138
+    ASSERT_MY_BIRTH_HEIGHT_FAILED = 139
+
 
 class ValidationError(Exception):
     def __init__(self, code: Err, error_msg: str = ""):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     "chiapos==1.0.11",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
-    "chia_rs==0.2.2",
+    "chia_rs==0.2.3",
     "clvm-tools-rs==0.1.30",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.4",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1892,6 +1892,15 @@ class TestBodyValidation:
     @pytest.mark.parametrize(
         "opcode,lock_value,expected,with_garbage",
         [
+            (co.ASSERT_MY_BIRTH_HEIGHT, -1, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_MY_BIRTH_HEIGHT, 0x100000000, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_MY_BIRTH_HEIGHT, 2, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_MY_BIRTH_HEIGHT, 3, rbr.NEW_PEAK, False),
+            (co.ASSERT_MY_BIRTH_SECONDS, -1, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_MY_BIRTH_SECONDS, 0x10000000000000000, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_MY_BIRTH_SECONDS, 10029, rbr.INVALID_BLOCK, False),
+            (co.ASSERT_MY_BIRTH_SECONDS, 10030, rbr.NEW_PEAK, False),
+            (co.ASSERT_MY_BIRTH_SECONDS, 10031, rbr.INVALID_BLOCK, False),
             (co.ASSERT_SECONDS_RELATIVE, -2, rbr.NEW_PEAK, False),
             (co.ASSERT_SECONDS_RELATIVE, -1, rbr.NEW_PEAK, False),
             (co.ASSERT_SECONDS_RELATIVE, 0, rbr.NEW_PEAK, False),
@@ -1921,6 +1930,14 @@ class TestBodyValidation:
             constants = test_constants.replace(SOFT_FORK2_HEIGHT=0)
         else:
             constants = test_constants
+
+            # if the softfork is not active in this test, fixup all the
+            # tests to instead expect NEW_PEAK unconditionally
+            if opcode in [
+                ConditionOpcode.ASSERT_MY_BIRTH_HEIGHT,
+                ConditionOpcode.ASSERT_MY_BIRTH_SECONDS,
+            ]:
+                expected = ReceiveBlockResult.NEW_PEAK
 
         async with make_empty_blockchain(constants) as b:
 

--- a/tests/core/full_node/test_generator_tools.py
+++ b/tests/core/full_node/test_generator_tools.py
@@ -19,6 +19,8 @@ spends: List[Spend] = [
         uint64(5),
         None,
         None,
+        None,
+        None,
         [
             (phs[2], uint64(123), b""),
             (phs[3], uint64(0), b"1" * 300),
@@ -34,6 +36,8 @@ spends: List[Spend] = [
         uint64(2),
         None,
         None,
+        None,
+        None,
         [
             (phs[5], uint64(123), b""),
             (phs[6], uint64(0), b"1" * 300),
@@ -46,7 +50,7 @@ spends: List[Spend] = [
 
 
 def test_tx_removals_and_additions() -> None:
-    conditions = SpendBundleConditions(spends, uint64(0), uint32(0), uint64(0), None, None, [], uint64(0))
+    conditions = SpendBundleConditions(spends, uint64(0), uint32(0), uint64(0), None, None, [], uint64(0), 0, 0)
     expected_rems = [coin_ids[0], coin_ids[1]]
     expected_additions = []
     for spend in spends:

--- a/tests/core/full_node/test_hint_management.py
+++ b/tests/core/full_node/test_hint_management.py
@@ -26,6 +26,8 @@ spends: List[Spend] = [
         uint64(5),
         None,
         None,
+        None,
+        None,
         [
             (phs[2], uint64(123), b""),
             (phs[4], uint64(3), b"1" * 32),
@@ -38,6 +40,8 @@ spends: List[Spend] = [
         phs[0],
         None,
         uint64(6),
+        None,
+        None,
         None,
         None,
         [
@@ -53,6 +57,8 @@ spends: List[Spend] = [
         phs[7],
         None,
         uint64(2),
+        None,
+        None,
         None,
         None,
         [
@@ -77,7 +83,7 @@ async def test_hints_to_add(bt: BlockTools, empty_blockchain: Blockchain) -> Non
     br: Optional[BlockRecord] = empty_blockchain.get_peak()
     assert br is not None
     sbc: SpendBundleConditions = SpendBundleConditions(
-        spends, uint64(0), uint32(0), uint64(0), None, None, [], uint64(0)
+        spends, uint64(0), uint32(0), uint64(0), None, None, [], uint64(0), 0, 0
     )
     npc_res = [NPCResult(None, None, uint64(0)), NPCResult(None, sbc, uint64(0))]
 
@@ -99,7 +105,7 @@ async def test_lookup_coin_ids(bt: BlockTools, empty_blockchain: Blockchain) -> 
     br: Optional[BlockRecord] = empty_blockchain.get_peak()
     assert br is not None
     sbc: SpendBundleConditions = SpendBundleConditions(
-        spends, uint64(0), uint32(0), uint64(0), None, None, [], uint64(0)
+        spends, uint64(0), uint32(0), uint64(0), None, None, [], uint64(0), 0, 0
     )
     npc_res = [NPCResult(None, None, uint64(0)), NPCResult(None, sbc, uint64(0))]
 

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -371,6 +371,15 @@ class TestMempoolManager:
     @pytest.mark.parametrize(
         "opcode,lock_value,expected",
         [
+            (co.ASSERT_MY_BIRTH_HEIGHT, -1, mis.FAILED),
+            (co.ASSERT_MY_BIRTH_HEIGHT, 0x100000000, mis.FAILED),
+            (co.ASSERT_MY_BIRTH_HEIGHT, 5, mis.FAILED),
+            (co.ASSERT_MY_BIRTH_HEIGHT, 6, mis.SUCCESS),
+            (co.ASSERT_MY_BIRTH_SECONDS, -1, mis.FAILED),
+            (co.ASSERT_MY_BIRTH_SECONDS, 0x10000000000000000, mis.FAILED),
+            (co.ASSERT_MY_BIRTH_SECONDS, 10049, mis.FAILED),
+            (co.ASSERT_MY_BIRTH_SECONDS, 10050, mis.SUCCESS),
+            (co.ASSERT_MY_BIRTH_SECONDS, 10051, mis.FAILED),
             (co.ASSERT_SECONDS_RELATIVE, -2, mis.SUCCESS),
             (co.ASSERT_SECONDS_RELATIVE, -1, mis.SUCCESS),
             (co.ASSERT_SECONDS_RELATIVE, 0, mis.SUCCESS),

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -94,7 +94,7 @@ def make_item(idx: int, cost: uint64 = uint64(80), assert_height=100) -> Mempool
     return MempoolItem(
         SpendBundle([], G2Element()),
         uint64(0),
-        NPCResult(None, SpendBundleConditions([], 0, 0, 0, None, None, [], cost), cost),
+        NPCResult(None, SpendBundleConditions([], 0, 0, 0, None, None, [], cost, 0, 0), cost),
         spend_bundle_name,
         uint32(0),
         assert_height,
@@ -2516,15 +2516,15 @@ class TestPkmPairs:
     pk2 = G1Element.generator()
 
     def test_empty_list(self, softfork):
-        conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0)
+        conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0, 0, 0)
         pks, msgs = pkm_pairs(conds, b"foobar", soft_fork=softfork)
         assert pks == []
         assert msgs == []
 
     def test_no_agg_sigs(self, softfork):
         # one create coin: h1 amount: 1 and not hint
-        spends = [Spend(self.h3, self.h4, None, 0, None, None, [(self.h1, 1, b"")], [], 0)]
-        conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], 0)
+        spends = [Spend(self.h3, self.h4, None, 0, None, None, None, None, [(self.h1, 1, b"")], [], 0)]
+        conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], 0, 0, 0)
         pks, msgs = pkm_pairs(conds, b"foobar", soft_fork=softfork)
         assert pks == []
         assert msgs == []
@@ -2538,34 +2538,36 @@ class TestPkmPairs:
                 0,
                 None,
                 None,
+                None,
+                None,
                 [],
                 [(bytes48(self.pk1), b"msg1"), (bytes48(self.pk2), b"msg2")],
                 0,
             )
         ]
-        conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], 0)
+        conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], 0, 0, 0)
         pks, msgs = pkm_pairs(conds, b"foobar", soft_fork=softfork)
         assert [bytes(pk) for pk in pks] == [bytes(self.pk1), bytes(self.pk2)]
         assert msgs == [b"msg1" + self.h1 + b"foobar", b"msg2" + self.h1 + b"foobar"]
 
     def test_agg_sig_unsafe(self, softfork):
         conds = SpendBundleConditions(
-            [], 0, 0, 0, None, None, [(bytes48(self.pk1), b"msg1"), (bytes48(self.pk2), b"msg2")], 0
+            [], 0, 0, 0, None, None, [(bytes48(self.pk1), b"msg1"), (bytes48(self.pk2), b"msg2")], 0, 0, 0
         )
         pks, msgs = pkm_pairs(conds, b"foobar", soft_fork=softfork)
         assert [bytes(pk) for pk in pks] == [bytes(self.pk1), bytes(self.pk2)]
         assert msgs == [b"msg1", b"msg2"]
 
     def test_agg_sig_mixed(self, softfork):
-        spends = [Spend(self.h1, self.h2, None, 0, None, None, [], [(bytes48(self.pk1), b"msg1")], 0)]
-        conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [(bytes48(self.pk2), b"msg2")], 0)
+        spends = [Spend(self.h1, self.h2, None, 0, None, None, None, None, [], [(bytes48(self.pk1), b"msg1")], 0)]
+        conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [(bytes48(self.pk2), b"msg2")], 0, 0, 0)
         pks, msgs = pkm_pairs(conds, b"foobar", soft_fork=softfork)
         assert [bytes(pk) for pk in pks] == [bytes(self.pk2), bytes(self.pk1)]
         assert msgs == [b"msg2", b"msg1" + self.h1 + b"foobar"]
 
     def test_agg_sig_unsafe_restriction(self) -> None:
         conds = SpendBundleConditions(
-            [], 0, 0, 0, None, None, [(bytes48(self.pk1), b"msg1"), (bytes48(self.pk2), b"msg2")], 0
+            [], 0, 0, 0, None, None, [(bytes48(self.pk1), b"msg1"), (bytes48(self.pk2), b"msg2")], 0, 0, 0
         )
         pks, msgs = pkm_pairs(conds, b"msg1", soft_fork=False)
         assert [bytes(pk) for pk in pks] == [bytes(self.pk1), bytes(self.pk2)]

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -105,13 +105,29 @@ def make_test_conds(
     seconds_absolute: uint64 = uint64(0),
 ) -> SpendBundleConditions:
     return SpendBundleConditions(
-        [Spend(TEST_COIN.name(), IDENTITY_PUZZLE_HASH, height_relative, seconds_relative, None, None, [], [], 0)],
+        [
+            Spend(
+                TEST_COIN.name(),
+                IDENTITY_PUZZLE_HASH,
+                height_relative,
+                seconds_relative,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [],
+                0,
+            )
+        ],
         0,
         height_absolute,
         seconds_absolute,
         None,
         None,
         [],
+        0,
+        0,
         0,
     )
 
@@ -216,27 +232,54 @@ def test_compute_assert_height() -> None:
 
     # 42 is the absolute height condition
     conds = SpendBundleConditions(
-        [Spend(coin_id, bytes32(b"c" * 32), None, 0, None, None, [], [], 0)], 0, 42, 0, None, None, [], 0
+        [Spend(coin_id, bytes32(b"c" * 32), None, 0, None, None, None, None, [], [], 0)],
+        0,
+        42,
+        0,
+        None,
+        None,
+        [],
+        0,
+        0,
+        0,
     )
     assert compute_assert_height(coin_records, conds) == 42
 
     # 1 is a relative height, but that only amounts to 13, so the absolute
     # height is more restrictive
     conds = SpendBundleConditions(
-        [Spend(coin_id, bytes32(b"c" * 32), 1, 0, None, None, [], [], 0)], 0, 42, 0, None, None, [], 0
+        [Spend(coin_id, bytes32(b"c" * 32), 1, 0, None, None, None, None, [], [], 0)], 0, 42, 0, None, None, [], 0, 0, 0
     )
     assert compute_assert_height(coin_records, conds) == 42
 
     # 100 is a relative height, and sinec the coin was confirmed at height 12,
     # that's 112
     conds = SpendBundleConditions(
-        [Spend(coin_id, bytes32(b"c" * 32), 100, 0, None, None, [], [], 0)], 0, 42, 0, None, None, [], 0
+        [Spend(coin_id, bytes32(b"c" * 32), 100, 0, None, None, None, None, [], [], 0)],
+        0,
+        42,
+        0,
+        None,
+        None,
+        [],
+        0,
+        0,
+        0,
     )
     assert compute_assert_height(coin_records, conds) == 112
 
     # Same thing but without the absolute height
     conds = SpendBundleConditions(
-        [Spend(coin_id, bytes32(b"c" * 32), 100, 0, None, None, [], [], 0)], 0, 0, 0, None, None, [], 0
+        [Spend(coin_id, bytes32(b"c" * 32), 100, 0, None, None, None, None, [], [], 0)],
+        0,
+        0,
+        0,
+        None,
+        None,
+        [],
+        0,
+        0,
+        0,
     )
     assert compute_assert_height(coin_records, conds) == 112
 

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -99,6 +99,8 @@ async def instantiate_mempool_manager(
 
 def make_test_conds(
     *,
+    birth_height: Optional[uint32] = None,
+    birth_seconds: Optional[uint64] = None,
     height_relative: Optional[uint32] = None,
     height_absolute: uint32 = uint32(0),
     seconds_relative: uint64 = uint64(0),
@@ -113,8 +115,8 @@ def make_test_conds(
                 seconds_relative,
                 None,
                 None,
-                None,
-                None,
+                birth_height,
+                birth_seconds,
                 [],
                 [],
                 0,
@@ -218,6 +220,46 @@ class TestCheckTimeLocks:
         expected_error: Optional[Err],
     ) -> None:
         conds = make_test_conds(seconds_absolute=value)
+        assert (
+            mempool_check_time_locks(self.REMOVALS, conds, self.PREV_BLOCK_HEIGHT, self.PREV_BLOCK_TIMESTAMP)
+            == expected_error
+        )
+
+    @pytest.mark.parametrize(
+        "value,expected_error",
+        [
+            # the coin's birth height is
+            (9, Err.ASSERT_MY_BIRTH_HEIGHT_FAILED),
+            (10, None),
+            (11, Err.ASSERT_MY_BIRTH_HEIGHT_FAILED),
+        ],
+    )
+    def test_assert_my_birth_height(
+        self,
+        value: uint32,
+        expected_error: Optional[Err],
+    ) -> None:
+        conds = make_test_conds(birth_height=value)
+        assert (
+            mempool_check_time_locks(self.REMOVALS, conds, self.PREV_BLOCK_HEIGHT, self.PREV_BLOCK_TIMESTAMP)
+            == expected_error
+        )
+
+    @pytest.mark.parametrize(
+        "value,expected_error",
+        [
+            # the coin's birth timestamp is
+            (9999, Err.ASSERT_MY_BIRTH_SECONDS_FAILED),
+            (10000, None),
+            (10001, Err.ASSERT_MY_BIRTH_SECONDS_FAILED),
+        ],
+    )
+    def test_assert_my_birth_seconds(
+        self,
+        value: uint64,
+        expected_error: Optional[Err],
+    ) -> None:
+        conds = make_test_conds(birth_seconds=value)
         assert (
             mempool_check_time_locks(self.REMOVALS, conds, self.PREV_BLOCK_HEIGHT, self.PREV_BLOCK_TIMESTAMP)
             == expected_error

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -43,7 +43,7 @@ def make_mempoolitem() -> MempoolItem:
 
     fee = uint64(10000000)
     spends: List[Spend] = []
-    conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], cost)
+    conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], cost, 0, 0)
     mempool_item = MempoolItem(
         spend_bundle,
         fee,

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -142,6 +142,8 @@ class TestROM:
             seconds_relative=0,
             before_height_relative=None,
             before_seconds_relative=None,
+            birth_height=None,
+            birth_seconds=None,
             create_coin=[(bytes([0] * 31 + [1]), 500, None)],
             agg_sig_me=[],
             flags=ELIGIBLE_FOR_DEDUP,


### PR DESCRIPTION
this patch bumps the chia_rs dependency to 0.2.3, which includes a number fixes and new features. Most importantly, it fixes a bug in the edge case parsing of `ASSERT_BEFORE_* conditions.

(The full changelog can be found [here](https://github.com/Chia-Network/chia_rs/releases/tag/0.2.3))

* The `Spend` type (as the result of parsing conditions) now include two optional integers, `birth_height` and `birth_seconds`, in case those conditions were specified. This affects tests that create objects of this type.
* The `SpendBundleConditions` now include two new fields, the sum of all addition amounts and removal amounts for the spend bundle. This can be used to easily compute the fee. This affects tests that create objects of this type.
* There are two new condition codes, `ASSERT_MY_BIRTH_HEIGHT` and `ASSERT_MY_BIRTH_SECONDS`
* There are two new error codes, `ASSERT_MY_BIRTH_SECONDS_FAILED` and `ASSERT_MY_BIRTH_HEIGHT_FAILED`
* There is new logic that implements the behavior of these new conditions. (it's fairly straight-forward, it just amends `mempool_check_time_lock()`

This PR is best reviewed one commit at a time.