### PR TITLE
Add a path in wallets_prefarm test fixture for generating an RPC client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -733,13 +733,14 @@ async def wallets_prefarm_services(two_wallet_nodes_services, self_hostname, tru
         (wallet_node_0, wallet_0_rewards),
         (wallet_node_1, wallet_1_rewards),
         (wallet_0_rpc_client, wallet_1_rpc_client),
+        (wallet_service_0, wallet_service_1),
         full_node_api,
     )
 
 
 @pytest_asyncio.fixture(scope="function")
 async def wallets_prefarm(wallets_prefarm_services):
-    return wallets_prefarm_services[0], wallets_prefarm_services[1], wallets_prefarm_services[3]
+    return wallets_prefarm_services[0], wallets_prefarm_services[1], wallets_prefarm_services[4]
 
 
 @pytest_asyncio.fixture(scope="function")


### PR DESCRIPTION
Previously, it was impossible to use the `wallets_prefarm` test fixture and get the information you needed to spin up a `WalletRpcClient` to use in a test.  This PR modifies the fixture to add all of the arguments you would need to do so to a private variable on the wallet node `._test_client_args`.  This way, you can now go `WalletRpcClient.create(*wallet_node._test_client_args)` to get an RPC client in a test that uses this fixture.