### PR TITLE
support calling daemon commands from chia rpc CLI

### DIFF
--- a/chia/cmds/rpc.py
+++ b/chia/cmds/rpc.py
@@ -91,7 +91,7 @@ def endpoints_cmd(service: str) -> None:
     try:
         routes = get_routes(service, config)
         for route in routes["routes"]:
-            print(route[1:])
+            print(route[1:] if route[0] == "/" else route)
     except Exception as e:
         print(e)
 

--- a/chia/cmds/rpc.py
+++ b/chia/cmds/rpc.py
@@ -18,11 +18,13 @@ services: List[str] = ["crawler", "daemon", "farmer", "full_node", "harvester", 
 async def call_endpoint(service: str, endpoint: str, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
     if service == "daemon":
         return await call_daemon_command(endpoint, request, config)
-    
+
     return await call_rpc_service_endpoint(service, endpoint, request, config)
 
 
-async def call_rpc_service_endpoint(service: str, endpoint: str, request: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+async def call_rpc_service_endpoint(
+    service: str, endpoint: str, request: Dict[str, Any], config: Dict[str, Any]
+) -> Dict[str, Any]:
     from chia.rpc.rpc_client import RpcClient
 
     port: uint16

--- a/chia/cmds/rpc.py
+++ b/chia/cmds/rpc.py
@@ -93,7 +93,7 @@ def endpoints_cmd(service: str) -> None:
     try:
         routes = get_routes(service, config)
         for route in routes["routes"]:
-            print(route[1:] if route[0] == "/" else route)
+            print(route.lstrip("/"))
     except Exception as e:
         print(e)
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -356,7 +356,7 @@ class WebSocketServer:
         elif command == "ping":
             response = await ping()
         else:
-            command_mapping = await self.get_command_mapping()
+            command_mapping = self.get_command_mapping()
             if command in command_mapping:
                 response = await command_mapping[command](websocket=websocket, request=data)
             else:
@@ -366,7 +366,7 @@ class WebSocketServer:
         full_response = format_response(message, response)
         return full_response, {websocket}
 
-    async def get_command_mapping(self) -> Dict[str, Command]:
+    def get_command_mapping(self) -> Dict[str, Command]:
         """
         Returns a mapping of commands to their respective function calls.
         """
@@ -388,6 +388,7 @@ class WebSocketServer:
             "get_status": self.get_status,
             "get_version": self.get_version,
             "get_plotters": self.get_plotters,
+            "get_routes": self.get_routes,
         }
 
     async def is_keyring_locked(self, websocket: WebSocketResponse, request: Dict[str, Any]) -> Dict[str, Any]:
@@ -553,6 +554,11 @@ class WebSocketServer:
     async def get_plotters(self, websocket: WebSocketResponse, request: Dict[str, Any]) -> Dict[str, Any]:
         plotters: Dict[str, Any] = get_available_plotters(self.root_path)
         response: Dict[str, Any] = {"success": True, "plotters": plotters}
+        return response
+
+    async def get_routes(self, websocket: WebSocketResponse, request: Dict[str, Any]) -> Dict[str, Any]:
+        routes = list(self.get_command_mapping().keys())
+        response: Dict[str, Any] = {"success": True, "routes": routes}
         return response
 
     async def _keyring_status_changed(self, keyring_status: Dict[str, Any], destination: str):

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -59,6 +59,14 @@ class Daemon:
     services: Dict[str, Union[List[Service], Service]]
     connections: Dict[str, Optional[List[Any]]]
 
+    def get_command_mapping(self) -> Dict[str, Any]:
+        return {
+            "get_routes": None,
+            "example_one": None,
+            "example_two": None,
+            "example_three": None,
+        }
+
     def is_service_running(self, service_name: str) -> bool:
         return WebSocketServer.is_service_running(cast(WebSocketServer, self), service_name)
 
@@ -67,6 +75,12 @@ class Daemon:
 
     async def is_running(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return await WebSocketServer.is_running(cast(WebSocketServer, self), request)
+
+    async def get_routes_command(self, websocket: Any, request: Dict[str, Any]) -> Dict[str, Any]:
+        return await self.get_routes(request)
+
+    async def get_routes(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return await WebSocketServer.get_routes(cast(WebSocketServer, self), websocket=None, request=request)
 
 
 test_key_data = KeyData.from_mnemonic(
@@ -413,6 +427,15 @@ async def test_running_services_with_services_and_connections(mock_daemon_with_s
         response, {"success": True, "running_services": ["my_refrigerator", "apple", "banana", service_plotter]}
     )
 
+
+@pytest.mark.asyncio
+async def test_get_routes(mock_lonely_daemon):
+    daemon = mock_lonely_daemon
+    response = await daemon.get_routes({})
+    assert response == {
+        "success": True,
+        "routes": ["get_routes", "example_one", "example_two", "example_three"],
+    }
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import aiohttp
 import pytest
+from aiohttp.web_ws import WebSocketResponse
 
 from chia.daemon.keychain_server import (
     DeleteLabelRequest,
@@ -80,7 +81,9 @@ class Daemon:
         return await self.get_routes(request)
 
     async def get_routes(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        return await WebSocketServer.get_routes(cast(WebSocketServer, self), websocket=None, request=request)
+        return await WebSocketServer.get_routes(
+            cast(WebSocketServer, self), websocket=WebSocketResponse(), request=request
+        )
 
 
 test_key_data = KeyData.from_mnemonic(
@@ -436,6 +439,7 @@ async def test_get_routes(mock_lonely_daemon):
         "success": True,
         "routes": ["get_routes", "example_one", "example_two", "example_three"],
     }
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -77,9 +77,6 @@ class Daemon:
     async def is_running(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return await WebSocketServer.is_running(cast(WebSocketServer, self), request)
 
-    async def get_routes_command(self, websocket: Any, request: Dict[str, Any]) -> Dict[str, Any]:
-        return await self.get_routes(request)
-
     async def get_routes(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return await WebSocketServer.get_routes(
             cast(WebSocketServer, self), websocket=WebSocketResponse(), request=request


### PR DESCRIPTION
### Purpose:
Extends the `chia rpc` CLI to support calling daemon commands.

Examples:
```
$ chia rpc daemon running_services
{
    "running_services": [
        "chia_harvester",
        "chia_wallet",
        "chia_full_node",
        "chia_farmer"
    ],
    "success": true
}

$ chia rpc daemon validate_keyring_passphrase '{"key":"badpassphrase"}'
{
    "error": null,
    "success": false
}
```

### Current Behavior:
`chia rpc` currently handles RPC requests for all services _except_ the daemon


### New Behavior:
`chia rpc daemon <command>` can be used



### Testing Notes:
Manually tested starting/stopping services, calling daemon commands correctly, calling daemon commands incorrectly, calling unsupported daemon commands.

