### PR TITLE
Check all peers when subscribing/tracking to new DL singleton

### DIFF
--- a/chia/data_layer/data_layer_errors.py
+++ b/chia/data_layer/data_layer_errors.py
@@ -40,3 +40,7 @@ class KeyNotFoundError(Exception):
 
 class OfferIntegrityError(Exception):
     pass
+
+
+class LauncherCoinNotFoundError(Exception):
+    pass

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -11,7 +11,7 @@ from clvm.EvalError import EvalError
 from typing_extensions import final
 
 from chia.consensus.block_record import BlockRecord
-from chia.data_layer.data_layer_errors import OfferIntegrityError
+from chia.data_layer.data_layer_errors import LauncherCoinNotFoundError, OfferIntegrityError
 from chia.data_layer.data_layer_util import OfferStore, ProofOfInclusion, ProofOfInclusionLayer, StoreProofs, leaf_hash
 from chia.protocols.wallet_protocol import CoinState
 from chia.server.ws_connection import WSChiaConnection
@@ -199,7 +199,7 @@ class DataLayerWallet:
         )
 
         if len(coin_states) == 0:
-            raise ValueError(f"Launcher ID {launcher_id} is not a valid coin")
+            raise LauncherCoinNotFoundError(f"Launcher ID {launcher_id} is not a valid coin")
         if coin_states[0].coin.puzzle_hash != SINGLETON_LAUNCHER.get_tree_hash():
             raise ValueError(f"Coin with ID {launcher_id} is not a singleton launcher")
         if coin_states[0].created_height is None:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, Union
 from blspy import AugSchemeMPL, G1Element, G2Element, PrivateKey
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward
+from chia.data_layer.data_layer_errors import LauncherCoinNotFoundError
 from chia.data_layer.data_layer_wallet import DataLayerWallet
 from chia.pools.pool_wallet import PoolWallet
 from chia.pools.pool_wallet_info import FARMING_TO_POOL, PoolState, PoolWalletInfo, create_pool_state
@@ -3185,10 +3186,18 @@ class WalletRpcApi:
                 dl_wallet = await DataLayerWallet.create_new_dl_wallet(
                     self.service.wallet_state_manager,
                 )
-        await dl_wallet.track_new_launcher_id(
-            bytes32.from_hexstr(request["launcher_id"]),
-            self.service.get_full_node_peer(),
-        )
+        peer_list = self.service.get_full_node_peers_in_order()
+        peer_length = len(peer_list)
+        for i, peer in enumerate(peer_list):
+            try:
+                await dl_wallet.track_new_launcher_id(
+                    bytes32.from_hexstr(request["launcher_id"]),
+                    peer,
+                )
+            except LauncherCoinNotFoundError as e:
+                if i == peer_length - 1:
+                    raise e  # raise the error if we've tried all peers
+                continue  # try some other peers, maybe someone has it
         return {}
 
     async def dl_stop_tracking(self, request) -> Dict:

--- a/tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -111,6 +111,10 @@ class TestWalletRpc:
 
             assert await client.dl_history(launcher_id) == [new_singleton_record, singleton_record]
 
+            # Test tracking a launcher id that does not exist
+            with pytest.raises(ValueError):
+                await client_2.dl_track_new(bytes32([1] * 32))
+
             await client_2.dl_track_new(launcher_id)
 
             async def is_singleton_generation(rpc_client: WalletRpcClient, lid: bytes32, generation: int) -> bool:


### PR DESCRIPTION
Fixes #15414 

Well, it can only partially fix that - if none of the peers actually know about the coin, it's possible you can still get an error when trying to subscribe, but this should substantially reduce the probability by asking all the peers and only returning an error if none of the peers knows about the coin.

Note that there may be other instances where asking all the peers for similar RPCs should be done, but this is targeted specifically for this singular use case.