### PR TITLE
Dedup offer cancellation logic

### DIFF
--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -245,6 +245,7 @@ class TradeManager:
                 if not secure:
                     self.wallet_state_manager.state_changed("offer_cancelled")
                     await self.trade_store.set_status(trade.trade_id, TradeStatus.CANCELLED)
+                    continue
 
                 cancellation_additions: List[Coin] = []
                 for coin in Offer.from_bytes(trade.offer).get_cancellation_coins():

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -212,181 +212,112 @@ class TradeManager:
         record = await self.trade_store.get_trade_record(trade_id)
         return record
 
-    async def cancel_pending_offer(self, trade_id: bytes32) -> None:
-        await self.trade_store.set_status(trade_id, TradeStatus.CANCELLED)
-        self.wallet_state_manager.state_changed("offer_cancelled")
-
     async def fail_pending_offer(self, trade_id: bytes32) -> None:
         await self.trade_store.set_status(trade_id, TradeStatus.FAILED)
         self.wallet_state_manager.state_changed("offer_failed")
 
-    async def cancel_pending_offer_safely(
-        self, trade_id: bytes32, fee: uint64 = uint64(0)
-    ) -> Optional[List[TransactionRecord]]:
-        """This will create a transaction that includes coins that were offered"""
-        self.log.info(f"Secure-Cancel pending offer with id trade_id {trade_id.hex()}")
-        trade = await self.trade_store.get_trade_record(trade_id)
-        if trade is None:
-            return None
-
-        all_txs: List[TransactionRecord] = []
-        fee_to_pay: uint64 = fee
-        for coin in Offer.from_bytes(trade.offer).get_cancellation_coins():
-            wallet = await self.wallet_state_manager.get_wallet_for_coin(coin.name())
-
-            if wallet is None:
-                continue
-
-            if wallet.type() == WalletType.NFT:
-                new_ph = await wallet.wallet_state_manager.main_wallet.get_new_puzzlehash()
-            else:
-                new_ph = await wallet.get_new_puzzlehash()
-            # This should probably not switch on whether or not we're spending a XCH but it has to for now
-            if wallet.type() == WalletType.STANDARD_WALLET:
-                if fee_to_pay > coin.amount:
-                    selected_coins: Set[Coin] = await wallet.select_coins(
-                        uint64(fee_to_pay - coin.amount),
-                        exclude=[coin],
-                    )
-                    selected_coins.add(coin)
-                else:
-                    selected_coins = {coin}
-                tx = await wallet.generate_signed_transaction(
-                    uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
-                    new_ph,
-                    fee=fee_to_pay,
-                    coins=selected_coins,
-                    ignore_max_send_amount=True,
-                )
-                all_txs.append(tx)
-            else:
-                # ATTENTION: new_wallets
-                txs = await wallet.generate_signed_transaction(
-                    [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
-                )
-                all_txs.extend(txs)
-            fee_to_pay = uint64(0)
-
-            cancellation_addition = Coin(coin.name(), new_ph, coin.amount)
-            all_txs.append(
-                TransactionRecord(
-                    confirmed_at_height=uint32(0),
-                    created_at_time=uint64(int(time.time())),
-                    to_puzzle_hash=new_ph,
-                    amount=uint64(coin.amount),
-                    fee_amount=fee,
-                    confirmed=False,
-                    sent=uint32(10),
-                    spend_bundle=None,
-                    additions=[cancellation_addition],
-                    removals=[coin],
-                    wallet_id=wallet.id(),
-                    sent_to=[],
-                    trade_id=None,
-                    type=uint32(TransactionType.INCOMING_TX.value),
-                    name=cancellation_addition.name(),
-                    memos=[],
-                )
-            )
-
-        for tx in all_txs:
-            await self.wallet_state_manager.add_pending_transaction(tx_record=dataclasses.replace(tx, fee_amount=fee))
-
-        await self.trade_store.set_status(trade_id, TradeStatus.PENDING_CANCEL)
-
-        return all_txs
-
     async def cancel_pending_offers(
-        self, trades: List[TradeRecord], fee: uint64 = uint64(0), secure: bool = True
+        self,
+        trades: List[bytes32],
+        fee: uint64 = uint64(0),
+        secure: bool = True,
+        trade_cache: Dict[bytes32, TradeRecord] = {},
     ) -> Optional[List[TransactionRecord]]:
         """This will create a transaction that includes coins that were offered"""
 
-        all_txs: List[TransactionRecord] = []
-        bundles: List[SpendBundle] = []
-        fee_to_pay: uint64 = fee
-        for trade in trades:
-            if trade is None:
-                self.log.error("Cannot find offer, skip cancellation.")
-                continue
-
-            for coin in Offer.from_bytes(trade.offer).get_primary_coins():
-                wallet = await self.wallet_state_manager.get_wallet_for_coin(coin.name())
-
-                if wallet is None:
-                    self.log.error(f"Cannot find wallet for offer {trade.trade_id}, skip cancellation.")
-                    continue
-
-                if wallet.type() == WalletType.NFT:
-                    new_ph = await wallet.wallet_state_manager.main_wallet.get_new_puzzlehash()
+        async with self.trade_store.db_wrapper.writer():
+            all_txs: List[TransactionRecord] = []
+            bundles: List[SpendBundle] = []
+            fee_to_pay: uint64 = fee
+            for trade_id in trades:
+                if trade_id in trade_cache:
+                    trade = trade_cache[trade_id]
                 else:
-                    new_ph = await wallet.get_new_puzzlehash()
-                # This should probably not switch on whether or not we're spending a XCH but it has to for now
-                if wallet.type() == WalletType.STANDARD_WALLET:
-                    if fee_to_pay > coin.amount:
-                        selected_coins: Set[Coin] = await wallet.select_coins(
-                            uint64(fee_to_pay - coin.amount),
-                            exclude=[coin],
-                        )
-                        selected_coins.add(coin)
+                    potential_trade = await self.trade_store.get_trade_record(trade_id)
+                    if potential_trade is None:
+                        self.log.error(f"Cannot find offer {trade_id.hex()}, skip cancellation.")
+                        continue
                     else:
-                        selected_coins = {coin}
-                    tx: TransactionRecord = await wallet.generate_signed_transaction(
-                        uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
-                        new_ph,
-                        fee=fee_to_pay,
-                        coins=selected_coins,
-                        ignore_max_send_amount=True,
-                    )
-                    if tx is not None and tx.spend_bundle is not None:
-                        bundles.append(tx.spend_bundle)
-                        all_txs.append(dataclasses.replace(tx, spend_bundle=None))
-                else:
-                    # ATTENTION: new_wallets
-                    txs = await wallet.generate_signed_transaction(
-                        [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
-                    )
-                    for tx in txs:
+                        trade = potential_trade
+
+                self.log.info(f"Secure-Cancel pending offer with id trade_id {trade_id.hex()}")
+
+                if not secure:
+                    self.wallet_state_manager.state_changed("offer_cancelled")
+                    await self.trade_store.set_status(trade.trade_id, TradeStatus.CANCELLED)
+
+                cancellation_additions: List[Coin] = []
+                for coin in Offer.from_bytes(trade.offer).get_cancellation_coins():
+                    wallet = await self.wallet_state_manager.get_wallet_for_coin(coin.name())
+
+                    if wallet is None:
+                        self.log.error(f"Cannot find wallet for offer {trade.trade_id}, skip cancellation.")
+                        continue
+
+                    new_ph = await wallet.wallet_state_manager.main_wallet.get_new_puzzlehash()
+                    # This should probably not switch on whether or not we're spending a XCH but it has to for now
+                    if wallet.type() == WalletType.STANDARD_WALLET:
+                        if fee_to_pay > coin.amount:
+                            selected_coins: Set[Coin] = await wallet.select_coins(
+                                uint64(fee_to_pay - coin.amount),
+                                exclude=[coin],
+                            )
+                            selected_coins.add(coin)
+                        else:
+                            selected_coins = {coin}
+                        tx: TransactionRecord = await wallet.generate_signed_transaction(
+                            uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
+                            new_ph,
+                            fee=fee_to_pay,
+                            coins=selected_coins,
+                            ignore_max_send_amount=True,
+                        )
                         if tx is not None and tx.spend_bundle is not None:
                             bundles.append(tx.spend_bundle)
+                            cancellation_additions.extend(tx.spend_bundle.additions())
                             all_txs.append(dataclasses.replace(tx, spend_bundle=None))
-                fee_to_pay = uint64(0)
+                    else:
+                        # ATTENTION: new_wallets
+                        txs = await wallet.generate_signed_transaction(
+                            [coin.amount], [new_ph], fee=fee_to_pay, coins={coin}, ignore_max_send_amount=True
+                        )
+                        for tx in txs:
+                            if tx is not None and tx.spend_bundle is not None:
+                                bundles.append(tx.spend_bundle)
+                                cancellation_additions.extend(tx.spend_bundle.additions())
+                                all_txs.append(dataclasses.replace(tx, spend_bundle=None))
+                    fee_to_pay = uint64(0)
 
-                cancellation_addition = Coin(coin.name(), new_ph, coin.amount)
-                all_txs.append(
-                    TransactionRecord(
-                        confirmed_at_height=uint32(0),
-                        created_at_time=uint64(int(time.time())),
-                        to_puzzle_hash=new_ph,
-                        amount=uint64(coin.amount),
-                        fee_amount=fee,
-                        confirmed=False,
-                        sent=uint32(10),
-                        spend_bundle=None,
-                        additions=[cancellation_addition],
-                        removals=[coin],
-                        wallet_id=wallet.id(),
-                        sent_to=[],
-                        trade_id=None,
-                        type=uint32(TransactionType.INCOMING_TX.value),
-                        name=cancellation_addition.name(),
-                        memos=[],
+                    all_txs.append(
+                        TransactionRecord(
+                            confirmed_at_height=uint32(0),
+                            created_at_time=uint64(int(time.time())),
+                            to_puzzle_hash=new_ph,
+                            amount=uint64(coin.amount),
+                            fee_amount=fee,
+                            confirmed=False,
+                            sent=uint32(10),
+                            spend_bundle=None,
+                            additions=cancellation_additions,
+                            removals=[coin],
+                            wallet_id=wallet.id(),
+                            sent_to=[],
+                            trade_id=None,
+                            type=uint32(TransactionType.INCOMING_TX.value),
+                            name=cancellation_additions[0].name(),
+                            memos=[],
+                        )
                     )
-                )
-        # Aggregate spend bundles to the first tx
-        if len(all_txs) > 0:
-            all_txs[0] = dataclasses.replace(all_txs[0], spend_bundle=SpendBundle.aggregate(bundles))
-        if secure:
+
+                await self.trade_store.set_status(trade_id, TradeStatus.PENDING_CANCEL)
+            # Aggregate spend bundles to the first tx
+            if len(all_txs) > 0:
+                all_txs[0] = dataclasses.replace(all_txs[0], spend_bundle=SpendBundle.aggregate(bundles))
             for tx in all_txs:
                 await self.wallet_state_manager.add_pending_transaction(
                     tx_record=dataclasses.replace(tx, fee_amount=fee)
                 )
-        else:
-            self.wallet_state_manager.state_changed("offer_cancelled")
-        for trade in trades:
-            if secure:
-                await self.trade_store.set_status(trade.trade_id, TradeStatus.PENDING_CANCEL)
-            else:
-                await self.trade_store.set_status(trade.trade_id, TradeStatus.CANCELLED)
+
         return all_txs
 
     async def save_trade(self, trade: TradeRecord, offer: Offer) -> None:

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -220,8 +220,8 @@ class TradeManager:
         self,
         trades: List[bytes32],
         fee: uint64 = uint64(0),
-        secure: bool = True,
-        trade_cache: Dict[bytes32, TradeRecord] = {},
+        secure: bool = True,  # Cancel with a transaction on chain
+        trade_cache: Dict[bytes32, TradeRecord] = {},  # Optional pre-fetched trade records for optimization
     ) -> Optional[List[TransactionRecord]]:
         """This will create a transaction that includes coins that were offered"""
 

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -641,7 +641,7 @@ class TestCATTrades:
         assert error is None
         assert success is True
         assert trade_make is not None
-        txs = await trade_manager_maker.cancel_pending_offer([trade_make.trade_id], fee=uint64(0), secure=True)
+        txs = await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], fee=uint64(0), secure=True)
         await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
         await full_node.process_transaction_records(records=txs)
 

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -556,7 +556,7 @@ class TestCATTrades:
 
         fee = uint64(2_000_000_000_000)
 
