### PR TITLE
remove softfork2 logic

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -68,7 +68,7 @@ class CostLogger:
             program,
             INFINITE_COST,
             mempool_mode=True,
-            height=DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT,
+            height=DEFAULT_CONSTANTS.SOFT_FORK3_HEIGHT,
             constants=DEFAULT_CONSTANTS,
         )
         self.cost_dict[descriptor] = npc_result.cost

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -495,17 +495,11 @@ async def validate_block_body(
     if npc_result is not None:
         assert npc_result.conds is not None
 
-        block_timestamp: uint64
-        if height < constants.SOFT_FORK2_HEIGHT:
-            block_timestamp = block.foliage_transaction_block.timestamp
-        else:
-            block_timestamp = prev_transaction_block_timestamp
-
         error = mempool_check_time_locks(
             removal_coin_records,
             npc_result.conds,
             prev_transaction_block_height,
-            block_timestamp,
+            prev_transaction_block_timestamp,
         )
         if error:
             return error, None

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -844,11 +844,7 @@ def validate_unfinished_header_block(
                 return None, ValidationError(Err.INVALID_TRANSACTIONS_FILTER_HASH)
 
         # 26a. The timestamp in Foliage Block must not be over 5 minutes in the future
-        if height >= constants.SOFT_FORK2_HEIGHT:
-            max_future_time = constants.MAX_FUTURE_TIME2
-        else:
-            max_future_time = constants.MAX_FUTURE_TIME
-        if header_block.foliage_transaction_block.timestamp > int(time.time() + max_future_time):
+        if header_block.foliage_transaction_block.timestamp > int(time.time() + constants.MAX_FUTURE_TIME2):
             return None, ValidationError(Err.TIMESTAMP_TOO_FAR_IN_FUTURE)
 
         if prev_b is not None:

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -35,7 +35,6 @@ class ConsensusConstants:
     MAX_PLOT_SIZE: int
     SUB_SLOT_TIME_TARGET: int  # The target number of seconds per sub-slot
     NUM_SP_INTERVALS_EXTRA: int  # The difference between signage point and infusion point (plus required_iters)
-    MAX_FUTURE_TIME: int  # The next block can have a timestamp of at most these many seconds more
     MAX_FUTURE_TIME2: int  # After soft-fork2, this is the new MAX_FUTURE_TIME
     NUMBER_OF_TIMESTAMPS: int  # Than the average of the last NUMBER_OF_TIMESTAMPS blocks
     # Used as the initial cc rc challenges, as well as first block back pointers, and first SES back pointer
@@ -62,9 +61,6 @@ class ConsensusConstants:
     MAX_GENERATOR_SIZE: uint32
     MAX_GENERATOR_REF_LIST_SIZE: uint32
     POOL_SUB_SLOT_ITERS: uint64
-
-    # soft fork initiated in 1.8.0 release
-    SOFT_FORK2_HEIGHT: uint32
 
     # soft fork initiated in 2.0 release
     SOFT_FORK3_HEIGHT: uint32

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -25,7 +25,6 @@ default_kwargs = {
     "MAX_PLOT_SIZE": 50,
     "SUB_SLOT_TIME_TARGET": 600,  # The target number of seconds per slot, mainnet 600
     "NUM_SP_INTERVALS_EXTRA": 3,  # The number of sp intervals to add to the signage point
-    "MAX_FUTURE_TIME": 5 * 60,  # The next block can have a timestamp of at most these many seconds in the future
     "MAX_FUTURE_TIME2": 2 * 60,  # The next block can have a timestamp of at most these many seconds in the future
     "NUMBER_OF_TIMESTAMPS": 11,  # Than the average of the last NUMBER_OF_TIMESTAMPS blocks
     # Used as the initial cc rc challenges, as well as first block back pointers, and first SES back pointer
@@ -56,7 +55,6 @@ default_kwargs = {
     "MAX_GENERATOR_SIZE": 1000000,
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
-    "SOFT_FORK2_HEIGHT": 3886635,
     # October 23, 2023
     "SOFT_FORK3_HEIGHT": 4410000,
     # June 2024

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -55,8 +55,7 @@ def get_name_puzzle_conditions(
     if mempool_mode:
         flags = flags | MEMPOOL_MODE
 
-    if height >= constants.SOFT_FORK2_HEIGHT:
-        flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+    flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 
     if height >= constants.SOFT_FORK3_HEIGHT:
         # the soft-fork initiated with 2.0. To activate end of October 2023

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -72,8 +72,6 @@ def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None
         return
     # activate softforks immediately on testnet
     # these numbers are supposed to match initial-config.yaml
-    if "SOFT_FORK2_HEIGHT" not in overrides:
-        overrides["SOFT_FORK2_HEIGHT"] = 0
     if "SOFT_FORK3_HEIGHT" not in overrides:
         overrides["SOFT_FORK3_HEIGHT"] = 2997292
     if "HARD_FORK_HEIGHT" not in overrides:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -149,8 +149,7 @@ test_constants = DEFAULT_CONSTANTS.replace(
         "SUB_SLOT_ITERS_STARTING": 2**10,  # Must be a multiple of 64
         "NUMBER_ZERO_BITS_PLOT_FILTER": 1,  # H(plot signature of the challenge) must start with these many zeroes
         # Allows creating blockchains with timestamps up to 10 days in the future, for testing
-        "MAX_FUTURE_TIME": 3600 * 24 * 10,
-        "MAX_FUTURE_TIME2": 3600 * 24 * 10,  # After the Fork
+        "MAX_FUTURE_TIME2": 3600 * 24 * 10,
         "MEMPOOL_BLOCK_BUFFER": 6,
         "UNIQUE_PLOTS_WINDOW": 2,
     }

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -71,7 +71,6 @@ network_overrides: &network_overrides
       GENESIS_PRE_FARM_POOL_PUZZLE_HASH: d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
-      SOFT_FORK2_HEIGHT: 0
       SOFT_FORK3_HEIGHT: 2997292
       # planned 2.0 release is July 26, height 2965036 on testnet
       # 1 week later

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -890,6 +890,19 @@ class TestBlockchainTransactions:
             full_node_1.blockchain, invalid_new_blocks[-1], expected_error=Err.ASSERT_SECONDS_RELATIVE_FAILED
         )
 
+        # we compare the timestamp against the previous transaction block, so in
+        # order to progress the timestamp, we need to farm one more block
+        blocks.extend(
+            bt.get_consecutive_blocks(
+                1,
+                blocks,
+                farmer_reward_puzzle_hash=coinbase_puzzlehash,
+                guarantee_transaction_block=True,
+                time_per_block=301,
+            )
+        )
+        await full_node_api_1.full_node.add_block(blocks[-1])
+
         valid_new_blocks = bt.get_consecutive_blocks(
             1,
             blocks,
@@ -950,6 +963,19 @@ class TestBlockchainTransactions:
         await _validate_and_add_block(
             full_node_1.blockchain, invalid_new_blocks[-1], expected_error=Err.ASSERT_SECONDS_ABSOLUTE_FAILED
         )
+
+        # we compare the timestamp against the previous transaction block, so in
+        # order to progress the timestamp, we need to farm one more block
+        blocks.extend(
+            bt.get_consecutive_blocks(
+                1,
+                blocks,
+                farmer_reward_puzzle_hash=coinbase_puzzlehash,
+                guarantee_transaction_block=True,
+                time_per_block=30,
+            )
+        )
+        await full_node_api_1.full_node.add_block(blocks[-1])
 
         valid_new_blocks = bt.get_consecutive_blocks(
             1,

--- a/tests/clvm/benchmark_costs.py
+++ b/tests/clvm/benchmark_costs.py
@@ -16,7 +16,7 @@ def cost_of_spend_bundle(spend_bundle: SpendBundle) -> int:
         program,
         INFINITE_COST,
         mempool_mode=True,
-        height=DEFAULT_CONSTANTS.SOFT_FORK2_HEIGHT,
+        height=DEFAULT_CONSTANTS.SOFT_FORK3_HEIGHT,
         constants=DEFAULT_CONSTANTS,
     )
     return npc_result.cost

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,7 @@ def db_version(request) -> int:
     return request.param
 
 
-@pytest.fixture(scope="function", params=[1000000, 3886635, 4410000, 5496000])
+@pytest.fixture(scope="function", params=[1000000, 4410000, 5496000])
 def softfork_height(request) -> int:
     return request.param
 
@@ -538,48 +538,6 @@ async def three_nodes_two_wallets():
 @pytest_asyncio.fixture(scope="function")
 async def one_node() -> AsyncIterator[Tuple[List[Service], List[FullNodeSimulator], BlockTools]]:
     async for _ in setup_simulators_and_wallets_service(1, 0, {}):
-        yield _
-
-
-@pytest.fixture(scope="function", params=[True, False])
-def enable_softfork2(request):
-    return request.param
-
-
-@pytest_asyncio.fixture(scope="function")
-async def one_node_one_block_with_softfork2(
-    enable_softfork2,
-) -> AsyncIterator[Tuple[Union[FullNodeAPI, FullNodeSimulator], ChiaServer, BlockTools]]:
-    if enable_softfork2:
-        constant_replacements = {"SOFT_FORK2_HEIGHT": 0}
-    else:
-        constant_replacements = {}
-
-    async_gen = setup_simulators_and_wallets(1, 0, constant_replacements)
-    nodes, _, bt = await async_gen.__anext__()
-    full_node_1 = nodes[0]
-    server_1 = full_node_1.full_node.server
-    wallet_a = bt.get_pool_wallet_tool()
-
-    reward_ph = wallet_a.get_new_puzzlehash()
-    blocks = bt.get_consecutive_blocks(
-        1,
-        guarantee_transaction_block=True,
-        farmer_reward_puzzle_hash=reward_ph,
-        pool_reward_puzzle_hash=reward_ph,
-        genesis_timestamp=uint64(10000),
-        time_per_block=10,
-    )
-    assert blocks[0].height == 0
-
-    for block in blocks:
-        await full_node_1.full_node.add_block(block)
-
-    await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
-
-    yield full_node_1, server_1, bt
-
-    async for _ in async_gen:
         yield _
 
 

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -60,19 +60,14 @@ async def check_spend_bundle_validity(
     blocks: List[FullBlock],
     spend_bundle: SpendBundle,
     expected_err: Optional[Err] = None,
-    softfork2: bool = False,
 ) -> Tuple[List[CoinRecord], List[CoinRecord], FullBlock]:
     """
     This test helper create an extra block after the given blocks that contains the given
     `SpendBundle`, and then invokes `add_block` to ensure that it's accepted (if `expected_err=None`)
     or fails with the correct error code.
     """
-    if softfork2:
-        constants = bt.constants.replace(SOFT_FORK2_HEIGHT=0)
-    else:
-        constants = bt.constants
 
-    db_wrapper, blockchain = await create_ram_blockchain(constants)
+    db_wrapper, blockchain = await create_ram_blockchain(bt.constants)
     try:
         for block in blocks:
             await _validate_and_add_block(blockchain, block)
@@ -111,7 +106,6 @@ async def check_conditions(
     condition_solution: Program,
     expected_err: Optional[Err] = None,
     spend_reward_index: int = -2,
-    softfork2: bool = False,
 ) -> Tuple[List[CoinRecord], List[CoinRecord], FullBlock]:
     blocks = await initial_blocks(bt)
     coin = list(blocks[spend_reward_index].get_included_reward_coins())[0]
@@ -121,7 +115,7 @@ async def check_conditions(
 
     # now let's try to create a block with the spend bundle and ensure that it doesn't validate
 
-    return await check_spend_bundle_validity(bt, blocks, spend_bundle, expected_err=expected_err, softfork2=softfork2)
+    return await check_spend_bundle_validity(bt, blocks, spend_bundle, expected_err=expected_err)
 
 
 co = ConditionOpcode
@@ -195,7 +189,6 @@ class TestConditions:
         assert new_block.transactions_info.cost - block_base_cost == expected_cost
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("softfork2", [True, False])
     @pytest.mark.parametrize(
         "opcode,value,expected",
         [
@@ -279,32 +272,9 @@ class TestConditions:
             (co.ASSERT_BEFORE_SECONDS_ABSOLUTE, 0x100000000, None),
         ],
     )
-    async def test_condition(self, opcode, value, expected, bt, softfork2):
+    async def test_condition(self, opcode, value, expected, bt):
         conditions = Program.to(assemble(f"(({opcode[0]} {value}))"))
-
-        # when soft fork 2 is not active, these conditions are also not active,
-        # and never constrain the block
-        if not softfork2 and opcode in [
-            co.ASSERT_MY_BIRTH_HEIGHT,
-            co.ASSERT_MY_BIRTH_SECONDS,
-            co.ASSERT_BEFORE_SECONDS_RELATIVE,
-            co.ASSERT_BEFORE_SECONDS_ABSOLUTE,
-            co.ASSERT_BEFORE_HEIGHT_RELATIVE,
-            co.ASSERT_BEFORE_HEIGHT_ABSOLUTE,
-        ]:
-            expected = None
-
-        if not softfork2:
-            # before soft-fork 2, the timestamp we compared against was the
-            # current block's timestamp as opposed to the previous tx-block's
-            # timestamp. These conditions used to be valid, before the soft-fork
-            if opcode == ConditionOpcode.ASSERT_SECONDS_RELATIVE and value > 10 and value <= 20:
-                expected = None
-
-            if opcode == ConditionOpcode.ASSERT_SECONDS_ABSOLUTE and value > 10030 and value <= 10040:
-                expected = None
-
-        await check_conditions(bt, conditions, expected_err=expected, softfork2=softfork2)
+        await check_conditions(bt, conditions, expected_err=expected)
 
     @pytest.mark.asyncio
     async def test_invalid_my_id(self, bt):
@@ -433,4 +403,4 @@ class TestConditions:
         conditions += b"\x80"
         conditions_program = Program.from_bytes(conditions)
 
-        await check_conditions(bt, conditions_program, expected_err=expect_err, softfork2=True)
+        await check_conditions(bt, conditions_program, expected_err=expect_err)

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -558,7 +558,6 @@ mis = MempoolInclusionStatus
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("softfork2", [False, True])
 @pytest.mark.parametrize(
     "opcode,lock_value,expected_status,expected_error",
     [
@@ -617,28 +616,13 @@ async def test_ephemeral_timelock(
     lock_value: int,
     expected_status: MempoolInclusionStatus,
     expected_error: Optional[Err],
-    softfork2: bool,
 ) -> None:
-    if softfork2:
-        constants = DEFAULT_CONSTANTS.replace(SOFT_FORK2_HEIGHT=0)
-    else:
-        constants = DEFAULT_CONSTANTS
-
     mempool_manager = await instantiate_mempool_manager(
         get_coin_record=get_coin_record_for_test_coins,
         block_height=uint32(5),
         block_timestamp=uint64(10050),
-        constants=constants,
+        constants=DEFAULT_CONSTANTS,
     )
-
-    if not softfork2 and opcode in [
-        co.ASSERT_BEFORE_HEIGHT_ABSOLUTE,
-        co.ASSERT_BEFORE_HEIGHT_RELATIVE,
-        co.ASSERT_BEFORE_SECONDS_ABSOLUTE,
-        co.ASSERT_BEFORE_SECONDS_RELATIVE,
-    ]:
-        expected_error = Err.INVALID_CONDITION
-        expected_status = MempoolInclusionStatus.FAILED
 
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
     created_coin = Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, 1)
@@ -1017,7 +1001,7 @@ async def test_assert_before_expiration(
         get_coin_record,
         block_height=uint32(10),
         block_timestamp=uint64(10000),
-        constants=DEFAULT_CONSTANTS.replace(SOFT_FORK2_HEIGHT=0),
+        constants=DEFAULT_CONSTANTS,
     )
 
     bundle = spend_bundle_from_conditions(

--- a/tests/util/test_testnet_overrides.py
+++ b/tests/util/test_testnet_overrides.py
@@ -9,7 +9,6 @@ def test_testnet10() -> None:
     overrides: Dict[str, Any] = {}
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
-        "SOFT_FORK2_HEIGHT": 0,
         "SOFT_FORK3_HEIGHT": 2997292,
         "HARD_FORK_HEIGHT": 2997292,
         "PLOT_FILTER_128_HEIGHT": 3061804,
@@ -20,7 +19,6 @@ def test_testnet10() -> None:
 
 def test_testnet10_existing() -> None:
     overrides: Dict[str, Any] = {
-        "SOFT_FORK2_HEIGHT": 42,
         "SOFT_FORK3_HEIGHT": 42,
         "HARD_FORK_HEIGHT": 42,
         "PLOT_FILTER_128_HEIGHT": 42,
@@ -29,7 +27,6 @@ def test_testnet10_existing() -> None:
     }
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
-        "SOFT_FORK2_HEIGHT": 42,
         "SOFT_FORK3_HEIGHT": 42,
         "HARD_FORK_HEIGHT": 42,
         "PLOT_FILTER_128_HEIGHT": 42,


### PR DESCRIPTION
Since soft-fork2 has activated on mainnet, we no longer need to preserve the special cases from before the soft-fork. This reduces the number of tests we run on CI and simplifies the consensus logic.

This change intends to make the consensus logic behave as if soft-fork2 activated at block 0. i.e. it was always active.

To ensure the mainnet chain did not violate any soft-fork2 rules prior to activation, I have successfully synced a node from scratch with this patch.