### PR TITLE
fix error in dao_get_treasury_balance RPC

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2417,7 +2417,10 @@ class WalletRpcApi:
         balances = {}
         for asset_id in asset_list:
             balance = await dao_wallet.get_balance_by_asset_type(asset_id=asset_id)
-            balances[asset_id] = balance
+            if asset_id is None:
+                balances["xch"] = balance
+            else:
+                balances[asset_id.hex()] = balance
         return {"success": True, "balances": balances}
 
     async def dao_get_treasury_id(self, request) -> EndpointResult:


### PR DESCRIPTION
### Purpose:
Fix error when calling `dao_get_treasury_balance` wallet RPC.


### Current Behavior:
Return 500 error, `500, message='Internal Server Error', url=URL('https://localhost:23706/dao_get_treasury_balance')`

#### stack trace from debug.log
```
2023-07-21T11:31:28.291 wallet aiohttp.server             : ERROR    Error handling request
Traceback (most recent call last):
  File "/Users/karlkim/kimsk/chia-blockchain/venv/lib/python3.11/site-packages/aiohttp/web_protocol.py", line 433, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/karlkim/kimsk/chia-blockchain/venv/lib/python3.11/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/karlkim/kimsk/chia-blockchain/chia/rpc/util.py", line 31, in inner
    return obj_to_response(res_object)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/karlkim/kimsk/chia-blockchain/chia/util/json_util.py", line 41, in obj_to_response
    json_str = dict_to_json_str(o)
               ^^^^^^^^^^^^^^^^^^^
  File "/Users/karlkim/kimsk/chia-blockchain/chia/util/json_util.py", line 33, in dict_to_json_str
    json_str = json.dumps(o, cls=EnhancedJSONEncoder, sort_keys=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'bytes32' and 'NoneType'
```

### New Behavior:
Return DAO treasury balances

#### DAO
<img width="955" alt="image" src="https://github.com/Chia-Network/chia-blockchain/assets/116863/c6412e6f-1164-4688-a0be-793debca57b4">

#### RPC result -- before and after
<img width="1002" alt="image" src="https://github.com/Chia-Network/chia-blockchain/assets/116863/ce3fa69c-9d12-4b68-8e98-f1a7aeaee51a">
