### PR TITLE
Update NFT wallet test timeout to 55m

### DIFF
--- a/tests/wallet/nft_wallet/config.py
+++ b/tests/wallet/nft_wallet/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 45
+job_timeout = 55
 checkout_blocks_and_plots = True


### PR DESCRIPTION
Adjust NFT wallet test timeout to 55m - research in to test optimizations and proper time are ongoing