### PR TITLE
fix DataStore.get_tree_generation() detection of no generations

### DIFF
--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -172,9 +172,11 @@ class DataStore:
 
         async with self.db_wrapper.writer() as writer:
             if generation is None:
-                existing_generation = await self.get_tree_generation(tree_id=tree_id)
-
-                if existing_generation is None:
+                try:
+                    existing_generation = await self.get_tree_generation(tree_id=tree_id)
+                except Exception as e:
+                    if not str(e).startswith("No generations found for tree ID:"):
+                        raise
                     generation = 0
                 else:
                     generation = existing_generation + 1
@@ -456,15 +458,21 @@ class DataStore:
             )
             row = await cursor.fetchone()
 
-        if row is None:
-            raise Exception(f"No generations found for tree ID: {tree_id.hex()}")
-        generation: int = row["MAX(generation)"]
-        return generation
+        if row is not None:
+            generation: Optional[int] = row["MAX(generation)"]
+
+            if generation is not None:
+                return generation
+
+        raise Exception(f"No generations found for tree ID: {tree_id.hex()}")
 
     async def get_tree_root(self, tree_id: bytes32, generation: Optional[int] = None) -> Root:
         async with self.db_wrapper.reader() as reader:
             if generation is None:
                 generation = await self.get_tree_generation(tree_id=tree_id)
+            if generation is None:
+                raise Exception("no gen available")
+
             cursor = await reader.execute(
                 "SELECT * FROM root WHERE tree_id == :tree_id AND generation == :generation AND status == :status",
                 {"tree_id": tree_id, "generation": generation, "status": Status.COMMITTED.value},

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -470,9 +470,6 @@ class DataStore:
         async with self.db_wrapper.reader() as reader:
             if generation is None:
                 generation = await self.get_tree_generation(tree_id=tree_id)
-            if generation is None:
-                raise Exception("no gen available")
-
             cursor = await reader.execute(
                 "SELECT * FROM root WHERE tree_id == :tree_id AND generation == :generation AND status == :status",
                 {"tree_id": tree_id, "generation": generation, "status": Status.COMMITTED.value},

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+import re
 import statistics
 from pathlib import Path
 from random import Random
@@ -193,6 +194,15 @@ async def test_insert_increments_generation(data_store: DataStore, tree_id: byte
         expected.append(expected_generation)
 
     assert generations == expected
+
+
+@pytest.mark.asyncio
+async def test_get_tree_generation_returns_none_when_none_available(
+    raw_data_store: DataStore,
+    tree_id: bytes32,
+) -> None:
+    with pytest.raises(Exception, match=re.escape(f"No generations found for tree ID: {tree_id.hex()}")):
+        await raw_data_store.get_tree_generation(tree_id=tree_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This will provide a more direct error message when there is no tree root to be found and `DataStore.get_tree_generation()` is called.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

`None` is returned and results in some downstream failure.

### New Behavior:

An exception is directly raised.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
