### PR TITLE
util: Streamable enums based on sized ints and `Enum`

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -63,7 +63,6 @@ jobs:
             matrix: '3.7'
             exclude_from:
               limited: True
-              main: True
           - name: '3.8'
             file_name: '3.8'
             action: '3.8'
@@ -72,7 +71,6 @@ jobs:
             matrix: '3.8'
             exclude_from:
               limited: True
-              main: True
           - name: '3.9'
             file_name: '3.9'
             action: '3.9'
@@ -87,7 +85,6 @@ jobs:
             matrix: '3.10'
             exclude_from:
               limited: True
-              main: True
           - name: '3.11'
             file_name: '3.11'
             action: '3.11'
@@ -96,7 +93,6 @@ jobs:
             matrix: '3.11'
             exclude_from:
               limited: True
-              main: True
         exclude:
           - os:
               matrix: macos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           python tests/build-job-matrix.py --per directory --verbose > matrix.json
           cat matrix.json
           echo configuration=$(cat matrix.json) >> $GITHUB_OUTPUT
-          echo matrix_mode=${{ ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || 'main' }} >> $GITHUB_OUTPUT
+          echo matrix_mode=${{ ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || 'all' }} >> $GITHUB_OUTPUT
 
     outputs:
       configuration: ${{ steps.configure.outputs.configuration }}

--- a/chia/util/ints.py
+++ b/chia/util/ints.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Union
 
 from chia.util.struct_stream import StructStream, parse_metadata_from_name
 
@@ -66,28 +65,29 @@ class int512(StructStream):
     MINIMUM = -(2**BITS) + 1
 
 
-class Int8Enum(int8, Enum):
+class SizedIntEnum(Enum):
     pass
 
 
-class Int16Enum(int16, Enum):
+class Int8Enum(int8, SizedIntEnum):
     pass
 
 
-class Int32Enum(int32, Enum):
+class Int16Enum(int16, SizedIntEnum):
     pass
 
 
-class UInt8Enum(uint8, Enum):
+class Int32Enum(int32, SizedIntEnum):
     pass
 
 
-class UInt16Enum(uint16, Enum):
+class UInt8Enum(uint8, SizedIntEnum):
     pass
 
 
-class UInt32Enum(uint32, Enum):
+class UInt16Enum(uint16, SizedIntEnum):
     pass
 
 
-SizedIntEnum = Union[Int8Enum, Int16Enum, Int32Enum, UInt8Enum, UInt16Enum, UInt32Enum]
+class UInt32Enum(uint32, SizedIntEnum):
+    pass

--- a/chia/util/ints.py
+++ b/chia/util/ints.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
-
 from chia.util.struct_stream import StructStream, parse_metadata_from_name
 
 
@@ -63,31 +61,3 @@ class int512(StructStream):
     # [-INT512_MAX, INT512_MAX]
     MAXIMUM_EXCLUSIVE = 2**BITS
     MINIMUM = -(2**BITS) + 1
-
-
-class SizedIntEnum(Enum):
-    pass
-
-
-class Int8Enum(int8, SizedIntEnum):
-    pass
-
-
-class Int16Enum(int16, SizedIntEnum):
-    pass
-
-
-class Int32Enum(int32, SizedIntEnum):
-    pass
-
-
-class UInt8Enum(uint8, SizedIntEnum):
-    pass
-
-
-class UInt16Enum(uint16, SizedIntEnum):
-    pass
-
-
-class UInt32Enum(uint32, SizedIntEnum):
-    pass

--- a/chia/util/ints.py
+++ b/chia/util/ints.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import ReprEnum
+from enum import Enum
 from typing import Union
 
 from chia.util.struct_stream import StructStream, parse_metadata_from_name
@@ -66,27 +66,27 @@ class int512(StructStream):
     MINIMUM = -(2**BITS) + 1
 
 
-class Int8Enum(int8, ReprEnum):
+class Int8Enum(int8, Enum):
     pass
 
 
-class Int16Enum(int16, ReprEnum):
+class Int16Enum(int16, Enum):
     pass
 
 
-class Int32Enum(int32, ReprEnum):
+class Int32Enum(int32, Enum):
     pass
 
 
-class UInt8Enum(uint8, ReprEnum):
+class UInt8Enum(uint8, Enum):
     pass
 
 
-class UInt16Enum(uint16, ReprEnum):
+class UInt16Enum(uint16, Enum):
     pass
 
 
-class UInt32Enum(uint32, ReprEnum):
+class UInt32Enum(uint32, Enum):
     pass
 
 

