### PR TITLE
wallet: Explicit hinting for transaction generation

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1454,7 +1454,7 @@ class WalletRpcApi:
                     fee,
                     cat_discrepancy=cat_discrepancy,
                     coins=coins,
-                    memos=memos if memos else None,
+                    memos=memos if memos else [[puzzle_hash] for puzzle_hash in puzzle_hashes],
                     min_coin_amount=min_coin_amount,
                     max_coin_amount=max_coin_amount,
                     exclude_coin_amounts=exclude_coin_amounts,
@@ -1469,7 +1469,7 @@ class WalletRpcApi:
                 puzzle_hashes,
                 fee,
                 coins=coins,
-                memos=memos if memos else None,
+                memos=memos if memos else [[puzzle_hash] for puzzle_hash in puzzle_hashes],
                 min_coin_amount=min_coin_amount,
                 max_coin_amount=max_coin_amount,
                 exclude_coin_amounts=exclude_coin_amounts,
@@ -2586,6 +2586,7 @@ class WalletRpcApi:
                 [uint64(nft_coin_info.coin.amount)],
                 [puzzle_hash],
                 coins={nft_coin_info.coin},
+                memos=[[puzzle_hash]],
                 fee=fee,
                 new_owner=b"",
                 new_did_inner_hash=b"",
@@ -2870,7 +2871,11 @@ class WalletRpcApi:
         if len(puzzle_hash_0) != 32:
             raise ValueError(f"Address must be 32 bytes. {puzzle_hash_0.hex()}")
 
-        memos_0 = [] if "memos" not in additions[0] else [mem.encode("utf-8") for mem in additions[0]["memos"]]
+        memos_0 = (
+            [bytes(puzzle_hash_0)]
+            if "memos" not in additions[0]
+            else [mem.encode("utf-8") for mem in additions[0]["memos"]]
+        )
 
         additional_outputs: List[Payment] = []
         for addition in additions[1:]:
@@ -2880,7 +2885,9 @@ class WalletRpcApi:
             amount = uint64(addition["amount"])
             if amount > self.service.constants.MAX_COIN_AMOUNT:
                 raise ValueError(f"Coin amount cannot exceed {self.service.constants.MAX_COIN_AMOUNT}")
-            memos = [] if "memos" not in addition else [mem.encode("utf-8") for mem in addition["memos"]]
+            memos = (
+                [bytes(receiver_ph)] if "memos" not in addition else [mem.encode("utf-8") for mem in addition["memos"]]
+            )
             additional_outputs.append(Payment(receiver_ph, amount, memos))
 
         fee: uint64 = uint64(request.get("fee", 0))

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -289,7 +289,11 @@ class CATWallet:
         if self.cost_of_single_tx is None:
             coin = spendable[0].coin
             txs = await self.generate_signed_transaction(
-                [uint64(coin.amount)], [coin.puzzle_hash], coins={coin}, ignore_max_send_amount=True
+                [uint64(coin.amount)],
+                [coin.puzzle_hash],
+                coins={coin},
+                memos=[[coin.puzzle_hash]],
+                ignore_max_send_amount=True,
             )
             assert txs[0].spend_bundle
             program: BlockGenerator = simple_solution_generator(txs[0].spend_bundle)
@@ -819,9 +823,7 @@ class CATWallet:
 
         payments = []
         for amount, puzhash, memo_list in zip(amounts, puzzle_hashes, memos):
-            memos_with_hint: List[bytes] = [puzhash]
-            memos_with_hint.extend(memo_list)
-            payments.append(Payment(puzhash, amount, memos_with_hint))
+            payments.append(Payment(puzhash, amount, memo_list))
 
         payment_sum = sum([p.amount for p in payments])
         if not ignore_max_send_amount:

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -513,6 +513,7 @@ class NFTWallet:
             [puzzle_hash],
             fee,
             {nft_coin_info.coin},
+            memos=[[puzzle_hash]],
             metadata_update=(key, uri),
             reuse_puzhash=reuse_puzhash,
         )
@@ -641,9 +642,7 @@ class NFTWallet:
 
         payments = []
         for amount, puzhash, memo_list in zip(amounts, puzzle_hashes, memos):
