### PR TITLE
fixup tests that do not close all event loops

### DIFF
--- a/tests/core/server/test_event_loop.py
+++ b/tests/core/server/test_event_loop.py
@@ -5,13 +5,10 @@ import inspect
 import sys
 import threading
 
-import pytest
-
 from chia.server.chia_policy import ChiaSelectorEventLoop, PausableServer, _chia_create_server, set_chia_policy
 
 
-@pytest.mark.asyncio
-async def test_base_event_loop_has_methods() -> None:
+def test_base_event_loop_has_methods() -> None:
     """
     `ChiaPolicy` overrides `create_server` to create and return the custom `PausableServer`
     instead of its base class `asyncio.base_events.Server`.
@@ -27,82 +24,86 @@ async def test_base_event_loop_has_methods() -> None:
     """
 
     selector_event_loop = ChiaSelectorEventLoop()
-    base_selector_event_loop = super(ChiaSelectorEventLoop, selector_event_loop)
+    try:
+        base_selector_event_loop = super(ChiaSelectorEventLoop, selector_event_loop)
 
-    assert hasattr(base_selector_event_loop, "create_server")
-    method = getattr(base_selector_event_loop, "create_server")
-    assert inspect.ismethod(method)
-    if sys.version_info >= (3, 11):
-        expected_signature = "(protocol_factory, host=None, port=None, *, family=<AddressFamily.AF_UNSPEC: 0>, flags=<AddressInfo.AI_PASSIVE: 1>, sock=None, backlog=100, ssl=None, reuse_address=None, reuse_port=None, ssl_handshake_timeout=None, ssl_shutdown_timeout=None, start_serving=True)"  # noqa: E501
-    else:
-        expected_signature = "(protocol_factory, host=None, port=None, *, family=<AddressFamily.AF_UNSPEC: 0>, flags=<AddressInfo.AI_PASSIVE: 1>, sock=None, backlog=100, ssl=None, reuse_address=None, reuse_port=None, ssl_handshake_timeout=None, start_serving=True)"  # noqa: E501
-    assert str(inspect.signature(method)) == expected_signature
+        assert hasattr(base_selector_event_loop, "create_server")
+        method = getattr(base_selector_event_loop, "create_server")
+        assert inspect.ismethod(method)
+        if sys.version_info >= (3, 11):
+            expected_signature = "(protocol_factory, host=None, port=None, *, family=<AddressFamily.AF_UNSPEC: 0>, flags=<AddressInfo.AI_PASSIVE: 1>, sock=None, backlog=100, ssl=None, reuse_address=None, reuse_port=None, ssl_handshake_timeout=None, ssl_shutdown_timeout=None, start_serving=True)"  # noqa: E501
+        else:
+            expected_signature = "(protocol_factory, host=None, port=None, *, family=<AddressFamily.AF_UNSPEC: 0>, flags=<AddressInfo.AI_PASSIVE: 1>, sock=None, backlog=100, ssl=None, reuse_address=None, reuse_port=None, ssl_handshake_timeout=None, start_serving=True)"  # noqa: E501
+        assert str(inspect.signature(method)) == expected_signature
 
