### PR TITLE
Add file suffix for intel mac installer

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -31,7 +31,7 @@ jobs:
         os:
           - runs-on: macos-10.14
             name: intel
-            file-suffix: ""
+            file-suffix: "-intel"
             mac-package-name: "Chia-darwin-x64"
             glue-name: "build-macos"
             bladebit-suffix: macos-x86-64.tar.gz


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This fixes the download link for amd64 latest_dev installers. The downloads page for dev builds lists the link as `https://download.chia.net/latest-dev/Chia-intel_latest_dev.dmg` but is currently `https://download.chia.net/latest-dev/Chia_latest_dev.dmg` without this change.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Link bad


### New Behavior:
Link good


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
