### PR TITLE
Fixed windows issues with passphrase prompt on CLI by flushing prompt

### DIFF
--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -91,7 +91,7 @@ def verify_passphrase_meets_requirements(
 
 def prompt_for_passphrase(prompt: str) -> str:
     if sys.platform == "win32" or sys.platform == "cygwin":
-        print(prompt, end="")
+        print(prompt, end="", flush=True)
         prompt = ""
     return getpass(prompt)
 


### PR DESCRIPTION
This fixes #14889 in my testing.
Unclear why this wasn't needed prior to 1.7.1, but possibly an update to colorama was responsible. 

Testing:
Using CLI on windows in 1.7.1, the passphrase prompt to unlock the passphrase did not appear, although the daemon was waiting for the user to type the passphrase