### PR TITLE
Fix clawback sender resync issue

### DIFF
--- a/chia/wallet/puzzles/clawback/drivers.py
+++ b/chia/wallet/puzzles/clawback/drivers.py
@@ -3,33 +3,22 @@ from __future__ import annotations
 import logging
 from typing import Any, List, Optional, Set, Union
 
-from blspy import G2Element
-
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.protocols.wallet_protocol import CoinState
-from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_for_solution
-from chia.util.ints import uint32, uint64
+from chia.util.ints import uint64
 from chia.util.misc import VersionedBlob
 from chia.wallet.puzzles.clawback.metadata import ClawbackMetadata
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import MOD
-from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import UncurriedPuzzle
-from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.curry_and_treehash import calculate_hash_of_quoted_mod_hash, curry_and_treehash
 from chia.wallet.util.merkle_tree import MerkleTree
-from chia.wallet.util.transaction_type import TransactionType
-from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import RemarkDataType
-from chia.wallet.wallet_puzzle_store import WalletPuzzleStore
-from chia.wallet.wallet_transaction_store import WalletTransactionStore
 
 P2_1_OF_N = load_clvm_maybe_recompile("p2_1_of_n.clsp")
 P2_CURRIED_PUZZLE_MOD = load_clvm_maybe_recompile("p2_puzzle_hash.clsp")
@@ -190,39 +179,3 @@ def generate_clawback_spend_bundle(
         time_lock, metadata.sender_puzzle_hash, metadata.recipient_puzzle_hash, inner_puzzle, inner_solution
     )
     return CoinSpend(coin, puzzle, solution)
-
-
-async def add_clawback_outgoing_tx(
-    created_timestamp: uint64,
-    puzzle_store: WalletPuzzleStore,
-    tx_store: WalletTransactionStore,
-    coin_state: CoinState,
-    peer: WSChiaConnection,
-    metadata: ClawbackMetadata,
-) -> None:
-    # Create Clawback outgoing transaction
-    assert coin_state.spent_height is not None
-    clawback_coin_spend: CoinSpend = await fetch_coin_spend_for_coin_state(coin_state, peer)
-    clawback_spend_bundle: SpendBundle = SpendBundle([clawback_coin_spend], G2Element())
-    if await puzzle_store.puzzle_hash_exists(clawback_spend_bundle.additions()[0].puzzle_hash):
-        tx_record = TransactionRecord(
-            confirmed_at_height=uint32(coin_state.spent_height),
-            created_at_time=created_timestamp,
-            to_puzzle_hash=metadata.sender_puzzle_hash
-            if clawback_spend_bundle.additions()[0].puzzle_hash == metadata.sender_puzzle_hash
-            else metadata.recipient_puzzle_hash,
-            amount=uint64(coin_state.coin.amount),
-            fee_amount=uint64(0),
-            confirmed=True,
-            sent=uint32(0),
-            spend_bundle=clawback_spend_bundle,
-            additions=clawback_spend_bundle.additions(),
-            removals=clawback_spend_bundle.removals(),
-            wallet_id=uint32(1),
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_CLAWBACK),
-            name=clawback_spend_bundle.name(),
-            memos=list(compute_memos(clawback_spend_bundle).items()),
-        )
-        await tx_store.add_transaction_record(tx_record)

--- a/chia/wallet/puzzles/clawback/drivers.py
+++ b/chia/wallet/puzzles/clawback/drivers.py
@@ -4,9 +4,9 @@ import logging
 from typing import Any, List, Optional, Set, Union
 
 from blspy import G2Element
-from chia_rs.chia_rs import CoinState
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.protocols.wallet_protocol import CoinState
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -201,6 +201,7 @@ async def add_clawback_outgoing_tx(
     metadata: ClawbackMetadata,
 ) -> None:
     # Create Clawback outgoing transaction
+    assert coin_state.spent_height is not None
     clawback_coin_spend: CoinSpend = await fetch_coin_spend_for_coin_state(coin_state, peer)
     clawback_spend_bundle: SpendBundle = SpendBundle([clawback_coin_spend], G2Element())
     if await puzzle_store.puzzle_hash_exists(clawback_spend_bundle.additions()[0].puzzle_hash):

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -457,6 +457,8 @@ class WalletNode:
             await proxy.close()
             await asyncio.sleep(0.5)  # https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
         self.wallet_peers = None
