### PR TITLE
remove synced status check from wallet rpc `/push_transactions` endpoint

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -538,9 +538,6 @@ class WalletRpcApi:
         return {}
 
     async def push_transactions(self, request: Dict) -> EndpointResult:
-        if await self.service.wallet_state_manager.synced() is False:
-            raise ValueError("Wallet needs to be fully synced before sending transactions")
-
         wallet = self.service.wallet_state_manager.main_wallet
 
         txs: List[TransactionRecord] = []


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This is causing trouble around creating transactions and then submitting them as the creation triggers the wallet to consider itself unsynced when creating a new address for change while building a transaction.  This creates a race between syncing and the calling code submitting the generated transaction.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Wallet must be synced for the `/push_transactions` endpoint, though it is not required for the singular `/push_tx`.

### New Behavior:

Synced status is not required for the plural transaction push endpoint.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
