### PR TITLE
Add DIDWallet.get_coin() to simplify DID wallet

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1435,10 +1435,7 @@ class WalletRpcApi:
                 return {"success": False, "error": f"DID for {entity_id.hex()} doesn't exist."}
             assert isinstance(selected_wallet, DIDWallet)
             pubkey, signature = await selected_wallet.sign_message(request["message"], is_hex)
-            latest_coin: Set[Coin] = await selected_wallet.select_coins(uint64(1))
-            latest_coin_id = None
-            if len(latest_coin) > 0:
-                latest_coin_id = latest_coin.pop().name()
+            latest_coin_id = (await selected_wallet.get_coin()).name()
         elif is_valid_address(request["id"], {AddressType.NFT}, self.service.config):
             target_nft: Optional[NFTCoinInfo] = None
             for wallet in self.service.wallet_state_manager.wallets.values():
@@ -1458,7 +1455,6 @@ class WalletRpcApi:
         else:
             return {"success": False, "error": f'Unknown ID type, {request["id"]}'}
 
-        assert latest_coin_id is not None
         return {
             "success": True,
             "pubkey": str(pubkey),
@@ -2124,11 +2120,10 @@ class WalletRpcApi:
                     await self.service.wallet_state_manager.update_wallet_puzzle_hashes(did_wallet.wallet_info.id)
 
             try:
-                coins = await did_wallet.select_coins(uint64(1))
-                coin = coins.pop()
+                coin = await did_wallet.get_coin()
                 if coin.name() == coin_state.coin.name():
                     return {"success": True, "latest_coin_id": coin.name().hex()}
-            except ValueError:
+            except RuntimeError:
                 # We don't have any coin for this wallet, add the coin
                 pass
 
@@ -2168,10 +2163,9 @@ class WalletRpcApi:
         my_did: str = encode_puzzle_hash(bytes32.fromhex(wallet.get_my_DID()), AddressType.DID.hrp(self.service.config))
         async with self.service.wallet_state_manager.lock:
             try:
-                coins = await wallet.select_coins(uint64(1))
-                coin = coins.pop()
+                coin = await wallet.get_coin()
                 return {"success": True, "wallet_id": wallet_id, "my_did": my_did, "coin_id": coin.name()}
-            except ValueError:
+            except RuntimeError:
                 return {"success": True, "wallet_id": wallet_id, "my_did": my_did}
 
     async def did_get_recovery_list(self, request) -> EndpointResult:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -20,7 +20,6 @@ from chia.types.coin_spend import CoinSpend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.ints import uint32, uint64, uint128
-from chia.wallet.coin_selection import select_coins
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk_unhardened
 from chia.wallet.did_wallet import did_wallet_puzzles
@@ -328,42 +327,10 @@ class DIDWallet:
         max_coin_amount: Optional[uint64] = None,
         excluded_coin_amounts: Optional[List[uint64]] = None,
     ) -> Set[Coin]:
-        """
-        Returns a set of coins that can be used for generating a new transaction.
-        Note: Must be called under wallet state manager lock
-        """
-
-        spendable_amount: uint128 = await self.get_spendable_balance()
-
-        if amount > spendable_amount:
-            error_msg = f"Can't select {amount}, from spendable {spendable_amount} for wallet id {self.id()}"
-            self.log.warning(error_msg)
-            raise ValueError(error_msg)
-
-        spendable_coins: List[WalletCoinRecord] = list(
-            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.wallet_info.id)
-        )
-
-        # Try to use coins from the store, if there isn't enough of "unused"
-        # coins use change coins that are not confirmed yet
-        unconfirmed_removals: Dict[bytes32, Coin] = await self.wallet_state_manager.unconfirmed_removals_for_wallet(
-            self.wallet_info.id
-        )
-        if max_coin_amount is None:
-            max_coin_amount = uint64(self.wallet_state_manager.constants.MAX_COIN_AMOUNT)
-        coins = await select_coins(
-            spendable_amount,
-            max_coin_amount,
-            spendable_coins,
-            unconfirmed_removals,
-            self.log,
-            uint128(amount),
-            exclude,
-            min_coin_amount,
-            excluded_coin_amounts,
-        )
-        assert sum(c.amount for c in coins) >= amount
-        return coins
+        try:
+            return {await self.get_coin()}
+        except RuntimeError:
+            return set()
 
     def _coin_is_first_singleton(self, coin: Coin) -> bool:
         parent = self.get_parent_for_coin(coin)
@@ -569,9 +536,7 @@ class DIDWallet:
     async def create_update_spend(self, fee: uint64 = uint64(0), reuse_puzhash: Optional[bool] = None):
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
-        coins = await self.select_coins(uint64(1))
-        assert coins is not None
-        coin = coins.pop()
+        coin = await self.get_coin()
         new_inner_puzzle = await self.get_new_did_innerpuz()
         uncurried = did_wallet_puzzles.uncurry_innerpuz(new_inner_puzzle)
         assert uncurried is not None
