### PR TITLE
bump chia_rs to 0.2.8

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional
 
-from chia_rs import ENABLE_ASSERT_BEFORE, LIMIT_STACK, MEMPOOL_MODE, NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+from chia_rs import ENABLE_ASSERT_BEFORE, MEMPOOL_MODE, NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_chia_program
 from clvm.casts import int_from_bytes
@@ -38,10 +38,9 @@ def get_name_puzzle_conditions(
     height: uint32,
     constants: ConsensusConstants = DEFAULT_CONSTANTS,
 ) -> NPCResult:
+    flags = 0
     if mempool_mode:
-        flags = MEMPOOL_MODE
-    else:
-        flags = LIMIT_STACK
+        flags = flags | MEMPOOL_MODE
 
     if height >= constants.SOFT_FORK2_HEIGHT:
         flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
@@ -75,6 +74,7 @@ def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin: Coin) -> S
             coin.parent_coin_info,
             coin.amount,
             coin.puzzle_hash,
+            0,
         )
         return SpendInfo(SerializedProgram.from_bytes(puzzle), SerializedProgram.from_bytes(solution))
     except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ dependencies = [
     "chiapos==1.0.11",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
-    "chia_rs==0.2.7",
+    "chia_rs==0.2.8",
     "clvm-tools-rs==0.1.34",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.4",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
bump `clvm_rs` dependency to the latest version, and the minimal changes required to stay compatible.

The new `chia_rs` has all of the new features required for the 2.0 hard-fork and soft-fork. They are all disabled by default and will be enabled in a later PR.

`LIMIT_STACK` was part of the 1.7 soft-fork which has activated, so it has been enabled by default and the flag has been removed.