### PR TITLE
bump chia_rs dependency to 0.2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ dependencies = [
     "chiapos==1.0.11",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
-    "chia_rs==0.2.5",
+    "chia_rs==0.2.6",
     "clvm-tools-rs==0.1.30",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.4",  # HTTP server for full node rpc
     "aiosqlite==0.17.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
The main change is an update to the `softfork` operator in mempool-mode.

The full changelog can be found here: https://github.com/Chia-Network/chia_rs/releases/tag/0.2.6