### PR TITLE
Add confirmed filter for get_transactions

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -875,6 +875,7 @@ class WalletRpcApi:
             reverse=reverse,
             to_puzzle_hash=to_puzzle_hash,
             type_filter=type_filter,
+            confirmed=request.get("confirmed", None),
         )
         return {
             "transactions": [

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -131,6 +131,7 @@ class WalletRpcClient(RpcClient):
         reverse: bool = False,
         to_address: Optional[str] = None,
         type_filter: Optional[TransactionTypeFilter] = None,
+        confirmed: Optional[bool] = None,
     ) -> List[TransactionRecord]:
         request: Dict[str, Any] = {"wallet_id": wallet_id}
 
@@ -147,6 +148,9 @@ class WalletRpcClient(RpcClient):
 
         if type_filter is not None:
             request["type_filter"] = type_filter.to_json_dict()
+
+        if confirmed is not None:
+            request["confirmed"] = confirmed
 
         res = await self.fetch(
             "get_transactions",

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -263,6 +263,7 @@ class WalletTransactionStore:
         end,
         sort_key=None,
         reverse=False,
+        confirmed: Optional[bool] = None,
         to_puzzle_hash: Optional[bytes32] = None,
         type_filter: Optional[TransactionTypeFilter] = None,
     ) -> List[TransactionRecord]:
@@ -286,6 +287,11 @@ class WalletTransactionStore:
         else:
             query_str = SortKey[sort_key].ascending()
 
+        if confirmed is None:
+            confirmed_str = ""
+        else:
+            confirmed_str = "AND confirmed=" + str(int(confirmed))
+
         if type_filter is None:
             type_filter_str = ""
         else:
@@ -297,7 +303,7 @@ class WalletTransactionStore:
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 f"SELECT transaction_record FROM transaction_record WHERE wallet_id=?{puzz_hash_where}"
-                f" {type_filter_str} {query_str}, rowid"
+                f" {type_filter_str} {confirmed_str} {query_str}, rowid"
                 f" LIMIT {start}, {limit}",
                 (wallet_id,),
             )

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -287,10 +287,9 @@ class WalletTransactionStore:
         else:
             query_str = SortKey[sort_key].ascending()
 
-        if confirmed is None:
-            confirmed_str = ""
-        else:
-            confirmed_str = "AND confirmed=" + str(int(confirmed))
+        confirmed_str = ""
+        if confirmed is not None:
+            confirmed_str = f"AND confirmed={int(confirmed)}"
 
         if type_filter is None:
             type_filter_str = ""

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -726,6 +726,13 @@ async def test_get_transactions(wallet_rpc_environment: WalletRpcTestEnvironment
     )
     assert len(all_transactions) == 5
     assert all(transaction.type == TransactionType.COINBASE_REWARD for transaction in all_transactions)
+    # Test confirmed filter
+    all_transactions = await client.get_transactions(1, confirmed=True)
+    assert len(all_transactions) == 10
+    assert all(transaction.confirmed for transaction in all_transactions)
+    all_transactions = await client.get_transactions(1, confirmed=False)
+    assert len(all_transactions) == 2
+    assert all(not transaction.confirmed for transaction in all_transactions)
 
 
 @pytest.mark.asyncio

--- a/tests/wallet/test_transaction_store.py
+++ b/tests/wallet/test_transaction_store.py
@@ -443,10 +443,10 @@ async def test_get_transactions_between_confirmed() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(1))
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(2))
-        tr4 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(3))
-        tr5 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(4))
+        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(1))
+        tr3 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(2))
+        tr4 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(3))
+        tr5 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(4))
         tr6 = dataclasses.replace(
             tr1, name=token_bytes(32), confirmed_at_height=uint32(5), type=uint32(TransactionType.COINBASE_REWARD.value)
         )
@@ -456,6 +456,10 @@ async def test_get_transactions_between_confirmed() -> None:
         await store.add_transaction_record(tr3)
         await store.add_transaction_record(tr4)
         await store.add_transaction_record(tr5)
+
+        # Test confirmed filter
+        assert await store.get_transactions_between(1, 0, 100, confirmed=True) == [tr2, tr3, tr4, tr5]
+        assert await store.get_transactions_between(1, 0, 100, confirmed=False) == [tr1]
 
         # test different limits
         assert await store.get_transactions_between(1, 0, 1) == [tr1]


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
We need to get unconfirmed txs for the Clawback


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
None


### New Behavior:
When confirmed=True only return confirmed txs
When confirmed=False only return unconfirmed txs
When confirmed=None return all txs


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Unit test


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
