### PR TITLE
Pass VC fee parameter all the way through and check balances in tests

### DIFF
--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -160,6 +160,7 @@ class VCWallet:
             provider_did,
             inner_puzzle_hash,
             [inner_puzzle_hash],
+            fee=fee,
         )
         solution = solution_for_conditions(dpuz.rest())
         original_puzzle = await self.standard_wallet.puzzle_for_puzzle_hash(original_coin.puzzle_hash)

--- a/tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/tests/wallet/vc_wallet/test_vc_wallet.py
@@ -6,7 +6,7 @@ import pytest
 
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.simulator.full_node_simulator import FullNodeSimulator
-from chia.simulator.time_out_assert import time_out_assert_not_none
+from chia.simulator.time_out_assert import time_out_assert, time_out_assert_not_none
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
@@ -30,6 +30,7 @@ async def test_vc_lifecycle(self_hostname: str, two_wallet_nodes_services: Any, 
     wallet_node_0 = wallet_service_0._node
     wallet_node_1 = wallet_service_1._node
     wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
+    wallet_1 = wallet_node_1.wallet_state_manager.main_wallet  # just to farm to for processing TXs
 
     client_0 = await WalletRpcClient.create(
         bt.config["self_hostname"],
@@ -52,21 +53,27 @@ async def test_vc_lifecycle(self_hostname: str, two_wallet_nodes_services: Any, 
     await wallet_node_0.server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await wallet_node_1.server.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
     await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+    confirmed_balance: int = await wallet_0.get_confirmed_balance()
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
         wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
     )
+    confirmed_balance -= 1
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
 
     spend_bundle = spend_bundle_list[0].spend_bundle
     assert spend_bundle
     await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
 
-    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
+    await time_out_assert(15, wallet_0.get_confirmed_balance, confirmed_balance)
     did_id = bytes32.from_hexstr(did_wallet.get_my_DID())
-    vc_record, txs = await client_0.vc_mint(did_id, target_address=await wallet_0.get_new_puzzlehash())
+    vc_record, txs = await client_0.vc_mint(did_id, target_address=await wallet_0.get_new_puzzlehash(), fee=uint64(200))
+    confirmed_balance -= 1
+    confirmed_balance -= 200
     spend_bundle = next(tx.spend_bundle for tx in txs if tx.spend_bundle is not None)
     await time_out_assert_not_none(30, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
-    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
+    await time_out_assert(15, wallet_0.get_confirmed_balance, confirmed_balance)
     vc_wallet = await wallet_node_0.wallet_state_manager.get_all_wallet_info_entries(wallet_type=WalletType.VC)
     assert len(vc_wallet) == 1
     new_vc_record: Optional[VCRecord] = await client_0.vc_get(vc_record.vc.launcher_id)
@@ -81,9 +88,11 @@ async def test_vc_lifecycle(self_hostname: str, two_wallet_nodes_services: Any, 
         new_proof_hash=proof_root,
         fee=uint64(100),
     )
+    confirmed_balance -= 100
     spend_bundle = next(tx.spend_bundle for tx in txs if tx.spend_bundle is not None)
     await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
-    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
+    await time_out_assert(15, wallet_0.get_confirmed_balance, confirmed_balance)
     vc_record_updated: Optional[VCRecord] = await client_0.vc_get(vc_record.vc.launcher_id)
     assert vc_record_updated is not None
     assert vc_record_updated.vc.proof_hash == proof_root
@@ -92,7 +101,8 @@ async def test_vc_lifecycle(self_hostname: str, two_wallet_nodes_services: Any, 
     txs = await client_0.vc_spend(vc_record.vc.launcher_id)
     spend_bundle = next(tx.spend_bundle for tx in txs if tx.spend_bundle is not None)
     await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
-    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
+    await time_out_assert(15, wallet_0.get_confirmed_balance, confirmed_balance)
     vc_record_updated = await client_0.vc_get(vc_record.vc.launcher_id)
     assert vc_record_updated is not None
 
@@ -105,9 +115,11 @@ async def test_vc_lifecycle(self_hostname: str, two_wallet_nodes_services: Any, 
 
     # Revoke VC
     txs = await client_0.vc_revoke(vc_record_updated.vc.coin.parent_coin_info, uint64(1))
+    confirmed_balance -= 1
     spend_bundle = next(tx.spend_bundle for tx in txs if tx.spend_bundle is not None)
     await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle.name())
-    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_0)
+    await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
+    await time_out_assert(15, wallet_0.get_confirmed_balance, confirmed_balance)
     vc_record_revoked: Optional[VCRecord] = await client_0.vc_get(vc_record.vc.launcher_id)
     assert vc_record_revoked is None
     assert (


### PR DESCRIPTION
The fee for VC minting wasn't being properly passed through to the drivers from the wallet.  This PR fixes that as well as adds better balance checks throughout the vc wallet tests.