### PR TITLE
wallet: Fix coin state sorting

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -315,6 +315,17 @@ def last_change_height_cs(cs: CoinState) -> uint32:
     return uint32(0)
 
 
+def sort_coin_states(coin_states: List[CoinState]) -> List[CoinState]:
+    return sorted(
+        coin_states,
+        key=lambda coin_state: (
+            last_change_height_cs(coin_state),
+            0 if coin_state.created_height is None else coin_state.created_height,
+            0 if coin_state.spent_height is None else coin_state.spent_height,
+        ),
+    )
+
+
 def get_block_header(block: FullBlock) -> HeaderBlock:
     return HeaderBlock(
         block.finished_sub_slots,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -56,10 +56,10 @@ from chia.wallet.util.wallet_sync_utils import (
     PeerRequestException,
     fetch_header_blocks_in_range,
     fetch_last_tx_from_peer,
-    last_change_height_cs,
     request_and_validate_additions,
     request_and_validate_removals,
     request_header_blocks,
+    sort_coin_states,
     subscribe_to_coin_updates,
     subscribe_to_phs,
 )
@@ -832,7 +832,7 @@ class WalletNode:
         # Ensure the list is sorted
 
         before = len(items_input)
-        items = await self.wallet_state_manager.filter_spam(list(sorted(items_input, key=last_change_height_cs)))
+        items = await self.wallet_state_manager.filter_spam(sort_coin_states(items_input))
         num_filtered = before - len(items)
         if num_filtered > 0:
             self.log.info(f"Filtered {num_filtered} spam transactions")

--- a/tests/wallet/test_wallet_utils.py
+++ b/tests/wallet/test_wallet_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from random import shuffle
+from typing import List, Optional, Tuple
+
+from chia_rs import Coin, CoinState
+
+from chia.wallet.util.wallet_sync_utils import sort_coin_states
+
+
+def dummy_coin_state(*, created_height: Optional[int], spent_height: Optional[int]) -> CoinState:
+    return CoinState(Coin(bytes(b"0" * 32), bytes(b"0" * 32), 0), spent_height, created_height)
+
+
+def heights(coin_states: List[CoinState]) -> List[Tuple[Optional[int], Optional[int]]]:
+    return [(coin_state.created_height, coin_state.spent_height) for coin_state in coin_states]
+
+
+def test_sort_coin_states() -> None:
+    sorted_coin_states = [
+        dummy_coin_state(created_height=None, spent_height=None),
+        dummy_coin_state(created_height=None, spent_height=None),
+        dummy_coin_state(created_height=1, spent_height=None),
+        dummy_coin_state(created_height=9, spent_height=10),
+        dummy_coin_state(created_height=10, spent_height=None),
+        dummy_coin_state(created_height=10, spent_height=10),
+        dummy_coin_state(created_height=10, spent_height=10),
+        dummy_coin_state(created_height=10, spent_height=11),
+        dummy_coin_state(created_height=11, spent_height=None),
+        dummy_coin_state(created_height=11, spent_height=11),
+        dummy_coin_state(created_height=10, spent_height=12),
+        dummy_coin_state(created_height=11, spent_height=12),
+        dummy_coin_state(created_height=12, spent_height=None),
+        dummy_coin_state(created_height=12, spent_height=12),
+        dummy_coin_state(created_height=1, spent_height=20),
+        dummy_coin_state(created_height=19, spent_height=20),
+    ]
+    unsorted_coin_states = sorted_coin_states.copy()
+    shuffle(unsorted_coin_states)
+    assert heights(unsorted_coin_states) != heights(sorted_coin_states)
+    assert heights(sort_coin_states(unsorted_coin_states)) == heights(sorted_coin_states)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fix sorting of coin states before we process them and with this fix some cases where we require coins to be processed in the correct order. I think this will definitely help with some mysterious issues we see in production and flakiness in CI in areas where we require processing in order.

Im not really deep into the chialisp of all our primitives and im not exactly sure so far in which cases we also might get problems due to this but it obviously has at least an impact on NFT and DID handling.. maybe Datalayer too? I can definitively reproduce issues in `test_creation_from_backup_file`, `test_did_recovery_with_multiple_backup_dids` (See  #15123 which triggers the failure cases i talk about below until this PR here is merged) where the new/recovered DID coin gets processed first and the original coin later which then leads to removal of the DID wallet here https://github.com/Chia-Network/chia-blockchain/blob/4c7f7e7d23f437cd3fdc32ac19f5e20b6b8ffc9d/chia/wallet/wallet_state_manager.py#L783 because the coin is not from our wallet and not a `sent_recovery_transaction` but matches our local DID info. This issue was basically hidden because we never clear out entries related to removed wallet ids in all our tables of the DB and the test asserts asking for the balance are still passing due to this but not passing in  #15123 because there it requires the wallets still be in `WalletStateManager.wallet`, example failure run: https://github.com/Chia-Network/chia-blockchain/actions/runs/4806236394/jobs/8553531409?pr=15123.

Maybe this is all is the reason why we need a `find_lost_did` feature, i never really looked into why that is there how how one can be lost, but with the issues here explained they are certainly get lost. 

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The coins are not sorted properly which leads to issues in some cases where we depend on the coins being processed in order.

If we currently have lets say the two coins:
- `A` - created: `10`, spent: `None`
- `B` - created: `7`, spent: `10`

We process `A` before `B`, i.e. we process the unspent coin before the spent coin wich was spent at the height the other one was createded.

### New Behavior:

The coin states are sorted properly and processed _mostly_ in the correct order. See `Related Issues` below for more details on the "mostly".

We process `B` before `A`. 

The difference in sorting is that we now sort by 3 "attributes" via `sorted(key=lamda x: attribute1, attribute2, attribute3))` in the following order:
1. `last_change_height_cs`
2. `created_height`
3. `spent_height`

There might be better ways to fix the sorting but thats what i came up with, im open for suggestions :) 

From my observations this also fixes some flaky failure cases i saw in `test_did_find_lost_did` and `test_did_attest_after_recovery`.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I added a test for the new method `sort_coin_states` which shuffles a list which is in expected order, sorts the and requires the sorted list to match the original list.

### Related Issues:

I think its also an issue that we split up coin processing into tasks here https://github.com/Chia-Network/chia-blockchain/blob/4c7f7e7d23f437cd3fdc32ac19f5e20b6b8ffc9d/chia/wallet/wallet_node.py#L892 which also might lead to coin states processed out of order which will as well might lead to problems in some cases. 
