### PR TITLE
wallet: Convert coin ids in `_add_coin_states` to `bytes32`

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1244,7 +1244,7 @@ class WalletStateManager:
         used_up_to = -1
         ph_to_index_cache: LRUCache[bytes32, uint32] = LRUCache(100)
 
-        coin_names = [coin_state.coin.name() for coin_state in coin_states]
+        coin_names = [bytes32(coin_state.coin.name()) for coin_state in coin_states]
         local_records = await self.coin_store.get_coin_records(coin_id_filter=HashFilter.include(coin_names))
 
         for coin_name, coin_state in zip(coin_names, coin_states):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Makes logging them more readable while not requiring to `.hex()` them when logging.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

`coin_name` logging prints ugly byte representations.

### New Behavior:

`coin_name` logging prints readable hex strings.
