### PR TITLE
Announce conditions limit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,9 +101,10 @@ def get_keychain():
 class Mode(Enum):
     PLAIN = 0
     HARD_FORK_2_0 = 1
+    SOFT_FORK3 = 2
 
 
-@pytest.fixture(scope="session", params=[Mode.PLAIN, Mode.HARD_FORK_2_0])
+@pytest.fixture(scope="session", params=[Mode.PLAIN, Mode.HARD_FORK_2_0, Mode.SOFT_FORK3])
 def consensus_mode(request):
     return request.param
 
@@ -112,6 +113,8 @@ def consensus_mode(request):
 def blockchain_constants(consensus_mode) -> ConsensusConstants:
     if consensus_mode == Mode.PLAIN:
         return test_constants
+    if consensus_mode == Mode.SOFT_FORK3:
+        return test_constants.replace(SOFT_FORK3_HEIGHT=3)
     if consensus_mode == Mode.HARD_FORK_2_0:
         return test_constants.replace(
             HARD_FORK_HEIGHT=2, PLOT_FILTER_128_HEIGHT=10, PLOT_FILTER_64_HEIGHT=15, PLOT_FILTER_32_HEIGHT=20

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -33,6 +33,7 @@ from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.wallet_sync_utils import PeerRequestException
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_weight_proof_handler import get_wp_fork_point
+from tests.conftest import Mode
 from tests.connection_utils import disconnect_all, disconnect_all_and_reconnect
 from tests.weight_proof.test_weight_proof import load_blocks_dont_validate
 
@@ -53,7 +54,10 @@ log = getLogger(__name__)
 
 class TestWalletSync:
     @pytest.mark.asyncio
-    async def test_request_block_headers(self, simulator_and_wallet, default_1000_blocks):
+    async def test_request_block_headers(self, simulator_and_wallet, default_1000_blocks, consensus_mode: Mode):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
         [full_node_api], [(wallet_node, _)], bt = simulator_and_wallet
 
@@ -154,7 +158,10 @@ class TestWalletSync:
         indirect=True,
     )
     @pytest.mark.asyncio
-    async def test_basic_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname):
+    async def test_basic_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname, consensus_mode: Mode):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -205,8 +212,13 @@ class TestWalletSync:
         indirect=True,
     )
     @pytest.mark.asyncio
-    async def test_almost_recent(self, two_wallet_nodes, default_400_blocks, self_hostname, blockchain_constants):
+    async def test_almost_recent(
+        self, two_wallet_nodes, default_400_blocks, self_hostname, blockchain_constants, consensus_mode: Mode
+    ):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -287,7 +299,12 @@ class TestWalletSync:
             await time_out_assert(100, wallet_height_at_least, True, wallet_node, 199)
 
     @pytest.mark.asyncio
-    async def test_long_sync_wallet(self, two_wallet_nodes, default_1000_blocks, default_400_blocks, self_hostname):
+    async def test_long_sync_wallet(
+        self, two_wallet_nodes, default_1000_blocks, default_400_blocks, self_hostname, consensus_mode: Mode
+    ):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -334,7 +351,10 @@ class TestWalletSync:
             )
 
     @pytest.mark.asyncio
-    async def test_wallet_reorg_sync(self, two_wallet_nodes, default_400_blocks, self_hostname):
+    async def test_wallet_reorg_sync(self, two_wallet_nodes, default_400_blocks, self_hostname, consensus_mode: Mode):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         num_blocks = 5
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -390,7 +410,12 @@ class TestWalletSync:
             await time_out_assert(60, wallet.get_confirmed_balance, 0)
 
     @pytest.mark.asyncio
-    async def test_wallet_reorg_get_coinbase(self, two_wallet_nodes, default_400_blocks, self_hostname):
+    async def test_wallet_reorg_get_coinbase(
+        self, two_wallet_nodes, default_400_blocks, self_hostname, consensus_mode: Mode
+    ):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -1292,7 +1317,12 @@ class TestWalletSync:
             await time_out_assert(30, wallet.get_confirmed_balance, 1_000_000_000_000)
 
     @pytest.mark.asyncio
-    async def test_bad_peak_mismatch(self, two_wallet_nodes, default_1000_blocks, self_hostname, blockchain_constants):
+    async def test_bad_peak_mismatch(
+        self, two_wallet_nodes, default_1000_blocks, self_hostname, blockchain_constants, consensus_mode
+    ):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("only run in PLAIN mode to save time")
+
         full_nodes, wallets, bt = two_wallet_nodes
         wallet_node, wallet_server = wallets[0]
         full_node_api = full_nodes[0]
@@ -1346,8 +1376,11 @@ class TestWalletSync:
 
 @pytest.mark.asyncio
 async def test_long_sync_untrusted_break(
-    setup_two_nodes_and_wallet, default_1000_blocks, default_400_blocks, self_hostname, caplog
+    setup_two_nodes_and_wallet, default_1000_blocks, default_400_blocks, self_hostname, caplog, consensus_mode: Mode
 ):
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("only run in PLAIN mode to save time")
+
     full_nodes, [(wallet_node, wallet_server)], bt = setup_two_nodes_and_wallet
     trusted_full_node_api = full_nodes[0]
     trusted_full_node_server = trusted_full_node_api.full_node.server


### PR DESCRIPTION
add test for soft-fork3 limit on number of announcements. This limit applies both to coin and puzzle assertions and creations. It also applies to `ASSERT_CONCURRENT_SPEND` and `ASSERT_CONCURRENT_PUZZLE`.

This is testing the `LIMIT_ANNOUNCES` flag, introduced in chia_rs here: https://github.com/Chia-Network/chia_rs/pull/175
The limit was later updated from 1000 -> 1024 here: https://github.com/Chia-Network/chia_rs/pull/185