### PR TITLE
Subscribe to the change children of CATs

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -658,7 +658,7 @@ class WalletStateManager:
         # Check if the coin is a CAT
         cat_curried_args = match_cat_puzzle(uncurried)
         if cat_curried_args is not None:
-            return await self.handle_cat(cat_curried_args, parent_coin_state, coin_state, coin_spend, peer)
+            return await self.handle_cat(cat_curried_args, parent_coin_state, coin_state, coin_spend)
 
         # Check if the coin is a NFT
         #                                                        hint
@@ -716,7 +716,6 @@ class WalletStateManager:
         parent_coin_state: CoinState,
         coin_state: CoinState,
         coin_spend: CoinSpend,
-        peer: WSChiaConnection,
     ) -> Optional[WalletIdentifier]:
         """
         Handle the new coin when it is a CAT
@@ -1163,10 +1162,9 @@ class WalletStateManager:
                                     if derivation_record is None:  # not change
                                         to_puzzle_hash = coin.puzzle_hash
                                         amount += coin.amount
-                                    else:
+                                    elif wallet_identifier.type == WalletType.CAT:
                                         # We subscribe to change for CATs since they didn't hint previously
-                                        if wallet_identifier.type == WalletType.CAT:
-                                            await self.add_interested_coin_ids([coin.name()])
+                                        await self.add_interested_coin_ids([coin.name()])
 
                                 if to_puzzle_hash is None:
                                     to_puzzle_hash = additions[0].puzzle_hash

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -658,7 +658,7 @@ class WalletStateManager:
         # Check if the coin is a CAT
         cat_curried_args = match_cat_puzzle(uncurried)
         if cat_curried_args is not None:
-            return await self.handle_cat(cat_curried_args, parent_coin_state, coin_state, coin_spend)
+            return await self.handle_cat(cat_curried_args, parent_coin_state, coin_state, coin_spend, peer)
 
         # Check if the coin is a NFT
         #                                                        hint
@@ -716,6 +716,7 @@ class WalletStateManager:
         parent_coin_state: CoinState,
         coin_state: CoinState,
         coin_spend: CoinSpend,
+        peer: WSChiaConnection,
     ) -> Optional[WalletIdentifier]:
         """
         Handle the new coin when it is a CAT
@@ -1159,9 +1160,13 @@ class WalletStateManager:
                                     derivation_record = await self.puzzle_store.get_derivation_record_for_puzzle_hash(
                                         coin.puzzle_hash
                                     )
-                                    if derivation_record is None:
+                                    if derivation_record is None:  # not change
                                         to_puzzle_hash = coin.puzzle_hash
                                         amount += coin.amount
+                                    else:
+                                        # We subscribe to change for CATs since they didn't hint previously
+                                        if wallet_identifier.type == WalletType.CAT:
+                                            await self.add_interested_coin_ids([coin.name()])
 
                                 if to_puzzle_hash is None:
                                     to_puzzle_hash = additions[0].puzzle_hash

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -846,10 +846,10 @@ class TestCATWallet:
     )
     @pytest.mark.asyncio
     async def test_cat_change_detection(
-        self, self_hostname: str, two_wallet_nodes_services: SimulatorsAndWalletsServices, trusted: bool
+        self, self_hostname: str, one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices, trusted: bool
     ) -> None:
         num_blocks = 1
-        full_nodes, wallets, bt = two_wallet_nodes_services
+        full_nodes, wallets, bt = one_wallet_and_one_simulator_services
         full_node_api: FullNodeSimulator = full_nodes[0]._api
         full_node_server = full_node_api.full_node.server
         wallet_service_0 = wallets[0]

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1,23 +1,34 @@
 from __future__ import annotations
 
 import asyncio
-from typing import List
+from typing import Any, List
 
 import pytest
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.rpc.wallet_rpc_api import WalletRpcApi
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
-from chia.simulator.time_out_assert import time_out_assert
-from chia.types.blockchain_format.coin import Coin
+from chia.simulator.time_out_assert import time_out_assert, time_out_assert_not_none
+from chia.types.blockchain_format.coin import Coin, coin_as_list
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_spend import CoinSpend
 from chia.types.peer_info import PeerInfo
+from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_info import LegacyCATInfo
 from chia.wallet.cat_wallet.cat_utils import construct_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
+from chia.wallet.derivation_record import DerivationRecord
+from chia.wallet.derive_keys import _derive_path_unhardened, master_sk_to_wallet_sk_unhardened_intermediate
+from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.cat_loader import CAT_MOD
+from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_pk
 from chia.wallet.transaction_record import TransactionRecord
+from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_info import WalletInfo
 
 
@@ -827,3 +838,162 @@ class TestCATWallet:
 
         await time_out_assert(20, cat_wallet.get_confirmed_balance, 35)
         await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 35)
