### PR TITLE
Fix flaky VC test

### DIFF
--- a/tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/tests/wallet/vc_wallet/test_vc_wallet.py
@@ -109,9 +109,10 @@ async def test_vc_lifecycle(self_hostname: str, two_wallet_nodes_services: Any, 
         parent_id: bytes32, client: WalletRpcClient, launcher_id: bytes32
     ) -> Optional[Literal[True]]:
         vc_record = await client.vc_get(launcher_id)
+        result: Optional[Literal[True]] = None
         if vc_record is not None:
-            return True if vc_record.vc.coin.parent_coin_info == parent_id else None
-        return None
+            result = True if vc_record.vc.coin.parent_coin_info == parent_id else None
+        return result
 
     await time_out_assert_not_none(
         10, check_vc_record_has_parent_id, vc_record_updated.vc.coin.name(), client_0, vc_record.vc.launcher_id

--- a/tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/tests/wallet/vc_wallet/test_vc_wallet.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 import pytest
+from typing_extensions import Literal
 
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.simulator.full_node_simulator import FullNodeSimulator


### PR DESCRIPTION
Occasionally, the revocation was happening before the next VC was confirmed on chain.