### PR TITLE
Fix the mempool fee rate calculation

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -54,7 +54,7 @@ class Mempool:
             # assert_height may be NIL
             generated = ""
             if not SQLITE_NO_GENERATED_COLUMNS:
-                generated = " GENERATED ALWAYS AS (fee / cost) VIRTUAL"
+                generated = " GENERATED ALWAYS AS (CAST(fee AS REAL) / cost) VIRTUAL"
 
             self._db_conn.execute(
                 f"""CREATE TABLE tx(

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -1103,3 +1103,31 @@ async def test_sufficient_total_fpc_increase() -> None:
     assert_sb_in_pool(mempool_manager, sb1234)
     assert_sb_not_in_pool(mempool_manager, sb12)
     assert_sb_not_in_pool(mempool_manager, sb3)
+
+
+@pytest.mark.asyncio
+async def test_spends_by_feerate() -> None:
+    # This test makes sure we're properly sorting items by fee rate
+    async def send_to_mempool_returning_item(
+        mempool_manager: MempoolManager, coin: Coin, *, fee: int = 0
+    ) -> MempoolItem:
+        conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, coin.amount - fee]]
+        sb = spend_bundle_from_conditions(conditions, coin)
+        result = await add_spendbundle(mempool_manager, sb, sb.name())
+        assert result[1] == MempoolInclusionStatus.SUCCESS
+        mi = mempool_manager.get_mempool_item(sb.name())
+        assert mi is not None
+        return mi
+
+    mempool_manager, coins = await setup_mempool_with_coins(coin_amounts=list(range(1000000000, 1000000005)))
+    # Create a ~3.73 FPC item
+    mi1 = await send_to_mempool_returning_item(mempool_manager, coins[0], fee=11000000)
+    # Create a ~3.39 FPC item
+    mi2 = await send_to_mempool_returning_item(mempool_manager, coins[1], fee=10000000)
+    # Create a ~3.56 FPC item
+    mi3 = await send_to_mempool_returning_item(mempool_manager, coins[2], fee=10500000)
+    assert mi1.fee_per_cost > mi2.fee_per_cost
+    assert mi1.fee_per_cost > mi3.fee_per_cost
+    assert mi3.fee_per_cost > mi2.fee_per_cost
+    items = mempool_manager.mempool.spends_by_feerate()
+    assert list(items) == [mi1, mi3, mi2]


### PR DESCRIPTION
It's currently performing integer division instead of float division, resulting in incorrect sorting of mempool items by fee rate. Items with `x.y` fee rate get all treated as items of `x.0` fee rate.