### PR TITLE
Fix #13393 offer shows network's XCH like TXCH on testnet10

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -651,11 +651,11 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
     if royalty_asset_dict != {}:
         fungible_asset_dict: Dict[Any, uint64] = {}
         for fungible_asset_id in fungible_assets_from_offer(offer):
-            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else network_xch.lower()
+            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else "xch"
             if fungible_asset_id_str in requested:
                 nft_royalty_currency: str = "Unknown CAT"
                 if fungible_asset_id is None:
-                    nft_royalty_currency = network_xch
+                    nft_royalty_currency = "XCH"
                 else:
                     result = await wallet_client.cat_asset_id_to_name(fungible_asset_id)
                     if result is not None:
@@ -671,7 +671,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
             for nft_id, summaries in royalty_summary.items():
                 print(f"  - For {nft_id}:")
                 for summary in summaries:
-                    divisor = units["chia"] if summary["asset"] == network_xch else units["cat"]
+                    divisor = units["chia"] if summary["asset"] == "XCH" else units["cat"]
                     converted_amount = Decimal(summary["amount"]) / divisor
                     total_amounts_requested.setdefault(summary["asset"], fungible_asset_dict[summary["asset"]])
                     total_amounts_requested[summary["asset"]] += summary["amount"]
@@ -682,7 +682,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
             print()
             print("Total Amounts Requested:")
             for asset, amount in total_amounts_requested.items():
-                divisor = units["chia"] if asset == network_xch else units["cat"]
+                divisor = units["chia"] if asset == "XCH" else units["cat"]
                 converted_amount = Decimal(amount) / divisor
                 print(f"  - {converted_amount} {asset} ({amount} mojos)")
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -630,7 +630,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
 
     offered, requested, _ = offer.summary()
     cat_name_resolver = wallet_client.cat_asset_id_to_name
-    network_xch = Address.NFT.hrp(config).upper()
+    network_xch = AddressType.NFT.hrp(config).upper()
     print("Summary:")
     print("  OFFERED:")
     await print_offer_summary(cat_name_resolver, offered)
@@ -651,7 +651,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
     if royalty_asset_dict != {}:
         fungible_asset_dict: Dict[Any, uint64] = {}
         for fungible_asset_id in fungible_assets_from_offer(offer):
-            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else network_xch.lower())
+            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else network_xch.lower()
             if fungible_asset_id_str in requested:
                 nft_royalty_currency: str = "Unknown CAT"
                 if fungible_asset_id is None:

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -651,7 +651,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
     if royalty_asset_dict != {}:
         fungible_asset_dict: Dict[Any, uint64] = {}
         for fungible_asset_id in fungible_assets_from_offer(offer):
-            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else network_xch.lower()
+            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else "xch"
             if fungible_asset_id_str in requested:
                 nft_royalty_currency: str = "Unknown CAT"
                 if fungible_asset_id is None:

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -481,7 +481,9 @@ def timestamp_to_time(timestamp):
     return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
 
 
-async def print_offer_summary(cat_name_resolver: CATNameResolver, sum_dict: Dict[str, int], has_fee: bool = False, network_xch = "XCH"):
+async def print_offer_summary(
+    cat_name_resolver: CATNameResolver, sum_dict: Dict[str, int], has_fee: bool = False, network_xch="XCH"
+):
     for asset_id, amount in sum_dict.items():
         description: str = ""
         unit: int = units["chia"]

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -630,6 +630,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
 
     offered, requested, _ = offer.summary()
     cat_name_resolver = wallet_client.cat_asset_id_to_name
+    network_xch = Address.NFT.hrp(config).upper()
     print("Summary:")
     print("  OFFERED:")
     await print_offer_summary(cat_name_resolver, offered)
@@ -650,11 +651,11 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
     if royalty_asset_dict != {}:
         fungible_asset_dict: Dict[Any, uint64] = {}
         for fungible_asset_id in fungible_assets_from_offer(offer):
-            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else "xch"
+            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else network_xch.lower())
             if fungible_asset_id_str in requested:
                 nft_royalty_currency: str = "Unknown CAT"
                 if fungible_asset_id is None:
