### PR TITLE
server: Store `Handshake.software_version` in connections as `str`

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -111,7 +111,7 @@ class WSChiaConnection:
     request_nonce: uint16 = uint16(0)
     peer_capabilities: List[Capability] = field(default_factory=list)
     # Used by the Chia Seeder.
-    version: Version = field(default_factory=lambda: Version("0"))
+    version: str = field(default_factory=str)
     protocol_version: Version = field(default_factory=lambda: Version("0"))
 
     log_rate_limit_last_time: Dict[ProtocolMessageTypes, float] = field(
@@ -219,7 +219,7 @@ class WSChiaConnection:
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
 
-            self.version = Version(inbound_handshake.software_version)
+            self.version = inbound_handshake.software_version
             self.protocol_version = Version(inbound_handshake.protocol_version)
             self.peer_server_port = inbound_handshake.server_port
             self.connection_type = NodeType(inbound_handshake.node_type)
@@ -247,7 +247,7 @@ class WSChiaConnection:
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
             await self._send_message(outbound_handshake)
-            self.version = Version(inbound_handshake.software_version)
+            self.version = inbound_handshake.software_version
             self.protocol_version = Version(inbound_handshake.protocol_version)
             self.peer_server_port = inbound_handshake.server_port
             self.connection_type = NodeType(inbound_handshake.node_type)
@@ -675,7 +675,7 @@ class WSChiaConnection:
 
     # Used by the Chia Seeder.
     def get_version(self) -> str:
-        return str(self.version)
+        return self.version
 
     def get_tls_version(self) -> str:
         ssl_obj = self._get_extra_info("ssl_object")

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -60,7 +60,7 @@ async def test_connection_versions(
     incoming_connection = full_node.server.all_connections[wallet_node.server.node_id]
     for connection in [outgoing_connection, incoming_connection]:
         assert connection.protocol_version == Version(protocol_version)
-        assert connection.version == Version(chia_full_version_str())
+        assert connection.version == chia_full_version_str()
         assert connection.get_version() == chia_full_version_str()
 
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Parsing it to `Version` here (introduced by #15330) enforces a certain client version format which leads to disconnecting from clients running other implementations which not follow the required format. While this currently makes sense for `protocol_version` we don't really depend on the client version for now and can just store it as it comes in to avoid those disconnects.

