### PR TITLE
wallet: Some cleanup of `WalletNode.fetch_puzzle_solution`

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -217,7 +217,7 @@ class DataLayerWallet:
             await self.new_launcher_spend(spend, peer, height)
         else:
             launcher_state: CoinState = await self.get_launcher_coin_state(launcher_id, peer)
-            launcher_spend = await self.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+            launcher_spend = await self.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
                 launcher_state, peer
             )
             await self.new_launcher_spend(launcher_spend, peer)
@@ -279,7 +279,7 @@ class DataLayerWallet:
         ] = await self.wallet_state_manager.coin_store.get_coin_record(new_singleton.name())
         while new_singleton_coin_record is not None and new_singleton_coin_record.spent_block_height > 0:
             # We've already synced this before, so we need to sort of force a resync
-            parent_spend: CoinSpend = await self.wallet_state_manager.wallet_node.fetch_puzzle_solution(
+            parent_spend: CoinSpend = await self.wallet_state_manager.wallet_node.fetch_coin_spend(
                 new_singleton_coin_record.spent_block_height, new_singleton, peer
             )
             await self.singleton_removed(parent_spend, new_singleton_coin_record.spent_block_height)
@@ -829,7 +829,7 @@ class DataLayerWallet:
             parent_state: CoinState = (
                 await self.wallet_state_manager.wallet_node.get_coin_state([coin.parent_coin_info], peer=peer)
             )[0]
-            parent_spend: Optional[CoinSpend] = await self.wallet_state_manager.wallet_node.fetch_puzzle_solution(
+            parent_spend: Optional[CoinSpend] = await self.wallet_state_manager.wallet_node.fetch_coin_spend(
                 height, parent_state.coin, peer
             )
             assert parent_spend is not None

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -50,6 +50,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.merkle_utils import _simplify_merkle_proof
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -217,9 +218,7 @@ class DataLayerWallet:
             await self.new_launcher_spend(spend, peer, height)
         else:
             launcher_state: CoinState = await self.get_launcher_coin_state(launcher_id, peer)
-            launcher_spend = await self.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
-                launcher_state, peer
-            )
+            launcher_spend = await fetch_coin_spend_for_coin_state(launcher_state, peer)
             await self.new_launcher_spend(launcher_spend, peer)
 
     async def new_launcher_spend(
@@ -279,9 +278,7 @@ class DataLayerWallet:
         ] = await self.wallet_state_manager.coin_store.get_coin_record(new_singleton.name())
         while new_singleton_coin_record is not None and new_singleton_coin_record.spent_block_height > 0:
             # We've already synced this before, so we need to sort of force a resync
-            parent_spend: CoinSpend = await self.wallet_state_manager.wallet_node.fetch_coin_spend(
-                new_singleton_coin_record.spent_block_height, new_singleton, peer
-            )
+            parent_spend = await fetch_coin_spend(new_singleton_coin_record.spent_block_height, new_singleton, peer)
             await self.singleton_removed(parent_spend, new_singleton_coin_record.spent_block_height)
             try:
                 additions = compute_additions(parent_spend)
@@ -829,9 +826,7 @@ class DataLayerWallet:
             parent_state: CoinState = (
                 await self.wallet_state_manager.wallet_node.get_coin_state([coin.parent_coin_info], peer=peer)
             )[0]
-            parent_spend: Optional[CoinSpend] = await self.wallet_state_manager.wallet_node.fetch_coin_spend(
-                height, parent_state.coin, peer
-            )
+            parent_spend = await fetch_coin_spend(height, parent_state.coin, peer)
             assert parent_spend is not None
             launcher_id, urls = get_mirror_info(
                 parent_spend.puzzle_reveal.to_program(), parent_spend.solution.to_program()

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -217,8 +217,8 @@ class DataLayerWallet:
             await self.new_launcher_spend(spend, peer, height)
         else:
             launcher_state: CoinState = await self.get_launcher_coin_state(launcher_id, peer)
-            launcher_spend: CoinSpend = await self.wallet_state_manager.wallet_node.fetch_puzzle_solution(
-                launcher_state.spent_height, launcher_state.coin, peer
+            launcher_spend = await self.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+                launcher_state, peer
             )
             await self.new_launcher_spend(launcher_spend, peer)
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -296,7 +296,7 @@ class WalletRpcApi:
         if parent_coin_state_list is None or len(parent_coin_state_list) < 1:
             raise ValueError(f"Parent coin record 0x{coin_state.coin.parent_coin_info.hex()} not found")
         parent_coin_state: CoinState = parent_coin_state_list[0]
-        coin_spend = await self.service.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+        coin_spend = await self.service.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
             parent_coin_state, peer
         )
         return coin_spend, coin_state
@@ -821,7 +821,7 @@ class WalletRpcApi:
                     [tr.additions[0].parent_coin_info], peer=peer
                 )
                 assert len(coin_state_list) == 1
