### PR TITLE
Removed "failed to write files" log spam from data layer

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -456,7 +456,7 @@ class DataLayer:
         while publish_generation > 0:
             write_file_result = await write_files_for_root(self.data_store, tree_id, root, self.server_files_location)
             if not write_file_result.result:
-                self.log.error("failed to write files")
+                # this particular return only happens if the files already exist, no need to log anything
                 break
             try:
                 if uploaders is not None and len(uploaders) > 0:


### PR DESCRIPTION
For DL plugins we introduced this log spam that caused this error to print out all the time even though the file exists and was not an actual error writing the files.

This is in new code and not a bug fix per se.