### PR TITLE
don't parameterize the blockchain tests on DB version

### DIFF
--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -55,6 +55,7 @@ from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block_multi_result,
     _validate_and_add_block_no_error,
 )
+from tests.conftest import Mode
 from tests.util.blockchain import create_blockchain
 
 log = logging.getLogger(__name__)
@@ -141,7 +142,10 @@ class TestGenesisBlock:
 
 class TestBlockHeaderValidation:
     @pytest.mark.asyncio
-    async def test_long_chain(self, empty_blockchain, default_1000_blocks):
+    async def test_long_chain(self, empty_blockchain, default_1000_blocks, consensus_mode: Mode):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         blocks = default_1000_blocks
         for block in blocks:
             if (
@@ -166,6 +170,7 @@ class TestBlockHeaderValidation:
                     block.finished_sub_slots[0].challenge_chain.new_difficulty,
                     block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
                 )
+                assert error
                 assert error.code == Err.INVALID_NEW_SUB_SLOT_ITERS
 
                 # Also fails calling the outer methods, but potentially with a different error
@@ -189,6 +194,7 @@ class TestBlockHeaderValidation:
                     block.finished_sub_slots[0].challenge_chain.new_difficulty,
                     block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
                 )
+                assert error
                 assert error.code == Err.INVALID_NEW_DIFFICULTY
 
                 # Also fails calling the outer methods, but potentially with a different error
@@ -221,6 +227,7 @@ class TestBlockHeaderValidation:
                     block.finished_sub_slots[0].challenge_chain.new_difficulty,
                     block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
                 )
+                assert error
                 assert error.code == Err.INVALID_SUB_EPOCH_SUMMARY
 
                 # Also fails calling the outer methods, but potentially with a different error
@@ -252,6 +259,7 @@ class TestBlockHeaderValidation:
                     block.finished_sub_slots[0].challenge_chain.new_difficulty,
                     block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
                 )
+                assert error
                 assert error.code == Err.INVALID_SUB_EPOCH_SUMMARY
 
                 # Also fails calling the outer methods, but potentially with a different error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,14 +131,14 @@ def self_hostname():
 #       the fixtures below. Just be aware of the filesystem modification during bt fixture creation
 
 
-@pytest_asyncio.fixture(scope="function", params=[1, 2])
-async def empty_blockchain(request, blockchain_constants):
+@pytest_asyncio.fixture(scope="function")
+async def empty_blockchain(latest_db_version, blockchain_constants):
     """
     Provides a list of 10 valid blocks, as well as a blockchain with 9 blocks added to it.
     """
     from tests.util.blockchain import create_blockchain
 
-    bc1, db_wrapper, db_path = await create_blockchain(blockchain_constants, request.param)
+    bc1, db_wrapper, db_path = await create_blockchain(blockchain_constants, latest_db_version)
     yield bc1
 
     await db_wrapper.close()
@@ -286,31 +286,31 @@ async def node_with_params(request):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_nodes(db_version, self_hostname, blockchain_constants):
+async def two_nodes(db_version: int, self_hostname, blockchain_constants):
     async for _ in setup_two_nodes(blockchain_constants, db_version=db_version, self_hostname=self_hostname):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup_two_nodes_fixture(db_version):
+async def setup_two_nodes_fixture(db_version: int):
     async for _ in setup_simulators_and_wallets(2, 0, {}, db_version=db_version):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def three_nodes(db_version, self_hostname, blockchain_constants):
+async def three_nodes(db_version: int, self_hostname, blockchain_constants):
     async for _ in setup_n_nodes(blockchain_constants, 3, db_version=db_version, self_hostname=self_hostname):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def four_nodes(db_version, self_hostname, blockchain_constants):
+async def four_nodes(db_version: int, self_hostname, blockchain_constants):
     async for _ in setup_n_nodes(blockchain_constants, 4, db_version=db_version, self_hostname=self_hostname):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def five_nodes(db_version, self_hostname, blockchain_constants):
+async def five_nodes(db_version: int, self_hostname, blockchain_constants):
     async for _ in setup_n_nodes(blockchain_constants, 5, db_version=db_version, self_hostname=self_hostname):
         yield _
 

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -23,13 +23,17 @@ from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.full_block import FullBlock
 from chia.util.ints import uint8, uint32, uint64
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
+from tests.conftest import Mode
 from tests.util.db_connection import DBConnection
 
 log = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-async def test_block_store(tmp_dir: Path, db_version: int, bt: BlockTools) -> None:
+async def test_block_store(tmp_dir: Path, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
+
     assert sqlite3.threadsafety >= 1
     blocks = bt.get_consecutive_blocks(10)
 
@@ -81,11 +85,13 @@ async def test_block_store(tmp_dir: Path, db_version: int, bt: BlockTools) -> No
 
 
 @pytest.mark.asyncio
-async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools) -> None:
+async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
     """
     This test was added because the store was deadlocking in certain situations, when fetching and
     adding blocks repeatedly. The issue was patched.
     """
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(db_version) as wrapper, DBConnection(db_version) as wrapper_2:
@@ -113,7 +119,9 @@ async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rollback(bt: BlockTools, tmp_dir: Path) -> None:
+async def test_rollback(bt: BlockTools, tmp_dir: Path, consensus_mode: Mode) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(2) as db_wrapper:
@@ -158,7 +166,9 @@ async def test_rollback(bt: BlockTools, tmp_dir: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int) -> None:
+async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int, consensus_mode: Mode) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(db_version) as db_wrapper:
@@ -177,7 +187,11 @@ async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_versi
 
 
 @pytest.mark.asyncio
