### PR TITLE
wallet: Select enough XCH to cover the fee when creating an offer

### DIFF
--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -551,9 +551,8 @@ class TradeManager:
 
             all_transactions: List[TransactionRecord] = []
             fee_left_to_pay: uint64 = fee
-            # TODO: Create the transaction in place above when we select the coins? The access of the sorted keys here
-            #       makes sure we create the XCH transaction first to make sure we pay fee with the XCH side of the
-            #       offer and don't create an extra fee transaction in other wallets.
+            # The access of the sorted keys here makes sure we create the XCH transaction first to make sure we pay fee
+            # with the XCH side of the offer and don't create an extra fee transaction in other wallets.
             for id in sorted(list(coins_to_offer.keys())):
                 selected_coins = coins_to_offer[id]
                 if isinstance(id, int):

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -553,7 +553,7 @@ class TradeManager:
             fee_left_to_pay: uint64 = fee
             # The access of the sorted keys here makes sure we create the XCH transaction first to make sure we pay fee
             # with the XCH side of the offer and don't create an extra fee transaction in other wallets.
-            for id in sorted(list(coins_to_offer.keys())):
+            for id in sorted(coins_to_offer.keys()):
                 selected_coins = coins_to_offer[id]
                 if isinstance(id, int):
                     wallet = self.wallet_state_manager.wallets[id]

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -508,11 +508,11 @@ class TradeManager:
                     if not callable(getattr(wallet, "get_coins_to_offer", None)):  # ATTENTION: new wallets
                         raise ValueError(f"Cannot offer coins from wallet id {wallet.id()}")
                     # For the XCH wallet also include the fee amount to the coins we use to pay this offer
-                    get_coin_amount = abs(amount)
+                    amount_to_select = abs(amount)
                     if wallet.type() == WalletType.STANDARD_WALLET:
-                        get_coin_amount += fee
+                        amount_to_select += fee
                     coins_to_offer[id] = await wallet.get_coins_to_offer(
-                        asset_id, uint64(get_coin_amount), min_coin_amount, max_coin_amount
+                        asset_id, uint64(amount_to_select), min_coin_amount, max_coin_amount
                     )
                     # Note: if we use check_for_special_offer_making, this is not used.
                 elif amount == 0:

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -379,19 +379,8 @@ class Wallet:
         change = spend_value - total_amount
         if negative_change_allowed:
             change = max(0, change)
-        # only kicks in if fee is missing
-        if change < 0 and fee + amount == total_amount:
-            fee_coins = await self.select_coins(
-                # change already includes fee amount
-                uint64(abs(change)),
-                excluded_coin_amounts=exclude_coin_amounts,
-                exclude=([] if exclude_coins is None else list(exclude_coins)) + list(coins or []),
-            )
-            coins = coins.union(fee_coins)
-            spend_value = sum([coin.amount for coin in coins])
-            self.log.info(f"Updated spend_value is {spend_value} and total_amount is {total_amount}")
-            change = spend_value - total_amount
-        assert change >= 0, f"change is negative: {change}"
+
+        assert change >= 0
 
         if coin_announcements_to_consume is not None:
             coin_announcements_bytes: Optional[Set[bytes32]] = {a.name() for a in coin_announcements_to_consume}


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Just cleanup / remove some extra logic from `Wallet._generate_unsigned_transaction` which was added in #14812 to get enough XCH amount to also pay the fee when creating the XCH side of an offer.  Just select enough coins during offer creation to also cover the fee instead of selecting extra coins for the fee in `Wallet._generate_unsigned_transaction`.

I think we should either pass in coins into this method or not. If not, we select what we need and if we pass coins in it should be enough to cover everything.

### New Behavior:

No change in behaviour.