### PR TITLE
wallet: Improve coin state retry wait logic and retry store test

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -466,8 +466,8 @@ class WalletNode:
     async def _retry_failed_states(self):
         while not self._shut_down:
             try:
+                await asyncio.sleep(self.coin_state_retry_seconds)
                 if self.wallet_state_manager is None:
-                    await asyncio.sleep(self.coin_state_retry_seconds)
                     continue
                 states_to_retry = await self.wallet_state_manager.retry_store.get_all_states_to_retry()
                 for state, peer_id, fork_height in states_to_retry:
@@ -478,7 +478,6 @@ class WalletNode:
                         peer = self.get_full_node_peer()
                         if peer is None:
                             self.log.info(f"disconnected from all peers, cannot retry state: {state}")
-                            await asyncio.sleep(self.coin_state_retry_seconds)
                             continue
                         else:
                             self.log.info(
@@ -496,7 +495,6 @@ class WalletNode:
                             self.log.exception(f"Exception while adding states.. : {e}")
                         else:
                             await self.wallet_state_manager.blockchain.clean_block_records()
-                await asyncio.sleep(self.coin_state_retry_seconds)
             except asyncio.CancelledError:
                 self.log.info("Retry task cancelled, exiting.")
                 raise

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -11,7 +11,6 @@ from colorlog import getLogger
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
-from chia.full_node.mempool_manager import MempoolManager
 from chia.full_node.weight_proof import WeightProofHandler
 from chia.protocols import full_node_protocol, wallet_protocol
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
@@ -1226,6 +1225,7 @@ class TestWalletSync:
             return new_func
 
         for wallet_node, wallet_server in wallets:
+            wallet_node.coin_state_retry_seconds = 1
             wallet_node.coin_state_flaky = True
             wallet_node.puzzle_solution_flaky = True
             wallet_node.fetch_children_flaky = True
@@ -1251,36 +1251,30 @@ class TestWalletSync:
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32([0] * 32)))
 
-            async def len_gt_0(func, *args):
-                return len((await func(*args))) > 0
+            async def retry_store_empty() -> bool:
+                return len(await wallet_node.wallet_state_manager.retry_store.get_all_states_to_retry()) == 0
 
-            await time_out_assert(
-                15, len_gt_0, True, wallet_node.wallet_state_manager.retry_store.get_all_states_to_retry
-            )
-            await time_out_assert(
-                30, len_gt_0, False, wallet_node.wallet_state_manager.retry_store.get_all_states_to_retry
-            )
+            async def assert_coin_state_retry() -> None:
+                # Wait for retry coin states to show up
+                await time_out_assert(15, retry_store_empty, False)
+                # And become retried/removed
+                await time_out_assert(30, retry_store_empty, True)
+
+            await assert_coin_state_retry()
 
             await time_out_assert(30, wallet.get_confirmed_balance, 2_000_000_000_000)
 
             tx = await wallet.generate_signed_transaction(1_000_000_000_000, bytes32([0] * 32), memos=[ph])
             await wallet_node.wallet_state_manager.add_pending_transaction(tx)
 
-            async def tx_in_pool(mempool: MempoolManager, tx_id: bytes32):
-                tx = mempool.get_spendbundle(tx_id)
-                if tx is None:
-                    return False
-                return True
+            async def tx_in_mempool():
+                return full_node_api.full_node.mempool_manager.get_spendbundle(tx.name) is not None
 
-            await time_out_assert(15, tx_in_pool, True, full_node_api.full_node.mempool_manager, tx.name)
+            await time_out_assert(15, tx_in_mempool)
             await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32([0] * 32)))
 
-            await time_out_assert(
-                15, len_gt_0, True, wallet_node.wallet_state_manager.retry_store.get_all_states_to_retry
-            )
-            await time_out_assert(
-                120, len_gt_0, False, wallet_node.wallet_state_manager.retry_store.get_all_states_to_retry
-            )
+            await assert_coin_state_retry()
+
             assert not wallet_node.coin_state_flaky
             assert not wallet_node.puzzle_solution_flaky
             assert not wallet_node.fetch_children_flaky


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

- Simplify the retry logic
- Remove an indent for all the retry code
- Simplify the test
- Speedup the test. Times on my system:
    - `main`: 51s
    - This PR: 225s

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The logic sleeps two/three times 5 seconds before retrying the coin states.

### New Behavior:

The code sleeps one time for `coin_state_retry_seconds` (10s) seconds before retrying the coin states.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Covered by tests.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
