### PR TITLE
wallet: Revert "Add new coin_type & metadata to coin_records (#15013)"

### DIFF
--- a/chia/wallet/util/wallet_types.py
+++ b/chia/wallet/util/wallet_types.py
@@ -29,11 +29,6 @@ class WalletType(IntEnum):
     DATA_LAYER_OFFER = 12
 
 
-class CoinType(IntEnum):
-    NORMAL = 0
-    CLAWBACK = 1
-
-
 class AmountWithPuzzlehash(TypedDict):
     amount: uint64
     puzzlehash: bytes32

--- a/chia/wallet/wallet_coin_record.py
+++ b/chia/wallet/wallet_coin_record.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import dataclass
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.util.ints import uint32, uint64
-from chia.util.misc import VersionedBlob
-from chia.wallet.util.wallet_types import CoinType, WalletType
+from chia.wallet.util.wallet_types import WalletType
 
 
 @dataclass(frozen=True)
@@ -25,11 +23,6 @@ class WalletCoinRecord:
     coinbase: bool
     wallet_type: WalletType
     wallet_id: int
-    # Cannot include new attributes in the hash since they will change the coin order in a set.
-    # The launcher coin ID will change and will break all hardcode offer tests in CAT/NFT/DL, etc.
-    # TODO Change hardcode offer in unit tests
-    coin_type: CoinType = field(default=CoinType.NORMAL, hash=False)
-    metadata: Optional[VersionedBlob] = field(default=None, hash=False)
 
     def name(self) -> bytes32:
         return self.coin.name()

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -7,8 +7,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.util.ints import uint32, uint64
-from chia.util.misc import VersionedBlob
-from chia.wallet.util.wallet_types import CoinType, WalletType
+from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 
 
@@ -55,21 +54,13 @@ class WalletCoinStore:
 
             await conn.execute("CREATE INDEX IF NOT EXISTS coin_amount on coin_record(amount)")
 
-            try:
-                await conn.execute("ALTER TABLE coin_record ADD COLUMN coin_type int DEFAULT 0")
-                await conn.execute("ALTER TABLE coin_record ADD COLUMN metadata blob")
-                await conn.execute("CREATE INDEX IF NOT EXISTS coin_record_coin_type on coin_record(coin_type)")
-            except sqlite3.OperationalError:
-                pass
         return self
 
-    async def count_small_unspent(self, cutoff: int, coin_type: CoinType = CoinType.NORMAL) -> int:
+    async def count_small_unspent(self, cutoff: int) -> int:
         amount_bytes = bytes(uint64(cutoff))
         async with self.db_wrapper.reader_no_transaction() as conn:
             row = await execute_fetchone(
-                conn,
-                "SELECT COUNT(*) FROM coin_record WHERE coin_type=? AND amount < ? AND spent=0",
-                (coin_type, amount_bytes),
+                conn, "SELECT COUNT(*) FROM coin_record WHERE amount < ? AND spent=0", (amount_bytes,)
             )
             return int(0 if row is None else row[0])
 
@@ -80,7 +71,7 @@ class WalletCoinStore:
         assert record.spent == (record.spent_block_height != 0)
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute_insert(
-                "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     name.hex(),
                     record.confirmed_block_height,
@@ -92,8 +83,6 @@ class WalletCoinStore:
                     bytes(uint64(record.coin.amount)),
                     record.wallet_type,
                     record.wallet_id,
-                    record.coin_type,
-                    None if record.metadata is None else bytes(record.metadata),
                 ),
             )
 
@@ -117,15 +106,7 @@ class WalletCoinStore:
     def coin_record_from_row(self, row: sqlite3.Row) -> WalletCoinRecord:
         coin = Coin(bytes32.fromhex(row[6]), bytes32.fromhex(row[5]), uint64.from_bytes(row[7]))
         return WalletCoinRecord(
-            coin,
-            uint32(row[1]),
-            uint32(row[2]),
-            bool(row[3]),
-            bool(row[4]),
-            WalletType(row[8]),
-            row[9],
-            CoinType(row[10]),
-            None if row[11] is None else VersionedBlob.from_bytes(row[11]),
+            coin, uint32(row[1]), uint32(row[2]), bool(row[3]), bool(row[4]), WalletType(row[8]), row[9]
         )
 
     async def get_coin_record(self, coin_name: bytes32) -> Optional[WalletCoinRecord]:
