### PR TITLE
Add reorg rollback to retry store

### DIFF
--- a/chia/wallet/wallet_retry_store.py
+++ b/chia/wallet/wallet_retry_store.py
@@ -55,3 +55,16 @@ class WalletRetryStore:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             cursor = await conn.execute("DELETE FROM retry_store where coin_state=?", (bytes(state),))
             await cursor.close()
+
+    async def rollback_to_block(self, height: int) -> None:
+        """
+        Delete all ignored states above a certain height
+        :param height: Reorg height
+        :return None:
+        """
+        async with self.db_wrapper.writer_maybe_transaction() as conn:
+            cursor = await conn.execute(
+                "DELETE from retry_store WHERE fork_height>?",
+                (height,),
+            )
+            await cursor.close()

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1649,6 +1649,7 @@ class WalletStateManager:
         Rolls back and updates the coin_store and transaction store. It's possible this height
         is the tip, or even beyond the tip.
         """
+        await self.retry_store.rollback_to_block(height)
         await self.nft_store.rollback_to_block(height)
         await self.coin_store.rollback_to_block(height)
         reorged: List[TransactionRecord] = await self.tx_store.get_transaction_above(height)


### PR DESCRIPTION
We don't need to retry states that are reorged and doing so will likely end up with some issues.