### PR TITLE
Print mypy version in CI jobs

### DIFF
--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -66,6 +66,7 @@ jobs:
 
     - name: Lint source with mypy
       run: |
+        echo "MYPY VERSION IS: $(mypy --version)"
         mypy
 
     - name: Lint source with pylint


### PR DESCRIPTION
Sometimes, you might get output from CI like this:

```
> Run mypy
chia/wallet/puzzle_drivers.py:107: error: Unused "type: ignore" comment
chia/wallet/puzzles/prefarm/make_prefarm_ph.py:32: error: Unused "type: ignore" comment
tests/wallet/nft_wallet/test_ownership_outer_puzzle.py:24: error: Unused "type: ignore" comment
tests/core/util/test_streamable.py:658: error: Unused "type: ignore" comment
Found 4 errors in 4 files (checked 753 source files)
```

You might be confused, because `pre-commit` ran fine on YOUR machine. "Why didn't it lint check clean in CI?", I hear you wonder.

Obviously, this has never happened to me. However, just in case you know someone if has happened to, this one's for you.

Changes CI output only.