@@ -672,9 +637,7 @@ class DIDWallet:
         """
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
-        coins = await self.select_coins(uint64(1))
-        assert coins is not None
-        coin = coins.pop()
+        coin = await self.get_coin()
         backup_ids = []
         backup_required = uint64(0)
         if with_recovery:
@@ -762,9 +725,7 @@ class DIDWallet:
     ):
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
-        coins = await self.select_coins(uint64(1))
-        assert coins is not None
-        coin = coins.pop()
+        coin = await self.get_coin()
         innerpuz: Program = self.did_info.current_inner
         # Quote message puzzle & solution
         if new_innerpuzzle is None:
@@ -812,9 +773,7 @@ class DIDWallet:
     async def create_exit_spend(self, puzhash: bytes32):
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
-        coins = await self.select_coins(uint64(1))
-        assert coins is not None
-        coin = coins.pop()
+        coin = await self.get_coin()
         message_puz = Program.to((1, [[51, puzhash, coin.amount - 1, [puzhash]], [51, 0x00, -113]]))
 
         # innerpuz solution is (mode p2_solution)
@@ -878,9 +837,7 @@ class DIDWallet:
         """
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
-        coins = await self.select_coins(uint64(1))
-        assert coins is not None and coins != set()
-        coin = coins.pop()
+        coin = await self.get_coin()
         message = did_wallet_puzzles.create_recovery_message_puzzle(recovering_coin_name, newpuz, pubkey)
         innermessage = message.get_tree_hash()
         innerpuz: Program = self.did_info.current_inner
@@ -946,14 +903,14 @@ class DIDWallet:
     async def get_info_for_recovery(self) -> Optional[Tuple[bytes32, bytes32, uint64]]:
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
-        coins = await self.select_coins(uint64(1))
-        if coins is not None:
-            coin = coins.pop()
-            parent = coin.parent_coin_info
-            innerpuzhash = self.did_info.current_inner.get_tree_hash()
-            amount = uint64(coin.amount)
-            return (parent, innerpuzhash, amount)
-        return None
+        try:
+            coin = await self.get_coin()
+        except RuntimeError:
+            return None
+        parent = coin.parent_coin_info
+        innerpuzhash = self.did_info.current_inner.get_tree_hash()
+        amount = uint64(coin.amount)
+        return (parent, innerpuzhash, amount)
 
     async def load_attest_files_for_recovery_spend(self, attest_data: List[str]) -> Tuple[List, SpendBundle]:
         spend_bundle_list = []
@@ -1467,3 +1424,11 @@ class DIDWallet:
 
     def require_derivation_paths(self) -> bool:
         return True
+
+    async def get_coin(self) -> Coin:
+        spendable_coins: List[WalletCoinRecord] = await self.wallet_state_manager.get_spendable_coins_for_wallet(
+            self.wallet_info.id
+        )
+        if len(spendable_coins) == 0:
+            raise RuntimeError("DID is not currently spendable")
+        return spendable_coins[0].coin

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1426,9 +1426,9 @@ class DIDWallet:
         return True
 
     async def get_coin(self) -> Coin:
-        spendable_coins: List[WalletCoinRecord] = await self.wallet_state_manager.get_spendable_coins_for_wallet(
+        spendable_coins: Set[WalletCoinRecord] = await self.wallet_state_manager.get_spendable_coins_for_wallet(
             self.wallet_info.id
         )
         if len(spendable_coins) == 0:
             raise RuntimeError("DID is not currently spendable")
-        return spendable_coins[0].coin
+        return list(spendable_coins)[0].coin

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -1287,9 +1287,7 @@ class NFTWallet:
 
         # Ensure we have a did coin and its next inner puzzle hash
         if did_coin is None:
-            coins = await did_wallet.select_coins(uint64(1))
-            assert coins is not None
-            did_coin = coins.pop()
+            did_coin = await did_wallet.get_coin()
         innerpuz: Program = did_wallet.did_info.current_inner
         if new_innerpuzhash is None:
             new_innerpuzhash = innerpuz.get_tree_hash()

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -378,8 +378,7 @@ class VCWallet:
         _, provider_inner_puzhash, _ = recovery_info
 
         # Generate spend specific nonce
-        coins = await did_wallet.select_coins(uint64(1))
-        assert coins is not None
+        coins = {await did_wallet.get_coin()}
         coins.add(vc.coin)
         if fee > 0:
             coins.update(await self.standard_wallet.select_coins(fee))

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -85,6 +85,9 @@ class TestDIDWallet:
                 wallet_node_0.wallet_state_manager, wallet_0, uint64(101)
             )
 
+        assert await did_wallet_0.select_coins(uint64(1)) == set()
+        assert await did_wallet_0.get_info_for_recovery() is None
+
         spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
             did_wallet_0.id()
         )

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -195,8 +195,7 @@ class TestDIDWallet:
             did_wallet_2 = await DIDWallet.create_new_did_wallet_from_recovery(
                 wallet_node_2.wallet_state_manager, wallet_2, backup_data
             )
