### PR TITLE
Fix variable name typo

### DIFF
--- a/build_scripts/installer-version.py
+++ b/build_scripts/installer-version.py
@@ -15,13 +15,13 @@ def main() -> None:
 
     if len(version) == 3:  # If the length of the version array is more than 2
         patch_release_number = version[2]
-        smc_patch_version = patch_release_number
+        scm_patch_version = patch_release_number
         dev_release_number = ""
     elif len(version) == 4:
-        smc_patch_version = version[2]
+        scm_patch_version = version[2]
         dev_release_number = "-" + version[3]
     else:
-        smc_patch_version = ""
+        scm_patch_version = ""
         dev_release_number = ""
 
     major_release_number = scm_major_version
@@ -33,23 +33,23 @@ def main() -> None:
         major_release_number = str(1 - int(scm_major_version))  # decrement the major release for beta
         minor_release_number = scm_major_version
         patch_release_number = orignial_minor_ver_list[1]
-        if smc_patch_version and "dev" in smc_patch_version:
-            dev_release_number = "." + smc_patch_version
+        if scm_patch_version and "dev" in scm_patch_version:
+            dev_release_number = "." + scm_patch_version
     elif "0rc" in version[1]:
         original_minor_ver_list = scm_minor_version.split("0rc")
         major_release_number = str(1 - int(scm_major_version))  # decrement the major release for release candidate
         minor_release_number = str(int(scm_major_version) + 1)  # RC is 0.2.1 for RC 1
         patch_release_number = original_minor_ver_list[1]
-        if smc_patch_version and "dev" in smc_patch_version:
-            dev_release_number = "." + smc_patch_version
+        if scm_patch_version and "dev" in scm_patch_version:
+            dev_release_number = "." + scm_patch_version
     elif len(version) == 2:
         patch_release_number = "0"
     elif len(version) == 4:  # for 1.0.5.dev2
-        patch_release_number = smc_patch_version
+        patch_release_number = scm_patch_version
     else:
         major_release_number = scm_major_version
         minor_release_number = scm_minor_version
-        patch_release_number = smc_patch_version
+        patch_release_number = scm_patch_version
         dev_release_number = ""
 
     install_release_number = major_release_number + "." + minor_release_number


### PR DESCRIPTION
Just fixing a minor variable name typo correcting "smc" -> "scm".