### PR TITLE
skip empty directories pre-commit

### DIFF
--- a/tests/build-init-files.py
+++ b/tests/build-init-files.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import pathlib
 import sys
 
@@ -53,6 +54,9 @@ def command(verbose, root_str):
         init_path = path.joinpath("__init__.py")
         # This has plenty of race hazards. If it messes up,
         # it will likely get caught the next time.
+        if len(os.listdir(path)) == 0:
+            logger.info(f"Skipping (empty directory)   : {init_path}")
+            continue
         if init_path.is_file() and not init_path.is_symlink():
             logger.info(f"Found   : {init_path}")
             continue


### PR DESCRIPTION
Sometimes empty directories are left in working copies when switching between branches and pre-commit forces some files to be created for these empty directories.  I don't see any need for this and it results in PRs like this: https://github.com/Chia-Network/chia-blockchain/pull/14858