### PR TITLE
seeder: Drop `CrawlerAPI.__getattr__`

### DIFF
--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 class Crawler:
     sync_store: Any
     coin_store: CoinStore
-    connection: aiosqlite.Connection
+    connection: Optional[aiosqlite.Connection]
     config: Dict
     _server: Optional[ChiaServer]
     crawl_store: Optional[CrawlStore]
@@ -63,6 +63,7 @@ class Crawler:
         self.initialized = False
         self.root_path = root_path
         self.config = config
+        self.connection = None
         self._server = None
         self._shut_down = False  # Set to true to close all infinite loops
         self.constants = consensus_constants
@@ -372,4 +373,5 @@ class Crawler:
         self._shut_down = True
 
     async def _await_closed(self):
-        await self.connection.close()
+        if self.connection is not None:
+            await self.connection.close()

--- a/chia/seeder/crawler_api.py
+++ b/chia/seeder/crawler_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 from chia.protocols import full_node_protocol, wallet_protocol
 from chia.seeder.crawler import Crawler
@@ -16,12 +16,6 @@ class CrawlerAPI:
 
     def __init__(self, crawler: Crawler) -> None:
         self.crawler = crawler
-
-    def __getattr__(self, attr_name: str) -> Any:
-        async def invoke(*args: Any, **kwargs: Any) -> Any:
-            pass
-
-        return invoke
 
     @property
     def server(self) -> ChiaServer:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol
 from chia.rpc.wallet_rpc_client import WalletRpcClient
+from chia.seeder.crawler import Crawler
 from chia.server.server import ChiaServer
 from chia.server.start_service import Service
 from chia.simulator.full_node_simulator import FullNodeSimulator
@@ -36,7 +37,7 @@ from chia.simulator.setup_nodes import (
     setup_simulators_and_wallets_service,
     setup_two_nodes,
 )
-from chia.simulator.setup_services import setup_daemon, setup_introducer, setup_timelord
+from chia.simulator.setup_services import setup_crawler, setup_daemon, setup_introducer, setup_timelord
 from chia.simulator.time_out_assert import time_out_assert
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.peer_info import PeerInfo
@@ -817,6 +818,12 @@ async def timelord(bt):
 async def timelord_service(bt):
     async for _ in setup_timelord(uint16(0), False, bt.constants, bt):
         yield _
+
+
+@pytest_asyncio.fixture(scope="function")
+async def crawler_service(bt: BlockTools) -> AsyncIterator[Service[Crawler]]:
+    async for service in setup_crawler(bt):
+        yield service
 
 
 @pytest.fixture(scope="function")

