### PR TITLE
server: Resolve introducer right before the connection attempt

### DIFF
--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -22,7 +22,7 @@ from chia.server.outbound_message import Message, NodeType, make_msg
 from chia.server.peer_store_resolver import PeerStoreResolver
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
-from chia.types.peer_info import PeerInfo, TimestampedPeerInfo
+from chia.types.peer_info import PeerInfo, TimestampedPeerInfo, UnresolvedPeerInfo
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint64
 from chia.util.network import IPAddress, get_host_addr
@@ -61,15 +61,9 @@ class FullNodeDiscovery:
         self.peers_file_path = peer_store_resolver.peers_file_path
         self.dns_servers = dns_servers
         random.shuffle(dns_servers)  # Don't always start with the same DNS server
+        self.introducer_info: Optional[UnresolvedPeerInfo] = None
         if introducer_info is not None:
-            # get_host_addr is blocking but this only gets called on startup or in the wallet after disconnecting from
-            # all trusted peers.
-            self.introducer_info: Optional[PeerInfo] = PeerInfo(
-                str(get_host_addr(introducer_info["host"], prefer_ipv6=False)),
-                introducer_info["port"],
-            )
-        else:
-            self.introducer_info = None
+            self.introducer_info = UnresolvedPeerInfo(introducer_info["host"], introducer_info["port"])
         self.peer_connect_interval = peer_connect_interval
         self.log = log
         self.relay_queue: Optional[asyncio.Queue[Tuple[TimestampedPeerInfo, int]]] = None
@@ -212,7 +206,9 @@ class FullNodeDiscovery:
             msg = make_msg(ProtocolMessageTypes.request_peers_introducer, RequestPeersIntroducer())
             await peer.send_message(msg)
 
-        await self.server.start_client(self.introducer_info, on_connect)
+        await self.server.start_client(
+            PeerInfo(get_host_addr(self.introducer_info.host, prefer_ipv6=False), self.introducer_info.port), on_connect
+        )
 
     async def _query_dns(self, dns_address: str) -> None:
         try:

--- a/chia/types/peer_info.py
+++ b/chia/types/peer_info.py
@@ -9,6 +9,12 @@ from chia.util.network import IPAddress
 from chia.util.streamable import Streamable, streamable
 
 
+@dataclass(frozen=True)
+class UnresolvedPeerInfo:
+    host: str
+    port: uint16
+
+
 # TODO, Replace unsafe_hash with frozen and drop the __init__ as soon as all PeerInfo call sites pass in an IPAddress.
 @dataclass(unsafe_hash=True)
 class PeerInfo:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fix issues like #14888 by delaying the introducer lookup.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Lookup the introducer IP on startup and fail the service startup hard due to uncatched exception.

### New Behavior:

Lookup the introducer IP right before the connection attempt and just continue the alternating between dns introducer and introducer connections if it fails because the exception gets handled in the new place where the lookup happens.
