### PR TITLE
optimize Mempool.add_to_pool()

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -470,6 +470,9 @@ class MempoolManager:
         if cost == 0:
             return Err.UNKNOWN, None, []
 
+        if cost > self.max_block_clvm_cost:
+            return Err.BLOCK_COST_EXCEEDS_MAX, None, []
+
         # this is not very likely to happen, but it's here to ensure SQLite
         # never runs out of precision in its computation of fees.
         # sqlite's integers are signed int64, so the max value they can

--- a/tests/fee_estimation/test_fee_estimation_integration.py
+++ b/tests/fee_estimation/test_fee_estimation_integration.py
@@ -38,7 +38,7 @@ def make_mempoolitem() -> MempoolItem:
     ph = wallet_tool.get_new_puzzlehash()
     coin = Coin(ph, ph, uint64(10000))
     spend_bundle = wallet_tool.generate_signed_transaction(uint64(10000), ph, coin)
-    cost = uint64(5000000)
+    cost = uint64(1000000)
     block_height = 1
 
     fee = uint64(10000000)


### PR DESCRIPTION
Instead of computing the total cost of items in the pool, compute it once and subtract the cost of the items being removed as we go. Also remove all items in a single call.

This is not a material improvement, but I'm working on a patch where I will add another similar check for items with assert-before conditions. Having this code a bit simpler may be more important once it's duplicated.

@trepca suggested further improvements by moving more logic into sqlite.

# current version

| operation | before | after | after / before |
| --- | --- | --- | --- |
| add_spend_bundle() | 6.5029s | 6.3214s | 97.21% |
| add_spend_bundle() with replace-by-fee | 6.4152s | 6.3519s | 99.01% |

# first version

| operation | before | after | after / before |
| --- | --- | --- | --- |
| add_spend_bundle() | 6.5029s | 6.4207s | 98.74% |
| add_spend_bundle() with replace-by-fee | 6.4152s | 6.3652s | 99.22% |