### PR TITLE
wallet: Cleanup `Wallet.generate_signed_transaction` output parameter

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -324,12 +324,10 @@ class DataLayerWallet:
         announcement_message: bytes32 = genesis_launcher_solution.get_tree_hash()
         announcement = Announcement(launcher_coin.name(), announcement_message)
         create_launcher_tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
-            amount=uint64(1),
-            puzzle_hash=SINGLETON_LAUNCHER.get_tree_hash(),
+            [Payment(SINGLETON_LAUNCHER.get_tree_hash(), uint64(1))],
             fee=fee,
             origin_id=launcher_parent.name(),
             coins=coins,
-            primaries=None,
             ignore_max_send_amount=False,
             coin_announcements_to_consume={announcement},
         )
@@ -391,8 +389,7 @@ class DataLayerWallet:
         coin_announcement: bool = True,
     ) -> TransactionRecord:
         chia_tx = await self.standard_wallet.generate_signed_transaction(
-            amount=uint64(0),
-            puzzle_hash=await self.standard_wallet.get_new_puzzlehash(),
+            [],
             fee=fee,
             negative_change_allowed=False,
             coin_announcements_to_consume={announcement_to_assert} if coin_announcement else None,
@@ -734,11 +731,8 @@ class DataLayerWallet:
         self, launcher_id: bytes32, amount: uint64, urls: List[bytes], fee: uint64 = uint64(0)
     ) -> List[TransactionRecord]:
         create_mirror_tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
-            amount=amount,
-            puzzle_hash=create_mirror_puzzle().get_tree_hash(),
+            [Payment(create_mirror_puzzle().get_tree_hash(), amount, [launcher_id, *(url for url in urls)])],
             fee=fee,
-            primaries=[],
-            memos=[launcher_id, *(url for url in urls)],
             ignore_max_send_amount=False,
         )
         assert create_mirror_tx_record is not None and create_mirror_tx_record.spend_bundle is not None
@@ -805,8 +799,7 @@ class DataLayerWallet:
 
         if excess_fee > 0:
             chia_tx: TransactionRecord = await self.wallet_state_manager.main_wallet.generate_signed_transaction(
-                uint64(1),
-                new_puzhash,
+                [Payment(new_puzhash, uint64(1))],
                 fee=uint64(excess_fee),
                 coin_announcements_to_consume={Announcement(mirror_coin.name(), b"$")},
             )

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -47,6 +47,7 @@ from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.derive_keys import find_owner_sk
+from chia.wallet.payment import Payment
 from chia.wallet.sign_coin_spends import sign_coin_spends
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
@@ -500,12 +501,10 @@ class PoolWallet:
         coin_announcements: Optional[Set[Announcement]] = None,
     ) -> TransactionRecord:
         fee_tx = await self.standard_wallet.generate_signed_transaction(
-            uint64(0),
-            (await self.standard_wallet.get_new_puzzlehash()),
+            [],
             fee=fee,
             origin_id=None,
             coins=None,
-            primaries=None,
             ignore_max_send_amount=False,
             coin_announcements_to_consume=coin_announcements,
         )
@@ -684,12 +683,10 @@ class PoolWallet:
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
         create_launcher_tx_record: Optional[TransactionRecord] = await standard_wallet.generate_signed_transaction(
-            amount,
-            genesis_launcher_puz.get_tree_hash(),
+            [Payment(genesis_launcher_puz.get_tree_hash(), amount)],
             fee,
             launcher_parent.name(),
             coins,
-            None,
             False,
             announcement_set,
         )

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1454,7 +1454,7 @@ class WalletRpcApi:
                     fee,
                     cat_discrepancy=cat_discrepancy,
                     coins=coins,
-                    memos=memos if memos else None,
+                    memos=memos if memos else [[puzzle_hash] for puzzle_hash in puzzle_hashes],
                     min_coin_amount=min_coin_amount,
                     max_coin_amount=max_coin_amount,
                     exclude_coin_amounts=exclude_coin_amounts,
@@ -1469,7 +1469,7 @@ class WalletRpcApi:
                 puzzle_hashes,
                 fee,
                 coins=coins,
-                memos=memos if memos else None,
+                memos=memos if memos else [[puzzle_hash] for puzzle_hash in puzzle_hashes],
                 min_coin_amount=min_coin_amount,
                 max_coin_amount=max_coin_amount,
                 exclude_coin_amounts=exclude_coin_amounts,
@@ -2586,6 +2586,7 @@ class WalletRpcApi:
                 [uint64(nft_coin_info.coin.amount)],
                 [puzzle_hash],
                 coins={nft_coin_info.coin},
+                memos=[[puzzle_hash]],
                 fee=fee,
                 new_owner=b"",
                 new_did_inner_hash=b"",
@@ -2870,7 +2871,11 @@ class WalletRpcApi:
         if len(puzzle_hash_0) != 32:
             raise ValueError(f"Address must be 32 bytes. {puzzle_hash_0.hex()}")
 
-        memos_0 = [] if "memos" not in additions[0] else [mem.encode("utf-8") for mem in additions[0]["memos"]]
+        memos_0 = (
+            [bytes(puzzle_hash_0)]
+            if "memos" not in additions[0]
+            else [mem.encode("utf-8") for mem in additions[0]["memos"]]
+        )
 
         additional_outputs: List[Payment] = []
         for addition in additions[1:]:
@@ -2880,7 +2885,9 @@ class WalletRpcApi:
             amount = uint64(addition["amount"])
             if amount > self.service.constants.MAX_COIN_AMOUNT:
                 raise ValueError(f"Coin amount cannot exceed {self.service.constants.MAX_COIN_AMOUNT}")
