### PR TITLE
Decorrelate forwards_compat and reuse_puzhash from trade test params

### DIFF
--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -35,12 +35,12 @@ buffer_blocks = 4
 class TestCATTrades:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "forwards_compat",
-        [True, False],
-    )
-    @pytest.mark.parametrize(
-        "reuse_puzhash",
-        [True, False],
+        "forwards_compat,reuse_puzhash",
+        [
+            (True, False),
+            (False, True),
+            (False, False),
+        ],
     )
     async def test_cat_trades(
         self, wallets_prefarm, forwards_compat: bool, reuse_puzhash: bool, softfork_height: uint32
@@ -165,7 +165,7 @@ class TestCATTrades:
             old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer),
             peer,
             fee=uint64(1),
-            reuse_puzhash=reuse_puzhash and not forwards_compat,
+            reuse_puzhash=reuse_puzhash,
         )
         assert trade_take is not None
         assert tx_records is not None
@@ -332,7 +332,7 @@ class TestCATTrades:
         trade_take, tx_records = await trade_manager_taker.respond_to_offer(
             old_maker_offer if forwards_compat else Offer.from_bytes(trade_make.offer),
             peer,
-            reuse_puzhash=reuse_puzhash and not forwards_compat,
+            reuse_puzhash=reuse_puzhash,
         )
         await time_out_assert(15, full_node.txs_in_mempool, True, tx_records)
         assert trade_take is not None


### PR DESCRIPTION
These two parameters were being semantically de correlated in the tests, which resulted in an extra test run of the exact same (essentially) parameters.  This eliminates one combination of parameters.