### PR TITLE
Renaming instances of 'decompresser' to 'decompressor'

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -81,7 +81,7 @@ class Harvester:
         self.state_changed_callback: Optional[StateChangedProtocol] = None
         self.parallel_read: bool = config.get("parallel_read", True)
 
-        context_count = config.get("parallel_decompressors_count", 5)
+        context_count = config.get("parallel_decompressor_count", 5)
         thread_count = config.get("decompressor_thread_count", 0)
         if thread_count == 0:
             thread_count = multiprocessing.cpu_count() // 2

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -81,8 +81,8 @@ class Harvester:
         self.state_changed_callback: Optional[StateChangedProtocol] = None
         self.parallel_read: bool = config.get("parallel_read", True)
 
-        context_count = config.get("parallel_decompressers_count", 5)
-        thread_count = config.get("decompresser_thread_count", 0)
+        context_count = config.get("parallel_decompressors_count", 5)
+        thread_count = config.get("decompressor_thread_count", 0)
         if thread_count == 0:
             thread_count = multiprocessing.cpu_count() // 2
         disable_cpu_affinity = config.get("disable_cpu_affinity", False)
@@ -92,7 +92,7 @@ class Harvester:
         enforce_gpu_index = config.get("enforce_gpu_index", False)
 
         try:
