### PR TITLE
util: Async DNS lookups

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -276,7 +276,7 @@ class RpcServer:
     async def open_connection(self, request: Dict[str, Any]) -> EndpointResult:
         host = request["host"]
         port = request["port"]
-        target_node: PeerInfo = PeerInfo(str(await resolve(host, prefer_ipv6=self.prefer_ipv6)), uint16(int(port)))
+        target_node: PeerInfo = PeerInfo(await resolve(host, prefer_ipv6=self.prefer_ipv6), uint16(int(port)))
         on_connect = None
         if hasattr(self.rpc_api.service, "on_connect"):
             on_connect = self.rpc_api.service.on_connect

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -276,7 +276,7 @@ class RpcServer:
     async def open_connection(self, request: Dict[str, Any]) -> EndpointResult:
         host = request["host"]
         port = request["port"]
-        target_node: PeerInfo = PeerInfo(str(resolve(host, prefer_ipv6=self.prefer_ipv6)), uint16(int(port)))
+        target_node: PeerInfo = PeerInfo(str(await resolve(host, prefer_ipv6=self.prefer_ipv6)), uint16(int(port)))
         on_connect = None
         if hasattr(self.rpc_api.service, "on_connect"):
             on_connect = self.rpc_api.service.on_connect

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -21,7 +21,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import str2bool
 from chia.util.ints import uint16
 from chia.util.json_util import dict_to_json_str
-from chia.util.network import WebServer, get_host_addr
+from chia.util.network import WebServer, resolve
 from chia.util.ws_message import WsRpcMessage, create_payload, create_payload_dict, format_response, pong
 
 log = logging.getLogger(__name__)
@@ -276,7 +276,7 @@ class RpcServer:
     async def open_connection(self, request: Dict[str, Any]) -> EndpointResult:
         host = request["host"]
         port = request["port"]
-        target_node: PeerInfo = PeerInfo(str(get_host_addr(host, prefer_ipv6=self.prefer_ipv6)), uint16(int(port)))
+        target_node: PeerInfo = PeerInfo(str(resolve(host, prefer_ipv6=self.prefer_ipv6)), uint16(int(port)))
         on_connect = None
         if hasattr(self.rpc_api.service, "on_connect"):
             on_connect = self.rpc_api.service.on_connect

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -127,7 +127,9 @@ class Crawler:
 
         try:
             connected = await self.create_client(
-                PeerInfo(str(resolve(peer.ip_address, prefer_ipv6=self.config.get("prefer_ipv6", False))), peer.port),
+                PeerInfo(
+                    str(await resolve(peer.ip_address, prefer_ipv6=self.config.get("prefer_ipv6", False))), peer.port
+                ),
                 peer_action,
             )
             if not connected:

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -23,7 +23,7 @@ from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint32, uint64
-from chia.util.network import get_host_addr
+from chia.util.network import resolve
 from chia.util.path import path_from_root
 
 log = logging.getLogger(__name__)
@@ -127,9 +127,7 @@ class Crawler:
 
         try:
             connected = await self.create_client(
-                PeerInfo(
-                    str(get_host_addr(peer.ip_address, prefer_ipv6=self.config.get("prefer_ipv6", False))), peer.port
-                ),
+                PeerInfo(str(resolve(peer.ip_address, prefer_ipv6=self.config.get("prefer_ipv6", False))), peer.port),
                 peer_action,
             )
             if not connected:

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -127,9 +127,7 @@ class Crawler:
 
         try:
             connected = await self.create_client(
-                PeerInfo(
-                    str(await resolve(peer.ip_address, prefer_ipv6=self.config.get("prefer_ipv6", False))), peer.port
-                ),
+                PeerInfo(await resolve(peer.ip_address, prefer_ipv6=self.config.get("prefer_ipv6", False)), peer.port),
                 peer_action,
             )
             if not connected:

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -207,7 +207,7 @@ class FullNodeDiscovery:
             await peer.send_message(msg)
 
         await self.server.start_client(
-            PeerInfo(resolve(self.introducer_info.host, prefer_ipv6=False), self.introducer_info.port), on_connect
+            PeerInfo(await resolve(self.introducer_info.host, prefer_ipv6=False), self.introducer_info.port), on_connect
         )
 
     async def _query_dns(self, dns_address: str) -> None:

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -25,7 +25,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import PeerInfo, TimestampedPeerInfo, UnresolvedPeerInfo
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint64
-from chia.util.network import IPAddress, get_host_addr
+from chia.util.network import IPAddress, resolve
 
 MAX_PEERS_RECEIVED_PER_REQUEST = 1000
 MAX_TOTAL_PEERS_RECEIVED = 3000
