### PR TITLE
Fixed an issue where `chia wallet did transfer` command mistreats the type of `fee`

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -878,14 +878,20 @@ def did_transfer_did(
     id: int,
     target_address: str,
     reset_recovery: bool,
-    fee: int,
+    fee: str,
     reuse: bool,
 ) -> None:
     from .wallet_funcs import transfer_did
 
     asyncio.run(
         transfer_did(
-            wallet_rpc_port, fingerprint, id, fee, target_address, reset_recovery is False, True if reuse else None
+            wallet_rpc_port,
+            fingerprint,
+            id,
+            Decimal(fee),
+            target_address,
+            reset_recovery is False,
+            True if reuse else None,
         )
     )
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1000,11 +1000,13 @@ async def transfer_did(
     wallet_rpc_port: Optional[int],
     fp: Optional[int],
     did_wallet_id: int,
-    fee: int,
+    d_fee: Decimal,
     target_address: str,
     with_recovery: bool,
     reuse_puzhash: Optional[bool],
 ) -> None:
+    fee: int = int(d_fee * units["chia"])
+
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
         try:
             response = await wallet_client.did_transfer_did(

--- a/tests/cmds/wallet/test_did.py
+++ b/tests/cmds/wallet/test_did.py
@@ -320,6 +320,6 @@ def test_did_transfer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
-        "did_transfer_did": [(w_id, t_address, "0.5", True, DEFAULT_TX_CONFIG.override(reuse_puzhash=True))],
+        "did_transfer_did": [(w_id, t_address, 500000000000, True, DEFAULT_TX_CONFIG.override(reuse_puzhash=True))],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)


### PR DESCRIPTION
### Purpose:
Fixed an issue found on newly added `chia wallet did transfer` CLI command

### Current Behavior:
When you run `chia wallet did transfer --fee 0.001`, `0.001` is treated as `0.001 mojo` while it should be `0.001 xch`.

### New Behavior:
In the case above, `0.001` will be treated as `0.001 xch` (0.001 * 10^12 mojo) as everyone expects.

### Testing Notes:

