### PR TITLE
full_node: Drop `peers_with_peak` removals

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1078,12 +1078,10 @@ class FullNode:
                     fetched = False
                     for peer in random.sample(new_peers_with_peak, len(new_peers_with_peak)):
                         if peer.closed:
-                            peers_with_peak.remove(peer)
                             continue
                         response = await peer.call_api(FullNodeAPI.request_blocks, request, timeout=30)
                         if response is None:
                             await peer.close()
-                            peers_with_peak.remove(peer)
                         elif isinstance(response, RespondBlocks):
                             await batch_queue.put((peer, response.blocks))
                             fetched = True
@@ -1116,8 +1114,6 @@ class FullNode:
                     blocks, peer, None if advanced_peak else uint32(fork_point_height), summaries
                 )
                 if success is False:
-                    if peer in peers_with_peak:
-                        peers_with_peak.remove(peer)
                     await peer.close(600)
                     raise ValueError(f"Failed to validate block batch {start_height} to {end_height}")
                 self.log.info(f"Added blocks {start_height} to {end_height}")


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Drop the removals from `peers_with_peak` since it doesn't make sense. We initially copy it into `new_peers_with_peak` which:

- Is the list we exclusively work with later
- Gets anyway replaced every time `SyncStore.peers_changed` gets triggered, which happens on a disconnect.

Alternative to #14803.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

There are cases where we try to remove peers which not longer exist in the original `peers_with_peak` list because we not work of this list anymore after the initial copying. 

### New Behavior:

The invalid removals are gone but the general behaviour is the same.
