### PR TITLE
Don't create a coin for 0 amount royalty payments

### DIFF
--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -912,7 +912,7 @@ class NFTWallet:
                 [
                     Announcement(royalty_ph, Program.to((launcher_id, [p.as_condition_args()])).get_tree_hash())
                     for launcher_id, p in payments
-                    if p.amount > 0
+                    if p.amount > 0 or old
                 ]
             )
 
@@ -944,7 +944,7 @@ class NFTWallet:
                                 }
                             )
                         ]
-                        if payment_sum > 0
+                        if payment_sum > 0 or old
                         else [],
                         fee=fee,
                         coins=offered_coins_by_asset[asset],
@@ -962,7 +962,7 @@ class NFTWallet:
                         trade_prices_list=[
                             list(price)
                             for price in trade_prices
-                            if math.floor(price[0] * (offered_royalty_percentages[asset] / 10000)) != 0
+                            if math.floor(price[0] * (offered_royalty_percentages[asset] / 10000)) != 0 or old
                         ],
                     )
                 else:
@@ -983,7 +983,7 @@ class NFTWallet:
 
                     # Skip it if we're paying 0 royalties
                     payments = royalty_payments[asset] if asset in royalty_payments else []
-                    if sum(p.amount for _, p in payments) == 0:
+                    if not old and sum(p.amount for _, p in payments) == 0:
                         continue
 
                     # We cannot create coins with the same puzzle hash and amount

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -5,7 +5,7 @@ import json
 import logging
 import math
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type, TypeVar
 
 from blspy import AugSchemeMPL, G1Element, G2Element
 from clvm.casts import int_from_bytes, int_to_bytes
@@ -825,7 +825,7 @@ class NFTWallet:
             elif amount < 0:
                 offer_side_royalty_split += 1
 
-        trade_prices: List[List[Union[uint64, bytes32]]] = []
+        trade_prices: List[Tuple[uint64, bytes32]] = []
         for asset, amount in fungible_asset_dict.items():  # requested fungible items
             if amount > 0 and offer_side_royalty_split > 0:
                 settlement_ph: bytes32 = (
@@ -833,13 +833,14 @@ class NFTWallet:
                     if asset is None
                     else construct_puzzle(driver_dict[asset], DESIRED_OFFER_MOD).get_tree_hash()
                 )
-                trade_prices.append([uint64(math.floor(amount / offer_side_royalty_split)), settlement_ph])
+                trade_prices.append((uint64(math.floor(amount / offer_side_royalty_split)), settlement_ph))
 
-        required_royalty_info: List[Tuple[bytes32, bytes32, uint16]] = []  # [(address, percentage)]
-        for asset, amount in royalty_nft_asset_dict.items():  # requested royalty enabled NFTs
+        required_royalty_info: List[Tuple[bytes32, bytes32, uint16]] = []  # [(launcher_id, address, percentage)]
+        offered_royalty_percentages: Dict[bytes32, uint16] = {}
+        for asset, amount in royalty_nft_asset_dict.items():  # royalty enabled NFTs
+            transfer_info = driver_dict[asset].also().also()  # type: ignore
+            assert isinstance(transfer_info, PuzzleInfo)
             if amount > 0:
-                transfer_info = driver_dict[asset].also().also()  # type: ignore
-                assert isinstance(transfer_info, PuzzleInfo)
                 required_royalty_info.append(
                     (
                         asset,
@@ -847,6 +848,8 @@ class NFTWallet:
                         uint16(transfer_info["transfer_program"]["royalty_percentage"]),
                     )
                 )
+            else:
+                offered_royalty_percentages[asset] = uint16(transfer_info["transfer_program"]["royalty_percentage"])
 
         royalty_payments: Dict[Optional[bytes32], List[Tuple[bytes32, Payment]]] = {}
         for asset, amount in fungible_asset_dict.items():  # offered fungible items
