### PR TITLE
Fork infrastructure

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -480,9 +480,7 @@ async def validate_block_body(
     pairs_msgs: List[bytes] = []
     if npc_result:
         assert npc_result.conds is not None
-        pairs_pks, pairs_msgs = pkm_pairs(
-            npc_result.conds, constants.AGG_SIG_ME_ADDITIONAL_DATA, soft_fork=height >= constants.SOFT_FORK_HEIGHT
-        )
+        pairs_pks, pairs_msgs = pkm_pairs(npc_result.conds, constants.AGG_SIG_ME_ADDITIONAL_DATA)
 
     # 22. Verify aggregated signature
     # TODO: move this to pre_validate_blocks_multiprocessing so we can sync faster

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -66,6 +66,18 @@ class ConsensusConstants:
     # soft fork initiated in 1.8.0 release
     SOFT_FORK2_HEIGHT: uint32
 
+    # soft fork initiated in 2.0 release
+    SOFT_FORK3_HEIGHT: uint32
+
+    # the hard fork planned with the 2.0 release
+    # this is the block with the first plot filter adjustment
+    HARD_FORK_HEIGHT: uint32
+
+    # the plot filter adjustment heights
+    PLOT_FILTER_128_HEIGHT: uint32
+    PLOT_FILTER_64_HEIGHT: uint32
+    PLOT_FILTER_32_HEIGHT: uint32
+
     def replace(self, **changes: object) -> "ConsensusConstants":
         return dataclasses.replace(self, **changes)
 

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -62,8 +62,6 @@ class ConsensusConstants:
     MAX_GENERATOR_SIZE: uint32
     MAX_GENERATOR_REF_LIST_SIZE: uint32
     POOL_SUB_SLOT_ITERS: uint64
-    # soft fork initiated in 1.7.0 release
-    SOFT_FORK_HEIGHT: uint32
 
     # soft fork initiated in 1.8.0 release
     SOFT_FORK2_HEIGHT: uint32

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -57,6 +57,16 @@ default_kwargs = {
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
     "SOFT_FORK2_HEIGHT": 3886635,
+    # Spetember 2023
+    "SOFT_FORK3_HEIGHT": 4200000,
+    # June 2024
+    "HARD_FORK_HEIGHT": 5496000,
+    # June 2027
+    "PLOT_FILTER_128_HEIGHT": 10542000,
+    # June 2030
+    "PLOT_FILTER_64_HEIGHT": 15592000,
+    # June 2033
+    "PLOT_FILTER_32_HEIGHT": 20643000,
 }
 
 

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -56,7 +56,6 @@ default_kwargs = {
     "MAX_GENERATOR_SIZE": 1000000,
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
-    "SOFT_FORK_HEIGHT": 3630000,
     "SOFT_FORK2_HEIGHT": 3886635,
 }
 

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -122,11 +122,7 @@ def batch_pre_validate_blocks(
                     if validate_signatures:
                         if npc_result is not None and block.transactions_info is not None:
                             assert npc_result.conds
-                            pairs_pks, pairs_msgs = pkm_pairs(
-                                npc_result.conds,
-                                constants.AGG_SIG_ME_ADDITIONAL_DATA,
-                                soft_fork=block.height >= constants.SOFT_FORK_HEIGHT,
-                            )
+                            pairs_pks, pairs_msgs = pkm_pairs(npc_result.conds, constants.AGG_SIG_ME_ADDITIONAL_DATA)
                             # Using AugSchemeMPL.aggregate_verify, so it's safe to use from_bytes_unchecked
                             pks_objects: List[G1Element] = [G1Element.from_bytes_unchecked(pk) for pk in pairs_pks]
                             if not AugSchemeMPL.aggregate_verify(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1879,11 +1879,7 @@ class FullNode:
             # blockchain.run_generator throws on errors, so npc_result is
             # guaranteed to represent a successful run
             assert npc_result.conds is not None
-            pairs_pks, pairs_msgs = pkm_pairs(
-                npc_result.conds,
-                self.constants.AGG_SIG_ME_ADDITIONAL_DATA,
-                soft_fork=height >= self.constants.SOFT_FORK_HEIGHT,
-            )
+            pairs_pks, pairs_msgs = pkm_pairs(npc_result.conds, self.constants.AGG_SIG_ME_ADDITIONAL_DATA)
             if not cached_bls.aggregate_verify(
                 pairs_pks, pairs_msgs, block.transactions_info.aggregated_signature, True
             ):

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -40,10 +40,8 @@ def get_name_puzzle_conditions(
 ) -> NPCResult:
     if mempool_mode:
         flags = MEMPOOL_MODE
-    elif height >= constants.SOFT_FORK_HEIGHT:
-        flags = LIMIT_STACK
     else:
-        flags = 0
+        flags = LIMIT_STACK
 
     if height >= constants.SOFT_FORK2_HEIGHT:
         flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -76,7 +76,7 @@ def validate_clvm_and_signature(
         pks: List[bytes48] = []
         msgs: List[bytes] = []
         assert result.conds is not None
-        pks, msgs = pkm_pairs(result.conds, additional_data, soft_fork=True)
+        pks, msgs = pkm_pairs(result.conds, additional_data)
 
         # Verify aggregated signature
         cache: LRUCache[bytes32, GTElement] = LRUCache(10000)

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -77,8 +77,6 @@ async def async_main(service_config: Dict[str, Any]) -> int:
         # activate softforks immediately on testnet
         if "SOFT_FORK2_HEIGHT" not in overrides:
             overrides["SOFT_FORK2_HEIGHT"] = 0
-        if "SOFT_FORK_HEIGHT" not in overrides:
-            overrides["SOFT_FORK_HEIGHT"] = 0
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
     initialize_service_logging(service_name=SERVICE_NAME, config=config)
     service = create_full_node_service(DEFAULT_ROOT_PATH, config, updated_constants)

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -55,15 +55,13 @@ def parse_sexp_to_conditions(sexp: Program) -> List[ConditionWithArgs]:
     return [parse_sexp_to_condition(s) for s in sexp.as_iter()]
 
 
-def pkm_pairs(
-    conditions: SpendBundleConditions, additional_data: bytes, *, soft_fork: bool
-) -> Tuple[List[bytes48], List[bytes]]:
+def pkm_pairs(conditions: SpendBundleConditions, additional_data: bytes) -> Tuple[List[bytes48], List[bytes]]:
     ret: Tuple[List[bytes48], List[bytes]] = ([], [])
 
     for pk, msg in conditions.agg_sig_unsafe:
         ret[0].append(bytes48(pk))
         ret[1].append(msg)
-        if soft_fork and msg.endswith(additional_data):
+        if msg.endswith(additional_data):
             raise ConsensusError(Err.INVALID_CONDITION)
 
     for spend in conditions.spends:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -71,7 +71,6 @@ network_overrides: &network_overrides
       GENESIS_PRE_FARM_POOL_PUZZLE_HASH: d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
-      SOFT_FORK_HEIGHT: 0
       SOFT_FORK2_HEIGHT: 0
   config:
     mainnet:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def db_version(request) -> int:
     return request.param
 
 
-@pytest.fixture(scope="function", params=[1000000, 3630000, 3886635])
+@pytest.fixture(scope="function", params=[1000000, 3886635])
 def softfork_height(request) -> int:
     return request.param
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def db_version(request) -> int:
     return request.param
 
 
-@pytest.fixture(scope="function", params=[1000000, 3886635])
+@pytest.fixture(scope="function", params=[1000000, 3886635, 4200000, 5496000])
 def softfork_height(request) -> int:
     return request.param
 

--- a/tools/analyze-chain.py
+++ b/tools/analyze-chain.py
@@ -140,7 +140,7 @@ def default_call(
         # create hash_key list for aggsig check
         pairs_pks: List[bytes48] = []
         pairs_msgs: List[bytes] = []
-        pairs_pks, pairs_msgs = pkm_pairs(result, DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA, soft_fork=False)
+        pairs_pks, pairs_msgs = pkm_pairs(result, DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
         pairs_g1s = [G1Element.from_bytes(x) for x in pairs_pks]
         assert block.transactions_info is not None
         assert block.transactions_info.aggregated_signature is not None


### PR DESCRIPTION
These commits are best reviewed one at a time.

These two commits:
1. Removes the soft-fork logic for the 1.7-soft fork (which has activated on mainnet)
2. Adds the constants for the next soft fork (soft_fork3) as well as the 2.0 hard fork and plot filter adjustment heights.

This patch does not implement any of the soft-forks or hard forks behavior, they will be separate PRs. But since multiple people coordinate on these constants, it makes sense to land them separately, first.