### PR TITLE
Listen on ::0 so we can respond to both ipv4 and ipv6

### DIFF
--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -100,8 +100,6 @@ class DNSServer:
     async def periodically_get_reliable_peers(self):
         sleep_interval = 0
         while True:
-            sleep_interval = min(15, sleep_interval + 1)
-            await asyncio.sleep(sleep_interval * 60)
             try:
                 # TODO: double check this. It shouldn't take this long to connect.
                 crawl_db = await aiosqlite.connect(self.db_path, timeout=600)
@@ -142,6 +140,9 @@ class DNSServer:
                 )
             except Exception as e:
                 log.error(f"Exception: {e}. Traceback: {traceback.format_exc()}.")
+
+            sleep_interval = min(15, sleep_interval + 1)
+            await asyncio.sleep(sleep_interval * 60)
 
     async def get_peers_to_respond(self, ipv4_count, ipv6_count):
         peers = []

--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -93,7 +93,7 @@ class DNSServer:
         # One protocol instance will be created to serve all
         # client requests.
         self.transport, self.protocol = await loop.create_datagram_endpoint(
-            lambda: EchoServerProtocol(self.dns_response), local_addr=("0.0.0.0", 53)
+            lambda: EchoServerProtocol(self.dns_response), local_addr=("::0", 53)
         )
         self.reliable_task = asyncio.create_task(self.periodically_get_reliable_peers())
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Have the DNS server listen on both ipv4 and ipv6. Also moves the 60 second sleep between refreshing peer IPs to AFTER the first attempt to load them, so that if we already have a crawler DB present, we don't have to wait 60 seconds to start responding to DNS requests.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Currently, it only listens on ipv4


### New Behavior:
Listens on both ipv4 and ipv6


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
~I'm not entirely sure what happens on an ipv4 only host with this change~. Tested on a host with no public ipv6 address, and it all still worked fine on ipv4.

I tested empty string, `None`, and a few other variants, and this was the only variant that ended up supporting both ipv4 and ipv6.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
