### PR TITLE
Cleanup CLI RPC connection error handling 

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -27,7 +27,7 @@ from chia.cmds.start import start_cmd
 from chia.cmds.stop import stop_cmd
 from chia.cmds.wallet import wallet_cmd
 from chia.util.default_root import DEFAULT_KEYS_ROOT_PATH, DEFAULT_ROOT_PATH
-from chia.util.errors import KeychainCurrentPassphraseIsInvalid
+from chia.util.errors import CliRpcConnectionError, KeychainCurrentPassphraseIsInvalid
 from chia.util.keychain import Keychain, set_keys_root_path
 from chia.util.ssl_check import check_ssl
 
@@ -132,7 +132,10 @@ cli.add_command(dev_cmd)
 
 
 def main() -> None:
-    cli()  # pylint: disable=no-value-for-parameter
+    try:
+        cli()  # pylint: disable=no-value-for-parameter
+    except CliRpcConnectionError:  # this happens when we cant connect to a client and is only comes from the cli code
+        exit(1)
 
 
 if __name__ == "__main__":

--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -100,10 +100,9 @@ async def get_any_service_client(
     try:
         # check if we can connect to node
         connected = await validate_client_connection(node_client, node_type, rpc_port, consume_errors)
-        if connected:
-            yield node_client, config
-        else:
+        if not connected:
             raise CliRpcConnectionError
+        yield node_client, config
     except Exception as e:  # this is only here to make the errors more user-friendly.
         if not consume_errors or isinstance(e, CliRpcConnectionError):
             raise
@@ -215,7 +214,6 @@ async def get_wallet_client(
 ) -> AsyncIterator[Tuple[WalletRpcClient, int, Dict[str, Any]]]:
     async with get_any_service_client(WalletRpcClient, wallet_rpc_port, root_path) as (wallet_client, config):
         new_fp = await get_wallet(root_path, wallet_client, fingerprint)
-        if new_fp is not None:
-            yield wallet_client, new_fp, config
-        else:
+        if new_fp is None:
             raise CliRpcConnectionError  # this is caught by the main cli function
+        yield wallet_client, new_fp, config

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -30,8 +30,6 @@ async def async_list(
     paginate: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, _, config):
-        if wallet_client is None:
-            return
         addr_prefix = selected_network_address_prefix(config)
         if paginate is None:
             paginate = sys.stdout.isatty()
@@ -130,8 +128,6 @@ async def async_combine(
     largest_first: bool,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         target_coin_ids: List[bytes32] = [bytes32.from_hexstr(coin_id) for coin_id in target_coin_ids_str]
         final_fee = uint64(int(fee * units["chia"]))
         if number_of_coins > 500:
@@ -211,8 +207,6 @@ async def async_split(
     target_coin_id_str: str,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         final_fee = uint64(int(fee * units["chia"]))
         target_coin_id: bytes32 = bytes32.from_hexstr(target_coin_id_str)
         if number_of_coins > 500:

--- a/chia/cmds/data_funcs.py
+++ b/chia/cmds/data_funcs.py
@@ -17,9 +17,8 @@ from chia.util.ints import uint64
 async def create_data_store_cmd(rpc_port: Optional[int], fee: Optional[str]) -> None:
     final_fee = None if fee is None else uint64(int(Decimal(fee) * units["chia"]))
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.create_data_store(fee=final_fee)
-            print(res)
+        res = await client.create_data_store(fee=final_fee)
+        print(res)
 
 
 async def get_value_cmd(rpc_port: Optional[int], store_id: str, key: str, root_hash: Optional[str]) -> None:
@@ -27,9 +26,8 @@ async def get_value_cmd(rpc_port: Optional[int], store_id: str, key: str, root_h
     key_bytes = hexstr_to_bytes(key)
     root_hash_bytes = None if root_hash is None else bytes32.from_hexstr(root_hash)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_value(store_id=store_id_bytes, key=key_bytes, root_hash=root_hash_bytes)
-            print(res)
+        res = await client.get_value(store_id=store_id_bytes, key=key_bytes, root_hash=root_hash_bytes)
+        print(res)
 
 
 async def update_data_store_cmd(
@@ -41,9 +39,8 @@ async def update_data_store_cmd(
     store_id_bytes = bytes32.from_hexstr(store_id)
     final_fee = None if fee is None else uint64(int(Decimal(fee) * units["chia"]))
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.update_data_store(store_id=store_id_bytes, changelist=changelist, fee=final_fee)
-            print(res)
+        res = await client.update_data_store(store_id=store_id_bytes, changelist=changelist, fee=final_fee)
+        print(res)
 
 
 async def get_keys_cmd(
@@ -54,9 +51,8 @@ async def get_keys_cmd(
     store_id_bytes = bytes32.from_hexstr(store_id)
     root_hash_bytes = None if root_hash is None else bytes32.from_hexstr(root_hash)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_keys(store_id=store_id_bytes, root_hash=root_hash_bytes)
-            print(res)
+        res = await client.get_keys(store_id=store_id_bytes, root_hash=root_hash_bytes)
+        print(res)
 
 
 async def get_keys_values_cmd(
@@ -67,9 +63,8 @@ async def get_keys_values_cmd(
     store_id_bytes = bytes32.from_hexstr(store_id)
     root_hash_bytes = None if root_hash is None else bytes32.from_hexstr(root_hash)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_keys_values(store_id=store_id_bytes, root_hash=root_hash_bytes)
-            print(res)
+        res = await client.get_keys_values(store_id=store_id_bytes, root_hash=root_hash_bytes)
+        print(res)
 
 
 async def get_root_cmd(
@@ -78,9 +73,8 @@ async def get_root_cmd(
 ) -> None:
     store_id_bytes = bytes32.from_hexstr(store_id)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_root(store_id=store_id_bytes)
-            print(res)
+        res = await client.get_root(store_id=store_id_bytes)
+        print(res)
 
 
 async def subscribe_cmd(
@@ -90,9 +84,8 @@ async def subscribe_cmd(
 ) -> None:
     store_id_bytes = bytes32.from_hexstr(store_id)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.subscribe(store_id=store_id_bytes, urls=urls)
-            print(res)
+        res = await client.subscribe(store_id=store_id_bytes, urls=urls)
+        print(res)
 
 
 async def unsubscribe_cmd(
@@ -101,9 +94,8 @@ async def unsubscribe_cmd(
 ) -> None:
     store_id_bytes = bytes32.from_hexstr(store_id)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.unsubscribe(store_id=store_id_bytes)
-            print(res)
+        res = await client.unsubscribe(store_id=store_id_bytes)
+        print(res)
 
 
 async def remove_subscriptions_cmd(
@@ -113,9 +105,8 @@ async def remove_subscriptions_cmd(
 ) -> None:
     store_id_bytes = bytes32.from_hexstr(store_id)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.remove_subscriptions(store_id=store_id_bytes, urls=urls)
-            print(res)
+        res = await client.remove_subscriptions(store_id=store_id_bytes, urls=urls)
+        print(res)
 
 
 async def get_kv_diff_cmd(
@@ -128,9 +119,8 @@ async def get_kv_diff_cmd(
     hash_1_bytes = bytes32.from_hexstr(hash_1)
     hash_2_bytes = bytes32.from_hexstr(hash_2)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_kv_diff(store_id=store_id_bytes, hash_1=hash_1_bytes, hash_2=hash_2_bytes)
-            print(res)
+        res = await client.get_kv_diff(store_id=store_id_bytes, hash_1=hash_1_bytes, hash_2=hash_2_bytes)
+        print(res)
 
 
 async def get_root_history_cmd(
@@ -139,22 +129,20 @@ async def get_root_history_cmd(
 ) -> None:
     store_id_bytes = bytes32.from_hexstr(store_id)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_root_history(store_id=store_id_bytes)
-            print(res)
+        res = await client.get_root_history(store_id=store_id_bytes)
+        print(res)
 
 
 async def add_missing_files_cmd(
     rpc_port: Optional[int], ids: Optional[List[str]], overwrite: bool, foldername: Optional[Path]
 ) -> None:
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.add_missing_files(
-                store_ids=(None if ids is None else [bytes32.from_hexstr(id) for id in ids]),
-                overwrite=overwrite,
-                foldername=foldername,
-            )
-            print(res)
+        res = await client.add_missing_files(
+            store_ids=(None if ids is None else [bytes32.from_hexstr(id) for id in ids]),
+            overwrite=overwrite,
+            foldername=foldername,
+        )
+        print(res)
 
 
 async def add_mirror_cmd(
@@ -163,48 +151,43 @@ async def add_mirror_cmd(
     store_id_bytes = bytes32.from_hexstr(store_id)
     final_fee = None if fee is None else uint64(int(Decimal(fee) * units["chia"]))
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.add_mirror(
-                store_id=store_id_bytes,
-                urls=urls,
-                amount=amount,
-                fee=final_fee,
-            )
-            print(res)
+        res = await client.add_mirror(
+            store_id=store_id_bytes,
+            urls=urls,
+            amount=amount,
+            fee=final_fee,
+        )
+        print(res)
 
 
 async def delete_mirror_cmd(rpc_port: Optional[int], coin_id: str, fee: Optional[str]) -> None:
     coin_id_bytes = bytes32.from_hexstr(coin_id)
     final_fee = None if fee is None else uint64(int(Decimal(fee) * units["chia"]))
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.delete_mirror(
-                coin_id=coin_id_bytes,
-                fee=final_fee,
-            )
-            print(res)
+        res = await client.delete_mirror(
+            coin_id=coin_id_bytes,
+            fee=final_fee,
+        )
+        print(res)
 
 
 async def get_mirrors_cmd(rpc_port: Optional[int], store_id: str) -> None:
     store_id_bytes = bytes32.from_hexstr(store_id)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_mirrors(store_id=store_id_bytes)
-            print(res)
+        res = await client.get_mirrors(store_id=store_id_bytes)
+        print(res)
 
 
 async def get_subscriptions_cmd(rpc_port: Optional[int]) -> None:
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_subscriptions()
-            print(res)
+        res = await client.get_subscriptions()
+        print(res)
 
 
 async def get_owned_stores_cmd(rpc_port: Optional[int]) -> None:
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_owned_stores()
-            print(res)
+        res = await client.get_owned_stores()
+        print(res)
 
 
 async def get_sync_status_cmd(
@@ -213,16 +196,14 @@ async def get_sync_status_cmd(
 ) -> None:
     store_id_bytes = bytes32.from_hexstr(store_id)
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.get_sync_status(store_id=store_id_bytes)
-            print(res)
+        res = await client.get_sync_status(store_id=store_id_bytes)
+        print(res)
 
 
 async def check_plugins_cmd(rpc_port: Optional[int]) -> None:
     async with get_any_service_client(DataLayerRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            res = await client.check_plugins()
-            print(json.dumps(res, indent=4, sort_keys=True))
+        res = await client.check_plugins()
+        print(json.dumps(res, indent=4, sort_keys=True))
 
 
 async def clear_pending_roots(
@@ -231,8 +212,7 @@ async def clear_pending_roots(
     root_path: Path = DEFAULT_ROOT_PATH,
 ) -> Dict[str, Any]:
     async with get_any_service_client(DataLayerRpcClient, rpc_port, root_path=root_path) as (client, _):
-        if client is not None:
-            result = await client.clear_pending_roots(store_id=store_id)
-            print(json.dumps(result, indent=4, sort_keys=True))
+        result = await client.clear_pending_roots(store_id=store_id)
+        print(json.dumps(result, indent=4, sort_keys=True))
 
     return result

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -16,53 +16,43 @@ SECONDS_PER_BLOCK = (24 * 3600) / 4608
 
 async def get_harvesters_summary(farmer_rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
     async with get_any_service_client(FarmerRpcClient, farmer_rpc_port) as (farmer_client, _):
-        if farmer_client is not None:
-            return await farmer_client.get_harvesters_summary()
-    return None
+        return await farmer_client.get_harvesters_summary()
 
 
 async def get_blockchain_state(rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
     async with get_any_service_client(FullNodeRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            return await client.get_blockchain_state()
-    return None
+        return await client.get_blockchain_state()
 
 
 async def get_average_block_time(rpc_port: Optional[int]) -> float:
     async with get_any_service_client(FullNodeRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            blocks_to_compare = 500
-            blockchain_state = await client.get_blockchain_state()
-            curr: Optional[BlockRecord] = blockchain_state["peak"]
-            if curr is None or curr.height < (blocks_to_compare + 100):
-                return SECONDS_PER_BLOCK
-            while curr is not None and curr.height > 0 and not curr.is_transaction_block:
-                curr = await client.get_block_record(curr.prev_hash)
-            if curr is None or curr.timestamp is None or curr.height is None:
-                # stupid mypy
-                return SECONDS_PER_BLOCK
-            past_curr = await client.get_block_record_by_height(curr.height - blocks_to_compare)
-            while past_curr is not None and past_curr.height > 0 and not past_curr.is_transaction_block:
-                past_curr = await client.get_block_record(past_curr.prev_hash)
-            if past_curr is None or past_curr.timestamp is None or past_curr.height is None:
-                # stupid mypy
-                return SECONDS_PER_BLOCK
-            return (curr.timestamp - past_curr.timestamp) / (curr.height - past_curr.height)
-    return SECONDS_PER_BLOCK
+        blocks_to_compare = 500
+        blockchain_state = await client.get_blockchain_state()
+        curr: Optional[BlockRecord] = blockchain_state["peak"]
+        if curr is None or curr.height < (blocks_to_compare + 100):
+            return SECONDS_PER_BLOCK
+        while curr is not None and curr.height > 0 and not curr.is_transaction_block:
+            curr = await client.get_block_record(curr.prev_hash)
+        if curr is None or curr.timestamp is None or curr.height is None:
+            # stupid mypy
+            return SECONDS_PER_BLOCK
+        past_curr = await client.get_block_record_by_height(curr.height - blocks_to_compare)
+        while past_curr is not None and past_curr.height > 0 and not past_curr.is_transaction_block:
+            past_curr = await client.get_block_record(past_curr.prev_hash)
+        if past_curr is None or past_curr.timestamp is None or past_curr.height is None:
+            # stupid mypy
+            return SECONDS_PER_BLOCK
+        return (curr.timestamp - past_curr.timestamp) / (curr.height - past_curr.height)
 
 
 async def get_wallets_stats(wallet_rpc_port: Optional[int]) -> Optional[Dict[str, Any]]:
     async with get_any_service_client(WalletRpcClient, wallet_rpc_port) as (wallet_client, _):
-        if wallet_client is not None:
-            return await wallet_client.get_farmed_amount()
-    return None
+        return await wallet_client.get_farmed_amount()
 
 
 async def get_challenges(farmer_rpc_port: Optional[int]) -> Optional[List[Dict[str, Any]]]:
     async with get_any_service_client(FarmerRpcClient, farmer_rpc_port) as (farmer_client, _):
-        if farmer_client is not None:
-            return await farmer_client.get_signage_points()
-    return None
+        return await farmer_client.get_signage_points()
 
 
 async def challenges(farmer_rpc_port: Optional[int], limit: int) -> None:

--- a/chia/cmds/netspace_funcs.py
+++ b/chia/cmds/netspace_funcs.py
@@ -13,43 +13,42 @@ async def netstorge_async(rpc_port: Optional[int], delta_block_height: str, star
     Calculates the estimated space on the network given two block header hashes.
     """
     async with get_any_service_client(FullNodeRpcClient, rpc_port) as (client, _):
-        if client is not None:
-            if delta_block_height:
-                if start == "":
-                    blockchain_state = await client.get_blockchain_state()
-                    if blockchain_state["peak"] is None:
-                        print("No blocks in blockchain")
-                        return None
+        if delta_block_height:
+            if start == "":
+                blockchain_state = await client.get_blockchain_state()
+                if blockchain_state["peak"] is None:
+                    print("No blocks in blockchain")
+                    return None
 
-                    newer_block_height = blockchain_state["peak"].height
+                newer_block_height = blockchain_state["peak"].height
+            else:
+                newer_block = await client.get_block_record(bytes32.from_hexstr(start))
+                if newer_block is None:
+                    print("Block header hash", start, "not found.")
+                    return None
                 else:
-                    newer_block = await client.get_block_record(bytes32.from_hexstr(start))
-                    if newer_block is None:
-                        print("Block header hash", start, "not found.")
-                        return None
-                    else:
-                        print("newer_height", newer_block.height)
-                        newer_block_height = newer_block.height
+                    print("newer_height", newer_block.height)
+                    newer_block_height = newer_block.height
 
-                newer_block_header = await client.get_block_record_by_height(newer_block_height)
-                older_block_height = max(0, newer_block_height - int(delta_block_height))
-                older_block_header = await client.get_block_record_by_height(older_block_height)
-                assert newer_block_header is not None and older_block_header is not None
-                network_space_bytes_estimate = await client.get_network_space(
-                    newer_block_header.header_hash, older_block_header.header_hash
-                )
-                print(
-                    "Older Block\n"
-                    f"Block Height: {older_block_header.height}\n"
-                    f"Weight:           {older_block_header.weight}\n"
-                    f"VDF Iterations:   {older_block_header.total_iters}\n"
-                    f"Header Hash:      0x{older_block_header.header_hash}\n"
-                )
-                print(
-                    "Newer Block\n"
-                    f"Block Height: {newer_block_header.height}\n"
-                    f"Weight:           {newer_block_header.weight}\n"
-                    f"VDF Iterations:   {newer_block_header.total_iters}\n"
-                    f"Header Hash:      0x{newer_block_header.header_hash}\n"
-                )
-                print(format_bytes(network_space_bytes_estimate))
+            newer_block_header = await client.get_block_record_by_height(newer_block_height)
+            older_block_height = max(0, newer_block_height - int(delta_block_height))
+            older_block_header = await client.get_block_record_by_height(older_block_height)
+            assert newer_block_header is not None and older_block_header is not None
+            network_space_bytes_estimate = await client.get_network_space(
+                newer_block_header.header_hash, older_block_header.header_hash
+            )
+            print(
+                "Older Block\n"
+                f"Block Height: {older_block_header.height}\n"
+                f"Weight:           {older_block_header.weight}\n"
+                f"VDF Iterations:   {older_block_header.total_iters}\n"
+                f"Header Hash:      0x{older_block_header.header_hash}\n"
+            )
+            print(
+                "Newer Block\n"
+                f"Block Height: {newer_block_header.height}\n"
+                f"Weight:           {newer_block_header.weight}\n"
+                f"VDF Iterations:   {newer_block_header.total_iters}\n"
+                f"Header Hash:      0x{newer_block_header.header_hash}\n"
+            )
+            print(format_bytes(network_space_bytes_estimate))

--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -115,13 +115,12 @@ async def peer_async(
 ) -> None:
     client_type = NODE_TYPES[node_type]
     async with get_any_service_client(client_type, rpc_port, root_path) as (rpc_client, config):
-        if rpc_client is not None:
-            # Check or edit node connections
-            if show_connections:
-                trusted_peers: Dict[str, Any] = config["full_node"].get("trusted_peers", {})
-                await print_connections(rpc_client, trusted_peers)
-                # if called together with state, leave a blank line
-            if add_connection:
-                await add_node_connection(rpc_client, add_connection)
-            if remove_connection:
-                await remove_node_connection(rpc_client, remove_connection)
+        # Check or edit node connections
+        if show_connections:
+            trusted_peers: Dict[str, Any] = config["full_node"].get("trusted_peers", {})
+            await print_connections(rpc_client, trusted_peers)
+            # if called together with state, leave a blank line
+        if add_connection:
+            await add_node_connection(rpc_client, add_connection)
+        if remove_connection:
+            await remove_node_connection(rpc_client, remove_connection)

--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -31,6 +31,7 @@ from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.errors import CliRpcConnectionError
 from chia.util.ints import uint32, uint64
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.wallet_types import WalletType
@@ -63,8 +64,6 @@ async def create(
     wallet_rpc_port: Optional[int], fingerprint: int, pool_url: Optional[str], state: str, fee: Decimal, prompt: bool
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, _):
-        if wallet_client is None:
-            return None
         fee_mojos = uint64(int(fee * units["chia"]))
         target_puzzle_hash: Optional[bytes32]
         # Could use initial_pool_state_from_dict to simplify
@@ -183,11 +182,9 @@ async def pprint_pool_wallet_state(
 
 
 async def show(wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id_passed_in: Optional[int]) -> None:
-    async with get_any_service_client(FarmerRpcClient) as (farmer_client, config):
-        async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, _):
-            if wallet_client is None:
-                return
-            if farmer_client is not None:
+    async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, _):
+        try:
+            async with get_any_service_client(FarmerRpcClient) as (farmer_client, config):
                 address_prefix = config["network_overrides"]["config"][config["selected_network"]]["address_prefix"]
                 summaries_response = await wallet_client.get_wallets()
                 pool_state_list = (await farmer_client.get_pool_state())["pool_state"]
@@ -212,34 +209,33 @@ async def show(wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id_pass
                         address_prefix,
                         pool_state_dict.get(pool_wallet_info.launcher_id),
                     )
-                else:
-                    print(f"Wallet height: {await wallet_client.get_height_info()}")
-                    print(f"Sync status: {'Synced' if (await wallet_client.get_synced()) else 'Not synced'}")
-                    for summary in summaries_response:
-                        wallet_id = summary["id"]
-                        typ = WalletType(int(summary["type"]))
-                        if typ == WalletType.POOLING_WALLET:
-                            print(f"Wallet id {wallet_id}: ")
-                            pool_wallet_info, _ = await wallet_client.pw_status(wallet_id)
-                            await pprint_pool_wallet_state(
-                                wallet_client,
-                                wallet_id,
-                                pool_wallet_info,
-                                address_prefix,
-                                pool_state_dict.get(pool_wallet_info.launcher_id),
-                            )
-                            print("")
+        except CliRpcConnectionError:  # we want to output this if we can't connect to the farmer
+            print(f"Wallet height: {await wallet_client.get_height_info()}")
+            print(f"Sync status: {'Synced' if (await wallet_client.get_synced()) else 'Not synced'}")
+            for summary in summaries_response:
+                wallet_id = summary["id"]
+                typ = WalletType(int(summary["type"]))
+                if typ == WalletType.POOLING_WALLET:
+                    print(f"Wallet id {wallet_id}: ")
+                    pool_wallet_info, _ = await wallet_client.pw_status(wallet_id)
+                    await pprint_pool_wallet_state(
+                        wallet_client,
+                        wallet_id,
+                        pool_wallet_info,
+                        address_prefix,
+                        pool_state_dict.get(pool_wallet_info.launcher_id),
+                    )
+                    print("")
 
 
 async def get_login_link(launcher_id_str: str) -> None:
     launcher_id: bytes32 = bytes32.from_hexstr(launcher_id_str)
     async with get_any_service_client(FarmerRpcClient) as (farmer_client, _):
-        if farmer_client is not None:
-            login_link: Optional[str] = await farmer_client.get_pool_login_link(launcher_id)
-            if login_link is None:
-                print("Was not able to get login link.")
-            else:
-                print(login_link)
+        login_link: Optional[str] = await farmer_client.get_pool_login_link(launcher_id)
+        if login_link is None:
+            print("Was not able to get login link.")
+        else:
+            print(login_link)
 
 
 async def submit_tx_with_confirmation(
@@ -284,8 +280,6 @@ async def join_pool(
     prompt: bool,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return None
         enforce_https = config["full_node"]["selected_network"] == "mainnet"
         fee_mojos = uint64(int(fee * units["chia"]))
 
@@ -331,8 +325,6 @@ async def self_pool(
     *, wallet_rpc_port: Optional[int], fingerprint: int, fee: Decimal, wallet_id: int, prompt: bool
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, _):
-        if wallet_client is None:
-            return None
         fee_mojos = uint64(int(fee * units["chia"]))
         msg = f"Will start self-farming with Plot NFT on wallet id {wallet_id} fingerprint {fingerprint}."
         func = functools.partial(wallet_client.pw_self_pool, wallet_id, fee_mojos)
@@ -341,8 +333,6 @@ async def self_pool(
 
 async def inspect_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_id: int) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, _):
-        if wallet_client is None:
-            return None
         pool_wallet_info, unconfirmed_transactions = await wallet_client.pw_status(wallet_id)
         print(
             {
@@ -356,8 +346,6 @@ async def inspect_cmd(wallet_rpc_port: Optional[int], fingerprint: int, wallet_i
 
 async def claim_cmd(*, wallet_rpc_port: Optional[int], fingerprint: int, fee: Decimal, wallet_id: int) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, _):
-        if wallet_client is None:
-            return None
         fee_mojos = uint64(int(fee * units["chia"]))
         msg = f"\nWill claim rewards for wallet ID: {wallet_id}."
         func = functools.partial(

--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -196,19 +196,18 @@ async def show_async(
     from chia.cmds.cmds_util import get_any_service_client
 
     async with get_any_service_client(FullNodeRpcClient, rpc_port, root_path) as (node_client, config):
-        if node_client is not None:
-            # Check State
-            if print_state:
-                if await print_blockchain_state(node_client, config) is True:
-                    return None  # if no blockchain is found
-            if print_fee_info_flag:
-                await print_fee_info(node_client)
-            # Get Block Information
-            if block_header_hash_by_height is not None:
-                block_header = await node_client.get_block_record_by_height(block_header_hash_by_height)
-                if block_header is not None:
-                    print(f"Header hash of block {block_header_hash_by_height}: {block_header.header_hash.hex()}")
-                else:
-                    print("Block height", block_header_hash_by_height, "not found")
-            if block_by_header_hash != "":
-                await print_block_from_hash(node_client, config, block_by_header_hash)
+        # Check State
+        if print_state:
+            if await print_blockchain_state(node_client, config) is True:
+                return None  # if no blockchain is found
+        if print_fee_info_flag:
+            await print_fee_info(node_client)
+        # Get Block Information
+        if block_header_hash_by_height is not None:
+            block_header = await node_client.get_block_record_by_height(block_header_hash_by_height)
+            if block_header is not None:
+                print(f"Header hash of block {block_header_hash_by_height}: {block_header.header_hash.hex()}")
+            else:
+                print("Block height", block_header_hash_by_height, "not found")
+        if block_by_header_hash != "":
+            await print_block_from_hash(node_client, config, block_by_header_hash)

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -135,8 +135,6 @@ async def get_transaction(
     *, wallet_rpc_port: Optional[int], fingerprint: Optional[int], tx_id: str, verbose: int
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         transaction_id = bytes32.from_hexstr(tx_id)
         address_prefix = selected_network_address_prefix(config)
         # The wallet id parameter is required by the client but unused by the RPC.
@@ -179,8 +177,6 @@ async def get_transactions(
     clawback: bool,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         if paginate is None:
             paginate = sys.stdout.isatty()
         type_filter = (
@@ -268,8 +264,6 @@ async def send(
     clawback_time_lock: int,
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, _):
-        if wallet_client is None:
-            return
         if memo is None:
             memos = None
         else:
@@ -349,32 +343,24 @@ async def send(
 
 async def get_address(wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id: int, new_address: bool) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         res = await wallet_client.get_next_address(wallet_id, new_address)
         print(res)
 
 
 async def delete_unconfirmed_transactions(wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id: int) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, _):
-        if wallet_client is None:
-            return
         await wallet_client.delete_unconfirmed_transactions(wallet_id)
         print(f"Successfully deleted all unconfirmed transactions for wallet id {wallet_id} on key {fingerprint}")
 
 
 async def get_derivation_index(wallet_rpc_port: Optional[int], fp: Optional[int]) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, _, _):
-        if wallet_client is None:
-            return
         res = await wallet_client.get_current_derivation_index()
         print(f"Last derivation index: {res}")
 
 
 async def update_derivation_index(wallet_rpc_port: Optional[int], fp: Optional[int], index: int) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, _, _):
-        if wallet_client is None:
-            return
         print("Updating derivation index... This may take a while.")
         res = await wallet_client.extend_derivation_index(index)
         print(f"Updated derivation index: {res}")
@@ -383,8 +369,6 @@ async def update_derivation_index(wallet_rpc_port: Optional[int], fp: Optional[i
 
 async def add_token(wallet_rpc_port: Optional[int], fp: Optional[int], asset_id: str, token_name: str) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, _):
-        if wallet_client is None:
-            return
         try:
             asset_id_bytes: bytes32 = bytes32.from_hexstr(asset_id)
             existing_info: Optional[Tuple[Optional[uint32], str]] = await wallet_client.cat_asset_id_to_name(
@@ -419,8 +403,6 @@ async def make_offer(
     reuse_puzhash: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         fee: int = int(d_fee * units["chia"])
 
         if offers == [] or requests == []:
@@ -651,8 +633,6 @@ async def get_offers(
     reverse: bool = False,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         file_contents: bool = (filepath is not None) or summaries
         records: List[TradeRecord] = []
         if offer_id is None:
@@ -698,8 +678,6 @@ async def take_offer(
     examine_only: bool,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         if os.path.exists(file):
             filepath = pathlib.Path(file)
             with open(filepath, "r") as ffile:
@@ -814,8 +792,6 @@ async def cancel_offer(
     wallet_rpc_port: Optional[int], fp: Optional[int], d_fee: Decimal, offer_id_hex: str, secure: bool
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         offer_id = bytes32.from_hexstr(offer_id_hex)
         fee: int = int(d_fee * units["chia"])
 
@@ -853,8 +829,6 @@ async def print_balances(
     wallet_rpc_port: Optional[int], fp: Optional[int], wallet_type: Optional[WalletType] = None
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         summaries_response = await wallet_client.get_wallets(wallet_type)
         address_prefix = selected_network_address_prefix(config)
 
@@ -918,8 +892,6 @@ async def create_did_wallet(
     wallet_rpc_port: Optional[int], fp: Optional[int], d_fee: Decimal, name: Optional[str], amount: int
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         fee: int = int(d_fee * units["chia"])
         try:
             response = await wallet_client.create_new_did_wallet(amount, fee, name)
@@ -933,8 +905,6 @@ async def create_did_wallet(
 
 async def did_set_wallet_name(wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id: int, name: str) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             await wallet_client.did_set_wallet_name(wallet_id, name)
             print(f"Successfully set a new name for DID wallet with id {wallet_id}: {name}")
@@ -944,8 +914,6 @@ async def did_set_wallet_name(wallet_rpc_port: Optional[int], fp: Optional[int],
 
 async def get_did(wallet_rpc_port: Optional[int], fp: Optional[int], did_wallet_id: int) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.get_did_id(did_wallet_id)
             my_did = response["my_did"]
@@ -958,8 +926,6 @@ async def get_did(wallet_rpc_port: Optional[int], fp: Optional[int], did_wallet_
 
 async def get_did_info(wallet_rpc_port: Optional[int], fp: Optional[int], coin_id: str, latest: bool) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         did_padding_length = 23
         try:
             response = await wallet_client.get_did_info(coin_id, latest)
@@ -983,8 +949,6 @@ async def update_did_metadata(
     wallet_rpc_port: Optional[int], fp: Optional[int], did_wallet_id: int, metadata: str, reuse_puzhash: bool
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.update_did_metadata(did_wallet_id, json.loads(metadata), reuse_puzhash)
             print(
@@ -1002,8 +966,6 @@ async def did_message_spend(
     coin_announcements: List[str],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.did_message_spend(did_wallet_id, puzzle_announcements, coin_announcements)
             print(f"Message Spend Bundle: {response['spend_bundle']}")
@@ -1021,8 +983,6 @@ async def transfer_did(
     reuse_puzhash: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.did_transfer_did(
                 did_wallet_id,
@@ -1048,8 +1008,6 @@ async def find_lost_did(
     num_verification: Optional[int],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.find_lost_did(
                 coin_id,
@@ -1069,8 +1027,6 @@ async def create_nft_wallet(
     wallet_rpc_port: Optional[int], fp: Optional[int], did_id: Optional[str] = None, name: Optional[str] = None
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.create_new_nft_wallet(did_id, name)
             wallet_id = response["wallet_id"]
@@ -1100,8 +1056,6 @@ async def mint_nft(
     reuse_puzhash: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         royalty_address = (
             None
             if not royalty_address
@@ -1164,8 +1118,6 @@ async def add_uri_to_nft(
     reuse_puzhash: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             if len([x for x in (uri, metadata_uri, license_uri) if x is not None]) > 1:
                 raise ValueError("You must provide only one of the URI flags")
@@ -1199,8 +1151,6 @@ async def transfer_nft(
     reuse_puzhash: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             target_address = ensure_valid_address(target_address, allowed_types={AddressType.XCH}, config=config)
             fee: int = int(d_fee * units["chia"])
@@ -1252,8 +1202,6 @@ def print_nft_info(nft: NFTInfo, *, config: Dict[str, Any]) -> None:
 
 async def list_nfts(wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id: int) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.list_nfts(wallet_id)
             nft_list = response["nft_list"]
@@ -1278,8 +1226,6 @@ async def set_nft_did(
     reuse_puzhash: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         fee: int = int(d_fee * units["chia"])
         try:
             response = await wallet_client.set_nft_did(wallet_id, did_id, nft_coin_id, fee, reuse_puzhash=reuse_puzhash)
@@ -1291,8 +1237,6 @@ async def set_nft_did(
 
 async def get_nft_info(wallet_rpc_port: Optional[int], fp: Optional[int], nft_coin_id: str) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         try:
             response = await wallet_client.get_nft_info(nft_coin_id)
             nft_info = NFTInfo.from_json_dict(response["nft_info"])
@@ -1367,8 +1311,6 @@ async def send_notification(
     d_amount: Decimal,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         address: bytes32 = decode_puzzle_hash(address_str)
         amount: uint64 = uint64(d_amount * units["chia"])
         message: bytes = bytes(message_hex, "utf8")
@@ -1384,8 +1326,6 @@ async def get_notifications(
     wallet_rpc_port: Optional[int], fp: Optional[int], str_ids: Sequence[str], start: Optional[int], end: Optional[int]
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         ids: Optional[List[bytes32]] = [bytes32.from_hexstr(sid) for sid in str_ids]
         if ids is not None and len(ids) == 0:
             ids = None
@@ -1402,8 +1342,6 @@ async def delete_notifications(
     wallet_rpc_port: Optional[int], fp: Optional[int], str_ids: Sequence[str], delete_all: bool
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         ids: Optional[List[bytes32]] = [bytes32.from_hexstr(sid) for sid in str_ids]
 
         if delete_all:
@@ -1423,8 +1361,6 @@ async def sign_message(
     nft_id: Optional[str] = None,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         if addr_type == AddressType.XCH:
             if address is None:
                 print("Address is required for XCH address type.")
@@ -1454,8 +1390,6 @@ async def spend_clawback(
     *, wallet_rpc_port: Optional[int], fp: Optional[int], fee: Decimal, tx_ids_str: str
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, _, _):
-        if wallet_client is None:
-            return
         tx_ids = []
         for tid in tx_ids_str.split(","):
             tx_ids.append(bytes32.from_hexstr(tid))
@@ -1473,8 +1407,6 @@ async def mint_vc(
     wallet_rpc_port: Optional[int], fp: Optional[int], did: str, d_fee: Decimal, target_address: Optional[str]
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         vc_record, txs = await wallet_client.vc_mint(
             decode_puzzle_hash(ensure_valid_address(did, allowed_types={AddressType.DID}, config=config)),
             None
@@ -1502,8 +1434,6 @@ async def get_vcs(
     wallet_rpc_port: Optional[int], fp: Optional[int], start: int, count: int
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         vc_records, proofs = await wallet_client.vc_get_list(start, count)
         print("Proofs:")
         for hash, proof_dict in proofs.items():
@@ -1536,8 +1466,6 @@ async def spend_vc(
     reuse_puzhash: bool,
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         txs = await wallet_client.vc_spend(
             bytes32.from_hexstr(vc_id),
             new_puzhash=None if new_puzhash is None else bytes32.from_hexstr(new_puzhash),
@@ -1563,8 +1491,6 @@ async def add_proof_reveal(
     wallet_rpc_port: Optional[int], fp: Optional[int], proofs: Sequence[str], root_only: bool
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         if len(proofs) == 0:
             print("Must specify at least one proof")
             return
@@ -1583,8 +1509,6 @@ async def get_proofs_for_root(
     wallet_rpc_port: Optional[int], fp: Optional[int], proof_hash: str
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         proof_dict: Dict[str, str] = await wallet_client.vc_get_proofs_for_root(bytes32.from_hexstr(proof_hash))
         print("Proofs:")
         for proof in proof_dict:
@@ -1600,8 +1524,6 @@ async def revoke_vc(
     reuse_puzhash: bool,
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
-        if wallet_client is None:
-            return
         if parent_coin_id is None:
             if vc_id is None:
                 print("Must specify either --parent-coin-id or --vc-id")

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -318,3 +318,12 @@ class InvalidPathError(Exception):
     def __init__(self, path: Path, error_message: str):
         super().__init__(f"{error_message}: {str(path)!r}")
         self.path = path
+
+
+class CliRpcConnectionError(Exception):
+    """
+    This error is raised when a rpc server cant be reached by the cli async generator & should always be caught by
+    the cli in cmds/chia.py:main.
+    """
+
+    pass


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This reduces complexity by catching a `generator didn't yield error` for the `get_any_service_client` async generator which gives clients a connected instance of a client for whatever service they need. This is instead of passing none and every function having to use it. 

This PR is part of a series to cleanup the cli.
Todo:
- [x] PR: #15628 Merged
- [x] This branch rebased on top of main
- [x] Edit all wallet commands, `cmds_util.py` and `plotnft_funcs.py`


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Error caught In generator, function expected to exit if given `None` as a value for the rpc client.


### New Behavior:
Error still caught, but nothing instead of `None` is yielded, and the yield error is caught by a wrapper around the base click command group.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Coverage Coming in next pr of series


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
