### PR TITLE
wallet: More use of `WalletCoinStore.get_coin_records` 

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -55,7 +55,7 @@ from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
-from chia.wallet.wallet_coin_store import HashFilter
+from chia.wallet.wallet_coin_store import HashFilter, unspent_range
 from chia.wallet.wallet_info import WalletInfo
 
 if TYPE_CHECKING:
@@ -268,7 +268,10 @@ class CATWallet:
 
     async def get_confirmed_balance(self, record_list: Optional[Set[WalletCoinRecord]] = None) -> uint128:
         if record_list is None:
-            record_list = await self.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(self.id())
+            result = await self.wallet_state_manager.coin_store.get_coin_records(
+                wallet_id=self.id(), spent_range=unspent_range
+            )
+            record_list = set(result.records)
 
         amount: uint128 = uint128(0)
         for record in record_list:

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -55,6 +55,7 @@ from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
+from chia.wallet.wallet_coin_store import HashFilter
 from chia.wallet.wallet_info import WalletInfo
 
 if TYPE_CHECKING:
@@ -372,7 +373,10 @@ class CATWallet:
             )
         else:
             # The parent is not a CAT which means we need to scrub all of its children from our DB
-            child_coin_records = await self.wallet_state_manager.coin_store.get_coin_records_by_parent_id(coin_name)
+            result = await self.wallet_state_manager.coin_store.get_coin_records(
+                parent_coin_id_filter=HashFilter.include([coin_name])
+            )
+            child_coin_records = result.records
             if len(child_coin_records) > 0:
                 for record in child_coin_records:
                     if record.wallet_id == self.id():

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -47,6 +47,7 @@ from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spen
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
+from chia.wallet.wallet_coin_store import unspent_range
 from chia.wallet.wallet_info import WalletInfo
 
 
@@ -286,7 +287,10 @@ class DIDWallet:
 
     async def get_confirmed_balance(self, record_list=None) -> uint128:
         if record_list is None:
-            record_list = await self.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(self.id())
+            result = await self.wallet_state_manager.coin_store.get_coin_records(
+                wallet_id=self.id(), spent_range=unspent_range
+            )
+            record_list = result.records
 
         amount: uint128 = uint128(0)
         for record in record_list:

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -343,14 +343,6 @@ class WalletCoinStore:
             )
         return set(self.coin_record_from_row(row) for row in rows)
 
-    # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them
-    async def get_coin_records_by_puzzle_hash(self, puzzle_hash: bytes32) -> List[WalletCoinRecord]:
-        """Returns a list of all coin records with the given puzzle hash"""
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall("SELECT * from coin_record WHERE puzzle_hash=?", (puzzle_hash.hex(),))
-
-        return [self.coin_record_from_row(row) for row in rows]
-
     async def rollback_to_block(self, height: int) -> None:
         """
         Rolls back the blockchain to block_index. All coins confirmed after this point are removed.

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -297,23 +297,6 @@ class WalletCoinStore:
             total_count,
         )
 
-    async def get_coin_records_between(
-        self, wallet_id: int, start: int, end: int, reverse: bool = False, coin_type: CoinType = CoinType.NORMAL
-    ) -> List[WalletCoinRecord]:
-        """Return a list of coins between start and end index. List is in reverse chronological order.
-        start = 0 is most recent transaction
-        """
-        limit = end - start
-        query_str = "ORDER BY confirmed_height " + ("DESC" if reverse else "ASC")
-
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                f"SELECT * FROM coin_record WHERE coin_type=? AND"
-                f" wallet_id=? {query_str}, rowid LIMIT {start}, {limit}",
-                (coin_type, wallet_id),
-            )
-        return [self.coin_record_from_row(row) for row in rows]
-
     async def get_first_coin_height(self) -> Optional[uint32]:
         """Returns height of first confirmed coin"""
         async with self.db_wrapper.reader_no_transaction() as conn:

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -16,6 +16,8 @@ from chia.util.streamable import Streamable, streamable
 from chia.wallet.util.wallet_types import CoinType, WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 
+unspent_range = UInt32Range(stop=uint32(0))
+
 
 class FilterMode(IntEnum):
     include = 1
@@ -306,17 +308,6 @@ class WalletCoinStore:
             return uint32(rows[0][0])
 
         return None
-
-    async def get_unspent_coins_for_wallet(
-        self, wallet_id: int, coin_type: CoinType = CoinType.NORMAL
-    ) -> Set[WalletCoinRecord]:
-        """Returns set of CoinRecords that have not been spent yet for a wallet."""
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                "SELECT * FROM coin_record WHERE coin_type=? AND wallet_id=? AND spent_height=0",
-                (coin_type, wallet_id),
-            )
-        return set(self.coin_record_from_row(row) for row in rows)
 
     async def get_all_unspent_coins(self, coin_type: CoinType = CoinType.NORMAL) -> Set[WalletCoinRecord]:
         """Returns set of CoinRecords that have not been spent yet for a wallet."""

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -139,16 +139,6 @@ class WalletCoinStore:
                 pass
         return self
 
-    async def count_small_unspent(self, cutoff: int, coin_type: CoinType = CoinType.NORMAL) -> int:
-        amount_bytes = bytes(uint64(cutoff))
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            row = await execute_fetchone(
-                conn,
-                "SELECT COUNT(*) FROM coin_record WHERE coin_type=? AND amount < ? AND spent=0",
-                (coin_type, amount_bytes),
-            )
-            return int(0 if row is None else row[0])
-
     # Store CoinRecord in DB and ram cache
     async def add_coin_record(self, record: WalletCoinRecord, name: Optional[bytes32] = None) -> None:
         if name is None:

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -351,16 +351,6 @@ class WalletCoinStore:
 
         return [self.coin_record_from_row(row) for row in rows]
 
-    # Checks DB and DiffStores for CoinRecords with parent_coin_info and returns them
-    async def get_coin_records_by_parent_id(self, parent_coin_info: bytes32) -> List[WalletCoinRecord]:
-        """Returns a list of all coin records with the given parent id"""
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                "SELECT * from coin_record WHERE coin_parent=?", (parent_coin_info.hex(),)
-            )
-
-        return [self.coin_record_from_row(row) for row in rows]
-
     async def rollback_to_block(self, height: int) -> None:
         """
         Rolls back the blockchain to block_index. All coins confirmed after this point are removed.

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -308,14 +308,6 @@ class WalletCoinStore:
             return uint32(rows[0][0])
 
         return None
