### PR TITLE
remove pytest as a CLVM compilation trigger

### DIFF
--- a/chia/wallet/puzzles/load_clvm.py
+++ b/chia/wallet/puzzles/load_clvm.py
@@ -17,7 +17,7 @@ from chia.util.lock import Lockfile
 
 compile_clvm_py = None
 
-recompile_requested = (os.environ.get("CHIA_DEV_COMPILE_CLVM_ON_IMPORT", "") != "") or ("pytest" in sys.modules)
+recompile_requested = (os.environ.get("CHIA_DEV_COMPILE_CLVM_ON_IMPORT", "") != "")
 
 
 def translate_path(p_):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Presently, it takes many seconds (20-30 per a couple devs) to do the CLVM recompilation for every single pytest run.  There may be a bug somewhere, there are certainly other alternative solutions to this.  I would like it to be improved.  As is, there is still the `CHIA_DEV_COMPILE_CLVM_ON_IMPORT` environment variable that can be set (presumably once per user per computer) to still make it always happen as desired.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Take forever to start processes for testing.

### New Behavior:

Doesn't take forever on CLVM stuff.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
