### PR TITLE
activate the soft-fork and soft-fork2 earlier on testnet10

### DIFF
--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -71,7 +71,15 @@ async def async_main(service_config: Dict[str, Any]) -> int:
     # TODO: refactor to avoid the double load
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     config[SERVICE_NAME] = service_config
-    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
+    network_id = service_config["selected_network"]
+    overrides = service_config["network_overrides"]["constants"][network_id]
+    if network_id == "testnet10":
+        # testnet10 is 1031258 blocks behind mainnet
+        testnet10_offset = 1031258
+        if "SOFT_FORK2_HEIGHT" not in overrides:
+            overrides["SOFT_FORK2_HEIGHT"] = 4000000 - testnet10_offset
+        if "SOFT_FORK_HEIGHT" not in overrides:
+            overrides["SOFT_FORK_HEIGHT"] = 3630000 - testnet10_offset
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
     initialize_service_logging(service_name=SERVICE_NAME, config=config)
     service = create_full_node_service(DEFAULT_ROOT_PATH, config, updated_constants)

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -71,6 +71,8 @@ network_overrides: &network_overrides
       GENESIS_PRE_FARM_POOL_PUZZLE_HASH: d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
+      SOFT_FORK_HEIGHT: 2598742
+      SOFT_FORK2_HEIGHT: 2968742
   config:
     mainnet:
       address_prefix: "xch"


### PR DESCRIPTION
To facilitate testing soft-fork2 features (like, `ASSERT_BEFORE_*` and other new condition codes), this patch makes the soft-fork activation heights lower when running on testnet10.

The current block height on testnet10 is about 2408931. The activation height proposed here is 5 weeks out.

I stepped through this in `pdb`, when running testnet, to ensure the constants were updated correctly.