### PR TITLE
Cleanup & Fix Simulator Sub Epoch Logic

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -626,6 +626,7 @@ class BlockTools:
         same_slot_as_last = True  # Only applies to first slot, to prevent old blocks from being added
         sub_slot_start_total_iters: uint128 = latest_block.ip_sub_slot_total_iters(constants)
         sub_slots_finished = 0
+        # this variable is true whenever there is a pending sub-epoch or epoch that needs to be added in the next block.
         pending_ses: bool = False
 
         # Start at the last block in block list
@@ -847,7 +848,7 @@ class BlockTools:
                     sub_slot_iters,
                     True,
                 )
-            # generate sub_epoch_summary, and if the last block was the last block of the sub-epoch
+            # generate sub_epoch_summary, and if the last block was the last block of the sub-epoch or epoch
             # include the hash in the next sub-slot
             sub_epoch_summary: Optional[SubEpochSummary] = None
             if not pending_ses:  # if we just created a sub-epoch summary, we can at least skip another sub-slot
@@ -858,7 +859,7 @@ class BlockTools:
                     block_list[-1],
                     False,
                 )
-            if sub_epoch_summary is not None:
+            if sub_epoch_summary is not None:  # the previous block is the last block of the sub-epoch or epoch
                 pending_ses = True
                 ses_hash: Optional[bytes32] = sub_epoch_summary.get_hash()
                 # if the last block is the last block of the epoch, we set the new sub-slot iters and difficulty
@@ -866,7 +867,7 @@ class BlockTools:
                 new_difficulty: Optional[uint64] = sub_epoch_summary.new_difficulty
 
                 self.log.info(f"Sub epoch summary: {sub_epoch_summary} for block {latest_block.height+1}")
-            else:
+            else:  # the previous block is not the last block of the sub-epoch or epoch
                 pending_ses = False
                 ses_hash = None
                 new_sub_slot_iters = None

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -848,7 +848,7 @@ class BlockTools:
                     True,
                 )
             # generate sub_epoch_summary, and if the last block was the last block of the sub-epoch
-            # update the difficulty and sub_slot_iters, and include the hash in the next sub-slot
+            # include the hash in the next sub-slot
             sub_epoch_summary: Optional[SubEpochSummary] = None
             if not pending_ses:  # if we just created a sub-epoch summary, we can at least skip another sub-slot
                 sub_epoch_summary = next_sub_epoch_summary(
@@ -861,6 +861,7 @@ class BlockTools:
             if sub_epoch_summary is not None:
                 pending_ses = True
                 ses_hash: Optional[bytes32] = sub_epoch_summary.get_hash()
+                # if the last block is the last block of the epoch, we set the new sub-slot iters and difficulty
                 new_sub_slot_iters: Optional[uint64] = sub_epoch_summary.new_sub_slot_iters
                 new_difficulty: Optional[uint64] = sub_epoch_summary.new_difficulty
 
@@ -870,7 +871,6 @@ class BlockTools:
                 ses_hash = None
                 new_sub_slot_iters = None
                 new_difficulty = None
-                self.log.debug(f"No sub epoch summary for block {latest_block.height+1}")
 
             if icc_eos_vdf is not None:
                 # Icc vdf (Deficit of latest block is <= 4)
@@ -947,7 +947,7 @@ class BlockTools:
             )
             blocks_added_this_sub_slot = 0  # Sub slot ended, overflows are in next sub slot
 
-            # Handle overflows: No overflows on new epoch
+            # Handle overflows: No overflows on new epoch or sub-epoch
             if new_sub_slot_iters is None and num_empty_slots_added >= skip_slots and not pending_ses:
                 for signage_point_index in range(
                     constants.NUM_SPS_SUB_SLOT - constants.NUM_SP_INTERVALS_EXTRA,
@@ -1087,9 +1087,7 @@ class BlockTools:
             if num_blocks < prev_num_of_blocks:
                 num_empty_slots_added += 1
 
-            if pending_ses:
-                assert new_sub_slot_iters is not None
-                assert new_difficulty is not None
+            if new_sub_slot_iters is not None and new_difficulty is not None:  # new epoch
                 sub_slot_iters = new_sub_slot_iters
                 difficulty = new_difficulty
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This fixes an issue where a sub epoch might not be included if the simulator decides to overflow blocks, as it checks if there is a difficulty change, and therefore a new epoch instead of a sub epoch 


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
No Breaking Change


### New Behavior:
N/A


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Testing is borderline impossible, because it requires making hundreds of thousands of blocks, however @nirajpathak13 said the issue was fixed.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
Crash log before fix:
```
(venv) niraj@summer:~/development/chia/chia-blockchain$ Traceback (most recent call last):
  File "/home/niraj/development/chia/chia-blockchain/venv/bin/chia_full_node", line 8, in <module>
    sys.exit(main())
  File "/home/niraj/development/chia/chia-blockchain/chia/server/start_full_node.py", line 117, in main
    return async_run(coro=async_main(service_config), connection_limit=target_peer_count)
  File "/home/niraj/development/chia/chia-blockchain/chia/server/start_service.py", line 319, in async_run
    return asyncio.run(coro)
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/niraj/development/chia/chia-blockchain/chia/server/start_full_node.py", line 100, in async_main
    await service.run()
  File "/home/niraj/development/chia/chia-blockchain/chia/server/start_service.py", line 224, in run
    await self.start()
  File "/home/niraj/development/chia/chia-blockchain/chia/server/start_service.py", line 183, in start
    await self._node._start()
  File "/home/niraj/development/chia/chia-blockchain/chia/full_node/full_node.py", line 401, in _start
    await self.peak_post_processing_2(full_peak, None, state_change_summary, ppp_result)
  File "/home/niraj/development/chia/chia-blockchain/chia/full_node/full_node.py", line 1522, in peak_post_processing_2
    await self.send_peak_to_timelords(block)
  File "/home/niraj/development/chia/chia-blockchain/chia/full_node/full_node.py", line 731, in send_peak_to_timelords
    ses: Optional[SubEpochSummary] = next_sub_epoch_summary(
  File "/home/niraj/development/chia/chia-blockchain/chia/consensus/make_sub_epoch_summary.py", line 198, in next_sub_epoch_summary
    return make_sub_epoch_summary(
  File "/home/niraj/development/chia/chia-blockchain/chia/consensus/make_sub_epoch_summary.py", line 68, in make_sub_epoch_summary
    uint8(curr.height % constants.SUB_EPOCH_BLOCKS),
  File "/home/niraj/development/chia/chia-blockchain/chia/util/struct_stream.py", line 73, in __init__
    raise ValueError(f"Value {self} does not fit into {type(self).__name__}")
ValueError: Value 335 does not fit into uint8
```