### PR TITLE
wallet: Don't just subscribe to all coin ids from the DB

### DIFF
--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -181,19 +181,6 @@ class WalletCoinStore:
             rows = await conn.execute_fetchall("SELECT * FROM coin_record WHERE spent_height=0")
         return set(self.coin_record_from_row(row) for row in rows)
 
-    async def get_coin_names_to_check(self, check_height) -> Set[bytes32]:
-        """Returns set of all CoinRecords."""
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                "SELECT coin_name from coin_record where spent_height=0 or spent_height>? or confirmed_height>?",
-                (
-                    check_height,
-                    check_height,
-                ),
-            )
-
-        return set(bytes32.fromhex(row[0]) for row in rows)
-
     # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them
     async def get_coin_records_by_puzzle_hash(self, puzzle_hash: bytes32) -> List[WalletCoinRecord]:
         """Returns a list of all coin records with the given puzzle hash"""

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -311,47 +311,6 @@ def record(c: Coin, *, confirmed: int, spent: int) -> WalletCoinRecord:
 
 
 @pytest.mark.asyncio
-async def test_get_coin_names_to_check() -> None:
-    r1 = record(coin_1, confirmed=1, spent=0)
-    r2 = record(coin_2, confirmed=2, spent=4)
-    r3 = record(coin_3, confirmed=3, spent=5)
-    r4 = record(coin_4, confirmed=4, spent=6)
-    r5 = record(coin_5, confirmed=5, spent=7)
-    # these spent heights violate the invariant
-    r6 = record(coin_6, confirmed=6, spent=1)
-    r7 = record(coin_7, confirmed=7, spent=2)
-
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        await store.add_coin_record(r1)
-        await store.add_coin_record(r2)
-        await store.add_coin_record(r3)
-        await store.add_coin_record(r4)
-        await store.add_coin_record(r5)
-        await store.add_coin_record(r6)
-        await store.add_coin_record(r7)
-
-        for i in range(10):
-            coins = await store.get_coin_names_to_check(i)
-
-            # r1 is unspent and should always be included, regardless of height
-            assert r1.coin.name() in coins
-            # r2 was spent at height 4
-            assert (r2.coin.name() in coins) == (i < 4)
-            # r3 was spent at height 5
-            assert (r3.coin.name() in coins) == (i < 5)
-            # r4 was spent at height 6
-            assert (r4.coin.name() in coins) == (i < 6)
-            # r5 was spent at height 7
-            assert (r5.coin.name() in coins) == (i < 7)
-            # r6 was confirmed at height 6
-            assert (r6.coin.name() in coins) == (i < 6)
-            # r7 was confirmed at height 7
-            assert (r7.coin.name() in coins) == (i < 7)
-
-
-@pytest.mark.asyncio
 async def test_get_first_coin_height() -> None:
     r1 = record(coin_1, confirmed=1, spent=0)
     r2 = record(coin_2, confirmed=2, spent=4)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Reduce number of subscriptions used from wallets on the full nodes. 

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Besides subscribing to the coin ids from `WalletInterestedStore` and `TradeManager` the wallet also subscribes to all coin ids included in the `WalletCoinStore` which from my understanding is not required because they are all already covered by the wallet's puzzle hash subscriptions. 

### New Behavior:

The wallet only subscribes to coin ids from `WalletInterestedStore` or `TradeManager`.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Should be covered by all tests which test wallet sync/generate/send coins because the coins or state changes would not even make it into the DB if the puzzle hash subscription would not cover them. Also, this subscribing only happens during long sync at which point the coins are already in the DB because they were covered by the puzzle hash subscriptions.