-                    nft_royalty_currency = "XCH"
+                    nft_royalty_currency = network_xch
                 else:
                     result = await wallet_client.cat_asset_id_to_name(fungible_asset_id)
                     if result is not None:
@@ -670,7 +671,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
             for nft_id, summaries in royalty_summary.items():
                 print(f"  - For {nft_id}:")
                 for summary in summaries:
-                    divisor = units["chia"] if summary["asset"] == "XCH" else units["cat"]
+                    divisor = units["chia"] if summary["asset"] == network_xch else units["cat"]
                     converted_amount = Decimal(summary["amount"]) / divisor
                     total_amounts_requested.setdefault(summary["asset"], fungible_asset_dict[summary["asset"]])
                     total_amounts_requested[summary["asset"]] += summary["amount"]
@@ -681,11 +682,11 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
             print()
             print("Total Amounts Requested:")
             for asset, amount in total_amounts_requested.items():
-                divisor = units["chia"] if asset == "XCH" else units["cat"]
+                divisor = units["chia"] if asset == network_xch else units["cat"]
                 converted_amount = Decimal(amount) / divisor
                 print(f"  - {converted_amount} {asset} ({amount} mojos)")
 
-    print(f"Included Fees: {Decimal(offer.fees()) / units['chia']} XCH, {offer.fees()} mojos")
+    print(f"Included Fees: {Decimal(offer.fees()) / units['chia']} {network_xch}, {offer.fees()} mojos")
 
     if not examine_only:
         print()

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -630,7 +630,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
 
     offered, requested, _ = offer.summary()
     cat_name_resolver = wallet_client.cat_asset_id_to_name
-    network_xch = AddressType.NFT.hrp(config).upper()
+    network_xch = AddressType.XCH.hrp(config).upper()
     print("Summary:")
     print("  OFFERED:")
     await print_offer_summary(cat_name_resolver, offered)
@@ -651,11 +651,11 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
     if royalty_asset_dict != {}:
         fungible_asset_dict: Dict[Any, uint64] = {}
         for fungible_asset_id in fungible_assets_from_offer(offer):
-            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else "xch"
+            fungible_asset_id_str = fungible_asset_id.hex() if fungible_asset_id is not None else network_xch.lower()
             if fungible_asset_id_str in requested:
                 nft_royalty_currency: str = "Unknown CAT"
                 if fungible_asset_id is None:
-                    nft_royalty_currency = "XCH"
+                    nft_royalty_currency = network_xch
                 else:
                     result = await wallet_client.cat_asset_id_to_name(fungible_asset_id)
                     if result is not None:
@@ -671,7 +671,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
             for nft_id, summaries in royalty_summary.items():
                 print(f"  - For {nft_id}:")
                 for summary in summaries:
-                    divisor = units["chia"] if summary["asset"] == "XCH" else units["cat"]
+                    divisor = units["chia"] if summary["asset"] == network_xch else units["cat"]
                     converted_amount = Decimal(summary["amount"]) / divisor
                     total_amounts_requested.setdefault(summary["asset"], fungible_asset_dict[summary["asset"]])
                     total_amounts_requested[summary["asset"]] += summary["amount"]
@@ -682,7 +682,7 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
             print()
             print("Total Amounts Requested:")
             for asset, amount in total_amounts_requested.items():
-                divisor = units["chia"] if asset == "XCH" else units["cat"]
+                divisor = units["chia"] if asset == network_xch else units["cat"]
                 converted_amount = Decimal(amount) / divisor
                 print(f"  - {converted_amount} {asset} ({amount} mojos)")
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -481,13 +481,13 @@ def timestamp_to_time(timestamp):
     return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
 
 
-async def print_offer_summary(cat_name_resolver: CATNameResolver, sum_dict: Dict[str, int], has_fee: bool = False):
+async def print_offer_summary(cat_name_resolver: CATNameResolver, sum_dict: Dict[str, int], has_fee: bool = False, network_xch = "XCH"):
     for asset_id, amount in sum_dict.items():
         description: str = ""
         unit: int = units["chia"]
         wid: str = "1" if asset_id == "xch" else ""
         mojo_amount: int = int(Decimal(amount))
-        name: str = "XCH"
+        name: str = network_xch
         if asset_id != "xch":
             name = asset_id
             if asset_id == "unknown":