-            memos = [] if "memos" not in addition else [mem.encode("utf-8") for mem in addition["memos"]]
+            memos = (
+                [bytes(receiver_ph)] if "memos" not in addition else [mem.encode("utf-8") for mem in addition["memos"]]
+            )
             additional_outputs.append(Payment(receiver_ph, amount, memos))
 
         fee: uint64 = uint64(request.get("fee", 0))

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -612,11 +612,7 @@ class FullNodeSimulator(FullNodeAPI):
 
                 if len(outputs_group) > 0:
                     async with wallet.wallet_state_manager.lock:
-                        tx = await wallet.generate_signed_transaction(
-                            amount=outputs_group[0].amount,
-                            puzzle_hash=outputs_group[0].puzzle_hash,
-                            primaries=outputs_group[1:],
-                        )
+                        tx = await wallet.generate_signed_transaction(outputs_group)
                     await wallet.push_transaction(tx=tx)
                     transaction_records.append(tx)
                 else:

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -601,7 +601,7 @@ class FullNodeSimulator(FullNodeAPI):
             outputs: List[Payment] = []
             for amount in amounts:
                 puzzle_hash = await wallet.get_new_puzzlehash()
-                outputs.append(Payment(puzzle_hash, amount, []))
+                outputs.append(Payment(puzzle_hash, amount))
 
             transaction_records: List[TransactionRecord] = []
             outputs_iterator = iter(outputs)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -289,7 +289,11 @@ class CATWallet:
         if self.cost_of_single_tx is None:
             coin = spendable[0].coin
             txs = await self.generate_signed_transaction(
-                [uint64(coin.amount)], [coin.puzzle_hash], coins={coin}, ignore_max_send_amount=True
+                [uint64(coin.amount)],
+                [coin.puzzle_hash],
+                coins={coin},
+                memos=[[coin.puzzle_hash]],
+                ignore_max_send_amount=True,
             )
             assert txs[0].spend_bundle
             program: BlockGenerator = simple_solution_generator(txs[0].spend_bundle)
@@ -819,9 +823,7 @@ class CATWallet:
 
         payments = []
         for amount, puzhash, memo_list in zip(amounts, puzzle_hashes, memos):
-            memos_with_hint: List[bytes] = [puzhash]
-            memos_with_hint.extend(memo_list)
-            payments.append(Payment(puzhash, amount, memos_with_hint))
+            payments.append(Payment(puzhash, amount, memo_list))
 
         payment_sum = sum([p.amount for p in payments])
         if not ignore_max_send_amount:

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -705,7 +705,7 @@ class CATWallet:
                         break
             else:
                 change_puzhash = await self.get_new_inner_hash()
-            primaries.append(Payment(change_puzhash, uint64(change), []))
+            primaries.append(Payment(change_puzhash, uint64(change)))
 
         # Loop through the coins we've selected and gather the information we need to spend them
         spendable_cat_list = []

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -586,8 +586,7 @@ class CATWallet:
             )
             origin_id = list(chia_coins)[0].name()
             chia_tx = await self.standard_wallet.generate_signed_transaction(
-                uint64(0),
-                (await self.standard_wallet.get_puzzle_hash(not reuse_puzhash)),
+                [],
                 fee=uint64(fee - amount_to_claim),
                 coins=chia_coins,
                 origin_id=origin_id,  # We specify this so that we know the coin that is making the announcement
@@ -616,8 +615,12 @@ class CATWallet:
             )
             selected_amount = sum([c.amount for c in chia_coins])
             chia_tx = await self.standard_wallet.generate_signed_transaction(
-                uint64(selected_amount + amount_to_claim - fee),
-                (await self.standard_wallet.get_puzzle_hash(not reuse_puzhash)),
+                [
+                    Payment(
+                        await self.standard_wallet.get_puzzle_hash(not reuse_puzhash),
+                        uint64(selected_amount + amount_to_claim - fee),
+                    )
+                ],
                 coins=chia_coins,
                 negative_change_allowed=True,
                 coin_announcements_to_consume={announcement_to_assert} if announcement_to_assert is not None else None,

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -891,7 +891,7 @@ class DIDWallet:
         p2_solution = self.standard_wallet.make_solution(
             primaries=[
                 Payment(innerpuz.get_tree_hash(), uint64(coin.amount), [p2_puzzle.get_tree_hash()]),
-                Payment(innermessage, uint64(0), []),
+                Payment(innermessage, uint64(0)),
             ],
         )
         innersol = Program.to([1, p2_solution])

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1236,7 +1236,7 @@ class DIDWallet:
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
         tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
-            amount, genesis_launcher_puz.get_tree_hash(), fee, origin.name(), coins, None, False, announcement_set
+            [Payment(genesis_launcher_puz.get_tree_hash(), amount)], fee, origin.name(), coins, False, announcement_set
         )
 
         genesis_launcher_solution = Program.to([did_puzzle_hash, amount, bytes(0x80)])

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -398,12 +398,10 @@ class NFTWallet:
         )
         # store the launcher transaction in the wallet state
         tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
-            uint64(amount),
-            nft_puzzles.LAUNCHER_PUZZLE_HASH,
+            [Payment(nft_puzzles.LAUNCHER_PUZZLE_HASH, uint64(amount))],
             fee,
             origin.name(),
             coins,
-            None,
             False,
             announcement_set,
         )
@@ -946,12 +944,11 @@ class NFTWallet:
                 if wallet.type() == WalletType.STANDARD_WALLET:
                     payments = royalty_payments[asset] if asset in royalty_payments else []
                     payment_sum = sum(p.amount for _, p in payments)