@@ -163,23 +144,6 @@ class WalletCoinStore:
 
         return ret
 
-    async def get_coin_records_between(
-        self, wallet_id: int, start: int, end: int, reverse: bool = False, coin_type: CoinType = CoinType.NORMAL
-    ) -> List[WalletCoinRecord]:
-        """Return a list of coins between start and end index. List is in reverse chronological order.
-        start = 0 is most recent transaction
-        """
-        limit = end - start
-        query_str = "ORDER BY confirmed_height " + ("DESC" if reverse else "ASC")
-
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                f"SELECT * FROM coin_record WHERE coin_type=? AND"
-                f" wallet_id=? {query_str}, rowid LIMIT {start}, {limit}",
-                (coin_type, wallet_id),
-            )
-        return [self.coin_record_from_row(row) for row in rows]
-
     async def get_first_coin_height(self) -> Optional[uint32]:
         """Returns height of first confirmed coin"""
         async with self.db_wrapper.reader_no_transaction() as conn:
@@ -190,23 +154,18 @@ class WalletCoinStore:
 
         return None
 
-    async def get_unspent_coins_for_wallet(
-        self, wallet_id: int, coin_type: CoinType = CoinType.NORMAL
-    ) -> Set[WalletCoinRecord]:
+    async def get_unspent_coins_for_wallet(self, wallet_id: int) -> Set[WalletCoinRecord]:
         """Returns set of CoinRecords that have not been spent yet for a wallet."""
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
-                "SELECT * FROM coin_record WHERE coin_type=? AND wallet_id=? AND spent_height=0",
-                (coin_type, wallet_id),
+                "SELECT * FROM coin_record WHERE wallet_id=? AND spent_height=0", (wallet_id,)
             )
         return set(self.coin_record_from_row(row) for row in rows)
 
-    async def get_all_unspent_coins(self, coin_type: CoinType = CoinType.NORMAL) -> Set[WalletCoinRecord]:
+    async def get_all_unspent_coins(self) -> Set[WalletCoinRecord]:
         """Returns set of CoinRecords that have not been spent yet for a wallet."""
         async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                "SELECT * FROM coin_record WHERE coin_type=? AND spent_height=0", (coin_type,)
-            )
+            rows = await conn.execute_fetchall("SELECT * FROM coin_record WHERE spent_height=0")
         return set(self.coin_record_from_row(row) for row in rows)
 
     # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1463,7 +1463,6 @@ class WalletStateManager:
             if tx_record.amount > 0:
                 await self.tx_store.add_transaction_record(tx_record)
 
-        # We only add normal coins here
         coin_record: WalletCoinRecord = WalletCoinRecord(
             coin, height, uint32(0), False, coinbase, wallet_type, wallet_id
         )

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -5,9 +5,8 @@ from secrets import token_bytes
 import pytest
 
 from chia.types.blockchain_format.coin import Coin
-from chia.util.ints import uint16, uint32, uint64
-from chia.util.misc import VersionedBlob
-from chia.wallet.util.wallet_types import CoinType, WalletType
+from chia.util.ints import uint32, uint64
+from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_coin_store import WalletCoinStore
 from tests.util.db_connection import DBConnection
@@ -19,7 +18,6 @@ coin_4 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
 coin_5 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
 coin_6 = Coin(token_bytes(32), coin_4.puzzle_hash, uint64(12312))
 coin_7 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
