### PR TITLE
data_layer: Avoid redundant coin state fetching

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -228,18 +228,7 @@ class DataLayerWallet:
 
         assert spend.coin.name() == launcher_id, "coin_id should always match the launcher_id here"
 
-        await self.new_launcher_spend(spend, peer, height)
-
-    async def new_launcher_spend(
-        self,
-        launcher_spend: CoinSpend,
-        peer: WSChiaConnection,
-        height: uint32,
-    ) -> None:
-        launcher_id: bytes32 = launcher_spend.coin.name()
-        full_puzhash, amount, root, inner_puzhash = launch_solution_to_singleton_info(
-            launcher_spend.solution.to_program()
-        )
+        full_puzhash, amount, root, inner_puzhash = launch_solution_to_singleton_info(spend.solution.to_program())
         new_singleton = Coin(launcher_id, full_puzhash, amount)
 
         singleton_record: Optional[SingletonRecord] = await self.wallet_state_manager.dl_store.get_latest_singleton(
@@ -274,7 +263,7 @@ class DataLayerWallet:
                 )
             )
 
-        await self.wallet_state_manager.dl_store.add_launcher(launcher_spend.coin)
+        await self.wallet_state_manager.dl_store.add_launcher(spend.coin)
         await self.wallet_state_manager.add_interested_puzzle_hashes([launcher_id], [self.id()])
         await self.wallet_state_manager.add_interested_coin_ids([new_singleton.name()])
 


### PR DESCRIPTION
### Purpose:

The first commit makes it always pass the height to `DataLayerWallet.new_launcher_spend` because we currently don't pass it after fetching the coin state and coin spend here https://github.com/Chia-Network/chia-blockchain/blob/16a204ccd0f7d792b4c1f8395f6c2b78cdb406e1/chia/data_layer/data_layer_wallet.py#L226-L228

which leads to fetching the coin state again here https://github.com/Chia-Network/chia-blockchain/blob/16a204ccd0f7d792b4c1f8395f6c2b78cdb406e1/chia/data_layer/data_layer_wallet.py#L237-L240

which is not required because we already know the height. 

The second commit merges `new_launcher_spend` it into `track_new_launcher_id` since its the only place where it's needed and there is not so much happening in both of them but i may drop this one if there are arguments for it.

### Current Behavior:

The coin state for the launcher id gets fetched twice.

### New Behavior:

Just one API call less for the same behaviour.