+
+    @pytest.mark.parametrize(
+        "trusted",
+        [True, False],
+    )
+    @pytest.mark.asyncio
+    async def test_cat_change_detection(self, self_hostname: str, two_wallet_nodes_services: Any, trusted: Any) -> None:
+        num_blocks = 1
+        full_nodes, wallets, bt = two_wallet_nodes_services
+        full_node_api: FullNodeSimulator = full_nodes[0]._api
+        full_node_server = full_node_api.full_node.server
+        wallet_service_0 = wallets[0]
+        wallet_node_0 = wallet_service_0._node
+        wallet_node_1 = wallet_service_0._node
+        wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
+        wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
+
+        client_0 = await WalletRpcClient.create(
+            bt.config["self_hostname"],
+            wallet_service_0.rpc_server.listen_port,
+            wallet_service_0.root_path,
+            wallet_service_0.config,
+        )
+        wallet_node_0.config["automatically_add_unknown_cats"] = True
+
+        if trusted:
+            wallet_node_0.config["trusted_peers"] = {
+                full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+            }
+        else:
+            wallet_node_0.config["trusted_peers"] = {}
+        wallet_node_0.config["automatically_add_unknown_cats"] = True
+
+        await wallet_node_0.server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_0, timeout=20)
+
+        # Mint CAT to ourselves, immediately spend it to an unhinted puzzle hash that we have manually added to the DB
+        # We should pick up this coin as balance even though it is unhinted because it is "change"
+        intermediate_sk_un = master_sk_to_wallet_sk_unhardened_intermediate(
+            wallet_node_0.wallet_state_manager.private_key
+        )
+        pubkey_unhardened = _derive_path_unhardened(intermediate_sk_un, [100000000]).get_g1()
+        inner_puzhash = puzzle_hash_for_pk(pubkey_unhardened)
+        puzzlehash_unhardened = construct_cat_puzzle(
+            CAT_MOD,
+            Program.to(None).get_tree_hash(),
+            inner_puzhash,  # type: ignore
+        ).get_tree_hash_precalc(inner_puzhash)
+        change_derivation = DerivationRecord(
+            uint32(0),
+            puzzlehash_unhardened,
+            pubkey_unhardened,
+            WalletType.CAT,
+            uint32(2),
+            False,
+        )
+        # Insert the derivation record before the wallet exists so that it is not subscribed to
+        await wallet_node_0.wallet_state_manager.puzzle_store.add_derivation_paths([change_derivation])
+        our_puzzle: Program = await wallet_0.get_new_puzzle()
+        cat_puzzle: Program = construct_cat_puzzle(
+            CAT_MOD,
+            Program.to(None).get_tree_hash(),
+            Program.to(1),
+        )
+        addr = encode_puzzle_hash(cat_puzzle.get_tree_hash(), "txch")
+        CAT_AMOUNT_0 = uint64(100)
+        CAT_AMOUNT_1 = uint64(5)
+
+        tx = await client_0.send_transaction(1, CAT_AMOUNT_0, addr)
+        spend_bundle = tx.spend_bundle
+        assert spend_bundle is not None
+
+        await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
+        await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_0, timeout=20)
+
+        # Do the eve spend back to our wallet and add the CR layer
+        cat_coin = next(c for c in spend_bundle.additions() if c.amount == CAT_AMOUNT_0)
+        next_coin = Coin(
+            cat_coin.name(),
+            construct_cat_puzzle(
+                CAT_MOD,
+                Program.to(None).get_tree_hash(),
+                our_puzzle,
+            ).get_tree_hash(),
+            CAT_AMOUNT_0,
+        )
+        eve_spend = await wallet_node_0.wallet_state_manager.main_wallet.sign_transaction(
+            [
+                CoinSpend(
+                    cat_coin,
+                    cat_puzzle,
+                    Program.to(
+                        [
+                            Program.to(
+                                [
+                                    [
+                                        51,
+                                        our_puzzle.get_tree_hash(),
+                                        CAT_AMOUNT_0,
+                                        [our_puzzle.get_tree_hash()],
+                                    ],
+                                    [51, None, -113, None, None],
+                                ]
+                            ),
+                            None,
+                            cat_coin.name(),
+                            coin_as_list(cat_coin),
+                            [cat_coin.parent_coin_info, Program.to(1).get_tree_hash(), cat_coin.amount],
+                            0,
+                            0,
+                        ]
+                    ),
+                ),
+                CoinSpend(
+                    next_coin,
+                    construct_cat_puzzle(
+                        CAT_MOD,
+                        Program.to(None).get_tree_hash(),
+                        our_puzzle,
+                    ),
+                    Program.to(
+                        [
+                            [
+                                None,
+                                (
+                                    1,
+                                    [
+                                        [51, inner_puzhash, CAT_AMOUNT_1],
+                                        [51, bytes32([0] * 32), CAT_AMOUNT_0 - CAT_AMOUNT_1],
+                                    ],
+                                ),
+                                None,
+                            ],
+                            LineageProof(
+                                cat_coin.parent_coin_info, Program.to(1).get_tree_hash(), CAT_AMOUNT_0
+                            ).to_program(),
+                            next_coin.name(),
+                            coin_as_list(next_coin),
+                            [next_coin.parent_coin_info, our_puzzle.get_tree_hash(), next_coin.amount],
+                            0,
+                            0,
+                        ]
+                    ),
+                ),
+            ],
+        )
+        await client_0.push_tx(eve_spend)
+        await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, eve_spend.name())
+        await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
+        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_0, timeout=20)
+
+        async def check_wallets(node):
+            return len(node.wallet_state_manager.wallets.keys())
+
+        await time_out_assert(20, check_wallets, 2, wallet_node_0)
+        cat_wallet = wallet_node_0.wallet_state_manager.wallets[2]
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, CAT_AMOUNT_1)

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -906,10 +906,10 @@ class TestCATWallet:
             Program.to(1),
         )
         addr = encode_puzzle_hash(cat_puzzle.get_tree_hash(), "txch")
