### PR TITLE
`can_replace()` tests

### DIFF
--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -26,6 +26,9 @@ class MempoolItem:
     def __lt__(self, other: MempoolItem) -> bool:
         return self.fee_per_cost < other.fee_per_cost
 
+    def __hash__(self) -> int:
+        return hash(self.spend_bundle_name)
+
     @property
     def fee_per_cost(self) -> float:
         return int(self.fee) / int(self.cost)


### PR DESCRIPTION
This patch factors out the `can_replace()` function from the mempool class into a free function. It doesn't need to access anything important from the class, and making it a free function makes it easier to unit test.

There are a few more refactors of the function to simplify its interface, to further simplify testing of it. Finally, a unit test is added to cover the interesting cases of this function's behavior.

This is preparing for extending the replace-by-fee rules, for the new `ASSERT_BEFORE_*` conditions.

These changes should be reviewed one commit at a time. Here's a summary of the changes in each commit:

## min_fee_increase is a constant
Remove it as a member function if `Mempool` as it just always returns a constant. Simplify the code by just making it a constant, not a member of the `Mempool` class

## move can_replace() out of the `Mempool` class
It doesn't need access to any information from the class, so it should be a free function. This makes it a lot simpler to unit test

## simplify can_replace() parameters
Instead of passing in `fees` and `fees_per_cost` as separate parameters, pass in the new `MempoolItem` (which includes both of those). This is not an obvious improvement, but it's a preparation for adding logic (in a separate PR) that needs more fields from the new `MempoolItem`

## simplify the `conflicts` parameter
Instead of passing in a dictionary, mapping bundle name to `MempoolItem`, pass in a set of `MempoolItems`. Right now, we build the dictionary outside the call to `can_replace()` just to pull out the `.values()` inside the call. This step also needs to make the mempool item support being placed in a set.

## simplify the `removals` parameter
Instead of passing in a dictionary, mapping coin names to `CoinRecord`, just pass in a list of the coin names being removed. That's all we need, and it greatly simplifies unit tests, to not have to create dummy `CoinRecord` objects. We were already creating the container of `removal_names` (I just changed it to be a set instead of a list).

## add unit tests
Lastly, add a unit test with all interesting edge cases. (Please make sure I didn't miss any).