--- a/tests/core/test_crawler.py
+++ b/tests/core/test_crawler.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+import pytest
+
+from chia.full_node.full_node_api import FullNodeAPI
+from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.protocols.wallet_protocol import RequestChildren
+from chia.seeder.crawler import Crawler
+from chia.seeder.crawler_api import CrawlerAPI
+from chia.server.outbound_message import make_msg
+from chia.simulator.setup_nodes import SimulatorsAndWalletsServices
+from chia.simulator.time_out_assert import time_out_assert
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.peer_info import PeerInfo
+from chia.util.ints import uint16
+
+
+@pytest.mark.asyncio
+async def test_unknown_messages(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    [full_node_service], [wallet_service], bt = one_wallet_and_one_simulator_services
+    wallet_node = wallet_service._node
+    full_node = full_node_service._node
+    await wallet_node.server.start_client(
+        PeerInfo(self_hostname, uint16(cast(FullNodeAPI, full_node_service._api).server._port)), None
+    )
+    send_connection = full_node.server.all_connections[wallet_node.server.node_id]
+    receive_connection = wallet_node.server.all_connections[full_node.server.node_id]
+    receive_connection.api = CrawlerAPI(Crawler(bt.config["seeder"], bt.root_path, bt.constants))
+    msg = make_msg(ProtocolMessageTypes.request_children, RequestChildren(bytes32(b"\0" * 32)))
+
+    def receiving_failed() -> bool:
+        return "Peer trying to call non api function request_children" in caplog.text
+
+    with caplog.at_level(logging.ERROR):
+        assert await send_connection.send_message(msg)
+        await time_out_assert(10, receiving_failed)

--- a/tests/core/test_crawler.py
+++ b/tests/core/test_crawler.py
@@ -36,7 +36,7 @@ async def test_unknown_messages(
     msg = make_msg(ProtocolMessageTypes.request_children, RequestChildren(bytes32(b"\0" * 32)))
 
     def receiving_failed() -> bool:
-        return "Peer trying to call non api function request_children" in caplog.text
+        return "Non existing function: request_children" in caplog.text
 
     with caplog.at_level(logging.ERROR):
         assert await send_connection.send_message(msg)

--- a/tests/core/test_crawler.py
+++ b/tests/core/test_crawler.py
@@ -9,8 +9,8 @@ from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.wallet_protocol import RequestChildren
 from chia.seeder.crawler import Crawler
-from chia.seeder.crawler_api import CrawlerAPI
 from chia.server.outbound_message import make_msg
+from chia.server.start_service import Service
 from chia.simulator.setup_nodes import SimulatorsAndWalletsServices
 from chia.simulator.time_out_assert import time_out_assert
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -21,23 +21,22 @@ from chia.util.ints import uint16
 @pytest.mark.asyncio
 async def test_unknown_messages(
     self_hostname: str,
-    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    one_node: SimulatorsAndWalletsServices,
+    crawler_service: Service[Crawler],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    [full_node_service], [wallet_service], bt = one_wallet_and_one_simulator_services
-    wallet_node = wallet_service._node
+    [full_node_service], _, _ = one_node
+    crawler = crawler_service._node
     full_node = full_node_service._node
-    await wallet_node.server.start_client(
+    assert await crawler.server.start_client(
         PeerInfo(self_hostname, uint16(cast(FullNodeAPI, full_node_service._api).server._port)), None
     )
-    send_connection = full_node.server.all_connections[wallet_node.server.node_id]
-    receive_connection = wallet_node.server.all_connections[full_node.server.node_id]
-    receive_connection.api = CrawlerAPI(Crawler(bt.config["seeder"], bt.root_path, bt.constants))
-    msg = make_msg(ProtocolMessageTypes.request_children, RequestChildren(bytes32(b"\0" * 32)))
+    connection = full_node.server.all_connections[crawler.server.node_id]
 
     def receiving_failed() -> bool:
         return "Non existing function: request_children" in caplog.text
 
     with caplog.at_level(logging.ERROR):
-        assert await send_connection.send_message(msg)
+        msg = make_msg(ProtocolMessageTypes.request_children, RequestChildren(bytes32(b"\0" * 32)))
+        assert await connection.send_message(msg)
         await time_out_assert(10, receiving_failed)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

It makes `CrawlerAPI` not reacting to issues in `ApiProtocol` from #15466 and after some investigation, from my understanding this is only to satisfy the `CrawlerAPI` accepting unknown messages here:

https://github.com/Chia-Network/chia-blockchain/blob/2e60325894a8d602f6e43d2a88b16bdb1af8ebe6/chia/server/ws_connection.py#L364-L368

which will then still fail here 

https://github.com/Chia-Network/chia-blockchain/blob/2e60325894a8d602f6e43d2a88b16bdb1af8ebe6/chia/server/ws_connection.py#L370-L373

because the function returned by `__getattr__` doesn't have metadata so its not a win at all to keep it. This probably somehow worked better/different before some of the _recent_ changes from @altendky to the API decorators. 

The above explanation also matches the test added here where the error changes from 

```
"Peer trying to call non api function request_children"
```

to 

```
"Non existing function: request_children"
```

in the here added test `test_unknown_messages` when `CrawlerAPI.__getattr__` gets dropped.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The crawler prints `"Peer trying to call non api function request_children"` for unknown incoming messages.

### New Behavior:

The crawler prints `"Non existing function: request_children"` for unknown incoming messages.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Added a test.

### Based on:

- #15498 