+        self.race_cache = {}
+        self.race_cache_hashes = []
         self._balance_cache = {}
 
     def _set_state_changed_callback(self, callback: StateChangedProtocol) -> None:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1417,9 +1417,7 @@ class WalletStateManager:
                             additions = [state.coin for state in children]
                             if len(children) > 0:
                                 fee = 0
-                                known_puzzle_hash: bool = await self.puzzle_store.puzzle_hash_exists(
-                                    coin_state.coin.puzzle_hash
-                                )
+
                                 to_puzzle_hash = None
                                 coin_spend: Optional[CoinSpend] = None
                                 clawback_metadata: Optional[ClawbackMetadata] = None
@@ -1441,7 +1439,7 @@ class WalletStateManager:
                                             solution: Program = coin_spend.solution.to_program()
                                             uncurried = uncurry_puzzle(puzzle)
                                             clawback_metadata = match_clawback_puzzle(uncurried, puzzle, solution)
-                                        if clawback_metadata is not None and known_puzzle_hash:
+                                        if clawback_metadata is not None:
                                             # Add the Clawback coin as the interested coin for the sender
                                             await self.add_interested_coin_ids([coin.name()])
                                     elif wallet_identifier.type == WalletType.CAT:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1762,10 +1762,11 @@ class WalletStateManager:
 
         parent_coin_record: Optional[WalletCoinRecord] = await self.coin_store.get_coin_record(coin.parent_coin_info)
         change = parent_coin_record is not None and wallet_type.value == parent_coin_record.wallet_type
-        # Check if it is a Clawback claim
-        clawback_claim = parent_coin_record is not None and parent_coin_record.coin_type == CoinType.CLAWBACK
+        # If the coin is from a Clawback spent, we want to add the INCOMING_TX,
+        # no matter if there is another TX updated.
+        clawback = parent_coin_record is not None and parent_coin_record.coin_type == CoinType.CLAWBACK
 
-        if coinbase or clawback_claim or not coin_confirmed_transaction and not change:
+        if coinbase or clawback or not coin_confirmed_transaction and not change:
             tx_record = TransactionRecord(
                 confirmed_at_height=uint32(height),
                 created_at_time=await self.wallet_node.get_timestamp_for_height(height),

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1493,7 +1493,12 @@ class WalletStateManager:
                             if record.coin_type == CoinType.CLAWBACK:
                                 await self.interested_store.remove_interested_coin_id(coin_state.coin.name())
                                 if len(confirmed_tx_records) == 1 and record.metadata is not None:
-                                    # Cannot find outgoing tx, trying to recover it
+                                    # For a spent Clawback coin we expect to update two TXs.
+                                    # If it only has one TXs to update,
+                                    # then it means the outgoing Clawback transaction is missing.
+                                    # This because of peers returned an unspent coin state during the resync.
+                                    # We need to add the outgoing TX.
+                                    # TODO Fix the outgoing TX missing issue for other coin types
                                     created_timestamp = await self.wallet_node.get_timestamp_for_height(
                                         uint32(coin_state.spent_height)
                                     )

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1275,7 +1275,6 @@ class WalletStateManager:
         for coin_name, coin_state in zip(coin_names, coin_states):
             if peer.closed:
                 raise ConnectionError("Connection closed")
-            print(f"{self.wallet_node.logged_in_fingerprint} {coin_state}")
             self.log.debug("Add coin state: %s: %s", coin_name, coin_state)
             local_record = local_records.coin_id_to_record.get(coin_name)
             rollback_wallets = None

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -836,8 +836,7 @@ class TestWalletSimulator:
         await time_out_assert(
             20, wallet_node_2.wallet_state_manager.coin_store.count_small_unspent, 0, 1000, CoinType.CLAWBACK
         )
-        assert wallet_node_1.wallet_state_manager is not None
-        assert wallet_node_2.wallet_state_manager is not None
+
         assert len(await wallet_node_1.wallet_state_manager.coin_store.get_all_unspent_coins()) == 6
         assert len(await wallet_node_2.wallet_state_manager.coin_store.get_all_unspent_coins()) == 0
         before_txs: Dict[str, Dict[TransactionType, int]] = {"sender": {}, "recipient": {}}
@@ -881,10 +880,8 @@ class TestWalletSimulator:
 
         # use second node to start the same wallet, reusing config and db
         await wallet_node_1._start()
-        assert wallet_node_1.wallet_state_manager is not None
         await wallet_server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await wallet_node_2._start()
-        assert wallet_node_2.wallet_state_manager is not None
         await wallet_server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=20)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -871,15 +871,18 @@ class TestWalletSimulator:
         ] = await wallet_node_2.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
             1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
         )
