### PR TITLE
Add potentially_inside_lock decorator for RPCs

### DIFF
--- a/chia/rpc/util.py
+++ b/chia/rpc/util.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import traceback
-from typing import Callable
+from typing import Any, Callable, Coroutine, Dict
 
 import aiohttp
 
@@ -31,3 +31,12 @@ def wrap_http_handler(f) -> Callable:
         return obj_to_response(res_object)
 
     return inner
+
+
+def potentially_inside_lock(
+    func: Callable[..., Coroutine[Any, Any, Dict[str, Any]]]
+) -> Callable[..., Coroutine[Any, Any, Dict[str, Any]]]:
+    async def rpc_endpoint(self, *args, hold_lock=True, **kwargs) -> Dict[str, Any]:
+        return await func(self, *args, hold_lock, **kwargs)
+
+    return rpc_endpoint

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -16,6 +16,7 @@ from chia.pools.pool_wallet_info import FARMING_TO_POOL, PoolState, PoolWalletIn
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.wallet_protocol import CoinState
 from chia.rpc.rpc_server import Endpoint, EndpointResult, default_get_connections
+from chia.rpc.util import potentially_inside_lock
 from chia.server.outbound_message import NodeType, make_msg
 from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
@@ -1495,6 +1496,7 @@ class WalletRpcApi:
         cats = await self.service.wallet_state_manager.interested_store.get_unacknowledged_tokens()
         return {"stray_cats": cats}
 
+    @potentially_inside_lock
     async def cat_spend(self, request, hold_lock=True) -> EndpointResult:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
@@ -3004,6 +3006,7 @@ class WalletRpcApi:
             "last_height_farmed": last_height_farmed,
         }
 
+    @potentially_inside_lock
     async def create_signed_transaction(self, request, hold_lock=True) -> EndpointResult:
         if "wallet_id" in request:
             wallet_id = uint32(request["wallet_id"])


### PR DESCRIPTION
The context here is that I was trying to add another decorator in another PR and it had issues because of this keyword argument on a couple of the RPCs.

This PR defines a decorator that RPCs can use to opt into an API where they are told whether or not they should grab the wallet state manager lock to complete their transactions.  Some of these are called from other RPCs that want to make multiple calls under one lock is the reason that this exists in the first place.