### PR TITLE
full_node: Add `max_height` to `CoinStore.get_coin_states_by_ids`

### DIFF
--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -446,6 +446,24 @@ class TestCoinStoreWithBlocks:
             assert len(await coin_store.get_coin_states_by_ids(True, coins, 300)) == 302
             assert len(await coin_store.get_coin_states_by_ids(True, coins, 603)) == 0
             assert len(await coin_store.get_coin_states_by_ids(True, bad_coins, 0)) == 0
+            # Test max_height
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(603))) == 600
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(602))) == 600
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(599))) == 598
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(400))) == 400
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(301))) == 300
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(300))) == 300
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(299))) == 298
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, max_height=uint32(0))) == 0
+            # Test min_height + max_height
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(603))) == 302
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(602))) == 302
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(599))) == 300
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(400))) == 102
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(301))) == 2
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(300))) == 2
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(299))) == 0
+            assert len(await coin_store.get_coin_states_by_ids(True, coins, uint32(300), max_height=uint32(0))) == 0
 
             # test max_items limit
             for limit in [0, 1, 42, 300]:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Allow to fetch `CoinState`'s based on min/max height instead of only min height as preparation for follow up PR to introduce new message `get_coin_infos`.

### New Behavior:

No change in behaviour.

### Based on:

- #15420 