### PR TITLE
wallet: Implement `WalletStateManager.remove_wallet`

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -125,10 +125,10 @@ class CATWallet:
             )
             assert self.cat_info.limitations_program_hash != empty_bytes
         except Exception:
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.remove_wallet(self.id(), remove_cache=False, trigger_state_changed=False)
             raise
         if spend_bundle is None:
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.remove_wallet(self.id(), remove_cache=False, trigger_state_changed=False)
             raise ValueError("Failed to create spend.")
 
         await self.wallet_state_manager.add_new_wallet(self)

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -125,11 +125,11 @@ class DIDWallet:
         try:
             spend_bundle = await self.generate_new_decentralised_id(amount, fee)
         except Exception:
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.remove_wallet(self.id(), remove_cache=False, trigger_state_changed=False)
             raise
 
         if spend_bundle is None:
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.remove_wallet(self.id(), remove_cache=False, trigger_state_changed=False)
             raise ValueError("Failed to create spend.")
         await self.wallet_state_manager.add_new_wallet(self)
 

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -303,8 +303,7 @@ class NFTWallet:
                     if did_wallet_info.origin_coin.name() == self.did_id:
                         return
                 self.log.info(f"No NFT, deleting wallet {self.wallet_info.name} ...")
-                await self.wallet_state_manager.user_store.delete_wallet(self.wallet_info.id)
-                self.wallet_state_manager.wallets.pop(self.wallet_info.id)
+                await self.wallet_state_manager.remove_wallet(self.wallet_info.id)
         else:
             self.log.info("Tried removing NFT coin that doesn't exist: %s", coin.name())
 

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -498,8 +498,7 @@ class TestDIDWallet:
         coin = coins.pop()
         await wallet_node.wallet_state_manager.coin_store.delete_coin_record(coin.name())
         await time_out_assert(15, did_wallet.get_confirmed_balance, 0)
-        await wallet_node.wallet_state_manager.user_store.delete_wallet(did_wallet.wallet_info.id)
-        wallet_node.wallet_state_manager.wallets.pop(did_wallet.wallet_info.id)
+        await wallet_node.wallet_state_manager.remove_wallet(did_wallet.wallet_id)
         assert len(wallet_node.wallet_state_manager.wallets) == 1
         # Find lost DID
         resp = await api_0.did_find_lost_did({"coin_id": did_wallet.did_info.origin_coin.name().hex()})

--- a/tests/wallet/test_wallet_state_manager.py
+++ b/tests/wallet/test_wallet_state_manager.py
@@ -1,17 +1,122 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, ClassVar, Dict, List, Optional, Set, Type
 
 import pytest
+from blspy import G1Element
+from chia_rs import Coin
 
