### PR TITLE
remove traceback from LockQueue._run() cancellation debug logging

### DIFF
--- a/chia/full_node/lock_queue.py
+++ b/chia/full_node/lock_queue.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
-import traceback
 from types import TracebackType
 from typing import Awaitable, Callable
 
@@ -58,8 +57,7 @@ class LockQueue:
                 await prioritized_callback.af()
                 await self._release_event.wait()
         except asyncio.CancelledError:
-            error_stack = traceback.format_exc()
-            log.debug(f"LockQueue._run() cancelled: {error_stack}")
+            log.debug("LockQueue._run() cancelled")
 
     def close(self) -> None:
         self._run_task.cancel()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Please weigh in on whether this should be applied to the release or retargeted to main.

Avoid noisy tracebacks for the expected case of cancellation.

```python-traceback
2023-03-10T21:44:02.901 full_node chia.full_node.lock_queue: DEBUG    LockQueue._run() cancelled: Traceback (most recent call last):
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/farm/chia-blockchain/chia/server/start_full_node.py", line 80, in async_main
    await service.run()
  File "/farm/chia-blockchain/chia/server/start_service.py", line 184, in run
    await self.wait_closed()
  File "/farm/chia-blockchain/chia/server/start_service.py", line 262, in wait_closed
    await self._server.await_closed()
  File "/farm/chia-blockchain/chia/server/server.py", line 621, in await_closed
    await self.webserver.await_closed()
  File "/farm/chia-blockchain/chia/util/network.py", line 100, in await_closed
    raise RuntimeError("WebServer stop not triggered")
RuntimeError: WebServer stop not triggered

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/farm/chia-blockchain/chia/full_node/lock_queue.py", line 55, in _run
    prioritized_callback = await self._task_queue.get()
  File "/usr/lib/python3.10/asyncio/queues.py", line 159, in get
    await getter
asyncio.exceptions.CancelledError
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
