### PR TITLE
wallet: Fix, simplify and test `TransactionRecord.is_valid`

### DIFF
--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -114,14 +114,13 @@ class TransactionRecord(Streamable):
         return formatted
 
     def is_valid(self) -> bool:
-        past_receipts = self.sent_to
-        if len(past_receipts) < minimum_send_attempts:
+        if len(self.sent_to) < minimum_send_attempts:
             # we haven't tried enough peers yet
             return True
-        if any([x[1] for x in past_receipts if x[1] == MempoolInclusionStatus.SUCCESS.value]):
+        if any(x[1] == MempoolInclusionStatus.SUCCESS for x in self.sent_to):
             # we managed to push it to mempool at least once
             return True
-        if any([x[2] for x in past_receipts if x[2] in (Err.INVALID_FEE_LOW_FEE.name, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO.name)]):
+        if any(x[2] in (Err.INVALID_FEE_LOW_FEE.name, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO.name) for x in self.sent_to):
             # we tried to push it to mempool and got a fee error so it's a temporary error
             return True
         return False

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -121,7 +121,7 @@ class TransactionRecord(Streamable):
         if any([x[1] for x in past_receipts if x[1] == MempoolInclusionStatus.SUCCESS.value]):
             # we managed to push it to mempool at least once
             return True
-        if any([x[2] for x in past_receipts if x[2] in (Err.INVALID_FEE_LOW_FEE, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO)]):
+        if any([x[2] for x in past_receipts if x[2] in (Err.INVALID_FEE_LOW_FEE.name, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO.name)]):
             # we tried to push it to mempool and got a fee error so it's a temporary error
             return True
         return False

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -16,6 +16,8 @@ from chia.wallet.util.transaction_type import TransactionType
 
 T = TypeVar("T")
 
+minimum_send_attempts = 6
+
 
 @dataclass
 class ItemAndTransactionRecords(Generic[T]):
@@ -113,7 +115,7 @@ class TransactionRecord(Streamable):
 
     def is_valid(self) -> bool:
         past_receipts = self.sent_to
-        if len(past_receipts) < 6:
+        if len(past_receipts) < minimum_send_attempts:
             # we haven't tried enough peers yet
             return True
         if any([x[0] for x in past_receipts if x[0] == MempoolInclusionStatus.SUCCESS.value]):

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -121,7 +121,7 @@ class TransactionRecord(Streamable):
         if any([x[1] for x in past_receipts if x[1] == MempoolInclusionStatus.SUCCESS.value]):
             # we managed to push it to mempool at least once
             return True
-        if any([x[1] for x in past_receipts if x[1] in (Err.INVALID_FEE_LOW_FEE, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO)]):
+        if any([x[2] for x in past_receipts if x[2] in (Err.INVALID_FEE_LOW_FEE, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO)]):
             # we tried to push it to mempool and got a fee error so it's a temporary error
             return True
         return False

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -118,7 +118,7 @@ class TransactionRecord(Streamable):
         if len(past_receipts) < minimum_send_attempts:
             # we haven't tried enough peers yet
             return True
-        if any([x[0] for x in past_receipts if x[0] == MempoolInclusionStatus.SUCCESS.value]):
+        if any([x[1] for x in past_receipts if x[1] == MempoolInclusionStatus.SUCCESS.value]):
             # we managed to push it to mempool at least once
             return True
         if any([x[1] for x in past_receipts if x[1] in (Err.INVALID_FEE_LOW_FEE, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO)]):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This fixes, simplifies and adds a test for `TransactionRecord.is_valid` which was implemented in #14812. See the individual commits.

It has three issues:

- 024186cce75dcdafd208e4d1836660abf04a12e3 - It expects the `MempoolInclusionStatus` at the wrong index
- dbf1771c511c466516048b9bf71e9393edd74dc5 - It expects the error at the wrong index
- 7ea1a33656a9a3979fe7ac0cecf716057983a76d - It expects the error to be an `Err` value although its a string

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Transaction records can unintentionally be treated as invalid.

### New Behavior:

Transaction records will be properly treated as valid. 

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Added a unit test for `TransactionRecord.is_valid`.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
