### PR TITLE
Mempool insertion order

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -55,18 +55,22 @@ class Mempool:
             generated = ""
             if not SQLITE_NO_GENERATED_COLUMNS:
                 generated = " GENERATED ALWAYS AS (CAST(fee AS REAL) / cost) VIRTUAL"
-
+            # the seq field indicates the order of items being added to the
+            # mempool. It's used as a tie-breaker for items with the same fee
+            # rate
             self._db_conn.execute(
                 f"""CREATE TABLE tx(
-                name BLOB PRIMARY KEY,
+                name BLOB,
                 cost INT NOT NULL,
                 fee INT NOT NULL,
                 assert_height INT,
                 assert_before_height INT,
                 assert_before_seconds INT,
-                fee_per_cost REAL{generated})
+                fee_per_cost REAL{generated},
+                seq INTEGER PRIMARY KEY AUTOINCREMENT)
                 """
             )
+            self._db_conn.execute("CREATE INDEX name_idx ON tx(name)")
             self._db_conn.execute("CREATE INDEX fee_sum ON tx(fee)")
             self._db_conn.execute("CREATE INDEX cost_sum ON tx(cost)")
             self._db_conn.execute("CREATE INDEX feerate ON tx(fee_per_cost)")
@@ -140,7 +144,7 @@ class Mempool:
     # bit more efficiently
     def spends_by_feerate(self) -> Iterator[MempoolItem]:
         with self._db_conn:
-            cursor = self._db_conn.execute("SELECT * FROM tx ORDER BY fee_per_cost DESC")
+            cursor = self._db_conn.execute("SELECT * FROM tx ORDER BY fee_per_cost DESC, seq ASC")
             for row in cursor:
                 yield self._row_to_item(row)
 
@@ -176,7 +180,7 @@ class Mempool:
 
             # Iterates through all spends in increasing fee per cost
             with self._db_conn:
-                cursor = self._db_conn.execute("SELECT cost,fee_per_cost FROM tx ORDER BY fee_per_cost ASC")
+                cursor = self._db_conn.execute("SELECT cost,fee_per_cost FROM tx ORDER BY fee_per_cost ASC, seq DESC")
 
                 item_cost: int
                 fee_per_cost: float
@@ -259,13 +263,15 @@ class Mempool:
         with self._db_conn:
             while self.at_full_capacity(item.cost):
                 # pick the item with the lowest fee per cost to remove
