### PR TITLE
Test cleanups

### DIFF
--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1919,11 +1919,6 @@ class TestBodyValidation:
             (co.ASSERT_SECONDS_ABSOLUTE, 10030, rbr.NEW_PEAK),
             (co.ASSERT_SECONDS_ABSOLUTE, 10031, rbr.INVALID_BLOCK),
             (co.ASSERT_SECONDS_ABSOLUTE, 10032, rbr.INVALID_BLOCK),
-            # additional garbage at the end of parameters
-            (co.ASSERT_SECONDS_RELATIVE, 0, rbr.NEW_PEAK),
-            (co.ASSERT_HEIGHT_RELATIVE, -1, rbr.NEW_PEAK),
-            (co.ASSERT_HEIGHT_ABSOLUTE, 2, rbr.NEW_PEAK),
-            (co.ASSERT_SECONDS_ABSOLUTE, 10029, rbr.NEW_PEAK),
         ],
     )
     async def test_ephemeral_timelock(self, opcode, lock_value, expected, with_garbage, with_softfork2, bt):

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1894,26 +1894,32 @@ class TestBodyValidation:
     @pytest.mark.parametrize(
         "opcode,lock_value,expected",
         [
+            # MY BIRHT HEIGHT
             (co.ASSERT_MY_BIRTH_HEIGHT, -1, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_HEIGHT, 0x100000000, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_HEIGHT, 2, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_HEIGHT, 3, rbr.NEW_PEAK),
+            # MY BIRHT SECONDS
             (co.ASSERT_MY_BIRTH_SECONDS, -1, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_SECONDS, 0x10000000000000000, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_SECONDS, 10029, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_SECONDS, 10030, rbr.NEW_PEAK),
             (co.ASSERT_MY_BIRTH_SECONDS, 10031, rbr.INVALID_BLOCK),
+            # SECONDS RELATIVE
             (co.ASSERT_SECONDS_RELATIVE, -2, rbr.NEW_PEAK),
             (co.ASSERT_SECONDS_RELATIVE, -1, rbr.NEW_PEAK),
             (co.ASSERT_SECONDS_RELATIVE, 0, rbr.NEW_PEAK),
             (co.ASSERT_SECONDS_RELATIVE, 1, rbr.INVALID_BLOCK),
+            # HEIGHT RELATIVE
             (co.ASSERT_HEIGHT_RELATIVE, -2, rbr.NEW_PEAK),
             (co.ASSERT_HEIGHT_RELATIVE, -1, rbr.NEW_PEAK),
             (co.ASSERT_HEIGHT_RELATIVE, 0, rbr.INVALID_BLOCK),
             (co.ASSERT_HEIGHT_RELATIVE, 1, rbr.INVALID_BLOCK),
+            # HEIGHT ABSOLUTE
             (co.ASSERT_HEIGHT_ABSOLUTE, 2, rbr.NEW_PEAK),
             (co.ASSERT_HEIGHT_ABSOLUTE, 3, rbr.INVALID_BLOCK),
             (co.ASSERT_HEIGHT_ABSOLUTE, 4, rbr.INVALID_BLOCK),
+            # SECONDS ABSOLUTE
             # genesis timestamp is 10000 and each block is 10 seconds
             (co.ASSERT_SECONDS_ABSOLUTE, 10029, rbr.NEW_PEAK),
             (co.ASSERT_SECONDS_ABSOLUTE, 10030, rbr.NEW_PEAK),

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -135,38 +135,41 @@ class TestConditions:
             # the coin being spent was created in the 3rd block (i.e. block 2)
             # ensure invalid heights fail and pass correctly, depending on
             # which end of the range they exceed
+            # MY BIRTH HEIGHT
             (co.ASSERT_MY_BIRTH_HEIGHT, -1, Err.ASSERT_MY_BIRTH_HEIGHT_FAILED),
             (co.ASSERT_MY_BIRTH_HEIGHT, 0x100000000, Err.ASSERT_MY_BIRTH_HEIGHT_FAILED),
             (co.ASSERT_MY_BIRTH_HEIGHT, 3, Err.ASSERT_MY_BIRTH_HEIGHT_FAILED),
             (co.ASSERT_MY_BIRTH_HEIGHT, 2, None),
+            # MY BIRTH SECONDS
             # genesis timestamp is 10000 and each block is 10 seconds
             (co.ASSERT_MY_BIRTH_SECONDS, -1, Err.ASSERT_MY_BIRTH_SECONDS_FAILED),
             (co.ASSERT_MY_BIRTH_SECONDS, 0x10000000000000000, Err.ASSERT_MY_BIRTH_SECONDS_FAILED),
             (co.ASSERT_MY_BIRTH_SECONDS, 10019, Err.ASSERT_MY_BIRTH_SECONDS_FAILED),
             (co.ASSERT_MY_BIRTH_SECONDS, 10020, None),
             (co.ASSERT_MY_BIRTH_SECONDS, 10021, Err.ASSERT_MY_BIRTH_SECONDS_FAILED),
+            # HEIGHT RELATIVE
             (co.ASSERT_HEIGHT_RELATIVE, -1, None),
             (co.ASSERT_HEIGHT_RELATIVE, 0, None),
+            (co.ASSERT_HEIGHT_RELATIVE, 1, None),
+            (co.ASSERT_HEIGHT_RELATIVE, 2, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
             (co.ASSERT_HEIGHT_RELATIVE, 0x100000000, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+            # HEIGHT ABSOLUTE
             (co.ASSERT_HEIGHT_ABSOLUTE, -1, None),
             (co.ASSERT_HEIGHT_ABSOLUTE, 0, None),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 3, None),
+            (co.ASSERT_HEIGHT_ABSOLUTE, 4, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
             (co.ASSERT_HEIGHT_ABSOLUTE, 0x100000000, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
+            # SECONDS RELATIVE
             (co.ASSERT_SECONDS_RELATIVE, -1, None),
             (co.ASSERT_SECONDS_RELATIVE, 0, None),
+            (co.ASSERT_SECONDS_RELATIVE, 30, Err.ASSERT_SECONDS_RELATIVE_FAILED),
             (co.ASSERT_SECONDS_RELATIVE, 0x10000000000000000, Err.ASSERT_SECONDS_RELATIVE_FAILED),
+            # SECONDS ABSOLUTE
             (co.ASSERT_SECONDS_ABSOLUTE, -1, None),
             (co.ASSERT_SECONDS_ABSOLUTE, 0, None),
-            (co.ASSERT_SECONDS_ABSOLUTE, 0x10000000000000000, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
-            # test boundary values
-            (co.ASSERT_HEIGHT_RELATIVE, 2, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
-            (co.ASSERT_HEIGHT_RELATIVE, 1, None),
-            (co.ASSERT_HEIGHT_ABSOLUTE, 4, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
-            (co.ASSERT_HEIGHT_ABSOLUTE, 3, None),
-            # genesis timestamp is 10000 and each block is 10 seconds
-            (co.ASSERT_SECONDS_ABSOLUTE, 10049, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
             (co.ASSERT_SECONDS_ABSOLUTE, 10000, None),
-            (co.ASSERT_SECONDS_RELATIVE, 30, Err.ASSERT_SECONDS_RELATIVE_FAILED),
-            (co.ASSERT_SECONDS_RELATIVE, 0, None),
+            (co.ASSERT_SECONDS_ABSOLUTE, 10049, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
+            (co.ASSERT_SECONDS_ABSOLUTE, 0x10000000000000000, Err.ASSERT_SECONDS_ABSOLUTE_FAILED),
         ],
     )
     async def test_condition(self, opcode, value, expected, bt, softfork2):

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -426,22 +426,30 @@ mis = MempoolInclusionStatus
 @pytest.mark.parametrize(
     "opcode,lock_value,expected_status,expected_error",
     [
+        # SECONDS RELATIVE
         (co.ASSERT_SECONDS_RELATIVE, -2, mis.SUCCESS, None),
         (co.ASSERT_SECONDS_RELATIVE, -1, mis.SUCCESS, None),
         # The rules allow spending an ephemeral coin with an ASSERT_SECONDS_RELATIVE 0 condition
         (co.ASSERT_SECONDS_RELATIVE, 0, mis.SUCCESS, None),
         (co.ASSERT_SECONDS_RELATIVE, 1, mis.FAILED, Err.ASSERT_SECONDS_RELATIVE_FAILED),
+        (co.ASSERT_SECONDS_RELATIVE, 9, mis.FAILED, Err.ASSERT_SECONDS_RELATIVE_FAILED),
+        (co.ASSERT_SECONDS_RELATIVE, 10, mis.FAILED, Err.ASSERT_SECONDS_RELATIVE_FAILED),
+        # HEIGHT RELATIVE
         (co.ASSERT_HEIGHT_RELATIVE, -2, mis.SUCCESS, None),
         (co.ASSERT_HEIGHT_RELATIVE, -1, mis.SUCCESS, None),
-        # Unlike ASSERT_SECONDS_RELATIVE, for ASSERT_HEIGHT_RELATIVE the block height
-        # must be greater than the coin creation height + the argument, which means
-        # the coin cannot be spent in the same block (where the height would be the same)
         (co.ASSERT_HEIGHT_RELATIVE, 0, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
         (co.ASSERT_HEIGHT_RELATIVE, 1, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, 5, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, 6, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, 7, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, 10, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        (co.ASSERT_HEIGHT_RELATIVE, 11, mis.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED),
+        # HEIGHT ABSOLUTE
         (co.ASSERT_HEIGHT_ABSOLUTE, 4, mis.SUCCESS, None),
         (co.ASSERT_HEIGHT_ABSOLUTE, 5, mis.SUCCESS, None),
         (co.ASSERT_HEIGHT_ABSOLUTE, 6, mis.PENDING, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
         (co.ASSERT_HEIGHT_ABSOLUTE, 7, mis.PENDING, Err.ASSERT_HEIGHT_ABSOLUTE_FAILED),
+        # SECONDS ABSOLUTE
         # Current block timestamp is 10050
         (co.ASSERT_SECONDS_ABSOLUTE, 10049, mis.SUCCESS, None),
         (co.ASSERT_SECONDS_ABSOLUTE, 10050, mis.SUCCESS, None),


### PR DESCRIPTION
This patch removes some duplicate test cases in `test_blockchain.py` `test_ephemeral_timelock` and re-orders some test cases into categories in `test_conditions`