### PR TITLE
Fix wallet type in sign_message_by_id

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1312,7 +1312,7 @@ class WalletRpcApi:
             is_hex = bool(is_hex)
         if is_valid_address(request["id"], {AddressType.DID}, self.service.config):
             for wallet in self.service.wallet_state_manager.wallets.values():
-                if wallet.type() == WalletType.DECENTRALIZED_ID.value:
+                if wallet.type() == WalletType.DECENTRALIZED_ID:
                     assert isinstance(wallet, DIDWallet)
                     assert wallet.did_info.origin_coin is not None
                     if wallet.did_info.origin_coin.name() == entity_id:
@@ -1329,7 +1329,7 @@ class WalletRpcApi:
         elif is_valid_address(request["id"], {AddressType.NFT}, self.service.config):
             target_nft: Optional[NFTCoinInfo] = None
             for wallet in self.service.wallet_state_manager.wallets.values():
-                if wallet.type() == WalletType.NFT.value:
+                if wallet.type() == WalletType.NFT:
                     assert isinstance(wallet, NFTWallet)
                     nft: Optional[NFTCoinInfo] = await wallet.get_nft(entity_id)
                     if nft is not None:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fix the issue that cannot find the existing DID wallet because of unmatch of WalletType and its value.
Notice: There are many places that have the same issue. We need to change all of them. There are majorly in the wallet_rpc_api and wallet_state_manager.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
wallet.type() == WalletType.DECENTRALIZED_ID.value

### New Behavior:
wallet.type() == WalletType.DECENTRALIZED_ID


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
