### PR TITLE
wallet: Introduce `WalletIdentifier`

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -139,11 +139,10 @@ class CATWallet:
         cat_coin = None
         puzzle_store = self.wallet_state_manager.puzzle_store
         for c in non_ephemeral_coins:
-            info = await puzzle_store.wallet_info_for_puzzle_hash(c.puzzle_hash)
-            if info is None:
+            wallet_identifier = await puzzle_store.get_wallet_identifier_for_puzzle_hash(c.puzzle_hash)
+            if wallet_identifier is None:
                 raise ValueError("Internal Error")
-            id, wallet_type = info
-            if id == self.id():
+            if wallet_identifier.id == self.id():
                 cat_coin = c
 
         if cat_coin is None:

--- a/chia/wallet/notification_manager.py
+++ b/chia/wallet/notification_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 from blspy import G2Element
 
@@ -58,12 +58,12 @@ class NotificationManager:
             coin_memos: List[bytes] = memos.get(coin_name, [])
             if len(coin_memos) == 0:
                 return False
-            wallet_info: Optional[
-                Tuple[uint32, WalletType]
-            ] = await self.wallet_state_manager.get_wallet_id_for_puzzle_hash(bytes32(coin_memos[0]))
+            wallet_identifier = await self.wallet_state_manager.get_wallet_identifier_for_puzzle_hash(
+                bytes32(coin_memos[0])
+            )
             if (
-                wallet_info is not None
-                and wallet_info[1] == WalletType.STANDARD_WALLET
+                wallet_identifier is not None
+                and wallet_identifier.type == WalletType.STANDARD_WALLET
                 and len(coin_memos) == 2
                 and construct_notification(bytes32(coin_memos[0]), uint64(coin_state.coin.amount)).get_tree_hash()
                 == coin_state.coin.puzzle_hash

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -640,11 +640,12 @@ class TradeManager:
 
         addition_dict: Dict[uint32, List[Coin]] = {}
         for addition in additions:
-            wallet_info = await self.wallet_state_manager.get_wallet_id_for_puzzle_hash(addition.puzzle_hash)
-            if wallet_info is not None:
-                wallet_id, _ = wallet_info
+            wallet_identifier = await self.wallet_state_manager.get_wallet_identifier_for_puzzle_hash(
+                addition.puzzle_hash
+            )
+            if wallet_identifier is not None:
                 if addition.parent_coin_info in settlement_coin_ids:
-                    wallet = self.wallet_state_manager.wallets[wallet_id]
+                    wallet = self.wallet_state_manager.wallets[wallet_identifier.id]
                     to_puzzle_hash = await wallet.convert_puzzle_hash(addition.puzzle_hash)  # ATTENTION: new wallets
                     txs.append(
                         TransactionRecord(
@@ -658,7 +659,7 @@ class TradeManager:
                             spend_bundle=None,
                             additions=[addition],
                             removals=[],
-                            wallet_id=wallet_id,
+                            wallet_id=wallet_identifier.id,
                             sent_to=[],
                             trade_id=offer.name(),
                             type=uint32(TransactionType.INCOMING_TRADE.value),
@@ -667,17 +668,18 @@ class TradeManager:
                         )
                     )
                 else:  # This is change
-                    addition_dict.setdefault(wallet_id, [])
-                    addition_dict[wallet_id].append(addition)
+                    addition_dict.setdefault(wallet_identifier.id, [])
+                    addition_dict[wallet_identifier.id].append(addition)
 
         # While we want additions to show up as separate records, removals of the same wallet should show as one
         removal_dict: Dict[uint32, List[Coin]] = {}
         for removal in removals:
-            wallet_info = await self.wallet_state_manager.get_wallet_id_for_puzzle_hash(removal.puzzle_hash)
-            if wallet_info is not None:
-                wallet_id, _ = wallet_info
-                removal_dict.setdefault(wallet_id, [])
-                removal_dict[wallet_id].append(removal)
+            wallet_identifier = await self.wallet_state_manager.get_wallet_identifier_for_puzzle_hash(
+                removal.puzzle_hash
+            )
+            if wallet_identifier is not None:
+                removal_dict.setdefault(wallet_identifier.id, [])
+                removal_dict[wallet_identifier.id].append(removal)
 
         all_removals: List[bytes32] = [r.name() for removals in removal_dict.values() for r in removals]
 

--- a/chia/wallet/util/wallet_types.py
+++ b/chia/wallet/util/wallet_types.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import IntEnum
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from typing_extensions import TypedDict
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.ints import uint64
+from chia.util.ints import uint32, uint64
+
+if TYPE_CHECKING:
+    from chia.wallet.wallet_protocol import WalletProtocol
 
 
 class WalletType(IntEnum):
@@ -29,3 +33,13 @@ class AmountWithPuzzlehash(TypedDict):
     amount: uint64
     puzzlehash: bytes32
     memos: List[bytes]
+
+
+@dataclass(frozen=True)
+class WalletIdentifier:
+    id: uint32
+    type: WalletType
+
+    @classmethod
+    def create(cls, wallet: WalletProtocol) -> WalletIdentifier:
+        return cls(wallet.id(), wallet.type())

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 from blspy import G1Element
 
@@ -11,7 +11,7 @@ from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32
 from chia.util.lru_cache import LRUCache
 from chia.wallet.derivation_record import DerivationRecord
-from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.util.wallet_types import WalletIdentifier, WalletType
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class WalletPuzzleStore:
 
     lock: asyncio.Lock
     db_wrapper: DBWrapper2
-    wallet_info_for_ph_cache: LRUCache
+    wallet_identifier_cache: LRUCache
     # maps wallet_id -> last_derivation_index
     last_wallet_derivation_index: Dict[uint32, uint32]
     last_derivation_index: Optional[uint32]
@@ -64,7 +64,7 @@ class WalletPuzzleStore:
 
         # the lock is locked by the users of this class
         self.lock = asyncio.Lock()
-        self.wallet_info_for_ph_cache = LRUCache(100)
+        self.wallet_identifier_cache = LRUCache(100)
         self.last_derivation_index = None
         self.last_wallet_derivation_index = {}
         return self
@@ -267,12 +267,12 @@ class WalletPuzzleStore:
 
         return None
 
-    async def wallet_info_for_puzzle_hash(self, puzzle_hash: bytes32) -> Optional[Tuple[int, WalletType]]:
+    async def get_wallet_identifier_for_puzzle_hash(self, puzzle_hash: bytes32) -> Optional[WalletIdentifier]:
         """
         Returns the derivation path for the puzzle_hash.
         Returns None if not present.
         """
-        cached = self.wallet_info_for_ph_cache.get(puzzle_hash)
+        cached = self.wallet_identifier_cache.get(puzzle_hash)
         if cached is not None:
             return cached
 
@@ -282,8 +282,9 @@ class WalletPuzzleStore:
             )
 
         if row is not None:
-            self.wallet_info_for_ph_cache.put(puzzle_hash, (row[1], WalletType(row[0])))
-            return row[1], WalletType(row[0])
+            wallet_identifier = WalletIdentifier(uint32(row[1]), WalletType(row[0]))
+            self.wallet_identifier_cache.put(puzzle_hash, wallet_identifier)
+            return wallet_identifier
 
         return None
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -73,7 +73,7 @@ from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_hints import compute_coin_hints
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_sync_utils import PeerRequestException, last_change_height_cs
-from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.util.wallet_types import WalletIdentifier, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_blockchain import WalletBlockchain
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -555,16 +555,8 @@ class WalletStateManager:
         """
         Returns true if we have the key for this coin.
         """
-        info = await self.puzzle_store.wallet_info_for_puzzle_hash(coin.puzzle_hash)
-
-        if info is None:
-            return False
-
-        coin_wallet_id, wallet_type = info
-        if wallet_id == coin_wallet_id:
-            return True
-
-        return False
+        wallet_identifier = await self.puzzle_store.get_wallet_identifier_for_puzzle_hash(coin.puzzle_hash)
+        return wallet_identifier is not None and wallet_identifier.id == wallet_id
 
     async def get_confirmed_balance_for_wallet(
         self,
@@ -619,19 +611,19 @@ class WalletStateManager:
 
     async def determine_coin_type(
         self, peer: WSChiaConnection, coin_state: CoinState, fork_height: Optional[uint32]
-    ) -> Tuple[Optional[uint32], Optional[WalletType]]:
+    ) -> Optional[WalletIdentifier]:
         if coin_state.created_height is not None and (
             self.is_pool_reward(uint32(coin_state.created_height), coin_state.coin)
             or self.is_farmer_reward(uint32(coin_state.created_height), coin_state.coin)
         ):
