### PR TITLE
fix checking of matrix.configuration.checkout_blocks_and_plots

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -193,7 +193,7 @@ jobs:
           key: ${{ env.BLOCKS_AND_PLOTS_VERSION }}
 
       - name: Checkout test blocks and plots (macOS, Ubuntu)
-        if: steps.test-blocks-plots.outputs.cache-hit != 'true' && (matrix.os.matrix == 'ubuntu' || matrix.os.matrix == 'macos')
+        if: matrix.configuration.checkout_blocks_and_plots && steps.test-blocks-plots.outputs.cache-hit != 'true' && (matrix.os.matrix == 'ubuntu' || matrix.os.matrix == 'macos')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -202,7 +202,7 @@ jobs:
           mv ${{ github.workspace }}/test-cache-${{ env.BLOCKS_AND_PLOTS_VERSION }}/* ${{ github.workspace }}/.chia
 
       - name: Checkout test blocks and plots (Windows)
-        if: steps.test-blocks-plots.outputs.cache-hit != 'true' && matrix.os.matrix == 'windows'
+        if: matrix.configuration.checkout_blocks_and_plots && steps.test-blocks-plots.outputs.cache-hit != 'true' && matrix.os.matrix == 'windows'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/tests/fee_estimation/config.py
+++ b/tests/fee_estimation/config.py
@@ -1,5 +1,3 @@
 from __future__ import annotations
 
-parallel = True
-job_timeout = 50
 checkout_blocks_and_plots = True

--- a/tests/wallet/vc_wallet/config.py
+++ b/tests/wallet/vc_wallet/config.py
@@ -1,5 +1,3 @@
 from __future__ import annotations
 
-parallel = True
-job_timeout = 50
 checkout_blocks_and_plots = True


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Fix fetching test blocks and plots based on the configuration.
<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

If you set the value to False, the test blocks and plots would still get fetched.

### New Behavior:

The config value is properly respected.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

Draft For:
- [x] reviewing failing tests and likely configuring to download the blocks and plots
- [x] https://github.com/Chia-Network/chia-blockchain/pull/15463 for (omitting) coverage