-
-    async def get_all_unspent_coins(self, coin_type: CoinType = CoinType.NORMAL) -> Set[WalletCoinRecord]:
-        """Returns set of CoinRecords that have not been spent yet for a wallet."""
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            rows = await conn.execute_fetchall(
-                "SELECT * FROM coin_record WHERE coin_type=? AND spent_height=0", (coin_type,)
-            )
-        return set(self.coin_record_from_row(row) for row in rows)
 
     async def rollback_to_block(self, height: int) -> None:
         """

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -73,6 +73,7 @@ from chia.wallet.util.wallet_sync_utils import (
     subscribe_to_coin_updates,
     subscribe_to_phs,
 )
+from chia.wallet.wallet_coin_store import unspent_range
 from chia.wallet.wallet_state_manager import WalletStateManager
 from chia.wallet.wallet_weight_proof_handler import WalletWeightProofHandler, get_wp_fork_point
 
@@ -1615,7 +1616,10 @@ class WalletNode:
     async def _update_balance_cache(self, wallet_id: uint32) -> None:
         assert self.wallet_state_manager.lock.locked(), "WalletStateManager.lock required"
         wallet = self.wallet_state_manager.wallets[wallet_id]
-        unspent_records = await self.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(wallet_id)
+        result = await self.wallet_state_manager.coin_store.get_coin_records(
+            wallet_id=wallet_id, spent_range=unspent_range
+        )
+        unspent_records = set(result.records)
         balance = await wallet.get_confirmed_balance(unspent_records)
         pending_balance = await wallet.get_unconfirmed_balance(unspent_records)
         spendable_balance = await wallet.get_spendable_balance(unspent_records)

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -10,6 +10,7 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator, backoff_times
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
+from chia.wallet.wallet_coin_store import unspent_range
 from chia.wallet.wallet_node import WalletNode
 
 
@@ -131,8 +132,10 @@ async def test_simulation_farm_rewards_to_wallet(
     assert [unconfirmed_balance, confirmed_balance] == [rewards, rewards]
 
     # The expected number of coins were received.
-    all_coin_records = await wallet.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(wallet.id())
-    assert len(all_coin_records) == coin_count
+    result = await wallet.wallet_state_manager.coin_store.get_coin_records(
+        wallet_id=wallet.id(), spent_range=unspent_range
+    )
+    assert len(result.records) == coin_count
 
 
 @pytest.mark.asyncio

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -208,43 +208,6 @@ async def test_set_spent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_all_unspent_coins() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        assert await store.get_all_unspent_coins() == set()
-
-        await store.add_coin_record(record_1)  # not spent
-        await store.add_coin_record(record_2)  # not spent
-        await store.add_coin_record(record_3)  # spent
-        await store.add_coin_record(record_8)  # spent
-        assert await store.get_all_unspent_coins() == set([record_1, record_2])
-
-        await store.add_coin_record(record_4)  # spent
-        await store.add_coin_record(record_5)  # not spent
-        await store.add_coin_record(record_6)  # spent
-        assert await store.get_all_unspent_coins() == set([record_1, record_2, record_5])
-
-        await store.add_coin_record(record_7)  # not spent
-        assert await store.get_all_unspent_coins() == set([record_1, record_2, record_5, record_7])
-
-        await store.set_spent(coin_4.name(), uint32(12))
-        assert await store.get_all_unspent_coins() == set([record_1, record_2, record_5, record_7])
-
-        await store.set_spent(coin_7.name(), uint32(12))
-        assert await store.get_all_unspent_coins() == set([record_1, record_2, record_5])
-
-        await store.set_spent(coin_5.name(), uint32(12))
-        assert await store.get_all_unspent_coins() == set([record_1, record_2])
-
-        await store.set_spent(coin_2.name(), uint32(12))
-        await store.set_spent(coin_1.name(), uint32(12))
-        assert await store.get_all_unspent_coins() == set()
-
-        assert await store.get_all_unspent_coins(coin_type=CoinType.CLAWBACK) == set([record_8])
-
-
-@pytest.mark.asyncio
 async def test_delete_coin_record() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -208,25 +208,6 @@ async def test_set_spent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_records_by_puzzle_hash() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        await store.add_coin_record(record_4)
-        await store.add_coin_record(record_5)
-
-        # adding duplicates is fine, we replace existing entry
-        await store.add_coin_record(record_5)
-
-        await store.add_coin_record(record_6)
-        assert len(await store.get_coin_records_by_puzzle_hash(record_6.coin.puzzle_hash)) == 2  # 4 and 6
-        assert len(await store.get_coin_records_by_puzzle_hash(token_bytes(32))) == 0
-
-        assert await store.get_coin_record(coin_6.name()) == record_6
-        assert await store.get_coin_record(token_bytes(32)) is None
-
-
-@pytest.mark.asyncio
 async def test_get_unspent_coins_for_wallet() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -807,42 +807,6 @@ async def test_rollback_to_block() -> None:
 
 
 @pytest.mark.asyncio
-async def test_count_small_unspent() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        coin_1 = Coin(token_bytes(32), token_bytes(32), uint64(1))
-        coin_2 = Coin(token_bytes(32), token_bytes(32), uint64(2))
-        coin_3 = Coin(token_bytes(32), token_bytes(32), uint64(4))
-
-        r1 = record(coin_1, confirmed=1, spent=0)
-        r2 = record(coin_2, confirmed=2, spent=0)
-        r3 = record(coin_3, confirmed=3, spent=0)
-
-        await store.add_coin_record(r1)
-        await store.add_coin_record(r2)
-        await store.add_coin_record(r3)
-        await store.add_coin_record(record_8)
-
-        assert await store.count_small_unspent(5) == 3
-        assert await store.count_small_unspent(4) == 2
-        assert await store.count_small_unspent(3) == 2
-        assert await store.count_small_unspent(2) == 1
-        assert await store.count_small_unspent(1) == 0
-        assert await store.count_small_unspent(3, coin_type=CoinType.CLAWBACK) == 1
-
-        await store.set_spent(coin_2.name(), uint32(12))
-        await store.set_spent(coin_8.name(), uint32(12))
-
-        assert await store.count_small_unspent(5) == 2
-        assert await store.count_small_unspent(4) == 1
-        assert await store.count_small_unspent(3) == 1
-        assert await store.count_small_unspent(2) == 1
-        assert await store.count_small_unspent(3, coin_type=CoinType.CLAWBACK) == 0
-        assert await store.count_small_unspent(1) == 0
-
-
-@pytest.mark.asyncio
 async def test_delete_wallet() -> None:
     dummy_records = DummyWalletCoinRecords()
     for i in range(5):

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -918,28 +918,6 @@ async def test_count_small_unspent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_coin_records_between() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        assert await store.get_all_unspent_coins() == set()
-
-        await store.add_coin_record(record_1)  # not spent
-        await store.add_coin_record(record_2)  # not spent
-        await store.add_coin_record(record_5)  # spent
-        await store.add_coin_record(record_8)  # spent
-
-        records = await store.get_coin_records_between(1, 0, 0)
-        assert len(records) == 0
-        records = await store.get_coin_records_between(1, 0, 3)
-        assert len(records) == 1
-        assert records[0] == record_5
-        records = await store.get_coin_records_between(1, 0, 4, coin_type=CoinType.CLAWBACK)
-        assert len(records) == 1
-        assert records[0] == record_8
-
-
-@pytest.mark.asyncio
 async def test_delete_wallet() -> None:
     dummy_records = DummyWalletCoinRecords()
     for i in range(5):

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -208,44 +208,6 @@ async def test_set_spent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_unspent_coins_for_wallet() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        assert await store.get_unspent_coins_for_wallet(1) == set()
-
-        await store.add_coin_record(record_4)  # this is spent and wallet 0
-        await store.add_coin_record(record_5)  # wallet 1
-        await store.add_coin_record(record_6)  # this is spent and wallet 2
-        await store.add_coin_record(record_7)  # wallet 2
-        await store.add_coin_record(record_8)
-
-        assert await store.get_unspent_coins_for_wallet(1) == set([record_5])
-        assert await store.get_unspent_coins_for_wallet(2) == set([record_7])
-        assert await store.get_unspent_coins_for_wallet(3) == set()
-
-        await store.set_spent(coin_4.name(), uint32(12))
-
-        assert await store.get_unspent_coins_for_wallet(1) == set([record_5])
-        assert await store.get_unspent_coins_for_wallet(2) == set([record_7])
-        assert await store.get_unspent_coins_for_wallet(3) == set()
-
-        await store.set_spent(coin_7.name(), uint32(12))
-
-        assert await store.get_unspent_coins_for_wallet(1) == set([record_5])
-        assert await store.get_unspent_coins_for_wallet(2) == set()
-        assert await store.get_unspent_coins_for_wallet(3) == set()
-
-        await store.set_spent(coin_5.name(), uint32(12))
-
-        assert await store.get_unspent_coins_for_wallet(1) == set()
-        assert await store.get_unspent_coins_for_wallet(2) == set()
-        assert await store.get_unspent_coins_for_wallet(3) == set()
-
-        assert await store.get_unspent_coins_for_wallet(1, coin_type=CoinType.CLAWBACK) == set([record_8])
-
-
-@pytest.mark.asyncio
 async def test_get_all_unspent_coins() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)

--- a/tests/wallet/test_wallet_coin_store.py
+++ b/tests/wallet/test_wallet_coin_store.py
@@ -302,28 +302,6 @@ async def test_get_all_unspent_coins() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_records_by_parent_id() -> None:
-    async with DBConnection(1) as db_wrapper:
-        store = await WalletCoinStore.create(db_wrapper)
-
-        await store.add_coin_record(record_1)
-        await store.add_coin_record(record_2)
-        await store.add_coin_record(record_3)
-        await store.add_coin_record(record_4)
-        await store.add_coin_record(record_5)
-        await store.add_coin_record(record_6)
-        await store.add_coin_record(record_7)
-
-        assert set(await store.get_coin_records_by_parent_id(coin_1.parent_coin_info)) == set([record_1, record_2])
-        assert set(await store.get_coin_records_by_parent_id(coin_2.parent_coin_info)) == set([record_1, record_2])
-        assert await store.get_coin_records_by_parent_id(coin_3.parent_coin_info) == [record_3]
-        assert await store.get_coin_records_by_parent_id(coin_4.parent_coin_info) == [record_4]
-        assert await store.get_coin_records_by_parent_id(coin_5.parent_coin_info) == [record_5]
-        assert await store.get_coin_records_by_parent_id(coin_6.parent_coin_info) == [record_6]
-        assert await store.get_coin_records_by_parent_id(coin_7.parent_coin_info) == [record_7]
-
-
-@pytest.mark.asyncio
 async def test_delete_coin_record() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This drops a bunch of use case specific methods in the coin store and the related tests, commit by commit, and uses `WalletCoinStore.get_coin_records` with the relevant parameters instead. There might be arguments to keep the specific methods for readability but i think since `get_coin_records` enables to remove them while still being pretty reasonable to read/understand the code it's a good thing to do, to have some less methods/tests to maintain. 

### New Behavior:

No change in behaviour.