### PR TITLE
Add scripts to generate licenses during the installer builds

### DIFF
--- a/build_scripts/build_license_directory.sh
+++ b/build_scripts/build_license_directory.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# PULL IN LICENSES USING NPM - LICENSE CHECKER
+
+cd $HOME/chia-blockchain/chia-blockchain-gui
+
+license_list=$(license-checker --json | jq -r '.[].licenseFile' | grep -v null)
+
+# Split the license list by newline character into an array
+IFS=$'\n' read -rd '' -a licenses <<< "$license_list"
+
+# print the contents of the array
+#printf '%s\n' "${licenses[@]}"
+
+cd ..
+for i in "${licenses[@]}"; do
+  dirname="Licenses/$(dirname "$i" | awk -F'/' '{print $NF}')"
+  mkdir -p "$dirname"
+  cp "$i" "$dirname"
+done
+
+# PULL IN THE LICENSES FROM PIP-LICENSE
+
+# capture the output of the command in a variable
+output=$(pip-licenses -l -f json | jq -r '.[].LicenseFile' | grep -v UNKNOWN)
+
+# initialize an empty array
+license_path_array=()
+
+# read the output line by line into the array
+while IFS= read -r line; do
+    license_path_array+=("$line")
+done <<< "$output"
+
+# print the contents of the array
+printf '%s\n' "${license_path_array[@]}"
+
+cd "$HOME/chia-blockchain"
+
+# create a dir for each license and copy the license file over
+for i in "${license_path_array[@]}"; do
+  dirname="Licenses/$(dirname "$i" | awk -F'/' '{print $NF}')"
+  echo "$dirname"
+  if [ ! -d "$dirname" ]; then
+    mkdir -p "$dirname"
+  fi
+  cp "$i" "$dirname"
+done


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
We are missing licenses from the installers. This will build a tree if directories that contain licenses from pip and npm.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
No


### New Behavior:
N/A


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Testing will be to ensure that the directory exists.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
