### PR TITLE
wallet: Raise in `WalletNode.get_full_node_peer` and move some of its calls

### DIFF
--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -470,12 +470,9 @@ class DIDWallet:
             did_wallet_puzzles.metadata_to_program(json.loads(self.did_info.metadata)),
         )
         wallet_node = self.wallet_state_manager.wallet_node
-        peer: WSChiaConnection = wallet_node.get_full_node_peer()
-        if peer is None:
-            raise ValueError("Could not find any peers to request puzzle and solution from")
-
         parent_coin: Coin = did_info.origin_coin
         while True:
+            peer = wallet_node.get_full_node_peer()
             children = await wallet_node.fetch_children(parent_coin.name(), peer)
             if len(children) == 0:
                 break

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -161,7 +161,6 @@ class TestCATTrades:
             assert trade_make is not None
 
         peer = wallet_node_taker.get_full_node_peer()
-        assert peer is not None
         trade_take, tx_records = await trade_manager_taker.respond_to_offer(
             old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer),
             peer,
@@ -675,7 +674,6 @@ class TestCATTrades:
         await time_out_assert(15, wallet_taker.get_confirmed_balance, taker_funds)
 
         peer = wallet_node_taker.get_full_node_peer()
-        assert peer is not None
         with pytest.raises(ValueError, match="This offer is no longer valid"):
             await trade_manager_taker.respond_to_offer(Offer.from_bytes(trade_make.offer), peer)
 

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -91,7 +91,6 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool, forwards_compat: b
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_taker, launcher_id_taker, taker_root)
 
     peer = wallet_node_taker.get_full_node_peer()
-    assert peer is not None
     await dl_wallet_maker.track_new_launcher_id(launcher_id_taker, peer)
     await dl_wallet_taker.track_new_launcher_id(launcher_id_maker, peer)
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_maker, launcher_id_taker, taker_root)
@@ -387,7 +386,6 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool, forwards_
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_taker, launcher_id_taker_2, taker_root)
 
     peer = wallet_node_taker.get_full_node_peer()
-    assert peer is not None
     await dl_wallet_maker.track_new_launcher_id(launcher_id_taker_1, peer)
     await dl_wallet_maker.track_new_launcher_id(launcher_id_taker_2, peer)
     await dl_wallet_taker.track_new_launcher_id(launcher_id_maker_1, peer)

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -189,7 +189,6 @@ class TestDLWallet:
         await asyncio.sleep(0.5)
 
         peer = wallet_node_1.get_full_node_peer()
-        assert peer is not None
         await dl_wallet_1.track_new_launcher_id(launcher_id, peer)
         await time_out_assert(15, is_singleton_confirmed, True, dl_wallet_1, launcher_id)
         await asyncio.sleep(0.5)
@@ -379,7 +378,6 @@ class TestDLWallet:
         await asyncio.sleep(0.5)
 
         peer = wallet_node_1.get_full_node_peer()
-        assert peer is not None
         await dl_wallet_1.track_new_launcher_id(launcher_id, peer)
         await time_out_assert(15, is_singleton_confirmed, True, dl_wallet_1, launcher_id)
         current_record = await dl_wallet_1.get_latest_singleton(launcher_id)
@@ -551,10 +549,8 @@ async def test_mirrors(wallets_prefarm: Any, trusted: bool) -> None:
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_2, launcher_id_2, bytes32([0] * 32))
 
     peer_1 = wallet_node_1.get_full_node_peer()
-    assert peer_1 is not None
     await dl_wallet_1.track_new_launcher_id(launcher_id_2, peer_1)
     peer_2 = wallet_node_2.get_full_node_peer()
-    assert peer_2 is not None
     await dl_wallet_2.track_new_launcher_id(launcher_id_1, peer_2)
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_1, launcher_id_2, bytes32([0] * 32))
     await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet_2, launcher_id_1, bytes32([0] * 32))

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -196,7 +196,6 @@ async def test_nft_offer_sell_nft(
     taker_fee = 1
     assert not mempool_not_empty(full_node_api)
     peer = wallet_node_taker.get_full_node_peer()
-    assert peer is not None
 
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer), peer, fee=uint64(taker_fee)
@@ -373,7 +372,6 @@ async def test_nft_offer_request_nft(
     taker_fee = 1
 
     peer = wallet_node_taker.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer), peer, fee=uint64(taker_fee)
     )
@@ -561,7 +559,6 @@ async def test_nft_offer_sell_did_to_did(
     taker_fee = 1
 
     peer = wallet_node_taker.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer), peer, fee=uint64(taker_fee)
     )
@@ -774,7 +771,6 @@ async def test_nft_offer_sell_nft_for_cat(
     taker_fee = 1
 
     peer = wallet_node_taker.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer), peer, fee=uint64(taker_fee)
     )
@@ -994,7 +990,6 @@ async def test_nft_offer_request_nft_for_cat(
     taker_fee = 1
 
     peer = wallet_node_taker.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer), peer, fee=uint64(taker_fee)
     )

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -156,7 +156,6 @@ async def test_nft_offer_with_fee(
     taker_fee = uint64(1)
 
     peer = wallet_node_1.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer),
         peer,
@@ -497,7 +496,6 @@ async def test_nft_offer_with_metadata_update(self_hostname: str, two_wallet_nod
     taker_fee = uint64(1)
 
     peer = wallet_node_1.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         Offer.from_bytes(trade_make.offer), peer, fee=taker_fee
     )
@@ -663,7 +661,6 @@ async def test_nft_offer_nft_for_cat(
     taker_fee = uint64(1)
 
     peer = wallet_node_1.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         Offer.from_bytes(trade_make.offer),
         peer,
@@ -887,7 +884,6 @@ async def test_nft_offer_nft_for_nft(self_hostname: str, two_wallet_nodes: Any, 
     taker_fee = uint64(1)
 
     peer = wallet_node_1.get_full_node_peer()
-    assert peer is not None
     trade_take, tx_records = await trade_manager_taker.respond_to_offer(
         Offer.from_bytes(trade_make.offer), peer, fee=taker_fee
     )


### PR DESCRIPTION
### Purpose:

Code cleanup which also moves peer fetching closer to the actual call/usage in some cases.

### Current Behavior:

The method returns `Optional[WSChiaConnection]`.

### New Behavior:

The method returns `WSChiaConnection` and in some cases the call of the method was moved closer to the actual call/usage to skip some async calls inbetween.
