### PR TITLE
increase wallet.nft_wallet test job timeout to 70 minutes

### DIFF
--- a/tests/wallet/nft_wallet/config.py
+++ b/tests/wallet/nft_wallet/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 45
+job_timeout = 70
 checkout_blocks_and_plots = True


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

from https://github.com/Chia-Network/chia-blockchain/actions/runs/4455716184/usage i see macos with nominal low 40s runtime and outliers into the low 50s, windows has a wider variance with highs in the low 50s and 8'ish hung runs that timed out at the 75 minute timeout, linux looks like 30'ish with a high of maybe 36.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
