### PR TITLE
pass consensus constants into get_name_puzzle_conditions().

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -65,7 +65,11 @@ class CostLogger:
     def add_cost(self, descriptor: str, spend_bundle: SpendBundle) -> SpendBundle:
         program: BlockGenerator = simple_solution_generator(spend_bundle)
         npc_result: NPCResult = get_name_puzzle_conditions(
-            program, INFINITE_COST, mempool_mode=True, height=DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT
+            program,
+            INFINITE_COST,
+            mempool_mode=True,
+            height=DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT,
+            constants=DEFAULT_CONSTANTS,
         )
         self.cost_dict[descriptor] = npc_result.cost
         cost_to_subtract: int = 0

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -131,7 +131,7 @@ def create_foliage(
         if block_generator is not None:
             generator_block_heights_list = block_generator.block_height_list
             result: NPCResult = get_name_puzzle_conditions(
-                block_generator, constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=height
+                block_generator, constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=height, constants=constants
             )
             cost = result.cost
 

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -450,7 +450,11 @@ class Blockchain(BlockchainInterface):
             block_generator: Optional[BlockGenerator] = await self.get_block_generator(block)
             assert block_generator is not None
             npc_result = get_name_puzzle_conditions(
-                block_generator, self.constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=block.height
+                block_generator,
+                self.constants.MAX_BLOCK_COST_CLVM,
+                mempool_mode=False,
+                height=block.height,
+                constants=self.constants,
             )
         tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
         return tx_removals, tx_additions, npc_result

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -373,6 +373,7 @@ def _run_generator(
             min(constants.MAX_BLOCK_COST_CLVM, unfinished_block.transactions_info.cost),
             mempool_mode=False,
             height=height,
+            constants=constants,
         )
         return bytes(npc_result)
     except ValidationError as e:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1107,6 +1107,7 @@ class FullNodeAPI:
                     self.full_node.constants.MAX_BLOCK_COST_CLVM,
                     mempool_mode=False,
                     height=request.height,
+                    constants=self.full_node.constants,
                 ),
             )
 

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -49,7 +49,7 @@ def get_name_puzzle_conditions(
     *,
     mempool_mode: bool,
     height: uint32,
-    constants: ConsensusConstants = DEFAULT_CONSTANTS,
+    constants: ConsensusConstants,
 ) -> NPCResult:
     flags = 0
     if mempool_mode:

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -314,7 +314,11 @@ class CATWallet:
             # will only matter once the wallet generates transactions relying on
             # new conditions, and we can change this by then
             result: NPCResult = get_name_puzzle_conditions(
-                program, self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=uint32(0)
+                program,
+                self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM,
+                mempool_mode=True,
+                height=uint32(0),
+                constants=self.wallet_state_manager.constants,
             )
             self.cost_of_single_tx = result.cost
             self.log.info(f"Cost of a single tx for CAT wallet: {self.cost_of_single_tx}")

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -101,7 +101,11 @@ class Wallet:
             # will only matter once the wallet generates transactions relying on
             # new conditions, and we can change this by then
             result: NPCResult = get_name_puzzle_conditions(
-                program, self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=uint32(0)
+                program,
+                self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM,
+                mempool_mode=True,
+                height=uint32(0),
+                constants=self.wallet_state_manager.constants,
             )
             self.cost_of_single_tx = result.cost
             self.log.info(f"Cost of a single tx for standard wallet: {self.cost_of_single_tx}")

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -2577,7 +2577,11 @@ class TestBodyValidation:
 
         block_generator: BlockGenerator = BlockGenerator(blocks[-1].transactions_generator, [], [])
         npc_result = get_name_puzzle_conditions(
-            block_generator, b.constants.MAX_BLOCK_COST_CLVM * 1000, mempool_mode=False, height=softfork_height
+            block_generator,
+            b.constants.MAX_BLOCK_COST_CLVM * 1000,
+            mempool_mode=False,
+            height=softfork_height,
+            constants=bt.constants,
         )
         err = (await b.add_block(blocks[-1], PreValidationResult(None, uint64(1), npc_result, True)))[1]
         assert err in [Err.BLOCK_COST_EXCEEDS_MAX]
@@ -2638,6 +2642,7 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             mempool_mode=False,
             height=softfork_height,
+            constants=bt.constants,
         )
         result, err, _ = await b.add_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))
         assert err == Err.INVALID_BLOCK_COST
@@ -2662,6 +2667,7 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             mempool_mode=False,
             height=softfork_height,
+            constants=bt.constants,
         )
         result, err, _ = await b.add_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))
         assert err == Err.INVALID_BLOCK_COST
