### PR TITLE
Fixing missing args for 'configure_decompressor()' seen in 'chia plots check, and set 'parallel_decompressers_count: 1' as the default

### DIFF
--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -61,11 +61,18 @@ def check_plots(
         thread_count = multiprocessing.cpu_count() // 2
     disable_cpu_affinity = config["harvester"].get("disable_cpu_affinity", False)
     max_compression_level_allowed = config["harvester"].get("max_compression_level_allowed", 7)
+    use_gpu_harvesting = config["harvester"].get("use_gpu_harvesting", False)
+    gpu_index = config["harvester"].get("gpu_index", 0)
+    enforce_gpu_index = config["harvester"].get("enforce_gpu_index", False)
+
     plot_manager.configure_decompresser(
         context_count,
         thread_count,
         disable_cpu_affinity,
         max_compression_level_allowed,
+        use_gpu_harvesting,
+        gpu_index,
+        enforce_gpu_index,
     )
 
     if num is not None:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -204,7 +204,7 @@ harvester:
     key: "config/ssl/ca/chia_ca.key"
 
   # Compressed harvesting.
-  parallel_decompressers_count: 5
+  parallel_decompressers_count: 1
   # If set to 0, `decompresser_thread_count` will default to half of nproc available on the machine.
   # A non-zero number overrides this default.
   decompresser_thread_count: 0


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
The command `chia plots check` was returning an error. This fixes that.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
> TypeError: PlotManager.configure_decompresser() missing 3 required positional arguments: 'use_gpu_harvesting', 'gpu_index', and 'enforce_gpu_index'


### New Behavior:
`chia plots check`
> 2023-05-13T01:17:37.492  chia.plotting.check_plots        : INFO     Loading plots in config.yaml using plot_manager loading code (parallel read: True)
> 
> 2023-05-13T01:17:37.810  chia.plotting.cache              : INFO     Loaded 10897957 bytes of cached data
> 2023-05-13T01:17:40.282  chia.plotting.cache              : INFO     Parsed 10873 cache entries in 2.46s

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