-            return None, None
+            return None
 
         response: List[CoinState] = await self.wallet_node.get_coin_state(
             [coin_state.coin.parent_coin_info], peer=peer, fork_height=fork_height
         )
         if len(response) == 0:
             self.log.warning(f"Could not find a parent coin with ID: {coin_state.coin.parent_coin_info}")
-            return None, None
+            return None
         parent_coin_state = response[0]
         assert parent_coin_state.spent_height == coin_state.created_height
 
@@ -639,7 +631,7 @@ class WalletStateManager:
             parent_coin_state.spent_height, parent_coin_state.coin, peer
         )
         if coin_spend is None:
-            return None, None
+            return None
 
         puzzle = Program.from_bytes(bytes(coin_spend.puzzle_reveal))
 
@@ -664,7 +656,7 @@ class WalletStateManager:
 
         await self.notification_manager.potentially_add_new_notification(coin_state, coin_spend)
 
-        return None, None
+        return None
 
     async def filter_spam(self, new_coin_state: List[CoinState]) -> List[CoinState]:
         xch_spam_amount = self.config.get("xch_spam_amount", 1000000)
@@ -697,12 +689,8 @@ class WalletStateManager:
         return filtered_cs
 
     async def is_standard_wallet_tx(self, coin_state: CoinState) -> bool:
-        wallet_info: Optional[Tuple[uint32, WalletType]] = await self.get_wallet_id_for_puzzle_hash(
-            coin_state.coin.puzzle_hash
-        )
-        if wallet_info is not None and wallet_info[1] == WalletType.STANDARD_WALLET:
-            return True
-        return False
+        wallet_identifier = await self.get_wallet_identifier_for_puzzle_hash(coin_state.coin.puzzle_hash)
+        return wallet_identifier is not None and wallet_identifier.type == WalletType.STANDARD_WALLET
 
     async def handle_cat(
         self,
@@ -710,7 +698,7 @@ class WalletStateManager:
         parent_coin_state: CoinState,
         coin_state: CoinState,
         coin_spend: CoinSpend,
-    ) -> Tuple[Optional[uint32], Optional[WalletType]]:
+    ) -> Optional[WalletIdentifier]:
         """
         Handle the new coin when it is a CAT
         :param curried_args: Curried arg of the CAT mod
@@ -719,8 +707,6 @@ class WalletStateManager:
         :param coin_spend: New coin spend
         :return: Wallet ID & Wallet Type
         """
-        wallet_id = None
-        wallet_type = None
         mod_hash, tail_hash, inner_puzzle = curried_args
 
         hint_list = compute_coin_hints(coin_spend)
@@ -732,20 +718,20 @@ class WalletStateManager:
 
         if derivation_record is None:
             self.log.info(f"Received state for the coin that doesn't belong to us {coin_state}")
+            return None
         else:
             our_inner_puzzle: Program = self.main_wallet.puzzle_for_pk(derivation_record.pubkey)
             asset_id: bytes32 = bytes32(bytes(tail_hash)[1:])
             cat_puzzle = construct_cat_puzzle(CAT_MOD, asset_id, our_inner_puzzle, CAT_MOD_HASH)
             if cat_puzzle.get_tree_hash() != coin_state.coin.puzzle_hash:
-                return None, None
+                return None
             if bytes(tail_hash).hex()[2:] in self.default_cats or self.config.get(
                 "automatically_add_unknown_cats", False
             ):
                 cat_wallet = await CATWallet.get_or_create_wallet_for_cat(
                     self, self.main_wallet, bytes(tail_hash).hex()[2:]
                 )
