### PR TITLE
Softfork2 testing

### DIFF
--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -74,12 +74,11 @@ async def async_main(service_config: Dict[str, Any]) -> int:
     network_id = service_config["selected_network"]
     overrides = service_config["network_overrides"]["constants"][network_id]
     if network_id == "testnet10":
-        # testnet10 is 1031258 blocks behind mainnet
-        testnet10_offset = 1031258
+        # activate softforks immediately on testnet
         if "SOFT_FORK2_HEIGHT" not in overrides:
-            overrides["SOFT_FORK2_HEIGHT"] = 3886635 - testnet10_offset
+            overrides["SOFT_FORK2_HEIGHT"] = 0
         if "SOFT_FORK_HEIGHT" not in overrides:
-            overrides["SOFT_FORK_HEIGHT"] = 3630000 - testnet10_offset
+            overrides["SOFT_FORK_HEIGHT"] = 0
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
     initialize_service_logging(service_name=SERVICE_NAME, config=config)
     service = create_full_node_service(DEFAULT_ROOT_PATH, config, updated_constants)

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -71,8 +71,8 @@ network_overrides: &network_overrides
       GENESIS_PRE_FARM_POOL_PUZZLE_HASH: d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
-      SOFT_FORK_HEIGHT: 2598742
-      SOFT_FORK2_HEIGHT: 2855377
+      SOFT_FORK_HEIGHT: 0
+      SOFT_FORK2_HEIGHT: 0
   config:
     mainnet:
       address_prefix: "xch"

--- a/tests/clvm/coin_store.py
+++ b/tests/clvm/coin_store.py
@@ -59,7 +59,7 @@ class CoinStore:
 
         program = simple_solution_generator(spend_bundle)
         # always use the post soft-fork2 semantics
-        result: NPCResult = get_name_puzzle_conditions(program, max_cost, mempool_mode=True, height=uint32(4000000))
+        result: NPCResult = get_name_puzzle_conditions(program, max_cost, mempool_mode=True, height=uint32(3886635))
         if result.error is not None:
             raise BadSpendBundleError(f"condition validation failure {Err(result.error)}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def db_version(request) -> int:
     return request.param
 
 
-@pytest.fixture(scope="function", params=[1000000, 3630000, 4000000])
+@pytest.fixture(scope="function", params=[1000000, 3630000, 3886635])
 def softfork_height(request) -> int:
     return request.param
 


### PR DESCRIPTION
* update tests to use the new softfork2 activation height.
* activate both soft forks immediately on testnet10