### PR TITLE
ignore pkg_resources deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -30,3 +30,4 @@ filterwarnings =
     ignore:BackendLoader.exec_module\(\) not found; falling back to load_module\(\):ImportWarning
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     ignore:Properties from keyring.util are no longer supported. Use jaraco.classes.properties instead.:DeprecationWarning
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

The latest version of [setuptools](https://pypi.org/project/setuptools/67.5.0/) appears to be triggering a `DeprecationWarning` for our use of `pkg_resources`. https://github.com/Chia-Network/chia-blockchain/actions/runs/4339058595/jobs/7576307782#step:16:23  I haven't looked into why it only affects Windows.  This PR should get us back to green CI so we can continue other work until we respond to the deprecation.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Tests fail because of a `DeprecationWarning` for our use of `pkg_resources`.

### New Behavior:

Tests pass because we are ignoring the `DeprecationWarning`.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Just want tests to be green.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
