### PR TITLE
Optimize check_removals() by checking for mempool conflicts all at once

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -524,19 +524,17 @@ class MempoolManager:
         having duplicate removals.
         """
         assert self.peak is not None
-        conflicts: Set[MempoolItem] = set()
-
+        removals_ids = []
         for record in removals.values():
             removal = record.coin
             # 1. Checks if it's been spent already
             if record.spent:
                 return Err.DOUBLE_SPEND, []
-            # 2. Checks if there's a mempool conflict
-            items: List[MempoolItem] = self.mempool.get_items_by_coin_id(removal.name())
-            conflicts.update(items)
-
+            removals_ids.append(removal.name())
+        # 2. Checks if there are mempool conflicts
+        conflicts = self.mempool.get_items_by_coin_ids(removals_ids)
         if len(conflicts) > 0:
-            return Err.MEMPOOL_CONFLICT, list(conflicts)
+            return Err.MEMPOOL_CONFLICT, conflicts
         # 5. If coins can be spent return list of unspents as we see them in local storage
         return None, []
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -516,7 +516,7 @@ class MempoolManager:
 
         return None, potential, [item.name for item in conflicts]
 
-    def check_removals(self, removals: Dict[bytes32, CoinRecord]) -> Tuple[Optional[Err], Set[MempoolItem]]:
+    def check_removals(self, removals: Dict[bytes32, CoinRecord]) -> Tuple[Optional[Err], List[MempoolItem]]:
         """
         This function checks for double spends, unknown spends and conflicting transactions in mempool.
         Returns Error (if any), the set of existing MempoolItems with conflicting spends (if any).
@@ -530,15 +530,15 @@ class MempoolManager:
             removal = record.coin
             # 1. Checks if it's been spent already
             if record.spent:
-                return Err.DOUBLE_SPEND, set()
+                return Err.DOUBLE_SPEND, []
             # 2. Checks if there's a mempool conflict
             items: List[MempoolItem] = self.mempool.get_items_by_coin_id(removal.name())
             conflicts.update(items)
 
         if len(conflicts) > 0:
-            return Err.MEMPOOL_CONFLICT, conflicts
+            return Err.MEMPOOL_CONFLICT, list(conflicts)
         # 5. If coins can be spent return list of unspents as we see them in local storage
-        return None, set()
+        return None, []
 
     def get_spendbundle(self, bundle_hash: bytes32) -> Optional[SpendBundle]:
         """Returns a full SpendBundle if it's inside one the mempools"""
@@ -663,7 +663,7 @@ def optional_max(a: Optional[T], b: Optional[T]) -> Optional[T]:
 
 
 def can_replace(
-    conflicting_items: Set[MempoolItem],
+    conflicting_items: List[MempoolItem],
     removal_names: Set[bytes32],
     new_item: MempoolItem,
 ) -> bool:

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -778,7 +778,7 @@ coins = make_test_coins()
 )
 def test_can_replace(existing_items: List[MempoolItem], new_item: MempoolItem, expected: bool) -> None:
     removals = set(c.name() for c in new_item.spend_bundle.removals())
-    assert can_replace(set(existing_items), removals, new_item) == expected
+    assert can_replace(existing_items, removals, new_item) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* Make `conflicting_items` a `list` instead of a `set` as we're only iterating over it, we're not leveraging set ownership.
* Optimize `check_removals()` by checking for mempool conflicts all at once.