### PR TITLE
close daemon client even for a BaseException in acquire_connection_to_daemon()

### DIFF
--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -209,12 +209,12 @@ async def acquire_connection_to_daemon(
     closed.
     """
 
+    daemon: Optional[DaemonProxy] = None
     try:
         daemon = await connect_to_daemon_and_validate(root_path, config, quiet=quiet)
-        try:
-            yield daemon
-        finally:
-            if daemon is not None:
-                await daemon.close()
+        yield daemon  # <----
     except Exception as e:
         print(f"Exception occurred while communicating with the daemon: {e}")
+    finally:
+        if daemon is not None:
+            await daemon.close()

--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -209,12 +209,12 @@ async def acquire_connection_to_daemon(
     closed.
     """
 
-    daemon: Optional[DaemonProxy] = None
     try:
         daemon = await connect_to_daemon_and_validate(root_path, config, quiet=quiet)
-        yield daemon  # <----
+        try:
+            yield daemon
+        finally:
+            if daemon is not None:
+                await daemon.close()
     except Exception as e:
         print(f"Exception occurred while communicating with the daemon: {e}")
-
-    if daemon is not None:
-        await daemon.close()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

As is this would not close the daemon if a BaseException were raised.  For example `KeyboardInterrupt` or `asyncio.CancelledError` (on 3.8+).

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
