### PR TITLE
S3 plugin config and endpoint updates

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -856,9 +856,7 @@ class DataLayer:
         for uploader in self.uploaders:
             async with aiohttp.ClientSession() as session:
                 try:
-                    async with session.post(
-                        "http://" + uploader + "/handle_upload", json={"store_id": tree_id.hex()}
-                    ) as response:
+                    async with session.post(uploader + "/handle_upload", json={"store_id": tree_id.hex()}) as response:
                         res_json = await response.json()
                         if res_json["handle_upload"]:
                             uploaders.append(uploader)

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -467,8 +467,8 @@ class DataLayer:
                                         "generation {publish_generation}"
                                     )
             except Exception as e:
-                self.log.error(f"Exception uploading files for {tree_id} - will retry later")
-                self.log.debug(f"Failed to upload files, clean local disc {e}")
+                self.log.error(f"Exception uploading files, will retry later: tree id {tree_id}")
+                self.log.debug(f"Failed to upload files, cleaning local files: {type(e).__name__}: {e}")
                 os.remove(write_file_result.full_tree)
                 os.remove(write_file_result.diff_tree)
             publish_generation -= 1

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -413,13 +413,13 @@ class DataLayer:
                 self.log.warning(f"Exception while downloading files for {tree_id}: {e} {traceback.format_exc()}.")
 
     async def get_downloader(self, tree_id: bytes32, url: str) -> Optional[str]:
-        request_json = {"id": tree_id.hex(), "url": url}
+        request_json = {"store_id": tree_id.hex(), "url": url}
         for d in self.downloaders:
             async with aiohttp.ClientSession() as session:
                 try:
                     async with session.post(d + "/handle_download", json=request_json) as response:
                         res_json = await response.json()
-                        if res_json["handles_download"]:
+                        if res_json["handle_download"]:
                             return d
                 except Exception as e:
                     self.log.error(f"get_downloader could not get response: {type(e).__name__}: {e}")
@@ -447,7 +447,7 @@ class DataLayer:
             try:
                 if uploaders is not None and len(uploaders) > 0:
                     request_json = {
-                        "id": tree_id.hex(),
+                        "store_id": tree_id.hex(),
                         "full_tree_path": str(write_file_result.full_tree),
                         "diff_path": str(write_file_result.diff_tree),
                     }
@@ -456,16 +456,16 @@ class DataLayer:
                         async with aiohttp.ClientSession() as session:
                             async with session.post(uploader + "/upload", json=request_json) as response:
                                 res_json = await response.json()
-                                if not res_json["uploaded"]:
-                                    self.log.error(
-                                        f"Failed to upload files to {uploader} : {res_json} - will retry later"
-                                    )
-                                    break  # todo this will retry all uploaders
-                                else:
+                                if res_json["uploaded"]:
                                     self.log.info(
                                         f"Uploaded files to {uploader} for store {tree_id.hex()} "
                                         "generation {publish_generation}"
                                     )
+                                else:
+                                    self.log.error(
+                                        f"Failed to upload files to, will retry later: {uploader} : {res_json}"
+                                    )
+                                    break  # todo this will retry all uploaders
             except Exception as e:
                 self.log.error(f"Exception uploading files, will retry later: tree id {tree_id}")
                 self.log.debug(f"Failed to upload files, cleaning local files: {type(e).__name__}: {e}")
@@ -857,10 +857,10 @@ class DataLayer:
             async with aiohttp.ClientSession() as session:
                 try:
                     async with session.post(
-                        "http://" + uploader + "/handle_upload", json={"id": tree_id.hex()}
+                        "http://" + uploader + "/handle_upload", json={"store_id": tree_id.hex()}
                     ) as response:
                         res_json = await response.json()