@@ -207,7 +207,7 @@ class FullNodeDiscovery:
             await peer.send_message(msg)
 
         await self.server.start_client(
-            PeerInfo(get_host_addr(self.introducer_info.host, prefer_ipv6=False), self.introducer_info.port), on_connect
+            PeerInfo(resolve(self.introducer_info.host, prefer_ipv6=False), self.introducer_info.port), on_connect
         )
 
     async def _query_dns(self, dns_address: str) -> None:

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -142,7 +142,7 @@ class Service(Generic[_T_RpcServiceProtocol]):
                 resolved = resolved_peers.get(unresolved)
                 if resolved is None:
                     try:
-                        resolved = PeerInfo(resolve(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port)
+                        resolved = PeerInfo(await resolve(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port)
                     except Exception as e:
                         self._log.warning(f"Failed to resolve {unresolved.host}: {e}")
                         continue
@@ -157,7 +157,9 @@ class Service(Generic[_T_RpcServiceProtocol]):
                     # Re-resolve to make sure the IP didn't change, this helps for example to keep dyndns hostnames
                     # up to date.
                     try:
-                        resolved_new = PeerInfo(resolve(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port)
+                        resolved_new = PeerInfo(
+                            await resolve(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port
+                        )
                     except Exception as e:
                         self._log.warning(f"Failed to resolve after connection failure {unresolved.host}: {e}")
                         continue

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -23,7 +23,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.peer_info import PeerInfo, UnresolvedPeerInfo
 from chia.util.ints import uint16
 from chia.util.lock import Lockfile, LockfileError
-from chia.util.network import get_host_addr
+from chia.util.network import resolve
 from chia.util.setproctitle import setproctitle
 
 from ..protocols.shared_protocol import capabilities
@@ -142,7 +142,7 @@ class Service(Generic[_T_RpcServiceProtocol]):
                 resolved = resolved_peers.get(unresolved)
                 if resolved is None:
                     try:
-                        resolved = PeerInfo(get_host_addr(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port)
+                        resolved = PeerInfo(resolve(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port)
                     except Exception as e:
                         self._log.warning(f"Failed to resolve {unresolved.host}: {e}")
                         continue
@@ -157,9 +157,7 @@ class Service(Generic[_T_RpcServiceProtocol]):
                     # Re-resolve to make sure the IP didn't change, this helps for example to keep dyndns hostnames
                     # up to date.
                     try:
-                        resolved_new = PeerInfo(
-                            get_host_addr(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port
-                        )
+                        resolved_new = PeerInfo(resolve(unresolved.host, prefer_ipv6=prefer_ipv6), unresolved.port)
                     except Exception as e:
                         self._log.warning(f"Failed to resolve after connection failure {unresolved.host}: {e}")
                         continue

--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -13,7 +13,7 @@ import pkg_resources
 from chia.util.chia_logging import initialize_logging
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
-from chia.util.network import get_host_addr
+from chia.util.network import resolve
 from chia.util.setproctitle import setproctitle
 
 active_processes: List = []
@@ -51,7 +51,7 @@ async def spawn_process(host: str, port: int, counter: int, lock: asyncio.Lock, 
         try:
             dirname = path_to_vdf_client.parent
             basename = path_to_vdf_client.name
-            resolved = get_host_addr(host, prefer_ipv6=prefer_ipv6)
+            resolved = resolve(host, prefer_ipv6=prefer_ipv6)
             proc = await asyncio.create_subprocess_shell(
                 f"{basename} {resolved} {port} {counter}",
                 stdout=asyncio.subprocess.PIPE,

--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -51,7 +51,7 @@ async def spawn_process(host: str, port: int, counter: int, lock: asyncio.Lock, 
         try:
             dirname = path_to_vdf_client.parent
             basename = path_to_vdf_client.name
-            resolved = resolve(host, prefer_ipv6=prefer_ipv6)
+            resolved = await resolve(host, prefer_ipv6=prefer_ipv6)
             proc = await asyncio.create_subprocess_shell(
                 f"{basename} {resolved} {port} {counter}",
                 stdout=asyncio.subprocess.PIPE,

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -145,14 +145,14 @@ def class_for_type(type: NodeType) -> Any:
     raise ValueError("No class for type")
 
 
-def resolve(host: str, *, prefer_ipv6: bool = False) -> IPAddress:
+async def resolve(host: str, *, prefer_ipv6: bool = False) -> IPAddress:
     try:
         return IPAddress.create(host)
     except ValueError:
         pass
     addrset: List[
         Tuple["socket.AddressFamily", "socket.SocketKind", int, str, Union[Tuple[str, int], Tuple[str, int, int, int]]]
-    ] = socket.getaddrinfo(host, None)
+    ] = await asyncio.get_event_loop().getaddrinfo(host, None)
     # The list returned by getaddrinfo is never empty, an exception is thrown or data is returned.
     ips_v4 = []
     ips_v6 = []

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -145,7 +145,7 @@ def class_for_type(type: NodeType) -> Any:
     raise ValueError("No class for type")
 
 
-def get_host_addr(host: str, *, prefer_ipv6: bool = False) -> IPAddress:
+def resolve(host: str, *, prefer_ipv6: bool = False) -> IPAddress:
     try:
         return IPAddress.create(host)
     except ValueError:

--- a/tests/util/test_network.py
+++ b/tests/util/test_network.py
@@ -15,10 +15,10 @@ class TestNetwork:
     async def test_resolve4(self):
         # Run these tests forcing IPv4 resolution
         prefer_ipv6 = False
-        assert resolve("127.0.0.1", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
-        assert resolve("10.11.12.13", prefer_ipv6=prefer_ipv6) == IPAddress.create("10.11.12.13")
-        assert resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
-        assert resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("93.184.216.34")
+        assert await resolve("127.0.0.1", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
+        assert await resolve("10.11.12.13", prefer_ipv6=prefer_ipv6) == IPAddress.create("10.11.12.13")
+        assert await resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
+        assert await resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("93.184.216.34")
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
@@ -28,13 +28,17 @@ class TestNetwork:
     async def test_resolve6(self):
         # Run these tests forcing IPv6 resolution
         prefer_ipv6 = True
-        assert resolve("::1", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        assert resolve("2000:1000::1234:abcd", prefer_ipv6=prefer_ipv6) == IPAddress.create("2000:1000::1234:abcd")
+        assert await resolve("::1", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+        assert await resolve("2000:1000::1234:abcd", prefer_ipv6=prefer_ipv6) == IPAddress.create(
+            "2000:1000::1234:abcd"
+        )
         # ip6-localhost is not always available, and localhost is IPv4 only
         # on some systems.  Just test neither here.
-        # assert resolve("ip6-localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        # assert resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        assert resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("2606:2800:220:1:248:1893:25c8:1946")
+        # assert await resolve("ip6-localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+        # assert await resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+        assert await resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create(
+            "2606:2800:220:1:248:1893:25c8:1946"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/util/test_network.py
+++ b/tests/util/test_network.py
@@ -7,38 +7,34 @@ from typing import Type, Union
 
 import pytest
 
-from chia.util.network import IPAddress, get_host_addr
+from chia.util.network import IPAddress, resolve
 
 
 class TestNetwork:
     @pytest.mark.asyncio
-    async def test_get_host_addr4(self):
+    async def test_resolve4(self):
         # Run these tests forcing IPv4 resolution
         prefer_ipv6 = False
-        assert get_host_addr("127.0.0.1", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
-        assert get_host_addr("10.11.12.13", prefer_ipv6=prefer_ipv6) == IPAddress.create("10.11.12.13")
-        assert get_host_addr("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
-        assert get_host_addr("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("93.184.216.34")
+        assert resolve("127.0.0.1", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
+        assert resolve("10.11.12.13", prefer_ipv6=prefer_ipv6) == IPAddress.create("10.11.12.13")
+        assert resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
+        assert resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("93.184.216.34")
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(
         condition=("GITHUB_ACTIONS" in os.environ) and (sys.platform in {"darwin", "win32"}),
         reason="macOS and Windows runners in GitHub Actions do not seem to support IPv6",
     )
-    async def test_get_host_addr6(self):
+    async def test_resolve6(self):
         # Run these tests forcing IPv6 resolution
         prefer_ipv6 = True
-        assert get_host_addr("::1", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        assert get_host_addr("2000:1000::1234:abcd", prefer_ipv6=prefer_ipv6) == IPAddress.create(
-            "2000:1000::1234:abcd"
-        )
+        assert resolve("::1", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+        assert resolve("2000:1000::1234:abcd", prefer_ipv6=prefer_ipv6) == IPAddress.create("2000:1000::1234:abcd")
         # ip6-localhost is not always available, and localhost is IPv4 only
         # on some systems.  Just test neither here.
-        # assert get_host_addr("ip6-localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        # assert get_host_addr("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        assert get_host_addr("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create(
-            "2606:2800:220:1:248:1893:25c8:1946"
-        )
+        # assert resolve("ip6-localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+        # assert resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+        assert resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("2606:2800:220:1:248:1893:25c8:1946")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

- Rename `get_host_addr` to `resolve`
- Make it a non-blocking `async` function by leveraging `asyncio.loop.getaddrinfo`

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

- `get_host_addr` blocks the main thread while doing DNS lookups.

### New Behavior:

The `resolve` lookup can now be `await` ed to let other tasks run in the meantime.

### Testing notes:

The lookups are tested in `test_network.py`.

### Based on:

- #14997 
- #14998 
