### PR TITLE
improve ignore handling in `__init__.py` creation script

### DIFF
--- a/tests/build-init-files.py
+++ b/tests/build-init-files.py
@@ -12,9 +12,8 @@
 from __future__ import annotations
 
 import logging
-import os
 import pathlib
-import sys
+from typing import List
 
 import click
 
@@ -26,6 +25,31 @@ log_levels = {
 
 
 ignores = {"__pycache__", ".pytest_cache"}
+
+
+def traverse_directory(path: pathlib.Path) -> List[pathlib.Path]:
+    of_interest: List[pathlib.Path] = []
+
+    file_found = False
+
+    for member in path.iterdir():
+        if not member.is_dir():
+            file_found = True
+            continue
+
+        if member.name in ignores:
+            continue
+
+        found = traverse_directory(path=member)
+        of_interest.extend(found)
+
+        if len(found) > 0:
+            of_interest.append(member)
+
+    if len(of_interest) > 0 or file_found:
+        of_interest.append(path)
+
+    return of_interest
 
 
 @click.command()
@@ -43,20 +67,14 @@ def command(verbose, root_str):
     tree_roots = ["benchmarks", "build_scripts", "chia", "tests", "tools"]
     failed = False
     root = pathlib.Path(root_str).resolve()
-    directories = sorted(
-        path
-        for tree_root in tree_roots
-        for path in root.joinpath(tree_root).rglob("**/")
-        if all(part not in ignores for part in path.parts)
-    )
+    directories = [
+        directory for tree_root in tree_roots for directory in traverse_directory(path=root.joinpath(tree_root))
+    ]
 
     for path in directories:
         init_path = path.joinpath("__init__.py")
         # This has plenty of race hazards. If it messes up,
         # it will likely get caught the next time.
-        if len(os.listdir(path)) == 0:
-            logger.info(f"Skipping (empty directory)   : {init_path}")
-            continue
         if init_path.is_file() and not init_path.is_symlink():
             logger.info(f"Found   : {init_path}")
             continue
@@ -66,7 +84,7 @@ def command(verbose, root_str):
             logger.warning(f"Created : {init_path}")
         else:
             failed = True
-            logger.error(f"Fail    : present but not a regular file: {init_path}", file=sys.stderr)
+            logger.error(f"Fail    : present but not a regular file: {init_path}")
 
     if failed:
         raise click.ClickException("At least one __init__.py created or not a regular file")


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

The ignore behavior for directories such as `__pycache__` was not working correctly and files inside of the ignored directories were triggering creation of `__init__.py` files outside of the ignored directory.  Such otherwise empty directories are often created when switching branches in git from a branch with a given directory to a branch without it.  The leftover `__pycache__`, left because it is not being tracked by git, then triggers this script to create a `__init__.py` that git does find of interest and...  annoyance ensues.

```console
$ find chia/{blue,red,green,black} -name __init__.py -exec rm {} \; ; tree chia/{red,green,blue,black}; venv/bin/pre-commit run --all-files --verbose init_py_files; find chia/{blue,red,green,black} -name __init__.py; tree chia/{red,green,blue,black}
chia/red
└── __pycache__
    └── x.py
chia/green
chia/blue
└── aqua
    └── __pycache__
        └── x.py
chia/black
└── gray
    └── white.py

1 directory, 1 file
__init__.py files........................................................Failed
- hook id: init_py_files
- duration: 0.05s
- exit code: 1

Created : /home/altendky/repos/chia-blockchain/chia/black/gray/__init__.py
Created : /home/altendky/repos/chia-blockchain/chia/black/__init__.py
Error: At least one __init__.py created or not a regular file

chia/black/__init__.py
chia/black/gray/__init__.py
chia/red
└── __pycache__
    └── x.py
chia/green
chia/blue
└── aqua
    └── __pycache__
        └── x.py
chia/black
├── gray
│   ├── __init__.py
│   └── white.py
└── __init__.py

1 directory, 3 files
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Files present in ignored directories such as `__pycache__` still trigger parents of the ignored directory to be given new `__init__.py` files.

```
chia/red
├── __init__.py
└── __pycache__
    └── x.py
```

### New Behavior:

Fewer `__init__.py` files are created.

```
chia/red
└── __pycache__
    └── x.py
chia/green
chia/blue 
└── aqua
    └── __pycache__
        └── x.py
chia/black
├── gray
│   ├── __init__.py
│   └── white.py
└── __init__.py
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