+                    additional = (
+                        [Payment(DESIRED_OFFER_MOD_HASH, uint64(payment_sum))] if payment_sum > 0 or old else []
+                    )
                     tx = await wallet.generate_signed_transaction(
-                        abs(amount),
-                        DESIRED_OFFER_MOD_HASH,
-                        primaries=[Payment(DESIRED_OFFER_MOD_HASH, uint64(payment_sum))]
-                        if payment_sum > 0 or old
-                        else [],
+                        [Payment(DESIRED_OFFER_MOD_HASH, uint64(abs(amount)))] + additional,
                         fee=fee,
                         coins=offered_coins_by_asset[asset],
                         puzzle_announcements_to_consume=announcements_to_assert,

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -950,7 +950,7 @@ class NFTWallet:
                     tx = await wallet.generate_signed_transaction(
                         abs(amount),
                         DESIRED_OFFER_MOD_HASH,
-                        primaries=[Payment(DESIRED_OFFER_MOD_HASH, uint64(payment_sum), [])]
+                        primaries=[Payment(DESIRED_OFFER_MOD_HASH, uint64(payment_sum))]
                         if payment_sum > 0 or old
                         else [],
                         fee=fee,
@@ -1022,7 +1022,6 @@ class NFTWallet:
                                         Payment(
                                             DESIRED_OFFER_MOD_HASH,
                                             uint64(sum(p.amount for _, p in duplicate_payments)),
-                                            [],
                                         ).as_condition_args()
                                     ],
                                 )

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -513,6 +513,7 @@ class NFTWallet:
             [puzzle_hash],
             fee,
             {nft_coin_info.coin},
+            memos=[[puzzle_hash]],
             metadata_update=(key, uri),
             reuse_puzhash=reuse_puzhash,
         )
@@ -641,9 +642,7 @@ class NFTWallet:
 
         payments = []
         for amount, puzhash, memo_list in zip(amounts, puzzle_hashes, memos):
