### PR TITLE
expose NFT coin info's latest_height to RPCs requesting NFT info

### DIFF
--- a/chia/wallet/nft_wallet/nft_info.py
+++ b/chia/wallet/nft_wallet/nft_info.py
@@ -29,6 +29,9 @@ class NFTInfo(Streamable):
     nft_coin_id: bytes32
     """Current NFT coin ID"""
 
+    nft_coin_confirmation_height: uint32
+    """Current NFT coin confirmation height"""
+
     owner_did: Optional[bytes32]
     """Owner DID"""
 

--- a/chia/wallet/nft_wallet/nft_puzzles.py
+++ b/chia/wallet/nft_wallet/nft_puzzles.py
@@ -109,6 +109,7 @@ async def get_nft_info_from_puzzle(
         encode_puzzle_hash(uncurried_nft.singleton_launcher_id, prefix=AddressType.NFT.hrp(config=config)),
         uncurried_nft.singleton_launcher_id,
         nft_coin_info.coin.name(),
+        nft_coin_info.latest_height,
         uncurried_nft.owner_did,
         uncurried_nft.trade_price_percentage,
         uncurried_nft.royalty_address,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
The GUI would like to have access to a sort key for NFTs that represents the order in which the NFTs are added into the user's wallet.
