### PR TITLE
wallet: Deduplicate coin states from peers

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from chia_rs import compute_merkle_set_root
 
@@ -318,7 +318,7 @@ def last_change_height_cs(cs: CoinState) -> uint32:
     return uint32(0)
 
 
-def sort_coin_states(coin_states: List[CoinState]) -> List[CoinState]:
+def sort_coin_states(coin_states: Set[CoinState]) -> List[CoinState]:
     return sorted(
         coin_states,
         key=lambda coin_state: (

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -865,9 +865,9 @@ class WalletNode:
         target_concurrent_tasks: int = 30
 
         # Ensure the list is sorted
-
-        before = len(items_input)
-        items = await self.wallet_state_manager.filter_spam(sort_coin_states(items_input))
+        unique_items = set(items_input)
+        before = len(unique_items)
+        items = await self.wallet_state_manager.filter_spam(sort_coin_states(unique_items))
         num_filtered = before - len(items)
         if num_filtered > 0:
             self.log.info(f"Filtered {num_filtered} spam transactions")

--- a/tests/wallet/test_wallet_utils.py
+++ b/tests/wallet/test_wallet_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from random import shuffle
-from typing import List, Optional, Tuple
+from typing import Collection, List, Optional, Tuple
 
 from chia_rs import Coin, CoinState
 
@@ -12,18 +11,16 @@ def dummy_coin_state(*, created_height: Optional[int], spent_height: Optional[in
     return CoinState(Coin(bytes(b"0" * 32), bytes(b"0" * 32), 0), spent_height, created_height)
 
 
-def heights(coin_states: List[CoinState]) -> List[Tuple[Optional[int], Optional[int]]]:
+def heights(coin_states: Collection[CoinState]) -> List[Tuple[Optional[int], Optional[int]]]:
     return [(coin_state.created_height, coin_state.spent_height) for coin_state in coin_states]
 
 
 def test_sort_coin_states() -> None:
     sorted_coin_states = [
         dummy_coin_state(created_height=None, spent_height=None),
-        dummy_coin_state(created_height=None, spent_height=None),
         dummy_coin_state(created_height=1, spent_height=None),
         dummy_coin_state(created_height=9, spent_height=10),
         dummy_coin_state(created_height=10, spent_height=None),
-        dummy_coin_state(created_height=10, spent_height=10),
         dummy_coin_state(created_height=10, spent_height=10),
         dummy_coin_state(created_height=10, spent_height=11),
         dummy_coin_state(created_height=11, spent_height=None),
@@ -35,7 +32,6 @@ def test_sort_coin_states() -> None:
         dummy_coin_state(created_height=1, spent_height=20),
         dummy_coin_state(created_height=19, spent_height=20),
     ]
-    unsorted_coin_states = sorted_coin_states.copy()
-    shuffle(unsorted_coin_states)
+    unsorted_coin_states = set(sorted_coin_states.copy())
     assert heights(unsorted_coin_states) != heights(sorted_coin_states)
     assert heights(sort_coin_states(unsorted_coin_states)) == heights(sorted_coin_states)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

The full node might send duplicated coin states which are currently getting processed if they are passed into `add_coin_states` in the same batch because we only avoid re-processing duplicated states which are already in the DB the moment we step into `add_coin_states` here https://github.com/Chia-Network/chia-blockchain/blob/b8a1515d7350f92e246a369b2685fafdc7864d5c/chia/wallet/wallet_state_manager.py#L1264-L1273 which isn't the case if there are two of the same in the input to that method because then the duplicated state will not be in `local_records` after first processing. We could add a set there to track what we processed in this round but deduplicating at the higher level here probably makes more sense. 

Alternative to #15593.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Duplicated sates from the full node will be processed if they come in the same batch into `add_coin_states`.

### New Behavior:

Duplicated states from the full node are removed.

