### PR TITLE
wallet: Return a dict in `WalletCoinStore.get_coin_records`

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -985,13 +985,10 @@ class WalletRpcApi:
             exclude_coin_amounts = [uint64(a) for a in exclude_coin_amounts]
         exclude_coin_ids: Optional[List] = request.get("exclude_coin_ids")
         if exclude_coin_ids is not None:
-            exclude_coins: Set[Coin] = {
-                wr.coin
-                for wr in await self.service.wallet_state_manager.coin_store.get_coin_records(
-                    [bytes32.from_hexstr(hex_id) for hex_id in exclude_coin_ids]
-                )
-                if wr is not None
-            }
+            coin_records = await self.service.wallet_state_manager.coin_store.get_coin_records(
+                [bytes32.from_hexstr(hex_id) for hex_id in exclude_coin_ids]
+            )
+            exclude_coins = {wr.coin for wr in coin_records.values()}
         else:
             exclude_coins = set()
 
@@ -1480,13 +1477,10 @@ class WalletRpcApi:
             exclude_coin_amounts = [uint64(a) for a in exclude_coin_amounts]
         exclude_coin_ids: Optional[List] = request.get("exclude_coin_ids")
         if exclude_coin_ids is not None:
-            exclude_coins: Optional[Set[Coin]] = {
-                wr.coin
-                for wr in await self.service.wallet_state_manager.coin_store.get_coin_records(
-                    [bytes32.from_hexstr(hex_id) for hex_id in exclude_coin_ids]
-                )
-                if wr is not None
-            }
+            coin_records = await self.service.wallet_state_manager.coin_store.get_coin_records(
+                [bytes32.from_hexstr(hex_id) for hex_id in exclude_coin_ids]
+            )
+            exclude_coins = {wr.coin for wr in coin_records.values()}
         else:
             exclude_coins = None
         if hold_lock:

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -137,7 +137,7 @@ class WalletCoinStore:
         include_spent_coins: bool = True,
         start_height: uint32 = uint32(0),
         end_height: uint32 = uint32((2**32) - 1),
-    ) -> List[Optional[WalletCoinRecord]]:
+    ) -> Dict[bytes32, WalletCoinRecord]:
         """Returns CoinRecord with specified coin id."""
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = list(
@@ -155,7 +155,7 @@ class WalletCoinStore:
             coin_name = bytes32.fromhex(row[0])
             ret[coin_name] = record
 
-        return [ret.get(name) for name in coin_names]
+        return ret
 
     async def get_first_coin_height(self) -> Optional[uint32]:
         """Returns height of first confirmed coin"""

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1034,12 +1034,10 @@ class WalletStateManager:
         used_up_to = -1
         ph_to_index_cache: LRUCache = LRUCache(100)
 
-        local_records: List[Optional[WalletCoinRecord]] = await self.coin_store.get_coin_records(
-            [st.coin.name() for st in coin_states]
-        )
+        local_records = await self.coin_store.get_coin_records([st.coin.name() for st in coin_states])
 
-        assert len(local_records) == len(coin_states)
-        for coin_state, local_record in zip(coin_states, local_records):
+        for coin_state in coin_states:
+            local_record = local_records.get(coin_state.coin.name())
             rollback_wallets = None
             try:
                 async with self.db_wrapper.writer():
@@ -1650,8 +1648,8 @@ class WalletStateManager:
         return wr.to_coin_record(timestamp)
 
     async def get_coin_records_by_coin_ids(self, **kwargs) -> List[CoinRecord]:
-        records: List[Optional[WalletCoinRecord]] = await self.coin_store.get_coin_records(**kwargs)
-        return [await self.get_coin_record_by_wallet_record(record) for record in records if record is not None]
+        records = await self.coin_store.get_coin_records(**kwargs)
+        return [await self.get_coin_record_by_wallet_record(record) for record in records.values()]
 
     async def is_addition_relevant(self, addition: Coin):
         """

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -106,7 +106,7 @@ async def test_bulk_get() -> None:
 
         store = await WalletCoinStore.create(db_wrapper)
         records = await store.get_coin_records([coin_1.name(), coin_2.name(), token_bytes(32), coin_4.name()])
-        assert records == [record_1, record_2, None, record_4]
+        assert records == {coin_1.name(): record_1, coin_2.name(): record_2, coin_4.name(): record_4}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Just to simplify/cleanup. I think its more intuitive to just return the dict instead of returning a list where we expect a `None` entry at the same index where we provided a coin id which was not found in the DB?

### New Behavior:

No change in behaviour.
