### PR TITLE
Fix Cli error when exiting on some builds of python.

### DIFF
--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -27,7 +27,7 @@ from chia.cmds.start import start_cmd
 from chia.cmds.stop import stop_cmd
 from chia.cmds.wallet import wallet_cmd
 from chia.util.default_root import DEFAULT_KEYS_ROOT_PATH, DEFAULT_ROOT_PATH
-from chia.util.errors import CliRpcConnectionError, KeychainCurrentPassphraseIsInvalid
+from chia.util.errors import KeychainCurrentPassphraseIsInvalid
 from chia.util.keychain import Keychain, set_keys_root_path
 from chia.util.ssl_check import check_ssl
 
@@ -62,7 +62,7 @@ def cli(
         set_keys_root_path(Path(keys_root_path))
 
     if passphrase_file is not None:
-        from sys import exit
+        import sys
 
         from chia.cmds.passphrase_funcs import cache_passphrase, read_passphrase_from_file
 
@@ -77,7 +77,7 @@ def cli(
                 print(f'Invalid passphrase found in "{passphrase_file.name}"')
             else:
                 print("Invalid passphrase")
-            exit(1)
+            sys.exit(1)
         except Exception as e:
             print(f"Failed to read passphrase: {e}")
 
@@ -132,10 +132,7 @@ cli.add_command(dev_cmd)
 
 
 def main() -> None:
-    try:
-        cli()  # pylint: disable=no-value-for-parameter
-    except CliRpcConnectionError:  # this happens when we cant connect to a client and is only comes from the cli code
-        exit(1)
+    cli()  # pylint: disable=no-value-for-parameter
 
 
 if __name__ == "__main__":

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -4,6 +4,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, List, Optional
 
+from click import ClickException
+
 
 class Err(Enum):
     # temporary errors. Don't blacklist
@@ -328,10 +330,9 @@ class InvalidPathError(Exception):
         self.path = path
 
 
-class CliRpcConnectionError(Exception):
+class CliRpcConnectionError(ClickException):
     """
-    This error is raised when a rpc server cant be reached by the cli async generator & should always be caught by
-    the cli in cmds/chia.py:main.
+    This error is raised when a rpc server cant be reached by the cli async generator
     """
 
     pass


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
originally made sure the catch runs sys.exit not exit() which is not in some builds of python.
It  also changed the error to a click exception to remove the need for the handling at all.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Changes to use click errors instead of std errors.


### New Behavior:
N/A


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Kinda hard to replicate, but this is a fix


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
