### PR TITLE
Rephrase async contextmanager DBConnection to use asynccontextmanager

### DIFF
--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -142,7 +142,6 @@ tests.pools.test_wallet_pool_store
 tests.simulation.test_simulation
 tests.tools.test_run_block
 tests.util.benchmark_cost
-tests.util.db_connection
 tests.util.generator_tools_testing
 tests.util.key_tool
 tests.util.test_full_block_utils

--- a/tests/util/db_connection.py
+++ b/tests/util/db_connection.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
 import tempfile
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import AsyncIterator
 
 from chia.util.db_wrapper import DBWrapper2
 
 
-class DBConnection:
-    def __init__(self, db_version: int) -> None:
-        self.db_version = db_version
-
-    async def __aenter__(self) -> DBWrapper2:
-        self.db_path = Path(tempfile.NamedTemporaryFile().name)
-        if self.db_path.exists():
-            self.db_path.unlink()
-        self._db_wrapper = await DBWrapper2.create(database=self.db_path, reader_count=4, db_version=self.db_version)
-
-        return self._db_wrapper
-
-    async def __aexit__(self, exc_t, exc_v, exc_tb) -> None:
-        await self._db_wrapper.close()
-        self.db_path.unlink()
+@asynccontextmanager
+async def DBConnection(db_version: int) -> AsyncIterator[DBWrapper2]:
+    db_path = Path(tempfile.NamedTemporaryFile().name)
+    if db_path.exists():
+        db_path.unlink()
+    _db_wrapper = await DBWrapper2.create(database=db_path, reader_count=4, db_version=db_version)
+    try:
+        yield _db_wrapper
+    finally:
+        await _db_wrapper.close()
+        db_path.unlink()


### PR DESCRIPTION
https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Code improvement suggested from https://github.com/Chia-Network/chia-blockchain/pull/14946 a PR meant to improve type-checking.

This PR updates DBConnection to use [asynccontextmanager](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager)

<!-- Does this PR introduce a breaking change? -->
No new behaviour.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
