### PR TITLE
Use "item" instead of "spend" in mempool's items functions names

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -223,7 +223,7 @@ class SpendSim:
     ) -> Tuple[List[Coin], List[Coin]]:
         # Fees get calculated
         fees = uint64(0)
-        for item in self.mempool_manager.mempool.all_spends():
+        for item in self.mempool_manager.mempool.all_items():
             fees = uint64(fees + item.fee)
 
         # Rewards get created
@@ -427,11 +427,11 @@ class SimClient:
             return CoinSpend(coin_record.coin, puzzle, solution)
 
     async def get_all_mempool_tx_ids(self) -> List[bytes32]:
-        return self.service.mempool_manager.mempool.all_spend_ids()
+        return self.service.mempool_manager.mempool.all_item_ids()
 
     async def get_all_mempool_items(self) -> Dict[bytes32, MempoolItem]:
         spends = {}
-        for item in self.service.mempool_manager.mempool.all_spends():
+        for item in self.service.mempool_manager.mempool.all_items():
             spends[item.name] = item
         return spends
 

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -140,20 +140,20 @@ class Mempool:
             val = cursor.fetchone()[0]
             return CLVMCost(uint64(0) if val is None else uint64(val))
 
-    def all_spends(self) -> Iterator[MempoolItem]:
+    def all_items(self) -> Iterator[MempoolItem]:
         with self._db_conn:
             cursor = self._db_conn.execute("SELECT * FROM tx")
             for row in cursor:
                 yield self._row_to_item(row)
 
-    def all_spend_ids(self) -> List[bytes32]:
+    def all_item_ids(self) -> List[bytes32]:
         with self._db_conn:
             cursor = self._db_conn.execute("SELECT name FROM tx")
             return [bytes32(row[0]) for row in cursor]
 
     # TODO: move "process_mempool_items()" into this class in order to do this a
     # bit more efficiently
-    def spends_by_feerate(self) -> Iterator[MempoolItem]:
+    def items_by_feerate(self) -> Iterator[MempoolItem]:
         with self._db_conn:
             cursor = self._db_conn.execute("SELECT * FROM tx ORDER BY fee_per_cost DESC, seq ASC")
             for row in cursor:
@@ -165,14 +165,14 @@ class Mempool:
             val = cursor.fetchone()
             return 0 if val is None else int(val[0])
 
-    def get_spend_by_id(self, spend_bundle_id: bytes32) -> Optional[MempoolItem]:
+    def get_item_by_id(self, item_id: bytes32) -> Optional[MempoolItem]:
         with self._db_conn:
-            cursor = self._db_conn.execute("SELECT * FROM tx WHERE name=?", (spend_bundle_id,))
+            cursor = self._db_conn.execute("SELECT * FROM tx WHERE name=?", (item_id,))
             row = cursor.fetchone()
             return None if row is None else self._row_to_item(row)
 
     # TODO: we need a bulk lookup function like this too
-    def get_spends_by_coin_id(self, spent_coin_id: bytes32) -> List[MempoolItem]:
+    def get_items_by_coin_id(self, spent_coin_id: bytes32) -> List[MempoolItem]:
         with self._db_conn:
             cursor = self._db_conn.execute(
                 "SELECT * FROM tx WHERE name in (SELECT tx FROM spends WHERE coin_id=?)",
@@ -382,7 +382,7 @@ class Mempool:
         spend_bundles: List[SpendBundle] = []
         additions: List[Coin] = []
         log.info(f"Starting to make block, max cost: {self.mempool_info.max_block_clvm_cost}")
-        for item in self.spends_by_feerate():
+        for item in self.items_by_feerate():
             if not item_inclusion_filter(item.name):
                 continue
             log.info("Cumulative cost: %d, fee per cost: %0.4f", cost_sum, item.fee_per_cost)

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -724,12 +724,12 @@ class FullNodeRpcApi:
         }
 
     async def get_all_mempool_tx_ids(self, _: Dict[str, Any]) -> EndpointResult:
-        ids = list(self.service.mempool_manager.mempool.all_spend_ids())
+        ids = list(self.service.mempool_manager.mempool.all_item_ids())
         return {"tx_ids": ids}
 
     async def get_all_mempool_items(self, _: Dict[str, Any]) -> EndpointResult:
         spends = {}
-        for item in self.service.mempool_manager.mempool.all_spends():
+        for item in self.service.mempool_manager.mempool.all_items():
             spends[item.name.hex()] = item.to_json_dict()
         return {"mempool_items": spends}
 

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2686,7 +2686,7 @@ coins = make_test_coins()
         ),
     ],
 )
-def test_spends_by_feerate(items: List[MempoolItem], expected: List[Coin]) -> None:
+def test_items_by_feerate(items: List[MempoolItem], expected: List[Coin]) -> None:
     fee_estimator = create_bitcoin_fee_estimator(uint64(11000000000))
 
     mempool_info = MempoolInfo(
@@ -2698,7 +2698,7 @@ def test_spends_by_feerate(items: List[MempoolItem], expected: List[Coin]) -> No
     for i in items:
         mempool.add_to_pool(i)
 
-    ordered_items = list(mempool.spends_by_feerate())
+    ordered_items = list(mempool.items_by_feerate())
 
     assert len(ordered_items) == len(expected)
 
@@ -2756,7 +2756,7 @@ def test_full_mempool(items: List[int], add: int, expected: List[int]) -> None:
     # now, add the item we're testing
     mempool.add_to_pool(item_cost(add, 3.1))
 
-    ordered_items = list(mempool.spends_by_feerate())
+    ordered_items = list(mempool.items_by_feerate())
 
     assert len(ordered_items) == len(expected)
 
@@ -2818,14 +2818,14 @@ def test_limit_expiring_transactions(height: bool, items: List[int], expected: L
 
     ordered_costs = [
         item.cost
-        for item in mempool.spends_by_feerate()
+        for item in mempool.items_by_feerate()
         if item.assert_before_height is not None or item.assert_before_seconds is not None
     ]
 
     assert ordered_costs == expected
 
     print("")
-    for item in mempool.spends_by_feerate():
+    for item in mempool.items_by_feerate():
         if item.assert_before_seconds is not None or item.assert_before_height is not None:
             ttl = "yes"
         else:

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -36,7 +36,7 @@ def assert_sb_not_in_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
 
 
 def evict_from_pool(node: FullNodeAPI, sb: SpendBundle) -> None:
-    mempool_item = node.full_node.mempool_manager.mempool.get_spend_by_id(sb.name())
+    mempool_item = node.full_node.mempool_manager.mempool.get_item_by_id(sb.name())
     assert mempool_item is not None
     node.full_node.mempool_manager.mempool.remove_from_pool([mempool_item.name], MempoolRemoveReason.CONFLICT)
     node.full_node.mempool_manager.remove_seen(sb.name())


### PR DESCRIPTION
With this we're consistent with mempool's internal items map (`_items`) and `_row_to_item` as well as the return types.