### PR TITLE
Added some sanity checks to upload and download for S3 plugin

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -448,8 +448,8 @@ class DataLayer:
                 if uploaders is not None and len(uploaders) > 0:
                     request_json = {
                         "store_id": tree_id.hex(),
-                        "full_tree_path": str(write_file_result.full_tree),
-                        "diff_path": str(write_file_result.diff_tree),
+                        "full_tree_filename": str(write_file_result.full_tree.name),
+                        "diff_filename": str(write_file_result.diff_tree.name),
                     }
                     for uploader in uploaders:
                         self.log.info(f"Using uploader {uploader} for store {tree_id.hex()}")

--- a/chia/data_layer/s3_plugin_config.yml
+++ b/chia/data_layer/s3_plugin_config.yml
@@ -1,5 +1,6 @@
 instance-1:
   log_filename: "s3_plugin.log"
+  server_files_location: "/Users/test/.chia/mainnet/data_layer/db/server_files_location_testnet10"
   port: 8998
   aws_credentials:
     access_key_id: "xxx"
@@ -16,6 +17,7 @@ instance-1:
 
 instance-2:
   port: 8999
+  server_files_location: "/tmp/"
   aws_credentials:
     access_key_id: "xxx"
     secret_access_key: "xxx"

--- a/chia/data_layer/s3_plugin_config.yml
+++ b/chia/data_layer/s3_plugin_config.yml
@@ -17,7 +17,7 @@ instance-1:
 
 instance-2:
   port: 8999
-  server_files_location: "/tmp/"
+  server_files_location: "/Users/test/.chia/mainnet/data_layer/db/server_files_location_testnet10"
   aws_credentials:
     access_key_id: "xxx"
     secret_access_key: "xxx"

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -149,7 +149,7 @@ class S3Plugin:
             parse_result = urlparse(url)
             should_download = False
             for store in self.stores:
-                if store.id == filename_tree_id and parse_result.scheme == "s3" and data["url"] in store.urls:
+                if store.id == filename_tree_id and parse_result.scheme == "s3" and url in store.urls:
                     should_download = True
 
             # filename must follow the DataLayer naming convention

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -88,20 +88,20 @@ class S3Plugin:
             data = await request.json()
             store_id = bytes32.from_hexstr(data["store_id"])
             bucket = self.get_bucket(store_id)
-            full_tree_path_name = Path(data["full_tree_path"]).name
-            diff_path_name = Path(data["diff_path"]).name
-            full_tree_path = self.server_files_path / full_tree_path_name
-            diff_path = self.server_files_path / diff_path_name
+            full_tree_name: str = data["full_tree_filename"]
+            diff_name: str = data["diff_filename"]
+            full_tree_path = self.server_files_path.joinpath(full_tree_name)
+            diff_path = self.server_files_path.joinpath(diff_name)
 
             # Pull the store_id from the filename to make sure we only upload for configured stores
-            full_tree_path_tree_id = bytes32(bytes.fromhex(full_tree_path_name.split("-")[0]))
-            diff_path_tree_id = bytes32(bytes.fromhex(diff_path_name.split("-")[0]))
+            full_tree_id = bytes32(bytes.fromhex(full_tree_name.split("-")[0]))
+            diff_tree_id = bytes32(bytes.fromhex(diff_name.split("-")[0]))
 
             # filenames must follow the DataLayer naming convention
             if (
-                not is_filename_valid(full_tree_path_name)
-                or not is_filename_valid(diff_path_name)
-                or not (full_tree_path_tree_id == diff_path_tree_id == store_id)
+                not is_filename_valid(full_tree_name)
+                or not is_filename_valid(diff_name)
+                or not (full_tree_id == diff_tree_id == store_id)
             ):
                 return web.json_response({"uploaded": False})
 

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -256,7 +256,7 @@ def run_server() -> None:
     except KeyError:
         sys.exit("Missing port in config file.")
 
