### PR TITLE
Skip clawback incoming txs while deleting the unconfirmed txs

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -694,31 +694,6 @@ async def take_offer(
             print("Please enter a valid offer file or hex blob")
             return
 
-        ###
-        # This is temporary code, delete it when we no longer care about incorrectly parsing CAT1s
-        # There's also temp code in test_wallet_rpc.py and wallet_rpc_api.py
-        from chia.types.spend_bundle import SpendBundle
-        from chia.util.bech32m import bech32_decode, convertbits
-        from chia.wallet.util.puzzle_compression import decompress_object_with_puzzles
-
-        hrpgot, data = bech32_decode(offer_hex, max_length=len(offer_hex))
-        if data is None:
-            raise ValueError("Invalid Offer")
-        decoded = convertbits(list(data), 5, 8, False)
-        decoded_bytes = bytes(decoded)
-        try:
-            decompressed_bytes = decompress_object_with_puzzles(decoded_bytes)
-        except TypeError:
-            decompressed_bytes = decoded_bytes
-        bundle = SpendBundle.from_bytes(decompressed_bytes)
-        for spend in bundle.coin_spends:
-            mod, _ = spend.puzzle_reveal.to_program().uncurry()
-            if mod.get_tree_hash() == bytes32.from_hexstr(
-                "72dec062874cd4d3aab892a0906688a1ae412b0109982e1797a170add88bdcdc"
-            ):
-                raise ValueError("CAT1s are no longer supported")
-        ###
-
         offered, requested, _ = offer.summary()
         cat_name_resolver = wallet_client.cat_asset_id_to_name
         network_xch = AddressType.XCH.hrp(config).upper()

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1677,8 +1677,8 @@ class WalletRpcApi:
         offer_hex: str = request["offer"]
 
         ###
-        # This is temporary code, delete it when we no longer care about incorrectly parsing CAT1s or old offers
-        # There's also temp code in test_wallet_rpc.py and wallet_funcs.py
+        # This is temporary code, delete it when we no longer care about incorrectly parsing old offers
+        # There's also temp code in test_wallet_rpc.py
         from chia.util.bech32m import bech32_decode, convertbits
         from chia.wallet.util.puzzle_compression import OFFER_MOD_OLD, decompress_object_with_puzzles
 
@@ -1691,19 +1691,6 @@ class WalletRpcApi:
             decompressed_bytes = decompress_object_with_puzzles(decoded_bytes)
         except zlib.error:
             decompressed_bytes = decoded_bytes
-        ###
-        ###
-        # This is temporary code, delete it when we no longer care about incorrectly parsing CAT1s
-        bundle = SpendBundle.from_bytes(decompressed_bytes)
-        for spend in bundle.coin_spends:
-            mod, _ = spend.puzzle_reveal.to_program().uncurry()
-            if mod.get_tree_hash() == bytes32.from_hexstr(
-                "72dec062874cd4d3aab892a0906688a1ae412b0109982e1797a170add88bdcdc"
-            ):
-                raise ValueError("CAT1s are no longer supported")
-        ###
-        ###
-        # This is temporary code, delete it when we no longer care about incorrectly parsing old offers
         if bytes(OFFER_MOD_OLD) in decompressed_bytes:
             raise ValueError("Old offer format is no longer supported")
         ###

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -387,5 +387,12 @@ class WalletTransactionStore:
     async def delete_unconfirmed_transactions(self, wallet_id: int):
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (
-                await conn.execute("DELETE FROM transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,))
+                await conn.execute(
+                    "DELETE FROM transaction_record WHERE confirmed=0 AND wallet_id=? AND type not in (?,?)",
+                    (
+                        wallet_id,
+                        TransactionType.INCOMING_CLAWBACK_SEND.value,
+                        TransactionType.INCOMING_CLAWBACK_RECEIVE.value,
+                    ),
+                )
             ).close()

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1140,28 +1140,6 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     assert len(all_offers) == 2
 
     ###
-    # This is temporary code, delete it when we no longer care about incorrectly parsing CAT1s
-    # There's also temp code in wallet_rpc_api.py and wallet_funcs.py
-    with pytest.raises(ValueError, match="CAT1s are no longer supported"):
-        await wallet_1_rpc.fetch(
-            "get_offer_summary",
-            {
-                "offer": "offer1qqp83w76wzru6cmqvpsxygqq4c96al7mw0a8es5t4rp80gn8femj6mkjl8luv7wrldg87dhkq6ejylvc8f"
-                "vtprkkww3lthrg85m44nud6eesxhw0sx9m6p297u8zfd0mtjumc6k85sz38536z6h884rxujw2zfe704surksmm4m"
-                "7usy4u48tmafcajc4dc0dmqa4h9z5f27e3qnuzf37yr78sl6kslts9aua5zfdg3r7knncj78pzg4nvrn0a6dkjvmme7"
-                "jjzz72xmlruuhmawm0eedl7fpfjkhnf70al2tw34pdgqje0m8wt6v8uaxw8gtjlkfzlw4447fk429f42tmn9x6l4qm9u"
-                "2n404j74ls5yv2grt0tzstm2l8hukgx4v6h42908px8dh0avzhdlxw7ruj5t53etc9dt2n2wm7098ks89waeunnfexdn"
-                "dmhf5dmhyjs6wvjzvvlj0scdh3np6mgmur6m2jj2y474cwuaurph0tq28ee6y3hxahhkkfqzlc8g7hm3lllvrl2nhlm7"
-                "2hgau9lgdumy9m99hy78dv5uwdr69jfkvu6a5qc0jlzkas6cry3zh7hasdwg785nmhhsl680m4fxdseavzdk8mg93dank"
-                "88ue2hned4tarn0al7gl4wq6ct4gd3c3q5a6l2gjlvd8ftteddfxxq5v4zdu0ycv2vuwslf7rz2u56nl7guqatk0ut7cy"
-                "ga0zu096k7rhdl99kc5jmscmtdz9vme2mmg86dwq7nk088spawraxfgftl0lqkycapflf725mjht2law69wh0rq8l7ue"
-                "gztx0xnvgc8y7wvvuwv3th5pcwckkm07jacznlgeuu8kcw0yuu4utjrm2mut8ekm8rmzp6vlzcm6e4f8xzytjx3ytnye"
-                "kany0a9l4tq0zxnh3rjwhve88658nd0xwhmgectl33u3us6klkk5c7vjyuurr6yetk7ua654my4cmxmtrjazfu3ara9"
-                "yc449jqxg4mfgx0sw3p9"
-            },
-        )
-    ###
-    ###
     # This is temporary code, delete it when we no longer care about incorrectly parsing old offers
     # There's also temp code in wallet_rpc_api.py
     with pytest.raises(ValueError, match="Old offer format is no longer supported"):

--- a/tests/wallet/test_transaction_store.py
+++ b/tests/wallet/test_transaction_store.py
@@ -443,11 +443,13 @@ async def test_delete_unconfirmed() -> None:
         tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True)
         tr3 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, wallet_id=2)
         tr4 = dataclasses.replace(tr1, name=token_bytes(32), wallet_id=2)