-                        if res_json["handles_upload"]:
+                        if res_json["handle_upload"]:
                             uploaders.append(uploader)
                 except Exception as e:
                     self.log.error(f"get_uploader could not get response {e}")

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -157,10 +157,12 @@ async def insert_from_delta_file(
             if not await http_download(client_foldername, filename, proxy_url, server_info, timeout, log):
                 break
         else:
+            log.info(f"Using downloader {downloader} for store {tree_id.hex()}.")
             async with aiohttp.ClientSession() as session:
                 async with session.post(downloader + "/download", json=request_json) as response:
                     res_json = await response.json()
                     if not res_json["downloaded"]:
+                        log.error(f"Failed to download delta file {filename} from {downloader}: {res_json}")
                         break
 
         log.info(f"Successfully downloaded delta file {filename}.")

--- a/chia/data_layer/s3_plugin_config.yml
+++ b/chia/data_layer/s3_plugin_config.yml
@@ -7,11 +7,11 @@ instance-1:
 
   store_ids:
     - id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
-      bucket: "chia-datalayer-test-bucket-2"
-      urls: ["s3://hello", "s3://goodbye"]
+      upload_bucket: "chia-datalayer-test-bucket-2"
+      download_urls: ["s3://hello", "s3://goodbye"]
     - id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
-      bucket:
-      urls: ["s3://hello", "s3://goodbye"]
+      upload_bucket:
+      download_urls: ["s3://hello", "s3://goodbye"]
 
 instance-2:
   port: 8999
@@ -22,8 +22,8 @@ instance-2:
 
   store_ids:
     - id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
-      bucket: "chia-datalayer-test-bucket-1"
-      urls: []
+      upload_bucket: "chia-datalayer-test-bucket-1"
+      download_urls: []
     - id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
-      bucket: "chia-datalayer-test-bucket-1"
-      urls: []
+      upload_bucket: "chia-datalayer-test-bucket-1"
+      download_urls: []

--- a/chia/data_layer/s3_plugin_config.yml
+++ b/chia/data_layer/s3_plugin_config.yml
@@ -5,12 +5,13 @@ instance-1:
     secret_access_key: "xxx"
     region: "xxx"
 
-  store_ids: ["xxx"]
-
-  urls: [ "xxx"]
-
-  buckets:
-    chia-datalayer-test-bucket-2: ["xxx"]
+  store_ids:
+    - id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
+      bucket: "chia-datalayer-test-bucket-2"
+      urls: ["s3://hello", "s3://goodbye"]
+    - id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
+      bucket:
+      urls: ["s3://hello", "s3://goodbye"]
 
 instance-2:
   port: 8999
@@ -19,9 +20,10 @@ instance-2:
     secret_access_key: "xxx"
     region: "xxx"
 
-  store_ids: ["xxx", "xxx" ]
-
-  urls: [ "xxx"]
-
-  buckets:
-    chia-datalayer-test-bucket-1: [ "xxx", "xxx" ]
+  store_ids:
+    - id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
+      bucket: "chia-datalayer-test-bucket-1"
+      urls: []
+    - id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
+      bucket: "chia-datalayer-test-bucket-1"
+      urls: []

--- a/chia/data_layer/s3_plugin_config.yml
+++ b/chia/data_layer/s3_plugin_config.yml
@@ -5,11 +5,11 @@ instance-1:
     secret_access_key: "xxx"
     region: "xxx"
 
-  store_ids:
-    - id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
+  stores:
+    - store_id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
       upload_bucket: "chia-datalayer-test-bucket-2"
       download_urls: ["s3://hello", "s3://goodbye"]
-    - id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
+    - store_id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
       upload_bucket:
       download_urls: ["s3://hello", "s3://goodbye"]
 
@@ -20,10 +20,10 @@ instance-2:
     secret_access_key: "xxx"
     region: "xxx"
 
-  store_ids:
-    - id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
-      upload_bucket: "chia-datalayer-test-bucket-1"
+  stores:
+    - store_id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
+      upload_bucket: ""
       download_urls: []
-    - id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
+    - store_id: "a14daf55d41ced6419bcd011fbc1f74ab9567fe55340d88435aa6493d628fa47"
       upload_bucket: "chia-datalayer-test-bucket-1"
       download_urls: []

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -153,7 +153,12 @@ def read_store_ids_from_config(config: Dict[str, Any]) -> List[StoreId]:
         try:
             store_ids.append(StoreId.from_dict(store))
         except Exception as e:
-            print("Ignoring Invalid store id '%s': %s" % (store.get("id", ""), e))
+            raw_store_id = store.get("id")
+            if "id" in store:
+                bad_store_id = f"{store["id"]!r}"
+            else:
+                bad_store_id = "<missing>"
+            print(f"Ignoring invalid store id: {bad_store_id}: {type(e).__name__} {e}")
             pass
 
     return store_ids
@@ -167,7 +172,7 @@ def make_app(config: Dict[str, Any], instance_name: str):  # type: ignore
     except KeyError as e:
         sys.exit(
             "config file must have aws_credentials with region, access_key_id, and secret_access_key. "
-            f"Missing config key: {e}"
+            f"Missing config key: {e.args[0]!r}"
         )
     store_ids = read_store_ids_from_config(config)
 

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -5,8 +5,9 @@ import concurrent.futures
 import functools
 import logging
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlparse
 
 import boto3 as boto3
@@ -19,15 +20,27 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 log = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class StoreId:
+    id: bytes32
+    bucket: Optional[str]
+    urls: Set[str]
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> StoreId:
+        return StoreId(bytes32.from_hexstr(d["id"]), d.get("bucket", None), d.get("urls", set()))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"id": self.id.hex(), "bucket": self.bucket, "urls": self.urls}
+
+
 class S3Plugin:
     boto_client: boto3.client
     port: int
     region: str
     aws_access_key_id: str
     aws_secret_access_key: str
