### PR TITLE
wallet: Move `WalletPeers` init to the end of `_start_with_fingerprint`

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -377,9 +377,6 @@ class WalletNode:
             self,
         )
 
-        if self.wallet_peers is None:
-            self.initialize_wallet_peers()
-
         if self.state_changed_callback is not None:
             self.wallet_state_manager.set_callback(self.state_changed_callback)
 
@@ -403,6 +400,10 @@ class WalletNode:
             index = await self.wallet_state_manager.puzzle_store.get_last_derivation_path()
             if index is None or index < self.wallet_state_manager.initial_num_public_keys - 1:
                 await self.wallet_state_manager.create_more_puzzle_hashes(from_zero=True)
+
+        if self.wallet_peers is None:
+            self.initialize_wallet_peers()
+
         return True
 
     def _close(self) -> None:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Moves the init of `WalletPeers` to the end of the `WalletNode`'s start method to make sure we only connect to peers after we initialised and set up everything properly. This should like #15149 and #15148 also fix #15142 because we should not come into the situation where we modify `WalletStateManager.wallets` without connecting to peers, but yeah, i think it makes sense take them all into the release :)

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The wallet starts to connect to peers before everything is setup properly in `WalletNode`.

### New Behavior:

The wallet starts to connect to peers when everything is setup and initialised.
