### PR TITLE
Change some types of bad file handling for datalayer

### DIFF
--- a/chia/data_layer/data_layer_errors.py
+++ b/chia/data_layer/data_layer_errors.py
@@ -9,6 +9,10 @@ class IntegrityError(Exception):
     pass
 
 
+class FileDownloadError(Exception):
+    pass
+
+
 def build_message_with_hashes(message: str, bytes_objects: Iterable[bytes]) -> str:
     return "\n".join([message, *[f"    {b.hex()}" for b in bytes_objects]])
 


### PR DESCRIPTION
Previously when a file is downloaded for data layer that cann't be read properly due to incorrect sizing of bytes, or an unexpected format the server was then subject to a 7-day ban for giving a bad file.

However, this file is possibly bad due to download issues or disk issues and not server malfeasance.

This PR adjusts the errors such that in some error cases the file is treated as a missing download as opposed to a bad file. Note that if the file has the proper format, but doesn't hash properly, the 7-day ban will apply.

Added several tests for bad files of various types