### PR TITLE
Fix max-line-lengh for pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -364,7 +364,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module
 max-module-lines=1000


### PR DESCRIPTION
The current codes are using max line length for 120, and which is specified in black and flake8, but the pylint config is outdated.