### PR TITLE
wallet: Hint `wallet.py`

### DIFF
--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -48,6 +48,7 @@ from chia.wallet.wallet_info import WalletInfo
 
 if TYPE_CHECKING:
     from chia.server.ws_connection import WSChiaConnection
+    from chia.wallet.wallet_state_manager import WalletStateManager
 
 # https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md#signmessage
 CHIP_0002_SIGN_MESSAGE_PREFIX = "Chia Signed Message"
@@ -60,7 +61,7 @@ class Wallet:
         _protocol_check: ClassVar[WalletProtocol] = cast("Wallet", None)
 
     wallet_info: WalletInfo
-    wallet_state_manager: Any
+    wallet_state_manager: WalletStateManager
     log: logging.Logger
     wallet_id: uint32
     secret_key_store: SecretKeyStore
@@ -70,10 +71,10 @@ class Wallet:
     async def create(
         wallet_state_manager: Any,
         info: WalletInfo,
-        name: str = None,
-    ):
+        name: str = __name__,
+    ) -> Wallet:
         self = Wallet()
-        self.log = logging.getLogger(name if name else __name__)
+        self.log = logging.getLogger(name)
         self.wallet_state_manager = wallet_state_manager
         self.wallet_id = info.id
         self.secret_key_store = SecretKeyStore()
@@ -226,7 +227,7 @@ class Wallet:
         puzzle_announcements: Optional[Set[bytes]] = None,
         puzzle_announcements_to_assert: Optional[Set[bytes32]] = None,
         magic_conditions: Optional[List[Any]] = None,
-        fee=0,
+        fee: uint64 = uint64(0),
     ) -> Program:
         assert fee >= 0
         condition_list = []
@@ -254,7 +255,7 @@ class Wallet:
     def add_condition_to_solution(self, condition: Program, solution: Program) -> Program:
         python_program = solution.as_python()
         python_program[1].append(condition)
-        return Program.to(python_program)
+        return cast(Program, Program.to(python_program))
 
     async def select_coins(
         self,
@@ -299,12 +300,12 @@ class Wallet:
         amount: uint64,
         newpuzzlehash: bytes32,
         fee: uint64 = uint64(0),
-        origin_id: bytes32 = None,
-        coins: Set[Coin] = None,
+        origin_id: Optional[bytes32] = None,
+        coins: Optional[Set[Coin]] = None,
         primaries_input: Optional[List[Payment]] = None,
         ignore_max_send_amount: bool = False,
-        coin_announcements_to_consume: Set[Announcement] = None,
-        puzzle_announcements_to_consume: Set[Announcement] = None,
+        coin_announcements_to_consume: Optional[Set[Announcement]] = None,
+        puzzle_announcements_to_consume: Optional[Set[Announcement]] = None,
         memos: Optional[List[bytes]] = None,
         negative_change_allowed: bool = False,
         min_coin_amount: Optional[uint64] = None,
@@ -463,12 +464,12 @@ class Wallet:
         amount: uint64,
         puzzle_hash: bytes32,
         fee: uint64 = uint64(0),
-        origin_id: bytes32 = None,
-        coins: Set[Coin] = None,
+        origin_id: Optional[bytes32] = None,
+        coins: Optional[Set[Coin]] = None,
         primaries: Optional[List[Payment]] = None,
         ignore_max_send_amount: bool = False,
-        coin_announcements_to_consume: Set[Announcement] = None,
-        puzzle_announcements_to_consume: Set[Announcement] = None,
+        coin_announcements_to_consume: Optional[Set[Announcement]] = None,
+        puzzle_announcements_to_consume: Optional[Set[Announcement]] = None,
         memos: Optional[List[bytes]] = None,
         negative_change_allowed: bool = False,
         min_coin_amount: Optional[uint64] = None,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -218,7 +218,7 @@ class WalletStateManager:
             AssetType.CAT: CATWallet,
         }
 
-        wallet = None
+        wallet: Optional[WalletProtocol] = None
         for wallet_info in await self.get_all_wallet_info_entries():
             wallet_type = WalletType(wallet_info.type)
             if wallet_type == WalletType.STANDARD_WALLET:

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -5,7 +5,6 @@ chia.cmds.start_funcs
 chia.cmds.wallet
 chia.cmds.wallet_funcs
 chia.daemon.server
-chia.data_layer.data_layer_wallet
 chia.introducer.introducer
 chia.introducer.introducer_api
 chia.plotters.bladebit
@@ -53,7 +52,6 @@ chia.util.profiler
 chia.util.service_groups
 chia.util.ssl_check
 chia.wallet.block_record
-chia.wallet.cat_wallet.cat_wallet
 chia.wallet.chialisp
 chia.wallet.did_wallet.did_wallet
 chia.wallet.did_wallet.did_wallet_puzzles
@@ -75,7 +73,6 @@ chia.wallet.trading.trade_store
 chia.wallet.transaction_record
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
-chia.wallet.wallet
 chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store
 chia.wallet.wallet_node_api


### PR DESCRIPTION
### Purpose:

More type hints.


Note that `chia.wallet.cat_wallet.cat_wallet` and `chia.data_layer.data_layer_wallet` are also dropped from the exclusions because they are implicitly fixed by this PR too.

### New Behavior:

No change in behaviour.

### Based on:

- #15361 
- #15422 