### PR TITLE
wallet: List the columns for `INSERT` into `coin_record`

### DIFF
--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -71,7 +71,9 @@ class WalletCoinStore:
         assert record.spent == (record.spent_block_height != 0)
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute_insert(
-                "INSERT OR REPLACE INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR REPLACE INTO coin_record ("
+                "coin_name, confirmed_height, spent_height, spent, coinbase, puzzle_hash, coin_parent, amount, "
+                "wallet_type, wallet_id) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     name.hex(),
                     record.confirmed_block_height,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

List the column names for the `INSERT INTO coin_records` statement to make downgrading (at least to 1.8.0) possible if we decide to stick to #15013 for the next release. 

### Current Behavior:

The `INSERT` statement will fail if there are new columns with default values added if they are not provided to the query.

### New Behavior:

The `INSERT` statement can still run successfully if the new default value columns are not part of the query.


### Based on:

- #15154 
