### PR TITLE
avoid ValueErrors when FullNode.fetch_block_batches() when removing already removed peer

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1075,12 +1075,18 @@ class FullNode:
                     fetched = False
                     for peer in random.sample(new_peers_with_peak, len(new_peers_with_peak)):
                         if peer.closed:
-                            peers_with_peak.remove(peer)
+                            try:
+                                peers_with_peak.remove(peer)
+                            except ValueError:
+                                pass
                             continue
                         response = await peer.call_api(FullNodeAPI.request_blocks, request, timeout=30)
                         if response is None:
                             await peer.close()
-                            peers_with_peak.remove(peer)
+                            try:
+                                peers_with_peak.remove(peer)
+                            except ValueError:
+                                pass
                         elif isinstance(response, RespondBlocks):
                             await batch_queue.put((peer, response.blocks))
                             fetched = True


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Please weigh in on whether this should be applied to the release or retargeted to `main`.

Avoid both the exception message below and also unexpected termination of the function.

```
2023-03-11T04:54:23.167 full_node chia.full_node.full_node: ERROR    Exception fetching 452768 to 452800 from peer list.remove(x): x not in list
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
