### PR TITLE
Hard fork 2.0

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,7 +3,20 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional
 
-from chia_rs import ENABLE_ASSERT_BEFORE, MEMPOOL_MODE, NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+from chia_rs import (
+    AGG_SIG_ARGS,
+    ALLOW_BACKREFS,
+    ENABLE_ASSERT_BEFORE,
+    ENABLE_BLS_OPS,
+    ENABLE_BLS_OPS_OUTSIDE_GUARD,
+    ENABLE_FIXED_DIV,
+    ENABLE_SECP_OPS,
+    ENABLE_SOFTFORK_CONDITION,
+    LIMIT_ANNOUNCES,
+    LIMIT_OBJECTS,
+    MEMPOOL_MODE,
+    NO_RELATIVE_CONDITIONS_ON_EPHEMERAL,
+)
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_chia_program
 from clvm.casts import int_from_bytes
@@ -44,6 +57,39 @@ def get_name_puzzle_conditions(
 
     if height >= constants.SOFT_FORK2_HEIGHT:
         flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+
+    if height >= constants.SOFT_FORK3_HEIGHT:
+        # the soft-fork initiated with 2.0. To activate end of October 2023
+        # * the number of announces created and asserted are limited per spend
+        # * the total number of CLVM objects (atoms or pairs) are limited
+        # * BLS operators enabled, behind the softfork op. This set of operators
+        #   also includes coinid, % and modpow
+        # * secp operators enabled
+        flags = flags | LIMIT_ANNOUNCES | LIMIT_OBJECTS | ENABLE_BLS_OPS | ENABLE_SECP_OPS
+
+    if height >= constants.HARD_FORK_HEIGHT:
+        # the hard-fork initiated with 2.0. To activate June 2024
+        # * costs are ascribed to some unknown condition codes, to allow for
+        #    soft-forking in new conditions with cost
+        # * a new condition, SOFTFORK, is added which takes a first parameter to
+        #   specify its cost. This allows soft-forks similar to the softfork
+        #   operator
+        # * BLS operators introduced in the soft-fork (behind the softfork
+        #   guard) are made available outside of the guard.
+        # * division with negative numbers are allowed, and round toward
+        #   negative infinity
+        # * AGG_SIG_* conditions are allowed to have unknown additional
+        #   arguments
+        # * Allow the block generator to be serialized with the improved clvm
+        #   serialization format (with back-references)
+        flags = (
+            flags
+            | ENABLE_SOFTFORK_CONDITION
+            | ENABLE_BLS_OPS_OUTSIDE_GUARD
+            | ENABLE_FIXED_DIV
+            | AGG_SIG_ARGS
+            | ALLOW_BACKREFS
+        )
 
     try:
         block_args = [bytes(gen) for gen in generator.generator_refs]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,9 +100,10 @@ def get_keychain():
 
 class Mode(Enum):
     PLAIN = 0
+    HARD_FORK_2_0 = 1
 
 
-@pytest.fixture(scope="session", params=[Mode.PLAIN])
+@pytest.fixture(scope="session", params=[Mode.PLAIN, Mode.HARD_FORK_2_0])
 def consensus_mode(request):
     return request.param
 
@@ -111,6 +112,10 @@ def consensus_mode(request):
 def blockchain_constants(consensus_mode) -> ConsensusConstants:
     if consensus_mode == Mode.PLAIN:
         return test_constants
+    if consensus_mode == Mode.HARD_FORK_2_0:
+        return test_constants.replace(
+            HARD_FORK_HEIGHT=2, PLOT_FILTER_128_HEIGHT=10, PLOT_FILTER_64_HEIGHT=15, PLOT_FILTER_32_HEIGHT=20
+        )
     raise AssertionError("Invalid Blockchain mode in simulation")
 
 

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2201,14 +2201,24 @@ class TestGeneratorConditions:
         assert coins == [(puzzle_hash_1.encode("ascii"), 5, hint.encode("ascii"))]
 
     @pytest.mark.parametrize("mempool", [True, False])
-    def test_unknown_condition(self, mempool: bool, softfork_height: uint32):
-        for c in ['(2 100 "foo" "bar")', "(100)", "(4 1) (2 2) (3 3)", '("foobar")']:
-            npc_result = generator_condition_tester(c, mempool_mode=mempool, height=softfork_height)
-            print(npc_result)
-            if mempool:
-                assert npc_result.error == Err.INVALID_CONDITION.value
-            else:
-                assert npc_result.error is None
+    @pytest.mark.parametrize(
+        "condition",
+        [
+            '(2 100 "foo" "bar")',
+            "(100)",
+            "(4 1) (2 2) (3 3)",
+            '("foobar")',
+            '(0x100 "foobar")',
+            '(0x1ff "foobar")',
+        ],
+    )
+    def test_unknown_condition(self, mempool: bool, condition: str, softfork_height: uint32):
+        npc_result = generator_condition_tester(condition, mempool_mode=mempool, height=softfork_height)
+        print(npc_result)
+        if mempool:
+            assert npc_result.error == Err.INVALID_CONDITION.value
+        else:
+            assert npc_result.error is None
 
 
 # the tests below are malicious generator programs

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -12,6 +12,7 @@ from clvm_tools import binutils
 
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.cost_calculator import NPCResult
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI
@@ -2004,6 +2005,11 @@ class TestGeneratorConditions:
             mempool_mode=mempool,
             height=softfork_height,
         )