-async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int) -> None:
+async def test_count_uncompactified_blocks(
+    bt: BlockTools, tmp_dir: Path, db_version: int, consensus_mode: Mode
+) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(db_version) as db_wrapper:
@@ -196,7 +210,9 @@ async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_ver
 
 
 @pytest.mark.asyncio
-async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int) -> None:
+async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int, consensus_mode: Mode) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     blocks = bt.get_consecutive_blocks(10)
 
     def rand_bytes(num: int) -> bytes:
@@ -242,7 +258,9 @@ async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int) -> 
 
 
 @pytest.mark.asyncio
-async def test_get_generator(bt: BlockTools, db_version: int) -> None:
+async def test_get_generator(bt: BlockTools, db_version: int, consensus_mode: Mode) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     blocks = bt.get_consecutive_blocks(10)
 
     def generator(i: int) -> SerializedProgram:
@@ -282,7 +300,9 @@ async def test_get_generator(bt: BlockTools, db_version: int) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int) -> None:
+async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int, consensus_mode: Mode) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     assert sqlite3.threadsafety >= 1
     blocks = bt.get_consecutive_blocks(10)
 
@@ -320,7 +340,9 @@ async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int
 
 
 @pytest.mark.asyncio
-async def test_get_block_bytes_in_range(tmp_dir: Path, bt: BlockTools, db_version: int) -> None:
+async def test_get_block_bytes_in_range(tmp_dir: Path, bt: BlockTools, db_version: int, consensus_mode: Mode) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
     assert sqlite3.threadsafety >= 1
     blocks = bt.get_consecutive_blocks(10)
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -23,6 +23,7 @@ from chia.util.generator_tools import tx_removals_and_additions
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
+from tests.conftest import Mode
 from tests.util.db_connection import DBConnection
 
 constants = test_constants
@@ -52,7 +53,12 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 
 class TestCoinStoreWithBlocks:
     @pytest.mark.asyncio
-    async def test_basic_coin_store(self, db_version: int, softfork_height: uint32, bt: BlockTools) -> None:
+    async def test_basic_coin_store(
+        self, db_version: int, softfork_height: uint32, bt: BlockTools, consensus_mode: Mode
+    ) -> None:
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         wallet_a = WALLET_A
         reward_ph = wallet_a.get_new_puzzlehash()
 
@@ -159,7 +165,10 @@ class TestCoinStoreWithBlocks:
                     should_be_included = set()
 
     @pytest.mark.asyncio
-    async def test_set_spent(self, db_version: int, bt: BlockTools) -> None:
+    async def test_set_spent(self, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         blocks = bt.get_consecutive_blocks(9, [])
 
         async with DBConnection(db_version) as db_wrapper:
@@ -202,7 +211,10 @@ class TestCoinStoreWithBlocks:
                         assert record.spent_block_index == block.height
 
     @pytest.mark.asyncio
-    async def test_num_unspent(self, bt: BlockTools, db_version: int) -> None:
+    async def test_num_unspent(self, bt: BlockTools, db_version: int, consensus_mode: Mode) -> None:
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         blocks = bt.get_consecutive_blocks(37, [])
 
         expect_unspent = 0
@@ -234,7 +246,10 @@ class TestCoinStoreWithBlocks:
         assert test_excercised
 
     @pytest.mark.asyncio
-    async def test_rollback(self, db_version: int, bt: BlockTools) -> None:
+    async def test_rollback(self, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         blocks = bt.get_consecutive_blocks(20)
 
         async with DBConnection(db_version) as db_wrapper:
@@ -372,7 +387,10 @@ class TestCoinStoreWithBlocks:
                 b.shut_down()
 
     @pytest.mark.asyncio
-    async def test_get_puzzle_hash(self, tmp_dir: Path, db_version: int, bt: BlockTools) -> None:
+    async def test_get_puzzle_hash(self, tmp_dir: Path, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         async with DBConnection(db_version) as db_wrapper:
             num_blocks = 20
             farmer_ph = bytes32(32 * b"0")
@@ -401,7 +419,10 @@ class TestCoinStoreWithBlocks:
             b.shut_down()
 
     @pytest.mark.asyncio
-    async def test_get_coin_states(self, db_version: int) -> None:
+    async def test_get_coin_states(self, db_version: int, consensus_mode: Mode) -> None:
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         async with DBConnection(db_version) as db_wrapper:
             crs = [
                 CoinRecord(


### PR DESCRIPTION
We're about to need a lot more CI time. The first commit saves CI time by not running the blockchain tests with both v1 and v2 database schemas, but just v2. These are primarily system tests anyway, and the underlying `CoinStore` and `BlockStore` classes are still unit tested using both v1 and v2 schemas.

Another aspect of this patch is to use the `db_version` fixture rather than (unnamed) parameters directly.

The second commit makes tests of `CoinStore`, `BlockStore` and `FullNodeStore` only run in `PLAIN` consensus mode. This is currently the only mode we have, but we're about to add two new modes (for the hard fork and soft fork). This avoids running these unit tests 3 times instead of 1.

This PR brings the blockchain CI times from 24 minutes to 15 minutes.