### PR TITLE
wallet: Handle trade coins in the `try` block of `new_coin_state`

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1030,7 +1030,6 @@ class WalletStateManager:
 
         trade_removals = await self.trade_manager.get_coins_of_interest()
         all_unconfirmed: List[TransactionRecord] = await self.tx_store.get_all_unconfirmed()
-        trade_coin_removed: List[CoinState] = []
         used_up_to = -1
         ph_to_index_cache: LRUCache = LRUCache(100)
 
@@ -1066,7 +1065,7 @@ class WalletStateManager:
                             continue
 
                     if coin_state.spent_height is not None and coin_name in trade_removals:
-                        trade_coin_removed.append(coin_state)
+                        await self.trade_manager.coins_of_interest_farmed(coin_state, fork_height, peer)
                     wallet_id: Optional[uint32] = None
                     wallet_type: Optional[WalletType] = None
                     if wallet_info is not None:
@@ -1400,8 +1399,6 @@ class WalletStateManager:
                 else:
                     await self.retry_store.remove_state(coin_state)
                 continue
-        for coin_state_removed in trade_coin_removed:
-            await self.trade_manager.coins_of_interest_farmed(coin_state_removed, fork_height, peer)
 
     async def have_a_pool_wallet_with_launched_id(self, launcher_id: bytes32) -> bool:
         for wallet_id, wallet in self.wallets.items():


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Maybe i miss the point why this was put at the outside the `try` block but the idea here is to avoid aborting the whole sync if the processing of a trade removal raises which might happen because it for example involves peer communication and DB access. Also this lets them be added to the retry store if the relevant exceptions are raised.

One reason i can think of why it was put at the end (doesn't explain why its outside the `try` block though) would be that it depends on the state being processed already but from looking inside `coins_of_interest_farmed` it doesn't seem like? 

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

All trade related coins are processed together at the end of `new_coin_state` outside the `try`/`except` block.

### New Behavior:

All trade related coins are processed separately in the `try`/`except` block.
