### PR TITLE
fix typo in chia plots check

### DIFF
--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -170,6 +170,7 @@ def check_plots(
 
                             ver_quality_str = v.validate_proof(pr.get_id(), pr.get_size(), challenge, proof)
                             assert quality_str == ver_quality_str
+                            total_proofs += 1
                         except AssertionError as e:
                             log.error(
                                 f"{type(e)}: {e} error in proving/verifying for plot {plot_path}. Filepath: {plot_path}"


### PR DESCRIPTION
This was a typo introduced when pulling out the multi-threaded plots check patch from the compression branch