### PR TITLE
Add config option to accept private network addresses from introducers

### DIFF
--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -40,6 +40,7 @@ NETWORK_ID_DEFAULT_PORTS = {
 
 class FullNodeDiscovery:
     resolver: Optional[dns.asyncresolver.Resolver]
+    enable_private_networks: bool
 
     def __init__(
         self,
@@ -64,6 +65,7 @@ class FullNodeDiscovery:
         self.introducer_info: Optional[UnresolvedPeerInfo] = None
         if introducer_info is not None:
             self.introducer_info = UnresolvedPeerInfo(introducer_info["host"], introducer_info["port"])
+            self.enable_private_networks = introducer_info.get("enable_private_networks", False)
         self.peer_connect_interval = peer_connect_interval
         self.log = log
         self.relay_queue: Optional[asyncio.Queue[Tuple[TimestampedPeerInfo, int]]] = None
@@ -112,6 +114,8 @@ class FullNodeDiscovery:
 
     async def initialize_address_manager(self) -> None:
         self.address_manager = await AddressManagerStore.create_address_manager(self.peers_file_path)
+        if self.enable_private_networks:
+            self.address_manager.make_private_subnets_valid()
         self.server.set_received_message_callback(self.update_peer_timestamp_on_message)
 
     async def start_tasks(self) -> None:

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -66,6 +66,8 @@ class FullNodeDiscovery:
         if introducer_info is not None:
             self.introducer_info = UnresolvedPeerInfo(introducer_info["host"], introducer_info["port"])
             self.enable_private_networks = introducer_info.get("enable_private_networks", False)
+        else:
+            self.enable_private_networks = False
         self.peer_connect_interval = peer_connect_interval
         self.log = log
         self.relay_queue: Optional[asyncio.Queue[Tuple[TimestampedPeerInfo, int]]] = None

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -429,6 +429,7 @@ full_node:
   introducer_peer:
     host: introducer.chia.net # Chia AWS introducer IPv4/IPv6
     port: 8444
+    enable_private_networks: False
   wallet_peer:
     host: *self_hostname
     port: 8449
@@ -541,6 +542,7 @@ wallet:
   introducer_peer:
     host: introducer.chia.net # Chia AWS introducer IPv4/IPv6
     port: 8444
+    enable_private_networks: False
 
   ssl:
     private_crt: "config/ssl/wallet/private_wallet.crt"

--- a/tests/core/server/test_node_discovery.py
+++ b/tests/core/server/test_node_discovery.py
@@ -40,6 +40,8 @@ async def test_enable_private_networks(
     )
     assert discovery0 is not None
     assert discovery0.enable_private_networks is False
+    await discovery0.initialize_address_manager()
+    assert discovery0.address_manager.allow_private_subnets is False
 
     # Test with enable_private_networks set to False in Config
     discovery1 = FullNodeDiscovery(
@@ -62,6 +64,8 @@ async def test_enable_private_networks(
     )
     assert discovery1 is not None
     assert discovery1.enable_private_networks is False
+    await discovery1.initialize_address_manager()
+    assert discovery1.address_manager.allow_private_subnets is False
 
     # Test with enable_private_networks set to True in Config
     discovery2 = FullNodeDiscovery(
@@ -84,3 +88,5 @@ async def test_enable_private_networks(
     )
     assert discovery2 is not None
     assert discovery2.enable_private_networks is True
+    await discovery2.initialize_address_manager()
+    assert discovery2.address_manager.allow_private_subnets is True

--- a/tests/core/server/test_node_discovery.py
+++ b/tests/core/server/test_node_discovery.py
@@ -41,6 +41,7 @@ async def test_enable_private_networks(
     assert discovery0 is not None
     assert discovery0.enable_private_networks is False
     await discovery0.initialize_address_manager()
+    assert discovery0.address_manager is not None
     assert discovery0.address_manager.allow_private_subnets is False
 
     # Test with enable_private_networks set to False in Config
@@ -65,6 +66,7 @@ async def test_enable_private_networks(
     assert discovery1 is not None
     assert discovery1.enable_private_networks is False
     await discovery1.initialize_address_manager()
+    assert discovery1.address_manager is not None
     assert discovery1.address_manager.allow_private_subnets is False
 
     # Test with enable_private_networks set to True in Config
@@ -89,4 +91,5 @@ async def test_enable_private_networks(
     assert discovery2 is not None
     assert discovery2.enable_private_networks is True
     await discovery2.initialize_address_manager()
+    assert discovery2.address_manager is not None
     assert discovery2.address_manager.allow_private_subnets is True

--- a/tests/core/server/test_node_discovery.py
+++ b/tests/core/server/test_node_discovery.py
@@ -1,7 +1,9 @@
-import pytest
+from __future__ import annotations
 
 from logging import Logger
 from typing import Tuple
+
+import pytest
 
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.server.node_discovery import FullNodeDiscovery
@@ -10,8 +12,11 @@ from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.util.default_root import SIMULATOR_ROOT_PATH
 
+
 @pytest.mark.asyncio
-async def test_enable_private_networks(two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],) -> None:
+async def test_enable_private_networks(
+    two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+) -> None:
     chia_server = two_nodes[2]
 
     # Missing `enable_private_networks` config entry in introducer_peer should default to False for back compat
@@ -26,7 +31,7 @@ async def test_enable_private_networks(two_nodes: Tuple[FullNodeAPI, FullNodeAPI
             legacy_peer_db_path_key="db/peer_table_node.sqlite",
             default_peers_file_path="db/peers.dat",
         ),
-        {"host":"introducer.chia.net", "port": 8444},
+        {"host": "introducer.chia.net", "port": 8444},
         [],
         0,
         chia_server.config["selected_network"],
@@ -48,7 +53,7 @@ async def test_enable_private_networks(two_nodes: Tuple[FullNodeAPI, FullNodeAPI
             legacy_peer_db_path_key="db/peer_table_node.sqlite",
             default_peers_file_path="db/peers.dat",
         ),
-        {"host":"introducer.chia.net", "port": 8444, "enable_private_networks": False},
+        {"host": "introducer.chia.net", "port": 8444, "enable_private_networks": False},
         [],
         0,
         chia_server.config["selected_network"],
@@ -70,7 +75,7 @@ async def test_enable_private_networks(two_nodes: Tuple[FullNodeAPI, FullNodeAPI
             legacy_peer_db_path_key="db/peer_table_node.sqlite",
             default_peers_file_path="db/peers.dat",
         ),
-        {"host":"introducer.chia.net", "port": 8444, "enable_private_networks": True},
+        {"host": "introducer.chia.net", "port": 8444, "enable_private_networks": True},
         [],
         0,
         chia_server.config["selected_network"],

--- a/tests/core/server/test_node_discovery.py
+++ b/tests/core/server/test_node_discovery.py
@@ -1,0 +1,81 @@
+import pytest
+
+from logging import Logger
+from typing import Tuple
+
+from chia.full_node.full_node_api import FullNodeAPI
+from chia.server.node_discovery import FullNodeDiscovery
+from chia.server.peer_store_resolver import PeerStoreResolver
+from chia.server.server import ChiaServer
+from chia.simulator.block_tools import BlockTools
+from chia.util.default_root import SIMULATOR_ROOT_PATH
+
+@pytest.mark.asyncio
+async def test_enable_private_networks(two_nodes: Tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],) -> None:
+    chia_server = two_nodes[2]
+
+    # Missing `enable_private_networks` config entry in introducer_peer should default to False for back compat
+    discovery0 = FullNodeDiscovery(
+        chia_server,
+        0,
+        PeerStoreResolver(
+            SIMULATOR_ROOT_PATH,
+            chia_server.config,
+            selected_network=chia_server.config["selected_network"],
+            peers_file_path_key="peers_file_path",
+            legacy_peer_db_path_key="db/peer_table_node.sqlite",
+            default_peers_file_path="db/peers.dat",
+        ),
+        {"host":"introducer.chia.net", "port": 8444},
+        [],
+        0,
+        chia_server.config["selected_network"],
+        None,
+        Logger("node_discovery_tests"),
+    )
+    assert discovery0 is not None
+    assert discovery0.enable_private_networks is False
+
+    # Test with enable_private_networks set to False in Config
+    discovery1 = FullNodeDiscovery(
+        chia_server,
+        0,
+        PeerStoreResolver(
+            SIMULATOR_ROOT_PATH,
+            chia_server.config,
+            selected_network=chia_server.config["selected_network"],
+            peers_file_path_key="peers_file_path",
+            legacy_peer_db_path_key="db/peer_table_node.sqlite",
+            default_peers_file_path="db/peers.dat",
+        ),
+        {"host":"introducer.chia.net", "port": 8444, "enable_private_networks": False},
+        [],
+        0,
+        chia_server.config["selected_network"],
+        None,
+        Logger("node_discovery_tests"),
+    )
+    assert discovery1 is not None
+    assert discovery1.enable_private_networks is False
+
+    # Test with enable_private_networks set to True in Config
+    discovery2 = FullNodeDiscovery(
+        chia_server,
+        0,
+        PeerStoreResolver(
+            SIMULATOR_ROOT_PATH,
+            chia_server.config,
+            selected_network=chia_server.config["selected_network"],
+            peers_file_path_key="peers_file_path",
+            legacy_peer_db_path_key="db/peer_table_node.sqlite",
+            default_peers_file_path="db/peers.dat",
+        ),
+        {"host":"introducer.chia.net", "port": 8444, "enable_private_networks": True},
+        [],
+        0,
+        chia_server.config["selected_network"],
+        None,
+        Logger("node_discovery_tests"),
+    )
+    assert discovery2 is not None
+    assert discovery2.enable_private_networks is True


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
In some cases, we have test networks that run on private networks and we need to be able to automatically discover peers on private IP addresses


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Nodes wont connect to private IPs gossiped from introducers/peers


### New Behavior:
Nodes will connect to private IPs gossiped from introducers/peers IF the option is set to True in the config. Defaults to False in config and if the config entry is missing, to retain the old behavior