+        tr5 = dataclasses.replace(tr1, name=token_bytes(32), wallet_id=2, type=uint32(TransactionType.COINBASE_REWARD.value))
 
         await store.add_transaction_record(tr1)
         await store.add_transaction_record(tr2)
         await store.add_transaction_record(tr3)
         await store.add_transaction_record(tr4)
+        await store.add_transaction_record(tr5)
 
         assert cmp(await store.get_all_transactions(), [tr1, tr2, tr3, tr4])
         await store.delete_unconfirmed_transactions(1)

--- a/tests/wallet/test_transaction_store.py
+++ b/tests/wallet/test_transaction_store.py
@@ -443,7 +443,9 @@ async def test_delete_unconfirmed() -> None:
         tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True)
         tr3 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, wallet_id=2)
         tr4 = dataclasses.replace(tr1, name=token_bytes(32), wallet_id=2)
-        tr5 = dataclasses.replace(tr1, name=token_bytes(32), wallet_id=2, type=uint32(TransactionType.COINBASE_REWARD.value))
+        tr5 = dataclasses.replace(
+            tr1, name=token_bytes(32), wallet_id=2, type=uint32(TransactionType.INCOMING_CLAWBACK_RECEIVE.value)
+        )
 
         await store.add_transaction_record(tr1)
         await store.add_transaction_record(tr2)
@@ -451,11 +453,11 @@ async def test_delete_unconfirmed() -> None:
         await store.add_transaction_record(tr4)
         await store.add_transaction_record(tr5)
 
-        assert cmp(await store.get_all_transactions(), [tr1, tr2, tr3, tr4])
+        assert cmp(await store.get_all_transactions(), [tr1, tr2, tr3, tr4, tr5])
         await store.delete_unconfirmed_transactions(1)
-        assert cmp(await store.get_all_transactions(), [tr2, tr3, tr4])
+        assert cmp(await store.get_all_transactions(), [tr2, tr3, tr4, tr5])
         await store.delete_unconfirmed_transactions(2)
-        assert cmp(await store.get_all_transactions(), [tr2, tr3])
+        assert cmp(await store.get_all_transactions(), [tr2, tr3, tr5])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
When users trying to delete unconfirmed TXs they will delete Clawback incoming TX transactions unintentionally. This fix will prevent unexpected deletion.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Delete all TXs which confirmed as 0


### New Behavior:
Delete all TXs which confirmed as 0 and not a Clawback incoming tx.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Unit test


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
