### PR TITLE
use a more aggresive activation schedule on testnet10

### DIFF
--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -67,16 +67,32 @@ def create_full_node_service(
     )
 
 
+def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None:
+    if network_id != "testnet10":
+        return
+    # activate softforks immediately on testnet
+    # these numbers are supposed to match initial-config.yaml
+    if "SOFT_FORK2_HEIGHT" not in overrides:
+        overrides["SOFT_FORK2_HEIGHT"] = 0
+    if "SOFT_FORK3_HEIGHT" not in overrides:
+        overrides["SOFT_FORK3_HEIGHT"] = 0
+    if "HARD_FORK_HEIGHT" not in overrides:
+        overrides["HARD_FORK_HEIGHT"] = 2997292
+    if "PLOT_FILTER_128_HEIGHT" not in overrides:
+        overrides["PLOT_FILTER_128_HEIGHT"] = 3061804
+    if "PLOT_FILTER_64_HEIGHT" not in overrides:
+        overrides["PLOT_FILTER_64_HEIGHT"] = 8010796
+    if "PLOT_FILTER_32_HEIGHT" not in overrides:
+        overrides["PLOT_FILTER_32_HEIGHT"] = 13056556
+
+
 async def async_main(service_config: Dict[str, Any]) -> int:
     # TODO: refactor to avoid the double load
     config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
     config[SERVICE_NAME] = service_config
     network_id = service_config["selected_network"]
     overrides = service_config["network_overrides"]["constants"][network_id]
-    if network_id == "testnet10":
-        # activate softforks immediately on testnet
-        if "SOFT_FORK2_HEIGHT" not in overrides:
-            overrides["SOFT_FORK2_HEIGHT"] = 0
+    update_testnet_overrides(network_id, overrides)
     updated_constants = DEFAULT_CONSTANTS.replace_str_to_bytes(**overrides)
     initialize_service_logging(service_name=SERVICE_NAME, config=config)
     service = create_full_node_service(DEFAULT_ROOT_PATH, config, updated_constants)

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -72,6 +72,16 @@ network_overrides: &network_overrides
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
       SOFT_FORK2_HEIGHT: 0
+      SOFT_FORK3_HEIGHT: 0
+      # planned 2.0 release is July 26, height 2965036 on testnet
+      # 1 week later
+      HARD_FORK_HEIGHT": 2997292
+      # another 2 weeks later
+      PLOT_FILTER_128_HEIGHT": 3061804
+      # 3 years later
+      PLOT_FILTER_64_HEIGHT": 8010796
+      # 3 years later
+      PLOT_FILTER_32_HEIGHT": 13056556
   config:
     mainnet:
       address_prefix: "xch"

--- a/tests/util/test_testnet_overrides.py
+++ b/tests/util/test_testnet_overrides.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from chia.server.start_full_node import update_testnet_overrides
+
+
+def test_testnet10() -> None:
+    overrides: Dict[str, Any] = {}
+    update_testnet_overrides("testnet10", overrides)
+    assert overrides == {
+        "SOFT_FORK2_HEIGHT": 0,
+        "SOFT_FORK3_HEIGHT": 0,
+        "HARD_FORK_HEIGHT": 2997292,
+        "PLOT_FILTER_128_HEIGHT": 3061804,
+        "PLOT_FILTER_64_HEIGHT": 8010796,
+        "PLOT_FILTER_32_HEIGHT": 13056556,
+    }
+
+
+def test_testnet10_existing() -> None:
+    overrides: Dict[str, Any] = {
+        "SOFT_FORK2_HEIGHT": 42,
+        "SOFT_FORK3_HEIGHT": 42,
+        "HARD_FORK_HEIGHT": 42,
+        "PLOT_FILTER_128_HEIGHT": 42,
+        "PLOT_FILTER_64_HEIGHT": 42,
+        "PLOT_FILTER_32_HEIGHT": 42,
+    }
+    update_testnet_overrides("testnet10", overrides)
+    assert overrides == {
+        "SOFT_FORK2_HEIGHT": 42,
+        "SOFT_FORK3_HEIGHT": 42,
+        "HARD_FORK_HEIGHT": 42,
+        "PLOT_FILTER_128_HEIGHT": 42,
+        "PLOT_FILTER_64_HEIGHT": 42,
+        "PLOT_FILTER_32_HEIGHT": 42,
+    }
+
+
+def test_mainnet() -> None:
+    overrides: Dict[str, Any] = {}
+    update_testnet_overrides("mainnet", overrides)
+    assert overrides == {}


### PR DESCRIPTION
As the comments suggests, this activates the:

* 2.0 *softfork* immediately
* 2.0 *hardfork* 1 weeks after (planned) release (which also reduces the plot filter by one bit)
* the next plot filter reduction 2 weeks after that
* the next plot filter reduction 3 years after that
* the last plot filter reduction 3 years after that
Note that these are all `testnet10` block heights, which is about a million behind `mainnet`