+from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.setup_nodes import SimulatorsAndWallets
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.ints import uint32
+from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_coin_record import WalletCoinRecord
+from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_state_manager import WalletStateManager
+from tests.pools.test_wallet_pool_store import DummySpends
+from tests.wallet.test_nft_store import DummyNFTs
+from tests.wallet.test_wallet_coin_store import DummyWalletCoinRecords
+
+
+@dataclass
+class DummyWallet:
+    wallet_type: ClassVar[WalletType]
+    wallet_info: WalletInfo
+    wallet_state_manager: WalletStateManager
+
+    @classmethod
+    def type(cls) -> WalletType:
+        return cls.wallet_type
+
+    def id(self) -> uint32:
+        return self.wallet_info.id
+
+    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection) -> None:
+        raise Exception("Not supported for DummyWallet")
+
+    async def select_coins(
+        self,
+        amount: uint64,
+        exclude: Optional[List[Coin]] = None,
+        min_coin_amount: Optional[uint64] = None,
+        max_coin_amount: Optional[uint64] = None,
+        excluded_coin_amounts: Optional[List[uint64]] = None,
+    ) -> Set[Coin]:
+        raise Exception("Not supported for DummyWallet")
+
+    async def get_confirmed_balance(self, record_list: Optional[Set[WalletCoinRecord]] = None) -> uint128:
+        raise Exception("Not supported for DummyWallet")
+
+    async def get_unconfirmed_balance(self, unspent_records: Optional[Set[WalletCoinRecord]] = None) -> uint128:
+        raise Exception("Not supported for DummyWallet")
+
+    async def get_spendable_balance(self, unspent_records: Optional[Set[WalletCoinRecord]] = None) -> uint128:
+        raise Exception("Not supported for DummyWallet")
+
+    async def get_pending_change_balance(self) -> uint64:
+        raise Exception("Not supported for DummyWallet")
+
+    async def get_max_send_amount(self, records: Optional[Set[WalletCoinRecord]] = None) -> uint128:
+        raise Exception("Not supported for DummyWallet")
+
+    def puzzle_hash_for_pk(self, pubkey: G1Element) -> bytes32:
+        return bytes32(bytes(pubkey)[:32])
+
+    def require_derivation_paths(self) -> bool:
+        return self.wallet_type in {WalletType.STANDARD_WALLET, WalletType.CAT, WalletType.DECENTRALIZED_ID}
+
+    def get_name(self) -> str:
+        raise Exception("Not supported for DummyWallet")
+
+
+@dataclass
+class DummyPoolWallet(DummyWallet):
+    wallet_type = WalletType.POOLING_WALLET
+
+
+@dataclass
+class DummyCATWallet(DummyWallet):
+    wallet_type = WalletType.CAT
+
+
+@dataclass
+class DummyNFTWallet(DummyWallet):
+    wallet_type = WalletType.NFT
+
+
+async def generate_dummy_wallet(
+    wallet_state_manager: WalletStateManager, wallet_id: int, wallet_class: Type[DummyWallet]
+) -> DummyWallet:
+    wallet_info = await wallet_state_manager.user_store.create_wallet(str(wallet_id), wallet_class.wallet_type, "")
+    dummy_wallet = wallet_class(wallet_info, wallet_state_manager)
+    await wallet_state_manager.add_new_wallet(dummy_wallet)
+
+    dummy_coin_records = DummyWalletCoinRecords()
+    dummy_coin_records.generate(wallet_id, 10)
+    for wallet_id, coin_records in dummy_coin_records.records_per_wallet.items():
+        for record in coin_records:
+            await wallet_state_manager.coin_store.add_coin_record(record)
+
+    if wallet_class == DummyPoolWallet:
+        dummy_spends = DummySpends()
+        dummy_spends.generate(dummy_wallet.id(), 10)
+        for wallet_id, spends in dummy_spends.spends_per_wallet.items():
+            for i, spend in enumerate(spends):
+                await wallet_state_manager.pool_store.add_spend(wallet_id, spend, uint32(i))
+    if wallet_class == DummyNFTWallet:
+        dummy_nfts = DummyNFTs()
+        dummy_nfts.generate(dummy_wallet.id(), 10)
+        for wallet_id, nfts in dummy_nfts.nfts_per_wallet.items():
+            for nft in nfts:
+                await wallet_state_manager.nft_store.save_nft(wallet_id, None, nft)
+
+    return dummy_wallet
 
 
 @asynccontextmanager
