### PR TITLE
drop `GIT_DIR` for check sql statements

### DIFF
--- a/tests/check_sql_statements.py
+++ b/tests/check_sql_statements.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
 import sys
 from subprocess import check_output
 from typing import Dict, Set, Tuple
@@ -9,7 +10,10 @@ from typing import Dict, Set, Tuple
 
 
 def check_create(sql_type: str, cwd: str, exemptions: Set[Tuple[str, str]] = set()) -> int:
-    lines = check_output(["git", "grep", f"CREATE {sql_type}"], cwd=cwd).decode("ascii").split("\n")
+    # the need for this isn't fully understood
+    # https://gist.github.com/altendky/b1bde4d15c63e889a766a6f1c6fcf33d
+    env = {k: v for k, v in os.environ.items() if k != "GIT_DIR"}
+    lines = check_output(["git", "grep", f"CREATE {sql_type}"], cwd=cwd, env=env).decode("ascii").split("\n")
 
     ret = 0
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

It seems that having `GIT_DIR` set, which happens when git is running the pre-commit precommit hook, that `git grep` fails to find anything when run in a subdirectory...  I dunno.

https://gist.github.com/altendky/b1bde4d15c63e889a766a6f1c6fcf33d

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