-        txs = await trade_manager_maker.cancel_pending_offes([trade_make.trade_id], fee=fee, secure=True)
+        txs = await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], fee=fee, secure=True)
         await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
         await full_node.process_transaction_records(records=txs)
 

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -534,7 +534,8 @@ class TestCATTrades:
         assert success is True
         assert trade_make is not None
 
-        await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], secure=False)
+        # Cancelling the trade and trying an ID that doesn't exist just in case
+        await trade_manager_maker.cancel_pending_offers([trade_make.trade_id, bytes32([0] * 32)], secure=False)
         await time_out_assert(15, get_trade_and_status, TradeStatus.CANCELLED, trade_manager_maker, trade_make)
 
         # Due to current mempool rules, trying to force a take out of the mempool with a cancel will not work.

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -534,7 +534,7 @@ class TestCATTrades:
         assert success is True
         assert trade_make is not None
 
-        await trade_manager_maker.cancel_pending_offer(trade_make.trade_id)
+        await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], secure=False)
         await time_out_assert(15, get_trade_and_status, TradeStatus.CANCELLED, trade_manager_maker, trade_make)
 
         # Due to current mempool rules, trying to force a take out of the mempool with a cancel will not work.
@@ -556,7 +556,7 @@ class TestCATTrades:
 
         fee = uint64(2_000_000_000_000)
 
