### PR TITLE
Rename method to clarify that it takes a list of amounts and a list of puzzle hashes

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -617,7 +617,7 @@ class DataLayerWallet:
 
         return txs
 
-    async def generate_signed_transaction(
+    async def generate_signed_transactions(
         self,
         amounts: List[uint64],
         puzzle_hashes: List[bytes32],
@@ -1146,7 +1146,7 @@ class DataLayerWallet:
                 this_solver = solver["0x" + launcher.hex()]
             new_root: bytes32 = this_solver["new_root"]
             new_ph: bytes32 = await wallet_state_manager.main_wallet.get_new_puzzlehash()
-            txs: List[TransactionRecord] = await dl_wallet.generate_signed_transaction(
+            txs: List[TransactionRecord] = await dl_wallet.generate_signed_transactions(
                 [uint64(1)],
                 [new_ph],
                 fee=fee_left_to_pay,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1475,7 +1475,7 @@ class WalletRpcApi:
                 )
         if hold_lock:
             async with self.service.wallet_state_manager.lock:
-                txs: List[TransactionRecord] = await wallet.generate_signed_transaction(
+                txs: List[TransactionRecord] = await wallet.generate_signed_transactions(
                     amounts,
                     puzzle_hashes,
                     fee,
@@ -1491,7 +1491,7 @@ class WalletRpcApi:
                 for tx in txs:
                     await wallet.standard_wallet.push_transaction(tx)
         else:
-            txs = await wallet.generate_signed_transaction(
+            txs = await wallet.generate_signed_transactions(
                 amounts,
                 puzzle_hashes,
                 fee,
@@ -2985,7 +2985,7 @@ class WalletRpcApi:
             else:
                 assert isinstance(wallet, CATWallet)
 
-                txs = await wallet.generate_signed_transaction(
+                txs = await wallet.generate_signed_transactions(
                     [amount_0] + [output.amount for output in additional_outputs],
                     [bytes32(puzzle_hash_0)] + [output.puzzle_hash for output in additional_outputs],
                     fee,

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -288,7 +288,7 @@ class CATWallet:
         spendable.sort(reverse=True, key=lambda record: record.coin.amount)
         if self.cost_of_single_tx is None:
             coin = spendable[0].coin
-            txs = await self.generate_signed_transaction(
+            txs = await self.generate_signed_transactions(
                 [uint64(coin.amount)], [coin.puzzle_hash], coins={coin}, ignore_max_send_amount=True
             )
             assert txs[0].spend_bundle
@@ -794,7 +794,7 @@ class CATWallet:
             chia_tx,
         )
 
-    async def generate_signed_transaction(
+    async def generate_signed_transactions(
         self,
         amounts: List[uint64],
         puzzle_hashes: List[bytes32],

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -960,7 +960,7 @@ class NFTWallet:
                     txs = [tx]
                 elif asset not in fungible_asset_dict:
                     assert asset is not None
-                    txs = await wallet.generate_signed_transaction(
+                    txs = await wallet.generate_signed_transactions(
                         [abs(amount)],
                         [DESIRED_OFFER_MOD_HASH],
                         fee=fee_left_to_pay,
@@ -974,7 +974,7 @@ class NFTWallet:
                     )
                 else:
                     payments = royalty_payments[asset] if asset in royalty_payments else []
-                    txs = await wallet.generate_signed_transaction(
+                    txs = await wallet.generate_signed_transactions(
                         [abs(amount), sum(p.amount for _, p in payments)],
                         [DESIRED_OFFER_MOD_HASH, DESIRED_OFFER_MOD_HASH],
                         fee=fee_left_to_pay,

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -261,7 +261,7 @@ class TradeManager:
                 all_txs.append(tx)
             else:
                 # ATTENTION: new_wallets
-                txs = await wallet.generate_signed_transaction(
+                txs = await wallet.generate_signed_transactions(
                     [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
                 )
                 all_txs.extend(txs)
@@ -342,7 +342,7 @@ class TradeManager:
                         all_txs.append(dataclasses.replace(tx, spend_bundle=None))
                 else:
                     # ATTENTION: new_wallets
-                    txs = await wallet.generate_signed_transaction(
+                    txs = await wallet.generate_signed_transactions(
                         [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
                     )
                     for tx in txs:
@@ -581,7 +581,7 @@ class TradeManager:
                     # This is to generate the tx for specific nft assets, i.e. not using
                     # wallet_id as the selector which would select any coins from nft_wallet
                     amounts = [coin.amount for coin in selected_coins]
-                    txs = await wallet.generate_signed_transaction(
+                    txs = await wallet.generate_signed_transactions(
                         # [abs(offer_dict[id])],
                         amounts,
                         [OFFER_MOD_OLD_HASH if old else Offer.ph()],
@@ -593,7 +593,7 @@ class TradeManager:
                     all_transactions.extend(txs)
                 else:
                     # ATTENTION: new_wallets
-                    txs = await wallet.generate_signed_transaction(
+                    txs = await wallet.generate_signed_transactions(
                         [abs(offer_dict[id])],
                         [OFFER_MOD_OLD_HASH if old else Offer.ph()],
                         fee=fee_left_to_pay,

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -204,7 +204,7 @@ class TestCATWallet:
         assert cat_wallet.cat_info.limitations_program_hash == cat_wallet_2.cat_info.limitations_program_hash
 
         cat_2_hash = await cat_wallet_2.get_new_inner_hash()
-        tx_records = await cat_wallet.generate_signed_transaction([uint64(60)], [cat_2_hash], fee=uint64(1))
+        tx_records = await cat_wallet.generate_signed_transactions([uint64(60)], [cat_2_hash], fee=uint64(1))
         tx_id = None
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
@@ -237,7 +237,7 @@ class TestCATWallet:
         assert len(memos[tx_id]) == 2
         assert list(memos[tx_id].values())[0][0] == cat_2_hash.hex()
         cat_hash = await cat_wallet.get_new_inner_hash()
-        tx_records = await cat_wallet_2.generate_signed_transaction([uint64(15)], [cat_hash])
+        tx_records = await cat_wallet_2.generate_signed_transactions([uint64(15)], [cat_hash])
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
 
@@ -311,7 +311,7 @@ class TestCATWallet:
         assert cat_wallet.cat_info.limitations_program_hash == cat_wallet_2.cat_info.limitations_program_hash
 
         cat_2_hash = await cat_wallet_2.get_new_inner_hash()
-        tx_records = await cat_wallet.generate_signed_transaction(
+        tx_records = await cat_wallet.generate_signed_transactions(
             [uint64(60)], [cat_2_hash], fee=uint64(1), reuse_puzhash=True
         )
         for tx_record in tx_records:
@@ -341,7 +341,7 @@ class TestCATWallet:
         await time_out_assert(30, cat_wallet_2.get_unconfirmed_balance, 60)
 
         cat_hash = await cat_wallet.get_new_inner_hash()
-        tx_records = await cat_wallet_2.generate_signed_transaction([uint64(15)], [cat_hash])
+        tx_records = await cat_wallet_2.generate_signed_transactions([uint64(15)], [cat_hash])
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
 
@@ -467,7 +467,7 @@ class TestCATWallet:
         assert cat_wallet.cat_info.limitations_program_hash == cat_wallet_2.cat_info.limitations_program_hash
 
         cat_2_hash = await cat_wallet_2.get_new_inner_hash()
-        tx_records = await cat_wallet.generate_signed_transaction([uint64(60)], [cat_2_hash], fee=uint64(1))
+        tx_records = await cat_wallet.generate_signed_transactions([uint64(60)], [cat_2_hash], fee=uint64(1))
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
         await full_node_api.process_transaction_records(records=tx_records)
@@ -482,7 +482,7 @@ class TestCATWallet:
         await time_out_assert(20, cat_wallet_2.get_unconfirmed_balance, 60)
 
         cc2_ph = await cat_wallet_2.get_new_cat_puzzle_hash()
-        tx_record = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(10, cc2_ph, 0)
+        tx_record = await wallet.wallet_state_manager.main_wallet.generate_signed_transactions(10, cc2_ph, 0)
         await wallet.wallet_state_manager.add_pending_transaction(tx_record)
         await full_node_api.process_transaction_records(records=[tx_record])
 
@@ -564,7 +564,7 @@ class TestCATWallet:
         cat_1_hash = await cat_wallet_1.get_new_inner_hash()
         cat_2_hash = await cat_wallet_2.get_new_inner_hash()
 
-        tx_records = await cat_wallet_0.generate_signed_transaction([uint64(60), uint64(20)], [cat_1_hash, cat_2_hash])
+        tx_records = await cat_wallet_0.generate_signed_transactions([uint64(60), uint64(20)], [cat_1_hash, cat_2_hash])
         for tx_record in tx_records:
             await wallet_0.wallet_state_manager.add_pending_transaction(tx_record)
         await full_node_api.process_transaction_records(records=tx_records)
@@ -580,11 +580,11 @@ class TestCATWallet:
 
         cat_hash = await cat_wallet_0.get_new_inner_hash()
 
-        tx_records = await cat_wallet_1.generate_signed_transaction([uint64(15)], [cat_hash])
+        tx_records = await cat_wallet_1.generate_signed_transactions([uint64(15)], [cat_hash])
         for tx_record in tx_records:
             await wallet_1.wallet_state_manager.add_pending_transaction(tx_record)
 
-        tx_records_2 = await cat_wallet_2.generate_signed_transaction([uint64(20)], [cat_hash])
+        tx_records_2 = await cat_wallet_2.generate_signed_transactions([uint64(20)], [cat_hash])
         for tx_record in tx_records_2:
             await wallet_2.wallet_state_manager.add_pending_transaction(tx_record)
 
@@ -602,11 +602,11 @@ class TestCATWallet:
         txs = await wallet_1.wallet_state_manager.tx_store.get_transactions_between(cat_wallet_1.id(), 0, 100000)
         print(len(txs))
         # Test with Memo
-        tx_records_3: TransactionRecord = await cat_wallet_1.generate_signed_transaction(
+        tx_records_3: TransactionRecord = await cat_wallet_1.generate_signed_transactions(
             [uint64(30)], [cat_hash], memos=[[b"Markus Walburg"]]
         )
         with pytest.raises(ValueError):
-            await cat_wallet_1.generate_signed_transaction(
+            await cat_wallet_1.generate_signed_transactions(
                 [uint64(30)], [cat_hash], memos=[[b"too"], [b"many"], [b"memos"]]
             )
 
@@ -678,7 +678,7 @@ class TestCATWallet:
             amounts.append(uint64(i))
             puzzle_hashes.append(cat_2_hash)
         spent_coint = (await cat_wallet.get_cat_spendable_coins())[0].coin
-        tx_records = await cat_wallet.generate_signed_transaction(amounts, puzzle_hashes, coins={spent_coint})
+        tx_records = await cat_wallet.generate_signed_transactions(amounts, puzzle_hashes, coins={spent_coint})
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
         await full_node_api.process_transaction_records(records=tx_records)
@@ -704,7 +704,7 @@ class TestCATWallet:
         max_sent_amount = await cat_wallet.get_max_send_amount()
 
         # 1) Generate transaction that is under the limit
-        [transaction_record] = await cat_wallet.generate_signed_transaction(
+        [transaction_record] = await cat_wallet.generate_signed_transactions(
             [max_sent_amount - 1],
             [ph],
         )
@@ -712,7 +712,7 @@ class TestCATWallet:
         assert transaction_record.amount == uint64(max_sent_amount - 1)
 
         # 2) Generate transaction that is equal to limit
-        [transaction_record] = await cat_wallet.generate_signed_transaction(
+        [transaction_record] = await cat_wallet.generate_signed_transactions(
             [max_sent_amount],
             [ph],
         )
@@ -721,7 +721,7 @@ class TestCATWallet:
 
         # 3) Generate transaction that is greater than limit
         with pytest.raises(ValueError):
-            await cat_wallet.generate_signed_transaction(
+            await cat_wallet.generate_signed_transactions(
                 [max_sent_amount + 1],
                 [ph],
             )
@@ -782,7 +782,7 @@ class TestCATWallet:
         assert cat_wallet.cat_info.limitations_program_hash is not None
 
         cat_2_hash = await wallet2.get_new_puzzlehash()
-        tx_records = await cat_wallet.generate_signed_transaction([uint64(60)], [cat_2_hash], memos=[[cat_2_hash]])
+        tx_records = await cat_wallet.generate_signed_transactions([uint64(60)], [cat_2_hash], memos=[[cat_2_hash]])
 
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
@@ -812,7 +812,7 @@ class TestCATWallet:
         }
 
         # Then we send another transaction
-        tx_records = await cat_wallet.generate_signed_transaction([uint64(10)], [cat_2_hash], memos=[[cat_2_hash]])
+        tx_records = await cat_wallet.generate_signed_transactions([uint64(10)], [cat_2_hash], memos=[[cat_2_hash]])
 
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
@@ -831,7 +831,7 @@ class TestCATWallet:
         await time_out_assert(30, cat_wallet_2.get_unconfirmed_balance, 70)
 
         cat_hash = await cat_wallet.get_new_inner_hash()
-        tx_records = await cat_wallet_2.generate_signed_transaction([uint64(5)], [cat_hash])
+        tx_records = await cat_wallet_2.generate_signed_transactions([uint64(5)], [cat_hash])
         for tx_record in tx_records:
             await wallet.wallet_state_manager.add_pending_transaction(tx_record)
 

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -266,7 +266,7 @@ class TestDLWallet:
 
         new_root = MerkleTree([Program.to("root").get_tree_hash()]).calculate_root()
 
-        txs = await dl_wallet.generate_signed_transaction(
+        txs = await dl_wallet.generate_signed_transactions(
             [previous_record.lineage_proof.amount],
             [previous_record.inner_puzzle_hash],
             launcher_id=previous_record.launcher_id,
@@ -275,7 +275,7 @@ class TestDLWallet:
         )
         assert txs[0].spend_bundle is not None
         with pytest.raises(ValueError, match="is currently pending"):
-            await dl_wallet.generate_signed_transaction(
+            await dl_wallet.generate_signed_transactions(
                 [previous_record.lineage_proof.amount],
                 [previous_record.inner_puzzle_hash],
                 coins=set([txs[0].spend_bundle.removals()[0]]),

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -726,7 +726,7 @@ async def test_nft_offer_sell_nft_for_cat(
 
     ph_taker_cat_1 = await wallet_taker.get_new_puzzlehash()
     ph_taker_cat_2 = await wallet_taker.get_new_puzzlehash()
-    cat_tx_records = await cat_wallet_maker.generate_signed_transaction(
+    cat_tx_records = await cat_wallet_maker.generate_signed_transactions(
         [cats_to_trade, cats_to_trade], [ph_taker_cat_1, ph_taker_cat_2], memos=[[ph_taker_cat_1], [ph_taker_cat_2]]
     )
     for tx_record in cat_tx_records:
@@ -942,7 +942,7 @@ async def test_nft_offer_request_nft_for_cat(
         extra_change = cats_to_mint - (2 * cats_to_trade)
         amounts.append(uint64(extra_change))
         puzzle_hashes.append(ph_taker_cat_1)
-    cat_tx_records = await cat_wallet_maker.generate_signed_transaction(amounts, puzzle_hashes)
+    cat_tx_records = await cat_wallet_maker.generate_signed_transactions(amounts, puzzle_hashes)
     for tx_record in cat_tx_records:
         await wallet_maker.wallet_state_manager.add_pending_transaction(tx_record)
     await full_node_api.process_transaction_records(records=cat_tx_records)


### PR DESCRIPTION
No behaviour changes. Renamed method.

These two methods shared the name `generate_signed_transaction`

https://github.com/Chia-Network/chia-blockchain/blob/main/chia/wallet/cat_wallet/cat_wallet.py#L797

https://github.com/Chia-Network/chia-blockchain/blob/main/chia/wallet/wallet.py#L478
