### PR TITLE
forward `flags` in `get_puzzle_and_solution_for_coin()`

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -418,7 +418,7 @@ class SimClient:
         generator: BlockGenerator = filtered_generators[0].transactions_generator  # type: ignore[assignment]
         coin_record = await self.service.coin_store.get_coin_record(coin_id)
         assert coin_record is not None
-        spend_info = get_puzzle_and_solution_for_coin(generator, coin_record.coin)
+        spend_info = get_puzzle_and_solution_for_coin(generator, coin_record.coin, 0)
         return CoinSpend(coin_record.coin, spend_info.puzzle, spend_info.solution)
 
     async def get_all_mempool_tx_ids(self) -> List[bytes32]:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1302,7 +1302,7 @@ class FullNodeAPI:
         assert block_generator is not None
         try:
             spend_info = await asyncio.get_running_loop().run_in_executor(
-                self.executor, get_puzzle_and_solution_for_coin, block_generator, coin_record.coin
+                self.executor, get_puzzle_and_solution_for_coin, block_generator, coin_record.coin, 0
             )
         except ValueError:
             return reject_msg

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -59,7 +59,7 @@ def get_name_puzzle_conditions(
         return NPCResult(uint16(Err.GENERATOR_RUNTIME_ERROR.value), None, uint64(0))
 
 
-def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin: Coin) -> SpendInfo:
+def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin: Coin, flags: int) -> SpendInfo:
     try:
         args = bytearray(b"\xff")
         args += bytes(DESERIALIZE_MOD)
@@ -74,7 +74,7 @@ def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin: Coin) -> S
             coin.parent_coin_info,
             coin.amount,
             coin.puzzle_hash,
-            0,
+            flags,
         )
         return SpendInfo(SerializedProgram.from_bytes(puzzle), SerializedProgram.from_bytes(solution))
     except Exception as e:

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -695,7 +695,7 @@ class FullNodeRpcApi:
 
         block_generator: Optional[BlockGenerator] = await self.service.blockchain.get_block_generator(block)
         assert block_generator is not None
-        spend_info = get_puzzle_and_solution_for_coin(block_generator, coin_record.coin)
+        spend_info = get_puzzle_and_solution_for_coin(block_generator, coin_record.coin, 0)
         return {"coin_solution": CoinSpend(coin_record.coin, spend_info.puzzle, spend_info.solution)}
 
     async def get_additions_and_removals(self, request: Dict[str, Any]) -> EndpointResult:

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2944,4 +2944,4 @@ def test_get_puzzle_and_solution_for_coin_failure():
     with pytest.raises(
         ValueError, match=f"Failed to get puzzle and solution for coin {TEST_COIN}, error: failed to fill whole buffer"
     ):
-        get_puzzle_and_solution_for_coin(BlockGenerator(SerializedProgram(), [], []), TEST_COIN)
+        get_puzzle_and_solution_for_coin(BlockGenerator(SerializedProgram(), [], []), TEST_COIN, 0)

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -85,7 +85,7 @@ class TestCostCalculation:
 
         coin_spend = spend_bundle.coin_spends[0]
         assert coin_spend.coin.name() == npc_result.conds.spends[0].coin_id
-        spend_info = get_puzzle_and_solution_for_coin(program, coin_spend.coin)
+        spend_info = get_puzzle_and_solution_for_coin(program, coin_spend.coin, 0)
         assert spend_info.puzzle == coin_spend.puzzle_reveal
         assert spend_info.solution == coin_spend.solution
 
@@ -155,7 +155,7 @@ class TestCostCalculation:
             bytes32.fromhex("14947eb0e69ee8fc8279190fc2d38cb4bbb61ba28f1a270cfd643a0e8d759576"),
             300,
         )
-        spend_info = get_puzzle_and_solution_for_coin(generator, coin)
+        spend_info = get_puzzle_and_solution_for_coin(generator, coin, 0)
         assert spend_info.puzzle.to_program() == puzzle
 
     @pytest.mark.asyncio
@@ -273,5 +273,5 @@ async def test_get_puzzle_and_solution_for_coin_performance():
     with assert_runtime(seconds=7, label="get_puzzle_and_solution_for_coin"):
         for i in range(3):
             for c in spends:
-                spend_info = get_puzzle_and_solution_for_coin(generator, c)
+                spend_info = get_puzzle_and_solution_for_coin(generator, c, 0)
                 assert spend_info.puzzle.get_tree_hash() == c.puzzle_hash

--- a/tests/generator/test_compression.py
+++ b/tests/generator/test_compression.py
@@ -158,12 +158,12 @@ class TestCompression:
         ca = CompressorArg(uint32(0), SerializedProgram.from_bytes(original_generator), start, end)
         c = compressed_spend_bundle_solution(ca, sb)
         removal = sb.coin_spends[0].coin
-        spend_info = get_puzzle_and_solution_for_coin(c, removal)
+        spend_info = get_puzzle_and_solution_for_coin(c, removal, 0)
         assert bytes(spend_info.puzzle) == bytes(sb.coin_spends[0].puzzle_reveal)
         assert bytes(spend_info.solution) == bytes(sb.coin_spends[0].solution)
         # Test non compressed generator as well
         s = simple_solution_generator(sb)
-        spend_info = get_puzzle_and_solution_for_coin(s, removal)
+        spend_info = get_puzzle_and_solution_for_coin(s, removal, 0)
         assert bytes(spend_info.puzzle) == bytes(sb.coin_spends[0].puzzle_reveal)
         assert bytes(spend_info.solution) == bytes(sb.coin_spends[0].solution)
 


### PR DESCRIPTION
### Purpose:

This patch adds a new `flags`-parameter to `get_puzzle_and_solution_for_coin()` which is forwarded to the underlying call to run the CLVM. The main (future) use case for this is to be able to pass in `ALLOW_BACKREFS`, once we're ready to support that.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

`get_puzzle_and_solution_for_coin()` does not support any configuration of the underlying interpreter.

### New Behavior:

`get_puzzle_and_solution_for_coin()` supports configuration of the underlying interpreter, most notably `ALLOW_BACKREFS`.

### Testing Notes:

This function already has existing test coverage. Once we start making use of this flag we need coverage for those cases also.