-        txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=fee)
+        txs = await trade_manager_maker.cancel_pending_offes([trade_make.trade_id], fee=fee, secure=True)
         await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
         await full_node.process_transaction_records(records=txs)
 
@@ -594,7 +594,7 @@ class TestCATTrades:
         ):
             await trade_manager_taker.respond_to_offer(Offer.from_bytes(trade_make.offer), peer)
 
-        txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=uint64(0))
+        txs = await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], fee=uint64(0), secure=True)
         await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
         await full_node.process_transaction_records(records=txs)
 
@@ -641,7 +641,7 @@ class TestCATTrades:
         assert error is None
         assert success is True
         assert trade_make is not None
-        txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=uint64(0))
+        txs = await trade_manager_maker.cancel_pending_offer([trade_make.trade_id], fee=uint64(0), secure=True)
         await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
         await full_node.process_transaction_records(records=txs)
 

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -285,7 +285,9 @@ async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> Non
     assert success is True
     assert offer is not None
 
-    cancellation_txs = await trade_manager.cancel_pending_offer_safely(offer.trade_id, fee=uint64(2_000_000_000_000))
+    cancellation_txs = await trade_manager.cancel_pending_offers(
+        [offer.trade_id], fee=uint64(2_000_000_000_000), secure=True
+    )
     assert len(cancellation_txs) == 3
     await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager, offer)
     await full_node_api.process_transaction_records(records=cancellation_txs)

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -288,7 +288,7 @@ async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> Non
     cancellation_txs = await trade_manager.cancel_pending_offers(
         [offer.trade_id], fee=uint64(2_000_000_000_000), secure=True
     )