-    store_ids: List[bytes32]
-    bukets: Dict[str, List[str]]
-    urls: List[str]
+    store_ids: List[StoreId]
     instance_name: str
 
     def __init__(
@@ -35,9 +48,7 @@ class S3Plugin:
         region: str,
         aws_access_key_id: str,
         aws_secret_access_key: str,
-        store_ids: List[bytes32],
-        buckets: Dict[str, List[str]],
-        urls: List[str],
+        store_ids: List[StoreId],
         instance_name: str,
     ):
         self.boto_client = boto3.client(
@@ -47,21 +58,22 @@ class S3Plugin:
             aws_secret_access_key=aws_secret_access_key,
         )
         self.store_ids = store_ids
-        self.buckets = buckets
-        self.urls = urls
         self.instance_name = instance_name
 
-    async def check_store_id(self, request: web.Request) -> web.Response:
+    async def handle_upload(self, request: web.Request) -> web.Response:
         self.update_instance_from_config()
         try:
             data = await request.json()
         except Exception as e:
             print(f"failed parsing request {request} {e}")
-            return web.json_response({"handles_url": False})
-        store_id = bytes32.from_hexstr(data["id"])
-        if store_id in self.store_ids:
-            return web.json_response({"handles_store": True})
-        return web.json_response({"handles_store": False})
+            return web.json_response({"handles_upload": False})
+
+        id = bytes32.from_hexstr(data["id"])
+        for store_id in self.store_ids:
+            if store_id.id == id and store_id.bucket and len(store_id.bucket) > 0:
+                return web.json_response({"handles_upload": True, "bucket": store_id.bucket})
+
+        return web.json_response({"handles_upload": False})
 
     async def upload(self, request: web.Request) -> web.Response:
         try:
@@ -87,17 +99,21 @@ class S3Plugin:
             return web.json_response({"handles_url": False})
         return web.json_response({"uploaded": True})
 
-    async def check_url(self, request: web.Request) -> web.Response:
+    async def handle_download(self, request: web.Request) -> web.Response:
         self.update_instance_from_config()
         try:
             data = await request.json()
         except Exception as e:
             print(f"failed parsing request {request} {e}")
-            return web.json_response({"handles_url": False})
+            return web.json_response({"handles_download": False})
+
+        id = bytes32.from_hexstr(data["id"])
         parse_result = urlparse(data["url"])
-        if parse_result.scheme == "s3" and data["url"] in self.urls:
-            return web.json_response({"handles_url": True})
-        return web.json_response({"handles_url": False})
+        for store_id in self.store_ids:
+            if store_id.id == id and parse_result.scheme == "s3" and data["url"] in store_id.urls:
+                return web.json_response({"handles_download": True, "urls": list(store_id.urls)})
+
+        return web.json_response({"handles_download": False})
 
     async def download(self, request: web.Request) -> web.Response:
         try:
