### PR TITLE
Add type filter for get_transactions

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -71,6 +71,7 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType, is_valid_address
 from chia.wallet.util.compute_hints import compute_coin_hints
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.util.query_filter import TransactionTypeFilter
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import WalletType
@@ -80,7 +81,6 @@ from chia.wallet.wallet_coin_store import HashFilter
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_protocol import WalletProtocol
-from chia.wallet.wallet_transaction_store import TypeFilter
 
 # Timeout for response from wallet/full node for sending a transaction
 TIMEOUT = 30
@@ -850,7 +850,7 @@ class WalletRpcApi:
             to_puzzle_hash = decode_puzzle_hash(to_address)
         type_filter = None
         if "type_filter" in request:
-            type_filter = TypeFilter.from_json_dict(request["type_filter"])
+            type_filter = TransactionTypeFilter.from_json_dict(request["type_filter"])
 
         transactions = await self.service.wallet_state_manager.tx_store.get_transactions_between(
             wallet_id,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -30,7 +30,7 @@ from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, str2bool
 from chia.util.errors import KeychainIsLocked
-from chia.util.ints import uint8, uint16, uint32, uint64
+from chia.util.ints import uint16, uint32, uint64
 from chia.util.keychain import bytes_to_mnemonic, generate_mnemonic
 from chia.util.misc import UInt32Range
 from chia.util.path import path_from_root
@@ -80,10 +80,9 @@ from chia.wallet.wallet_coin_store import HashFilter
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_protocol import WalletProtocol
-
-# Timeout for response from wallet/full node for sending a transaction
 from chia.wallet.wallet_transaction_store import TypeFilter
 
+# Timeout for response from wallet/full node for sending a transaction
 TIMEOUT = 30
 MAX_DERIVATION_INDEX_DELTA = 1000
 MAX_NFT_CHUNK_SIZE = 25
@@ -851,12 +850,7 @@ class WalletRpcApi:
             to_puzzle_hash = decode_puzzle_hash(to_address)
         type_filter = None
         if "type_filter" in request:
-            include = request["type_filter"].get("include", True)
-            types = [uint8(t) for t in request["type_filter"].get("types", [])]
-            if include:
-                type_filter = TypeFilter.includes(types)
-            else:
-                type_filter = TypeFilter.excludes(types)
+            type_filter = TypeFilter.from_json_dict(request["type_filter"])
 
         transactions = await self.service.wallet_state_manager.tx_store.get_transactions_between(
             wallet_id,

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -16,8 +16,8 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.transaction_sorting import SortKey
+from chia.wallet.util.query_filter import TransactionTypeFilter
 from chia.wallet.util.wallet_types import WalletType
-from chia.wallet.wallet_transaction_store import TypeFilter
 
 
 def parse_result_transactions(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -127,7 +127,7 @@ class WalletRpcClient(RpcClient):
         sort_key: SortKey = None,
         reverse: bool = False,
         to_address: Optional[str] = None,
-        type_filter: Optional[TypeFilter] = None,
+        type_filter: Optional[TransactionTypeFilter] = None,
     ) -> List[TransactionRecord]:
         request: Dict[str, Any] = {"wallet_id": wallet_id}
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -17,6 +17,7 @@ from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.transaction_sorting import SortKey
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_transaction_store import TypeFilter
 
 
 def parse_result_transactions(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -126,6 +127,7 @@ class WalletRpcClient(RpcClient):
         sort_key: SortKey = None,
         reverse: bool = False,
         to_address: Optional[str] = None,
+        type_filter: Optional[TypeFilter] = None,
     ) -> List[TransactionRecord]:
         request: Dict[str, Any] = {"wallet_id": wallet_id}
 
@@ -139,6 +141,9 @@ class WalletRpcClient(RpcClient):
 
         if to_address is not None:
             request["to_address"] = to_address
+
+        if type_filter is not None:
+            request["type_filter"] = type_filter.to_json_dict()
 
         res = await self.fetch(
             "get_transactions",

--- a/chia/wallet/util/query_filter.py
+++ b/chia/wallet/util/query_filter.py
@@ -15,11 +15,6 @@ class FilterMode(IntEnum):
     exclude = 2
 
 
-class CoinRecordOrder(IntEnum):
-    confirmed_height = 1
-    spent_height = 2
-
-
 @streamable
 @dataclass(frozen=True)
 class TransactionTypeFilter(Streamable):

--- a/chia/wallet/util/query_filter.py
+++ b/chia/wallet/util/query_filter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import List
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint8, uint64
+from chia.util.streamable import Streamable, streamable
+from chia.wallet.util.transaction_type import TransactionType
+
+
+class FilterMode(IntEnum):
+    include = 1
+    exclude = 2
+
+
+class CoinRecordOrder(IntEnum):
+    confirmed_height = 1
+    spent_height = 2
+
+
+@streamable
+@dataclass(frozen=True)
+class TransactionTypeFilter(Streamable):
+    values: List[uint8]
+    mode: uint8  # FilterMode
+
+    @classmethod
+    def include(cls, values: List[TransactionType]) -> TransactionTypeFilter:
+        return cls([uint8(t.value) for t in values], uint8(FilterMode.include))
+
+    @classmethod
+    def exclude(cls, values: List[TransactionType]) -> TransactionTypeFilter:
+        return cls([uint8(t.value) for t in values], uint8(FilterMode.exclude))
+
+
+@streamable
+@dataclass(frozen=True)
+class AmountFilter(Streamable):
+    values: List[uint64]
+    mode: uint8  # FilterMode
+
+    @classmethod
+    def include(cls, values: List[uint64]) -> AmountFilter:
+        return cls(values, mode=uint8(FilterMode.include))
+
+    @classmethod
+    def exclude(cls, values: List[uint64]) -> AmountFilter:
+        return cls(values, mode=uint8(FilterMode.exclude))
+
+
+@streamable
+@dataclass(frozen=True)
+class HashFilter(Streamable):
+    values: List[bytes32]
+    mode: uint8  # FilterMode
+
+    @classmethod
+    def include(cls, values: List[bytes32]) -> HashFilter:
+        return cls(values, mode=uint8(FilterMode.include))
+
+    @classmethod
+    def exclude(cls, values: List[bytes32]) -> HashFilter:
+        return cls(values, mode=uint8(FilterMode.exclude))

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import Dict, List, Optional, Set
 
 from chia.types.blockchain_format.coin import Coin
@@ -12,9 +13,14 @@ from chia.util.ints import uint8, uint32, uint64
 from chia.util.lru_cache import LRUCache
 from chia.util.misc import UInt32Range, UInt64Range, VersionedBlob
 from chia.util.streamable import Streamable, streamable
-from chia.wallet.util.query_filter import AmountFilter, CoinRecordOrder, FilterMode, HashFilter
+from chia.wallet.util.query_filter import AmountFilter, FilterMode, HashFilter
 from chia.wallet.util.wallet_types import CoinType, WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
+
+
+class CoinRecordOrder(IntEnum):
+    confirmed_height = 1
+    spent_height = 2
 
 
 @streamable

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from enum import IntEnum
 from typing import Dict, List, Optional, Set
 
 from chia.types.blockchain_format.coin import Coin
@@ -13,48 +12,9 @@ from chia.util.ints import uint8, uint32, uint64
 from chia.util.lru_cache import LRUCache
 from chia.util.misc import UInt32Range, UInt64Range, VersionedBlob
 from chia.util.streamable import Streamable, streamable
+from chia.wallet.util.query_filter import AmountFilter, CoinRecordOrder, FilterMode, HashFilter
 from chia.wallet.util.wallet_types import CoinType, WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
-
-
-class FilterMode(IntEnum):
-    include = 1
-    exclude = 2
-
-
-@streamable
-@dataclass(frozen=True)
-class AmountFilter(Streamable):
-    values: List[uint64]
-    mode: uint8  # FilterMode
-
-    @classmethod
-    def include(cls, values: List[uint64]):
-        return cls(values, mode=uint8(FilterMode.include))
-
-    @classmethod
-    def exclude(cls, values: List[uint64]):
-        return cls(values, mode=uint8(FilterMode.exclude))
-
-
-@streamable
-@dataclass(frozen=True)
-class HashFilter(Streamable):
-    values: List[bytes32]
-    mode: uint8  # FilterMode
-
-    @classmethod
-    def include(cls, values: List[bytes32]):
-        return cls(values, mode=uint8(FilterMode.include))
-
-    @classmethod
-    def exclude(cls, values: List[bytes32]):
-        return cls(values, mode=uint8(FilterMode.exclude))
-
-
-class CoinRecordOrder(IntEnum):
-    confirmed_height = 1
-    spent_height = 2
 
 
 @streamable

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -289,15 +289,10 @@ class WalletTransactionStore:
         if type_filter is None:
             type_filter_str = ""
         else:
-            if len(type_filter.values) == 0 and type_filter.mode == FilterMode.include:
-                return []
-            if len(type_filter.values) == 0 and type_filter.mode == FilterMode.exclude:
-                type_filter_str = ""
-            else:
-                type_filter_str = (
-                    f"AND type {'' if type_filter.mode == FilterMode.include else 'NOT'} "
-                    f"IN ({','.join([str(x) for x in type_filter.values])})"
-                )
+            type_filter_str = (
+                f"AND type {'' if type_filter.mode == FilterMode.include else 'NOT'} "
+                f"IN ({','.join([str(x) for x in type_filter.values])})"
+            )
 
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -49,12 +49,12 @@ from chia.wallet.transaction_sorting import SortKey
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.util.query_filter import TransactionTypeFilter
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_protocol import WalletProtocol
-from chia.wallet.wallet_transaction_store import TypeFilter
 
 log = logging.getLogger(__name__)
 
@@ -641,10 +641,10 @@ async def test_get_transactions(wallet_rpc_environment: WalletRpcTestEnvironment
 
     # Test type filter
     all_transactions = await client.get_transactions(
-        1, type_filter=TypeFilter.include([TransactionType.COINBASE_REWARD])
+        1, type_filter=TransactionTypeFilter.include([TransactionType.COINBASE_REWARD])
     )
     assert len(all_transactions) == 5
-    assert all_transactions[0].type == TransactionType.COINBASE_REWARD
+    assert all(transaction.type == TransactionType.COINBASE_REWARD for transaction in all_transactions)
 
 
 @pytest.mark.asyncio

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -49,10 +49,12 @@ from chia.wallet.transaction_sorting import SortKey
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_protocol import WalletProtocol
+from chia.wallet.wallet_transaction_store import TypeFilter
 
 log = logging.getLogger(__name__)
 
@@ -636,6 +638,13 @@ async def test_get_transactions(wallet_rpc_environment: WalletRpcTestEnvironment
     tx_for_address = await client.get_transactions(1, to_address=encode_puzzle_hash(ph_by_addr, "txch"))
     assert len(tx_for_address) == 1
     assert tx_for_address[0].to_puzzle_hash == ph_by_addr
+
+    # Test type filter
+    all_transactions = await client.get_transactions(
+        1, type_filter=TypeFilter.include([TransactionType.COINBASE_REWARD])
+    )
+    assert len(all_transactions) == 5
+    assert all_transactions[0].type == TransactionType.COINBASE_REWARD
 
 
 @pytest.mark.asyncio

--- a/tests/wallet/test_transaction_store.py
+++ b/tests/wallet/test_transaction_store.py
@@ -486,11 +486,26 @@ async def test_get_transactions_between_confirmed() -> None:
         # test type filter (coinbase reward)
         await store.add_transaction_record(tr6)
         assert await store.get_transactions_between(
-            1, 0, 1, reverse=True, type_filter=TypeFilter.includes([uint8(TransactionType.COINBASE_REWARD.value)])
+            1, 0, 1, reverse=True, type_filter=TypeFilter.include([TransactionType.COINBASE_REWARD])
         ) == [tr6]
         assert await store.get_transactions_between(
-            1, 0, 1, reverse=True, type_filter=TypeFilter.excludes([uint8(TransactionType.COINBASE_REWARD.value)])
+            1, 0, 1, reverse=True, type_filter=TypeFilter.exclude([TransactionType.COINBASE_REWARD])
         ) == [tr5]
+        assert await store.get_transactions_between(1, 0, 100, reverse=True, type_filter=TypeFilter.include([])) == [
+            tr6,
+            tr5,
+            tr4,
+            tr3,
+            tr2,
+            tr1,
+        ]
+        assert await store.get_transactions_between(
+            1,
+            0,
+            100,
+            reverse=True,
+            type_filter=TypeFilter.include([TransactionType.COINBASE_REWARD, TransactionType.OUTGOING_TX]),
+        ) == [tr6, tr5, tr4, tr3, tr2, tr1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

UI team needs to filter out Clawback transactions

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Doesn't support filter by tx type.

### New Behavior:
Add type_filter parameter for the get_transactions API. Example: {type_filter: {include: True, types:[1,2,3]}}


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Unit tests


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