-            self.plot_manager.configure_decompresser(
+            self.plot_manager.configure_decompressor(
                 context_count,
                 thread_count,
                 disable_cpu_affinity,
@@ -102,7 +102,7 @@ class Harvester:
                 enforce_gpu_index,
             )
         except Exception as e:
-            self.log.error(f"{type(e)} {e} while configuring decompresser.")
+            self.log.error(f"{type(e)} {e} while configuring decompressor.")
             raise
 
     async def _start(self) -> None:

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -54,8 +54,8 @@ def check_plots(
         refresh_callback=plot_refresh_callback,
     )
 
-    context_count = config["harvester"].get("parallel_decompressers_count", 5)
-    thread_count = config["harvester"].get("decompresser_thread_count", 0)
+    context_count = config["harvester"].get("parallel_decompressors_count", 5)
+    thread_count = config["harvester"].get("decompressor_thread_count", 0)
     if thread_count == 0:
         thread_count = multiprocessing.cpu_count() // 2
     disable_cpu_affinity = config["harvester"].get("disable_cpu_affinity", False)
@@ -64,7 +64,7 @@ def check_plots(
     gpu_index = config["harvester"].get("gpu_index", 0)
     enforce_gpu_index = config["harvester"].get("enforce_gpu_index", False)
 
-    plot_manager.configure_decompresser(
+    plot_manager.configure_decompressor(
         context_count,
         thread_count,
         disable_cpu_affinity,

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -54,7 +54,7 @@ def check_plots(
         refresh_callback=plot_refresh_callback,
     )
 
-    context_count = config["harvester"].get("parallel_decompressors_count", 5)
+    context_count = config["harvester"].get("parallel_decompressor_count", 5)
     thread_count = config["harvester"].get("decompressor_thread_count", 0)
     if thread_count == 0:
         thread_count = multiprocessing.cpu_count() // 2

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from blspy import G1Element
-from chiapos import DiskProver, decompresser_context_queue
+from chiapos import DiskProver, decompressor_context_queue
 
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR, _expected_plot_size
 from chia.plotting.cache import Cache, CacheEntry
@@ -75,7 +75,7 @@ class PlotManager:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self._lock.release()
 
-    def configure_decompresser(
+    def configure_decompressor(
         self,
         context_count: int,
         thread_count: int,
@@ -92,7 +92,7 @@ class PlotManager:
                 "Setting max_compression_level_allowed to 7."
             )
             max_compression_level_allowed = 7
-        is_using_gpu = decompresser_context_queue.init(
+        is_using_gpu = decompressor_context_queue.init(
             context_count,
             thread_count,
             disable_cpu_affinity,
@@ -104,7 +104,7 @@ class PlotManager:
         if not is_using_gpu and use_gpu_harvesting:
             log.error(
                 "GPU harvesting failed initialization. "
-                f"Falling back to CPU harvesting: {context_count} decompressers count, {thread_count} threads."
+                f"Falling back to CPU harvesting: {context_count} decompressors count, {thread_count} threads."
             )
         self.max_compression_level_allowed = max_compression_level_allowed
 

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -291,7 +291,7 @@ async def setup_harvester(
         config["harvester"]["rpc_port"] = 0
         config["harvester"]["plot_directories"] = [str(b_tools.plot_dir.resolve())]
         # CI doesn't like GPU compressed farming
-        config["harvester"]["parallel_decompressers_count"] = 0
+        config["harvester"]["parallel_decompressors_count"] = 0
         save_config(root_path, "config.yaml", config)
     service = create_harvester_service(
         root_path,

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -291,7 +291,7 @@ async def setup_harvester(
         config["harvester"]["rpc_port"] = 0
         config["harvester"]["plot_directories"] = [str(b_tools.plot_dir.resolve())]
         # CI doesn't like GPU compressed farming
-        config["harvester"]["parallel_decompressors_count"] = 0
+        config["harvester"]["parallel_decompressor_count"] = 0
         save_config(root_path, "config.yaml", config)
     service = create_harvester_service(
         root_path,

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -212,10 +212,10 @@ harvester:
     key: "config/ssl/ca/chia_ca.key"
 
   # Compressed harvesting.
-  parallel_decompressers_count: 0
-  # If set to 0, `decompresser_thread_count` will default to half of nproc available on the machine.
+  parallel_decompressors_count: 0
+  # If set to 0, `decompressor_thread_count` will default to half of nproc available on the machine.
   # A non-zero number overrides this default.
-  decompresser_thread_count: 0
+  decompressor_thread_count: 0
   disable_cpu_affinity: False
   # Ignore compressed plots with compression level greater than this.
   max_compression_level_allowed: 7

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -212,7 +212,7 @@ harvester:
     key: "config/ssl/ca/chia_ca.key"
 
   # Compressed harvesting.
-  parallel_decompressors_count: 0
+  parallel_decompressor_count: 0
   # If set to 0, `decompressor_thread_count` will default to half of nproc available on the machine.
   # A non-zero number overrides this default.
   decompressor_thread_count: 0

--- a/chia/wallet/puzzles/rom_bootstrap_generator.clsp
+++ b/chia/wallet/puzzles/rom_bootstrap_generator.clsp
@@ -1,4 +1,4 @@
-(mod (block_decompresser_program (historical_blocks_tree))
+(mod (block_decompressor_program (historical_blocks_tree))
 
   (defconstant local_deserialize_mod
     ;; this monstrosity is the assembly output of `chialisp_deserialisation.clsp`
@@ -33,5 +33,5 @@
     (c (recurse coin_spends) block-level-extras)
   )
 
-(process-decompressor (a block_decompresser_program (list local_deserialize_mod historical_blocks_tree))))
+(process-decompressor (a block_decompressor_program (list local_deserialize_mod historical_blocks_tree))))
 )

--- a/chia/wallet/puzzles/rom_bootstrap_generator.clsp
+++ b/chia/wallet/puzzles/rom_bootstrap_generator.clsp
@@ -1,4 +1,4 @@
-(mod (block_decompressor_program (historical_blocks_tree))
+(mod (block_decompresser_program (historical_blocks_tree))
 
   (defconstant local_deserialize_mod
     ;; this monstrosity is the assembly output of `chialisp_deserialisation.clsp`
@@ -33,5 +33,5 @@
     (c (recurse coin_spends) block-level-extras)
   )
 
-(process-decompressor (a block_decompressor_program (list local_deserialize_mod historical_blocks_tree))))
+(process-decompressor (a block_decompresser_program (list local_deserialize_mod historical_blocks_tree))))
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ dependencies = [
     "boto3==1.26.161",  # AWS S3 for DL s3 plugin
     "chiavdf==1.0.9",  # timelord and vdf verification
     "chiabip158==1.2",  # bip158-style wallet filters
-    "chiapos==2.0.0b3",  # proof of space
+    "chiapos==2.0.0b4",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
     "chia_rs==0.2.8",

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -1100,7 +1100,7 @@ async def test_bad_json(daemon_connection_and_temp_keychain: Tuple[aiohttp.Clien
         response={
             "success": True,
             "plotters": {
-                "chiapos": {"display_name": "Chia Proof of Space", "installed": True, "version": "2.0.0b3"},
+                "chiapos": {"display_name": "Chia Proof of Space", "installed": True, "version": "2.0.0b4"},
                 "madmax": {"can_install": True, "display_name": "madMAx Plotter", "installed": False},
             },
         },


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
We had mixed spelling of `decompresser`/`decompressor` across chiapos, blockchain, and bladebit repos. This PR standardizes the spelling to `decompressor`, and should be pulled in after this PR gets merged, and a new chiapos wheel is built with these corrections - https://github.com/Chia-Network/chiapos/pull/374

I may include an update to `setup.py` that references this new version of chiapos.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
decompresser


### New Behavior:
decompressor


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