@@ -77,3 +182,82 @@ async def test_get_private_key_failure(simulator_and_wallet: SimulatorsAndWallet
     invalid_puzzle_hash = bytes32(b"1" * 32)
     with pytest.raises(ValueError, match=f"No key for puzzle hash: {invalid_puzzle_hash.hex()}"):
         await wallet_state_manager.get_private_key(bytes32(b"1" * 32))
+
+
+@pytest.mark.parametrize("remove_cache", [True, False])
+@pytest.mark.parametrize("trigger_state_changed", [True, False])
+@pytest.mark.asyncio
+async def test_remove_wallet(
+    simulator_and_wallet: SimulatorsAndWallets, remove_cache: bool, trigger_state_changed: bool
+) -> None:
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wallet_state_manager = wallet_node.wallet_state_manager
+
+    dummy_wallets = [
+        await generate_dummy_wallet(wallet_state_manager, 2, DummyCATWallet),
+        await generate_dummy_wallet(wallet_state_manager, 3, DummyPoolWallet),
+        await generate_dummy_wallet(wallet_state_manager, 4, DummyNFTWallet),
+    ]
+
+    for wallet in dummy_wallets:
+        state_changed = False
+        assert wallet.id() in wallet_state_manager.wallets
+
+        if wallet.require_derivation_paths():
+            last_derivation_record = await wallet_state_manager.puzzle_store.get_last_derivation_path_for_wallet(
+                wallet.id()
+            )
+            assert last_derivation_record == wallet_state_manager.initial_num_public_keys - 1
+
+        if type(wallet) == DummyPoolWallet:
+            assert len(await wallet_state_manager.pool_store.get_spends_for_wallet(wallet.id())) > 0
+        if type(wallet) == DummyNFTWallet:
+            assert await wallet_state_manager.nft_store.count(wallet.id()) > 0
+
+        def state_changed_callback(change: str, change_data: Optional[Dict[str, Any]]) -> None:
+            nonlocal state_changed
+            assert change == "wallet_removed"
+            assert change_data == {
+                "state": change,
+                "wallet_id": wallet.id(),
+            }
+            state_changed = True
+
+        wallet_state_manager.set_callback(state_changed_callback)
+        await wallet_state_manager.remove_wallet(
+            wallet.id(), remove_cache=remove_cache, trigger_state_changed=trigger_state_changed
+        )
+        assert state_changed == trigger_state_changed
+        assert (wallet.id() in wallet_state_manager.wallets) == (not remove_cache)
+        assert await wallet_state_manager.puzzle_store.get_last_derivation_path_for_wallet(wallet.id()) is None
+        assert await wallet_state_manager.nft_store.count(wallet.id()) == 0
+        assert await wallet_state_manager.pool_store.get_spends_for_wallet(wallet.id()) == []
+        assert (await wallet_state_manager.coin_store.get_coin_records(wallet_id=wallet.id())).records == []
+
+
+@pytest.mark.parametrize("remove_cache", [True, False])
+@pytest.mark.parametrize("trigger_state_changed", [True, False])
+@pytest.mark.asyncio
+async def test_remove_wallet_invalid_wallet_id(
+    simulator_and_wallet: SimulatorsAndWallets,
+    caplog: pytest.LogCaptureFixture,
+    remove_cache: bool,
+    trigger_state_changed: bool,
+) -> None:
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wallet_state_manager = wallet_node.wallet_state_manager
+    state_changed = False
+
+    def state_changed_callback(change: str, change_data: Optional[Dict[str, Any]]) -> None:
+        nonlocal state_changed
+        state_changed = True
+
+    wallet_state_manager.set_callback(state_changed_callback)
+
+    with caplog.at_level(logging.WARNING):
+        await wallet_state_manager.remove_wallet(
+            uint32(10), remove_cache=remove_cache, trigger_state_changed=trigger_state_changed
+        )
+
+    assert ("Tried to remove non-existing wallet_id: 10" in caplog.text) == remove_cache
+    assert state_changed == (not remove_cache and trigger_state_changed)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Implement and use `WalletStateManager.remove_wallet` wherever we remove wallets to have a general method which takes care of wallet removals. It removes the wallet from the DB, from the cache on request and also triggers a state change about the wallet removal on request.

> **Note**
It does not remove `TransactionRecords` yet since im not sure they might still be useful? Im open for thoughts or suggestions here.

### New Behavior:

In some places we trigger a state changed where we didn't before and also we clear out all DB entries related to removed wallets. 

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I added tests for the new method but not really for the places where its used, those should be covered already since i just replaced existing plain removals with `WalletStateManager.remove_wallet`.

### Based on:
- #15124
- #15125 
- #15126 
- #15127 
- #15128 