-            memos_with_hint: List[bytes] = [puzhash]
-            memos_with_hint.extend(memo_list)
-            payments.append(Payment(puzhash, amount, memos_with_hint))
+            payments.append(Payment(puzhash, amount, memo_list))
 
         payment_sum = sum([p.amount for p in payments])
         unsigned_spend_bundle, chia_tx = await self.generate_unsigned_spendbundle(
@@ -965,6 +964,7 @@ class NFTWallet:
                         [DESIRED_OFFER_MOD_HASH],
                         fee=fee_left_to_pay,
                         coins=offered_coins_by_asset[asset],
+                        memos=[[DESIRED_OFFER_MOD_HASH]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                         trade_prices_list=[
                             list(price)
@@ -979,6 +979,7 @@ class NFTWallet:
                         [DESIRED_OFFER_MOD_HASH, DESIRED_OFFER_MOD_HASH],
                         fee=fee_left_to_pay,
                         coins=offered_coins_by_asset[asset],
+                        memos=[[DESIRED_OFFER_MOD_HASH], [DESIRED_OFFER_MOD_HASH]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                     )
                 all_transactions.extend(txs)
@@ -1118,15 +1119,16 @@ class NFTWallet:
         for nft_coin_info in nft_list:
             unft = UncurriedNFT.uncurry(*nft_coin_info.full_puzzle.uncurry())
             assert unft is not None
-            puzzle_hashes_to_sign = [unft.p2_puzzle.get_tree_hash()]
+            puzzle_hash = unft.p2_puzzle.get_tree_hash()
             if not first:
                 fee = uint64(0)
             nft_tx_record.extend(
                 await self.generate_signed_transaction(
                     [uint64(nft_coin_info.coin.amount)],
-                    puzzle_hashes_to_sign,
+                    [puzzle_hash],
                     fee,
                     {nft_coin_info.coin},
+                    memos=[[puzzle_hash]],
                     new_owner=did_id,
                     new_did_inner_hash=did_inner_hash,
                     reuse_puzhash=reuse_puzhash,
@@ -1166,6 +1168,7 @@ class NFTWallet:
                     [uint64(nft_coin_info.coin.amount)],
                     [puzzle_hash],
                     coins={nft_coin_info.coin},
+                    memos=[[puzzle_hash]],
                     fee=fee,
                     new_owner=b"",
                     new_did_inner_hash=b"",
@@ -1196,7 +1199,7 @@ class NFTWallet:
         unft = UncurriedNFT.uncurry(*nft_coin_info.full_puzzle.uncurry())
         assert unft is not None
         nft_id = unft.singleton_launcher_id
-        puzzle_hashes_to_sign = [unft.p2_puzzle.get_tree_hash()]
+        puzzle_hash = unft.p2_puzzle.get_tree_hash()
         did_inner_hash = b""
         additional_bundles = []
         if did_id != b"":
@@ -1205,9 +1208,10 @@ class NFTWallet:
 
         nft_tx_record = await self.generate_signed_transaction(
             [uint64(nft_coin_info.coin.amount)],
-            puzzle_hashes_to_sign,
+            [puzzle_hash],
             fee,
             {nft_coin_info.coin},
+            memos=[[puzzle_hash]],
             new_owner=did_id,
             new_did_inner_hash=did_inner_hash,
             additional_bundles=additional_bundles,

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -255,7 +255,7 @@ class TradeManager:
             else:
                 # ATTENTION: new_wallets
                 txs = await wallet.generate_signed_transaction(
-                    [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
+                    [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, memos=[[new_ph]], ignore_max_send_amount=True
                 )
                 all_txs.extend(txs)
             fee_to_pay = uint64(0)
@@ -336,7 +336,12 @@ class TradeManager:
                 else:
                     # ATTENTION: new_wallets
                     txs = await wallet.generate_signed_transaction(
-                        [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
+                        [coin.amount],
+                        [new_ph],
+                        fee=fee_to_pay,
+                        coins={coin},
+                        memos=[[new_ph]],
+                        ignore_max_send_amount=True,
                     )
                     for tx in txs:
                         if tx is not None and tx.spend_bundle is not None:
@@ -560,10 +565,11 @@ class TradeManager:
                 else:
                     wallet = await self.wallet_state_manager.get_wallet_for_asset_id(id.hex())
                 # This should probably not switch on whether or not we're spending XCH but it has to for now
+                puzzle_hash = OFFER_MOD_OLD_HASH if old else Offer.ph()
                 if wallet.type() == WalletType.STANDARD_WALLET:
                     tx = await wallet.generate_signed_transaction(
                         abs(offer_dict[id]),
-                        OFFER_MOD_OLD_HASH if old else Offer.ph(),
+                        puzzle_hash,
                         fee=fee_left_to_pay,
                         coins=set(selected_coins),
                         puzzle_announcements_to_consume=announcements_to_assert,
@@ -577,9 +583,10 @@ class TradeManager:
                     txs = await wallet.generate_signed_transaction(
                         # [abs(offer_dict[id])],
                         amounts,
-                        [OFFER_MOD_OLD_HASH if old else Offer.ph()],
+                        [puzzle_hash],
                         fee=fee_left_to_pay,
                         coins=set(selected_coins),
+                        memos=[[puzzle_hash]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                         reuse_puzhash=reuse_puzhash,
                     )
@@ -588,9 +595,10 @@ class TradeManager:
                     # ATTENTION: new_wallets
                     txs = await wallet.generate_signed_transaction(
                         [abs(offer_dict[id])],
-                        [OFFER_MOD_OLD_HASH if old else Offer.ph()],
+                        [puzzle_hash],
                         fee=fee_left_to_pay,
                         coins=set(selected_coins),
+                        memos=[[puzzle_hash]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                         reuse_puzhash=reuse_puzhash,
                     )

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -936,13 +936,15 @@ async def test_nft_offer_request_nft_for_cat(
         cat_1 = await wallet_taker.get_new_puzzlehash()
         cat_2 = await wallet_taker.get_new_puzzlehash()
     puzzle_hashes = [cat_1, cat_2]
+    memos = [[cat_1], [cat_2]]
     amounts = [cats_to_trade, cats_to_trade]
     if test_change:
         ph_taker_cat_1 = await wallet_taker.get_new_puzzlehash()
         extra_change = cats_to_mint - (2 * cats_to_trade)
         amounts.append(uint64(extra_change))
         puzzle_hashes.append(ph_taker_cat_1)
-    cat_tx_records = await cat_wallet_maker.generate_signed_transaction(amounts, puzzle_hashes)
+        memos.append([ph_taker_cat_1])
+    cat_tx_records = await cat_wallet_maker.generate_signed_transaction(amounts, puzzle_hashes, memos=memos)
     for tx_record in cat_tx_records:
         await wallet_maker.wallet_state_manager.add_pending_transaction(tx_record)
     await full_node_api.process_transaction_records(records=cat_tx_records)

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -143,7 +143,12 @@ async def test_nft_wallet_creation_automatically(self_hostname: str, two_wallet_
     coins = await nft_wallet_0.get_current_nfts()
     assert len(coins) == 1, "nft not generated"
 
-    txs = await nft_wallet_0.generate_signed_transaction([uint64(coins[0].coin.amount)], [ph1], coins={coins[0].coin})
+    txs = await nft_wallet_0.generate_signed_transaction(
+        [uint64(coins[0].coin.amount)],
+        [ph1],
+        coins={coins[0].coin},
+        memos=[[ph1]],
+    )
     assert len(txs) == 1
     assert txs[0].spend_bundle is not None
     await wallet_node_0.wallet_state_manager.add_pending_transaction(txs[0])
@@ -278,7 +283,12 @@ async def test_nft_wallet_creation_and_transfer(self_hostname: str, two_wallet_n
     nft_wallet_1 = await NFTWallet.create_new_nft_wallet(
         wallet_node_1.wallet_state_manager, wallet_1, name="NFT WALLET 2"
     )
-    txs = await nft_wallet_0.generate_signed_transaction([uint64(coins[1].coin.amount)], [ph1], coins={coins[1].coin})
+    txs = await nft_wallet_0.generate_signed_transaction(
+        [uint64(coins[1].coin.amount)],
+        [ph1],
+        coins={coins[1].coin},
+        memos=[[ph1]],
+    )
     assert len(txs) == 1
     assert txs[0].spend_bundle is not None
     await wallet_node_0.wallet_state_manager.add_pending_transaction(txs[0])
@@ -298,7 +308,12 @@ async def test_nft_wallet_creation_and_transfer(self_hostname: str, two_wallet_n
     await time_out_assert(30, wallet_1.get_pending_change_balance, 0)
 
     # Send it back to original owner
-    txs = await nft_wallet_1.generate_signed_transaction([uint64(coins[0].coin.amount)], [ph], coins={coins[0].coin})
+    txs = await nft_wallet_1.generate_signed_transaction(
+        [uint64(coins[0].coin.amount)],
+        [ph],
+        coins={coins[0].coin},
+        memos=[[ph]],
+    )
     assert len(txs) == 1
     assert txs[0].spend_bundle is not None
     await wallet_node_1.wallet_state_manager.add_pending_transaction(txs[0])

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -1137,6 +1137,7 @@ class TestWalletSync:
             [uint64(nft_coins[0].coin.amount)],
             [dust_ph],
             coins={nft_coins[0].coin},
+            memos=[[dust_ph]],
         )
         assert len(txs) == 1
         assert txs[0].spend_bundle is not None


### PR DESCRIPTION
### Purpose:

This removes the implicit hinting from `NFTWallet.generate_signed_transaction` and `CATWallet.generate_signed_transaction`, just to be explicit about the hinting.. There are at least the three cases below where we currently double hint NFT transactions, unless i miss the point of it. Maybe there are other places, might be also related to CATs. Alternative to this PR is to drop the redundant hints but i feel like this PR also helps to avoid double hinting in the future.

https://github.com/Chia-Network/chia-blockchain/blob/dcebabab303507a238ba575c8a8e7de727a89995/chia/wallet/nft_wallet/nft_wallet.py#L446

https://github.com/Chia-Network/chia-blockchain/blob/dcebabab303507a238ba575c8a8e7de727a89995/chia/wallet/nft_wallet/nft_wallet.py#L1415

https://github.com/Chia-Network/chia-blockchain/blob/dcebabab303507a238ba575c8a8e7de727a89995/chia/wallet/nft_wallet/nft_wallet.py#L1652

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The `generate_signed_transaction` methods implicitly hint each payment with its puzzle hash.

### New Behavior:

The `generate_signed_transaction` doesn't implicitly add hints, instead all call sites add them explicitly. 