-        coins = await did_wallet_1.select_coins(1)
-        coin = coins.copy().pop()
+        coin = await did_wallet_1.get_coin()
         assert did_wallet_2.did_info.temp_coin == coin
         newpuzhash = await did_wallet_2.get_new_did_inner_hash()
         pubkey = bytes(
@@ -347,8 +346,7 @@ class TestDIDWallet:
         assert did_wallet_3.did_info.backup_ids == recovery_list
         await time_out_assert(15, did_wallet_3.get_confirmed_balance, 201)
         await time_out_assert(15, did_wallet_3.get_unconfirmed_balance, 201)
-        coins = await did_wallet_3.select_coins(1)
-        coin = coins.pop()
+        coin = await did_wallet_3.get_coin()
 
         backup_data = did_wallet_3.create_backup()
 
@@ -448,8 +446,7 @@ class TestDIDWallet:
 
         await time_out_assert(15, did_wallet.get_confirmed_balance, 101)
         await time_out_assert(15, did_wallet.get_unconfirmed_balance, 101)
-        coins = await did_wallet.select_coins(1)
-        coin = coins.pop()
+        coin = await did_wallet.get_coin()
         info = Program.to([])
         pubkey = (await did_wallet.wallet_state_manager.get_unused_derivation_record(did_wallet.wallet_info.id)).pubkey
         try:
@@ -503,8 +500,7 @@ class TestDIDWallet:
         await time_out_assert(15, did_wallet.get_confirmed_balance, 101)
         await time_out_assert(15, did_wallet.get_unconfirmed_balance, 101)
         # Delete the coin and wallet
-        coins = await did_wallet.select_coins(uint64(1))
-        coin = coins.pop()
+        coin = await did_wallet.get_coin()
         await wallet_node.wallet_state_manager.coin_store.delete_coin_record(coin.name())
         await time_out_assert(15, did_wallet.get_confirmed_balance, 0)
         await wallet_node.wallet_state_manager.user_store.delete_wallet(did_wallet.wallet_info.id)
@@ -535,8 +531,7 @@ class TestDIDWallet:
         await time_out_assert(15, did_wallet.get_confirmed_balance, 101)
         await time_out_assert(15, did_wallet.get_unconfirmed_balance, 101)
         # Delete the coin and change inner puzzle
-        coins = await did_wallet.select_coins(uint64(1))
-        coin = coins.pop()
+        coin = await did_wallet.get_coin()
         await wallet_node.wallet_state_manager.coin_store.delete_coin_record(coin.name())
         await time_out_assert(15, did_wallet.get_confirmed_balance, 0)
         new_inner_puzzle = await did_wallet.get_new_did_innerpuz()
@@ -629,8 +624,7 @@ class TestDIDWallet:
                 backup_data,
             )
         new_ph = await did_wallet_3.get_new_did_inner_hash()
-        coins = await did_wallet_2.select_coins(1)
-        coin = coins.pop()
+        coin = await did_wallet_2.get_coin()
         pubkey = (
             await did_wallet_3.wallet_state_manager.get_unused_derivation_record(did_wallet_3.wallet_info.id)
         ).pubkey
@@ -668,8 +662,7 @@ class TestDIDWallet:
                 wallet2,
                 backup_data,
             )
-        coins = await did_wallet.select_coins(1)
-        coin = coins.pop()
+        coin = await did_wallet.get_coin()
         new_ph = await did_wallet_4.get_new_did_inner_hash()
         pubkey = (
             await did_wallet_4.wallet_state_manager.get_unused_derivation_record(did_wallet_4.wallet_info.id)
@@ -890,7 +883,7 @@ class TestDIDWallet:
             did_wallet_1.did_info.current_inner, did_wallet_1.did_info.origin_coin.name()
         )
         assert response["metadata"]["twitter"] == "twitter"
-        assert response["latest_coin"] == (await did_wallet_1.select_coins(uint64(1))).pop().name().hex()
+        assert response["latest_coin"] == (await did_wallet_1.get_coin()).name().hex()
         assert response["num_verification"] == 0
         assert response["recovery_list_hash"] == Program(Program.to([])).get_tree_hash().hex()
         assert decode_puzzle_hash(response["p2_address"]).hex() == response["hints"][0]


### PR DESCRIPTION
Right now we use DIDWallet.select_coins when we just want to get the current DID coin.  The parameters to this function are almost always exactly `1`. This adds a method to just do that as a simplification that way any changes to the `select_coins` protocol doesn't balloon quite so large to other wallets that use the DID wallet.

I did decide to leave `select_coins` functional in some respect because it seems like that's the only way if you're using the RPC to get the current DID coin info.  This is probably not good, but is a more controversial and thoughtful change that should go in a separate PR.