### PR TITLE
wallet: Implement `WalletPoolStore.delete_wallet`

### DIFF
--- a/chia/wallet/wallet_pool_store.py
+++ b/chia/wallet/wallet_pool_store.py
@@ -113,3 +113,8 @@ class WalletPoolStore:
                 "DELETE FROM pool_state_transitions WHERE height>? AND wallet_id=?", (height, wallet_id_arg)
             )
             await cursor.close()
+
+    async def delete_wallet(self, wallet_id: uint32) -> None:
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
+            cursor = await conn.execute("DELETE FROM pool_state_transitions WHERE wallet_id=?", (wallet_id,))
+            await cursor.close()

--- a/tests/pools/test_wallet_pool_store.py
+++ b/tests/pools/test_wallet_pool_store.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from secrets import token_bytes
-from typing import Optional
+from typing import Dict, List, Optional
 
 import pytest
 from clvm_tools import binutils
@@ -11,18 +12,19 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
-from chia.util.ints import uint64
+from chia.util.ints import uint32, uint64
 from chia.wallet.wallet_pool_store import WalletPoolStore
 from tests.util.db_connection import DBConnection
 
 
-def make_child_solution(coin_spend: CoinSpend, new_coin: Optional[Coin] = None) -> CoinSpend:
+def make_child_solution(coin_spend: Optional[CoinSpend], new_coin: Optional[Coin] = None) -> CoinSpend:
     new_puzzle_hash: bytes32 = bytes32(token_bytes(32))
     solution = "()"
     puzzle = f"(q . ((51 0x{new_puzzle_hash.hex()} 1)))"
     puzzle_prog = Program.to(binutils.assemble(puzzle))
     solution_prog = Program.to(binutils.assemble(solution))
     if new_coin is None:
+        assert coin_spend is not None
         new_coin = compute_additions(coin_spend)[0]
     sol: CoinSpend = CoinSpend(
         new_coin,
@@ -30,6 +32,27 @@ def make_child_solution(coin_spend: CoinSpend, new_coin: Optional[Coin] = None) 
         SerializedProgram.from_program(solution_prog),
     )
     return sol
+
+
+async def assert_db_spends(store: WalletPoolStore, wallet_id: int, spends: List[CoinSpend]) -> None:
+    db_spends = await store.get_spends_for_wallet(wallet_id)
+    assert len(db_spends) == len(spends)
+    for spend, (_, db_spend) in zip(spends, db_spends):
+        assert spend == db_spend
+
+
+@dataclass
+class DummySpends:
+    spends_per_wallet: Dict[int, List[CoinSpend]] = field(default_factory=dict)
+
+    def generate(self, wallet_id: int, count: int) -> None:
+        current = self.spends_per_wallet.setdefault(wallet_id, [])
+        for _ in range(count):
+            coin = None
+            last_spend = None if len(current) == 0 else current[-1]
+            if last_spend is None:
+                coin = Coin(token_bytes(32), token_bytes(32), uint64(12312))
+            current.append(make_child_solution(last_spend, coin))
 
 
 class TestWalletPoolStore:
@@ -107,3 +130,23 @@ class TestWalletPoolStore:
             await store.add_spend(1, solution_5, 105)
             await store.rollback(99, 1)
             assert await store.get_spends_for_wallet(1) == []
+
+
+@pytest.mark.asyncio
+async def test_delete_wallet() -> None:
+    dummy_spends = DummySpends()
+    for i in range(5):
+        dummy_spends.generate(i, i * 5)
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletPoolStore.create(db_wrapper)
+        # Add the spends per wallet and verify them
+        for wallet_id, spends in dummy_spends.spends_per_wallet.items():
+            for i, spend in enumerate(spends):
+                await store.add_spend(wallet_id, spend, uint32(i + wallet_id))
+            await assert_db_spends(store, wallet_id, spends)
+        # Remove one wallet after the other and verify before and after each
+        for wallet_id, spends in dummy_spends.spends_per_wallet.items():
+            # Assert the existence again here to make sure the previous removals did not affect other wallet_ids
+            await assert_db_spends(store, wallet_id, spends)
+            await store.delete_wallet(wallet_id)
+            await assert_db_spends(store, wallet_id, [])


### PR DESCRIPTION
### Purpose:

Adds `WalletPoolStore.delete_wallet` which allows to remove all DB entries for a given `wallet_id`.

### New Behavior:

No change in behaviour. Will be used in a follow up PR.

### Testing Notes:

Added tests for the new method.