-        CAT_AMOUNT_0 = uint64(100)
-        CAT_AMOUNT_1 = uint64(5)
+        cat_amount_0 = uint64(100)
+        cat_amount_1 = uint64(5)
 
-        tx = await client_0.send_transaction(1, CAT_AMOUNT_0, addr)
+        tx = await client_0.send_transaction(1, cat_amount_0, addr)
         spend_bundle = tx.spend_bundle
         assert spend_bundle is not None
 
@@ -918,7 +918,7 @@ class TestCATWallet:
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_0, timeout=20)
 
         # Do the eve spend back to our wallet and add the CR layer
-        cat_coin = next(c for c in spend_bundle.additions() if c.amount == CAT_AMOUNT_0)
+        cat_coin = next(c for c in spend_bundle.additions() if c.amount == cat_amount_0)
         next_coin = Coin(
             cat_coin.name(),
             construct_cat_puzzle(
@@ -926,7 +926,7 @@ class TestCATWallet:
                 Program.to(None).get_tree_hash(),
                 our_puzzle,
             ).get_tree_hash(),
-            CAT_AMOUNT_0,
+            cat_amount_0,
         )
         eve_spend = await wallet_node_0.wallet_state_manager.main_wallet.sign_transaction(
             [
@@ -940,7 +940,7 @@ class TestCATWallet:
                                     [
                                         51,
                                         our_puzzle.get_tree_hash(),
-                                        CAT_AMOUNT_0,
+                                        cat_amount_0,
                                         [our_puzzle.get_tree_hash()],
                                     ],
                                     [51, None, -113, None, None],
@@ -969,14 +969,14 @@ class TestCATWallet:
                                 (
                                     1,
                                     [
-                                        [51, inner_puzhash, CAT_AMOUNT_1],
-                                        [51, bytes32([0] * 32), CAT_AMOUNT_0 - CAT_AMOUNT_1],
+                                        [51, inner_puzhash, cat_amount_1],
+                                        [51, bytes32([0] * 32), cat_amount_0 - cat_amount_1],
                                     ],
                                 ),
                                 None,
                             ],
                             LineageProof(
-                                cat_coin.parent_coin_info, Program.to(1).get_tree_hash(), CAT_AMOUNT_0
+                                cat_coin.parent_coin_info, Program.to(1).get_tree_hash(), cat_amount_0
                             ).to_program(),
                             next_coin.name(),
                             coin_as_list(next_coin),
@@ -998,5 +998,5 @@ class TestCATWallet:
 
         await time_out_assert(20, check_wallets, 2, wallet_node_0)
         cat_wallet = wallet_node_0.wallet_state_manager.wallets[uint32(2)]
-        await time_out_assert(20, cat_wallet.get_confirmed_balance, CAT_AMOUNT_1)
+        await time_out_assert(20, cat_wallet.get_confirmed_balance, cat_amount_1)
         assert not full_node_api.full_node.subscriptions.has_ph_subscription(puzzlehash_unhardened)

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -887,7 +887,7 @@ class TestCATWallet:
         puzzlehash_unhardened = construct_cat_puzzle(
             CAT_MOD,
             Program.to(None).get_tree_hash(),
-            inner_puzhash,  # type: ignore
+            inner_puzhash,  # type: ignore[arg-type]
         ).get_tree_hash_precalc(inner_puzhash)
         change_derivation = DerivationRecord(
             uint32(0),


### PR DESCRIPTION
This is a PR to lay the ground work for removing subscriptions from everything except for standard puzzle hashes.  Currently, we pick up change because we subscribe the the CAT-wrapped version of every puzzle hash that our standard wallet generates.  We also do not hint to the change (currently, soon to change) which means that picking it up via the standard means we do for other CATs is not viable.  To solve this, this PR just adds an extra subscription to the change of a CAT that we have identified as ours and that has been spent.