### PR TITLE
wallet: Refactor `WalletStateManager.get_keys`

### DIFF
--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -504,11 +504,7 @@ class CATWallet:
             if args is not None:
                 _, _, inner_puzzle = args
                 puzzle_hash = inner_puzzle.get_tree_hash()
-                ret = await self.wallet_state_manager.get_keys(puzzle_hash)
-                if ret is None:
-                    # Abort signing the entire SpendBundle - sign all or none
-                    raise RuntimeError(f"Failed to get keys for puzzle_hash {puzzle_hash}")
-                pubkey, private = ret
+                private = await self.wallet_state_manager.get_private_key(puzzle_hash)
                 synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
                 conditions = conditions_dict_for_solution(
                     spend.puzzle_reveal.to_program(),

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1175,7 +1175,7 @@ class DIDWallet:
         if puzzle_args is not None:
             p2_puzzle, _, _, _, _ = puzzle_args
             puzzle_hash = p2_puzzle.get_tree_hash()
-            pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
+            private = await self.wallet_state_manager.get_private_key(puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
             synthetic_pk = synthetic_secret_key.get_g1()
             if is_hex:
@@ -1193,7 +1193,7 @@ class DIDWallet:
             if puzzle_args is not None:
                 p2_puzzle, _, _, _, _ = puzzle_args
                 puzzle_hash = p2_puzzle.get_tree_hash()
-                pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
+                private = await self.wallet_state_manager.get_private_key(puzzle_hash)
                 synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
                 conditions = conditions_dict_for_solution(
                     spend.puzzle_reveal.to_program(),

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -464,9 +464,8 @@ class NFTWallet:
                     self.log.debug("Found a NFT state layer to sign")
                     puzzle_hashes.append(uncurried_nft.p2_puzzle.get_tree_hash())
             for ph in puzzle_hashes:
-                keys = await self.wallet_state_manager.get_keys(ph)
-                assert keys
-                pks[bytes(keys[0])] = private = keys[1]
+                private = await self.wallet_state_manager.get_private_key(ph)
+                pks[bytes(private.get_g1())] = private
                 synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
                 synthetic_pk = synthetic_secret_key.get_g1()
                 pks[bytes(synthetic_pk)] = synthetic_secret_key
@@ -563,7 +562,7 @@ class NFTWallet:
         if uncurried_nft is not None:
             p2_puzzle = uncurried_nft.p2_puzzle
             puzzle_hash = p2_puzzle.get_tree_hash()
-            pubkey, private = await self.wallet_state_manager.get_keys(puzzle_hash)
+            private = await self.wallet_state_manager.get_private_key(puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
             synthetic_pk = synthetic_secret_key.get_g1()
             if is_hex:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -8,20 +8,7 @@ import traceback
 from contextlib import asynccontextmanager
 from pathlib import Path
 from secrets import token_bytes
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AsyncIterator,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Dict, Iterator, List, Optional, Set, Type, TypeVar
 
 import aiosqlite
 from blspy import G1Element, PrivateKey
@@ -275,17 +262,13 @@ class WalletStateManager:
     def get_public_key_unhardened(self, index: uint32) -> G1Element:
         return master_sk_to_wallet_sk_unhardened(self.private_key, index).get_g1()
 
-    async def get_keys(self, puzzle_hash: bytes32) -> Optional[Tuple[G1Element, PrivateKey]]:
+    async def get_private_key(self, puzzle_hash: bytes32) -> PrivateKey:
         record = await self.puzzle_store.record_for_puzzle_hash(puzzle_hash)
         if record is None:
-            raise ValueError(f"No key for this puzzlehash {puzzle_hash})")
+            raise ValueError(f"No key for puzzle hash: {puzzle_hash.hex()}")
         if record.hardened:
-            private = master_sk_to_wallet_sk(self.private_key, record.index)
-            pubkey = private.get_g1()
-            return pubkey, private
-        private = master_sk_to_wallet_sk_unhardened(self.private_key, record.index)
-        pubkey = private.get_g1()
-        return pubkey, private
+            return master_sk_to_wallet_sk(self.private_key, record.index)
+        return master_sk_to_wallet_sk_unhardened(self.private_key, record.index)
 
     def get_wallet(self, id: uint32, required_type: Type[TWalletType]) -> TWalletType:
         wallet = self.wallets[id]

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -58,13 +58,8 @@ class TestDIDWallet:
         ph0 = await wallet_0.get_new_puzzlehash()
         ph1 = await wallet_1.get_new_puzzlehash()
 
-        keys0 = await wallet_node_0.wallet_state_manager.get_keys(ph0)
-        keys1 = await wallet_node_1.wallet_state_manager.get_keys(ph1)
-        assert keys0
-        assert keys1
-        pk0, sk0 = keys0
-        pk1, sk1 = keys1
-        assert pk0 == pk1
+        sk0 = await wallet_node_0.wallet_state_manager.get_private_key(ph0)
+        sk1 = await wallet_node_1.wallet_state_manager.get_private_key(ph1)
         assert sk0 == sk1
 
         if trusted:
@@ -1152,13 +1147,8 @@ class TestDIDWallet:
         ph0 = await wallet_0.get_new_puzzlehash()
         ph1 = await wallet_1.get_new_puzzlehash()
 
-        keys0 = await wallet_node_0.wallet_state_manager.get_keys(ph0)
-        keys1 = await wallet_node_1.wallet_state_manager.get_keys(ph1)
-        assert keys0
-        assert keys1
-        pk0, sk0 = keys0
-        pk1, sk1 = keys1
-        assert pk0 == pk1
+        sk0 = await wallet_node_0.wallet_state_manager.get_private_key(ph0)
+        sk1 = await wallet_node_1.wallet_state_manager.get_private_key(ph1)
         assert sk0 == sk1
 
         if trusted:

--- a/tests/wallet/test_wallet_state_manager.py
+++ b/tests/wallet/test_wallet_state_manager.py
@@ -6,7 +6,11 @@ from typing import AsyncIterator
 import pytest
 
 from chia.simulator.setup_nodes import SimulatorsAndWallets
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32
+from chia.wallet.derivation_record import DerivationRecord
+from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
+from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_state_manager import WalletStateManager
 
 
@@ -44,3 +48,32 @@ async def test_set_sync_mode_exception(simulator_and_wallet: SimulatorsAndWallet
     _, [(wallet_node, _)], _ = simulator_and_wallet
     async with assert_sync_mode(wallet_node.wallet_state_manager, uint32(1)):
         raise Exception
+
+
+@pytest.mark.parametrize("hardened", [True, False])
+@pytest.mark.asyncio
+async def test_get_private_key(simulator_and_wallet: SimulatorsAndWallets, hardened: bool) -> None:
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wallet_state_manager: WalletStateManager = wallet_node.wallet_state_manager
+    derivation_index = uint32(10000)
+    conversion_method = master_sk_to_wallet_sk if hardened else master_sk_to_wallet_sk_unhardened
+    expected_private_key = conversion_method(wallet_state_manager.private_key, derivation_index)
+    record = DerivationRecord(
+        derivation_index,
+        bytes32(b"0" * 32),
+        expected_private_key.get_g1(),
+        WalletType.STANDARD_WALLET,
+        uint32(1),
+        hardened,
+    )
+    await wallet_state_manager.puzzle_store.add_derivation_paths([record])
+    assert await wallet_state_manager.get_private_key(record.puzzle_hash) == expected_private_key
+
+
+@pytest.mark.asyncio
+async def test_get_private_key_failure(simulator_and_wallet: SimulatorsAndWallets) -> None:
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wallet_state_manager: WalletStateManager = wallet_node.wallet_state_manager
+    invalid_puzzle_hash = bytes32(b"1" * 32)
+    with pytest.raises(ValueError, match=f"No key for puzzle hash: {invalid_puzzle_hash.hex()}"):
+        await wallet_state_manager.get_private_key(bytes32(b"1" * 32))


### PR DESCRIPTION
### Purpose:

Implicitly fixes hinting because the function didn't return `Optional` in preparation for a "Fix `Wallet` mypy" PR and get rid of the tuple return which isn't really needed because we only use the public key in one place where we can just calculate it instead (which happens currently even in two places in the method itself). 

### New Behavior:

No change in behaviour.