@@ -2686,6 +2692,7 @@ class TestBodyValidation:
             min(b.constants.MAX_BLOCK_COST_CLVM * 1000, block.transactions_info.cost),
             mempool_mode=False,
             height=softfork_height,
+            constants=bt.constants,
         )
 
         result, err, _ = await b.add_block(block_2, PreValidationResult(None, uint64(1), npc_result, False))
@@ -3504,7 +3511,7 @@ async def test_chain_failed_rollback(empty_blockchain, bt):
     await b.coin_store.rollback_to_block(2)
     print(f"{await b.coin_store.get_coin_record(spend_bundle.coin_spends[0].coin.name())}")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid operation to set spent"):
         await _validate_and_add_block(b, blocks_reorg_chain[-1])
 
     assert b.get_peak().height == 19

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -324,7 +324,10 @@ class TestBlockchainTransactions:
 
         coin_2 = None
         for coin in run_and_get_removals_and_additions(
-            new_blocks[-1], test_constants.MAX_BLOCK_COST_CLVM, height=softfork_height
+            new_blocks[-1],
+            test_constants.MAX_BLOCK_COST_CLVM,
+            height=softfork_height,
+            constants=bt.constants,
         )[1]:
             if coin.puzzle_hash == receiver_1_puzzlehash:
                 coin_2 = coin
@@ -345,7 +348,10 @@ class TestBlockchainTransactions:
 
         coin_3 = None
         for coin in run_and_get_removals_and_additions(
-            new_blocks[-1], test_constants.MAX_BLOCK_COST_CLVM, height=softfork_height
+            new_blocks[-1],
+            test_constants.MAX_BLOCK_COST_CLVM,
+            height=softfork_height,
+            constants=bt.constants,
         )[1]:
             if coin.puzzle_hash == receiver_2_puzzlehash:
                 coin_3 = coin

--- a/tests/clvm/benchmark_costs.py
+++ b/tests/clvm/benchmark_costs.py
@@ -13,6 +13,10 @@ def cost_of_spend_bundle(spend_bundle: SpendBundle) -> int:
     program: BlockGenerator = simple_solution_generator(spend_bundle)
     # always use the post soft-fork2 semantics
     npc_result: NPCResult = get_name_puzzle_conditions(
-        program, INFINITE_COST, mempool_mode=True, height=DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT
+        program,
+        INFINITE_COST,
+        mempool_mode=True,
+        height=DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT,
+        constants=DEFAULT_CONSTANTS,
     )
     return npc_result.cost

--- a/tests/clvm/coin_store.py
+++ b/tests/clvm/coin_store.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass, replace
 from typing import Dict, Iterator, Optional
 
+from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
@@ -28,10 +29,11 @@ class CoinTimestamp:
 
 
 class CoinStore:
-    def __init__(self, reward_mask: int = 0):
+    def __init__(self, constants: ConsensusConstants, reward_mask: int = 0):
         self._db: Dict[bytes32, CoinRecord] = dict()
         self._ph_index: Dict = defaultdict(list)
         self._reward_mask = reward_mask