+
+        # with the 2.0 hard fork, division with negative numbers is allowed
+        if operand < 0 and softfork_height >= DEFAULT_CONSTANTS.HARD_FORK_HEIGHT:
+            expected = None
+
         assert npc_result.error == expected
 
     def test_invalid_condition_list_terminator(self, softfork_height):

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2484,7 +2484,12 @@ class TestMaliciousGenerators:
     )
     @pytest.mark.benchmark
     def test_duplicate_coin_announces(self, request, opcode, softfork_height):
-        condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
+        # with soft-fork3, we only allow 1024 create- or assert announcements
+        # per spend
+        if softfork_height >= DEFAULT_CONSTANTS.SOFT_FORK3_HEIGHT:
+            condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=1024)
+        else:
+            condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
 
         with assert_runtime(seconds=9, label=request.node.name):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)

--- a/tests/wallet/test_singleton_lifecycle.py
+++ b/tests/wallet/test_singleton_lifecycle.py
@@ -112,7 +112,7 @@ async def test_only_odd_coins_0(bt):
     conditions = Program.to(condition_list)
     coin_spend = CoinSpend(farmed_coin, ANYONE_CAN_SPEND_PUZZLE, conditions)
     spend_bundle = SpendBundle.aggregate([launcher_spend_bundle, SpendBundle([coin_spend], G2Element())])
-    coins_added, coins_removed = await check_spend_bundle_validity(bt, blocks, spend_bundle)
+    coins_added, coins_removed, _ = await check_spend_bundle_validity(bt, blocks, spend_bundle)
 
     coin_set_added = set([_.coin for _ in coins_added])
     coin_set_removed = set([_.coin for _ in coins_removed])


### PR DESCRIPTION
This PR hooks up all the soft-fork and hard-fork features from `chia_rs` as well as adds some tests.

This PR is best reviewed one commit at a time. Some commits have some commentary.

It can be summarised by the commit that enables `chia_rs` features based on block height:

```
    if height >= constants.SOFT_FORK3_HEIGHT:
        # the soft-fork initiated with 2.0. To activate end of October 2023
        # * the number of announces created and asserted are limited per spend
        # * the total number of CLVM objects (atoms or pairs) are limited
        # * BLS operators enabled, behind the softfork op. This set of operators
        #   also include coinid, % and modpow
        # * secp operators enabled
        flags = flags | LIMIT_ANNOUNCES | LIMIT_OBJECTS | ENABLE_BLS_OPS | ENABLE_SECP_OPS

    if height >= constants.HARD_FORK_HEIGHT:
        # the hard-fork initiated with 2.0. To activate June 2024
        # * costs are ascribed to some unknown condition codes, to allow for
        #    soft-forking in new conditions with cost
        # * a new condition, SOFTFORK, is added which takes a first parameter to
        #   specify its cost. This allows soft-forks similar to the softfork
        #   operator
        # * BLS operators introduced in the soft-fork (behind the softfork
        #   guard) are made available outside of the guard.
        # * division with negative numbers are allowed, and round toward
        #   negative infinity
        # * AGG_SIG_* conditions are allowed to have unknown additional
        #   arguments
        # * Allow the block generator to be serialized with the improved clvm
        #   serialization format (with back-references)
        flags = (
            flags
            | ENABLE_SOFTFORK_CONDITION
            | ENABLE_BLS_OPS_OUTSIDE_GUARD
            | ENABLE_FIXED_DIV
            | AGG_SIG_ARGS
            | ALLOW_BACKREFS
        )
```