### PR TITLE
windows fix of memory profiler

### DIFF
--- a/chia/util/profiler.py
+++ b/chia/util/profiler.py
@@ -158,7 +158,7 @@ profiler.py <profile-directory> <first-slot> <last-slot>
 
 
 async def mem_profile_task(root_path: pathlib.Path, service: str, log: logging.Logger) -> None:
-    profile_dir = path_from_root(root_path, f"memory-profile-{service}") / datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+    profile_dir = path_from_root(root_path, f"memory-profile-{service}") / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     log.info("Starting memory profiler. saving to %s" % profile_dir)
     profile_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
when enabling memory profiler, use a directory name compatible with windows' filesystems. Currently the timestamp included in the directory name contains colon (`:`), which is a reserved character on windows.