-                coin_spend = await self.service.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+                coin_spend = await self.service.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
                     coin_state_list[0], peer
                 )
                 tr = dataclasses.replace(tr, spend_bundle=SpendBundle([coin_spend], G2Element()))

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -70,6 +70,7 @@ from chia.wallet.util.address_type import AddressType, is_valid_address
 from chia.wallet.util.compute_hints import compute_coin_hints
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
 from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -296,9 +297,7 @@ class WalletRpcApi:
         if parent_coin_state_list is None or len(parent_coin_state_list) < 1:
             raise ValueError(f"Parent coin record 0x{coin_state.coin.parent_coin_info.hex()} not found")
         parent_coin_state: CoinState = parent_coin_state_list[0]
-        coin_spend = await self.service.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
-            parent_coin_state, peer
-        )
+        coin_spend = await fetch_coin_spend_for_coin_state(parent_coin_state, peer)
         return coin_spend, coin_state
 
     ##########################################################################################
@@ -821,9 +820,7 @@ class WalletRpcApi:
                     [tr.additions[0].parent_coin_info], peer=peer
                 )
                 assert len(coin_state_list) == 1
-                coin_spend = await self.service.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
-                    coin_state_list[0], peer
-                )
+                coin_spend = await fetch_coin_spend_for_coin_state(coin_state_list[0], peer)
                 tr = dataclasses.replace(tr, spend_bundle=SpendBundle([coin_spend], G2Element()))
             else:
                 raise ValueError(f"Transaction 0x{transaction_id.hex()} doesn't have any coin spend.")

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -296,8 +296,8 @@ class WalletRpcApi:
         if parent_coin_state_list is None or len(parent_coin_state_list) < 1:
             raise ValueError(f"Parent coin record 0x{coin_state.coin.parent_coin_info.hex()} not found")
         parent_coin_state: CoinState = parent_coin_state_list[0]
-        coin_spend: CoinSpend = await self.service.wallet_state_manager.wallet_node.fetch_puzzle_solution(
-            parent_coin_state.spent_height, parent_coin_state.coin, peer
+        coin_spend = await self.service.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+            parent_coin_state, peer
         )
         return coin_spend, coin_state
 
@@ -821,8 +821,8 @@ class WalletRpcApi:
                     [tr.additions[0].parent_coin_info], peer=peer
                 )
                 assert len(coin_state_list) == 1
-                coin_spend: CoinSpend = await self.service.wallet_state_manager.wallet_node.fetch_puzzle_solution(
-                    coin_state_list[0].spent_height, coin_state_list[0].coin, peer
+                coin_spend = await self.service.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+                    coin_state_list[0], peer
                 )
                 tr = dataclasses.replace(tr, spend_bundle=SpendBundle([coin_spend], G2Element()))
             else:

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -347,7 +347,7 @@ class CATWallet:
                     [coin.parent_coin_info], peer=peer
                 )
                 assert coin_state[0].coin.name() == coin.parent_coin_info
-                coin_spend = await self.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+                coin_spend = await self.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
                     coin_state[0], peer
                 )
                 await self.puzzle_solution_received(coin_spend, parent_coin=coin_state[0].coin)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -51,6 +51,7 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.curry_and_treehash import calculate_hash_of_quoted_mod_hash, curry_and_treehash
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -347,9 +348,7 @@ class CATWallet:
                     [coin.parent_coin_info], peer=peer
                 )
                 assert coin_state[0].coin.name() == coin.parent_coin_info
