### PR TITLE
lower MAX_FUTURE_TIME to 2 minutes with the 1.8.0 soft-fork activation

### DIFF
--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -815,7 +815,11 @@ def validate_unfinished_header_block(
                 return None, ValidationError(Err.INVALID_TRANSACTIONS_FILTER_HASH)
 
         # 26a. The timestamp in Foliage Block must not be over 5 minutes in the future
-        if header_block.foliage_transaction_block.timestamp > int(time.time() + constants.MAX_FUTURE_TIME):
+        if height >= constants.SOFT_FORK2_HEIGHT:
+            max_future_time = constants.MAX_FUTURE_TIME2
+        else:
+            max_future_time = constants.MAX_FUTURE_TIME
+        if header_block.foliage_transaction_block.timestamp > int(time.time() + max_future_time):
             return None, ValidationError(Err.TIMESTAMP_TOO_FAR_IN_FUTURE)
 
         if prev_b is not None:

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -36,6 +36,7 @@ class ConsensusConstants:
     SUB_SLOT_TIME_TARGET: int  # The target number of seconds per sub-slot
     NUM_SP_INTERVALS_EXTRA: int  # The difference between signage point and infusion point (plus required_iters)
     MAX_FUTURE_TIME: int  # The next block can have a timestamp of at most these many seconds more
+    MAX_FUTURE_TIME2: int  # After soft-fork2, this is the new MAX_FUTURE_TIME
     NUMBER_OF_TIMESTAMPS: int  # Than the average of the last NUMBER_OF_TIMESTAMPS blocks
     # Used as the initial cc rc challenges, as well as first block back pointers, and first SES back pointer
     # We override this value based on the chain being run (testnet0, testnet1, mainnet, etc)

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -26,6 +26,7 @@ default_kwargs = {
     "SUB_SLOT_TIME_TARGET": 600,  # The target number of seconds per slot, mainnet 600
     "NUM_SP_INTERVALS_EXTRA": 3,  # The number of sp intervals to add to the signage point
     "MAX_FUTURE_TIME": 5 * 60,  # The next block can have a timestamp of at most these many seconds in the future
+    "MAX_FUTURE_TIME2": 2 * 60,  # The next block can have a timestamp of at most these many seconds in the future
     "NUMBER_OF_TIMESTAMPS": 11,  # Than the average of the last NUMBER_OF_TIMESTAMPS blocks
     # Used as the initial cc rc challenges, as well as first block back pointers, and first SES back pointer
     # We override this value based on the chain being run (testnet0, testnet1, mainnet, etc)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1486,55 +1486,81 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(empty_blockchain, blocks[-1])
 
     @pytest.mark.asyncio
-    async def test_bad_timestamp(self, empty_blockchain, bt):
+    @pytest.mark.parametrize("with_softfork2", [False, True])
+    async def test_bad_timestamp(self, bt, with_softfork2):
         # 26
+        if with_softfork2:
+            # enable softfork2 at height 0, to make it apply to this test
+            # the test constants set MAX_FUTURE_TIME to 10 days, restore it to
+            # default for this test
+            constants = test_constants.replace(SOFT_FORK2_HEIGHT=0, MAX_FUTURE_TIME=5 * 60)
+            time_delta = 2 * 60
+        else:
+            constants = test_constants.replace(MAX_FUTURE_TIME=5 * 60)
+            time_delta = 5 * 60
+
         blocks = bt.get_consecutive_blocks(1)
-        await _validate_and_add_block(empty_blockchain, blocks[0])
-        while True:
-            blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
-            if blocks[-1].foliage_transaction_block is not None:
-                block_bad: FullBlock = recursive_replace(
-                    blocks[-1],
-                    "foliage_transaction_block.timestamp",
-                    blocks[0].foliage_transaction_block.timestamp - 10,
-                )
-                block_bad: FullBlock = recursive_replace(
-                    block_bad, "foliage.foliage_transaction_block_hash", block_bad.foliage_transaction_block.get_hash()
-                )
-                new_m = block_bad.foliage.foliage_transaction_block_hash
-                new_fbh_sig = bt.get_plot_signature(new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key)
-                block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
-                await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
 
-                block_bad: FullBlock = recursive_replace(
-                    blocks[-1],
-                    "foliage_transaction_block.timestamp",
-                    blocks[0].foliage_transaction_block.timestamp,
-                )
-                block_bad: FullBlock = recursive_replace(
-                    block_bad, "foliage.foliage_transaction_block_hash", block_bad.foliage_transaction_block.get_hash()
-                )
-                new_m = block_bad.foliage.foliage_transaction_block_hash
-                new_fbh_sig = bt.get_plot_signature(new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key)
-                block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
-                await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
+        async with make_empty_blockchain(constants) as b:
+            await _validate_and_add_block(b, blocks[0])
+            while True:
+                blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
+                if blocks[-1].foliage_transaction_block is not None:
+                    block_bad: FullBlock = recursive_replace(
+                        blocks[-1],
+                        "foliage_transaction_block.timestamp",
+                        blocks[0].foliage_transaction_block.timestamp - 10,
+                    )
+                    block_bad: FullBlock = recursive_replace(
+                        block_bad,
+                        "foliage.foliage_transaction_block_hash",
+                        block_bad.foliage_transaction_block.get_hash(),
+                    )
+                    new_m = block_bad.foliage.foliage_transaction_block_hash
+                    new_fbh_sig = bt.get_plot_signature(
+                        new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key
+                    )
+                    block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
+                    await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
 
-                block_bad: FullBlock = recursive_replace(
-                    blocks[-1],
-                    "foliage_transaction_block.timestamp",
-                    blocks[0].foliage_transaction_block.timestamp + 10000000,
-                )
-                block_bad: FullBlock = recursive_replace(
-                    block_bad, "foliage.foliage_transaction_block_hash", block_bad.foliage_transaction_block.get_hash()
-                )
-                new_m = block_bad.foliage.foliage_transaction_block_hash
-                new_fbh_sig = bt.get_plot_signature(new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key)
-                block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
-                await _validate_and_add_block(
-                    empty_blockchain, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_FUTURE
-                )
-                return None
-            await _validate_and_add_block(empty_blockchain, blocks[-1])
+                    block_bad: FullBlock = recursive_replace(
+                        blocks[-1],
+                        "foliage_transaction_block.timestamp",
+                        blocks[0].foliage_transaction_block.timestamp,
+                    )
+                    block_bad: FullBlock = recursive_replace(
+                        block_bad,
+                        "foliage.foliage_transaction_block_hash",
+                        block_bad.foliage_transaction_block.get_hash(),
+                    )
+                    new_m = block_bad.foliage.foliage_transaction_block_hash
+                    new_fbh_sig = bt.get_plot_signature(
+                        new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key
+                    )
+                    block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
+                    await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
+
+                    # since tests can run slow sometimes, and since we're using
+                    # the system clock, add some extra slack
+                    slack = 5
+                    block_bad: FullBlock = recursive_replace(
+                        blocks[-1],
+                        "foliage_transaction_block.timestamp",
+                        blocks[0].foliage_transaction_block.timestamp + time_delta + slack,
+                    )
+                    block_bad: FullBlock = recursive_replace(
+                        block_bad,
+                        "foliage.foliage_transaction_block_hash",
+                        block_bad.foliage_transaction_block.get_hash(),
+                    )
+                    new_m = block_bad.foliage.foliage_transaction_block_hash
+                    new_fbh_sig = bt.get_plot_signature(
+                        new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key
+                    )
+                    block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
+                    await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_FUTURE)
+                    return None
+                await _validate_and_add_block(b, blocks[-1])
 
     @pytest.mark.asyncio
     async def test_height(self, empty_blockchain, bt):


### PR DESCRIPTION
To reduce the ability for farmers to manipulate block timestamps. To be conservative, the new `MAX_FUTURE_TIME` takes effect at the 1.8 soft fork activation.

Based on a ~50 hour sample of mainnet, **this would have rejected ~0.32% of unfinished blocks** because they had a timestamp too far into the future.
The maximum positive offset measured during this time (the unfinished block with a timestamp the farthest into the future) was 264 seconds.
94.84% of all samples were negative, i.e. the timestamp of the unfinished blocks were in the past. This is expected for farmers with correct clocks, since the propagation and validation delay will take some time.

The distribution of time offsets looked like this:
![blockchain-timestamp-offsets-cdf](https://user-images.githubusercontent.com/661450/233387470-298804ca-eb10-4d64-afea-9f8f42f65027.png)


To zoom in on the interesting window, where the time offsets are higher than expected:
![blockchain-timestamp-offsets-cdf-zoom](https://user-images.githubusercontent.com/661450/233387048-59a62eca-d073-4c04-950c-08e533ab6b5a.png)

