### PR TITLE
fix flaky `MAX_FUTURE_TIME` test

### DIFF
--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1503,10 +1503,10 @@ class TestBlockHeaderValidation:
             # the test constants set MAX_FUTURE_TIME to 10 days, restore it to
             # default for this test
             constants = bt.constants.replace(SOFT_FORK2_HEIGHT=0, MAX_FUTURE_TIME=5 * 60)
-            time_delta = 2 * 60
+            time_delta = 2 * 60 + 1
         else:
             constants = bt.constants.replace(MAX_FUTURE_TIME=5 * 60)
-            time_delta = 5 * 60
+            time_delta = 5 * 60 + 1
 
         blocks = bt.get_consecutive_blocks(1)
 


### PR DESCRIPTION
It appears that if the test ran too fast, and the (seconds) timestamp did not progress between starting the test and arriving to the block validation, it would not fail as expected.