### PR TITLE
Unify test_create_coins_with_amounts() versions into one

### DIFF
--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -417,40 +417,6 @@ class TestSimulation:
     @pytest.mark.parametrize(
         argnames="amounts",
         argvalues=[
-            *[pytest.param([uint64(1)] * n, id=f"1 mojo x {n}") for n in [0, 1, 10, 49, 51, 103]],
-            *[
-                pytest.param(list(uint64(x) for x in range(1, n + 1)), id=f"incrementing x {n}")
-                for n in [1, 10, 49, 51, 103]
-            ],
-        ],
-    )
-    async def test_create_coins_with_amounts(
-        self,
-        self_hostname: str,
-        amounts: List[uint64],
-        simulator_and_wallet: SimulatorsAndWallets,
-    ) -> None:
-        [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
-
-        await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
-
-        # Avoiding an attribute hint issue below.
-        assert wallet_node.wallet_state_manager is not None
-
-        wallet = wallet_node.wallet_state_manager.main_wallet
-
-        await full_node_api.farm_rewards_to_wallet(amount=sum(amounts), wallet=wallet)
-        # Get some more coins.  The creator helper doesn't get you all the coins you
-        # need yet.
-        await full_node_api.farm_blocks_to_wallet(count=2, wallet=wallet)
-        coins = await full_node_api.create_coins_with_amounts(amounts=amounts, wallet=wallet)
-
-        assert sorted(coin.amount for coin in coins) == sorted(amounts)
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        argnames="amounts",
-        argvalues=[
             [uint64(0)],
             # cheating on type since -5 can't be heald in a proper uint64
             [uint64(5), -5],

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -8,6 +8,7 @@ from chia.cmds.units import units
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator, backoff_times
+from chia.simulator.setup_nodes import SimulatorsAndWallets
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint64
 from chia.wallet.wallet_node import WalletNode
@@ -214,24 +215,18 @@ async def test_process_transaction_records(
     ],
 )
 async def test_create_coins_with_amounts(
-    amounts: List[uint64],
-    simulator_and_wallet: Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools],
+    self_hostname: str, amounts: List[uint64], simulator_and_wallet: SimulatorsAndWallets
 ) -> None:
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
-
-    await wallet_server.start_client(PeerInfo("127.0.0.1", uint16(full_node_api.server._port)), None)
-
+    await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
     # Avoiding an attribute hint issue below.
     assert wallet_node.wallet_state_manager is not None
-
     wallet = wallet_node.wallet_state_manager.main_wallet
-
     await full_node_api.farm_rewards_to_wallet(amount=sum(amounts), wallet=wallet)
     # Get some more coins.  The creator helper doesn't get you all the coins you
     # need yet.
     await full_node_api.farm_blocks_to_wallet(count=2, wallet=wallet)
     coins = await full_node_api.create_coins_with_amounts(amounts=amounts, wallet=wallet)
-
     assert sorted(coin.amount for coin in coins) == sorted(amounts)
 
 


### PR DESCRIPTION
We ended up with different versions of this test while attempting to separate tests of the simulator from tests using the simulator in combination with the block and transaction processing helpers effort.

This unifies both versions while keeping with the spirit of that separation. They're essentially equal.