-
         # Resync start
+        wallet_node_1.race_cache.clear()
+        wallet_node_1.race_cache_hashes.clear()
+        wallet_node_2.race_cache.clear()
+        wallet_node_2.race_cache_hashes.clear()
         wallet_node_1._close()
         await wallet_node_1._await_closed()
         wallet_node_2._close()
         await wallet_node_2._await_closed()
         wallet_node_1.config["database_path"] = "wallet/db/blockchain_wallet_v2_test1_CHALLENGE_KEY.sqlite"
         wallet_node_2.config["database_path"] = "wallet/db/blockchain_wallet_v2_test2_CHALLENGE_KEY.sqlite"
-
+        print("Resync")
         # use second node to start the same wallet, reusing config and db
         await wallet_node_1._start()
         assert wallet_node_1._wallet_state_manager

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -872,10 +872,6 @@ class TestWalletSimulator:
             1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
         )
         # Resync start
-        wallet_node_1.race_cache.clear()
-        wallet_node_1.race_cache_hashes.clear()
-        wallet_node_2.race_cache.clear()
-        wallet_node_2.race_cache_hashes.clear()
         wallet_node_1._close()
         await wallet_node_1._await_closed()
         wallet_node_2._close()
@@ -885,10 +881,10 @@ class TestWalletSimulator:
 
         # use second node to start the same wallet, reusing config and db
         await wallet_node_1._start()
-        assert wallet_node_1._wallet_state_manager
+        assert wallet_node_1.wallet_state_manager is not None
         await wallet_server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await wallet_node_2._start()
-        assert wallet_node_2._wallet_state_manager
+        assert wallet_node_2.wallet_state_manager is not None
         await wallet_server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=20)
@@ -948,7 +944,7 @@ class TestWalletSimulator:
         assert before_txs["recipient"] == after_txs["recipient"]
 
         # Check unspent coins
