### PR TITLE
Add force option for spend_clawback_coin

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -309,12 +309,22 @@ def get_address_cmd(wallet_rpc_port: Optional[int], id: int, fingerprint: int, n
 @click.option(
     "-m", "--fee", help="A fee to add to the offer when it gets taken, in XCH", default="0", show_default=True
 )
+@click.option(
+    "--force",
+    help="Force to push the spend bundle even it may be a double spend",
+    is_flag=True,
+    default=False,
+)
 def clawback(
-    wallet_rpc_port: Optional[int], id: int, fingerprint: int, tx_ids: str, fee: str
+    wallet_rpc_port: Optional[int], id: int, fingerprint: int, tx_ids: str, fee: str, force: bool
 ) -> None:  # pragma: no cover
     from .wallet_funcs import spend_clawback
 
-    asyncio.run(spend_clawback(wallet_rpc_port=wallet_rpc_port, fp=fingerprint, fee=Decimal(fee), tx_ids_str=tx_ids))
+    asyncio.run(
+        spend_clawback(
+            wallet_rpc_port=wallet_rpc_port, fp=fingerprint, fee=Decimal(fee), tx_ids_str=tx_ids, force=force
+        )
+    )
 
 
 @wallet_cmd.command("delete_unconfirmed_transactions", help="Deletes all unconfirmed transactions for this wallet ID")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1387,7 +1387,7 @@ async def sign_message(
 
 
 async def spend_clawback(
-    *, wallet_rpc_port: Optional[int], fp: Optional[int], fee: Decimal, tx_ids_str: str
+    *, wallet_rpc_port: Optional[int], fp: Optional[int], fee: Decimal, tx_ids_str: str, force: bool = False
 ) -> None:  # pragma: no cover
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, _, _):
         tx_ids = []
@@ -1399,7 +1399,7 @@ async def spend_clawback(
         if fee < 0:
             print("Batch fee cannot be negative.")
             return
-        response = await wallet_client.spend_clawback_coins(tx_ids, int(fee * units["chia"]))
+        response = await wallet_client.spend_clawback_coins(tx_ids, int(fee * units["chia"]), force)
         print(str(response))
 
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1079,12 +1079,24 @@ class WalletRpcApi:
             try:
                 coins[coin_record.coin] = coin_record.parsed_metadata()
                 if len(coins) >= batch_size:
-                    tx_id_list.extend((await self.service.wallet_state_manager.spend_clawback_coins(coins, tx_fee)))
+                    tx_id_list.extend(
+                        (
+                            await self.service.wallet_state_manager.spend_clawback_coins(
+                                coins, tx_fee, request.get("force", False)
+                            )
+                        )
+                    )
                     coins = {}
             except Exception as e:
                 log.error(f"Failed to spend clawback coin {coin_id.hex()}: %s", e)
         if len(coins) > 0:
-            tx_id_list.extend((await self.service.wallet_state_manager.spend_clawback_coins(coins, tx_fee)))
+            tx_id_list.extend(
+                (
+                    await self.service.wallet_state_manager.spend_clawback_coins(
+                        coins, tx_fee, request.get("force", False)
+                    )
+                )
+            )
         return {
             "success": True,
             "transaction_ids": [tx.hex() for tx in tx_id_list],

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -249,10 +249,11 @@ class WalletRpcClient(RpcClient):
         self,
         coin_ids: List[bytes32],
         fee: int = 0,
+        force: bool = False,
     ) -> Dict:
         response = await self.fetch(
             "spend_clawback_coins",
-            {"coin_ids": [cid.hex() for cid in coin_ids], "fee": fee},
+            {"coin_ids": [cid.hex() for cid in coin_ids], "fee": fee, "force": force},
         )
         return response
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -731,7 +731,9 @@ class WalletStateManager:
         if len(clawback_coins) > 0:
             await self.spend_clawback_coins(clawback_coins, tx_fee)
 
-    async def spend_clawback_coins(self, clawback_coins: Dict[Coin, ClawbackMetadata], fee: uint64) -> List[bytes32]:
+    async def spend_clawback_coins(
+        self, clawback_coins: Dict[Coin, ClawbackMetadata], fee: uint64, force: bool = False
+    ) -> List[bytes32]:
         assert len(clawback_coins) > 0
         coin_spends: List[CoinSpend] = []
         message: bytes32 = std_hash(b"".join([c.name() for c in clawback_coins.keys()]))
@@ -744,7 +746,7 @@ class WalletStateManager:
                 # Get incoming tx
                 incoming_tx = await self.tx_store.get_transaction_record(coin.name())
                 assert incoming_tx is not None, f"Cannot find incoming tx for clawback coin {coin.name().hex()}"
-                if incoming_tx.sent > 0:
+                if incoming_tx.sent > 0 and not force:
                     self.log.error(
                         f"Clawback coin {coin.name().hex()} is already in a pending spend bundle. {incoming_tx}"
                     )


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
When the auto claim doesn't work as expected, we need a way to force the clawback spent.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
If there is a spend bundle sent to peers, the later spent will be rejected


### New Behavior:
In the force mode, later spent will not be rejected.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