-            memos_with_hint: List[bytes] = [puzhash]
-            memos_with_hint.extend(memo_list)
-            payments.append(Payment(puzhash, amount, memos_with_hint))
+            payments.append(Payment(puzhash, amount, memo_list))
 
         payment_sum = sum([p.amount for p in payments])
         unsigned_spend_bundle, chia_tx = await self.generate_unsigned_spendbundle(
@@ -965,6 +964,7 @@ class NFTWallet:
                         [DESIRED_OFFER_MOD_HASH],
                         fee=fee_left_to_pay,
                         coins=offered_coins_by_asset[asset],
+                        memos=[[DESIRED_OFFER_MOD_HASH]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                         trade_prices_list=[
                             list(price)
@@ -979,6 +979,7 @@ class NFTWallet:
                         [DESIRED_OFFER_MOD_HASH, DESIRED_OFFER_MOD_HASH],
                         fee=fee_left_to_pay,
                         coins=offered_coins_by_asset[asset],
+                        memos=[[DESIRED_OFFER_MOD_HASH], [DESIRED_OFFER_MOD_HASH]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                     )
                 all_transactions.extend(txs)
@@ -1117,15 +1118,16 @@ class NFTWallet:
         for nft_coin_info in nft_list:
             unft = UncurriedNFT.uncurry(*nft_coin_info.full_puzzle.uncurry())
             assert unft is not None
-            puzzle_hashes_to_sign = [unft.p2_puzzle.get_tree_hash()]
+            puzzle_hash = unft.p2_puzzle.get_tree_hash()
             if not first:
                 fee = uint64(0)
             nft_tx_record.extend(
                 await self.generate_signed_transaction(
                     [uint64(nft_coin_info.coin.amount)],
-                    puzzle_hashes_to_sign,
+                    [puzzle_hash],
                     fee,
                     {nft_coin_info.coin},
+                    memos=[[puzzle_hash]],
                     new_owner=did_id,
                     new_did_inner_hash=did_inner_hash,
                     reuse_puzhash=reuse_puzhash,
@@ -1165,6 +1167,7 @@ class NFTWallet:
                     [uint64(nft_coin_info.coin.amount)],
                     [puzzle_hash],
                     coins={nft_coin_info.coin},
+                    memos=[[puzzle_hash]],
                     fee=fee,
                     new_owner=b"",
                     new_did_inner_hash=b"",
@@ -1195,7 +1198,7 @@ class NFTWallet:
         unft = UncurriedNFT.uncurry(*nft_coin_info.full_puzzle.uncurry())
         assert unft is not None
         nft_id = unft.singleton_launcher_id
-        puzzle_hashes_to_sign = [unft.p2_puzzle.get_tree_hash()]
+        puzzle_hash = unft.p2_puzzle.get_tree_hash()
         did_inner_hash = b""
         additional_bundles = []
         if did_id != b"":
@@ -1204,9 +1207,10 @@ class NFTWallet:
 
         nft_tx_record = await self.generate_signed_transaction(
             [uint64(nft_coin_info.coin.amount)],
-            puzzle_hashes_to_sign,
+            [puzzle_hash],
             fee,
             {nft_coin_info.coin},
+            memos=[[puzzle_hash]],
             new_owner=did_id,
             new_did_inner_hash=did_inner_hash,
             additional_bundles=additional_bundles,

--- a/chia/wallet/notification_manager.py
+++ b/chia/wallet/notification_manager.py
@@ -16,6 +16,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
 from chia.wallet.notification_store import Notification, NotificationStore
+from chia.wallet.payment import Payment
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_memos import compute_memos_for_spend
 from chia.wallet.util.notifications import construct_notification
@@ -96,13 +97,11 @@ class NotificationManager:
         )
         extra_spend_bundle = SpendBundle([notification_spend], G2Element())
         chia_tx = await self.wallet_state_manager.main_wallet.generate_signed_transaction(
-            amount,
-            notification_hash,
+            [Payment(notification_hash, amount, [target, msg])],
             fee,
             coins=coins,
             origin_id=origin_coin,
             coin_announcements_to_consume={Announcement(notification_coin.name(), b"")},
-            memos=[target, msg],
         )
         full_tx: TransactionRecord = dataclasses.replace(
             chia_tx, spend_bundle=SpendBundle.aggregate([chia_tx.spend_bundle, extra_spend_bundle])

--- a/chia/wallet/payment.py
+++ b/chia/wallet/payment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 from chia.types.blockchain_format.program import Program
@@ -13,7 +13,7 @@ from chia.util.ints import uint64
 class Payment:
     puzzle_hash: bytes32
     amount: uint64
-    memos: List[bytes]
+    memos: List[bytes] = field(default_factory=list)
 
     def as_condition_args(self) -> List:
         return [self.puzzle_hash, self.amount, self.memos]

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -86,7 +86,7 @@ class GenesisById(LimitationsProgram):
         minted_cat_puzzle_hash: bytes32 = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), cat_inner).get_tree_hash()
 
         tx_record: TransactionRecord = await wallet.standard_wallet.generate_signed_transaction(
-            amount, minted_cat_puzzle_hash, uint64(0), origin_id, coins
+            [Payment(minted_cat_puzzle_hash, amount)], uint64(0), origin_id, coins
         )
         assert tx_record.spend_bundle is not None
 

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -92,7 +92,7 @@ class GenesisById(LimitationsProgram):
 
         inner_solution = wallet.standard_wallet.add_condition_to_solution(
             Program.to([51, 0, -113, tail, []]),
-            wallet.standard_wallet.make_solution(primaries=[Payment(cat_inner.get_tree_hash(), amount, [])]),
+            wallet.standard_wallet.make_solution(primaries=[Payment(cat_inner.get_tree_hash(), amount)]),
         )
         eve_spend = unsigned_spend_bundle_for_spendable_cats(
             CAT_MOD,

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -255,7 +255,7 @@ class TradeManager:
             else:
                 # ATTENTION: new_wallets
                 txs = await wallet.generate_signed_transaction(
-                    [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
+                    [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, memos=[[new_ph]], ignore_max_send_amount=True
                 )
                 all_txs.extend(txs)
             fee_to_pay = uint64(0)
@@ -336,7 +336,12 @@ class TradeManager:
                 else:
                     # ATTENTION: new_wallets
                     txs = await wallet.generate_signed_transaction(
-                        [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
+                        [coin.amount],
+                        [new_ph],
+                        fee=fee_to_pay,
+                        coins={coin},
+                        memos=[[new_ph]],
+                        ignore_max_send_amount=True,
                     )
                     for tx in txs:
                         if tx is not None and tx.spend_bundle is not None:
@@ -560,10 +565,11 @@ class TradeManager:
                 else:
                     wallet = await self.wallet_state_manager.get_wallet_for_asset_id(id.hex())
                 # This should probably not switch on whether or not we're spending XCH but it has to for now
+                puzzle_hash = OFFER_MOD_OLD_HASH if old else Offer.ph()
                 if wallet.type() == WalletType.STANDARD_WALLET:
                     tx = await wallet.generate_signed_transaction(
                         abs(offer_dict[id]),
-                        OFFER_MOD_OLD_HASH if old else Offer.ph(),
+                        puzzle_hash,
                         fee=fee_left_to_pay,
                         coins=set(selected_coins),
                         puzzle_announcements_to_consume=announcements_to_assert,
@@ -577,9 +583,10 @@ class TradeManager:
                     txs = await wallet.generate_signed_transaction(
                         # [abs(offer_dict[id])],
                         amounts,
-                        [OFFER_MOD_OLD_HASH if old else Offer.ph()],
+                        [puzzle_hash],
                         fee=fee_left_to_pay,
                         coins=set(selected_coins),
+                        memos=[[puzzle_hash]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                         reuse_puzhash=reuse_puzhash,
                     )
@@ -588,9 +595,10 @@ class TradeManager:
                     # ATTENTION: new_wallets
                     txs = await wallet.generate_signed_transaction(
                         [abs(offer_dict[id])],
-                        [OFFER_MOD_OLD_HASH if old else Offer.ph()],
+                        [puzzle_hash],
                         fee=fee_left_to_pay,
                         coins=set(selected_coins),
+                        memos=[[puzzle_hash]],
                         puzzle_announcements_to_consume=announcements_to_assert,
                         reuse_puzhash=reuse_puzhash,
                     )

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -245,8 +245,7 @@ class TradeManager:
                 else:
                     selected_coins = {coin}
                 tx = await wallet.generate_signed_transaction(
-                    uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
-                    new_ph,
+                    [Payment(new_ph, uint64(sum(coin.amount for coin in selected_coins) - fee_to_pay))],
                     fee=fee_to_pay,
                     coins=selected_coins,
                     ignore_max_send_amount=True,
@@ -324,8 +323,7 @@ class TradeManager:
                     else:
                         selected_coins = {coin}
                     tx: TransactionRecord = await wallet.generate_signed_transaction(
-                        uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
-                        new_ph,
+                        [Payment(new_ph, uint64(sum([c.amount for c in selected_coins]) - fee_to_pay))],
                         fee=fee_to_pay,
                         coins=selected_coins,
                         ignore_max_send_amount=True,
@@ -568,8 +566,7 @@ class TradeManager:
                 puzzle_hash = OFFER_MOD_OLD_HASH if old else Offer.ph()
                 if wallet.type() == WalletType.STANDARD_WALLET:
                     tx = await wallet.generate_signed_transaction(
-                        abs(offer_dict[id]),
-                        puzzle_hash,
+                        [Payment(puzzle_hash, uint64(abs(offer_dict[id])))],
                         fee=fee_left_to_pay,
                         coins=set(selected_coins),
                         puzzle_announcements_to_consume=announcements_to_assert,

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -459,7 +459,7 @@ class Offer:
             if arbitrage_amount > 0:
                 assert arbitrage_amount is not None
                 assert arbitrage_ph is not None
-                all_payments.append(NotarizedPayment(arbitrage_ph, uint64(arbitrage_amount), []))
+                all_payments.append(NotarizedPayment(arbitrage_ph, uint64(arbitrage_amount)))
 
             # Some assets need to know about siblings so we need to collect all spends first to be able to use them
             coin_to_spend_dict: Dict[Coin, CoinSpend] = {}

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -410,7 +410,7 @@ class Wallet:
                                 break
                     else:
                         change_puzzle_hash = await self.get_new_puzzlehash()
-                    primaries.append(Payment(change_puzzle_hash, uint64(change), []))
+                    primaries.append(Payment(change_puzzle_hash, uint64(change)))
                 message_list: List[bytes32] = [c.name() for c in coins]
                 for primary in primaries:
                     message_list.append(Coin(coin.name(), primary.puzzle_hash, primary.amount).name())

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -48,6 +48,7 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.util.recursive_replace import recursive_replace
 from chia.util.vdf_prover import get_vdf_info_and_proof
+from chia.wallet.payment import Payment
 from chia.wallet.transaction_record import TransactionRecord
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block, _validate_and_add_block_no_error
 from tests.connection_utils import add_dummy_connection, connect_and_get_peer
@@ -131,10 +132,7 @@ class TestFullNodeBlockCompression:
         await full_node_1.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=30)
 
         # Send a transaction to mempool
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
-            tx_size,
-            ph,
-        )
+        tr: TransactionRecord = await wallet.generate_signed_transaction([Payment(ph, uint64(tx_size))])
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -163,10 +161,7 @@ class TestFullNodeBlockCompression:
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         # Send another tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
-            20000,
-            ph,
-        )
+        tr: TransactionRecord = await wallet.generate_signed_transaction([Payment(ph, uint64(20000))])
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -199,10 +194,7 @@ class TestFullNodeBlockCompression:
         await full_node_1.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=30)
 
         # Send another 2 tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
-            30000,
-            ph,
-        )
+        tr: TransactionRecord = await wallet.generate_signed_transaction([Payment(ph, uint64(30000))])
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -210,22 +202,7 @@ class TestFullNodeBlockCompression:
             tr.spend_bundle,
             tr.name,
         )
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
-            40000,
-            ph,
-        )
-        await wallet.push_transaction(tx=tr)
-        await time_out_assert(
-            10,
-            full_node_2.full_node.mempool_manager.get_spendbundle,
-            tr.spend_bundle,
-            tr.name,
-        )
-
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
-            50000,
-            ph,
-        )
+        tr: TransactionRecord = await wallet.generate_signed_transaction([Payment(ph, uint64(40000))])
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -234,10 +211,16 @@ class TestFullNodeBlockCompression:
             tr.name,
         )
 
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
-            3000000000000,
-            ph,
+        tr: TransactionRecord = await wallet.generate_signed_transaction([Payment(ph, uint64(50000))])
+        await wallet.push_transaction(tx=tr)
+        await time_out_assert(
+            10,
+            full_node_2.full_node.mempool_manager.get_spendbundle,
+            tr.spend_bundle,
+            tr.name,
         )
+
+        tr: TransactionRecord = await wallet.generate_signed_transaction([Payment(ph, uint64(3000000000000))])
         await wallet.push_transaction(tx=tr)
         await time_out_assert(
             10,
@@ -263,8 +246,7 @@ class TestFullNodeBlockCompression:
 
         # Creates a standard_transaction and an anyone-can-spend tx
         tr: TransactionRecord = await wallet.generate_signed_transaction(
-            30000,
-            Program.to(1).get_tree_hash(),
+            [Payment(Program.to(1).get_tree_hash(), uint64(30000))]
         )
         extra_spend = SpendBundle(
             [
@@ -308,8 +290,7 @@ class TestFullNodeBlockCompression:
 
         # Make a standard transaction and an anyone-can-spend transaction
         tr: TransactionRecord = await wallet.generate_signed_transaction(
-            30000,
-            Program.to(1).get_tree_hash(),
+            [Payment(Program.to(1).get_tree_hash(), uint64(30000))]
         )
         extra_spend = SpendBundle(
             [

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -11,8 +11,10 @@ from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
-from chia.util.ints import uint16, uint32
+from chia.util.ints import uint16, uint32, uint64
+from chia.wallet.payment import Payment
 
 
 class TestTransactions:
@@ -81,7 +83,7 @@ class TestTransactions:
         await time_out_assert(20, peak_height, num_blocks, full_node_api_1)
         await time_out_assert(20, peak_height, num_blocks, full_node_api_2)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, ph1, 0)
+        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction([Payment(ph1, uint64(10))], 0)
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(
@@ -153,7 +155,9 @@ class TestTransactions:
         )
         await time_out_assert(20, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, token_bytes(), 0)
+        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+            [Payment(bytes32(token_bytes()), uint64(10))], 0
+        )
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -22,6 +22,7 @@ from chia.simulator.time_out_assert import time_out_assert
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
+from chia.wallet.payment import Payment
 from chia.wallet.wallet_node import WalletNode
 
 test_constants_modified = test_constants.replace(
@@ -170,8 +171,7 @@ class TestSimulation:
         await time_out_assert(10, wallet.get_confirmed_balance, funds)
         await time_out_assert(5, wallet.get_unconfirmed_balance, funds)
         tx = await wallet.generate_signed_transaction(
-            uint64(10),
-            await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
+            [Payment(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), uint64(10))],
             uint64(0),
         )
         await wallet.push_transaction(tx)
@@ -343,8 +343,7 @@ class TestSimulation:
         # repeating just to try to expose any flakiness
         for coin in coins:
             tx = await wallet.generate_signed_transaction(
-                amount=uint64(tx_amount),
-                puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
+                [Payment(await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(), uint64(tx_amount))],
                 coins={coin},
             )
             await wallet.push_transaction(tx)
@@ -388,8 +387,11 @@ class TestSimulation:
             coins = [next(coins_iter) for _ in range(tx_per_repeat)]
             transactions = [
                 await wallet.generate_signed_transaction(
-                    amount=uint64(tx_amount),
-                    puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
+                    [
+                        Payment(
+                            await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(), uint64(tx_amount)
+                        )
+                    ],
                     coins={coin},
                 )
                 for coin in coins

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -10,6 +10,7 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator, backoff_times
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
+from chia.wallet.payment import Payment
 from chia.wallet.wallet_node import WalletNode
 
 
@@ -158,8 +159,7 @@ async def test_wait_transaction_records_entered_mempool(
     # repeating just to try to expose any flakiness
     for coin in coins:
         tx = await wallet.generate_signed_transaction(
-            amount=uint64(tx_amount),
-            puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
+            [Payment(await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(), uint64(tx_amount))],
             coins={coin},
         )
         await wallet.push_transaction(tx)
@@ -192,8 +192,7 @@ async def test_process_transaction_records(
     # repeating just to try to expose any flakiness
     for coin in coins:
         tx = await wallet.generate_signed_transaction(
-            amount=uint64(tx_amount),
-            puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
+            [Payment(await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(), uint64(tx_amount))],
             coins={coin},
         )
         await wallet.push_transaction(tx)

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -16,6 +16,7 @@ from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_info import LegacyCATInfo
 from chia.wallet.cat_wallet.cat_utils import construct_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
+from chia.wallet.payment import Payment
 from chia.wallet.puzzles.cat_loader import CAT_MOD
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_info import WalletInfo
@@ -474,7 +475,9 @@ class TestCATWallet:
         await time_out_assert(20, cat_wallet_2.get_unconfirmed_balance, 60)
 
         cc2_ph = await cat_wallet_2.get_new_cat_puzzle_hash()
-        tx_record = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(10, cc2_ph, 0)
+        tx_record = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(
+            [Payment(cc2_ph, uint64(10))], 0
+        )
         await wallet.wallet_state_manager.add_pending_transaction(tx_record)
         await full_node_api.process_transaction_records(records=[tx_record])
 

--- a/tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -60,7 +60,7 @@ async def generate_coins(
             if tail_str:
                 tail: Program = str_to_tail(tail_str)  # Making a fake but unique TAIL
                 cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), acs)
-                payments.append(Payment(cat_puzzle.get_tree_hash(), amount, []))
+                payments.append(Payment(cat_puzzle.get_tree_hash(), amount))
                 cat_bundles.append(
                     unsigned_spend_bundle_for_spendable_cats(
                         CAT_MOD,
@@ -75,7 +75,7 @@ async def generate_coins(
                     )
                 )
             else:
-                payments.append(Payment(acs_ph, amount, []))
+                payments.append(Payment(acs_ph, amount))
 
     # This bundle creates all of the initial coins
     parent_bundle = SpendBundle(

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -21,6 +21,7 @@ from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.condition_tools import conditions_dict_for_solution
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.did_wallet.did_wallet import DIDWallet
+from chia.wallet.payment import Payment
 from chia.wallet.singleton import create_singleton_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.wallet_types import WalletType
@@ -1039,8 +1040,7 @@ class TestDIDWallet:
         coin_1 = (await wallet.select_coins(odd_amount, exclude=[coin])).pop()
         assert coin_1.amount % 2 == 0
         tx = await wallet.generate_signed_transaction(
-            odd_amount,
-            ph1,
+            [Payment(ph1, odd_amount)],
             fee,
             exclude_coins=set([coin]),
         )

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -936,13 +936,15 @@ async def test_nft_offer_request_nft_for_cat(
         cat_1 = await wallet_taker.get_new_puzzlehash()
         cat_2 = await wallet_taker.get_new_puzzlehash()
     puzzle_hashes = [cat_1, cat_2]
+    memos = [[cat_1], [cat_2]]
     amounts = [cats_to_trade, cats_to_trade]
     if test_change:
         ph_taker_cat_1 = await wallet_taker.get_new_puzzlehash()
         extra_change = cats_to_mint - (2 * cats_to_trade)
         amounts.append(uint64(extra_change))
         puzzle_hashes.append(ph_taker_cat_1)
-    cat_tx_records = await cat_wallet_maker.generate_signed_transaction(amounts, puzzle_hashes)
+        memos.append([ph_taker_cat_1])
+    cat_tx_records = await cat_wallet_maker.generate_signed_transaction(amounts, puzzle_hashes, memos=memos)
     for tx_record in cat_tx_records:
         await wallet_maker.wallet_state_manager.add_pending_transaction(tx_record)
     await full_node_api.process_transaction_records(records=cat_tx_records)

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -143,7 +143,12 @@ async def test_nft_wallet_creation_automatically(self_hostname: str, two_wallet_
     coins = await nft_wallet_0.get_current_nfts()
     assert len(coins) == 1, "nft not generated"
 
-    txs = await nft_wallet_0.generate_signed_transaction([uint64(coins[0].coin.amount)], [ph1], coins={coins[0].coin})
+    txs = await nft_wallet_0.generate_signed_transaction(
+        [uint64(coins[0].coin.amount)],
+        [ph1],
+        coins={coins[0].coin},
+        memos=[[ph1]],
+    )
     assert len(txs) == 1
     assert txs[0].spend_bundle is not None
     await wallet_node_0.wallet_state_manager.add_pending_transaction(txs[0])
@@ -278,7 +283,12 @@ async def test_nft_wallet_creation_and_transfer(self_hostname: str, two_wallet_n
     nft_wallet_1 = await NFTWallet.create_new_nft_wallet(
         wallet_node_1.wallet_state_manager, wallet_1, name="NFT WALLET 2"
     )
-    txs = await nft_wallet_0.generate_signed_transaction([uint64(coins[1].coin.amount)], [ph1], coins={coins[1].coin})
+    txs = await nft_wallet_0.generate_signed_transaction(
+        [uint64(coins[1].coin.amount)],
+        [ph1],
+        coins={coins[1].coin},
+        memos=[[ph1]],
+    )
     assert len(txs) == 1
     assert txs[0].spend_bundle is not None
     await wallet_node_0.wallet_state_manager.add_pending_transaction(txs[0])
@@ -298,7 +308,12 @@ async def test_nft_wallet_creation_and_transfer(self_hostname: str, two_wallet_n
     await time_out_assert(30, wallet_1.get_pending_change_balance, 0)
 
     # Send it back to original owner
-    txs = await nft_wallet_1.generate_signed_transaction([uint64(coins[0].coin.amount)], [ph], coins={coins[0].coin})
+    txs = await nft_wallet_1.generate_signed_transaction(
+        [uint64(coins[0].coin.amount)],
+        [ph],
+        coins={coins[0].coin},
+        memos=[[ph]],
+    )
     assert len(txs) == 1
     assert txs[0].spend_bundle is not None
     await wallet_node_1.wallet_state_manager.add_pending_transaction(txs[0])

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -514,7 +514,7 @@ class TestWalletSync:
             payees.append(Payment(payee_ph, uint64(i + 100)))
             payees.append(Payment(payee_ph, uint64(i + 200)))
 
-        tx: TransactionRecord = await wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -570,7 +570,7 @@ class TestWalletSync:
         assert response.header_hash == last_block.header_hash
         assert response.proofs is None
         assert len(response.coins) == 12
-        assert sum([len(c_list) for _, c_list in response.coins]) == 24
+        assert sum([len(c_list) for _, c_list in response.coins]) == 23
 
         # [] for puzzle hashes returns nothing
         res4: Optional[Message] = await full_node_api.request_additions(
@@ -723,7 +723,7 @@ class TestWalletSync:
         payees.append(Payment(payee_ph, uint64(dust_value)))
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -783,7 +783,7 @@ class TestWalletSync:
             # This greatly speeds up the overall process
             if dust_remaining % 100 == 0 and dust_remaining != new_dust:
                 # construct and send tx
-                tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+                tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
                 await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
                 last_block: Optional[BlockRecord] = full_node_api.full_node.blockchain.get_peak()
@@ -796,7 +796,7 @@ class TestWalletSync:
         # Only need to create tx if there was new dust to be added
         if new_dust >= 1:
             # construct and send tx
-            tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+            tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
             await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
             # advance the chain and sync both wallets
@@ -843,7 +843,7 @@ class TestWalletSync:
             payees.append(Payment(payee_ph, uint64(xch_spam_amount)))
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -882,7 +882,7 @@ class TestWalletSync:
         payees.append(Payment(payee_ph, uint64(dust_value)))
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -941,7 +941,7 @@ class TestWalletSync:
                 large_dust_balance += dust_value
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -977,7 +977,7 @@ class TestWalletSync:
         payees = [Payment(payee_ph, uint64(balance))]
 
         # construct and send tx
-        tx: TransactionRecord = await dust_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await dust_wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -1020,7 +1020,7 @@ class TestWalletSync:
             # This greatly speeds up the overall process
             if coins_remaining % 100 == 0 and coins_remaining != spam_filter_after_n_txs:
                 # construct and send tx
-                tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+                tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
                 await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
                 last_block: Optional[BlockRecord] = full_node_api.full_node.blockchain.get_peak()
@@ -1031,7 +1031,7 @@ class TestWalletSync:
             coins_remaining -= 1
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -1060,7 +1060,7 @@ class TestWalletSync:
         payees = [Payment(payee_ph, uint64(1))]
 
         # construct and send tx
-        tx: TransactionRecord = await dust_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
+        tx: TransactionRecord = await dust_wallet.generate_signed_transaction(payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -1273,7 +1273,7 @@ class TestWalletSync:
 
             await time_out_assert(30, wallet.get_confirmed_balance, 2_000_000_000_000)
 
-            tx = await wallet.generate_signed_transaction(1_000_000_000_000, bytes32([0] * 32), memos=[ph])
+            tx = await wallet.generate_signed_transaction([Payment(bytes32([0] * 32), uint64(1_000_000_000_000), [ph])])
             await wallet_node.wallet_state_manager.add_pending_transaction(tx)
 
             async def tx_in_mempool():

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -1137,6 +1137,7 @@ class TestWalletSync:
             [uint64(nft_coins[0].coin.amount)],
             [dust_ph],
             coins={nft_coins[0].coin},
+            memos=[[dust_ph]],
         )
         assert len(txs) == 1
         assert txs[0].spend_bundle is not None

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -511,8 +511,8 @@ class TestWalletSync:
         payees: List[Payment] = []
         for i in range(10):
             payee_ph = await wallet.get_new_puzzlehash()
-            payees.append(Payment(payee_ph, uint64(i + 100), []))
-            payees.append(Payment(payee_ph, uint64(i + 200), []))
+            payees.append(Payment(payee_ph, uint64(i + 100)))
+            payees.append(Payment(payee_ph, uint64(i + 200)))
 
         tx: TransactionRecord = await wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
@@ -720,7 +720,7 @@ class TestWalletSync:
         # Part 1: create a single dust coin
         payees: List[Payment] = []
         payee_ph = await dust_wallet.get_new_puzzlehash()
-        payees.append(Payment(payee_ph, uint64(dust_value), []))
+        payees.append(Payment(payee_ph, uint64(dust_value)))
 
         # construct and send tx
         tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
@@ -777,7 +777,7 @@ class TestWalletSync:
 
         while dust_remaining > 0:
             payee_ph = await dust_wallet.get_new_puzzlehash()
-            payees.append(Payment(payee_ph, uint64(dust_value), []))
+            payees.append(Payment(payee_ph, uint64(dust_value)))
 
             # After every 100 (at most) coins added, push the tx and advance the chain
             # This greatly speeds up the overall process
@@ -840,7 +840,7 @@ class TestWalletSync:
 
         for i in range(large_coins):
             payee_ph = await dust_wallet.get_new_puzzlehash()
-            payees.append(Payment(payee_ph, uint64(xch_spam_amount), []))
+            payees.append(Payment(payee_ph, uint64(xch_spam_amount)))
 
         # construct and send tx
         tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
@@ -879,7 +879,7 @@ class TestWalletSync:
         payees = []
 
         payee_ph = await dust_wallet.get_new_puzzlehash()
-        payees.append(Payment(payee_ph, uint64(dust_value), []))
+        payees.append(Payment(payee_ph, uint64(dust_value)))
 
         # construct and send tx
         tx: TransactionRecord = await farm_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
@@ -923,7 +923,7 @@ class TestWalletSync:
             payee_ph = await dust_wallet.get_new_puzzlehash()
 
             # Create a large coin and add on the appropriate balance.
-            payees.append(Payment(payee_ph, uint64(xch_spam_amount + i), []))
+            payees.append(Payment(payee_ph, uint64(xch_spam_amount + i)))
             large_coins += 1
             large_coin_balance += xch_spam_amount + i
 
@@ -931,9 +931,9 @@ class TestWalletSync:
 
             # Make sure we are always creating coins with a positive value.
             if xch_spam_amount - dust_value - i > 0:
-                payees.append(Payment(payee_ph, uint64(xch_spam_amount - dust_value - i), []))
+                payees.append(Payment(payee_ph, uint64(xch_spam_amount - dust_value - i)))
             else:
-                payees.append(Payment(payee_ph, uint64(dust_value), []))
+                payees.append(Payment(payee_ph, uint64(dust_value)))
             # In cases where xch_spam_amount is sufficiently low,
             # the new dust should be considered a large coina and not be filtered.
             if xch_spam_amount <= dust_value:
@@ -974,7 +974,7 @@ class TestWalletSync:
         # Send 1 mojo from the dust wallet. The dust wallet should receive a change coin valued at "xch_spam_amount-1".
 
         payee_ph = await farm_wallet.get_new_puzzlehash()
-        payees = [Payment(payee_ph, uint64(balance), [])]
+        payees = [Payment(payee_ph, uint64(balance))]
 
         # construct and send tx
         tx: TransactionRecord = await dust_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)
@@ -1014,7 +1014,7 @@ class TestWalletSync:
 
         while coins_remaining > 0:
             payee_ph = await dust_wallet.get_new_puzzlehash()
-            payees.append(Payment(payee_ph, uint64(coin_value), []))
+            payees.append(Payment(payee_ph, uint64(coin_value)))
 
             # After every 100 (at most) coins added, push the tx and advance the chain
             # This greatly speeds up the overall process
@@ -1057,7 +1057,7 @@ class TestWalletSync:
 
         # Send a 1 mojo coin from the dust wallet to the farm wallet
         payee_ph = await farm_wallet.get_new_puzzlehash()
-        payees = [Payment(payee_ph, uint64(1), [])]
+        payees = [Payment(payee_ph, uint64(1))]
 
         # construct and send tx
         tx: TransactionRecord = await dust_wallet.generate_signed_transaction(uint64(0), ph, primaries=payees)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -566,7 +566,7 @@ class TestWalletSimulator:
 
         await time_out_assert(20, wallet.get_confirmed_balance, expected_confirmed_balance)
 
-        primaries = [Payment(ph, uint64(1000000000 + i), []) for i in range(60)]
+        primaries = [Payment(ph, uint64(1000000000 + i)) for i in range(60)]
         tx_split_coins = await wallet.generate_signed_transaction(uint64(1), ph, uint64(0), primaries=primaries)
         assert tx_split_coins.spend_bundle is not None
 

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -15,6 +15,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint16, uint64
+from chia.wallet.payment import Payment
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_node import WalletNode
 
@@ -62,7 +63,7 @@ async def test_wallet_tx_retry(
     await farm_blocks(full_node_1, reward_ph, 2)
     await full_node_1.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=wait_secs)
 
-    transaction: TransactionRecord = await wallet_1.generate_signed_transaction(uint64(100), reward_ph)
+    transaction: TransactionRecord = await wallet_1.generate_signed_transaction([Payment(reward_ph, uint64(100))])
     sb1: Optional[SpendBundle] = transaction.spend_bundle
     assert sb1 is not None
     await wallet_1.push_transaction(transaction)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Merge the some parameter of `Wallet.generate_signed_transaction`: 

```python
amount: uint64
puzzle_hash: bytes32
primaries: Optional[List[Payment]] = None
memos: Optional[List[bytes]] = None
```

into 

```python
payments: List[Payment]
```

### New Behavior:

No change in behaviour, just some cleanup.

### Based on:

- #15113 
- #15172 
- #15171 