-        assert len(await wallet_node_1._wallet_state_manager.coin_store.get_all_unspent_coins()) == 6
+        assert len(await wallet_node_1.wallet_state_manager.coin_store.get_all_unspent_coins()) == 6
 
     @pytest.mark.parametrize(
         "trusted",

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -777,7 +777,7 @@ class TestWalletSimulator:
         await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
         expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
-        normal_puzhash = await wallet.get_new_puzzlehash()
+        normal_puzhash = bytes32(b"\00" * 32)
         # Transfer to normal wallet
         tx = await wallet.generate_signed_transaction(
             uint64(500),
@@ -841,6 +841,7 @@ class TestWalletSimulator:
         # transactions should be the same
         assert len(after_txs) == len(before_txs)
         # Check clawback
+
         clawback_tx = await wallet_node_2.wallet_state_manager.tx_store.get_transaction_record(clawback_coin_id)
         assert clawback_tx is not None
         assert clawback_tx.confirmed

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -21,7 +21,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import compute_additions
 from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
-from chia.util.config import load_config
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from chia.wallet.payment import Payment
@@ -762,96 +761,191 @@ class TestWalletSimulator:
         num_blocks = 1
         full_nodes, wallets, _ = two_wallet_nodes
         full_node_api = full_nodes[0]
-        server_1 = full_node_api.full_node.server
-        wallet_node, server_2 = wallets[0]
-        wallet_node_2, server_3 = wallets[1]
-        wallet = wallet_node.wallet_state_manager.main_wallet
-        api_0 = WalletRpcApi(wallet_node)
+        full_node_server = full_node_api.full_node.server
+        wallet_node_1, wallet_server_1 = wallets[0]
+        wallet_node_2, wallet_server_2 = wallets[1]
+        wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
+        wallet_2 = wallet_node_2.wallet_state_manager.main_wallet
+        api_1 = WalletRpcApi(wallet_node_1)
         if trusted:
-            wallet_node.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
-            wallet_node_2.config["trusted_peers"] = {server_1.node_id.hex(): server_1.node_id.hex()}
+            wallet_node_1.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
+            wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
         else:
-            wallet_node.config["trusted_peers"] = {}
+            wallet_node_1.config["trusted_peers"] = {}
             wallet_node_2.config["trusted_peers"] = {}
 
-        await server_2.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
-        await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
-        expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
-        normal_puzhash = bytes32(b"\00" * 32)
+        await wallet_server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        await wallet_server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
+        wallet_1_puzhash = await wallet_1.get_new_puzzlehash()
+        wallet_2_puzhash = await wallet_2.get_new_puzzlehash()
+
         # Transfer to normal wallet
-        tx = await wallet.generate_signed_transaction(
+        tx1 = await wallet_1.generate_signed_transaction(
             uint64(500),
-            normal_puzhash,
+            wallet_2_puzhash,
             uint64(0),
             puzzle_decorator_override=[{"decorator": "CLAWBACK", "clawback_timelock": 5}],
         )
-        clawback_coin_id = tx.additions[0].name()
-        assert tx.spend_bundle is not None
-        await wallet.push_transaction(tx)
-        await full_node_api.wait_transaction_records_entered_mempool(records=[tx])
-        expected_confirmed_balance += await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
+
+        clawback_coin_id_1 = tx1.additions[0].name()
+        assert tx1.spend_bundle is not None
+        await wallet_1.push_transaction(tx1)
+        await full_node_api.wait_transaction_records_entered_mempool(records=[tx1])
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
         # Check merkle coins
         await time_out_assert(
-            20, wallet_node.wallet_state_manager.coin_store.count_small_unspent, 1, 1000, CoinType.CLAWBACK
+            20, wallet_node_1.wallet_state_manager.coin_store.count_small_unspent, 1, 1000, CoinType.CLAWBACK
         )
-        assert await wallet.get_confirmed_balance() == 3999999999500
+        await time_out_assert(
+            20, wallet_node_2.wallet_state_manager.coin_store.count_small_unspent, 1, 1000, CoinType.CLAWBACK
+        )
+        tx2 = await wallet_1.generate_signed_transaction(
+            uint64(700),
+            wallet_1_puzhash,
+            uint64(0),
+            puzzle_decorator_override=[{"decorator": "CLAWBACK", "clawback_timelock": 5}],
+        )
+        clawback_coin_id_2 = tx2.additions[0].name()
+        assert tx2.spend_bundle is not None
+        await wallet_1.push_transaction(tx2)
+        await full_node_api.wait_transaction_records_entered_mempool(records=[tx2])
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
+        # Check merkle coins
+        await time_out_assert(
+            20, wallet_node_1.wallet_state_manager.coin_store.count_small_unspent, 2, 1000, CoinType.CLAWBACK
+        )
+        await time_out_assert(
+            20, wallet_node_2.wallet_state_manager.coin_store.count_small_unspent, 1, 1000, CoinType.CLAWBACK
+        )
+        assert await wallet_1.get_confirmed_balance() == 1999999998800
+        assert await wallet_2.get_confirmed_balance() == 0
         await asyncio.sleep(10)
         # clawback merkle coin
-        resp = await api_0.spend_clawback_coins(
-            dict({"coin_ids": [normal_puzhash.hex(), clawback_coin_id.hex()], "fee": 0})
-        )
+        resp = await api_1.spend_clawback_coins(dict({"coin_ids": [clawback_coin_id_1.hex()], "fee": 0}))
         json.dumps(resp)
         assert resp["success"]
         assert len(resp["transaction_ids"]) == 1
-        expected_confirmed_balance += await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
+        resp = await api_1.spend_clawback_coins(dict({"coin_ids": [clawback_coin_id_2.hex()], "fee": 0}))
+        assert resp["success"]
+        assert len(resp["transaction_ids"]) == 1
+        expected_confirmed_balance += await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
         await time_out_assert(
-            20, wallet_node.wallet_state_manager.coin_store.count_small_unspent, 0, 1000, CoinType.CLAWBACK
+            20, wallet_node_1.wallet_state_manager.coin_store.count_small_unspent, 0, 1000, CoinType.CLAWBACK
         )
+        await time_out_assert(
+            20, wallet_node_2.wallet_state_manager.coin_store.count_small_unspent, 0, 1000, CoinType.CLAWBACK
+        )
+        assert wallet_node_1.wallet_state_manager is not None
+        assert wallet_node_2.wallet_state_manager is not None
+        assert len(await wallet_node_1.wallet_state_manager.coin_store.get_all_unspent_coins()) == 6
+        assert len(await wallet_node_2.wallet_state_manager.coin_store.get_all_unspent_coins()) == 0
+        before_txs: Dict[str, Dict[TransactionType, int]] = {"sender": {}, "recipient": {}}
+        before_txs["sender"][
+            TransactionType.INCOMING_CLAWBACK_SEND
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
+        )
+        before_txs["sender"][
+            TransactionType.OUTGOING_CLAWBACK
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.OUTGOING_CLAWBACK])
+        )
+        before_txs["sender"][
+            TransactionType.OUTGOING_TX
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.OUTGOING_TX])
+        )
+        before_txs["sender"][
+            TransactionType.INCOMING_TX
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_TX])
+        )
+        before_txs["sender"][
+            TransactionType.COINBASE_REWARD
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.COINBASE_REWARD])
+        )
+        before_txs["recipient"][
+            TransactionType.INCOMING_CLAWBACK_RECEIVE
+        ] = await wallet_node_2.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
+        )
+
+        # Resync start
+        wallet_node_1._close()
+        await wallet_node_1._await_closed()
         wallet_node_2._close()
         await wallet_node_2._await_closed()
