### PR TITLE
hardcode `num` param when listing NFTs from CLI

### DIFF
--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -914,7 +914,7 @@ class WalletRpcClient(RpcClient):
         return response
 
     async def list_nfts(self, wallet_id):
-        request: Dict[str, Any] = {"wallet_id": wallet_id}
+        request: Dict[str, Any] = {"wallet_id": wallet_id, "num": 100_000}
         response = await self.fetch("nft_get_nfts", request)
         return response
 


### PR DESCRIPTION
### Purpose:
Temporarily address the cap of 50 NFTs displayed when listing NFTs using the CLI (i.e. `chia wallet nft list -i <wallet_id>`). A subsequent set of changes will improve the CLI options to include pagination parameters.


### Current Behavior:
Only the first 50 NFTs will be displayed by the CLI when using `chia wallet nft list -i <wallet_id>`


### New Behavior:
This change hardcodes the `"num"` param to `100_000` when the CLI calls the `nft_get_nfts` RPC


### Testing Notes:
Manually tested by temporarily changing the default value of 50 to something much smaller and ensuring that the listing includes all NFTs.
