### PR TITLE
seeder: case-insensitive DNS label matching to support bit 0x20 use

### DIFF
--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -208,7 +208,9 @@ class DNSServer:
             }
 
             qname = request.q.qname
-            qn = str(qname)
+            # DNS labels are mixed case with DNS resolvers that implement the use of bit 0x20 to improve
+            # transaction identity. See https://datatracker.ietf.org/doc/html/draft-vixie-dnsext-dns0x20-00
+            qn = str(qname).lower()
             qtype = request.q.qtype
             qt = QTYPE[qtype]
             if qn == D or qn.endswith("." + D):


### PR DESCRIPTION
Some DNS resolvers (notably 8.8.8.8) have implemented the use of bit 0x20 in DNS labels to make cache poisoning attacks more difficult.

See https://datatracker.ietf.org/doc/html/draft-vixie-dnsext-dns0x20-00 for more details.

Without this patch, resolution though Google public DNS fails:

```
$ dig dns-introducer.chia.net @8.8.8.8 +short | wc -l
       0
```

Whereas it works as expected on a seeder which already deployed this patch:

```
$ dig chia.ctrlaltdel.ch @8.8.8.8 +short | wc -l
      32
```

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