@@ -909,6 +912,7 @@ class NFTWallet:
                 [
                     Announcement(royalty_ph, Program.to((launcher_id, [p.as_condition_args()])).get_tree_hash())
                     for launcher_id, p in payments
+                    if p.amount > 0
                 ]
             )
 
@@ -927,31 +931,39 @@ class NFTWallet:
                 # First, sending all the coins to the OFFER_MOD
                 if wallet.type() == WalletType.STANDARD_WALLET:
                     payments = royalty_payments[asset] if asset in royalty_payments else []
+                    payment_sum = sum(p.amount for _, p in payments)
                     tx = await wallet.generate_signed_transaction(
                         abs(amount),
                         DESIRED_OFFER_MOD_HASH,
                         primaries=[
                             AmountWithPuzzlehash(
                                 {
-                                    "amount": uint64(sum(p.amount for _, p in payments)),
+                                    "amount": uint64(payment_sum),
                                     "puzzlehash": DESIRED_OFFER_MOD_HASH,
                                     "memos": [],
                                 }
                             )
-                        ],
+                        ]
+                        if payment_sum > 0
+                        else [],
                         fee=fee,
                         coins=offered_coins_by_asset[asset],
                         puzzle_announcements_to_consume=announcements_to_assert,
                     )
                     txs = [tx]
                 elif asset not in fungible_asset_dict:
+                    assert asset is not None
                     txs = await wallet.generate_signed_transaction(
                         [abs(amount)],
                         [DESIRED_OFFER_MOD_HASH],
                         fee=fee_left_to_pay,
                         coins=offered_coins_by_asset[asset],
                         puzzle_announcements_to_consume=announcements_to_assert,
-                        trade_prices_list=trade_prices,
+                        trade_prices_list=[
+                            list(price)
+                            for price in trade_prices
+                            if math.floor(price[0] * (offered_royalty_percentages[asset] / 10000)) != 0
+                        ],
                     )
                 else:
                     payments = royalty_payments[asset] if asset in royalty_payments else []
@@ -968,6 +980,11 @@ class NFTWallet:
                 # Then, adding in the spends for the royalty offer mod
                 if asset in fungible_asset_dict:
                     # Create a coin_spend for the royalty payout from OFFER MOD
+
+                    # Skip it if we're paying 0 royalties
+                    payments = royalty_payments[asset] if asset in royalty_payments else []
+                    if sum(p.amount for _, p in payments) == 0:
+                        continue
 
                     # We cannot create coins with the same puzzle hash and amount
                     # So if there's multiple NFTs with the same royalty puzhash/percentage, we must create multiple

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import sys
 from secrets import token_bytes
-from typing import Any, Callable, Coroutine, Tuple, Optional
+from typing import Any, Callable, Coroutine, Optional, Tuple
 
 import pytest
 
