### PR TITLE
Make sql pre-commit check work when pre-commit hooks are in non-standard locations

### DIFF
--- a/tests/check_sql_statements.py
+++ b/tests/check_sql_statements.py
@@ -9,7 +9,8 @@ from typing import Dict, Set, Tuple
 
 
 def check_create(sql_type: str, cwd: str, exemptions: Set[Tuple[str, str]] = set()) -> int:
-    lines = check_output(["git", "grep", f"CREATE {sql_type}"], cwd=cwd).decode("ascii").split("\n")
+    exemptions = set((cwd + "/" + file, name) for file, name in exemptions)
+    lines = check_output(["git", "grep", f"CREATE {sql_type}"]).decode("ascii").split("\n")
 
     ret = 0
 
@@ -20,6 +21,8 @@ def check_create(sql_type: str, cwd: str, exemptions: Set[Tuple[str, str]] = set
         if line.startswith("tests/"):
             continue
         if "db_upgrade_func.py" in line:
+            continue
+        if not line.startswith(cwd):
             continue
 
         name = line.split(f"CREATE {sql_type}")[1]

--- a/tests/check_sql_statements.py
+++ b/tests/check_sql_statements.py
@@ -9,6 +9,11 @@ from typing import Dict, Set, Tuple
 
 
 def check_create(sql_type: str, cwd: str, exemptions: Set[Tuple[str, str]] = set()) -> int:
+    # the need for this change seems to come from the git precommit plus the python pre-commit environment
+    # having GIT_DIR specified but not GIT_WORK_TREE.  this is an issue in some less common git setups
+    # such as with worktrees, at least in particular uses of them.  i think that we could switch to letting
+    # pre-commit provide the file list instead of reaching out to git to build that list ourselves.  until we
+    # make time to handle that, this is an alternative to alleviate the issue.
     exemptions = set((cwd + "/" + file, name) for file, name in exemptions)
     lines = check_output(["git", "grep", f"CREATE {sql_type}"]).decode("ascii").split("\n")
 


### PR DESCRIPTION
I have an admittedly pretty weird development setup involving git worktrees that all share some state.  Previously I have been unable to run pre-commit because of the use of the `cwd=` kwarg on `check_output`.  I lack the debugging skills to nail this down 100% apparently, but my best guess is that because the pre-commit hooks get installed in a non-standard location, trying to `cd` into the directories results in an error because the relative path is different than this check is expecting it to be.

The change I have proposed here fixes my issue by not using the `cwd=` kwarg and instead only checking certain segments of the full grep at a time.  I believe this is slightly more general to accomodate my edge case without removing the functionality from others.