@@ -633,9 +633,9 @@ async def take_offer(args: dict, wallet_client: WalletRpcClient, fingerprint: in
     network_xch = AddressType.XCH.hrp(config).upper()
     print("Summary:")
     print("  OFFERED:")
-    await print_offer_summary(cat_name_resolver, offered)
+    await print_offer_summary(cat_name_resolver, offered, network_xch=network_xch)
     print("  REQUESTED:")
-    await print_offer_summary(cat_name_resolver, requested)
+    await print_offer_summary(cat_name_resolver, requested, network_xch=network_xch)
 
     print()
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Fixes #13393 

#13393 is currently assigned to @paninaro however I picked it up thinking it was assigned to force the issue to stay open instead of being closed for staleness. 
I also thought it'd be a relatively straight forward issue for me to contribute for 🤓 


This PR is something I roughed in. I'm very open to changing anything about it. 

It is rough like:
- I change `print_offer_summary(...)` signature 
  - reasoning: getting config from `load_config` in again seemed like an anti-pattern in looking at how the lifecycle of commands would do that once at the top level
- I use `AddressType.XCH.hrp()` to get `XCH`||`TXCH`
  - reasoning: this seemed like a pretty straight forward method while I was looking for things that were reading the config, which would have the network information, `take_offer(...)` does already use this for generating the correct address
- I didn't dive in to see how this is handled elsewhere, to follow that pattern.
- I used a variable name called `network_xch` which I am not attached to and think there could be named something better

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

When using `chia wallet take_offer` on `testnet10` the summary will print like:

```
Summary:
  OFFERED:
    - Testnet Dexie Bucks (Wallet ID: 3): 793.438 (793438 mojos)
  REQUESTED:
    - XCH (Wallet ID: 1): 1.00394 (1003940000000 mojos)

Included Fees: 0.00055 XCH, 550000000 mojos
```
or when there are royalties like:

```
Summary:
  OFFERED:
    - 3fb9955bcde745722ce913b74b26f1c18c9efe6c13db1d9ba5fe76e6e41efc31: 0.001 (1 mojo)
  REQUESTED:
    - XCH (Wallet ID: 1): 1e-09 (1000 mojos)

Royalties Summary:
  - For nft187ue2k7duazhyt8fzwm5kfh3cxxfalnvz0d3mxa9lemwdeq7lscstsjpsr:
    - 5E-11 XCH (50 mojos) to txch1nu0dulhuhczyf60upcqml379sq2tggprl4nt92x6unf0m2uc0vpsffqh5d

Total Amounts Requested:
  - 1.05E-9 XCH (1050 mojos)
Included Fees: 0 XCH, 0 mojos
```




### New Behavior:

When using `chia wallet take_offer` on `testnet10` the summary will print like:

```
Summary:
  OFFERED:
    - Testnet Dexie Bucks (Wallet ID: 3): 793.438 (793438 mojos)
  REQUESTED:
    - TXCH (Wallet ID: 1): 1.00394 (1003940000000 mojos)

Included Fees: 0.00055 TXCH, 550000000 mojos
```

and with royalties like:

```
Summary:
  OFFERED:
    - 3fb9955bcde745722ce913b74b26f1c18c9efe6c13db1d9ba5fe76e6e41efc31: 0.001 (1 mojo)
  REQUESTED:
    - TXCH (Wallet ID: 1): 1e-09 (1000 mojos)
Royalties Summary:
  - For nft187ue2k7duazhyt8fzwm5kfh3cxxfalnvz0d3mxa9lemwdeq7lscstsjpsr:
    - 5E-11 TXCH (50 mojos) to txch1nu0dulhuhczyf60upcqml379sq2tggprl4nt92x6unf0m2uc0vpsffqh5d
Total Amounts Requested:
  - 1.05E-9 TXCH (1050 mojos)
Included Fees: 0 TXCH, 0 mojos
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

The extent of my testing was running 2 offers with `chia wallet take_offer -e offer...`:
One I had from using the tibetswap v2 test, made up of CATs and TXCH 
One I pulled from a recent dexie.space testnet NFT trade.

I did not run the test suite.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