-        # set flag to reset wallet sync data on start
-        await api_0.set_wallet_resync_on_startup({"enable": True})
-        fingerprint = wallet_node.logged_in_fingerprint
-        assert wallet_node._wallet_state_manager
-        # 2 reward coins, 1 clawbacked coin
-        assert len(await wallet_node._wallet_state_manager.coin_store.get_all_unspent_coins()) == 7
-        # standard wallet
-        assert len(await wallet_node.wallet_state_manager.user_store.get_all_wallet_info_entries()) == 1
-        before_txs = await wallet_node.wallet_state_manager.tx_store.get_all_transactions()
-        # Delete tx records
-        await wallet_node.wallet_state_manager.tx_store.rollback_to_block(0)
-        wallet_node._close()
-        await wallet_node._await_closed()
-        config = load_config(wallet_node.root_path, "config.yaml")
-        # check that flag was set in config file
-        assert config["wallet"]["reset_sync_for_fingerprint"] == fingerprint
-        new_config = wallet_node.config.copy()
-        new_config["reset_sync_for_fingerprint"] = config["wallet"]["reset_sync_for_fingerprint"]
-        new_config["database_path"] = "wallet/db/blockchain_wallet_v2_test_CHALLENGE_KEY.sqlite"
-        wallet_node_2.config = new_config
-        wallet_node_2.root_path = wallet_node.root_path
-        wallet_node_2.local_keychain = wallet_node.local_keychain
-        # use second node to start the same wallet, reusing config and db
-        await wallet_node_2._start_with_fingerprint(fingerprint)
-        assert wallet_node_2._wallet_state_manager
-        await server_3.start_client(PeerInfo(self_hostname, uint16(server_1._port)), None)
-        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
-        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_2, timeout=20)
-        after_txs = await wallet_node_2.wallet_state_manager.tx_store.get_all_transactions()
-        # transactions should be the same
-        assert len(after_txs) == len(before_txs)
-        # Check clawback
+        wallet_node_1.config["database_path"] = "wallet/db/blockchain_wallet_v2_test1_CHALLENGE_KEY.sqlite"
+        wallet_node_2.config["database_path"] = "wallet/db/blockchain_wallet_v2_test2_CHALLENGE_KEY.sqlite"
 
