### PR TITLE
Return fee estimates as integer mojos

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -810,6 +810,7 @@ class FullNodeRpcApi:
         # at set times into the future. This can lead to situations that users do not expect,
         # such as estimating a higher fee for a longer transaction time.
         estimates = make_monotonically_decreasing(estimates)
+        estimates = [uint64(e) for e in estimates]
         current_fee_rate = estimator.estimate_fee_rate(time_offset_seconds=1)
         mempool_size = self.service.mempool_manager.mempool.total_mempool_cost()
         mempool_fees = self.service.mempool_manager.mempool.total_mempool_fees()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The "estimates" field in the return of the `get_fee_estimate` API contains an array of mojos. Currently, they can be fractional.


### New Behavior:

This change ensures that the estimates are integers, not floats.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
