### PR TITLE
Ak.exception during get timestamp for height.with exceptions

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -564,7 +564,10 @@ class WalletRpcApi:
         return {}
 
     async def get_timestamp_for_height(self, request) -> EndpointResult:
-        return {"timestamp": await self.service.get_timestamp_for_height(uint32(request["height"]))}
+        timestamp = await self.service.get_timestamp_for_height(uint32(request["height"]))
+        if timestamp is None:
+            raise ValueError("Error fetching timestamp for height '%s'", request["height"])
+        return {"timestamp": timestamp}
 
     ##########################################################################################
     # Wallet Management

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1004,10 +1004,13 @@ class WalletNode:
                 neither.append(node)
         return synced_and_trusted + synced + trusted + neither
 
-    async def get_timestamp_for_height(self, height: uint32) -> uint64:
+    async def get_timestamp_for_height(self, height: uint32) -> Optional[uint64]:
         """
-        Returns the timestamp for transaction block at h=height, if not transaction block, backtracks until it finds
-        a transaction block
+        Returns the timestamp for transaction block at h=height, if `height` is not a transaction block,
+        backtracks until it finds a transaction block.
+
+        Note that `get_timestamp_for_height` can fail if a height is requested that we do not yet have a block for.
+        If we are running in "light wallet" mode, we may not yet have this information. Return None in that case.
         """
         if height in self.height_to_time:
             return self.height_to_time[height]
@@ -1017,10 +1020,14 @@ class WalletNode:
             if cache_ts is not None:
                 return cache_ts
 
+        if all([peak[0] < height for peak in self.node_peaks.values()]):
+            self.log.warning("Error fetching timestamp for height %s. No peers are that high.", height)
+            return None
+
         peers: List[WSChiaConnection] = self.get_full_node_peers_in_order()
-        last_tx_block: Optional[HeaderBlock] = None
+
         for peer in peers:
-            last_tx_block = await fetch_last_tx_from_peer(height, peer)
+            last_tx_block: Optional[HeaderBlock] = await fetch_last_tx_from_peer(height, peer)
             if last_tx_block is None:
                 continue
 
@@ -1028,7 +1035,8 @@ class WalletNode:
             self.get_cache_for_peer(peer).add_to_blocks(last_tx_block)
             return last_tx_block.foliage_transaction_block.timestamp
 
-        raise PeerRequestException("Error fetching timestamp from all peers")
+        self.log.warning("Error fetching timestamp for height %s. Peer peaks: %s", height, self.node_peaks)
+        return None
 
     async def new_peak_wallet(self, new_peak: wallet_protocol.NewPeakWallet, peer: WSChiaConnection):
         if self._wallet_state_manager is None:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1155,6 +1155,14 @@ class WalletStateManager:
                                 created_timestamp = await self.wallet_node.get_timestamp_for_height(
                                     coin_state.created_height
                                 )
+                                if created_timestamp is None:
+                                    raise ValueError(
+                                        "Error fetching timestamp for height '%s'. "
+                                        "Aborting coin processing for coin %s",
+                                        coin_state.created_height,
+                                        coin_state.coin.name(),
+                                    )
+
                                 tx_record = TransactionRecord(
                                     confirmed_at_height=uint32(coin_state.created_height),
                                     created_at_time=uint64(created_timestamp),
@@ -1202,6 +1210,13 @@ class WalletStateManager:
                                 spent_timestamp = await self.wallet_node.get_timestamp_for_height(
                                     coin_state.spent_height
                                 )
+                                if spent_timestamp is None:
+                                    raise ValueError(
+                                        "Error fetching timestamp for height '%s'. "
+                                        "Aborting coin processing for coin %s",
+                                        coin_state.spent_height,
+                                        coin_state.coin.name(),
+                                    )
 
                                 # Reorg rollback adds reorged transactions so it's possible there is tx_record already
                                 # Even though we are just adding coin record to the db (after reorg)
@@ -1495,6 +1510,10 @@ class WalletStateManager:
             else:
                 tx_type = TransactionType.FEE_REWARD.value
             timestamp = await self.wallet_node.get_timestamp_for_height(height)
+            if timestamp is None:
+                raise ValueError(
+                    "Error fetching timestamp for height '%s'. Aborting coin processing for coin %s", height, coin_name
+                )
 
             tx_record = TransactionRecord(
                 confirmed_at_height=uint32(height),
@@ -1659,6 +1678,9 @@ class WalletStateManager:
 
     async def get_coin_record_by_wallet_record(self, wr: WalletCoinRecord) -> CoinRecord:
         timestamp: uint64 = await self.wallet_node.get_timestamp_for_height(wr.confirmed_block_height)
+        if timestamp is None:
+            raise ValueError("Error fetching timestamp for height '%s'.", wr.confirmed_block_height)
+
         return wr.to_coin_record(timestamp)
 
     async def get_coin_records_by_coin_ids(self, **kwargs) -> List[CoinRecord]:


### PR DESCRIPTION
DO NOT MERGE.

This PR is for discussing changes to `WalletNode.get_timestamp_for_height`

When we introduced the "Light Wallet" mode, it became possible to for `get_timestamp_for_height` to fail, because we might try to process a coin that has a spend height higher than any untrusted peer we are connected to has.

Quex made the issue more visible in this commit:
https://github.com/Chia-Network/chia-blockchain/commit/76a78ed180

This PR is not a "fix" for that issue, but makes clear what is happening. Once we reach consensus on the fix, I'll make a new PR.

I think the version of `get_timestamp_for_height` returning `Optional` is better, for two reasons:

One, it shows clearly that the call can fail.

Two, mypy will force the user to deal with the `None` case.


