### PR TITLE
wallet: Drop `WalletCoinStore.get_multiple_coin_records`

### DIFF
--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -64,19 +64,6 @@ class WalletCoinStore:
             )
             return int(0 if row is None else row[0])
 
-    async def get_multiple_coin_records(self, coin_names: List[bytes32]) -> List[WalletCoinRecord]:
-        """Return WalletCoinRecord(s) that have a coin name in the specified list"""
-        if len(coin_names) == 0:
-            return []
-
-        as_hexes = [cn.hex() for cn in coin_names]
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                f'SELECT * from coin_record WHERE coin_name in ({"?," * (len(as_hexes) - 1)}?)', tuple(as_hexes)
-            )
-
-        return [self.coin_record_from_row(row) for row in rows]
-
     # Store CoinRecord in DB and ram cache
     async def add_coin_record(self, record: WalletCoinRecord, name: Optional[bytes32] = None) -> None:
         if name is None:

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -232,42 +232,6 @@ async def test_get_records_by_parent_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_multiple_coin_records() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        await store.add_coin_record(record_1)
-        await store.add_coin_record(record_2)
-        await store.add_coin_record(record_3)
-        await store.add_coin_record(record_4)
-        await store.add_coin_record(record_5)
-        await store.add_coin_record(record_6)
-        await store.add_coin_record(record_7)
-
-        assert set(await store.get_multiple_coin_records([coin_1.name(), coin_2.name(), coin_3.name()])) == set(
-            [record_1, record_2, record_3]
-        )
-
-        assert set(await store.get_multiple_coin_records([coin_5.name(), coin_6.name(), coin_7.name()])) == set(
-            [record_5, record_6, record_7]
-        )
-
-        assert set(
-            await store.get_multiple_coin_records(
-                [
-                    coin_1.name(),
-                    coin_2.name(),
-                    coin_3.name(),
-                    coin_4.name(),
-                    coin_5.name(),
-                    coin_6.name(),
-                    coin_7.name(),
-                ]
-            )
-        ) == set([record_1, record_2, record_3, record_4, record_5, record_6, record_7])
-
-
-@pytest.mark.asyncio
 async def test_delete_coin_record() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
@@ -281,17 +245,19 @@ async def test_delete_coin_record() -> None:
         await store.add_coin_record(record_7)
 
         assert set(
-            await store.get_multiple_coin_records(
-                [
-                    coin_1.name(),
-                    coin_2.name(),
-                    coin_3.name(),
-                    coin_4.name(),
-                    coin_5.name(),
-                    coin_6.name(),
-                    coin_7.name(),
-                ]
-            )
+            (
+                await store.get_coin_records(
+                    [
+                        coin_1.name(),
+                        coin_2.name(),
+                        coin_3.name(),
+                        coin_4.name(),
+                        coin_5.name(),
+                        coin_6.name(),
+                        coin_7.name(),
+                    ]
+                )
+            ).values()
         ) == set([record_1, record_2, record_3, record_4, record_5, record_6, record_7])
 
         assert await store.get_coin_record(coin_1.name()) == record_1
@@ -300,9 +266,11 @@ async def test_delete_coin_record() -> None:
 
         assert await store.get_coin_record(coin_1.name()) is None
         assert set(
-            await store.get_multiple_coin_records(
-                [coin_2.name(), coin_3.name(), coin_4.name(), coin_5.name(), coin_6.name(), coin_7.name()]
-            )
+            (
+                await store.get_coin_records(
+                    [coin_2.name(), coin_3.name(), coin_4.name(), coin_5.name(), coin_6.name(), coin_7.name()]
+                )
+            ).values()
         ) == set([record_2, record_3, record_4, record_5, record_6, record_7])
 
 
@@ -353,15 +321,17 @@ async def test_rollback_to_block() -> None:
         await store.add_coin_record(r5)
 
         assert set(
-            await store.get_multiple_coin_records(
-                [
-                    coin_1.name(),
-                    coin_2.name(),
-                    coin_3.name(),
-                    coin_4.name(),
-                    coin_5.name(),
-                ]
-            )
+            (
+                await store.get_coin_records(
+                    [
+                        coin_1.name(),
+                        coin_2.name(),
+                        coin_3.name(),
+                        coin_4.name(),
+                        coin_5.name(),
+                    ]
+                )
+            ).values()
         ) == set(
             [
                 r1,


### PR DESCRIPTION
### Purpose:

Remove some redundant code since we can just use `WalletCoinStore.get_coin_records` there. Actually in both cases its not really required to get the full record to begin with but this should be addressed separately.

### New Behavior:

No change in behaviour.
