### PR TITLE
Fixed add lock around plot info

### DIFF
--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -5,6 +5,7 @@ import logging
 import multiprocessing
 from collections import Counter
 from pathlib import Path
+from threading import Lock
 from time import sleep, time
 from typing import List, Optional
 
@@ -54,7 +55,7 @@ def check_plots(
         refresh_callback=plot_refresh_callback,
     )
 
-    context_count = config["harvester"].get("parallel_decompressor_count", 5)
+    context_count = config["harvester"].get("parallel_decompressor_count", 1)
     thread_count = config["harvester"].get("decompressor_thread_count", 0)
     if thread_count == 0:
         thread_count = multiprocessing.cpu_count() // 2
@@ -135,18 +136,12 @@ def check_plots(
 
     with plot_manager:
 
-        def process_plot(plot_path: Path, plot_info: PlotInfo, num_start: int, num_end: int) -> None:
+        def process_plot(plot_path: Path, plot_info: PlotInfo, num_start: int, num_end: int, lock: Lock) -> None:
             nonlocal total_good_plots
             nonlocal total_size
             nonlocal bad_plots_list
 
             pr = plot_info.prover
-            log.info(f"Testing plot {plot_path} k={pr.get_size()}")
-            if plot_info.pool_public_key is not None:
-                log.info(f"\t{'Pool public key:':<23} {plot_info.pool_public_key}")
-            if plot_info.pool_contract_puzzle_hash is not None:
-                pca: str = encode_puzzle_hash(plot_info.pool_contract_puzzle_hash, address_prefix)
-                log.info(f"\t{'Pool contract address:':<23} {pca}")
 
             # Look up local_sk from plot to save locked memory
             (
@@ -155,8 +150,17 @@ def check_plots(
                 local_master_sk,
             ) = parse_plot_info(pr.get_memo())
             local_sk = master_sk_to_local_sk(local_master_sk)
-            log.info(f"\t{'Farmer public key:' :<23} {farmer_public_key}")
-            log.info(f"\t{'Local sk:' :<23} {local_sk}")
+
+            with lock:
+                log.info(f"Testing plot {plot_path} k={pr.get_size()}")
+                if plot_info.pool_public_key is not None:
+                    log.info(f"\t{'Pool public key:':<23} {plot_info.pool_public_key}")
+                if plot_info.pool_contract_puzzle_hash is not None:
+                    pca: str = encode_puzzle_hash(plot_info.pool_contract_puzzle_hash, address_prefix)
+                    log.info(f"\t{'Pool contract address:':<23} {pca}")
+                log.info(f"\t{'Farmer public key:' :<23} {farmer_public_key}")
+                log.info(f"\t{'Local sk:' :<23} {local_sk}")
+
             total_proofs = 0
             caught_exception: bool = False
             for i in range(num_start, num_end):
@@ -235,9 +239,10 @@ def check_plots(
                 bad_plots_list.append(plot_path)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=context_count) as executor:
+            logger_lock = Lock()
             futures = []
             for plot_path, plot_info in plot_manager.plots.items():
-                futures.append(executor.submit(process_plot, plot_path, plot_info, num_start, num_end))
+                futures.append(executor.submit(process_plot, plot_path, plot_info, num_start, num_end, logger_lock))
 
             for future in concurrent.futures.as_completed(futures):
                 _ = future.result()

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -55,7 +55,7 @@ def check_plots(
         refresh_callback=plot_refresh_callback,
     )
 
-    context_count = config["harvester"].get("parallel_decompressor_count", 1)
+    context_count = config["harvester"].get("parallel_decompressor_count", 5)
     thread_count = config["harvester"].get("decompressor_thread_count", 0)
     if thread_count == 0:
         thread_count = multiprocessing.cpu_count() // 2


### PR DESCRIPTION
### Purpose:

Prevent interleaving of plot information due to thread preemption

### Current Behavior:

Interleaved plot info. eg, 
https://discord.com/channels/1034523881404370984/1034870571864948777/1129134869960724540

### New Behavior:

Lock groups plot info

### Testing Notes:

Please test on windows and linux
