### PR TITLE
multi threaded `chia plots check`

### DIFF
--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -211,13 +211,12 @@ class HarvesterAPI:
             time_taken = time.time() - start
             if time_taken > 5:
                 self.harvester.log.warning(
-                    f"Looking up qualities on {filename} took: {time_taken}. This should be below 5 seconds "
-                    f"to minimize risk of losing rewards."
+                    f"Looking up qualities on {filename} took: {time_taken}. This should be below 5 seconds"
+                    f" to minimize risk of losing rewards."
                 )
             else:
                 pass
-                # If you want additional logs, uncomment the following line
-                # self.harvester.log.debug(f"Looking up qualities on {filename} took: {time_taken}")
+                # self.harvester.log.info(f"Looking up qualities on {filename} took: {time_taken}")
             for response in sublist:
                 total_proofs_found += 1
                 msg = make_msg(ProtocolMessageTypes.new_proof_of_space, response)


### PR DESCRIPTION
fix some log messages in harvester
running `chia plots check` in multiple threads. 5 by default but configurable via `harvester/parallel_decompressers_count`.
a failure in `check plots` is not fatal, but will log the error and keep going