-                wallet_id = cat_wallet.id()
-                wallet_type = cat_wallet.type()
+                return WalletIdentifier.create(cat_wallet)
             else:
                 # Found unacknowledged CAT, save it in the database.
                 await self.interested_store.add_unacknowledged_token(
@@ -755,7 +741,7 @@ class WalletStateManager:
                     parent_coin_state.coin.puzzle_hash,
                 )
                 self.state_changed("added_stray_cat")
-        return wallet_id, wallet_type
+                return None
 
     async def handle_did(
         self,
@@ -764,7 +750,7 @@ class WalletStateManager:
         coin_state: CoinState,
         coin_spend: CoinSpend,
         peer: WSChiaConnection,
-    ) -> Tuple[Optional[uint32], Optional[WalletType]]:
+    ) -> Optional[WalletIdentifier]:
         """
         Handle the new coin when it is a DID
         :param curried_args: Curried arg of the DID mod
@@ -773,8 +759,6 @@ class WalletStateManager:
         :param coin_spend: New coin spend
         :return: Wallet ID & Wallet Type
         """
-        wallet_id = None
-        wallet_type = None
         p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = curried_args
         inner_puzzle_hash = p2_puzzle.get_tree_hash()
         self.log.info(f"parent: {parent_coin_state.coin.name()} inner_puzzle_hash for parent is {inner_puzzle_hash}")
@@ -805,6 +789,7 @@ class WalletStateManager:
                 self.wallets.pop(remove_id)
                 self.log.info(f"Removed DID wallet {remove_id}, Launch_ID: {launch_id.hex()}")
                 self.state_changed("wallet_removed", remove_id)
+            return None
         else:
             our_inner_puzzle: Program = self.main_wallet.puzzle_for_pk(derivation_record.pubkey)
 
@@ -823,12 +808,12 @@ class WalletStateManager:
                     self.log.info("DID recovery list was reset by the previous owner.")
                 else:
                     self.log.error("DID puzzle hash doesn't match, please check curried parameters.")
-                    return None, None
+                    return None
             # Create DID wallet
             response: List[CoinState] = await self.wallet_node.get_coin_state([launch_id], peer=peer)
             if len(response) == 0:
                 self.log.warning(f"Could not find the launch coin with ID: {launch_id}")
-                return None, None
+                return None
             launch_coin: CoinState = response[0]
             origin_coin = launch_coin.coin
 
@@ -837,7 +822,7 @@ class WalletStateManager:
                     assert isinstance(wallet, DIDWallet)
                     assert wallet.did_info.origin_coin is not None
                     if origin_coin.name() == wallet.did_info.origin_coin.name():
-                        return wallet.id(), wallet.type()
+                        return WalletIdentifier.create(wallet)
             did_wallet = await DIDWallet.create_new_did_wallet_from_coin_spend(
                 self,
                 self.main_wallet,
@@ -846,10 +831,9 @@ class WalletStateManager:
                 coin_spend,
                 f"DID {encode_puzzle_hash(launch_id, AddressType.DID.hrp(self.config))}",
             )
-            wallet_id = did_wallet.id()
-            wallet_type = did_wallet.type()
-            self.state_changed("wallet_created", wallet_id, {"did_id": did_wallet.get_my_DID()})
-        return wallet_id, wallet_type
+            wallet_identifier = WalletIdentifier.create(did_wallet)
+            self.state_changed("wallet_created", wallet_identifier.id, {"did_id": did_wallet.get_my_DID()})
+            return wallet_identifier
 
     async def get_minter_did(self, launcher_coin: Coin, peer: WSChiaConnection) -> Optional[bytes32]:
         # Get minter DID