-        clawback_tx = await wallet_node_2.wallet_state_manager.tx_store.get_transaction_record(clawback_coin_id)
-        assert clawback_tx is not None
-        assert clawback_tx.confirmed
-        outgoing_clawback_txs = await wallet_node_2.wallet_state_manager.tx_store.get_transactions_between(
+        # use second node to start the same wallet, reusing config and db
+        await wallet_node_1._start()
+        assert wallet_node_1._wallet_state_manager
+        await wallet_server_1.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        await wallet_node_2._start()
+        assert wallet_node_2._wallet_state_manager
+        await wallet_server_2.start_client(PeerInfo(self_hostname, uint16(full_node_server._port)), None)
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32(b"\00" * 32)))
+        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=20)
+        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_2, timeout=20)
+        after_txs: Dict[str, Dict[TransactionType, int]] = {"sender": {}, "recipient": {}}
+        after_txs["sender"][
+            TransactionType.INCOMING_CLAWBACK_SEND
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
+        )
+        after_txs["sender"][
+            TransactionType.OUTGOING_CLAWBACK
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.OUTGOING_CLAWBACK])
+        )
+        after_txs["sender"][
+            TransactionType.OUTGOING_TX
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.OUTGOING_TX])
+        )
+        after_txs["sender"][
+            TransactionType.INCOMING_TX
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_TX])
+        )
+        after_txs["sender"][
+            TransactionType.COINBASE_REWARD
+        ] = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.COINBASE_REWARD])
+        )
+        after_txs["recipient"][
+            TransactionType.INCOMING_CLAWBACK_RECEIVE
+        ] = await wallet_node_2.wallet_state_manager.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
+        )
+        # Check clawback
+        clawback_tx_1 = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_record(clawback_coin_id_1)
+        clawback_tx_2 = await wallet_node_1.wallet_state_manager.tx_store.get_transaction_record(clawback_coin_id_2)
+        assert clawback_tx_1 is not None
+        assert clawback_tx_1.confirmed
+        assert clawback_tx_2 is not None
+        assert clawback_tx_2.confirmed
+        outgoing_clawback_txs = await wallet_node_1.wallet_state_manager.tx_store.get_transactions_between(
             1, 0, 100, type_filter=TransactionTypeFilter.include([TransactionType.OUTGOING_CLAWBACK])
         )
-        assert len(outgoing_clawback_txs) == 1
+        assert len(outgoing_clawback_txs) == 2
         assert outgoing_clawback_txs[0].confirmed
+        assert outgoing_clawback_txs[1].confirmed
+
+        # transactions should be the same
+        print(before_txs)
+        assert (
+            before_txs["sender"][TransactionType.OUTGOING_CLAWBACK]
+            == after_txs["sender"][TransactionType.OUTGOING_CLAWBACK]
+        )
+        assert before_txs["sender"] == after_txs["sender"]
+        assert before_txs["recipient"] == after_txs["recipient"]
+
         # Check unspent coins
-        assert len(await wallet_node_2._wallet_state_manager.coin_store.get_all_unspent_coins()) == 7
+        assert len(await wallet_node_1._wallet_state_manager.coin_store.get_all_unspent_coins()) == 6
 
     @pytest.mark.parametrize(
         "trusted",

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -882,7 +882,7 @@ class TestWalletSimulator:
         await wallet_node_2._await_closed()
         wallet_node_1.config["database_path"] = "wallet/db/blockchain_wallet_v2_test1_CHALLENGE_KEY.sqlite"
         wallet_node_2.config["database_path"] = "wallet/db/blockchain_wallet_v2_test2_CHALLENGE_KEY.sqlite"
-        print("Resync")
+
         # use second node to start the same wallet, reusing config and db
         await wallet_node_1._start()
         assert wallet_node_1._wallet_state_manager
@@ -939,7 +939,7 @@ class TestWalletSimulator:
         assert outgoing_clawback_txs[1].confirmed
 
         # transactions should be the same
-        print(before_txs)
+
         assert (
             before_txs["sender"][TransactionType.OUTGOING_CLAWBACK]
             == after_txs["sender"][TransactionType.OUTGOING_CLAWBACK]


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This PR fixes two issues:
1. Clawback sender cannot claim their fund after the resync.
2. Add missing INCOMING_TX for the claim side and ensure the tx counts are the same after the resync.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
1. After resync, the interested_coins table will not recovery as expected. The Clawback sender will not receive the coin state of the clawback coin.
2. After the claim and before the resync, the wallet will not add an INCOMING_TX for the claimed fund. But after the resync, this tx will be added


### New Behavior:
1. For resync coins only, check if the coin is a clawback coin. If it is, then add it to the interested_coins.
2. If it is a clawback's child, add the tx no matter if there is a pending tx related to it.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Unit test


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