--- a/chia/util/ints.py
+++ b/chia/util/ints.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from enum import ReprEnum
+from typing import Union
+
 from chia.util.struct_stream import StructStream, parse_metadata_from_name
 
 
@@ -61,3 +64,30 @@ class int512(StructStream):
     # [-INT512_MAX, INT512_MAX]
     MAXIMUM_EXCLUSIVE = 2**BITS
     MINIMUM = -(2**BITS) + 1
+
+
+class Int8Enum(int8, ReprEnum):
+    pass
+
+
+class Int16Enum(int16, ReprEnum):
+    pass
+
+
+class Int32Enum(int32, ReprEnum):
+    pass
+
+
+class UInt8Enum(uint8, ReprEnum):
+    pass
+
+
+class UInt16Enum(uint16, ReprEnum):
+    pass
+
+
+class UInt32Enum(uint32, ReprEnum):
+    pass
+
+
+SizedIntEnum = Union[Int8Enum, Int16Enum, Int32Enum, UInt8Enum, UInt16Enum, UInt32Enum]

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import dataclasses
 import signal
 import sys
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Sequence, Union
 
 from chia.util.errors import InvalidPathError
-from chia.util.ints import uint16
+from chia.util.ints import int8, int16, int32, uint8, uint16, uint32
 from chia.util.streamable import Streamable, recurse_jsonify, streamable
 
 
@@ -115,3 +116,31 @@ if sys.platform == "win32" or sys.platform == "cygwin":
 else:
     termination_signals = [signal.SIGINT, signal.SIGTERM]
     sendable_termination_signals = termination_signals
+
+
+class SizedIntEnum(Enum):
+    pass
+
+
+class Int8Enum(int8, SizedIntEnum):
+    pass
+
+
+class Int16Enum(int16, SizedIntEnum):
+    pass
+
+
+class Int32Enum(int32, SizedIntEnum):
+    pass
+
+
+class UInt8Enum(uint8, SizedIntEnum):
+    pass
+
+
+class UInt16Enum(uint16, SizedIntEnum):
+    pass
+
+
+class UInt32Enum(uint32, SizedIntEnum):
+    pass

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -325,12 +325,12 @@ def recurse_jsonify(d: Any) -> Any:
 
     elif type(d).__name__ in unhashable_types or issubclass(type(d), bytes):
         return f"0x{bytes(d).hex()}"
+    elif isinstance(d, bool):
+        return d
     elif isinstance(d, int):
         return int(d)
     elif isinstance(d, Enum):
         return d.name
-    elif isinstance(d, bool):
-        return d
     elif d is None or type(d) == str:
         return d
     elif hasattr(d, "to_json_dict"):

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -325,12 +325,12 @@ def recurse_jsonify(d: Any) -> Any:
 
     elif type(d).__name__ in unhashable_types or issubclass(type(d), bytes):
         return f"0x{bytes(d).hex()}"
+    elif isinstance(d, int):
+        return int(d)
     elif isinstance(d, Enum):
         return d.name
     elif isinstance(d, bool):
         return d
-    elif isinstance(d, int):
-        return int(d)
     elif d is None or type(d) == str:
         return d
     elif hasattr(d, "to_json_dict"):

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -17,7 +17,8 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes4, bytes32
 from chia.types.full_block import FullBlock
 from chia.types.weight_proof import SubEpochChallengeSegment
