### PR TITLE
Update the README to link to the Chia website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chia-blockchain
 
-![Alt text](https://www.chia.net/wp-content/uploads/2022/09/chia-logo.svg)
+[![Chia Network logo](https://www.chia.net/wp-content/uploads/2022/09/chia-logo.svg "Chia logo")](https://www.chia.net/)
 
 | Current Release/main | Development Branch/dev |
 |         :---:          |          :---:         |
@@ -19,8 +19,7 @@ Chia is a modern cryptocurrency built from scratch, designed to be efficient, de
 * Support for light clients with fast, objective syncing
 * A growing community of farmers and developers around the world
 
-Please check out the [wiki](https://github.com/Chia-Network/chia-blockchain/wiki)
-and [FAQ](https://github.com/Chia-Network/chia-blockchain/wiki/FAQ) for
+Please check out the [Chia website](https://www.chia.net/), the [wiki](https://github.com/Chia-Network/chia-blockchain/wiki), and [FAQ](https://github.com/Chia-Network/chia-blockchain/wiki/FAQ) for
 information on this project.
 
 Python 3.7+ is required. Make sure your default python version is >=3.7


### PR DESCRIPTION
### Purpose:

Chia has a nice website.  The README should mention it and link to it somewhere.  Lends credibility to the project and provides easy access to info people might be looking for.  

### Current Behavior:
No mention of https://www.chia.net/ in the README!  Also the alt-text for the Chia logo image was a placeholder. 


### New Behavior:
Link to the Chia website!  Also link the logo to the Chia website and provide some pleasant alt-text