@@ -119,20 +135,20 @@ class S3Plugin:
             return web.json_response({"downloaded": False})
         return web.json_response({"downloaded": True})
 
-    def get_bucket(self, store_id: bytes32) -> str:
-        for bucket in self.buckets:
-            if store_id.hex() in self.buckets[bucket]:
-                return bucket
-        raise Exception(f"bucket not found for store id {store_id.hex()}")
+    def get_bucket(self, id: bytes32) -> str:
+        for store_id in self.store_ids:
+            if store_id.id == id and store_id.bucket and len(store_id.bucket) > 0:
+                return store_id.bucket
+
+        raise Exception(f"bucket not found for store id {id.hex()}")
 
     def update_instance_from_config(self) -> None:
         config = load_config(self.instance_name)
-        store_ids = config["store_ids"]
-        buckets: Dict[str, List[str]] = config["buckets"]
-        urls = config["urls"]
-        self.buckets = buckets
+        store_ids = []
+        for store in config["store_ids"]:
+            store_ids.append(StoreId.from_dict(store))
+
         self.store_ids = store_ids
-        self.urls = urls
 
 
 def make_app(config: Dict[str, Any], instance_name: str):  # type: ignore
@@ -141,14 +157,12 @@ def make_app(config: Dict[str, Any], instance_name: str):  # type: ignore
     aws_secret_access_key = config["aws_credentials"]["secret_access_key"]
     store_ids = []
     for store in config["store_ids"]:
-        store_ids.append(bytes32.from_hexstr(store))
-    buckets: Dict[str, List[str]] = config["buckets"]
-    urls = config["urls"]
-    s3_client = S3Plugin(region, aws_access_key_id, aws_secret_access_key, store_ids, buckets, urls, instance_name)
+        store_ids.append(StoreId.from_dict(store))
+    s3_client = S3Plugin(region, aws_access_key_id, aws_secret_access_key, store_ids, instance_name)
     app = web.Application()
-    app.add_routes([web.post("/check_store_id", s3_client.check_store_id)])
+    app.add_routes([web.post("/handle_upload", s3_client.handle_upload)])
     app.add_routes([web.post("/upload", s3_client.upload)])
-    app.add_routes([web.post("/check_url", s3_client.check_url)])
+    app.add_routes([web.post("/handle_download", s3_client.handle_download)])
     app.add_routes([web.post("/download", s3_client.download)])
     return app
 

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -28,10 +28,10 @@ class StoreId:
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> StoreId:
-        return StoreId(bytes32.from_hexstr(d["id"]), d.get("bucket", None), d.get("urls", set()))
+        return StoreId(bytes32.from_hexstr(d["id"]), d.get("upload_bucket", None), d.get("download_urls", set()))
 
     def to_dict(self) -> Dict[str, Any]:
-        return {"id": self.id.hex(), "bucket": self.bucket, "urls": self.urls}
+        return {"id": self.id.hex(), "upload_bucket": self.bucket, "download_urls": self.urls}
 
 
 class S3Plugin:

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -29,7 +29,7 @@ class StoreConfig:
     @classmethod
     def unmarshal(cls, d: Dict[str, Any]) -> StoreConfig:
         upload_bucket = d.get("upload_bucket", None)
-        if len(upload_bucket) == 0:
+        if upload_bucket and len(upload_bucket) == 0:
             upload_bucket = None
 
         return StoreConfig(bytes32.from_hexstr(d["store_id"]), upload_bucket, d.get("download_urls", set()))

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -148,14 +148,14 @@ class S3Plugin:
 
     def update_instance_from_config(self) -> None:
         config = load_config(self.instance_name)
-        self.store_ids = read_store_ids_from_config(config)
+        self.stores = read_store_ids_from_config(config)
 
 
 def read_store_ids_from_config(config: Dict[str, Any]) -> List[StoreConfig]:
-    store_ids = []
+    stores = []
     for store in config.get("stores", []):
         try:
