### PR TITLE
Add check to ubuntu_cmake_install for distribution ID

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -47,7 +47,7 @@ THE_PATH=$(python -c 'import pkg_resources; print( pkg_resources.get_distributio
 CHIAVDF_VERSION=$(python -c 'import os; os.environ["CHIA_SKIP_SETUP"] = "1"; from setup import dependencies; t = [_ for _ in dependencies if _.startswith("chiavdf")][0]; print(t)')
 
 ubuntu_cmake_install() {
-	UBUNTU_PRE_2004=$(python -c 'import subprocess; process = subprocess.run(["lsb_release", "-rs"], stdout=subprocess.PIPE); print(float(process.stdout) < float(20.04))')
+	UBUNTU_PRE_2004=$(python -c 'import subprocess; id = subprocess.run(["lsb_release", "-is"], stdout=subprocess.PIPE); version = subprocess.run(["lsb_release", "-rs"], stdout=subprocess.PIPE); print(id.stdout.decode("ascii") == "Ubuntu\n" and float(version.stdout) < float(20.04))')
 	if [ "$UBUNTU_PRE_2004" = "True" ]; then
 		echo "Installing CMake with snap."
 		sudo apt-get install snapd -y


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
install-timelord.sh has extra logic for older versions of Ubuntu to ensure a new-ish version of cmake is installed on the system. However, this logic is also run on Debian systems, where it would _always_ be true in Debian, as the latest Debian version number is less than 20.04. However, Debian apt packages have had cmake 3.18+ in the official apt repos since Bullseye.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
On all debian systems, install-timelord.sh currently attempts to install cmake from snap.


### New Behavior:
cmake is only installed from snap packages on older versions of Ubuntu. Debian Bullseye and up will use the version of cmake from the official apt repos. Worth noting, anybody running Debian Buster, or older, will have issues running install-timelord.sh. 


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Ran three Ubuntu containers:
```
docker run --rm -it ubuntu:18.04 /bin/bash
docker run --rm -it ubuntu:20.04 /bin/bash
docker run --rm -it ubuntu:latest /bin/bash
```
Installed python3 and lsb-release in all three. Then ran this command (the python command that is changed by this PR.) It returns true in the ubuntu:18.04 container only, correctly returning false for the later two versions.

Then ran the same test in multiple debian containers, where it always returned false.

Finally, I built chiavdf using this script (with my changes) inside the chia-docker container, which is a debian bullseye-based image.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