-coin_8 = Coin(token_bytes(32), token_bytes(32), uint64(2))
 record_replaced = WalletCoinRecord(coin_1, uint32(8), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
 record_1 = WalletCoinRecord(coin_1, uint32(4), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
 record_2 = WalletCoinRecord(coin_2, uint32(5), uint32(0), False, True, WalletType.STANDARD_WALLET, 0)
@@ -68,17 +66,6 @@ record_7 = WalletCoinRecord(
     WalletType.POOLING_WALLET,
     2,
 )
-record_8 = WalletCoinRecord(
-    coin_8,
-    uint32(1),
-    uint32(0),
-    False,
-    False,
-    WalletType.STANDARD_WALLET,
-    1,
-    CoinType.CLAWBACK,
-    VersionedBlob(uint16(1), b"TEST"),
-)
 
 
 @pytest.mark.asyncio
@@ -116,7 +103,6 @@ async def test_bulk_get() -> None:
         await store.add_coin_record(record_2)
         await store.add_coin_record(record_3)
         await store.add_coin_record(record_4)
-        await store.add_coin_record(record_8)
 
         store = await WalletCoinStore.create(db_wrapper)
         records = await store.get_coin_records([coin_1.name(), coin_2.name(), token_bytes(32), coin_4.name()])
@@ -165,7 +151,6 @@ async def test_get_unspent_coins_for_wallet() -> None:
         await store.add_coin_record(record_5)  # wallet 1
         await store.add_coin_record(record_6)  # this is spent and wallet 2
         await store.add_coin_record(record_7)  # wallet 2
-        await store.add_coin_record(record_8)
 
         assert await store.get_unspent_coins_for_wallet(1) == set([record_5])
         assert await store.get_unspent_coins_for_wallet(2) == set([record_7])
@@ -189,8 +174,6 @@ async def test_get_unspent_coins_for_wallet() -> None:
         assert await store.get_unspent_coins_for_wallet(2) == set()
         assert await store.get_unspent_coins_for_wallet(3) == set()
 
-        assert await store.get_unspent_coins_for_wallet(1, coin_type=CoinType.CLAWBACK) == set([record_8])
-
 
 @pytest.mark.asyncio
 async def test_get_all_unspent_coins() -> None:
@@ -202,7 +185,6 @@ async def test_get_all_unspent_coins() -> None:
         await store.add_coin_record(record_1)  # not spent
         await store.add_coin_record(record_2)  # not spent
         await store.add_coin_record(record_3)  # spent
-        await store.add_coin_record(record_8)  # spent
         assert await store.get_all_unspent_coins() == set([record_1, record_2])
 
         await store.add_coin_record(record_4)  # spent
@@ -225,8 +207,6 @@ async def test_get_all_unspent_coins() -> None:
         await store.set_spent(coin_2.name(), uint32(12))
         await store.set_spent(coin_1.name(), uint32(12))
         assert await store.get_all_unspent_coins() == set()
-
-        assert await store.get_all_unspent_coins(coin_type=CoinType.CLAWBACK) == set([record_8])
 
 
 @pytest.mark.asyncio
@@ -398,43 +378,17 @@ async def test_count_small_unspent() -> None:
         await store.add_coin_record(r1)
         await store.add_coin_record(r2)
         await store.add_coin_record(r3)
-        await store.add_coin_record(record_8)
 
         assert await store.count_small_unspent(5) == 3
         assert await store.count_small_unspent(4) == 2
         assert await store.count_small_unspent(3) == 2
         assert await store.count_small_unspent(2) == 1
         assert await store.count_small_unspent(1) == 0
-        assert await store.count_small_unspent(3, coin_type=CoinType.CLAWBACK) == 1
 
         await store.set_spent(coin_2.name(), uint32(12))
-        await store.set_spent(coin_8.name(), uint32(12))
 
         assert await store.count_small_unspent(5) == 2
         assert await store.count_small_unspent(4) == 1
         assert await store.count_small_unspent(3) == 1
         assert await store.count_small_unspent(2) == 1
-        assert await store.count_small_unspent(3, coin_type=CoinType.CLAWBACK) == 0
         assert await store.count_small_unspent(1) == 0
-
-
-@pytest.mark.asyncio
-async def test_get_coin_records_between() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        assert await store.get_all_unspent_coins() == set()
-
-        await store.add_coin_record(record_1)  # not spent
-        await store.add_coin_record(record_2)  # not spent
-        await store.add_coin_record(record_5)  # spent
-        await store.add_coin_record(record_8)  # spent
-
-        records = await store.get_coin_records_between(1, 0, 0)
-        assert len(records) == 0
-        records = await store.get_coin_records_between(1, 0, 3)
-        assert len(records) == 1
-        assert records[0] == record_5
-        records = await store.get_coin_records_between(1, 0, 4, coin_type=CoinType.CLAWBACK)
-        assert len(records) == 1
-        assert records[0] == record_8


### PR DESCRIPTION
### Purpose:

This reverts #15013 because clawback was postponed and we don't need this two extra columns for this release. 

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The wallet adds two new columns to the DB on first start of 1.8.0.  

### New Behavior:

The wallet does not add the two new columns to the DB anymore. 