-            store_ids.append(StoreConfig.unmarshal(store))
+            stores.append(StoreConfig.unmarshal(store))
         except Exception as e:
             if "store_id" in store:
                 bad_store_id = f"{store['store_id']!r}"
@@ -164,7 +164,7 @@ def read_store_ids_from_config(config: Dict[str, Any]) -> List[StoreConfig]:
             print(f"Ignoring invalid store id: {bad_store_id}: {type(e).__name__} {e}")
             pass
 
-    return store_ids
+    return stores
 
 
 def make_app(config: Dict[str, Any], instance_name: str) -> web.Application:
@@ -177,9 +177,9 @@ def make_app(config: Dict[str, Any], instance_name: str) -> web.Application:
             "config file must have aws_credentials with region, access_key_id, and secret_access_key. "
             f"Missing config key: {e.args[0]!r}"
         )
-    store_ids = read_store_ids_from_config(config)
+    stores = read_store_ids_from_config(config)
 
-    s3_client = S3Plugin(region, aws_access_key_id, aws_secret_access_key, store_ids, instance_name)
+    s3_client = S3Plugin(region, aws_access_key_id, aws_secret_access_key, stores, instance_name)
     app = web.Application()
     app.add_routes([web.post("/handle_upload", s3_client.handle_upload)])
     app.add_routes([web.post("/upload", s3_client.upload)])

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -211,3 +211,7 @@ def run_server() -> None:
 
     print(f"run instance {instance_name}")
     web.run_app(make_app(config, instance_name), port=port)
+
+
+if __name__ == "__main__":
+    run_server()

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -100,7 +100,7 @@ class S3Plugin:
                 return web.json_response({"uploaded": False})
         except Exception as e:
             print(f"failed handling request {request} {e}")
-            return web.json_response({"handles_url": False})
+            return web.json_response({"uploaded": False})
         return web.json_response({"uploaded": True})
 
     async def handle_download(self, request: web.Request) -> web.Response:

--- a/chia/pyinstaller.spec
+++ b/chia/pyinstaller.spec
@@ -202,6 +202,7 @@ for server in SERVERS:
 add_binary("start_crawler", f"{ROOT}/chia/seeder/start_crawler.py", COLLECT_ARGS)
 add_binary("start_seeder", f"{ROOT}/chia/seeder/dns_server.py", COLLECT_ARGS)
 add_binary("start_data_layer_http", f"{ROOT}/chia/data_layer/data_layer_server.py", COLLECT_ARGS)
+add_binary("start_data_layer_s3_plugin", f"{ROOT}/chia/data_layer/s3_plugin_service.py", COLLECT_ARGS)
 
 COLLECT_KWARGS = dict(
     strip=False,

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ kwargs = dict(
             "chia_full_node_simulator = chia.simulator.start_simulator:main",
             "chia_data_layer = chia.server.start_data_layer:main",
             "chia_data_layer_http = chia.data_layer.data_layer_server:main",
+            "chia_data_layer_s3_plugin = chia.data_layer.s3_plugin_service:run_server",
         ]
     },
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import setup
 dependencies = [
     "aiofiles==23.1.0",  # Async IO for files
     "anyio==3.6.2",
+    "boto3==1.26.111",  # AWS S3 for DL s3 plugin
     "blspy==1.0.16",  # Signature library
     "chiavdf==1.0.8",  # timelord and vdf verification
     "chiabip158==1.2",  # bip158-style wallet filters


### PR DESCRIPTION
Changed `/check_url` to `/handle_download` - also now requires the store_id in the request along with the url
Changed `/check_store_id` to `/handle_upload` - no other change to expected parameters

`/handle_download` returns `{"handle_download": true/false}`
`/handle_upload` returns `{"handle_upload": true/false}`

(the return key is singular like the endpoint name)

Changed "id" key to be "store_id" for more clarity in RPCs and config

Modified the plugin config to move urls and bucket to underneath a specific store id eg:
```
  stores:
    - store_id: "7acfcbd1ed73bfe2b698508f4ea5ed353c60ace154360272ce91f9ab0c8423c3"
      upload_bucket: "chia-datalayer-test-bucket-2"
      download_urls: ["s3://hello", "s3://goodbye"]
```