### PR TITLE
process new signage points no more than once

### DIFF
--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -367,11 +367,11 @@ class FullNodeStore:
             or signage_point.cc_proof is None
             or signage_point.rc_proof is None
         ):
-            return None
+            return
         if signage_point.rc_vdf.challenge not in self.future_sp_cache:
             self.future_sp_cache[signage_point.rc_vdf.challenge] = []
         if self.in_future_sp_cache(signage_point, index):
-            return None
+            return
 
         self.future_cache_key_times[signage_point.rc_vdf.challenge] = int(time.time())
         self.future_sp_cache[signage_point.rc_vdf.challenge].append((index, signage_point))


### PR DESCRIPTION
there are two places we call `signage_point_post_processing()` from.

1. when we receive a new signage point from a peer, and we don't already know about it. We add it to our full node store and call the post processing function. We do all of this while holding the `timelord_lock`. This ensures we don't receive the same SP multiple times and end up adding them multiple times. The checking if we have it, adding it and post processing all happens atomically, by holding the `timelord_lock`.
2. when receiving a new peak, we iterate over the signage points of the block, and we call the post processing function for them. We do not currently hold the lock or check to see if we have already seen the signage point.

This patch acquires the `timelord_lock` while iterating over the signage points in a new peak, to ensure the iteration does not interleave with receiving any new signage points. It also checks to see if we already have the signage point, and if so, skips calling the post processing function for it.

This is believed to fix an issue where we sometimes would send the same signage point multiple times to the farmer.