@@ -893,7 +877,7 @@ class WalletStateManager:
 
     async def handle_nft(
         self, coin_spend: CoinSpend, uncurried_nft: UncurriedNFT, parent_coin_state: CoinState, coin_state: CoinState
-    ) -> Tuple[Optional[uint32], Optional[WalletType]]:
+    ) -> Optional[WalletIdentifier]:
         """
         Handle the new coin when it is a NFT
         :param coin_spend: New coin spend
@@ -902,8 +886,7 @@ class WalletStateManager:
         :param coin_state: Current coin state
         :return: Wallet ID & Wallet Type
         """
-        wallet_id = None
-        wallet_type = None
+        wallet_identifier = None
         # DID ID determines which NFT wallet should process the NFT
         new_did_id = None
         old_did_id = None
@@ -939,7 +922,7 @@ class WalletStateManager:
                 "Cannot find a P2 puzzle hash for NFT:%s, this NFT belongs to others.",
                 uncurried_nft.singleton_launcher_id.hex(),
             )
-            return wallet_id, wallet_type
+            return wallet_identifier
         for wallet_info in await self.get_all_wallet_info_entries(wallet_type=WalletType.NFT):
             nft_wallet_info: NFTWalletInfo = NFTWalletInfo.from_json_dict(json.loads(wallet_info.data))
             if nft_wallet_info.did_id == old_did_id and old_derivation_record is not None:
@@ -971,10 +954,9 @@ class WalletStateManager:
                     uncurried_nft.singleton_launcher_id.hex(),
                     new_did_id,
                 )
-                wallet_id = wallet_info.id
-                wallet_type = WalletType.NFT
+                wallet_identifier = WalletIdentifier(wallet_info.id, WalletType.NFT)
 
-        if wallet_id is None and new_derivation_record is not None:
+        if wallet_identifier is None and new_derivation_record is not None:
             # Cannot find an existed NFT wallet for the new NFT
             self.log.info(
                 "Cannot find a NFT wallet for NFT_ID: %s DID_ID: %s, creating a new one.",
@@ -984,9 +966,8 @@ class WalletStateManager:
             new_nft_wallet: NFTWallet = await NFTWallet.create_new_nft_wallet(
                 self, self.main_wallet, did_id=new_did_id, name="NFT Wallet"
             )
-            wallet_id = uint32(new_nft_wallet.wallet_id)
-            wallet_type = WalletType.NFT
-        return wallet_id, wallet_type
+            wallet_identifier = WalletIdentifier.create(new_nft_wallet)
+        return wallet_identifier
 
     async def add_coin_states(
         self,
@@ -1021,9 +1002,7 @@ class WalletStateManager:
                     # This only succeeds if we don't raise out of the transaction
                     await self.retry_store.remove_state(coin_state)
 
-                    wallet_info: Optional[Tuple[uint32, WalletType]] = await self.get_wallet_id_for_puzzle_hash(
-                        coin_state.coin.puzzle_hash
-                    )
+                    wallet_identifier = await self.get_wallet_identifier_for_puzzle_hash(coin_state.coin.puzzle_hash)
 
                     # If we already have this coin, & it was spent & confirmed at the same heights, then return (done)
                     if local_record is not None:
@@ -1038,25 +1017,21 @@ class WalletStateManager:
 
                     if coin_state.spent_height is not None and coin_name in trade_removals:
                         await self.trade_manager.coins_of_interest_farmed(coin_state, fork_height, peer)
-                    wallet_id: Optional[uint32] = None
-                    wallet_type: Optional[WalletType] = None
-                    if wallet_info is not None:
-                        wallet_id, wallet_type = wallet_info
+                    if wallet_identifier is not None:
+                        self.log.debug(f"Found existing wallet_identifier: {wallet_identifier}, coin: {coin_name}")
                     elif local_record is not None:
-                        wallet_id = uint32(local_record.wallet_id)
-                        wallet_type = local_record.wallet_type
+                        wallet_identifier = WalletIdentifier(uint32(local_record.wallet_id), local_record.wallet_type)
                     elif coin_state.created_height is not None:
-                        wallet_id, wallet_type = await self.determine_coin_type(peer, coin_state, fork_height)
+                        wallet_identifier = await self.determine_coin_type(peer, coin_state, fork_height)
                         potential_dl = self.get_dl_wallet()
                         if potential_dl is not None:
                             if (
                                 await potential_dl.get_singleton_record(coin_name) is not None
                                 or coin_state.coin.puzzle_hash == MIRROR_PUZZLE_HASH
                             ):
-                                wallet_id = potential_dl.id()
-                                wallet_type = potential_dl.type()
+                                wallet_identifier = WalletIdentifier.create(potential_dl)
 
-                    if wallet_id is None or wallet_type is None:
+                    if wallet_identifier is None:
                         self.log.debug(f"No wallet for coin state: {coin_state}")
                         continue
 
@@ -1081,8 +1056,8 @@ class WalletStateManager:
                                 coin_state.coin,
                                 uint32(coin_state.created_height),
                                 all_unconfirmed,
-                                wallet_id,
-                                wallet_type,
+                                wallet_identifier.id,
+                                wallet_identifier.type,
                                 peer,
                                 coin_name,
                             )
@@ -1110,15 +1085,18 @@ class WalletStateManager:
                                 uint32(coin_state.spent_height),
                                 True,
                                 farmer_reward or pool_reward,
-                                wallet_type,
-                                wallet_id,
+                                wallet_identifier.type,
+                                wallet_identifier.id,
                             )
                             await self.coin_store.add_coin_record(record)
                             # Coin first received
                             parent_coin_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(
                                 coin_state.coin.parent_coin_info
                             )
