### PR TITLE
wallet: Improve `WalletCoinStore.get_coin_records`

### DIFF
--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Sequence, Union
 
 from chia.util.errors import InvalidPathError
-from chia.util.ints import uint16
+from chia.util.ints import uint16, uint32, uint64
 from chia.util.streamable import Streamable, recurse_jsonify, streamable
 
 
@@ -115,3 +115,17 @@ if sys.platform == "win32" or sys.platform == "cygwin":
 else:
     termination_signals = [signal.SIGINT, signal.SIGTERM]
     sendable_termination_signals = termination_signals
+
+
+@streamable
+@dataclasses.dataclass(frozen=True)
+class UInt32Range(Streamable):
+    start: uint32 = uint32(0)
+    stop: uint32 = uint32(uint32.MAXIMUM_EXCLUSIVE - 1)
+
+
+@streamable
+@dataclasses.dataclass(frozen=True)
+class UInt64Range(Streamable):
+    start: uint64 = uint64(0)
+    stop: uint64 = uint64(uint64.MAXIMUM_EXCLUSIVE - 1)

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -1,15 +1,87 @@
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import dataclass
+from enum import IntEnum
 from typing import Dict, List, Optional, Set
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone
-from chia.util.ints import uint32, uint64
-from chia.util.misc import VersionedBlob
+from chia.util.hash import std_hash
+from chia.util.ints import uint8, uint32, uint64
+from chia.util.lru_cache import LRUCache
+from chia.util.misc import UInt32Range, UInt64Range, VersionedBlob
+from chia.util.streamable import Streamable, streamable
 from chia.wallet.util.wallet_types import CoinType, WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
+
+
+class FilterMode(IntEnum):
+    include = 1
+    exclude = 2
+
+
+@streamable
+@dataclass(frozen=True)
+class AmountFilter(Streamable):
+    values: List[uint64]
+    mode: uint8  # FilterMode
+
+    @classmethod
+    def include(cls, values: List[uint64]):
+        return cls(values, mode=uint8(FilterMode.include))
+
+    @classmethod
+    def exclude(cls, values: List[uint64]):
+        return cls(values, mode=uint8(FilterMode.exclude))
+
+
+@streamable
+@dataclass(frozen=True)
+class HashFilter(Streamable):
+    values: List[bytes32]
+    mode: uint8  # FilterMode
+
+    @classmethod
+    def include(cls, values: List[bytes32]):
+        return cls(values, mode=uint8(FilterMode.include))
+
+    @classmethod
+    def exclude(cls, values: List[bytes32]):
+        return cls(values, mode=uint8(FilterMode.exclude))
+
+
+class CoinRecordOrder(IntEnum):
+    confirmed_height = 1
+    spent_height = 2
+
+
+@streamable
+@dataclass(frozen=True)
+class GetCoinRecords(Streamable):
+    offset: uint32 = uint32(0)
+    limit: uint32 = uint32(uint32.MAXIMUM_EXCLUSIVE - 1)
+    wallet_id: Optional[uint32] = None
+    wallet_type: Optional[uint8] = None  # WalletType
+    coin_type: Optional[uint8] = None  # CoinType
+    coin_id_filter: Optional[HashFilter] = None
+    puzzle_hash_filter: Optional[HashFilter] = None
+    parent_coin_id_filter: Optional[HashFilter] = None
+    amount_filter: Optional[AmountFilter] = None
+    amount_range: Optional[UInt64Range] = None
+    confirmed_range: Optional[UInt32Range] = None
+    spent_range: Optional[UInt32Range] = None
+    order: uint8 = uint8(CoinRecordOrder.confirmed_height)
+    reverse: bool = False
+    include_total_count: bool = False  # Include the total number of entries for the query without applying offset/limit
+
+
+@dataclass(frozen=True)
+class GetCoinRecordsResult:
+    records: List[WalletCoinRecord]
+    coin_id_to_record: Dict[bytes32, WalletCoinRecord]
+    total_count: Optional[uint32]
 
 
 class WalletCoinStore:
