### PR TITLE
disable soft-fork 2 (for now)

### DIFF
--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -56,6 +56,7 @@ default_kwargs = {
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
     "SOFT_FORK_HEIGHT": 3630000,
+    # the soft-fork 2 is disabled (for now)
     "SOFT_FORK2_HEIGHT": 3830000,
 }
 

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from chia_rs import ENABLE_ASSERT_BEFORE, LIMIT_STACK, MEMPOOL_MODE
+from chia_rs import LIMIT_STACK, MEMPOOL_MODE
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_chia_program
 from clvm.casts import int_from_bytes
@@ -53,8 +53,9 @@ def get_name_puzzle_conditions(
     else:
         flags = 0
 
-    if height is not None and height >= constants.SOFT_FORK2_HEIGHT:
-        flags = flags | ENABLE_ASSERT_BEFORE
+    # soft-fork2 is disabled (for now)
+    # if height is not None and height >= constants.SOFT_FORK2_HEIGHT:
+    #    flags = flags | ENABLE_ASSERT_BEFORE
 
     try:
         block_args = [bytes(gen) for gen in generator.generator_refs]

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1888,7 +1888,8 @@ class TestBodyValidation:
         assert (res, error, state_change.fork_height if state_change else None) == expected
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("with_softfork2", [False, True])
+    # soft-fork 2 is disabled (for now)
+    @pytest.mark.parametrize("with_softfork2", [False])
     @pytest.mark.parametrize("with_garbage", [True, False])
     @pytest.mark.parametrize(
         "opcode,lock_value,expected",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -457,7 +457,8 @@ async def one_node() -> AsyncIterator[Tuple[List[Service], List[FullNodeSimulato
         yield _
 
 
-@pytest.fixture(scope="function", params=[True, False])
+# soft-fork 2 is disabled (for now)
+@pytest.fixture(scope="function", params=[False])
 def enable_softfork2(request):
     return request.param
 

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -126,7 +126,8 @@ co = ConditionOpcode
 
 class TestConditions:
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("softfork2", [True, False])
+    # soft-fork 2 is disabled (for now)
+    @pytest.mark.parametrize("softfork2", [False])
     @pytest.mark.parametrize(
         "opcode,value,expected",
         [

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -406,7 +406,8 @@ mis = MempoolInclusionStatus
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("softfork2", [False, True])
+# soft-fork 2 is disabled (for now)
+@pytest.mark.parametrize("softfork2", [False])
 @pytest.mark.parametrize(
     "opcode,lock_value,expected_status,expected_error",
     [


### PR DESCRIPTION
A few questions have come up about how to handle ephemeral coin spends in combination with time-lock conditions that we need some more time to resolve. This disables the soft-fork 2, for now. We will enable it again once we know how we want to move forward.