### PR TITLE
make sure tests that use BlockTools use a single source of consensus constants

### DIFF
--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -70,7 +70,7 @@ async def setup_two_nodes(
     """
 
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
-        bt1 = await create_block_tools_async(constants=test_constants, keychain=keychain1)
+        bt1 = await create_block_tools_async(constants=consensus_constants, keychain=keychain1)
         node_iters = [
             setup_full_node(
                 consensus_constants,
@@ -84,7 +84,7 @@ async def setup_two_nodes(
                 consensus_constants,
                 "blockchain_test_2.db",
                 self_hostname,
-                await create_block_tools_async(constants=test_constants, keychain=keychain2),
+                await create_block_tools_async(constants=consensus_constants, keychain=keychain2),
                 simulator=False,
                 db_version=db_version,
             ),
@@ -116,7 +116,7 @@ async def setup_n_nodes(
                 consensus_constants,
                 f"blockchain_test_{i}.db",
                 self_hostname,
-                await create_block_tools_async(constants=test_constants, keychain=keyring.get_keychain()),
+                await create_block_tools_async(constants=consensus_constants, keychain=keyring.get_keychain()),
                 simulator=False,
                 db_version=db_version,
             )
@@ -390,9 +390,9 @@ async def setup_full_system_inner(
     Tuple[Any, Any, Harvester, Farmer, Any, Service[Timelord], object, object, Any, ChiaServer],
 ]:
     if b_tools is None:
-        b_tools = await create_block_tools_async(constants=test_constants, keychain=keychain1)
+        b_tools = await create_block_tools_async(constants=consensus_constants, keychain=keychain1)
     if b_tools_1 is None:
-        b_tools_1 = await create_block_tools_async(constants=test_constants, keychain=keychain2)
+        b_tools_1 = await create_block_tools_async(constants=consensus_constants, keychain=keychain2)
     daemon_ws = None
     if connect_to_daemon:
         daemon_iter = setup_daemon(btools=b_tools)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -21,7 +21,7 @@ from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.bundle_tools import detect_potential_template_generator
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
-from chia.simulator.block_tools import create_block_tools_async, test_constants
+from chia.simulator.block_tools import create_block_tools_async
 from chia.simulator.keyring import TempKeyring
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.classgroup import ClassgroupElement
@@ -62,7 +62,7 @@ bad_element = ClassgroupElement.from_bytes(b"\x00")
 
 
 @asynccontextmanager
-async def make_empty_blockchain(constants: ConsensusConstants = test_constants):
+async def make_empty_blockchain(constants: ConsensusConstants):
     """
     Provides a list of 10 valid blocks, as well as a blockchain with 9 blocks added to it.
     """
@@ -77,27 +77,36 @@ async def make_empty_blockchain(constants: ConsensusConstants = test_constants):
 
 class TestGenesisBlock:
     @pytest.mark.asyncio
-    async def test_block_tools_proofs_400(self, default_400_blocks):
+    async def test_block_tools_proofs_400(self, default_400_blocks, blockchain_constants):
         vdf, proof = get_vdf_info_and_proof(
-            test_constants, ClassgroupElement.get_default_element(), test_constants.GENESIS_CHALLENGE, uint64(231)
+            blockchain_constants,
+            ClassgroupElement.get_default_element(),
+            blockchain_constants.GENESIS_CHALLENGE,
+            uint64(231),
         )
-        if proof.is_valid(test_constants, ClassgroupElement.get_default_element(), vdf) is False:
+        if proof.is_valid(blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
             raise Exception("invalid proof")
 
     @pytest.mark.asyncio
-    async def test_block_tools_proofs_1000(self, default_1000_blocks):
+    async def test_block_tools_proofs_1000(self, default_1000_blocks, blockchain_constants):
         vdf, proof = get_vdf_info_and_proof(
-            test_constants, ClassgroupElement.get_default_element(), test_constants.GENESIS_CHALLENGE, uint64(231)
+            blockchain_constants,
+            ClassgroupElement.get_default_element(),
+            blockchain_constants.GENESIS_CHALLENGE,
+            uint64(231),
         )
-        if proof.is_valid(test_constants, ClassgroupElement.get_default_element(), vdf) is False:
+        if proof.is_valid(blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
             raise Exception("invalid proof")
 
     @pytest.mark.asyncio
-    async def test_block_tools_proofs(self):
+    async def test_block_tools_proofs(self, blockchain_constants):
         vdf, proof = get_vdf_info_and_proof(
-            test_constants, ClassgroupElement.get_default_element(), test_constants.GENESIS_CHALLENGE, uint64(231)
+            blockchain_constants,
+            ClassgroupElement.get_default_element(),
+            blockchain_constants.GENESIS_CHALLENGE,
+            uint64(231),
         )
-        if proof.is_valid(test_constants, ClassgroupElement.get_default_element(), vdf) is False:
+        if proof.is_valid(blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
             raise Exception("invalid proof")
 
     @pytest.mark.asyncio
@@ -545,9 +554,9 @@ class TestBlockHeaderValidation:
         )
         await _validate_and_add_block(empty_blockchain, block_0_bad, expected_error=Err.SHOULD_NOT_HAVE_ICC)
 
-    async def do_test_invalid_icc_sub_slot_vdf(self, keychain, db_version):
+    async def do_test_invalid_icc_sub_slot_vdf(self, keychain, db_version, constants: ConsensusConstants):
         bt_high_iters = await create_block_tools_async(
-            constants=test_constants.replace(SUB_SLOT_ITERS_STARTING=(2**12), DIFFICULTY_STARTING=(2**14)),
+            constants=constants.replace(SUB_SLOT_ITERS_STARTING=(2**12), DIFFICULTY_STARTING=(2**14)),
             keychain=keychain,
         )
         bc1, db_wrapper, db_path = await create_blockchain(bt_high_iters.constants, db_version)
@@ -627,9 +636,9 @@ class TestBlockHeaderValidation:
         db_path.unlink()
 
     @pytest.mark.asyncio
-    async def test_invalid_icc_sub_slot_vdf(self, db_version):
+    async def test_invalid_icc_sub_slot_vdf(self, db_version, blockchain_constants):
         with TempKeyring() as keychain:
-            await self.do_test_invalid_icc_sub_slot_vdf(keychain, db_version)
+            await self.do_test_invalid_icc_sub_slot_vdf(keychain, db_version, blockchain_constants)
 
     @pytest.mark.asyncio
     async def test_invalid_icc_into_cc(self, empty_blockchain, bt):
@@ -641,7 +650,7 @@ class TestBlockHeaderValidation:
             blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1)
             block = blocks[-1]
             if len(block.finished_sub_slots) > 0 and block.finished_sub_slots[-1].infused_challenge_chain is not None:
-                if block.finished_sub_slots[-1].reward_chain.deficit == test_constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK:
+                if block.finished_sub_slots[-1].reward_chain.deficit == bt.constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK:
                     # 2g
                     case_1 = True
                     new_finished_ss = recursive_replace(
@@ -756,8 +765,8 @@ class TestBlockHeaderValidation:
         # 2m
         # Tests adding an empty sub slot after the sub-epoch / epoch.
         # Also tests overflow block in epoch
-        blocks_base = default_400_blocks[: test_constants.EPOCH_BLOCKS]
-        assert len(blocks_base) == test_constants.EPOCH_BLOCKS
+        blocks_base = default_400_blocks[: bt.constants.EPOCH_BLOCKS]
+        assert len(blocks_base) == bt.constants.EPOCH_BLOCKS
         blocks_1 = bt.get_consecutive_blocks(1, block_list_input=blocks_base, force_overflow=True)
         blocks_2 = bt.get_consecutive_blocks(1, skip_slots=3, block_list_input=blocks_base, force_overflow=True)
         for block in blocks_base:
@@ -799,7 +808,7 @@ class TestBlockHeaderValidation:
             block = blocks[-1]
             if (
                 len(block.finished_sub_slots)
-                and is_overflow_block(test_constants, block.reward_chain_block.signage_point_index)
+                and is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index)
                 and block.finished_sub_slots[-1].challenge_chain.challenge_chain_end_of_slot_vdf.output
                 != ClassgroupElement.get_default_element()
             ):
@@ -969,7 +978,7 @@ class TestBlockHeaderValidation:
             recursive_replace(
                 block.finished_sub_slots[-1].reward_chain,
                 "deficit",
-                test_constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK - 1,
+                bt.constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK - 1,
             ),
         )
         block_bad = recursive_replace(block, "finished_sub_slots", block.finished_sub_slots[:-1] + [new_finished_ss])
@@ -1046,7 +1055,7 @@ class TestBlockHeaderValidation:
         while True:
             blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
             if len(blocks[-1].finished_sub_slots) > 0 and is_overflow_block(
-                test_constants, blocks[-1].reward_chain_block.signage_point_index
+                bt.constants, blocks[-1].reward_chain_block.signage_point_index
             ):
                 new_finished_ss: EndOfSubSlotBundle = recursive_replace(
                     blocks[-1].finished_sub_slots[0],
@@ -1131,12 +1140,12 @@ class TestBlockHeaderValidation:
 
         with pytest.raises(ValueError):
             block_bad = recursive_replace(
-                blocks[-1], "reward_chain_block.signage_point_index", test_constants.NUM_SPS_SUB_SLOT
+                blocks[-1], "reward_chain_block.signage_point_index", bt.constants.NUM_SPS_SUB_SLOT
             )
             await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_SP_INDEX)
         with pytest.raises(ValueError):
             block_bad = recursive_replace(
-                blocks[-1], "reward_chain_block.signage_point_index", test_constants.NUM_SPS_SUB_SLOT + 1
+                blocks[-1], "reward_chain_block.signage_point_index", bt.constants.NUM_SPS_SUB_SLOT + 1
             )
             await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_SP_INDEX)
 
@@ -1152,7 +1161,7 @@ class TestBlockHeaderValidation:
                 block_bad = recursive_replace(blocks[-1], "reward_chain_block.signage_point_index", uint8(1))
                 await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_SP_INDEX)
 
-            elif not is_overflow_block(test_constants, blocks[-1].reward_chain_block.signage_point_index):
+            elif not is_overflow_block(bt.constants, blocks[-1].reward_chain_block.signage_point_index):
                 case_2 = True
                 block_bad = recursive_replace(blocks[-1], "reward_chain_block.signage_point_index", uint8(0))
                 await _validate_and_add_block_multi_error(
@@ -1493,10 +1502,10 @@ class TestBlockHeaderValidation:
             # enable softfork2 at height 0, to make it apply to this test
             # the test constants set MAX_FUTURE_TIME to 10 days, restore it to
             # default for this test
-            constants = test_constants.replace(SOFT_FORK2_HEIGHT=0, MAX_FUTURE_TIME=5 * 60)
+            constants = bt.constants.replace(SOFT_FORK2_HEIGHT=0, MAX_FUTURE_TIME=5 * 60)
             time_delta = 2 * 60
         else:
-            constants = test_constants.replace(MAX_FUTURE_TIME=5 * 60)
+            constants = bt.constants.replace(MAX_FUTURE_TIME=5 * 60)
             time_delta = 5 * 60
 
         blocks = bt.get_consecutive_blocks(1)
@@ -1927,9 +1936,9 @@ class TestBodyValidation:
     async def test_timelock_conditions(self, opcode, lock_value, expected, with_softfork2, bt):
         if with_softfork2:
             # enable softfork2 at height 0, to make it apply to this test
-            constants = test_constants.replace(SOFT_FORK2_HEIGHT=0)
+            constants = bt.constants.replace(SOFT_FORK2_HEIGHT=0)
         else:
-            constants = test_constants
+            constants = bt.constants
 
             # if the softfork is not active in this test, fixup all the
             # tests to instead expect NEW_PEAK unconditionally
@@ -2117,7 +2126,7 @@ class TestBodyValidation:
     async def test_ephemeral_timelock(self, opcode, lock_value, expected, with_garbage, with_softfork2, bt):
         if with_softfork2:
             # enable softfork2 at height 0, to make it apply to this test
-            constants = test_constants.replace(SOFT_FORK2_HEIGHT=0)
+            constants = bt.constants.replace(SOFT_FORK2_HEIGHT=0)
 
             # after the softfork, we don't allow any birth assertions, not
             # relative time locks on ephemeral coins. This test is only for
@@ -2131,7 +2140,7 @@ class TestBodyValidation:
                 expected = AddBlockResult.INVALID_BLOCK
 
         else:
-            constants = test_constants
+            constants = bt.constants
 
             # if the softfork is not active in this test, fixup all the
             # tests to instead expect NEW_PEAK unconditionally
@@ -2677,7 +2686,7 @@ class TestBodyValidation:
         pass
         #
         # with TempKeyring() as keychain:
-        #     new_test_constants = test_constants.replace(
+        #     new_test_constants = bt.constants.replace(
         #         **{"GENESIS_PRE_FARM_POOL_PUZZLE_HASH": bt.pool_ph, "GENESIS_PRE_FARM_FARMER_PUZZLE_HASH": bt.pool_ph}
         #     )
         #     b, db_wrapper, db_path = await create_blockchain(new_test_constants, db_version)
@@ -3134,8 +3143,8 @@ class TestReorgs:
         # Reorg longer than a difficulty adjustment
         # Also tests higher weight chain but lower height
         b = empty_blockchain
-        num_blocks_chain_1 = 3 * test_constants.EPOCH_BLOCKS + test_constants.MAX_SUB_SLOT_BLOCKS + 10
-        num_blocks_chain_2_start = test_constants.EPOCH_BLOCKS - 20
+        num_blocks_chain_1 = 3 * bt.constants.EPOCH_BLOCKS + bt.constants.MAX_SUB_SLOT_BLOCKS + 10
+        num_blocks_chain_2_start = bt.constants.EPOCH_BLOCKS - 20
 
         assert num_blocks_chain_1 < 10000
         blocks = default_1500_blocks[:num_blocks_chain_1]

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -12,7 +12,6 @@ import pytest
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol
 from chia.protocols.shared_protocol import Capability
-from chia.simulator.block_tools import test_constants
 from chia.simulator.time_out_assert import time_out_assert
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.full_block import FullBlock
@@ -38,10 +37,10 @@ class TestFullSync:
         server_5 = full_node_5.full_node.server
 
         # If this constant is changed, update the tests to use more blocks
-        assert test_constants.WEIGHT_PROOF_RECENT_BLOCKS < 400
+        assert bt.constants.WEIGHT_PROOF_RECENT_BLOCKS < 400
 
         # Syncs up less than recent blocks
-        for block in blocks[: test_constants.WEIGHT_PROOF_RECENT_BLOCKS - 5]:
+        for block in blocks[: bt.constants.WEIGHT_PROOF_RECENT_BLOCKS - 5]:
             await full_node_1.full_node.add_block(block)
 
         await server_2.start_client(
@@ -52,12 +51,10 @@ class TestFullSync:
 
         # The second node should eventually catch up to the first one
         await time_out_assert(
-            timeout_seconds, node_height_exactly, True, full_node_2, test_constants.WEIGHT_PROOF_RECENT_BLOCKS - 5 - 1
+            timeout_seconds, node_height_exactly, True, full_node_2, bt.constants.WEIGHT_PROOF_RECENT_BLOCKS - 5 - 1
         )
 
-        for block in blocks[
-            test_constants.WEIGHT_PROOF_RECENT_BLOCKS - 5 : test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 5
-        ]:
+        for block in blocks[bt.constants.WEIGHT_PROOF_RECENT_BLOCKS - 5 : bt.constants.WEIGHT_PROOF_RECENT_BLOCKS + 5]:
             await full_node_1.full_node.add_block(block)
 
         await server_3.start_client(
@@ -66,16 +63,16 @@ class TestFullSync:
 
         # Node 3 and Node 2 sync up to node 1
         await time_out_assert(
-            timeout_seconds, node_height_exactly, True, full_node_2, test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 5 - 1
+            timeout_seconds, node_height_exactly, True, full_node_2, bt.constants.WEIGHT_PROOF_RECENT_BLOCKS + 5 - 1
         )
         await time_out_assert(
-            timeout_seconds, node_height_exactly, True, full_node_3, test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 5 - 1
+            timeout_seconds, node_height_exactly, True, full_node_3, bt.constants.WEIGHT_PROOF_RECENT_BLOCKS + 5 - 1
         )
 
         cons = list(server_1.all_connections.values())[:]
         for con in cons:
             await con.close()
-        for block in blocks[test_constants.WEIGHT_PROOF_RECENT_BLOCKS + 5 :]:
+        for block in blocks[bt.constants.WEIGHT_PROOF_RECENT_BLOCKS + 5 :]:
             await full_node_1.full_node.add_block(block)
 
         await server_2.start_client(

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -14,7 +14,6 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.full_block_to_block_record import header_block_to_sub_block_record
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
-from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import VDFProof
@@ -35,7 +34,7 @@ async def test_block_store(tmp_dir, db_version, bt):
         # Use a different file for the blockchain
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, bt.constants, tmp_dir, 2)
 
         store = await BlockStore.create(db_wrapper)
         await BlockStore.create(db_wrapper_2)
@@ -90,7 +89,7 @@ async def test_deadlock(tmp_dir, db_version, bt):
         store = await BlockStore.create(wrapper)
         coin_store_2 = await CoinStore.create(wrapper_2)
         store_2 = await BlockStore.create(wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, bt.constants, tmp_dir, 2)
         block_records = []
         for block in blocks:
             await _validate_and_add_block(bc, block)
@@ -118,7 +117,7 @@ async def test_rollback(bt, tmp_dir):
         # Use a different file for the blockchain
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store, block_store, bt.constants, tmp_dir, 2)
 
         # insert all blocks
         count = 0
@@ -162,7 +161,7 @@ async def test_count_compactified_blocks(bt, tmp_dir, db_version):
     async with DBConnection(db_version) as db_wrapper:
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store, block_store, bt.constants, tmp_dir, 2)
 
         count = await block_store.count_compactified_blocks()
         assert count == 0
@@ -181,7 +180,7 @@ async def test_count_uncompactified_blocks(bt, tmp_dir, db_version):
     async with DBConnection(db_version) as db_wrapper:
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store, block_store, bt.constants, tmp_dir, 2)
 
         count = await block_store.count_uncompactified_blocks()
         assert count == 0
@@ -213,7 +212,7 @@ async def test_replace_proof(bt, tmp_dir, db_version):
     async with DBConnection(db_version) as db_wrapper:
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store, block_store, bt.constants, tmp_dir, 2)
         for block in blocks:
             await _validate_and_add_block(bc, block)
 
@@ -286,11 +285,12 @@ async def test_get_blocks_by_hash(tmp_dir, bt, db_version):
         # Use a different file for the blockchain
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, bt.constants, tmp_dir, 2)
 
         store = await BlockStore.create(db_wrapper)
         await BlockStore.create(db_wrapper_2)
 
+        print("starting test")
         hashes = []
         # Save/get block
         for block in blocks:
@@ -323,7 +323,7 @@ async def test_get_block_bytes_in_range(tmp_dir, bt, db_version):
         # Use a different file for the blockchain
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, test_constants, tmp_dir, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, bt.constants, tmp_dir, 2)
 
         await BlockStore.create(db_wrapper_2)
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -320,7 +320,7 @@ class TestCoinStoreWithBlocks:
             blocks = bt.get_consecutive_blocks(initial_block_count)
             coin_store = await CoinStore.create(db_wrapper)
             store = await BlockStore.create(db_wrapper)
-            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, tmp_dir, 2)
+            b: Blockchain = await Blockchain.create(coin_store, store, bt.constants, tmp_dir, 2)
             try:
                 records: List[Optional[CoinRecord]] = []
 
@@ -379,7 +379,7 @@ class TestCoinStoreWithBlocks:
             )
             coin_store = await CoinStore.create(db_wrapper)
             store = await BlockStore.create(db_wrapper)
-            b: Blockchain = await Blockchain.create(coin_store, store, test_constants, tmp_dir, 2)
+            b: Blockchain = await Blockchain.create(coin_store, store, bt.constants, tmp_dir, 2)
             for block in blocks:
                 await _validate_and_add_block(b, block)
             peak = b.get_peak()

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -16,7 +16,6 @@ from chia.full_node.signage_point import SignagePoint
 from chia.protocols import timelord_protocol
 from chia.protocols.timelord_protocol import NewInfusionPointVDF
 from chia.simulator.block_tools import create_block_tools_async, get_signage_point
-from chia.simulator.block_tools import test_constants as test_constants_original
 from chia.simulator.keyring import TempKeyring
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.unfinished_block import UnfinishedBlock
@@ -26,19 +25,24 @@ from chia.util.ints import uint8, uint32, uint64, uint128
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block, _validate_and_add_block_no_error
 from tests.util.blockchain import create_blockchain
 
-test_constants = test_constants_original.replace(**{"DISCRIMINANT_SIZE_BITS": 32, "SUB_SLOT_ITERS_STARTING": 2**12})
 log = logging.getLogger(__name__)
 
 
 @pytest_asyncio.fixture(scope="function")
-async def custom_block_tools():
+async def custom_block_tools(blockchain_constants):
     with TempKeyring() as keychain:
-        yield await create_block_tools_async(constants=test_constants, keychain=keychain)
+        patched_constants = blockchain_constants.replace(
+            **{"DISCRIMINANT_SIZE_BITS": 32, "SUB_SLOT_ITERS_STARTING": 2**12}
+        )
+        yield await create_block_tools_async(constants=patched_constants, keychain=keychain)
 
 
 @pytest_asyncio.fixture(scope="function", params=[1, 2])
-async def empty_blockchain(request):
-    bc1, db_wrapper, db_path = await create_blockchain(test_constants, request.param)
+async def empty_blockchain(request, blockchain_constants):
+    patched_constants = blockchain_constants.replace(
+        **{"DISCRIMINANT_SIZE_BITS": 32, "SUB_SLOT_ITERS_STARTING": 2**12}
+    )
+    bc1, db_wrapper, db_path = await create_blockchain(patched_constants, request.param)
     yield bc1
     await db_wrapper.close()
     bc1.shut_down()
@@ -46,8 +50,8 @@ async def empty_blockchain(request):
 
 
 @pytest_asyncio.fixture(scope="function", params=[1, 2])
-async def empty_blockchain_with_original_constants(request):
-    bc1, db_wrapper, db_path = await create_blockchain(test_constants_original, request.param)
+async def empty_blockchain_with_original_constants(request, blockchain_constants):
+    bc1, db_wrapper, db_path = await create_blockchain(blockchain_constants, request.param)
     yield bc1
     await db_wrapper.close()
     bc1.shut_down()
@@ -67,7 +71,7 @@ class TestFullNodeStore:
             normalized_to_identity_cc_sp=normalized_to_identity,
         )
 
-        store = FullNodeStore(test_constants)
+        store = FullNodeStore(empty_blockchain.constants)
 
         unfinished_blocks = []
         for block in blocks:
@@ -134,7 +138,7 @@ class TestFullNodeStore:
             == []
         )
         # Test adding non-connecting sub-slots genesis
-        assert store.get_sub_slot(test_constants.GENESIS_CHALLENGE) is None
+        assert store.get_sub_slot(empty_blockchain.constants.GENESIS_CHALLENGE) is None
         assert store.get_sub_slot(sub_slots[0].challenge_chain.get_hash()) is None
         assert store.get_sub_slot(sub_slots[1].challenge_chain.get_hash()) is None
         assert store.new_finished_sub_slot(sub_slots[1], blockchain, None, None) is None
@@ -260,10 +264,12 @@ class TestFullNodeStore:
 
         # Test adding signage point
         peak = blockchain.get_peak()
-        ss_start_iters = peak.ip_sub_slot_total_iters(test_constants)
-        for i in range(1, test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA):
+        ss_start_iters = peak.ip_sub_slot_total_iters(custom_block_tools.constants)
+        for i in range(
+            1, custom_block_tools.constants.NUM_SPS_SUB_SLOT - custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA
+        ):
             sp = get_signage_point(
-                test_constants,
+                custom_block_tools.constants,
                 blockchain,
                 peak,
                 ss_start_iters,
@@ -320,15 +326,15 @@ class TestFullNodeStore:
         assert len(store.finished_sub_slots) == 4
 
         # Test adding signage points for overflow blocks (sp_sub_slot)
-        ss_start_iters = peak.sp_sub_slot_total_iters(test_constants)
-        # for i in range(peak.signage_point_index, test_constants.NUM_SPS_SUB_SLOT):
+        ss_start_iters = peak.sp_sub_slot_total_iters(custom_block_tools.constants)
+        # for i in range(peak.signage_point_index, custom_block_tools.constants.NUM_SPS_SUB_SLOT):
         #     if i < peak.signage_point_index:
         #         continue
         #     latest = peak
-        #     while latest.total_iters > peak.sp_total_iters(test_constants):
+        #     while latest.total_iters > peak.sp_total_iters(custom_block_tools.constants):
         #         latest = blockchain.blocks[latest.prev_hash]
         #     sp = get_signage_point(
-        #         test_constants,
+        #         custom_block_tools.constants,
         #         blockchain.blocks,
         #         latest,
         #         ss_start_iters,
@@ -339,12 +345,14 @@ class TestFullNodeStore:
         #     assert store.new_signage_point(i, blockchain.blocks, peak, peak.sub_slot_iters, sp)
 
         # Test adding signage points for overflow blocks (ip_sub_slot)
-        for i in range(1, test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA):
+        for i in range(
+            1, custom_block_tools.constants.NUM_SPS_SUB_SLOT - custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA
+        ):
             sp = get_signage_point(
-                test_constants,
+                custom_block_tools.constants,
                 blockchain,
                 peak,
-                peak.ip_sub_slot_total_iters(test_constants),
+                peak.ip_sub_slot_total_iters(custom_block_tools.constants),
                 uint8(i),
                 [],
                 peak.sub_slot_iters,
@@ -356,13 +364,13 @@ class TestFullNodeStore:
         for slot_offset in range(1, len(finished_sub_slots)):
             for i in range(
                 1,
-                test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA,
+                custom_block_tools.constants.NUM_SPS_SUB_SLOT - custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
             ):
                 sp = get_signage_point(
-                    test_constants,
+                    custom_block_tools.constants,
                     blockchain,
                     peak,
-                    peak.ip_sub_slot_total_iters(test_constants) + slot_offset * peak.sub_slot_iters,
+                    peak.ip_sub_slot_total_iters(custom_block_tools.constants) + slot_offset * peak.sub_slot_iters,
                     uint8(i),
                     finished_sub_slots[:slot_offset],
                     peak.sub_slot_iters,
@@ -372,12 +380,15 @@ class TestFullNodeStore:
                 assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
 
         # Test adding future signage point (bad)
-        for i in range(1, test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA):
+        for i in range(
+            1, custom_block_tools.constants.NUM_SPS_SUB_SLOT - custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA
+        ):
             sp = get_signage_point(
-                test_constants,
+                custom_block_tools.constants,
                 blockchain,
                 peak,
-                peak.ip_sub_slot_total_iters(test_constants) + len(finished_sub_slots) * peak.sub_slot_iters,
+                peak.ip_sub_slot_total_iters(custom_block_tools.constants)
+                + len(finished_sub_slots) * peak.sub_slot_iters,
                 uint8(i),
                 finished_sub_slots[: len(finished_sub_slots)],
                 peak.sub_slot_iters,
@@ -395,7 +406,7 @@ class TestFullNodeStore:
             blocks[1].reward_chain_block.signage_point_index,
             blockchain,
             peak,
-            blockchain.block_record(blocks[1].header_hash).sp_sub_slot_total_iters(test_constants),
+            blockchain.block_record(blocks[1].header_hash).sp_sub_slot_total_iters(custom_block_tools.constants),
             sp,
         )
 
@@ -422,9 +433,11 @@ class TestFullNodeStore:
         # Test adding signage points before genesis
         store.initialize_genesis_sub_slot()
         assert len(store.finished_sub_slots) == 1
-        for i in range(1, test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA):
+        for i in range(
+            1, custom_block_tools.constants.NUM_SPS_SUB_SLOT - custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA
+        ):
             sp = get_signage_point(
-                test_constants,
+                custom_block_tools.constants,
                 BlockCache({}, {}),
                 None,
                 uint128(0),
@@ -450,10 +463,10 @@ class TestFullNodeStore:
         for slot_offset in range(1, len(finished_sub_slots) + 1):
             for i in range(
                 1,
-                test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA,
+                custom_block_tools.constants.NUM_SPS_SUB_SLOT - custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
             ):
                 sp = get_signage_point(
-                    test_constants,
+                    custom_block_tools.constants,
                     BlockCache({}, {}),
                     None,
                     slot_offset * peak.sub_slot_iters,
@@ -484,23 +497,23 @@ class TestFullNodeStore:
         # If this is not the case, fix test to find a block that is
         assert (
             blocks_4[-1].reward_chain_block.signage_point_index
-            < test_constants.NUM_SPS_SUB_SLOT - test_constants.NUM_SP_INTERVALS_EXTRA
+            < custom_block_tools.constants.NUM_SPS_SUB_SLOT - custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA
         )
         await _validate_and_add_block(blockchain, blocks_4[-1], expected_result=AddBlockResult.ADDED_AS_ORPHAN)
 
         sb = blockchain.block_record(blocks_4[-1].header_hash)
         store.new_peak(sb, blocks_4[-1], None, None, None, blockchain)
         for i in range(
-            sb.signage_point_index + test_constants.NUM_SP_INTERVALS_EXTRA,
-            test_constants.NUM_SPS_SUB_SLOT,
+            sb.signage_point_index + custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
+            custom_block_tools.constants.NUM_SPS_SUB_SLOT,
         ):
-            if is_overflow_block(test_constants, uint8(i)):
+            if is_overflow_block(custom_block_tools.constants, uint8(i)):
                 finished_sub_slots = blocks_5[-1].finished_sub_slots
             else:
                 finished_sub_slots = []
 
             sp = get_signage_point(
-                test_constants,
+                custom_block_tools.constants,
                 blockchain,
                 sb,
                 uint128(0),
@@ -632,13 +645,13 @@ class TestFullNodeStore:
             i1 = blocks[-1].reward_chain_block.signage_point_index
             if (
                 len(blocks[-2].finished_sub_slots) == len(blocks[-1].finished_sub_slots) == 0
-                and not is_overflow_block(test_constants, signage_point_index=i2)
-                and not is_overflow_block(test_constants, signage_point_index=i1)
+                and not is_overflow_block(custom_block_tools.constants, signage_point_index=i2)
+                and not is_overflow_block(custom_block_tools.constants, signage_point_index=i1)
                 and i2 > i3 + 3
                 and i1 > (i2 + 3)
             ):
                 # We hit all the conditions that we want
-                all_sps: List[Optional[SignagePoint]] = [None] * test_constants.NUM_SPS_SUB_SLOT
+                all_sps: List[Optional[SignagePoint]] = [None] * custom_block_tools.constants.NUM_SPS_SUB_SLOT
 
                 def assert_sp_none(sp_index: int, is_none: bool):
                     sp_to_check: Optional[SignagePoint] = all_sps[sp_index]
@@ -649,10 +662,10 @@ class TestFullNodeStore:
                     if fetched is not None:
                         assert fetched == sp_to_check
 
-                for i in range(i3 + 1, test_constants.NUM_SPS_SUB_SLOT - 3):
+                for i in range(i3 + 1, custom_block_tools.constants.NUM_SPS_SUB_SLOT - 3):
                     finished_sub_slots = []
                     sp = get_signage_point(
-                        test_constants,
+                        custom_block_tools.constants,
                         blockchain,
                         peak,
                         uint128(peak.ip_sub_slot_total_iters(custom_block_tools.constants)),
@@ -675,8 +688,8 @@ class TestFullNodeStore:
                 assert_sp_none(i1 + 1, True)
                 assert_sp_none(i1 + 4, True)
 
-                for i in range(i2, test_constants.NUM_SPS_SUB_SLOT):
-                    if is_overflow_block(test_constants, uint8(i)):
+                for i in range(i2, custom_block_tools.constants.NUM_SPS_SUB_SLOT):
+                    if is_overflow_block(custom_block_tools.constants, uint8(i)):
                         blocks_alt = custom_block_tools.get_consecutive_blocks(
                             1, block_list_input=blocks[:-1], skip_slots=1
                         )
@@ -684,7 +697,7 @@ class TestFullNodeStore:
                     else:
                         finished_sub_slots = []
                     sp = get_signage_point(
-                        test_constants,
+                        custom_block_tools.constants,
                         blockchain,
                         peak,
                         uint128(peak.ip_sub_slot_total_iters(custom_block_tools.constants)),
@@ -732,7 +745,7 @@ class TestFullNodeStore:
     @pytest.mark.asyncio
     async def test_long_chain_slots(self, empty_blockchain_with_original_constants, default_1000_blocks):
         blockchain = empty_blockchain_with_original_constants
-        store = FullNodeStore(test_constants_original)
+        store = FullNodeStore(blockchain.constants)
         blocks = default_1000_blocks
         peak = None
         peak_full_block = None

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -25,7 +25,7 @@ from chia.protocols.wallet_protocol import SendTransaction, TransactionAck
 from chia.server.address_manager import AddressManager
 from chia.server.outbound_message import Message, NodeType
 from chia.server.server import ChiaServer
-from chia.simulator.block_tools import BlockTools, get_signage_point, test_constants
+from chia.simulator.block_tools import BlockTools, get_signage_point
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.simulator.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 from chia.types.blockchain_format.classgroup import ClassgroupElement
@@ -592,7 +592,7 @@ class TestFullNodeProtocol:
         # Create empty slots
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=6)
         block = blocks[-1]
-        if is_overflow_block(test_constants, block.reward_chain_block.signage_point_index):
+        if is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index):
             finished_ss = block.finished_sub_slots[:-1]
         else:
             finished_ss = block.finished_sub_slots
@@ -624,7 +624,7 @@ class TestFullNodeProtocol:
 
         block = blocks[-1]
 
-        if is_overflow_block(test_constants, block.reward_chain_block.signage_point_index):
+        if is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index):
             finished_ss = block.finished_sub_slots[:-1]
         else:
             finished_ss = block.finished_sub_slots
@@ -1168,7 +1168,7 @@ class TestFullNodeProtocol:
 
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
         block: FullBlock = blocks[-1]
-        overflow = is_overflow_block(test_constants, block.reward_chain_block.signage_point_index)
+        overflow = is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index)
         unf = UnfinishedBlock(
             block.finished_sub_slots[:] if not overflow else block.finished_sub_slots[:-1],
             block.reward_chain_block.get_unfinished(),
@@ -1212,7 +1212,7 @@ class TestFullNodeProtocol:
 
         blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
         block: FullBlock = blocks[0]
-        overflow = is_overflow_block(test_constants, block.reward_chain_block.signage_point_index)
+        overflow = is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index)
 
         replaced_generator = SerializedProgram.from_bytes(b"\x80")
 
@@ -1364,7 +1364,7 @@ class TestFullNodeProtocol:
         )
 
         block: FullBlock = blocks[-1]
-        overflow = is_overflow_block(test_constants, block.reward_chain_block.signage_point_index)
+        overflow = is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index)
         unf: UnfinishedBlock = UnfinishedBlock(
             block.finished_sub_slots[:] if not overflow else block.finished_sub_slots[:-1],
             block.reward_chain_block.get_unfinished(),
@@ -1401,7 +1401,7 @@ class TestFullNodeProtocol:
         for block in blocks[:-1]:
             await full_node_1.full_node.add_block(block)
         block: FullBlock = blocks[-1]
-        overflow = is_overflow_block(test_constants, block.reward_chain_block.signage_point_index)
+        overflow = is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index)
         unf = UnfinishedBlock(
             block.finished_sub_slots[:] if not overflow else block.finished_sub_slots[:-1],
             block.reward_chain_block.get_unfinished(),
@@ -1436,10 +1436,10 @@ class TestFullNodeProtocol:
         peak = blockchain.get_peak()
 
         sp = get_signage_point(
-            test_constants,
+            bt.constants,
             blockchain,
             peak,
-            peak.ip_sub_slot_total_iters(test_constants),
+            peak.ip_sub_slot_total_iters(bt.constants),
             uint8(11),
             [],
             peak.sub_slot_iters,
@@ -1502,10 +1502,10 @@ class TestFullNodeProtocol:
         # Creates a signage point based on the last block
         peak_2 = second_blockchain.get_peak()
         sp: SignagePoint = get_signage_point(
-            test_constants,
+            bt.constants,
             blockchain,
             peak_2,
-            peak_2.ip_sub_slot_total_iters(test_constants),
+            peak_2.ip_sub_slot_total_iters(bt.constants),
             uint8(4),
             [],
             peak_2.sub_slot_iters,
@@ -1572,7 +1572,7 @@ class TestFullNodeProtocol:
         cc_eos_count = 0
         for sub_slot in block.finished_sub_slots:
             vdf_info, vdf_proof = get_vdf_info_and_proof(
-                test_constants,
+                bt.constants,
                 ClassgroupElement.get_default_element(),
                 sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.challenge,
                 sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.number_of_iterations,
@@ -1597,7 +1597,7 @@ class TestFullNodeProtocol:
             if sub_slot.infused_challenge_chain is not None:
                 icc_eos_count += 1
                 vdf_info, vdf_proof = get_vdf_info_and_proof(
-                    test_constants,
+                    bt.constants,
                     ClassgroupElement.get_default_element(),
                     sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.challenge,
                     sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.number_of_iterations,
@@ -1614,7 +1614,7 @@ class TestFullNodeProtocol:
                 )
         assert block.reward_chain_block.challenge_chain_sp_vdf is not None
         vdf_info, vdf_proof = get_vdf_info_and_proof(
-            test_constants,
+            bt.constants,
             ClassgroupElement.get_default_element(),
             block.reward_chain_block.challenge_chain_sp_vdf.challenge,
             block.reward_chain_block.challenge_chain_sp_vdf.number_of_iterations,
@@ -1630,7 +1630,7 @@ class TestFullNodeProtocol:
             )
         )
         vdf_info, vdf_proof = get_vdf_info_and_proof(
-            test_constants,
+            bt.constants,
             ClassgroupElement.get_default_element(),
             block.reward_chain_block.challenge_chain_ip_vdf.challenge,
             block.reward_chain_block.challenge_chain_ip_vdf.number_of_iterations,
@@ -1690,7 +1690,7 @@ class TestFullNodeProtocol:
         # (wrong_vdf_info, wrong_vdf_proof) pair verifies, but it's not present in the blockchain at all.
         block = blocks_2[2]
         wrong_vdf_info, wrong_vdf_proof = get_vdf_info_and_proof(
-            test_constants,
+            bt.constants,
             ClassgroupElement.get_default_element(),
             block.reward_chain_block.challenge_chain_ip_vdf.challenge,
             block.reward_chain_block.challenge_chain_ip_vdf.number_of_iterations,
@@ -1701,7 +1701,7 @@ class TestFullNodeProtocol:
         for block in blocks_2[:2]:
             for sub_slot in block.finished_sub_slots:
                 vdf_info, correct_vdf_proof = get_vdf_info_and_proof(
-                    test_constants,
+                    bt.constants,
                     ClassgroupElement.get_default_element(),
                     sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.challenge,
                     sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.number_of_iterations,
@@ -1728,7 +1728,7 @@ class TestFullNodeProtocol:
                 )
                 if sub_slot.infused_challenge_chain is not None:
                     vdf_info, correct_vdf_proof = get_vdf_info_and_proof(
-                        test_constants,
+                        bt.constants,
                         ClassgroupElement.get_default_element(),
                         sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.challenge,
                         sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.number_of_iterations,
@@ -1756,7 +1756,7 @@ class TestFullNodeProtocol:
 
             if block.reward_chain_block.challenge_chain_sp_vdf is not None:
                 vdf_info, correct_vdf_proof = get_vdf_info_and_proof(
-                    test_constants,
+                    bt.constants,
                     ClassgroupElement.get_default_element(),
                     block.reward_chain_block.challenge_chain_sp_vdf.challenge,
                     block.reward_chain_block.challenge_chain_sp_vdf.number_of_iterations,
@@ -1786,7 +1786,7 @@ class TestFullNodeProtocol:
                 )
 
             vdf_info, correct_vdf_proof = get_vdf_info_and_proof(
-                test_constants,
+                bt.constants,
                 ClassgroupElement.get_default_element(),
                 block.reward_chain_block.challenge_chain_ip_vdf.challenge,
                 block.reward_chain_block.challenge_chain_ip_vdf.number_of_iterations,
@@ -1918,7 +1918,7 @@ class TestFullNodeProtocol:
             await full_node_1.full_node.add_block(block)
             await full_node_2.full_node.add_block(block)
             vdf_info, vdf_proof = get_vdf_info_and_proof(
-                test_constants,
+                bt.constants,
                 ClassgroupElement.get_default_element(),
                 block.reward_chain_block.challenge_chain_ip_vdf.challenge,
                 block.reward_chain_block.challenge_chain_ip_vdf.number_of_iterations,

--- a/tests/core/server/test_rate_limits.py
+++ b/tests/core/server/test_rate_limits.py
@@ -13,12 +13,10 @@ from chia.server.rate_limit_numbers import rate_limits as rl_numbers
 from chia.server.rate_limits import RateLimiter
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
-from chia.simulator.block_tools import test_constants
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16
 from tests.conftest import node_with_params
 
-constants = test_constants
 rl_v2 = [Capability.BASE, Capability.BLOCK_HEADERS, Capability.RATE_LIMITS_V2]
 rl_v1 = [Capability.BASE]
 node_with_params_b = node_with_params

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -77,7 +77,7 @@ class TestCostCalculation:
         program: BlockGenerator = simple_solution_generator(spend_bundle)
 
         npc_result: NPCResult = get_name_puzzle_conditions(
-            program, test_constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+            program, bt.constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
         )
 
         assert npc_result.error is None
@@ -90,7 +90,7 @@ class TestCostCalculation:
         assert spend_info.solution == coin_spend.solution
 
         clvm_cost = 404560
-        byte_cost = len(bytes(program.program)) * test_constants.COST_PER_BYTE
+        byte_cost = len(bytes(program.program)) * bt.constants.COST_PER_BYTE
         assert (
             npc_result.conds.cost
             == ConditionCost.CREATE_COIN.value + ConditionCost.AGG_SIG.value + clvm_cost + byte_cost
@@ -101,7 +101,7 @@ class TestCostCalculation:
             npc_result.cost
             == ConditionCost.CREATE_COIN.value
             + ConditionCost.AGG_SIG.value
-            + len(bytes(program.program)) * test_constants.COST_PER_BYTE
+            + len(bytes(program.program)) * bt.constants.COST_PER_BYTE
             + clvm_cost
         )
 
@@ -142,11 +142,11 @@ class TestCostCalculation:
         )
         generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
-            generator, test_constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=softfork_height
+            generator, bt.constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=softfork_height
         )
         assert npc_result.error is not None
         npc_result = get_name_puzzle_conditions(
-            generator, test_constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+            generator, bt.constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
         )
         assert npc_result.error is None
 

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -12,7 +12,7 @@ from chia.full_node.signage_point import SignagePoint
 from chia.protocols import full_node_protocol
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.server.outbound_message import NodeType
-from chia.simulator.block_tools import get_signage_point, test_constants
+from chia.simulator.block_tools import get_signage_point
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
 from chia.simulator.time_out_assert import time_out_assert
 from chia.simulator.wallet_tools import WalletTool
@@ -59,7 +59,7 @@ class TestRpc:
             assert len(await client.get_unfinished_block_headers()) == 0
             assert len((await client.get_block_records(0, 100))) == 0
             for block in blocks:
-                if is_overflow_block(test_constants, block.reward_chain_block.signage_point_index):
+                if is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index):
                     finished_ss = block.finished_sub_slots[:-1]
                 else:
                     finished_ss = block.finished_sub_slots
@@ -347,10 +347,10 @@ class TestRpc:
             # Creates a signage point based on the last block
             peak_2 = second_blockchain.get_peak()
             sp: SignagePoint = get_signage_point(
-                test_constants,
+                bt.constants,
                 blockchain,
                 peak_2,
-                peak_2.ip_sub_slot_total_iters(test_constants),
+                peak_2.ip_sub_slot_total_iters(bt.constants),
                 uint8(4),
                 [],
                 peak_2.sub_slot_iters,

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -6,7 +6,6 @@ import pytest
 
 from chia.consensus.blockchain import AddBlockResult
 from chia.protocols import full_node_protocol
-from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.weight_proof import WeightProof
 from chia.util.generator_tools import get_block_header
@@ -48,7 +47,7 @@ class TestWalletBlockchain:
 
         async with DBConnection(1) as db_wrapper:
             store = await KeyValStore.create(db_wrapper)
-            chain = await WalletBlockchain.create(store, test_constants)
+            chain = await WalletBlockchain.create(store, bt.constants)
 
             assert (await chain.get_peak_block()) is None
             assert chain.get_latest_timestamp() == 0

--- a/tests/weight_proof/test_weight_proof.py
+++ b/tests/weight_proof/test_weight_proof.py
@@ -7,12 +7,12 @@ import aiosqlite
 import pytest
 
 from chia.consensus.block_record import BlockRecord
+from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.full_node.block_store import BlockStore
 from chia.full_node.weight_proof import WeightProofHandler, _map_sub_epoch_summaries, _validate_summaries_weight
-from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
@@ -51,7 +51,7 @@ def get_prev_ses_block(sub_blocks, last_hash) -> Tuple[BlockRecord, int]:
 
 
 async def load_blocks_dont_validate(
-    blocks,
+    blocks, constants: ConsensusConstants
 ) -> Tuple[
     Dict[bytes32, HeaderBlock], Dict[uint32, bytes32], Dict[bytes32, BlockRecord], Dict[uint32, SubEpochSummary]
 ]:
@@ -60,7 +60,7 @@ async def load_blocks_dont_validate(
     sub_blocks: Dict[bytes32, BlockRecord] = {}
     sub_epoch_summaries: Dict[uint32, SubEpochSummary] = {}
     prev_block = None
-    difficulty = test_constants.DIFFICULTY_STARTING
+    difficulty = constants.DIFFICULTY_STARTING
     block: FullBlock
     for block in blocks:
         if block.height > 0:
@@ -75,14 +75,14 @@ async def load_blocks_dont_validate(
 
         quality_string: Optional[bytes32] = verify_and_get_quality_string(
             block.reward_chain_block.proof_of_space,
-            test_constants,
+            constants,
             block.reward_chain_block.pos_ss_cc_challenge_hash,
             cc_sp,
         )
         assert quality_string is not None
 
         required_iters: uint64 = calculate_iterations_quality(
-            test_constants.DIFFICULTY_CONSTANT_FACTOR,
+            constants.DIFFICULTY_CONSTANT_FACTOR,
             quality_string,
             block.reward_chain_block.proof_of_space.size,
             difficulty,
@@ -90,7 +90,7 @@ async def load_blocks_dont_validate(
         )
 
         sub_block = block_to_block_record(
-            test_constants,
+            constants,
             BlockCache(sub_blocks, height_to_hash=height_to_hash),
             required_iters,
             block,
@@ -105,7 +105,9 @@ async def load_blocks_dont_validate(
     return header_cache, height_to_hash, sub_blocks, sub_epoch_summaries
 
 
-async def _test_map_summaries(blocks, header_cache, height_to_hash, sub_blocks, summaries):
+async def _test_map_summaries(
+    blocks, header_cache, height_to_hash, sub_blocks, summaries, constants: ConsensusConstants
+):
     curr = sub_blocks[blocks[-1].header_hash]
     orig_summaries: Dict[int, SubEpochSummary] = {}
     while curr.height > 0:
@@ -114,36 +116,46 @@ async def _test_map_summaries(blocks, header_cache, height_to_hash, sub_blocks, 
         # next sub block
         curr = sub_blocks[curr.prev_hash]
 
-    wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+    wpf = WeightProofHandler(constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
 
     wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
     assert wp is not None
     # sub epoch summaries validate hashes
     summaries, sub_epoch_data_weight, _ = _map_sub_epoch_summaries(
-        test_constants.SUB_EPOCH_BLOCKS,
-        test_constants.GENESIS_CHALLENGE,
+        constants.SUB_EPOCH_BLOCKS,
+        constants.GENESIS_CHALLENGE,
         wp.sub_epochs,
-        test_constants.DIFFICULTY_STARTING,
+        constants.DIFFICULTY_STARTING,
     )
     assert len(summaries) == len(orig_summaries)
 
 
 class TestWeightProof:
     @pytest.mark.asyncio
-    async def test_weight_proof_map_summaries_1(self, default_400_blocks):
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(default_400_blocks)
-        await _test_map_summaries(default_400_blocks, header_cache, height_to_hash, sub_blocks, summaries)
+    async def test_weight_proof_map_summaries_1(self, default_400_blocks, blockchain_constants):
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            default_400_blocks, blockchain_constants
+        )
+        await _test_map_summaries(
+            default_400_blocks, header_cache, height_to_hash, sub_blocks, summaries, blockchain_constants
+        )
 
     @pytest.mark.asyncio
-    async def test_weight_proof_map_summaries_2(self, default_1000_blocks):
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(default_1000_blocks)
-        await _test_map_summaries(default_1000_blocks, header_cache, height_to_hash, sub_blocks, summaries)
+    async def test_weight_proof_map_summaries_2(self, default_1000_blocks, blockchain_constants):
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            default_1000_blocks, blockchain_constants
+        )
+        await _test_map_summaries(
+            default_1000_blocks, header_cache, height_to_hash, sub_blocks, summaries, blockchain_constants
+        )
 
     @pytest.mark.asyncio
-    async def test_weight_proof_summaries_1000_blocks(self, default_1000_blocks):
+    async def test_weight_proof_summaries_1000_blocks(self, default_1000_blocks, blockchain_constants):
         blocks = default_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         summaries, sub_epoch_data_weight, _ = _map_sub_epoch_summaries(
             wpf.constants.SUB_EPOCH_BLOCKS,
@@ -151,23 +163,27 @@ class TestWeightProof:
             wp.sub_epochs,
             wpf.constants.DIFFICULTY_STARTING,
         )
-        assert _validate_summaries_weight(test_constants, sub_epoch_data_weight, summaries, wp)
+        assert _validate_summaries_weight(blockchain_constants, sub_epoch_data_weight, summaries, wp)
         # assert res is not None
 
     @pytest.mark.asyncio
-    async def test_weight_proof_bad_peak_hash(self, default_1000_blocks):
+    async def test_weight_proof_bad_peak_hash(self, default_1000_blocks, blockchain_constants):
         blocks = default_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(b"sadgfhjhgdgsfadfgh")
         assert wp is None
 
     @pytest.mark.asyncio
     @pytest.mark.skip(reason="broken")
-    async def test_weight_proof_from_genesis(self, default_400_blocks):
+    async def test_weight_proof_from_genesis(self, default_400_blocks, blockchain_constants):
         blocks = default_400_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         assert wp is not None
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
@@ -299,51 +315,59 @@ class TestWeightProof:
             force_overflow=False,
         )
 
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks, bt.constants)
+        wpf = WeightProofHandler(bt.constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         assert wp is not None
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        wpf = WeightProofHandler(bt.constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
         valid, fork_point = wpf.validate_weight_proof_single_proc(wp)
 
         assert valid
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof1000(self, default_1000_blocks):
+    async def test_weight_proof1000(self, default_1000_blocks, blockchain_constants):
         blocks = default_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         assert wp is not None
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
         valid, fork_point = wpf.validate_weight_proof_single_proc(wp)
 
         assert valid
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof1000_pre_genesis_empty_slots(self, pre_genesis_empty_slots_1000_blocks):
+    async def test_weight_proof1000_pre_genesis_empty_slots(
+        self, pre_genesis_empty_slots_1000_blocks, blockchain_constants
+    ):
         blocks = pre_genesis_empty_slots_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
 
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         assert wp is not None
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
         valid, fork_point = wpf.validate_weight_proof_single_proc(wp)
 
         assert valid
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof10000__blocks_compact(self, default_10000_blocks_compact):
+    async def test_weight_proof10000__blocks_compact(self, default_10000_blocks_compact, blockchain_constants):
         blocks = default_10000_blocks_compact
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         assert wp is not None
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
         valid, fork_point = wpf.validate_weight_proof_single_proc(wp)
 
         assert valid
@@ -359,35 +383,39 @@ class TestWeightProof:
             normalized_to_identity_cc_eos=True,
             normalized_to_identity_icc_eos=True,
         )
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks, bt.constants)
+        wpf = WeightProofHandler(bt.constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         assert wp is not None
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        wpf = WeightProofHandler(bt.constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
         valid, fork_point = wpf.validate_weight_proof_single_proc(wp)
 
         assert valid
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof10000(self, default_10000_blocks):
+    async def test_weight_proof10000(self, default_10000_blocks, blockchain_constants):
         blocks = default_10000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
 
         assert wp is not None
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, {}, height_to_hash, {}))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, {}, height_to_hash, {}))
         valid, fork_point = wpf.validate_weight_proof_single_proc(wp)
 
         assert valid
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_check_num_of_samples(self, default_10000_blocks):
+    async def test_check_num_of_samples(self, default_10000_blocks, blockchain_constants):
         blocks = default_10000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         wp = await wpf.get_proof_of_weight(blocks[-1].header_hash)
         curr = -1
         samples = 0
@@ -398,15 +426,21 @@ class TestWeightProof:
         assert samples <= wpf.MAX_SAMPLES
 
     @pytest.mark.asyncio
-    async def test_weight_proof_extend_no_ses(self, default_1000_blocks):
+    async def test_weight_proof_extend_no_ses(self, default_1000_blocks, blockchain_constants):
         blocks = default_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
         last_ses_height = sorted(summaries.keys())[-1]
-        wpf_synced = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        wpf_synced = WeightProofHandler(
+            blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries)
+        )
         wp = await wpf_synced.get_proof_of_weight(blocks[last_ses_height].header_hash)
         assert wp is not None
         # todo for each sampled sub epoch, validate number of segments
-        wpf_not_synced = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        wpf_not_synced = WeightProofHandler(
+            blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {})
+        )
         valid, fork_point, _ = await wpf_not_synced.validate_weight_proof(wp)
         assert valid
         assert fork_point == 0
@@ -417,22 +451,28 @@ class TestWeightProof:
         assert fork_point == 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof_extend_new_ses(self, default_1000_blocks):
+    async def test_weight_proof_extend_new_ses(self, default_1000_blocks, blockchain_constants):
         blocks = default_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
         # delete last summary
         last_ses_height = sorted(summaries.keys())[-1]
         last_ses = summaries[last_ses_height]
         del summaries[last_ses_height]
-        wpf_synced = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        wpf_synced = WeightProofHandler(
+            blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries)
+        )
         wp = await wpf_synced.get_proof_of_weight(blocks[last_ses_height - 10].header_hash)
         assert wp is not None
-        wpf_not_synced = WeightProofHandler(test_constants, BlockCache(sub_blocks, height_to_hash, header_cache, {}))
+        wpf_not_synced = WeightProofHandler(
+            blockchain_constants, BlockCache(sub_blocks, height_to_hash, header_cache, {})
+        )
         valid, fork_point, _ = await wpf_not_synced.validate_weight_proof(wp)
         assert valid
         assert fork_point == 0
         # extend proof with 100 blocks
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         summaries[last_ses_height] = last_ses
         wpf_synced.blockchain = BlockCache(sub_blocks, header_cache, height_to_hash, summaries)
         new_wp = await wpf_synced._create_proof_of_weight(blocks[-1].header_hash)
@@ -449,15 +489,17 @@ class TestWeightProof:
         assert fork_point != 0
 
     @pytest.mark.asyncio
-    async def test_weight_proof_extend_multiple_ses(self, default_1000_blocks):
+    async def test_weight_proof_extend_multiple_ses(self, default_1000_blocks, blockchain_constants):
         blocks = default_1000_blocks
-        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(blocks)
+        header_cache, height_to_hash, sub_blocks, summaries = await load_blocks_dont_validate(
+            blocks, blockchain_constants
+        )
         last_ses_height = sorted(summaries.keys())[-1]
         last_ses = summaries[last_ses_height]
         before_last_ses_height = sorted(summaries.keys())[-2]
         before_last_ses = summaries[before_last_ses_height]
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
-        wpf_verify = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        wpf_verify = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, {}))
         for x in range(10, -1, -1):
             wp = await wpf.get_proof_of_weight(blocks[before_last_ses_height - x].header_hash)
             assert wp is not None
@@ -467,7 +509,7 @@ class TestWeightProof:
         # extend proof with 100 blocks
         summaries[last_ses_height] = last_ses
         summaries[before_last_ses_height] = before_last_ses
-        wpf = WeightProofHandler(test_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
+        wpf = WeightProofHandler(blockchain_constants, BlockCache(sub_blocks, header_cache, height_to_hash, summaries))
         new_wp = await wpf._create_proof_of_weight(blocks[-1].header_hash)
         valid, fork_point, _ = await wpf.validate_weight_proof(new_wp)
         assert valid


### PR DESCRIPTION
This is in preparations for being able to run tests with different sets of constants, e.g. the hard-fork constants

A lot of our tests, currently, assume that the `bt` fixture always uses `test_constants`. This is true today, but I would like to make `bt` parametrized to run with different consensus constants. One use case for this is to also run simulations with the constants after the 2.0 hard fork has activated.