@@ -18,12 +90,14 @@ class WalletCoinStore:
     """
 
     db_wrapper: DBWrapper2
+    total_count_cache: LRUCache[bytes32, uint32]
 
     @classmethod
     async def create(cls, wrapper: DBWrapper2):
         self = cls()
 
         self.db_wrapper = wrapper
+        self.total_count_cache = LRUCache(100)
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
@@ -96,11 +170,13 @@ class WalletCoinStore:
                     None if record.metadata is None else bytes(record.metadata),
                 ),
             )
+        self.total_count_cache.cache.clear()
 
     # Sometimes we realize that a coin is actually not interesting to us so we need to delete it
     async def delete_coin_record(self, coin_name: bytes32) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (await conn.execute("DELETE FROM coin_record WHERE coin_name=?", (coin_name.hex(),))).close()
+        self.total_count_cache.cache.clear()
 
     # Update coin_record to be spent in DB
     async def set_spent(self, coin_name: bytes32, height: uint32) -> None:
@@ -113,6 +189,7 @@ class WalletCoinStore:
                     coin_name.hex(),
                 ),
             )
+        self.total_count_cache.cache.clear()
 
     def coin_record_from_row(self, row: sqlite3.Row) -> WalletCoinRecord:
         coin = Coin(bytes32.fromhex(row[6]), bytes32.fromhex(row[5]), uint64.from_bytes(row[7]))
@@ -139,29 +216,84 @@ class WalletCoinStore:
 
     async def get_coin_records(
         self,
-        coin_names: List[bytes32],
-        include_spent_coins: bool = True,
-        start_height: uint32 = uint32(0),
-        end_height: uint32 = uint32((2**32) - 1),
-    ) -> Dict[bytes32, WalletCoinRecord]:
-        """Returns CoinRecord with specified coin id."""
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = list(
-                await conn.execute_fetchall(
-                    f"SELECT * from coin_record WHERE coin_name in ({','.join('?'*len(coin_names))}) "
-                    f"AND confirmed_height>=? AND confirmed_height<? "
-                    f"{'' if include_spent_coins else 'AND spent=0'}",
-                    tuple([c.hex() for c in coin_names]) + (start_height, end_height),
-                )
+        *,
+        offset: uint32 = uint32(0),
+        limit: uint32 = uint32(uint32.MAXIMUM_EXCLUSIVE - 1),
+        wallet_id: Optional[uint32] = None,
+        wallet_type: Optional[WalletType] = None,
+        coin_type: Optional[CoinType] = None,
+        coin_id_filter: Optional[HashFilter] = None,
+        puzzle_hash_filter: Optional[HashFilter] = None,
+        parent_coin_id_filter: Optional[HashFilter] = None,
+        amount_filter: Optional[AmountFilter] = None,
+        amount_range: Optional[UInt64Range] = None,
+        confirmed_range: Optional[UInt32Range] = None,
+        spent_range: Optional[UInt32Range] = None,
+        order: CoinRecordOrder = CoinRecordOrder.confirmed_height,
+        reverse: bool = False,
+        include_total_count: bool = False,
+    ) -> GetCoinRecordsResult:
+        conditions = []
+        if wallet_id is not None:
+            conditions.append(f"wallet_id={wallet_id}")
+        if wallet_type is not None:
+            conditions.append(f"wallet_type={wallet_type.value}")
+        if coin_type is not None:
+            conditions.append(f"coin_type={coin_type.value}")
+        for field, hash_filter in {
+            "coin_name": coin_id_filter,
+            "coin_parent": parent_coin_id_filter,
+            "puzzle_hash": puzzle_hash_filter,
+        }.items():
+            if hash_filter is None:
+                continue
+            entries = ",".join(f"{value.hex()!r}" for value in hash_filter.values)
+            conditions.append(
+                f"{field} {'not' if FilterMode(hash_filter.mode) == FilterMode.exclude else ''} in ({entries})"
+            )
+        if confirmed_range is not None and confirmed_range != UInt32Range():
+            conditions.append(f"confirmed_height BETWEEN {confirmed_range.start} AND {confirmed_range.stop}")
+        if spent_range is not None and spent_range != UInt32Range():
+            conditions.append(f"spent_height BETWEEN {spent_range.start} AND {spent_range.stop}")
+        if amount_filter is not None:
+            entries = ",".join(f"X'{bytes(value).hex()}'" for value in amount_filter.values)
+            conditions.append(
+                f"amount {'not' if FilterMode(amount_filter.mode) == FilterMode.exclude else ''} in ({entries})"
+            )
+        if amount_range is not None and amount_range != UInt64Range():
+            conditions.append(
+                f"amount BETWEEN X'{bytes(amount_range.start).hex()}' AND X'{bytes(amount_range.stop).hex()}'"
             )
 
-        ret: Dict[bytes32, WalletCoinRecord] = {}
-        for row in rows:
-            record = self.coin_record_from_row(row)
-            coin_name = bytes32.fromhex(row[0])
-            ret[coin_name] = record
+        where_sql = "WHERE " + " AND ".join(conditions) if len(conditions) > 0 else ""
+        order_sql = f"ORDER BY {order.name} {'DESC' if reverse else 'ASC'}, rowid"
+        limit_sql = f"LIMIT {offset}, {limit}" if offset > 0 or limit < uint32.MAXIMUM_EXCLUSIVE - 1 else ""
+        query_sql = f"{where_sql} {order_sql} {limit_sql}"
 
-        return ret
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            rows = await conn.execute_fetchall(f"SELECT * FROM coin_record {query_sql}")
+
+            total_count = None
+            if include_total_count:
+                cache_hash = std_hash(bytes(where_sql, encoding="utf8"))  # Only use the conditions here
+                total_count = self.total_count_cache.get(cache_hash)
+                if total_count is None:
+                    row = await execute_fetchone(conn, f"SELECT COUNT(coin_name) FROM coin_record {where_sql}")
+                    assert row is not None and len(row) == 1, "COUNT should always return one value"
+                    total_count = uint32(row[0])
+                    self.total_count_cache.put(cache_hash, total_count)
+
+        records: List[WalletCoinRecord] = []
+        coin_id_to_record: Dict[bytes32, WalletCoinRecord] = {}
+        for row in rows:
+            records.append(self.coin_record_from_row(row))
+            coin_id_to_record[bytes32.fromhex(row[0])] = records[-1]
+
+        return GetCoinRecordsResult(
+            records,
+            coin_id_to_record,
+            total_count,
+        )
 
     async def get_coin_records_between(
         self, wallet_id: int, start: int, end: int, reverse: bool = False, coin_type: CoinType = CoinType.NORMAL
@@ -241,3 +373,4 @@ class WalletCoinStore:
                     (height,),
                 )
             ).close()
+        self.total_count_cache.cache.clear()

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -92,7 +92,7 @@ from chia.wallet.util.wallet_types import WalletIdentifier, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_blockchain import WalletBlockchain
 from chia.wallet.wallet_coin_record import WalletCoinRecord
-from chia.wallet.wallet_coin_store import WalletCoinStore
+from chia.wallet.wallet_coin_store import HashFilter, WalletCoinStore
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_interested_store import WalletInterestedStore
 from chia.wallet.wallet_nft_store import WalletNftStore
@@ -1004,13 +1004,13 @@ class WalletStateManager:
         ph_to_index_cache: LRUCache[bytes32, uint32] = LRUCache(100)
 
         coin_names = [coin_state.coin.name() for coin_state in coin_states]
-        local_records = await self.coin_store.get_coin_records(coin_names)
+        local_records = await self.coin_store.get_coin_records(coin_id_filter=HashFilter.include(coin_names))
 
         for coin_name, coin_state in zip(coin_names, coin_states):
             if peer.closed:
                 raise ConnectionError("Connection closed")
             self.log.debug("Add coin state: %s: %s", coin_name, coin_state)
-            local_record = local_records.get(coin_name)
+            local_record = local_records.coin_id_to_record.get(coin_name)
             rollback_wallets = None
             try:
                 async with self.db_wrapper.writer():
@@ -1592,8 +1592,8 @@ class WalletStateManager:
         return wr.to_coin_record(timestamp)
 
     async def get_coin_records_by_coin_ids(self, **kwargs: Any) -> List[CoinRecord]:
-        records = await self.coin_store.get_coin_records(**kwargs)
-        return [await self.get_coin_record_by_wallet_record(record) for record in records.values()]
+        result = await self.coin_store.get_coin_records(**kwargs)
+        return [await self.get_coin_record_by_wallet_record(record) for record in result.records]
 
     async def get_wallet_for_coin(self, coin_id: bytes32) -> Optional[WalletProtocol]:
         coin_record = await self.coin_store.get_coin_record(coin_id)

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -2,15 +2,23 @@ from __future__ import annotations
 
 from dataclasses import replace
 from secrets import token_bytes
+from typing import List, Optional, Tuple
 
 import pytest
 
 from chia.types.blockchain_format.coin import Coin
-from chia.util.ints import uint16, uint32, uint64
-from chia.util.misc import VersionedBlob
+from chia.util.ints import uint8, uint16, uint32, uint64
+from chia.util.misc import UInt32Range, UInt64Range, VersionedBlob
 from chia.wallet.util.wallet_types import CoinType, WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
-from chia.wallet.wallet_coin_store import WalletCoinStore
+from chia.wallet.wallet_coin_store import (
+    AmountFilter,
+    CoinRecordOrder,
+    GetCoinRecords,
+    GetCoinRecordsResult,
+    HashFilter,
+    WalletCoinStore,
+)
 from tests.util.db_connection import DBConnection
 
 coin_1 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
@@ -21,6 +29,7 @@ coin_5 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
 coin_6 = Coin(token_bytes(32), coin_4.puzzle_hash, uint64(12312))
 coin_7 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
 coin_8 = Coin(token_bytes(32), token_bytes(32), uint64(2))
+coin_9 = Coin(coin_5.name(), token_bytes(32), uint64(4))
 record_replaced = WalletCoinRecord(coin_1, uint32(8), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
 record_1 = WalletCoinRecord(coin_1, uint32(4), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
 record_2 = WalletCoinRecord(coin_2, uint32(5), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
@@ -77,6 +86,17 @@ record_8 = WalletCoinRecord(
     False,
     WalletType.STANDARD_WALLET,
     1,
+    CoinType.CLAWBACK,
+    VersionedBlob(uint16(1), b"TEST"),
+)
+record_9 = WalletCoinRecord(
+    coin_9,
+    uint32(1),
+    uint32(2),
+    True,
+    False,
+    WalletType.STANDARD_WALLET,
+    2,
     CoinType.CLAWBACK,
     VersionedBlob(uint16(1), b"TEST"),
 )
@@ -151,21 +171,6 @@ async def test_persistance() -> None:
 
         store = await WalletCoinStore.create(db_wrapper)
         assert await store.get_coin_record(coin_1.name()) == record_1
-
-
-@pytest.mark.asyncio
-async def test_bulk_get() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-        await store.add_coin_record(record_1)
-        await store.add_coin_record(record_2)
-        await store.add_coin_record(record_3)
-        await store.add_coin_record(record_4)
-        await store.add_coin_record(record_8)
-
-        store = await WalletCoinStore.create(db_wrapper)
-        records = await store.get_coin_records([coin_1.name(), coin_2.name(), token_bytes(32), coin_4.name()])
-        assert records == {coin_1.name(): record_1, coin_2.name(): record_2, coin_4.name(): record_4}
 
 
 @pytest.mark.asyncio
@@ -309,9 +314,9 @@ async def test_delete_coin_record() -> None:
         await store.add_coin_record(record_6)
         await store.add_coin_record(record_7)
 
-        assert set(
-            (
-                await store.get_coin_records(
+        assert (
+            await store.get_coin_records(
+                coin_id_filter=HashFilter.include(
                     [
                         coin_1.name(),
                         coin_2.name(),
@@ -322,21 +327,490 @@ async def test_delete_coin_record() -> None:
                         coin_7.name(),
                     ]
                 )
-            ).values()
-        ) == set([record_1, record_2, record_3, record_4, record_5, record_6, record_7])
+            )
+        ).records == [record_1, record_2, record_3, record_4, record_5, record_6, record_7]
 
         assert await store.get_coin_record(coin_1.name()) == record_1
 
         await store.delete_coin_record(coin_1.name())
 
         assert await store.get_coin_record(coin_1.name()) is None
-        assert set(
-            (
-                await store.get_coin_records(
+        assert (
+            await store.get_coin_records(
+                coin_id_filter=HashFilter.include(
                     [coin_2.name(), coin_3.name(), coin_4.name(), coin_5.name(), coin_6.name(), coin_7.name()]
                 )
-            ).values()
-        ) == set([record_2, record_3, record_4, record_5, record_6, record_7])
+            )
+        ).records == [record_2, record_3, record_4, record_5, record_6, record_7]
+
+
+get_coin_records_offset_limit_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(offset=uint32(0), limit=uint32(0)), []),
+    (GetCoinRecords(offset=uint32(10), limit=uint32(0)), []),
+    (GetCoinRecords(offset=uint32(0), limit=uint32(1)), [record_8]),
+    (GetCoinRecords(offset=uint32(1), limit=uint32(1)), [record_9]),
+    (GetCoinRecords(offset=uint32(0), limit=uint32(2)), [record_8, record_9]),
+    (GetCoinRecords(offset=uint32(0), limit=uint32(5)), [record_8, record_9, record_1, record_2, record_3]),
+    (GetCoinRecords(coin_type=uint8(CoinType.CLAWBACK), offset=uint32(0), limit=uint32(5)), [record_8, record_9]),
+    (GetCoinRecords(offset=uint32(2), limit=uint32(5)), [record_1, record_2, record_3, record_4, record_5]),
+    (GetCoinRecords(coin_type=uint8(CoinType.CLAWBACK), offset=uint32(5), limit=uint32(1)), []),
+]
+
+get_coin_records_wallet_id_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (
+        GetCoinRecords(),
+        [record_8, record_9, record_1, record_2, record_3, record_4, record_5, record_6, record_7],
+    ),
+    (GetCoinRecords(wallet_id=uint32(0)), [record_1, record_2, record_3, record_4]),
+    (GetCoinRecords(wallet_id=uint32(1)), [record_8, record_5]),
+    (GetCoinRecords(wallet_id=uint32(2)), [record_9, record_6, record_7]),
+]
+
+get_coin_records_wallet_type_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(wallet_id=uint32(2), wallet_type=uint8(WalletType.STANDARD_WALLET)), [record_9, record_6]),
+    (GetCoinRecords(wallet_type=uint8(WalletType.POOLING_WALLET)), [record_7]),
+    (GetCoinRecords(wallet_type=uint8(WalletType.NFT)), []),
+]
+
+get_coin_records_coin_type_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(wallet_id=uint32(0), coin_type=uint8(CoinType.NORMAL)), [record_1, record_2, record_3, record_4]),
+    (GetCoinRecords(wallet_id=uint32(0), coin_type=uint8(CoinType.CLAWBACK)), []),
+    (GetCoinRecords(wallet_id=uint32(1), coin_type=uint8(CoinType.NORMAL)), [record_5]),
+    (GetCoinRecords(wallet_id=uint32(1), coin_type=uint8(CoinType.CLAWBACK)), [record_8]),
+    (GetCoinRecords(coin_type=uint8(CoinType.CLAWBACK)), [record_8, record_9]),
+]
+
+get_coin_records_coin_id_filter_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(coin_id_filter=HashFilter.include([])), []),
+    (GetCoinRecords(coin_id_filter=HashFilter.include([coin_1.name(), coin_4.name()])), [record_1, record_4]),
+    (GetCoinRecords(coin_id_filter=HashFilter.include([coin_1.name(), coin_4.puzzle_hash])), [record_1]),
+    (GetCoinRecords(coin_id_filter=HashFilter.include([coin_9.name()])), [record_9]),
+    (GetCoinRecords(wallet_id=uint32(0), coin_id_filter=HashFilter.include([coin_9.name()])), []),
+    (
+        GetCoinRecords(wallet_id=uint32(0), coin_id_filter=HashFilter.exclude([coin_9.name()])),
+        [record_1, record_2, record_3, record_4],
+    ),
+]
+
+
+get_coin_records_puzzle_hash_filter_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(puzzle_hash_filter=HashFilter.include([])), []),
+    (
+        GetCoinRecords(puzzle_hash_filter=HashFilter.include([coin_1.puzzle_hash, coin_4.puzzle_hash])),
+        [record_1, record_4, record_6],
+    ),
+    (GetCoinRecords(puzzle_hash_filter=HashFilter.include([coin_1.puzzle_hash, coin_4.name()])), [record_1]),
+    (GetCoinRecords(puzzle_hash_filter=HashFilter.include([coin_7.puzzle_hash])), [record_7]),
+    (
+        GetCoinRecords(
+            wallet_type=uint8(WalletType.STANDARD_WALLET), puzzle_hash_filter=HashFilter.include([coin_7.puzzle_hash])
+        ),
+        [],
+    ),
+    (
+        GetCoinRecords(
+            wallet_type=uint8(WalletType.STANDARD_WALLET),
+            puzzle_hash_filter=HashFilter.exclude([coin_7.puzzle_hash]),
+        ),
+        [record_8, record_9, record_1, record_2, record_3, record_4, record_5, record_6],
+    ),
+]
+
+get_coin_records_parent_coin_id_filter_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(parent_coin_id_filter=HashFilter.include([])), []),
+    (
+        GetCoinRecords(parent_coin_id_filter=HashFilter.include([coin_5.name(), coin_4.parent_coin_info])),
+        [record_9, record_4],
+    ),
+    (GetCoinRecords(parent_coin_id_filter=HashFilter.include([coin_1.parent_coin_info])), [record_1, record_2]),
+    (GetCoinRecords(parent_coin_id_filter=HashFilter.include([coin_7.puzzle_hash])), []),
+    (
+        GetCoinRecords(
+            coin_type=uint8(CoinType.CLAWBACK),
+            parent_coin_id_filter=HashFilter.include([coin_5.name(), coin_4.parent_coin_info]),
+        ),
+        [record_9],
+    ),
+    (
+        GetCoinRecords(
+            coin_type=uint8(CoinType.CLAWBACK),
+            parent_coin_id_filter=HashFilter.exclude([coin_5.name(), coin_4.parent_coin_info]),
+        ),
+        [record_8],
+    ),
+]
+
+get_coin_records_amount_filter_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(amount_filter=AmountFilter.include([])), []),
+    (
+        GetCoinRecords(amount_filter=AmountFilter.include([uint64(12312)])),
+        [record_1, record_3, record_4, record_5, record_6, record_7],
+    ),
+    (GetCoinRecords(amount_filter=AmountFilter.exclude([uint64(12312)])), [record_8, record_9, record_2]),
+    (GetCoinRecords(amount_filter=AmountFilter.include([uint64(2), uint64(4)])), [record_8, record_9]),
+    (
+        GetCoinRecords(amount_filter=AmountFilter.include([uint64(12311), uint64(2), uint64(4)])),
+        [record_8, record_9, record_2],
+    ),
+    (
+        GetCoinRecords(
+            coin_type=uint8(CoinType.CLAWBACK),
+            amount_filter=AmountFilter.include([uint64(12311), uint64(2), uint64(4)]),
+        ),
+        [record_8, record_9],
+    ),
+    (
+        GetCoinRecords(
+            coin_type=uint8(CoinType.CLAWBACK),
+            amount_filter=AmountFilter.exclude([uint64(12311), uint64(2), uint64(4)]),
+        ),
+        [],
+    ),
+]
+
+get_coin_records_amount_range_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(amount_range=UInt64Range(start=uint64(1000000))), []),
+    (GetCoinRecords(amount_range=UInt64Range(stop=uint64(0))), []),
+    (
+        GetCoinRecords(amount_range=UInt64Range(start=uint64(12312))),
+        [record_1, record_3, record_4, record_5, record_6, record_7],
+    ),
+    (GetCoinRecords(amount_range=UInt64Range(stop=uint64(4))), [record_8, record_9]),
+    (GetCoinRecords(amount_range=UInt64Range(start=uint64(2), stop=uint64(12311))), [record_8, record_9, record_2]),
+    (GetCoinRecords(amount_range=UInt64Range(start=uint64(4), stop=uint64(12311))), [record_9, record_2]),
+    (GetCoinRecords(amount_range=UInt64Range(start=uint64(5), stop=uint64(12311))), [record_2]),
+]
+
+get_coin_records_confirmed_range_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(confirmed_range=UInt32Range(start=uint32(20))), []),
+    (GetCoinRecords(confirmed_range=UInt32Range(stop=uint32(0))), []),
+    (GetCoinRecords(confirmed_range=UInt32Range(start=uint32(2), stop=uint32(1))), []),
+    (
+        GetCoinRecords(confirmed_range=UInt32Range(start=uint32(5))),
+        [record_2, record_3, record_4, record_5, record_6, record_7],
+    ),
+    (GetCoinRecords(confirmed_range=UInt32Range(stop=uint32(2))), [record_8, record_9]),
+    (GetCoinRecords(confirmed_range=UInt32Range(stop=uint32(4))), [record_8, record_9, record_1]),
+    (GetCoinRecords(confirmed_range=UInt32Range(start=uint32(4), stop=uint32(4))), [record_1]),
+    (
+        GetCoinRecords(confirmed_range=UInt32Range(start=uint32(4), stop=uint32(5))),
+        [record_1, record_2, record_3, record_4, record_5, record_6, record_7],
+    ),
+]
+
+get_coin_records_spent_range_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(spent_range=UInt32Range(start=uint32(20))), []),
+    (GetCoinRecords(spent_range=UInt32Range(stop=uint32(0))), [record_8, record_1, record_2, record_5, record_7]),
+    (GetCoinRecords(spent_range=UInt32Range(start=uint32(2), stop=uint32(1))), []),
+    (GetCoinRecords(spent_range=UInt32Range(start=uint32(5), stop=uint32(10))), [record_3]),
+    (GetCoinRecords(spent_range=UInt32Range(start=uint32(2), stop=uint32(10))), [record_9, record_3]),
+    (GetCoinRecords(spent_range=UInt32Range(start=uint32(5), stop=uint32(15))), [record_3, record_4, record_6]),
+]
+
+get_coin_records_order_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (
+        GetCoinRecords(wallet_id=uint32(0), order=uint8(CoinRecordOrder.spent_height)),
+        [record_1, record_2, record_3, record_4],
+    ),
+    (GetCoinRecords(wallet_id=uint32(1), order=uint8(CoinRecordOrder.spent_height)), [record_5, record_8]),
+    (
+        GetCoinRecords(
+            confirmed_range=UInt32Range(start=uint32(4), stop=uint32(5)), order=uint8(CoinRecordOrder.spent_height)
+        ),
+        [record_1, record_2, record_5, record_7, record_3, record_4, record_6],
+    ),
+]
+
+get_coin_records_reverse_tests: List[Tuple[GetCoinRecords, List[WalletCoinRecord]]] = [
+    (
+        GetCoinRecords(wallet_id=uint32(0), order=uint8(CoinRecordOrder.spent_height), reverse=True),
+        [record_4, record_3, record_1, record_2],
+    ),
+    (
+        GetCoinRecords(wallet_id=uint32(1), order=uint8(CoinRecordOrder.spent_height), reverse=True),
+        [record_5, record_8],
+    ),
+    (
+        GetCoinRecords(confirmed_range=UInt32Range(start=uint32(1), stop=uint32(4)), reverse=True),
+        [record_1, record_8, record_9],
+    ),
+    (
+        GetCoinRecords(
+            confirmed_range=UInt32Range(start=uint32(4), stop=uint32(5)),
+            order=uint8(CoinRecordOrder.spent_height),
+            reverse=True,
+        ),
+        [record_4, record_6, record_3, record_1, record_2, record_5, record_7],
+    ),
+]
+
+get_coin_records_include_total_count_tests: List[Tuple[GetCoinRecords, int, List[WalletCoinRecord]]] = [
+    (GetCoinRecords(wallet_id=uint32(0), include_total_count=True), 4, [record_1, record_2, record_3, record_4]),
+    (
+        GetCoinRecords(wallet_id=uint32(0), offset=uint32(1), limit=uint32(2), include_total_count=True),
+        4,
+        [record_2, record_3],
+    ),
+    (GetCoinRecords(wallet_id=uint32(1), include_total_count=True), 2, [record_8, record_5]),
+    (GetCoinRecords(wallet_type=uint8(WalletType.NFT), include_total_count=True), 0, []),
+    (GetCoinRecords(wallet_type=uint8(WalletType.POOLING_WALLET), include_total_count=True), 1, [record_7]),
+]
+
+get_coin_records_mixed_tests: List[Tuple[GetCoinRecords, int, List[WalletCoinRecord]]] = [
+    (
+        GetCoinRecords(
+            offset=uint32(2),
+            limit=uint32(2),
+            coin_id_filter=HashFilter.include([coin_1.name(), coin_5.name(), coin_8.name(), coin_9.name()]),
+            puzzle_hash_filter=HashFilter.exclude([coin_2.puzzle_hash]),
+            parent_coin_id_filter=HashFilter.exclude([coin_7.parent_coin_info]),
+            include_total_count=True,
+        ),
+        4,
+        [record_1, record_5],
+    ),
+    (
+        GetCoinRecords(
+            offset=uint32(3),
+            limit=uint32(4),
+            wallet_type=uint8(WalletType.STANDARD_WALLET),
+            coin_type=uint8(CoinType.NORMAL),
+            puzzle_hash_filter=HashFilter.exclude([coin_2.puzzle_hash]),
+            parent_coin_id_filter=HashFilter.exclude([coin_7.parent_coin_info]),
+            include_total_count=True,
+        ),
+        5,
+        [record_5, record_6],
+    ),
+    (
+        GetCoinRecords(
+            offset=uint32(1),
+            limit=uint32(2),
+            wallet_id=uint32(0),
+            wallet_type=uint8(WalletType.STANDARD_WALLET),
+            coin_type=uint8(CoinType.NORMAL),
+            coin_id_filter=HashFilter.exclude([coin_1.puzzle_hash]),
+            puzzle_hash_filter=HashFilter.include(
+                [coin_1.puzzle_hash, coin_2.puzzle_hash, coin_3.puzzle_hash, coin_4.puzzle_hash]
+            ),
+            parent_coin_id_filter=HashFilter.exclude([coin_7.parent_coin_info]),
+            amount_filter=AmountFilter.exclude([uint64(10)]),
+            amount_range=UInt64Range(start=uint64(20), stop=uint64(200000)),
+            confirmed_range=UInt32Range(start=uint32(2), stop=uint32(30)),
+            spent_range=UInt32Range(start=uint32(1), stop=uint32(15)),
+            order=uint8(CoinRecordOrder.spent_height),
+            reverse=True,
+            include_total_count=True,
+        ),
+        2,
+        [record_3],
+    ),
+]
+
+
+async def run_get_coin_records_test(
+    request: GetCoinRecords, total_count: Optional[int], coin_records: List[WalletCoinRecord]
+) -> None:
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletCoinStore.create(db_wrapper)
+
+        for record in [record_1, record_2, record_3, record_4, record_5, record_6, record_7, record_8, record_9]:
+            await store.add_coin_record(record)
+
+        result = await store.get_coin_records(
+            offset=request.offset,
+            limit=request.limit,
+            wallet_id=request.wallet_id,
+            wallet_type=None if request.wallet_type is None else WalletType(request.wallet_type),
+            coin_type=None if request.coin_type is None else CoinType(request.coin_type),
+            coin_id_filter=request.coin_id_filter,
+            puzzle_hash_filter=request.puzzle_hash_filter,
+            parent_coin_id_filter=request.parent_coin_id_filter,
+            amount_filter=request.amount_filter,
+            amount_range=request.amount_range,
+            confirmed_range=request.confirmed_range,
+            spent_range=request.spent_range,
+            order=CoinRecordOrder(request.order),
+            reverse=request.reverse,
+            include_total_count=request.include_total_count,
+        )
+
+        assert result.records == coin_records
+        assert result.coin_id_to_record == {coin.name(): coin for coin in coin_records}
+        assert result.total_count == total_count
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_offset_limit_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_offset_limit(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_wallet_id_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_wallet_id(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_wallet_type_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_wallet_type(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_coin_type_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_coin_type(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_coin_id_filter_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_coin_id_filter(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_puzzle_hash_filter_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_puzzle_hash_filter(
+    coins_request: GetCoinRecords, records: List[WalletCoinRecord]
+) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_parent_coin_id_filter_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_parent_coin_id_filter(
+    coins_request: GetCoinRecords, records: List[WalletCoinRecord]
+) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_amount_filter_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_amount_filter(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_confirmed_range_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_confirmed_range(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_spent_range_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_spent_range(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_amount_range_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_amount_range(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_order_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_order(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, records", [*get_coin_records_reverse_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_reverse(coins_request: GetCoinRecords, records: List[WalletCoinRecord]) -> None:
+    await run_get_coin_records_test(coins_request, None, records)
+
+
+@pytest.mark.parametrize("coins_request, total_count, records", [*get_coin_records_include_total_count_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_total_count(
+    coins_request: GetCoinRecords, total_count: int, records: List[WalletCoinRecord]
+) -> None:
+    await run_get_coin_records_test(coins_request, total_count, records)
+
+
+@pytest.mark.parametrize("coins_request, total_count, records", [*get_coin_records_mixed_tests])
+@pytest.mark.asyncio
+async def test_get_coin_records_mixed(
+    coins_request: GetCoinRecords, total_count: int, records: List[WalletCoinRecord]
+) -> None:
+    await run_get_coin_records_test(coins_request, total_count, records)
+
+
+@pytest.mark.asyncio
+async def test_get_coin_records_total_count_cache() -> None:
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletCoinStore.create(db_wrapper)
+
+        for record in [record_1, record_2, record_3]:
+            await store.add_coin_record(record)
+
+        # Make sure the total count increases for the same query when adding more records
+        assert (await store.get_coin_records(include_total_count=True)).total_count == 3
+        await store.add_coin_record(record_4)
+        assert (await store.get_coin_records(include_total_count=True)).total_count == 4
+        # Make sure the total count increases for the same query when changing spent state
+        assert (
+            await store.get_coin_records(spent_range=UInt32Range(start=uint32(10)), include_total_count=True)
+        ).total_count == 2
+        await store.set_spent(record_1.name(), 10)
+        assert (
+            await store.get_coin_records(spent_range=UInt32Range(start=uint32(10)), include_total_count=True)
+        ).total_count == 3
+        # Make sure the total count increases for the same query when deleting a coin record
+        assert (await store.get_coin_records(include_total_count=True)).total_count == 4
+        await store.delete_coin_record(record_4.name())
+        assert (await store.get_coin_records(include_total_count=True)).total_count == 3
+        # Make sure the total count increases for the same query when rolling back
+        assert (await store.get_coin_records(include_total_count=True)).total_count == 3
+        await store.rollback_to_block(0),
+        assert (await store.get_coin_records(include_total_count=True)).total_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_coin_records_total_count_cache_reset() -> None:
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletCoinStore.create(db_wrapper)
+
+        for record in [record_1, record_2, record_3, record_8, record_9]:
+            await store.add_coin_record(record)
+
+        def assert_result(result: GetCoinRecordsResult, *, expected_total_count: int, expected_cache_size: int) -> None:
+            assert result.total_count == expected_total_count
+            assert len(store.total_count_cache.cache) == expected_cache_size
+
+        async def test_cache() -> None:
+            # Try each request a few times and make sure the cache count states the same for each time but increases
+            # with every new request.
+            for _ in range(5):
+                result = await store.get_coin_records(
+                    coin_id_filter=HashFilter.include([record_1.name()]), include_total_count=True
+                )
+                assert_result(result, expected_total_count=1, expected_cache_size=1)
+            for _ in range(5):
+                result = await store.get_coin_records(coin_type=CoinType.CLAWBACK, include_total_count=True)
+                assert_result(result, expected_total_count=2, expected_cache_size=2)
+            for _ in range(5):
+                result = await store.get_coin_records(
+                    coin_id_filter=HashFilter.include([record_2.name()]), include_total_count=True
+                )
+                assert_result(result, expected_total_count=1, expected_cache_size=3)
+            for _ in range(5):
+                result = await store.get_coin_records(
+                    coin_id_filter=HashFilter.include([record_1.name(), record_2.name()]), include_total_count=True
+                )
+                assert_result(result, expected_total_count=2, expected_cache_size=4)
+
+        # All the actions in here should reset the cache and lead to the same results again in `test_cache`.
+        for trigger in [
+            store.add_coin_record(record_4),
+            store.set_spent(coin_4.name(), 10),
+            store.delete_coin_record(record_4.name()),
+            store.rollback_to_block(1000),
+        ]:
+            await test_cache()
+            await trigger
 
 
 def record(c: Coin, *, confirmed: int, spent: int) -> WalletCoinRecord:
@@ -385,9 +859,9 @@ async def test_rollback_to_block() -> None:
         await store.add_coin_record(r4)
         await store.add_coin_record(r5)
 
-        assert set(
-            (
-                await store.get_coin_records(
+        assert (
+            await store.get_coin_records(
+                coin_id_filter=HashFilter.include(
                     [
                         coin_1.name(),
                         coin_2.name(),
@@ -396,16 +870,14 @@ async def test_rollback_to_block() -> None:
                         coin_5.name(),
                     ]
                 )
-            ).values()
-        ) == set(
-            [
-                r1,
-                r2,
-                r3,
-                r4,
-                r5,
-            ]
-        )
+            )
+        ).records == [
+            r1,
+            r2,
+            r3,
+            r4,
+            r5,
+        ]
 
         assert await store.get_coin_record(coin_5.name()) == r5
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Make it more generalised and give it more parameters to allow fetching coin records in various ways. This:

- Is used in #15100 to integrate it into an RPC command `/get_coin_records` which allows for variable queries so that we don't need to add yet another `get_coin_by_*` RPC command if we want to fetch coins by another attribute. Instead with this its possible already get better filtered results with one command.
- Will allow for a bunch of cleanups in the `WalletCoinStore` and the wallet codebase overall which i will do in a follow up PR.  

The parameter set of the method looks like below now:

```python
async def get_coin_records(
    *,
    offset: uint32 = uint32(0),
    limit: uint32 = uint32(uint32.MAXIMUM_EXCLUSIVE - 1),
    wallet_id: Optional[uint32] = None,
    wallet_type: Optional[WalletType] = None,
    coin_type: Optional[CoinType] = None,
    coin_id_filter: Optional[HashFilter] = None,
    puzzle_hash_filter: Optional[HashFilter] = None,
    parent_coin_id_filter: Optional[HashFilter] = None,
    amount_filter: Optional[AmountFilter] = None,
    amount_range: Optional[UInt64Range] = None,
    confirmed_range: Optional[UInt32Range] = None,
    spent_range: Optional[UInt32Range] = None,
    order: CoinRecordOrder = CoinRecordOrder.confirmed_height,
    reverse: bool = False,
    include_total_count: bool = False,
) -> GetCoinRecordsResult:
```

Where `HashFilter` and `AmountFilter` are there to either include or exclude a given list of hashes/amounts and `UInt32Range` and `UInt64Range` range to query entries between two values.

Actually, the method could look like:

```python
async def get_coin_records(request: GetCoinRecords) -> GetCoinRecordsResult:
```

also but this would require to wrap the arguments in `GetCoinRecords` for every call site so i decided to just duplicate the parameters.

### New Behavior:

No change in behaviour.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I added tests with test cases for every parameter, some for mixed parameter sets and tests for the introduced caching for the total amount queries. 

The tests are split up by parameter because i'ts easier to understand which one failed if one fails. Im open for suggestions to maybe group them by name in one paramaterization without extra indentation or so, if possible. The parameterizations are in separate variables because it will also be used for the tests of the related RPC command in the follow up PR. 

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
