### PR TITLE
wallet: Avoid dict changes while iterating in `handle_nft`

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -916,7 +916,7 @@ class WalletStateManager:
                 uncurried_nft.singleton_launcher_id.hex(),
             )
             return wallet_identifier
-        for nft_wallet in self.wallets.values():
+        for nft_wallet in self.wallets.copy().values():
             if not isinstance(nft_wallet, NFTWallet):
                 continue
             if nft_wallet.nft_wallet_info.did_id == old_did_id and old_derivation_record is not None:


### PR DESCRIPTION
### Purpose:

Fix 

```
  File "chia/wallet/wallet_state_manager.py", line 646, in determine_coin_type
  File "chia/wallet/wallet_state_manager.py", line 919, in handle_nft
RuntimeError: dictionary changed size during iteration
```

which happens because add/remove wallets while we iterate over `WalletStateManager.wallets` which was introduced here #14969.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

We just iterate over the dict values.

### New Behavior:

We copy the dict first before iterating the values. We might as well just do `for nft_wallet in list(self.wallets.values())` but i think the explicit copy is more obvious to understand why it's done and there will be no tendency to remove it like with the list wrapping which could be seen as redundant list copying.