-    assert len(cancellation_txs) == 3
+    assert len(cancellation_txs) == 2
     await time_out_assert(15, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager, offer)
     await full_node_api.process_transaction_records(records=cancellation_txs)
     await time_out_assert(15, get_trade_and_status, TradeStatus.CANCELLED, trade_manager, offer)

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1158,7 +1158,7 @@ async def test_nft_offer_sell_cancel_in_batch(self_hostname: str, two_wallet_nod
     )
 
     FEE = uint64(2000000000000)
-    txs = await trade_manager_maker.cancel_pending_offers([trade_make], fee=FEE, secure=True)
+    txs = await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], fee=FEE, secure=True)
 
     async def get_trade_and_status(trade_manager: Any, trade: Any) -> TradeStatus:
         trade_rec = await trade_manager.get_trade_by_id(trade.trade_id)

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1040,7 +1040,7 @@ async def test_nft_offer_sell_cancel(self_hostname: str, two_wallet_nodes: Any, 
     )
 
     FEE = uint64(2000000000000)
-    txs = await trade_manager_maker.cancel_pending_offer([trade_make.trade_id], fee=FEE, secure=True)
+    txs = await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], fee=FEE, secure=True)
 
     async def get_trade_and_status(trade_manager: Any, trade: Any) -> TradeStatus:
         trade_rec = await trade_manager.get_trade_by_id(trade.trade_id)

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1040,7 +1040,7 @@ async def test_nft_offer_sell_cancel(self_hostname: str, two_wallet_nodes: Any, 
     )
 
     FEE = uint64(2000000000000)