-                            if parent_coin_record is not None and wallet_type.value == parent_coin_record.wallet_type:
+                            if (
+                                parent_coin_record is not None
+                                and wallet_identifier.type == parent_coin_record.wallet_type
+                            ):
                                 change = True
                             else:
                                 change = False
@@ -1131,7 +1109,9 @@ class WalletStateManager:
                                     confirmed_at_height=uint32(coin_state.created_height),
                                     created_at_time=uint64(created_timestamp),
                                     to_puzzle_hash=(
-                                        await self.convert_puzzle_hash(wallet_id, coin_state.coin.puzzle_hash)
+                                        await self.convert_puzzle_hash(
+                                            wallet_identifier.id, coin_state.coin.puzzle_hash
+                                        )
                                     ),
                                     amount=uint64(coin_state.coin.amount),
                                     fee_amount=uint64(0),
@@ -1140,7 +1120,7 @@ class WalletStateManager:
                                     spend_bundle=None,
                                     additions=[coin_state.coin],
                                     removals=[],
-                                    wallet_id=wallet_id,
+                                    wallet_id=wallet_identifier.id,
                                     sent_to=[],
                                     trade_id=None,
                                     type=uint32(tx_type),
@@ -1188,7 +1168,9 @@ class WalletStateManager:
                                     tx_record = TransactionRecord(
                                         confirmed_at_height=uint32(coin_state.spent_height),
                                         created_at_time=uint64(spent_timestamp),
-                                        to_puzzle_hash=(await self.convert_puzzle_hash(wallet_id, to_puzzle_hash)),
+                                        to_puzzle_hash=(
+                                            await self.convert_puzzle_hash(wallet_identifier.id, to_puzzle_hash)
+                                        ),
                                         amount=uint64(int(amount)),
                                         fee_amount=uint64(fee),
                                         confirmed=True,
@@ -1196,7 +1178,7 @@ class WalletStateManager:
                                         spend_bundle=None,
                                         additions=additions,
                                         removals=[coin_state.coin],
-                                        wallet_id=wallet_id,
+                                        wallet_id=wallet_identifier.id,
                                         sent_to=[],
                                         trade_id=None,
                                         type=uint32(TransactionType.OUTGOING_TX.value),
@@ -1400,11 +1382,10 @@ class WalletStateManager:
                 return True
         return False
 
-    async def get_wallet_id_for_puzzle_hash(self, puzzle_hash: bytes32) -> Optional[Tuple[uint32, WalletType]]:
-        info = await self.puzzle_store.wallet_info_for_puzzle_hash(puzzle_hash)
-        if info is not None:
-            wallet_id, wallet_type = info
-            return uint32(wallet_id), wallet_type
+    async def get_wallet_identifier_for_puzzle_hash(self, puzzle_hash: bytes32) -> Optional[WalletIdentifier]:
+        wallet_identifier = await self.puzzle_store.get_wallet_identifier_for_puzzle_hash(puzzle_hash)
+        if wallet_identifier is not None:
+            return wallet_identifier
 
         interested_wallet_id = await self.interested_store.get_interested_puzzle_hash_wallet_id(puzzle_hash=puzzle_hash)
         if interested_wallet_id is not None:
@@ -1412,7 +1393,7 @@ class WalletStateManager:
             if wallet_id not in self.wallets.keys():
                 self.log.warning(f"Do not have wallet {wallet_id} for puzzle_hash {puzzle_hash}")
                 return None
-            return uint32(wallet_id), self.wallets[uint32(wallet_id)].type()
+            return WalletIdentifier(uint32(wallet_id), self.wallets[uint32(wallet_id)].type())
         return None
 
     async def coin_added(

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -1240,8 +1240,10 @@ class TestWalletSync:
             wallet_node.get_timestamp_for_height = flaky_get_timestamp(
                 wallet_node, wallet_node.get_timestamp_for_height
             )
-            wallet_node.wallet_state_manager.puzzle_store.wallet_info_for_puzzle_hash = flaky_info_for_puzhash(
-                wallet_node, wallet_node.wallet_state_manager.puzzle_store.wallet_info_for_puzzle_hash
+            wallet_node.wallet_state_manager.puzzle_store.get_wallet_identifier_for_puzzle_hash = (
+                flaky_info_for_puzhash(
+                    wallet_node, wallet_node.wallet_state_manager.puzzle_store.get_wallet_identifier_for_puzzle_hash
+                )
             )
 
             await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)

--- a/tests/wallet/test_puzzle_store.py
+++ b/tests/wallet/test_puzzle_store.py
@@ -7,7 +7,7 @@ from blspy import AugSchemeMPL
 
 from chia.util.ints import uint32
 from chia.wallet.derivation_record import DerivationRecord
-from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.util.wallet_types import WalletIdentifier, WalletType
 from chia.wallet.wallet_puzzle_store import WalletPuzzleStore
 from tests.util.db_connection import DBConnection
 
@@ -45,7 +45,7 @@ class TestPuzzleStore:
             assert await db.puzzle_hash_exists(derivation_recs[0].puzzle_hash) is False
             assert await db.index_for_pubkey(derivation_recs[0].pubkey) is None
             assert await db.index_for_puzzle_hash(derivation_recs[2].puzzle_hash) is None
-            assert await db.wallet_info_for_puzzle_hash(derivation_recs[2].puzzle_hash) is None
+            assert await db.get_wallet_identifier_for_puzzle_hash(derivation_recs[2].puzzle_hash) is None
             assert len((await db.get_all_puzzle_hashes())) == 0
             assert await db.get_last_derivation_path() is None
             assert await db.get_unused_derivation_path() is None
@@ -57,7 +57,7 @@ class TestPuzzleStore:
 
             assert await db.index_for_pubkey(derivation_recs[4].pubkey) == 2
             assert await db.index_for_puzzle_hash(derivation_recs[2].puzzle_hash) == 1
-            assert await db.wallet_info_for_puzzle_hash(derivation_recs[2].puzzle_hash) == (
+            assert await db.get_wallet_identifier_for_puzzle_hash(derivation_recs[2].puzzle_hash) == WalletIdentifier(
                 derivation_recs[2].wallet_id,
                 derivation_recs[2].wallet_type,
             )


### PR DESCRIPTION
### Purpose:

Cleanup of all places where we use wallet id and wallet type as tuple.

This also renames:
- `WalletStateManager.get_wallet_id_for_puzzle_hash` -> `get_wallet_identifier_for_puzzle_hash`
- `WalletPuzzleStore.wallet_info_for_puzzle_hash` -> `get_wallet_identifier_for_puzzle_hash`
- `WalletPuzzleStore.wallet_info_for_ph_cache` -> `wallet_identifier_cache`

### New Behavior:

No change in behaviour.