### PR TITLE
wallet: Fix missing hint in `GenesisById.generate_issuance_bundle`

### DIFF
--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -92,7 +92,9 @@ class GenesisById(LimitationsProgram):
 
         inner_solution = wallet.standard_wallet.add_condition_to_solution(
             Program.to([51, 0, -113, tail, []]),
-            wallet.standard_wallet.make_solution(primaries=[Payment(cat_inner.get_tree_hash(), amount)]),
+            wallet.standard_wallet.make_solution(
+                primaries=[Payment(cat_inner.get_tree_hash(), amount, [cat_inner.get_tree_hash()])]
+            ),
         )
         eve_spend = unsigned_spend_bundle_for_spendable_cats(
             CAT_MOD,

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -90,11 +90,10 @@ class GenesisById(LimitationsProgram):
         )
         assert tx_record.spend_bundle is not None
 
+        inner_tree_hash = cat_inner.get_tree_hash()
         inner_solution = wallet.standard_wallet.add_condition_to_solution(
             Program.to([51, 0, -113, tail, []]),
-            wallet.standard_wallet.make_solution(
-                primaries=[Payment(cat_inner.get_tree_hash(), amount, [cat_inner.get_tree_hash()])]
-            ),
+            wallet.standard_wallet.make_solution(primaries=[Payment(inner_tree_hash, amount, [inner_tree_hash])]),
         )
         eve_spend = unsigned_spend_bundle_for_spendable_cats(
             CAT_MOD,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Avoid creation of unhinted CATs. Fixes a test failure in #15274.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

CATs created via `GenesisById.generate_issuance_bundle` are unhinted.

### New Behavior:

CATs created via `GenesisById.generate_issuance_bundle` are hinted.