-    txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=FEE)
+    txs = await trade_manager_maker.cancel_pending_offer([trade_make.trade_id], fee=FEE, secure=True)
 
     async def get_trade_and_status(trade_manager: Any, trade: Any) -> TradeStatus:
         trade_rec = await trade_manager.get_trade_by_id(trade.trade_id)

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -320,7 +320,7 @@ async def test_nft_offer_cancellations(self_hostname: str, two_wallet_nodes: Any
 
     cancel_fee = uint64(10)
 
-    txs = await trade_manager_maker.cancel_pending_offer([trade_make.trade_id], fee=cancel_fee, secure=True)
+    txs = await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], fee=cancel_fee, secure=True)
 
     await time_out_assert(20, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
     await full_node_api.process_transaction_records(records=txs)

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -315,12 +315,12 @@ async def test_nft_offer_cancellations(self_hostname: str, two_wallet_nodes: Any
     assert error is None
     assert trade_make is not None
 
-    # await trade_manager_maker.cancel_pending_offer(trade_make.trade_id)
+    # await trade_manager_maker.cancel_pending_offers([trade_make.trade_id], secure=False)
     # await time_out_assert(20, get_trade_and_status, TradeStatus.CANCELLED, trade_manager_maker, trade_make)
 
     cancel_fee = uint64(10)
 
-    txs = await trade_manager_maker.cancel_pending_offer_safely(trade_make.trade_id, fee=cancel_fee)
+    txs = await trade_manager_maker.cancel_pending_offer([trade_make.trade_id], fee=cancel_fee, secure=True)
 
     await time_out_assert(20, get_trade_and_status, TradeStatus.PENDING_CANCEL, trade_manager_maker, trade_make)
     await full_node_api.process_transaction_records(records=txs)


### PR DESCRIPTION
Right now, there's three functions for cancelling an offer, one for a single offer + insecure, one for a single offer + secure, and one for multiple offers secure/insecurely.  This PR collapses the three functions into the last one as well as gives the last one a bit of a cleanup.

Since two of these functions were next to each other, the diff is a little confusing and it's probably better if you just look at the function in trade manager just by itself (by clicking "View File").