### PR TITLE
wallet: Move assignments of `WalletStateManager._sync_target`

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -515,9 +515,9 @@ class WalletStateManager:
         if self.log.level == logging.DEBUG:
             self.log.debug(f"set_sync_mode enter {await self.blockchain.get_finished_sync_up_to()}-{target_height}")
         async with self.lock:
+            self._sync_target = target_height
             start_time = time.time()
             start_height = await self.blockchain.get_finished_sync_up_to()
-            self._sync_target = target_height
             self.log.info(f"set_sync_mode syncing - range: {start_height}-{target_height}")
             self.state_changed("sync_changed")
             try:
@@ -527,7 +527,6 @@ class WalletStateManager:
                     f"set_sync_mode failed - range: {start_height}-{target_height}, seconds: {time.time() - start_time}"
                 )
             finally:
-                self._sync_target = None
                 self.state_changed("sync_changed")
                 if self.log.level == logging.DEBUG:
                     self.log.debug(
@@ -535,6 +534,7 @@ class WalletStateManager:
                         f"get_finished_sync_up_to: {await self.blockchain.get_finished_sync_up_to()}, "
                         f"seconds: {time.time() - start_time}"
                     )
+                self._sync_target = None
 
     async def get_confirmed_spendable_balance_for_wallet(self, wallet_id: int, unspent_records=None) -> uint128:
         """


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Move the assignment of `WalletStateManager._sync_target` closer to the start/end of the sync context. Right now its set after an async `await` call inside the sync context which means there might be a "race" for code which depends on `WalletStateManager.sync_mode` and `WalletStateManager.lock` like the `get_balance` below where we could also just add another check like `and not self.wallet_state_manager.lock.locked()` but i think this PR makes more sense in general. 

https://github.com/Chia-Network/chia-blockchain/blob/322c54f6e3c5b5b0ac8ee726b96140019162669c/chia/wallet/wallet_node.py#L1609-L1611

So that `WalletStateManager.lock` might be already locked but the `sync_mode` is still `False` there. This can lead to changes in `WalletStateManager.wallets` during iteration here https://github.com/Chia-Network/chia-blockchain/blob/322c54f6e3c5b5b0ac8ee726b96140019162669c/chia/wallet/wallet_node.py#L387-L389

Should fix #15142 and also it should fix some GUI lockups (what i saw and heard reports about) when a balance check gets triggered into this scenario.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

`_sync_target` gets set after context switch inside the sync context.

### New Behavior:

`_sync_target` gets set right after entering the sync context. 