-    assert hasattr(base_selector_event_loop, "_start_serving")
-    method = getattr(base_selector_event_loop, "_start_serving")
-    assert inspect.ismethod(method)
-    if sys.version_info >= (3, 11):
-        expected_signature = "(protocol_factory, sock, sslcontext=None, server=None, backlog=100, ssl_handshake_timeout=60.0, ssl_shutdown_timeout=30.0)"  # noqa: E501
-    else:
-        expected_signature = (
-            "(protocol_factory, sock, sslcontext=None, server=None, backlog=100, ssl_handshake_timeout=60.0)"
-        )
-    assert str(inspect.signature(method)) == expected_signature
-
-    assert hasattr(base_selector_event_loop, "remove_reader")
-    method = getattr(base_selector_event_loop, "remove_reader")
-    assert inspect.ismethod(method)
-    expected_signature = "(fd)"
-    assert str(inspect.signature(method)) == expected_signature
-
-    assert hasattr(selector_event_loop, "create_server")
-    method = getattr(selector_event_loop, "create_server")
-    assert inspect.ismethod(method)
-    assert (
-        inspect.getsource(method)
-        == "    async def create_server(self, *args, **kwargs) -> PausableServer:  # type: ignore[no-untyped-def]\n        return await _chia_create_server(super(), *args, **kwargs)\n"  # noqa: E501
-    )
-
-    assert inspect.isfunction(_chia_create_server)
-    expected_signature = "(cls: 'Any', protocol_factory: '_ProtocolFactory', host: 'Any', port: 'Any', *, family: 'socket.AddressFamily' = <AddressFamily.AF_UNSPEC: 0>, flags: 'socket.AddressInfo' = <AddressInfo.AI_PASSIVE: 1>, sock: 'Any' = None, backlog: 'int' = 100, ssl: '_SSLContext' = None, reuse_address: 'Optional[bool]' = None, reuse_port: 'Optional[bool]' = None, ssl_handshake_timeout: 'Optional[float]' = 30, start_serving: 'bool' = True) -> 'PausableServer'"  # noqa: E501
-    assert str(inspect.signature(_chia_create_server)) == expected_signature
-
-    class EchoProtocol(asyncio.Protocol):
-        def connection_made(self, transport):  # type: ignore
-            self.transport = transport
-
-        def data_received(self, data):  # type: ignore
-            self.transport.write(data)
-
-    pausable_server = None
-
-    def in_thread() -> None:
-        async def main() -> None:
-            loop = asyncio.get_event_loop()
-            nonlocal pausable_server
-            pausable_server = await loop.create_server(
-                EchoProtocol, host="127.0.0.1", port=8000, ssl_handshake_timeout=None, start_serving=False
+        assert hasattr(base_selector_event_loop, "_start_serving")
+        method = getattr(base_selector_event_loop, "_start_serving")
+        assert inspect.ismethod(method)
+        if sys.version_info >= (3, 11):
+            expected_signature = "(protocol_factory, sock, sslcontext=None, server=None, backlog=100, ssl_handshake_timeout=60.0, ssl_shutdown_timeout=30.0)"  # noqa: E501
+        else:
+            expected_signature = (
+                "(protocol_factory, sock, sslcontext=None, server=None, backlog=100, ssl_handshake_timeout=60.0)"
             )
+        assert str(inspect.signature(method)) == expected_signature
 
-        set_chia_policy(connection_limit=0)
-        asyncio.run(main())
+        assert hasattr(base_selector_event_loop, "remove_reader")
+        method = getattr(base_selector_event_loop, "remove_reader")
+        assert inspect.ismethod(method)
+        expected_signature = "(fd)"
+        assert str(inspect.signature(method)) == expected_signature
 
-    thread = threading.Thread(target=in_thread)
-    thread.start()
-    thread.join()
-
-    base_server = super(PausableServer, pausable_server)
-
-    method = getattr(base_server, "__init__")
-    if sys.version_info >= (3, 11):
-        expected_signature = (
-            "(loop, sockets, protocol_factory, ssl_context, backlog, ssl_handshake_timeout, ssl_shutdown_timeout=None)"
+        assert hasattr(selector_event_loop, "create_server")
+        method = getattr(selector_event_loop, "create_server")
+        assert inspect.ismethod(method)
+        assert (
+            inspect.getsource(method)
+            == "    async def create_server(self, *args, **kwargs) -> PausableServer:  # type: ignore[no-untyped-def]\n        return await _chia_create_server(super(), *args, **kwargs)\n"  # noqa: E501
         )
-    else:
-        expected_signature = "(loop, sockets, protocol_factory, ssl_context, backlog, ssl_handshake_timeout)"
-    assert str(inspect.signature(method)) == expected_signature
 
-    for func in ("_attach", "_detach"):
-        assert hasattr(base_server, func)
-        method = getattr(base_server, func)
-        assert str(inspect.signature(method)) == "()"
+        assert inspect.isfunction(_chia_create_server)
+        expected_signature = "(cls: 'Any', protocol_factory: '_ProtocolFactory', host: 'Any', port: 'Any', *, family: 'socket.AddressFamily' = <AddressFamily.AF_UNSPEC: 0>, flags: 'socket.AddressInfo' = <AddressInfo.AI_PASSIVE: 1>, sock: 'Any' = None, backlog: 'int' = 100, ssl: '_SSLContext' = None, reuse_address: 'Optional[bool]' = None, reuse_port: 'Optional[bool]' = None, ssl_handshake_timeout: 'Optional[float]' = 30, start_serving: 'bool' = True) -> 'PausableServer'"  # noqa: E501
+        assert str(inspect.signature(_chia_create_server)) == expected_signature
+
+        class EchoProtocol(asyncio.Protocol):
+            def connection_made(self, transport):  # type: ignore
+                self.transport = transport
+
+            def data_received(self, data):  # type: ignore
+                self.transport.write(data)
+
+        pausable_server = None
+
+        def in_thread() -> None:
+            async def main() -> None:
+                loop = asyncio.get_event_loop()
+                nonlocal pausable_server
+                pausable_server = await loop.create_server(
+                    EchoProtocol, host="127.0.0.1", port=8000, ssl_handshake_timeout=None, start_serving=False
+                )
+
+            set_chia_policy(connection_limit=0)
+            asyncio.run(main())
+
+        thread = threading.Thread(target=in_thread)
+        thread.start()
+        thread.join()
+
+        base_server = super(PausableServer, pausable_server)
+
+        method = getattr(base_server, "__init__")
+        if sys.version_info >= (3, 11):
+            expected_signature = (
+                "(loop, sockets, protocol_factory, ssl_context, backlog, ssl_handshake_timeout,"
+                " ssl_shutdown_timeout=None)"
+            )
+        else:
+            expected_signature = "(loop, sockets, protocol_factory, ssl_context, backlog, ssl_handshake_timeout)"
+        assert str(inspect.signature(method)) == expected_signature
+
+        for func in ("_attach", "_detach"):
+            assert hasattr(base_server, func)
+            method = getattr(base_server, func)
+            assert str(inspect.signature(method)) == "()"
+    finally:
+        selector_event_loop.close()

--- a/tests/core/server/test_loop.py
+++ b/tests/core/server/test_loop.py
@@ -109,14 +109,14 @@ class ServeInThread:
 
     def _run(self) -> None:
         # TODO: yuck yuck, messes with a single global
+        original_event_loop_policy = asyncio.get_event_loop_policy()
         asyncio.set_event_loop_policy(chia_policy.ChiaPolicy())
-        asyncio.run(self.main())
-        # new_loop = asyncio.new_event_loop()
-        # asyncio.set_event_loop(new_loop)
-        # new_loop.run_until_complete(self.main())
+        try:
+            asyncio.run(self.main())
+        finally:
+            asyncio.set_event_loop_policy(original_event_loop_policy)
 
     async def main(self) -> None:
-        self.loop = asyncio.get_event_loop()
         self.server_task = asyncio.create_task(
             serve.async_main(
                 ip=self.ip,

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-from typing import Any, Iterator, List
+from typing import Any, List
 
 import pytest
 

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -21,12 +21,6 @@ from chia.wallet.util.merkle_tree import MerkleTree
 pytestmark = pytest.mark.data_layer
 
 
-@pytest.fixture(scope="module")
-def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    loop = asyncio.get_event_loop()
-    yield loop
-
-
 async def is_singleton_confirmed(dl_wallet: DataLayerWallet, lid: bytes32) -> bool:
     rec = await dl_wallet.get_latest_singleton(lid)
     if rec is None:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Clean up errors first noticed in https://github.com/Chia-Network/chia-blockchain/actions/runs/4467966491/jobs/7848229154?pr=14850#step:17:57.  These are triggered by the recent release of pytest-asyncio uncovering bad behavior in our tests.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
