### PR TITLE
Handle VC syncing exceptions better

### DIFF
--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import time
+import traceback
 from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from blspy import G1Element, G2Element
@@ -103,7 +104,12 @@ class VCWallet:
                 f"Cannot get verified credential coin: {coin.name().hex()} puzzle and solution"
             )  # pragma: no cover
             return  # pragma: no cover
-        vc = VerifiedCredential.get_next_from_coin_spend(cs)
+        try:
+            vc = VerifiedCredential.get_next_from_coin_spend(cs)
+        except Exception as e:
+            self.log.debug(
+                f"Syncing VC from coin spend failed (likely means it was revoked): {e}\n{traceback.format_exc()}"
+            )
         vc_record: VCRecord = VCRecord(vc, height)
         self.wallet_state_manager.state_changed(
             "vc_coin_added", self.id(), dict(launcher_id=vc_record.vc.launcher_id.hex())

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -110,6 +110,7 @@ class VCWallet:
             self.log.debug(
                 f"Syncing VC from coin spend failed (likely means it was revoked): {e}\n{traceback.format_exc()}"
             )
+            return
         vc_record: VCRecord = VCRecord(vc, height)
         self.wallet_state_manager.state_changed(
             "vc_coin_added", self.id(), dict(launcher_id=vc_record.vc.launcher_id.hex())

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -106,7 +106,7 @@ class VCWallet:
             return  # pragma: no cover
         try:
             vc = VerifiedCredential.get_next_from_coin_spend(cs)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             self.log.debug(
                 f"Syncing VC from coin spend failed (likely means it was revoked): {e}\n{traceback.format_exc()}"
             )


### PR DESCRIPTION
This just makes it so that standard non-debug logs don't get filled up with an exception that we expect to see when a VC is revoked.  It has the downside that if something genuinely goes wrong during syncing from the parent coin spend then we need to enable debug logs to see it, but this is probably fine.