-                coin_spend = await self.wallet_state_manager.wallet_node.fetch_coin_spend_for_coin_state(
-                    coin_state[0], peer
-                )
+                coin_spend = await fetch_coin_spend_for_coin_state(coin_state[0], peer)
                 await self.puzzle_solution_received(coin_spend, parent_coin=coin_state[0].coin)
             except Exception as e:
                 self.log.debug(f"Exception: {e}, traceback: {traceback.format_exc()}")

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -347,8 +347,8 @@ class CATWallet:
                     [coin.parent_coin_info], peer=peer
                 )
                 assert coin_state[0].coin.name() == coin.parent_coin_info
-                coin_spend = await self.wallet_state_manager.wallet_node.fetch_puzzle_solution(
-                    coin_state[0].spent_height, coin_state[0].coin, peer
+                coin_spend = await self.wallet_state_manager.wallet_node.get_coin_spend_for_coin_state(
+                    coin_state[0], peer
                 )
                 await self.puzzle_solution_received(coin_spend, parent_coin=coin_state[0].coin)
             except Exception as e:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -505,7 +505,7 @@ class DIDWallet:
 
                 await self.save_info(did_info)
                 assert children_state.created_height
-                parent_spend = await wallet_node.fetch_puzzle_solution(children_state.created_height, parent_coin, peer)
+                parent_spend = await wallet_node.fetch_coin_spend(children_state.created_height, parent_coin, peer)
                 assert parent_spend is not None
                 parent_innerpuz = get_inner_puzzle_from_singleton(parent_spend.puzzle_reveal.to_program())
                 assert parent_innerpuz is not None

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -44,6 +44,7 @@ from chia.wallet.singleton import (
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.util.wallet_sync_utils import fetch_coin_spend
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -505,7 +506,7 @@ class DIDWallet:
 
                 await self.save_info(did_info)
                 assert children_state.created_height
-                parent_spend = await wallet_node.fetch_coin_spend(children_state.created_height, parent_coin, peer)
+                parent_spend = await fetch_coin_spend(uint32(children_state.created_height), parent_coin, peer)
                 assert parent_spend is not None
                 parent_innerpuz = get_inner_puzzle_from_singleton(parent_spend.puzzle_reveal.to_program())
                 assert parent_innerpuz is not None

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -50,6 +50,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.util.wallet_sync_utils import fetch_coin_spend
 from chia.wallet.util.wallet_types import AmountWithPuzzlehash, WalletType
 from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -170,7 +171,7 @@ class NFTWallet:
             return
         assert coin_states
         parent_coin = coin_states[0].coin
-        cs = await wallet_node.fetch_coin_spend(height, parent_coin, peer)
+        cs = await fetch_coin_spend(height, parent_coin, peer)
         assert cs is not None
         await self.puzzle_solution_received(cs, peer)
 

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -170,7 +170,7 @@ class NFTWallet:
             return
         assert coin_states
         parent_coin = coin_states[0].coin
-        cs = await wallet_node.fetch_puzzle_solution(height, parent_coin, peer)
+        cs = await wallet_node.fetch_coin_spend(height, parent_coin, peer)
         assert cs is not None
         await self.puzzle_solution_received(cs, peer)
 

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -31,6 +31,7 @@ from chia.protocols.wallet_protocol import (
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_spend import CoinSpend
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
 from chia.util.ints import uint32
@@ -408,3 +409,25 @@ async def fetch_header_blocks_in_range(
         assert res_h_blocks is not None
         blocks.extend([bl for bl in res_h_blocks.header_blocks if bl.height >= start])
     return blocks
+
+
+async def fetch_coin_spend(height: uint32, coin: Coin, peer: WSChiaConnection) -> CoinSpend:
+    solution_response = await peer.call_api(
+        FullNodeAPI.request_puzzle_solution, wallet_protocol.RequestPuzzleSolution(coin.name(), height)
+    )
+    if solution_response is None or not isinstance(solution_response, wallet_protocol.RespondPuzzleSolution):
+        raise PeerRequestException(f"Was not able to obtain solution {solution_response}")
+    assert solution_response.response.puzzle.get_tree_hash() == coin.puzzle_hash
+    assert solution_response.response.coin_name == coin.name()
+
+    return CoinSpend(
+        coin,
+        solution_response.response.puzzle,
+        solution_response.response.solution,
+    )
+
+
+async def fetch_coin_spend_for_coin_state(coin_state: CoinState, peer: WSChiaConnection) -> CoinSpend:
+    if coin_state.spent_height is None:
+        raise ValueError("coin_state.coin must be spent coin")
+    return await fetch_coin_spend(uint32(coin_state.spent_height), coin_state.coin, peer)

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1556,7 +1556,7 @@ class WalletNode:
             peer_request_cache.add_to_blocks_validated(reward_chain_hash, height)
         return True
 
-    async def fetch_puzzle_solution(self, height: uint32, coin: Coin, peer: WSChiaConnection) -> CoinSpend:
+    async def fetch_coin_spend(self, height: uint32, coin: Coin, peer: WSChiaConnection) -> CoinSpend:
         solution_response = await peer.call_api(
             FullNodeAPI.request_puzzle_solution, wallet_protocol.RequestPuzzleSolution(coin.name(), height)
         )
@@ -1571,10 +1571,10 @@ class WalletNode:
             solution_response.response.solution,
         )
 
-    async def get_coin_spend_for_coin_state(self, coin_state: CoinState, peer: WSChiaConnection) -> CoinSpend:
+    async def fetch_coin_spend_for_coin_state(self, coin_state: CoinState, peer: WSChiaConnection) -> CoinSpend:
         if coin_state.spent_height is None:
             raise ValueError("coin_state.coin must be spent coin")
-        return await self.fetch_puzzle_solution(uint32(coin_state.spent_height), coin_state.coin, peer)
+        return await self.fetch_coin_spend(uint32(coin_state.spent_height), coin_state.coin, peer)
 
     async def get_coin_state(
         self, coin_names: List[bytes32], peer: WSChiaConnection, fork_height: Optional[uint32] = None

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1571,6 +1571,11 @@ class WalletNode:
             solution_response.response.solution,
         )
 
+    async def get_coin_spend_for_coin_state(self, coin_state: CoinState, peer: WSChiaConnection) -> CoinSpend:
+        if coin_state.spent_height is None:
+            raise ValueError("coin_state.coin must be spent coin")
+        return await self.fetch_puzzle_solution(uint32(coin_state.spent_height), coin_state.coin, peer)
+
     async def get_coin_state(
         self, coin_names: List[bytes32], peer: WSChiaConnection, fork_height: Optional[uint32] = None
     ) -> List[CoinState]:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -70,7 +70,11 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_hints import compute_coin_hints
 from chia.wallet.util.transaction_type import TransactionType
-from chia.wallet.util.wallet_sync_utils import PeerRequestException, last_change_height_cs
+from chia.wallet.util.wallet_sync_utils import (
+    PeerRequestException,
+    fetch_coin_spend_for_coin_state,
+    last_change_height_cs,
+)
 from chia.wallet.util.wallet_types import WalletIdentifier, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_blockchain import WalletBlockchain
@@ -621,7 +625,7 @@ class WalletStateManager:
         parent_coin_state = response[0]
         assert parent_coin_state.spent_height == coin_state.created_height
 
-        coin_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(parent_coin_state, peer)
+        coin_spend = await fetch_coin_spend_for_coin_state(parent_coin_state, peer)
         if coin_spend is None:
             return None
 
@@ -831,7 +835,7 @@ class WalletStateManager:
     async def get_minter_did(self, launcher_coin: Coin, peer: WSChiaConnection) -> Optional[bytes32]:
         # Get minter DID
         eve_coin = (await self.wallet_node.fetch_children(launcher_coin.name(), peer=peer))[0]
-        eve_coin_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(eve_coin, peer)
+        eve_coin_spend = await fetch_coin_spend_for_coin_state(eve_coin, peer)
         eve_full_puzzle: Program = Program.from_bytes(bytes(eve_coin_spend.puzzle_reveal))
         eve_uncurried_nft: Optional[UncurriedNFT] = UncurriedNFT.uncurry(*eve_full_puzzle.uncurry())
         if eve_uncurried_nft is None:
@@ -855,7 +859,7 @@ class WalletStateManager:
                 [launcher_parent[0].coin.parent_coin_info], peer=peer
             )
             assert did_coin is not None and len(did_coin) == 1 and did_coin[0].spent_height is not None
-            did_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(did_coin[0], peer)
+            did_spend = await fetch_coin_spend_for_coin_state(did_coin[0], peer)
             puzzle = Program.from_bytes(bytes(did_spend.puzzle_reveal))
             uncurried = uncurry_puzzle(puzzle)
             did_curried_args = match_did_puzzle(uncurried.mod, uncurried.args)
@@ -1204,7 +1208,7 @@ class WalletStateManager:
                                 curr_coin_state: CoinState = coin_state
 
                                 while curr_coin_state.spent_height is not None:
-                                    cs = await self.wallet_node.fetch_coin_spend_for_coin_state(curr_coin_state, peer)
+                                    cs = await fetch_coin_spend_for_coin_state(curr_coin_state, peer)
                                     success = await pool_wallet.apply_state_transition(
                                         cs, uint32(curr_coin_state.spent_height)
                                     )
@@ -1237,7 +1241,7 @@ class WalletStateManager:
                                     assert len(new_coin_state) == 1
                                     curr_coin_state = new_coin_state[0]
                         if record.wallet_type == WalletType.DATA_LAYER:
-                            singleton_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(coin_state, peer)
+                            singleton_spend = await fetch_coin_spend_for_coin_state(coin_state, peer)
                             dl_wallet = self.get_wallet(id=uint32(record.wallet_id), required_type=DataLayerWallet)
                             await dl_wallet.singleton_removed(
                                 singleton_spend,
@@ -1258,7 +1262,7 @@ class WalletStateManager:
                             if child.spent_height is None:
                                 # TODO handle spending launcher later block
                                 continue
-                            launcher_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(child, peer)
+                            launcher_spend = await fetch_coin_spend_for_coin_state(child, peer)
                             if launcher_spend is None:
                                 continue
                             try:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -621,7 +621,7 @@ class WalletStateManager:
         parent_coin_state = response[0]
         assert parent_coin_state.spent_height == coin_state.created_height
 
-        coin_spend = await self.wallet_node.get_coin_spend_for_coin_state(parent_coin_state, peer)
+        coin_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(parent_coin_state, peer)
         if coin_spend is None:
             return None
 
@@ -831,7 +831,7 @@ class WalletStateManager:
     async def get_minter_did(self, launcher_coin: Coin, peer: WSChiaConnection) -> Optional[bytes32]:
         # Get minter DID
         eve_coin = (await self.wallet_node.fetch_children(launcher_coin.name(), peer=peer))[0]
-        eve_coin_spend = await self.wallet_node.get_coin_spend_for_coin_state(eve_coin, peer)
+        eve_coin_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(eve_coin, peer)
         eve_full_puzzle: Program = Program.from_bytes(bytes(eve_coin_spend.puzzle_reveal))
         eve_uncurried_nft: Optional[UncurriedNFT] = UncurriedNFT.uncurry(*eve_full_puzzle.uncurry())
         if eve_uncurried_nft is None:
@@ -855,7 +855,7 @@ class WalletStateManager:
                 [launcher_parent[0].coin.parent_coin_info], peer=peer
             )
             assert did_coin is not None and len(did_coin) == 1 and did_coin[0].spent_height is not None
-            did_spend = await self.wallet_node.get_coin_spend_for_coin_state(did_coin[0], peer)
+            did_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(did_coin[0], peer)
             puzzle = Program.from_bytes(bytes(did_spend.puzzle_reveal))
             uncurried = uncurry_puzzle(puzzle)
             did_curried_args = match_did_puzzle(uncurried.mod, uncurried.args)
@@ -1204,7 +1204,7 @@ class WalletStateManager:
                                 curr_coin_state: CoinState = coin_state
 
                                 while curr_coin_state.spent_height is not None:
-                                    cs = await self.wallet_node.get_coin_spend_for_coin_state(curr_coin_state, peer)
+                                    cs = await self.wallet_node.fetch_coin_spend_for_coin_state(curr_coin_state, peer)
                                     success = await pool_wallet.apply_state_transition(
                                         cs, uint32(curr_coin_state.spent_height)
                                     )
@@ -1237,7 +1237,7 @@ class WalletStateManager:
                                     assert len(new_coin_state) == 1
                                     curr_coin_state = new_coin_state[0]
                         if record.wallet_type == WalletType.DATA_LAYER:
-                            singleton_spend = await self.wallet_node.get_coin_spend_for_coin_state(coin_state, peer)
+                            singleton_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(coin_state, peer)
                             dl_wallet = self.get_wallet(id=uint32(record.wallet_id), required_type=DataLayerWallet)
                             await dl_wallet.singleton_removed(
                                 singleton_spend,
@@ -1258,7 +1258,7 @@ class WalletStateManager:
                             if child.spent_height is None:
                                 # TODO handle spending launcher later block
                                 continue
-                            launcher_spend = await self.wallet_node.get_coin_spend_for_coin_state(child, peer)
+                            launcher_spend = await self.wallet_node.fetch_coin_spend_for_coin_state(child, peer)
                             if launcher_spend is None:
                                 continue
                             try:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -621,9 +621,7 @@ class WalletStateManager:
         parent_coin_state = response[0]
         assert parent_coin_state.spent_height == coin_state.created_height
 
-        coin_spend: Optional[CoinSpend] = await self.wallet_node.fetch_puzzle_solution(
-            parent_coin_state.spent_height, parent_coin_state.coin, peer
-        )
+        coin_spend = await self.wallet_node.get_coin_spend_for_coin_state(parent_coin_state, peer)
         if coin_spend is None:
             return None
 
@@ -833,9 +831,7 @@ class WalletStateManager:
     async def get_minter_did(self, launcher_coin: Coin, peer: WSChiaConnection) -> Optional[bytes32]:
         # Get minter DID
         eve_coin = (await self.wallet_node.fetch_children(launcher_coin.name(), peer=peer))[0]
-        eve_coin_spend: CoinSpend = await self.wallet_node.fetch_puzzle_solution(
-            eve_coin.spent_height, eve_coin.coin, peer
-        )
+        eve_coin_spend = await self.wallet_node.get_coin_spend_for_coin_state(eve_coin, peer)
         eve_full_puzzle: Program = Program.from_bytes(bytes(eve_coin_spend.puzzle_reveal))
         eve_uncurried_nft: Optional[UncurriedNFT] = UncurriedNFT.uncurry(*eve_full_puzzle.uncurry())
         if eve_uncurried_nft is None:
@@ -859,9 +855,7 @@ class WalletStateManager:
                 [launcher_parent[0].coin.parent_coin_info], peer=peer
             )
             assert did_coin is not None and len(did_coin) == 1 and did_coin[0].spent_height is not None
-            did_spend: CoinSpend = await self.wallet_node.fetch_puzzle_solution(
-                did_coin[0].spent_height, did_coin[0].coin, peer
-            )
+            did_spend = await self.wallet_node.get_coin_spend_for_coin_state(did_coin[0], peer)
             puzzle = Program.from_bytes(bytes(did_spend.puzzle_reveal))
             uncurried = uncurry_puzzle(puzzle)
             did_curried_args = match_did_puzzle(uncurried.mod, uncurried.args)
@@ -1210,9 +1204,7 @@ class WalletStateManager:
                                 curr_coin_state: CoinState = coin_state
 
                                 while curr_coin_state.spent_height is not None:
-                                    cs: CoinSpend = await self.wallet_node.fetch_puzzle_solution(
-                                        curr_coin_state.spent_height, curr_coin_state.coin, peer
-                                    )
+                                    cs = await self.wallet_node.get_coin_spend_for_coin_state(curr_coin_state, peer)
                                     success = await pool_wallet.apply_state_transition(
                                         cs, uint32(curr_coin_state.spent_height)
                                     )
@@ -1245,9 +1237,7 @@ class WalletStateManager:
                                     assert len(new_coin_state) == 1
                                     curr_coin_state = new_coin_state[0]
                         if record.wallet_type == WalletType.DATA_LAYER:
-                            singleton_spend = await self.wallet_node.fetch_puzzle_solution(
-                                coin_state.spent_height, coin_state.coin, peer
-                            )
+                            singleton_spend = await self.wallet_node.get_coin_spend_for_coin_state(coin_state, peer)
                             dl_wallet = self.get_wallet(id=uint32(record.wallet_id), required_type=DataLayerWallet)
                             await dl_wallet.singleton_removed(
                                 singleton_spend,
@@ -1268,9 +1258,7 @@ class WalletStateManager:
                             if child.spent_height is None:
                                 # TODO handle spending launcher later block
                                 continue
-                            launcher_spend: Optional[CoinSpend] = await self.wallet_node.fetch_puzzle_solution(
-                                child.spent_height, child.coin, peer
-                            )
+                            launcher_spend = await self.wallet_node.get_coin_spend_for_coin_state(child, peer)
                             if launcher_spend is None:
                                 continue
                             try:

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -1184,10 +1184,10 @@ class TestWalletSync:
 
             return new_func
 
-        def flaky_fetch_puzzle_solution(node, func):
+        def flaky_fetch_coin_spend(node, func):
             async def new_func(*args, **kwargs):
-                if node.puzzle_solution_flaky:
-                    node.puzzle_solution_flaky = False
+                if node.coin_spend_flaky:
+                    node.coin_spend_flaky = False
                     raise PeerRequestException()
                 else:
                     return await func(*args, **kwargs)
@@ -1227,15 +1227,13 @@ class TestWalletSync:
         for wallet_node, wallet_server in wallets:
             wallet_node.coin_state_retry_seconds = 1
             wallet_node.coin_state_flaky = True
-            wallet_node.puzzle_solution_flaky = True
+            wallet_node.coin_spend_flaky = True
             wallet_node.fetch_children_flaky = True
             wallet_node.get_timestamp_flaky = True
             wallet_node.db_flaky = True
 
             wallet_node.get_coin_state = flaky_get_coin_state(wallet_node, wallet_node.get_coin_state)
-            wallet_node.fetch_puzzle_solution = flaky_fetch_puzzle_solution(
-                wallet_node, wallet_node.fetch_puzzle_solution
-            )
+            wallet_node.fetch_coin_spend = flaky_fetch_coin_spend(wallet_node, wallet_node.fetch_coin_spend)
             wallet_node.fetch_children = flaky_fetch_children(wallet_node, wallet_node.fetch_children)
             wallet_node.get_timestamp_for_height = flaky_get_timestamp(
                 wallet_node, wallet_node.get_timestamp_for_height
@@ -1278,7 +1276,7 @@ class TestWalletSync:
             await assert_coin_state_retry()
 
             assert not wallet_node.coin_state_flaky
-            assert not wallet_node.puzzle_solution_flaky
+            assert not wallet_node.coin_spend_flaky
             assert not wallet_node.fetch_children_flaky
             assert not wallet_node.get_timestamp_flaky
             assert not wallet_node.db_flaky


### PR DESCRIPTION
### Purpose:

Cleanup - working towards hinted `WalletStateManager`.

1. Move it out of `WalletNode` and make it a free function in `wallet_sync_util.py`
2. Rename it to `fetch_coin_spend`. Even though we request the puzzle solution via `request_puzzle_solution`, `CoinSpend` is what we get in return and to me it seems clearer when reading code this way.
3. Adjust the retry-store test have the flakiness for coin spend fetching on the server side (`FullNodeAPI`), not on the client side (`WalletNode`).
4. Introduce `fetch_coin_spend_from_coin_state` to make `mypy` happy in some cases where we fetch the `CoinSpend` for an existing `CoinState` which has a `Optional[int]` spent height.

### New Behavior:

No change in behaviour.