-from chia.util.ints import Int8Enum, Int16Enum, Int32Enum, UInt8Enum, UInt16Enum, UInt32Enum, uint8, uint32, uint64
+from chia.util.ints import uint8, uint32, uint64
+from chia.util.misc import Int8Enum, Int16Enum, Int32Enum, UInt8Enum, UInt16Enum, UInt32Enum
 from chia.util.streamable import (
     ConversionError,
     DefinitionError,

--- a/tests/util/test_struct_stream.py
+++ b/tests/util/test_struct_stream.py
@@ -333,17 +333,18 @@ def test_int_enum(enum_type: Type[SizedIntEnum], int_type: Type[StructStream]) -
 @pytest.mark.parametrize(
     "enum_type, value, exception",
     [
-        (Int8Enum, int8.MAXIMUM_EXCLUSIVE, TypeError),
+        # Python 3.11 raises TypeError, Python 3.9 raises ValueError
+        (Int8Enum, int8.MAXIMUM_EXCLUSIVE, (ValueError, TypeError)),
         (Int8Enum, "text", ValueError),
-        (Int16Enum, int16.MAXIMUM_EXCLUSIVE, TypeError),
+        (Int16Enum, int16.MAXIMUM_EXCLUSIVE, (ValueError, TypeError)),
         (Int16Enum, "text", ValueError),
-        (Int32Enum, int32.MAXIMUM_EXCLUSIVE, TypeError),
+        (Int32Enum, int32.MAXIMUM_EXCLUSIVE, (ValueError, TypeError)),
         (Int32Enum, "text", ValueError),
-        (UInt8Enum, uint8.MAXIMUM_EXCLUSIVE, TypeError),
+        (UInt8Enum, uint8.MAXIMUM_EXCLUSIVE, (ValueError, TypeError)),
         (UInt8Enum, "text", ValueError),
-        (UInt16Enum, uint16.MAXIMUM_EXCLUSIVE, TypeError),
+        (UInt16Enum, uint16.MAXIMUM_EXCLUSIVE, (ValueError, TypeError)),
         (UInt16Enum, "text", ValueError),
-        (UInt32Enum, uint32.MAXIMUM_EXCLUSIVE, TypeError),
+        (UInt32Enum, uint32.MAXIMUM_EXCLUSIVE, (ValueError, TypeError)),
         (UInt32Enum, "text", ValueError),
     ],
 )

--- a/tests/util/test_struct_stream.py
+++ b/tests/util/test_struct_stream.py
@@ -4,7 +4,7 @@ import io
 import struct
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Iterable, List, Optional, Type, Union
+from typing import Iterable, List, Optional, Tuple, Type, Union
 
 import pytest
 
@@ -349,7 +349,9 @@ def test_int_enum(enum_type: Type[SizedIntEnum], int_type: Type[StructStream]) -
     ],
 )
 def test_int_enum_failure(
-    enum_type: Type[SizedIntEnum], value: Union[int32, uint32], exception: Type[Exception]
+    enum_type: Type[SizedIntEnum],
+    value: Union[int32, uint32],
+    exception: Union[Type[Exception], Tuple[Type[Exception], ...]],
 ) -> None:
     with pytest.raises(exception):
 

--- a/tests/util/test_struct_stream.py
+++ b/tests/util/test_struct_stream.py
@@ -323,9 +323,9 @@ def test_int_enum(enum_type: Type[SizedIntEnum], int_type: Type[StructStream]) -
         one = 1
         max = int_type.MAXIMUM_EXCLUSIVE - 1
 
-    assert TestEnumClass.one.name == "one"  # type: ignore[attr-defined]
-    assert type(TestEnumClass.one.value) == int_type  # type: ignore[attr-defined]
-    assert TestEnumClass.one.value == 1  # type: ignore[attr-defined]
+    assert TestEnumClass.one.name == "one"  # type: ignore[attr-defined] # pylint: disable = no-member
+    assert type(TestEnumClass.one.value) == int_type  # type: ignore[attr-defined] # pylint: disable = no-member
+    assert TestEnumClass.one.value == 1  # type: ignore[attr-defined] # pylint: disable = no-member
     assert int(TestEnumClass.one) == 1
     assert TestEnumClass(1) == TestEnumClass.one
 

--- a/tests/util/test_struct_stream.py
+++ b/tests/util/test_struct_stream.py
@@ -4,7 +4,7 @@ import io
 import struct
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Iterable, List, Optional, Type
+from typing import Iterable, List, Optional, Type, Union
 
 import pytest
 
@@ -15,7 +15,25 @@ from _pytest.fixtures import SubRequest
 from _pytest.mark.structures import ParameterSet
 from typing_extensions import final
 
-from chia.util.ints import int8, int16, int32, int64, int512, uint8, uint16, uint32, uint64, uint128
+from chia.util.ints import (
+    Int8Enum,
+    Int16Enum,
+    Int32Enum,
+    SizedIntEnum,
+    UInt8Enum,
+    UInt16Enum,
+    UInt32Enum,
+    int8,
+    int16,
+    int32,
+    int64,
+    int512,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
+    uint128,
+)
 from chia.util.struct_stream import StructStream, parse_metadata_from_name
 
 
@@ -285,3 +303,54 @@ class TestStructStream:
 
     def test_parse_metadata_from_name_correct_minimum(self, good: Good) -> None:
         assert good.cls.MINIMUM == good.minimum