+        self._constants = constants
 
     def farm_coin(
         self,
@@ -59,7 +61,9 @@ class CoinStore:
 
         program = simple_solution_generator(spend_bundle)
         # always use the post soft-fork2 semantics
-        result: NPCResult = get_name_puzzle_conditions(program, max_cost, mempool_mode=True, height=uint32(3886635))
+        result: NPCResult = get_name_puzzle_conditions(
+            program, max_cost, mempool_mode=True, height=uint32(3886635), constants=self._constants
+        )
         if result.error is not None:
             raise BadSpendBundleError(f"condition validation failure {Err(result.error)}")
 

--- a/tests/clvm/test_puzzles.py
+++ b/tests/clvm/test_puzzles.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 from blspy import AugSchemeMPL, BasicSchemeMPL, G1Element, G2Element
 
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
@@ -64,7 +65,7 @@ def do_test_spend(
     this time, signatures are not verified.
     """
 
-    coin_db = CoinStore()
+    coin_db = CoinStore(DEFAULT_CONSTANTS)
 
     puzzle_hash = puzzle_reveal.get_tree_hash()
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -103,7 +103,11 @@ class TestCoinStoreWithBlocks:
                     if block.transactions_generator is not None:
                         block_gen: BlockGenerator = BlockGenerator(block.transactions_generator, [], [])
                         npc_result = get_name_puzzle_conditions(
-                            block_gen, bt.constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+                            block_gen,
+                            bt.constants.MAX_BLOCK_COST_CLVM,
+                            mempool_mode=False,
+                            height=softfork_height,
+                            constants=bt.constants,
                         )
                         tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
                     else:

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -1973,7 +1973,9 @@ def generator_condition_tester(
     program = SerializedProgram.from_bytes(binutils.assemble(prg).as_bin())
     generator = BlockGenerator(program, [], [])
     print(f"len: {len(bytes(program))}")
-    npc_result: NPCResult = get_name_puzzle_conditions(generator, max_cost, mempool_mode=mempool_mode, height=height)
+    npc_result: NPCResult = get_name_puzzle_conditions(
+        generator, max_cost, mempool_mode=mempool_mode, height=height, constants=DEFAULT_CONSTANTS
+    )
     return npc_result
 
 
@@ -2157,7 +2159,7 @@ class TestGeneratorConditions:
         )
         generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
-            generator, MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+            generator, MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height, constants=DEFAULT_CONSTANTS
         )
         assert npc_result.error is None
         assert len(npc_result.conds.spends) == 2

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -366,7 +366,7 @@ def make_bundle_spends_map_and_fee(
 def mempool_item_from_spendbundle(spend_bundle: SpendBundle) -> MempoolItem:
     generator = simple_solution_generator(spend_bundle)
     npc_result = get_name_puzzle_conditions(
-        generator=generator, max_cost=INFINITE_COST, mempool_mode=True, height=uint32(0)
+        generator=generator, max_cost=INFINITE_COST, mempool_mode=True, height=uint32(0), constants=DEFAULT_CONSTANTS
     )
     bundle_coin_spends, fee = make_bundle_spends_map_and_fee(spend_bundle, npc_result)
     return MempoolItem(

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -77,7 +77,11 @@ class TestCostCalculation:
         program: BlockGenerator = simple_solution_generator(spend_bundle)
 
         npc_result: NPCResult = get_name_puzzle_conditions(
-            program, bt.constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+            program,
+            bt.constants.MAX_BLOCK_COST_CLVM,
+            mempool_mode=False,
+            height=softfork_height,
+            constants=bt.constants,
         )
 
         assert npc_result.error is None
@@ -142,11 +146,19 @@ class TestCostCalculation:
         )
         generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
-            generator, bt.constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=softfork_height
+            generator,
+            bt.constants.MAX_BLOCK_COST_CLVM,
+            mempool_mode=True,
+            height=softfork_height,
+            constants=bt.constants,
         )
         assert npc_result.error is not None
         npc_result = get_name_puzzle_conditions(
-            generator, bt.constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+            generator,
+            bt.constants.MAX_BLOCK_COST_CLVM,
+            mempool_mode=False,
+            height=softfork_height,
+            constants=bt.constants,
         )
         assert npc_result.error is None
 
@@ -169,11 +181,19 @@ class TestCostCalculation:
         program = SerializedProgram.from_bytes(binutils.assemble(f"(i (0xfe (q . 0)) (q . ()) {disassembly})").as_bin())
         generator = BlockGenerator(program, [], [])
         npc_result: NPCResult = get_name_puzzle_conditions(
-            generator, test_constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=softfork_height
+            generator,
+            test_constants.MAX_BLOCK_COST_CLVM,
+            mempool_mode=True,
+            height=softfork_height,
+            constants=test_constants,
         )
         assert npc_result.error is not None
         npc_result = get_name_puzzle_conditions(
-            generator, test_constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+            generator,
+            test_constants.MAX_BLOCK_COST_CLVM,
+            mempool_mode=False,
+            height=softfork_height,
+            constants=test_constants,
         )
         assert npc_result.error is None
 
@@ -187,7 +207,11 @@ class TestCostCalculation:
         with assert_runtime(seconds=0.5, label=request.node.name):
             generator = BlockGenerator(program, [], [])
             npc_result = get_name_puzzle_conditions(
-                generator, test_constants.MAX_BLOCK_COST_CLVM, mempool_mode=False, height=softfork_height
+                generator,
+                test_constants.MAX_BLOCK_COST_CLVM,
+                mempool_mode=False,
+                height=softfork_height,
+                constants=test_constants,
             )
 
         assert npc_result.error is None
@@ -208,14 +232,18 @@ class TestCostCalculation:
 
         # ensure we fail if the program exceeds the cost
         generator = BlockGenerator(program, [], [])
-        npc_result = get_name_puzzle_conditions(generator, 10000000, mempool_mode=False, height=softfork_height)
+        npc_result = get_name_puzzle_conditions(
+            generator, 10000000, mempool_mode=False, height=softfork_height, constants=test_constants
+        )
 
         assert npc_result.error is not None
         assert npc_result.cost == 0
 
         # raise the max cost to make sure this passes
         # ensure we pass if the program does not exceeds the cost
-        npc_result = get_name_puzzle_conditions(generator, 23000000, mempool_mode=False, height=softfork_height)
+        npc_result = get_name_puzzle_conditions(
+            generator, 23000000, mempool_mode=False, height=softfork_height, constants=test_constants
+        )
 
         assert npc_result.error is None
         assert npc_result.cost > 10000000

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -6,6 +6,7 @@ from clvm_tools import binutils
 from clvm_tools.clvmc import compile_clvm_text
 
 from chia.consensus.condition_costs import ConditionCost
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
@@ -122,7 +123,7 @@ class TestROM:
         print(r)
 
         npc_result = get_name_puzzle_conditions(
-            gen, max_cost=MAX_COST, mempool_mode=False, height=uint32(softfork_height)
+            gen, max_cost=MAX_COST, mempool_mode=False, height=uint32(softfork_height), constants=DEFAULT_CONSTANTS
         )
         assert npc_result.error is None
         assert npc_result.cost == EXPECTED_COST + ConditionCost.CREATE_COIN.value + (

--- a/tests/pools/test_pool_puzzles_lifecycle.py
+++ b/tests/pools/test_pool_puzzles_lifecycle.py
@@ -79,7 +79,7 @@ class TestPoolPuzzles(TestCase):
 
         # Get our starting standard coin created
         START_AMOUNT: uint64 = 1023
-        coin_db = CoinStore()
+        coin_db = CoinStore(DEFAULT_CONSTANTS)
         time = CoinTimestamp(10000000, 1)
         coin_db.farm_coin(starting_ph, time, START_AMOUNT)
         starting_coin: Coin = next(coin_db.all_unspent_coins())

--- a/tests/util/generator_tools_testing.py
+++ b/tests/util/generator_tools_testing.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
+from chia.consensus.constants import ConsensusConstants
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -12,7 +14,12 @@ from chia.util.ints import uint32
 
 
 def run_and_get_removals_and_additions(
-    block: FullBlock, max_cost: int, *, height: uint32, mempool_mode=False
+    block: FullBlock,
+    max_cost: int,
+    *,
+    height: uint32,
+    constants: ConsensusConstants = DEFAULT_CONSTANTS,
+    mempool_mode=False,
 ) -> Tuple[List[bytes32], List[Coin]]:
     removals: List[bytes32] = []
     additions: List[Coin] = []
@@ -23,7 +30,11 @@ def run_and_get_removals_and_additions(
 
     if block.transactions_generator is not None:
         npc_result = get_name_puzzle_conditions(
-            BlockGenerator(block.transactions_generator, [], []), max_cost, mempool_mode=mempool_mode, height=height
+            BlockGenerator(block.transactions_generator, [], []),
+            max_cost,
+            mempool_mode=mempool_mode,
+            height=height,
+            constants=constants,
         )
         assert npc_result.error is None
         rem, add = tx_removals_and_additions(npc_result.conds)

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -11,6 +11,7 @@ import pytest
 from blspy import G2Element
 
 from chia.consensus.cost_calculator import NPCResult
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
@@ -606,7 +607,7 @@ class TestCATTrades:
         bundle = Offer.aggregate([first_offer, second_offer, third_offer, fourth_offer, fifth_offer]).to_valid_spend()
         program = simple_solution_generator(bundle)
         result: NPCResult = get_name_puzzle_conditions(
-            program, INFINITE_COST, mempool_mode=True, height=softfork_height
+            program, INFINITE_COST, mempool_mode=True, height=softfork_height, constants=DEFAULT_CONSTANTS
         )
         assert result.error is None
 

--- a/tests/wallet/test_singleton_lifecycle_fast.py
+++ b/tests/wallet/test_singleton_lifecycle_fast.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from blspy import G1Element, G2Element
 from clvm_tools import binutils
 
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -474,7 +475,7 @@ def test_lifecycle_with_coinstore_as_wallet():
     #######
     # farm a coin
 
-    coin_store = CoinStore(int.from_bytes(POOL_REWARD_PREFIX_MAINNET, "big"))
+    coin_store = CoinStore(DEFAULT_CONSTANTS, int.from_bytes(POOL_REWARD_PREFIX_MAINNET, "big"))
     now = CoinTimestamp(10012300, 1)
 
     DELAY_SECONDS = 86400


### PR DESCRIPTION
 This is required for tests that use alternate constants, such as fork activation heights.

The core of this change is making the consensus constants passed into `get_name_puzzle_conditions()` mandatory, here:
https://github.com/Chia-Network/chia-blockchain/pull/15736/files#diff-c83e8da0205224011f82095884364d75a548ebc60f5beba113b286a62c42921bR52

The reason is that many tests fail to pass along the appropriate constants used in that test. This fixes that issue and also updates call sites to actually pass along the constants used by the test.