-                cursor = self._db_conn.execute("SELECT name FROM tx ORDER BY fee_per_cost ASC LIMIT 1")
+                cursor = self._db_conn.execute("SELECT name FROM tx ORDER BY fee_per_cost ASC, seq DESC LIMIT 1")
                 name = bytes32(cursor.fetchone()[0])
                 self.remove_from_pool([name], MempoolRemoveReason.POOL_FULL)
 
             if SQLITE_NO_GENERATED_COLUMNS:
                 self._db_conn.execute(
-                    "INSERT INTO tx VALUES(?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO "
+                    "tx(name,cost,fee,assert_height,assert_before_height,assert_before_seconds,fee_per_cost) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?)",
                     (
                         item.name,
                         item.cost,
@@ -278,7 +284,9 @@ class Mempool:
                 )
             else:
                 self._db_conn.execute(
-                    "INSERT INTO tx VALUES(?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO "
+                    "tx(name,cost,fee,assert_height,assert_before_height,assert_before_seconds) "
+                    "VALUES(?, ?, ?, ?, ?, ?)",
                     (
                         item.name,
                         item.cost,

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -53,6 +53,7 @@ from chia.util.ints import uint32, uint64
 from chia.util.recursive_replace import recursive_replace
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from tests.connection_utils import add_dummy_connection, connect_and_get_peer
+from tests.core.mempool.test_mempool_manager import make_test_coins, mk_item
 from tests.core.node_height import node_height_at_least
 from tests.util.misc import assert_runtime
 
@@ -2659,3 +2660,44 @@ class TestParseSexpCondition:
         err, conds = parse_sexp_to_conditions(Program.to([[bytes([49]), b"1", b"2", b"3", b"4", b"5", b"6"]]))
         assert err is None
         assert conds == [ConditionWithArgs(ConditionOpcode.AGG_SIG_UNSAFE, [b"1", b"2", b"3", b"4"])]
+
+
+coins = make_test_coins()
+
+
+# This test makes sure we're properly sorting items by fee rate
+@pytest.mark.parametrize(
+    "items,expected",
+    [
+        (
+            [
+                mk_item(coins[0:1], fee=110, cost=50),
+                mk_item(coins[1:2], fee=100, cost=50),
+                mk_item(coins[2:3], fee=105, cost=50),
+            ],
+            [coins[0], coins[2], coins[1]],
+        ),
+    ],
+)
+def test_spends_by_feerate(items: List[MempoolItem], expected: List[Coin]) -> None:
+    fee_estimator = create_bitcoin_fee_estimator(uint64(11000000000))
+
+    mempool_info = MempoolInfo(
+        CLVMCost(uint64(11000000000 * 3)),
+        FeeRate(uint64(1000000)),
+        CLVMCost(uint64(11000000000)),
+    )
+    mempool = Mempool(mempool_info, fee_estimator)
+    for i in items:
+        mempool.add_to_pool(i)
+
+    ordered_items = list(mempool.spends_by_feerate())
+
+    assert len(ordered_items) == len(expected)
+
+    last_fpc: Optional[float] = None
+    for mi, expected_coin in zip(ordered_items, expected):
+        assert len(mi.spend_bundle.coin_spends) == 1
+        assert mi.spend_bundle.coin_spends[0].coin == expected_coin
+        assert last_fpc is None or last_fpc >= mi.fee_per_cost
+        last_fpc = mi.fee_per_cost

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2669,6 +2669,8 @@ coins = make_test_coins()
 @pytest.mark.parametrize(
     "items,expected",
     [
+        # make sure fractions of fee-rate are ordered correctly (i.e. that
+        # we don't use integer division)
         (
             [
                 mk_item(coins[0:1], fee=110, cost=50),
@@ -2676,6 +2678,25 @@ coins = make_test_coins()
                 mk_item(coins[2:3], fee=105, cost=50),
             ],
             [coins[0], coins[2], coins[1]],
+        ),
+        # make sure insertion order is a tie-breaker for items with the same
+        # fee-rate
+        (
+            [
+                mk_item(coins[0:1], fee=100, cost=50),
+                mk_item(coins[1:2], fee=100, cost=50),
+                mk_item(coins[2:3], fee=100, cost=50),
+            ],
+            [coins[0], coins[1], coins[2]],
+        ),
+        # also for items that don't pay fees
+        (
+            [
+                mk_item(coins[2:3], fee=0, cost=50),
+                mk_item(coins[1:2], fee=0, cost=50),
+                mk_item(coins[0:1], fee=0, cost=50),
+            ],
+            [coins[2], coins[1], coins[0]],
         ),
     ],
 )

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -1115,31 +1115,3 @@ async def test_sufficient_total_fpc_increase() -> None:
     assert_sb_in_pool(mempool_manager, sb1234)
     assert_sb_not_in_pool(mempool_manager, sb12)
     assert_sb_not_in_pool(mempool_manager, sb3)
-
-
-@pytest.mark.asyncio
-async def test_spends_by_feerate() -> None:
-    # This test makes sure we're properly sorting items by fee rate
-    async def send_to_mempool_returning_item(
-        mempool_manager: MempoolManager, coin: Coin, *, fee: int = 0
-    ) -> MempoolItem:
-        conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, coin.amount - fee]]
-        sb = spend_bundle_from_conditions(conditions, coin)
-        result = await add_spendbundle(mempool_manager, sb, sb.name())
-        assert result[1] == MempoolInclusionStatus.SUCCESS
-        mi = mempool_manager.get_mempool_item(sb.name())
-        assert mi is not None
-        return mi
-
-    mempool_manager, coins = await setup_mempool_with_coins(coin_amounts=list(range(1000000000, 1000000005)))
-    # Create a ~3.73 FPC item
-    mi1 = await send_to_mempool_returning_item(mempool_manager, coins[0], fee=11000000)
-    # Create a ~3.39 FPC item
-    mi2 = await send_to_mempool_returning_item(mempool_manager, coins[1], fee=10000000)
-    # Create a ~3.56 FPC item
-    mi3 = await send_to_mempool_returning_item(mempool_manager, coins[2], fee=10500000)
-    assert mi1.fee_per_cost > mi2.fee_per_cost
-    assert mi1.fee_per_cost > mi3.fee_per_cost
-    assert mi3.fee_per_cost > mi2.fee_per_cost
-    items = mempool_manager.mempool.spends_by_feerate()
-    assert list(items) == [mi1, mi3, mi2]


### PR DESCRIPTION
When transitioning the mempool to use sqlite for its data structure, the iteration order of mempool items whose fee-rate is the same is no longer defined. The insertion order, into the mempool, used to be the tie-breaker.

This patch makes insertion order a tie-breaker when iterating mempool items (by fee rate) and adds test coverage.

The way it's achieved is by making the rowid explicit and marked with `AUTOINCREMENT`. Every time a new item is added to the mempool, the sequence number will be incremented. Lower numbers indicate an earlier insertion time, so when iterating over fee rate in *decending* order, the tie-break sequence number is *ascending*, and vice versa.