### PR TITLE
Reduce test runs for test_clear_pending_roots

### DIFF
--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -41,6 +41,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_node_api import WalletNodeAPI
+from tests.conftest import Mode
 
 pytestmark = pytest.mark.data_layer
 nodes = Tuple[WalletNode, FullNodeSimulator]
@@ -1867,7 +1868,11 @@ async def test_clear_pending_roots(
     tmp_path: Path,
     layer: InterfaceLayer,
     bt: BlockTools,
+    consensus_mode: Mode,
 ) -> None:
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("Skipped test - does not depend on Consensus rules")
+
     wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
         self_hostname, one_wallet_and_one_simulator_services
     )


### PR DESCRIPTION
As a workaround for test_clear_pending_roots flakes, reduce the number of test runs by only running the tests for the PLAIN consensus mode. The changes to consensus should have no impact on this test, and by reducing the number of times this test runs, it should help reduce the number of strange failures seen on Windows that seem entirely unrelated to the test itself.