+
+
+@pytest.mark.parametrize(
+    "enum_type, int_type",
+    [
+        (Int8Enum, int8),
+        (Int16Enum, int16),
+        (Int32Enum, int32),
+        (UInt8Enum, uint8),
+        (UInt16Enum, uint16),
+        (UInt32Enum, uint32),
+    ],
+)
+def test_int_enum(enum_type: Type[SizedIntEnum], int_type: Type[StructStream]) -> None:
+    # ignores here are to allow inheritance from `enum_type`
+    class TestEnumClass(enum_type):  # type: ignore[valid-type, misc]
+        min = int_type.MINIMUM
+        one = 1
+        max = int_type.MAXIMUM_EXCLUSIVE - 1
+
+    assert TestEnumClass.one.name == "one"  # type: ignore[attr-defined]
+    assert type(TestEnumClass.one.value) == int_type  # type: ignore[attr-defined]
+    assert TestEnumClass.one.value == 1  # type: ignore[attr-defined]
+    assert int(TestEnumClass.one) == 1
+    assert TestEnumClass(1) == TestEnumClass.one
+
+
+@pytest.mark.parametrize(
+    "enum_type, value, exception",
+    [
+        (Int8Enum, int8.MAXIMUM_EXCLUSIVE, TypeError),
+        (Int8Enum, "text", ValueError),
+        (Int16Enum, int16.MAXIMUM_EXCLUSIVE, TypeError),
+        (Int16Enum, "text", ValueError),
+        (Int32Enum, int32.MAXIMUM_EXCLUSIVE, TypeError),
+        (Int32Enum, "text", ValueError),
+        (UInt8Enum, uint8.MAXIMUM_EXCLUSIVE, TypeError),
+        (UInt8Enum, "text", ValueError),
+        (UInt16Enum, uint16.MAXIMUM_EXCLUSIVE, TypeError),
+        (UInt16Enum, "text", ValueError),
+        (UInt32Enum, uint32.MAXIMUM_EXCLUSIVE, TypeError),
+        (UInt32Enum, "text", ValueError),
+    ],
+)
+def test_int_enum_failure(
+    enum_type: Type[SizedIntEnum], value: Union[int32, uint32], exception: Type[Exception]
+) -> None:
+    with pytest.raises(exception):
+
+        class BadEnum(enum_type):  # type: ignore[valid-type, misc] # ignore to allow subclassing `enum_type`
+            bad_entry = value

--- a/tests/util/test_struct_stream.py
+++ b/tests/util/test_struct_stream.py
@@ -15,25 +15,8 @@ from _pytest.fixtures import SubRequest
 from _pytest.mark.structures import ParameterSet
 from typing_extensions import final
 
-from chia.util.ints import (
-    Int8Enum,
-    Int16Enum,
-    Int32Enum,
-    SizedIntEnum,
-    UInt8Enum,
-    UInt16Enum,
-    UInt32Enum,
-    int8,
-    int16,
-    int32,
-    int64,
-    int512,
-    uint8,
-    uint16,
-    uint32,
-    uint64,
-    uint128,
-)
+from chia.util.ints import int8, int16, int32, int64, int512, uint8, uint16, uint32, uint64, uint128
+from chia.util.misc import Int8Enum, Int16Enum, Int32Enum, SizedIntEnum, UInt8Enum, UInt16Enum, UInt32Enum
 from chia.util.struct_stream import StructStream, parse_metadata_from_name
 
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Make it possible to use enums in streamable classes. The way it works is that inheriting from the actual sized int adds `__bytes__` and `from_bytes` and with this, the enums are already supported in streamable while inheriting `Enum` adds enum features and forces the entries to be from the actual sized int.

There is only the move of the `int` conversion in `recurse_jsonify` required (see 1f2f5145f01dc7b2e2950621766855a931344114 ) to fully support it because we there currently return the name for normal `Enum` types. I checked the places where we call `recurse_jsonify` and it should not have an unintended impact on other JSON conversions. 

**Note:** This can not be just be swapped now retrospectively without further changes in all places and requires some more adjustments and considerations in some cases because swapping the type to an enum leads to deserialisation failure instead of the conversion failures we currently have when trying to convert the already deserialised value to the actual enum type.

### Example

```python
class TheEnum(UInt8Enum):
    a = 0
    b = 1
```

in the class

```python
@streamale
@dataclass(frozen=True)
class Example(Streamable)
    member: TheEnum
```

which had to look like 

```python
@streamale
@dataclass(frozen=True)
class Example(Streamable)
    member: uint8  # TheEnum
```

before this PR which leads to a bunch of conversations all over the place and just ambiguous usages of class members/values.

### New Behavior:

No change in behaviour.  It just adds support for it.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I added unit tests in this PR.
