### PR TITLE
correct Announcement.__str__() to present hex

### DIFF
--- a/chia/types/announcement.py
+++ b/chia/types/announcement.py
@@ -21,4 +21,4 @@ class Announcement:
         return std_hash(bytes(self.origin_info + message))
 
     def __str__(self):
-        return self.name().decode("utf-8")
+        return self.name().hex()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

A hash is quite unlikely to be valid UTF-8 data and even if it does decode it seems unlikely to be a useful representation.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Converting an `Announcement` to a `str` is likely to result in an exception.

### New Behavior:

Converting an `Announcement` to a `str` results in the hexadecimal representation of the bytes.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
