### PR TITLE
remove unused run_as_generator function on SerializedProgram

### DIFF
--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import io
-from typing import Optional, Tuple, Type, Union
+from typing import Tuple, Type
 
-from chia_rs import MEMPOOL_MODE, run_chia_program, run_generator, serialized_length, tree_hash
+from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, tree_hash
 from clvm import SExp
 
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.byte_types import hexstr_to_bytes
 
 
@@ -86,34 +85,6 @@ class SerializedProgram:
 
     def run_with_cost(self, max_cost: int, *args: object) -> Tuple[int, Program]:
         return self._run(max_cost, 0, *args)
-
-    # returns an optional error code and an optional SpendBundleConditions (from chia_rs)
-    # exactly one of those will hold a value
-    def run_as_generator(
-        self, max_cost: int, flags: int, *args: Union[Program, SerializedProgram]
-    ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]:
-        serialized_args = bytearray()
-        if len(args) > 1:
-            # when we have more than one argument, serialize them into a list
-            for a in args:
-                serialized_args += b"\xff"
-                serialized_args += _serialize(a)
-            serialized_args += b"\x80"
-        else:
-            serialized_args += _serialize(args[0])
-
-        err, ret = run_generator(
-            self._buf,
-            bytes(serialized_args),
-            max_cost,
-            flags,
-        )
-        if err is not None:
-            assert err != 0
-            return err, None
-
-        assert ret is not None
-        return None, ret
 
     def _run(self, max_cost: int, flags: int, *args: object) -> Tuple[int, Program]:
         # when multiple arguments are passed, concatenate them into a serialized


### PR DESCRIPTION
since we transitioned to the higher-level function, `run_block_generator()`, we no longer use the old `run_as_generator()`. So, we should remove it