### PR TITLE
remove unnecessary filtering of state_changed messages for the UI

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -246,26 +246,7 @@ class WalletRpcApi:
             # Metrics is the only current consumer for this event
             payloads.append(create_payload_dict(change, change_data, self.service_name, "metrics"))
 
-        if change in {
-            "offer_cancelled",
-            "offer_added",
-            "wallet_created",
-            "did_coin_added",
-            "nft_coin_added",
-            "nft_coin_removed",
-            "nft_coin_updated",
-            "nft_coin_did_set",
-            "new_block",
-            "coin_removed",
-            "coin_added",
-            "new_derivation_index",
-            "added_stray_cat",
-            "pending_transaction",
-            "tx_update",
-            "wallet_removed",
-            "new_on_chain_notification",
-        }:
-            payloads.append(create_payload_dict("state_changed", change_data, self.service_name, "wallet_ui"))
+        payloads.append(create_payload_dict("state_changed", change_data, self.service_name, "wallet_ui"))
 
         return payloads
 


### PR DESCRIPTION
### Purpose:
Too many times now the UI has been missing out on state_changed messages from the wallet backend because this silly hardcoded list doesn't get updated. The UI is interested in all state_changed messages from the wallet, so we can make life easier and just send all such messages. 


### Current Behavior:
vc_coin_added and vc_coin_removed state_changed messages are not sent to the UI. Others may not be sent as well...


### New Behavior:
All state_changed messages from the wallet backend are sent to the UI.


### Testing Notes:
Manually tested with the UI logging the previously unsent messages

