### PR TITLE
don't measure coverage of CI `tests/**/config.py` files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ relative_files=True
 source_pkgs=
   chia
   tests
+omit=
+  tests/**/config.py
 concurrency=multiprocessing
 parallel=True
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

`tests/**/config.py` don't need coverage measurement (at least for now).  https://github.com/Chia-Network/chia-blockchain/actions/runs/5192362237/jobs/9362350111?pr=15454#step:11:20

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
