### PR TITLE
full_node: More set usage in subscription code

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1509,7 +1509,7 @@ class FullNodeAPI:
         if len(hint_coin_ids) > 0:
             hint_states = await self.full_node.coin_store.get_coin_states_by_ids(
                 include_spent_coins=True,
-                coin_ids=list(hint_coin_ids),
+                coin_ids=hint_coin_ids,
                 min_height=request.min_height,
                 max_items=len(hint_coin_ids),
             )
@@ -1553,7 +1553,7 @@ class FullNodeAPI:
         self.full_node.subscriptions.add_coin_subscriptions(peer.peer_node_id, request.coin_ids, max_subscriptions)
 
         states: List[CoinState] = await self.full_node.coin_store.get_coin_states_by_ids(
-            include_spent_coins=True, coin_ids=request.coin_ids, min_height=request.min_height, max_items=max_items
+            include_spent_coins=True, coin_ids=set(request.coin_ids), min_height=request.min_height, max_items=max_items
         )
 
         response = wallet_protocol.RespondToCoinUpdates(request.coin_ids, request.min_height, states)

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -31,7 +31,7 @@ class PeerSubscriptions:
     def has_coin_subscription(self, coin_id: bytes32) -> bool:
         return coin_id in self._coin_subscriptions
 
-    def add_ph_subscriptions(self, peer_id: bytes32, phs: List[bytes32], max_items: int) -> List[bytes32]:
+    def add_ph_subscriptions(self, peer_id: bytes32, phs: List[bytes32], max_items: int) -> Set[bytes32]:
         """
         returns the puzzle hashes that were actually subscribed to. These may be
         fewer than requested in case:
@@ -43,7 +43,7 @@ class PeerSubscriptions:
         puzzle_hash_peers = self._peer_puzzle_hash.setdefault(peer_id, set())
         existing_sub_count = self._peer_sub_counter.setdefault(peer_id, 0)
 
-        ret: List[bytes32] = []
+        ret: Set[bytes32] = set()
 
         # if we've reached the limit on number of subscriptions, just bail
         if existing_sub_count >= max_items:
@@ -63,7 +63,7 @@ class PeerSubscriptions:
             if peer_id in ph_sub:
                 continue
 
-            ret.append(ph)
+            ret.add(ph)
             ph_sub.add(peer_id)
             puzzle_hash_peers.add(ph)
             self._peer_sub_counter[peer_id] += 1

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -420,26 +420,26 @@ class TestCoinStoreWithBlocks:
             coin_store = await CoinStore.create(db_wrapper)
             await coin_store._add_coin_records(crs)
 
-            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, [std_hash(b"2")], 0)) == 300
-            assert len(await coin_store.get_coin_states_by_puzzle_hashes(False, [std_hash(b"2")], 0)) == 0
-            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, [std_hash(b"2")], 300)) == 151
-            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, [std_hash(b"2")], 603)) == 0
-            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, [std_hash(b"1")], 0)) == 0
+            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, {std_hash(b"2")}, 0)) == 300
+            assert len(await coin_store.get_coin_states_by_puzzle_hashes(False, {std_hash(b"2")}, 0)) == 0
+            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, {std_hash(b"2")}, 300)) == 151
+            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, {std_hash(b"2")}, 603)) == 0
+            assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, {std_hash(b"1")}, 0)) == 0
 
             # test max_items limit
             for limit in [0, 1, 42, 300]:
                 assert (
-                    len(await coin_store.get_coin_states_by_puzzle_hashes(True, [std_hash(b"2")], 0, max_items=limit))
+                    len(await coin_store.get_coin_states_by_puzzle_hashes(True, {std_hash(b"2")}, 0, max_items=limit))
                     == limit
                 )
 
             # if the limit is very high, we should get all of them
             assert (
-                len(await coin_store.get_coin_states_by_puzzle_hashes(True, [std_hash(b"2")], 0, max_items=10000))
+                len(await coin_store.get_coin_states_by_puzzle_hashes(True, {std_hash(b"2")}, 0, max_items=10000))
                 == 300
             )
 
-            coins = [cr.coin.name() for cr in crs]
+            coins = {cr.coin.name() for cr in crs}
             bad_coins = [std_hash(cr.coin.name()) for cr in crs]
             assert len(await coin_store.get_coin_states_by_ids(True, coins, 0)) == 600
             assert len(await coin_store.get_coin_states_by_ids(False, coins, 0)) == 0

--- a/tests/core/full_node/test_subscriptions.py
+++ b/tests/core/full_node/test_subscriptions.py
@@ -24,14 +24,14 @@ def test_has_ph_sub() -> None:
     assert sub.has_ph_subscription(ph2) is False
 
     ret = sub.add_ph_subscriptions(peer1, [ph1], 100)
-    assert ret == [ph1]
+    assert ret == {ph1}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is False
 
     ret = sub.add_ph_subscriptions(peer1, [ph1, ph2], 100)
     # we have already subscribed to ph1, it's filtered in the returned list
-    assert ret == [ph2]
+    assert ret == {ph2}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is True
@@ -127,13 +127,13 @@ def test_overlapping_ph_subscriptions() -> None:
 
     # subscribed to different phs
     ret = sub.add_ph_subscriptions(peer1, [ph1], 100)
-    assert ret == [ph1]
+    assert ret == {ph1}
 
     assert sub.peers_for_puzzle_hash(ph1) == {peer1}
     assert sub.peers_for_puzzle_hash(ph2) == set()
 
     ret = sub.add_ph_subscriptions(peer2, [ph2], 100)
-    assert ret == [ph2]
+    assert ret == {ph2}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is True
@@ -143,7 +143,7 @@ def test_overlapping_ph_subscriptions() -> None:
 
     # peer1 is now subscribing to both phs
     ret = sub.add_ph_subscriptions(peer1, [ph2], 100)
-    assert ret == [ph2]
+    assert ret == {ph2}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is True
@@ -171,7 +171,7 @@ def test_ph_sub_limit() -> None:
 
     ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
     # we only ended up subscribing to 3 puzzle hashes because of the limit
-    assert ret == [ph1, ph2, ph3]
+    assert ret == {ph1, ph2, ph3}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is True
@@ -185,7 +185,7 @@ def test_ph_sub_limit() -> None:
 
     # peer1 should still be limited
     ret = sub.add_ph_subscriptions(peer1, [ph4], 3)
-    assert ret == []
+    assert ret == set()
 
     assert sub.has_ph_subscription(ph4) is False
     assert sub.peers_for_puzzle_hash(ph4) == set()
@@ -198,7 +198,7 @@ def test_ph_sub_limit() -> None:
 
     # peer2 is has its own limit
     ret = sub.add_ph_subscriptions(peer2, [ph4], 3)
-    assert ret == [ph4]
+    assert ret == {ph4}
 
     assert sub.has_ph_subscription(ph4) is True
     assert sub.peers_for_puzzle_hash(ph4) == {peer2}
@@ -216,7 +216,7 @@ def test_ph_sub_limit_incremental() -> None:
     assert sub.has_ph_subscription(ph3) is False
 
     ret = sub.add_ph_subscriptions(peer1, [ph1], 2)
-    assert ret == [ph1]
+    assert ret == {ph1}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is False
@@ -230,7 +230,7 @@ def test_ph_sub_limit_incremental() -> None:
 
     # this will cross the limit. Only ph2 will be added
     ret = sub.add_ph_subscriptions(peer1, [ph2, ph3], 2)
-    assert ret == [ph2]
+    assert ret == {ph2}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is True
@@ -273,7 +273,7 @@ def test_coin_sub_limit() -> None:
 
     # peer1 is also limied on ph subscriptions
     ret = sub.add_ph_subscriptions(peer1, [ph1], 3)
-    assert ret == []
+    assert ret == set()
 
     assert sub.has_ph_subscription(ph1) is False
     assert sub.peers_for_puzzle_hash(ph1) == set()
@@ -333,7 +333,7 @@ def test_ph_subscription_duplicates() -> None:
     assert sub.has_ph_subscription(ph4) is False
 
     ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3], 100)
-    assert ret == [ph1, ph2, ph3]
+    assert ret == {ph1, ph2, ph3}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is True
@@ -342,7 +342,7 @@ def test_ph_subscription_duplicates() -> None:
 
     # only ph4 is new, the others are duplicates and ignored
     ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
-    assert ret == [ph4]
+    assert ret == {ph4}
 
     assert sub.has_ph_subscription(ph1) is True
     assert sub.has_ph_subscription(ph2) is True

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -97,7 +97,7 @@ class TestSimpleSyncProtocol:
 
         all_messages = await get_all_messages_in_queue(incoming_queue)
 
-        zero_coin = await full_node_api.full_node.coin_store.get_coin_states_by_puzzle_hashes(True, [zero_ph])
+        zero_coin = await full_node_api.full_node.coin_store.get_coin_states_by_puzzle_hashes(True, {zero_ph})
         all_zero_coin = set(zero_coin)
         notified_zero_coins = set()
 
@@ -131,9 +131,9 @@ class TestSimpleSyncProtocol:
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(one_ph))
 
         zero_coins = await full_node_api.full_node.coin_store.get_coin_states_by_puzzle_hashes(
-            True, [zero_ph], peak.height + 1
+            True, {zero_ph}, peak.height + 1
         )
-        one_coins = await full_node_api.full_node.coin_store.get_coin_states_by_puzzle_hashes(True, [one_ph])
+        one_coins = await full_node_api.full_node.coin_store.get_coin_states_by_puzzle_hashes(True, {one_ph})
 
         all_coins = set(zero_coins)
         all_coins.update(one_coins)


### PR DESCRIPTION
### Purpose:

Avoid potentially querying duplicated coin states from the DB by just filtering the condition items before and remove some list<>set conversions.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

1. Query based on a `list` of subscription items
2. Create a `set` of `CoinState` items
3. Convert the `set` to a `list`

### New Behavior:

1. Query based on a `set` of subscription items
2. Create a `list` of `CoinState` items

### Based on:

- #15415 