@@ -55,16 +55,14 @@ async def get_nft_count(wallet: NFTWallet) -> int:
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat_and_zero",
+    "forwards_compat,zero_royalties",
     [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_sell_nft(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool, zero_royalties: bool
 ) -> None:
-    forwards_compat, zero_royalties = forwards_compat_and_zero
-
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -234,16 +232,14 @@ async def test_nft_offer_sell_nft(
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat_and_zero",
+    "forwards_compat,zero_royalties",
     [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_request_nft(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool, zero_royalties: bool
 ) -> None:
-    forwards_compat, zero_royalties = forwards_compat_and_zero
-
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -411,16 +407,14 @@ async def test_nft_offer_request_nft(
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat_and_zero",
+    "forwards_compat,zero_royalties",
     [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_sell_did_to_did(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool, zero_royalties: bool
 ) -> None:
-    forwards_compat, zero_royalties = forwards_compat_and_zero
-
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -611,16 +605,14 @@ async def test_nft_offer_sell_did_to_did(
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat_and_zero",
+    "forwards_compat,zero_royalties",
     [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_sell_nft_for_cat(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool, zero_royalties: bool
 ) -> None:
-    forwards_compat, zero_royalties = forwards_compat_and_zero
-
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -1279,19 +1271,17 @@ async def test_nft_offer_sell_cancel_in_batch(self_hostname: str, two_wallet_nod
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat_and_zero",
-    [(True, False), (False, False), (False, True)],
+    "forwards_compat,royalty_pts",
+    [(True, (200, 500, 500)), (False, (200, 500, 500)), (False, (0, 0, 0))],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_complex_nft_offer(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool, royalty_pts: Tuple[int, int, int]
 ) -> None:
     """
     This test is going to create an offer where the maker offers 1 NFT and 1 CAT for 2 NFTs, an XCH and a CAT
     """
-    forwards_compat, zero_royalties = forwards_compat_and_zero
-
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -1400,9 +1390,7 @@ async def test_complex_nft_offer(
     target_puzhash_taker = ph_taker
     royalty_puzhash_maker = ph_maker
     royalty_puzhash_taker = ph_taker
-    royalty_basis_pts_maker = uint16(0 if zero_royalties else 200)
-    royalty_basis_pts_taker_1 = uint16(0 if zero_royalties else 500)
-    royalty_basis_pts_taker_2 = uint16(0 if zero_royalties else 500)
+    royalty_basis_pts_maker, royalty_basis_pts_taker_1, royalty_basis_pts_taker_2 = royalty_pts
 
     nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
         wallet_node_maker.wallet_state_manager, wallet_maker, name="NFT WALLET DID 1", did_id=did_id_maker

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1390,7 +1390,11 @@ async def test_complex_nft_offer(
     target_puzhash_taker = ph_taker
     royalty_puzhash_maker = ph_maker
     royalty_puzhash_taker = ph_taker
-    royalty_basis_pts_maker, royalty_basis_pts_taker_1, royalty_basis_pts_taker_2 = royalty_pts
+    royalty_basis_pts_maker, royalty_basis_pts_taker_1, royalty_basis_pts_taker_2 = (
+        uint16(royalty_pts[0]),
+        uint16(royalty_pts[1]),
+        uint16(royalty_pts[2]),
+    )
 
     nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
         wallet_node_maker.wallet_state_manager, wallet_maker, name="NFT WALLET DID 1", did_id=did_id_maker

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import sys
 from secrets import token_bytes
-from typing import Any, Callable, Coroutine, Optional
+from typing import Any, Callable, Coroutine, Tuple, Optional
 
 import pytest
 
@@ -55,14 +55,16 @@ async def get_nft_count(wallet: NFTWallet) -> int:
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat",
-    [True, False],
+    "forwards_compat_and_zero",
+    [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_sell_nft(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
 ) -> None:
+    forwards_compat, zero_royalties = forwards_compat_and_zero
+
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -122,7 +124,7 @@ async def test_nft_offer_sell_nft(
     did_id = bytes32.fromhex(hex_did_id)
     target_puzhash = ph_maker
     royalty_puzhash = ph_maker
-    royalty_basis_pts = uint16(200)
+    royalty_basis_pts = uint16(0 if zero_royalties else 200)
 
     nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
         wallet_node_maker.wallet_state_manager, wallet_maker, name="NFT WALLET DID 1", did_id=did_id
@@ -232,14 +234,16 @@ async def test_nft_offer_sell_nft(
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat",
-    [True, False],
+    "forwards_compat_and_zero",
+    [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_request_nft(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
 ) -> None:
+    forwards_compat, zero_royalties = forwards_compat_and_zero
+
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -297,7 +301,7 @@ async def test_nft_offer_request_nft(
     did_id = bytes32.fromhex(hex_did_id)
     target_puzhash = ph_taker
     royalty_puzhash = ph_taker
-    royalty_basis_pts = uint16(200)
+    royalty_basis_pts = uint16(0 if zero_royalties else 200)
 
     nft_wallet_taker = await NFTWallet.create_new_nft_wallet(
         wallet_node_taker.wallet_state_manager, wallet_taker, name="NFT WALLET DID TAKER", did_id=did_id
@@ -407,14 +411,16 @@ async def test_nft_offer_request_nft(
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat",
-    [True, False],
+    "forwards_compat_and_zero",
+    [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_sell_did_to_did(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
 ) -> None:
+    forwards_compat, zero_royalties = forwards_compat_and_zero
+
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -472,7 +478,7 @@ async def test_nft_offer_sell_did_to_did(
     did_id = bytes32.fromhex(hex_did_id)
     target_puzhash = ph_maker
     royalty_puzhash = ph_maker
-    royalty_basis_pts = uint16(200)
+    royalty_basis_pts = uint16(0 if zero_royalties else 200)
 
     nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
         wallet_node_maker.wallet_state_manager, wallet_maker, name="NFT WALLET DID 1", did_id=did_id
@@ -605,14 +611,16 @@ async def test_nft_offer_sell_did_to_did(
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat",
-    [True, False],
+    "forwards_compat_and_zero",
+    [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_nft_offer_sell_nft_for_cat(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
 ) -> None:
+    forwards_compat, zero_royalties = forwards_compat_and_zero
+
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -672,7 +680,7 @@ async def test_nft_offer_sell_nft_for_cat(
     did_id = bytes32.fromhex(hex_did_id)
     target_puzhash = ph_maker
     royalty_puzhash = ph_maker
-    royalty_basis_pts = uint16(200)
+    royalty_basis_pts = uint16(0 if zero_royalties else 200)
 
     nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
         wallet_node_maker.wallet_state_manager, wallet_maker, name="NFT WALLET DID 1", did_id=did_id
@@ -1271,17 +1279,19 @@ async def test_nft_offer_sell_cancel_in_batch(self_hostname: str, two_wallet_nod
     [True, False],
 )
 @pytest.mark.parametrize(
-    "forwards_compat",
-    [True, False],
+    "forwards_compat_and_zero",
+    [(True, False), (False, False), (False, True)],
 )
 @pytest.mark.asyncio
 # @pytest.mark.skip
 async def test_complex_nft_offer(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat: bool
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, forwards_compat_and_zero: Tuple[bool, bool]
 ) -> None:
     """
     This test is going to create an offer where the maker offers 1 NFT and 1 CAT for 2 NFTs, an XCH and a CAT
     """
+    forwards_compat, zero_royalties = forwards_compat_and_zero
+
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]
     full_node_server = full_node_api.server
@@ -1390,9 +1400,9 @@ async def test_complex_nft_offer(
     target_puzhash_taker = ph_taker
     royalty_puzhash_maker = ph_maker
     royalty_puzhash_taker = ph_taker
-    royalty_basis_pts_maker = uint16(200)
-    royalty_basis_pts_taker_1 = uint16(500)
-    royalty_basis_pts_taker_2 = uint16(500)
+    royalty_basis_pts_maker = uint16(0 if zero_royalties else 200)
+    royalty_basis_pts_taker_1 = uint16(0 if zero_royalties else 500)
+    royalty_basis_pts_taker_2 = uint16(0 if zero_royalties else 500)
 
     nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
         wallet_node_maker.wallet_state_manager, wallet_maker, name="NFT WALLET DID 1", did_id=did_id_maker


### PR DESCRIPTION
### Purpose:

An inadvertent side effect of upgrading the OFFER_MOD was that 0 coins are no longer allowed as outputs.  This breaks our current system of paying royalties that are so small that they get rounded down to 0.  We used to create a coin for this anyway, so this PR just removes that behavior and simply does not recognize the zero payment as a payment that needs to be made.  This makes offers with royalties involved a little bit cheaper in some instances.

https://github.com/Chia-Network/chia-blockchain/issues/14744