### PR TITLE
Improve help text for deprecated 'chia show' commands.

### DIFF
--- a/chia/cmds/show.py
+++ b/chia/cmds/show.py
@@ -52,11 +52,11 @@ def show_cmd(
     import asyncio
 
     if connections:
-        print("'chia show -c' has been renamed to 'chia peer -c' ")
+        print("'chia show -c' has been renamed to 'chia peer full_node -c' ")
     if add_connection != "":
-        print("'chia show -a' has been renamed to 'chia peer -a' ")
+        print("'chia show -a' has been renamed to 'chia peer full_node -a' ")
     if remove_connection != "":
-        print("'chia show -r' has been renamed to 'chia peer -r' ")
+        print("'chia show -r' has been renamed to 'chia peer full_node -r' ")
     if wallet_rpc_port is not None:
         print("'chia show -wp' is not used, please remove it from your command.")
     asyncio.run(


### PR DESCRIPTION
### Purpose:

Improve help text provided by deprecated `chia show` commands.
Current text suggests running a command which also results in error.
We should suggest a command equivalent to the deprecated command the user ran. 

### Current Behavior:

```
$ chia show -c
'chia show -c' has been renamed to 'chia peer -c' 
$ chia peer -c
Usage: chia peer [OPTIONS]
                 {farmer|wallet|full_node|harvester|data_layer|simulator}
Try 'chia peer -h' for help.

Error: Missing argument '{farmer|wallet|full_node|harvester|data_layer|simulator}'. Choose from:
	farmer,
	wallet,
	full_node,
	harvester,
	data_layer,
	simulator
```

### New Behavior:

```
$ chia show -c
'chia show -c' has been renamed to 'chia peer full_node -c' 
$ chia peer full_node -c
<...snip...command works...>
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