-    web.run_app(make_app(config, instance_name), port=port)
+    web.run_app(make_app(config, instance_name), port=port, host="localhost")
     log.info(f"Stopped s3 plugin {instance_name}")
 
 

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -96,8 +96,8 @@ class S3Plugin:
                 return web.json_response({"uploaded": False})
 
             # Pull the store_id from the filename to make sure we only upload for configured stores
-            full_tree_id = bytes32(bytes.fromhex(full_tree_name[:64]))
-            diff_tree_id = bytes32(bytes.fromhex(diff_name[:64]))
+            full_tree_id = bytes32.fromhex(full_tree_name[:64])
+            diff_tree_id = bytes32.fromhex(diff_name[:64])
 
             if not (full_tree_id == diff_tree_id == store_id):
                 return web.json_response({"uploaded": False})
@@ -143,9 +143,13 @@ class S3Plugin:
             data = await request.json()
             url = data["url"]
             filename = data["filename"]
-            # Pull the store_id from the filename to make sure we only download for configured stores
-            filename_tree_id = bytes32(bytes.fromhex(filename.split("-")[0]))
 
+            # filename must follow the DataLayer naming convention
+            if not is_filename_valid(filename):
+                return web.json_response({"downloaded": False})
+
+            # Pull the store_id from the filename to make sure we only download for configured stores
+            filename_tree_id = bytes32.fromhex(filename[:64])
             parse_result = urlparse(url)
             should_download = False
             for store in self.stores:
@@ -153,8 +157,7 @@ class S3Plugin:
                     should_download = True
                     break
 
-            # filename must follow the DataLayer naming convention
-            if not should_download or not is_filename_valid(filename):
+            if not should_download:
                 return web.json_response({"downloaded": False})
 
             bucket = parse_result.netloc

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -90,20 +90,20 @@ class S3Plugin:
             bucket = self.get_bucket(store_id)
             full_tree_name: str = data["full_tree_filename"]
             diff_name: str = data["diff_filename"]
-            full_tree_path = self.server_files_path.joinpath(full_tree_name)
-            diff_path = self.server_files_path.joinpath(diff_name)
-
-            # Pull the store_id from the filename to make sure we only upload for configured stores
-            full_tree_id = bytes32(bytes.fromhex(full_tree_name.split("-")[0]))
-            diff_tree_id = bytes32(bytes.fromhex(diff_name.split("-")[0]))
 
             # filenames must follow the DataLayer naming convention
-            if (
-                not is_filename_valid(full_tree_name)
-                or not is_filename_valid(diff_name)
-                or not (full_tree_id == diff_tree_id == store_id)
-            ):
+            if not is_filename_valid(full_tree_name) or not is_filename_valid(diff_name):
                 return web.json_response({"uploaded": False})
+
+            # Pull the store_id from the filename to make sure we only upload for configured stores
+            full_tree_id = bytes32(bytes.fromhex(full_tree_name[:64]))
+            diff_tree_id = bytes32(bytes.fromhex(diff_name[:64]))
+
+            if not (full_tree_id == diff_tree_id == store_id):
+                return web.json_response({"uploaded": False})
+
+            full_tree_path = self.server_files_path.joinpath(full_tree_name)
+            diff_path = self.server_files_path.joinpath(diff_name)
 
             try:
                 with concurrent.futures.ThreadPoolExecutor() as pool:

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -151,6 +151,7 @@ class S3Plugin:
             for store in self.stores:
                 if store.id == filename_tree_id and parse_result.scheme == "s3" and url in store.urls:
                     should_download = True
+                    break
 
             # filename must follow the DataLayer naming convention
             if not should_download or not is_filename_valid(filename):


### PR DESCRIPTION
Add required config for `server_files_location` where the plugin will always download and upload to. This will need to be set to the same localtion as the `server_files_location` for datalayer in the chia config. At this time, this is a manual configuration

Added checks for the S3 plugin checks that all the files follow the Datalayer naming convention

Datalayer now only sends the filenames themselves for `/upload` and the plugin expects to find these files at the configured `server_files_location`