### PR TITLE
make ConditionOpcodes not streamable

### DIFF
--- a/chia/types/condition_opcodes.py
+++ b/chia/types/condition_opcodes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import enum
-from typing import Any
 
 
 # See chia/wallet/puzzles/condition_codes.clib
@@ -67,11 +66,3 @@ class ConditionOpcode(bytes, enum.Enum):
 
     # A condition that is always true and always ignore all arguments
     REMARK = bytes([1])
-
-    def __bytes__(self) -> bytes:
-        return bytes(self.value)
-
-    @classmethod
-    def from_bytes(cls: Any, blob: bytes) -> Any:
-        assert len(blob) == 1
-        return cls(blob)

--- a/chia/types/condition_with_args.py
+++ b/chia/types/condition_with_args.py
@@ -4,12 +4,10 @@ from dataclasses import dataclass
 from typing import List
 
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.util.streamable import Streamable, streamable
 
 
-@streamable
 @dataclass(frozen=True)
-class ConditionWithArgs(Streamable):
+class ConditionWithArgs:
     """
     This structure is used to store parsed CLVM conditions
     Conditions in CLVM have either format of (opcode, var1) or (opcode, var1, var2)

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -86,7 +86,6 @@ size_hints = {
     "PrivateKey": PrivateKey.PRIVATE_KEY_SIZE,
     "G1Element": G1Element.SIZE,
     "G2Element": G2Element.SIZE,
-    "ConditionOpcode": 1,
 }
 unhashable_types = [
     "PrivateKey",
@@ -578,7 +577,6 @@ class Streamable:
     * BLS signatures serialized in bls format (96 bytes)
     * bool serialized into 1 byte (0x01 or 0x00)
     * bytes serialized as a 4 byte size prefix and then the bytes.
-    * ConditionOpcode is serialized as a 1 byte value.
     * str serialized as a 4 byte size prefix and then the utf-8 representation in bytes.
 
     An item is one of:

--- a/tests/util/test_condition_tools.py
+++ b/tests/util/test_condition_tools.py
@@ -71,13 +71,15 @@ def test_pkm_pairs_vs_for_conditions_dict(opcode: ConditionOpcode) -> None:
     conds = mk_agg_sig_conditions(opcode, agg_sig_data=[(bytes48(PK1), b"msg1"), (bytes48(PK2), b"msg2")])
     pks, msgs = pkm_pairs(conds, b"foobar")
     result_aligned = [(x, y) for x, y in zip(pks, msgs)]
-    conditions_dict = {opcode: [ConditionWithArgs(opcode, [PK1, b"msg1"]), ConditionWithArgs(opcode, [PK2, b"msg2"])]}
+    conditions_dict = {
+        opcode: [ConditionWithArgs(opcode, [bytes48(PK1), b"msg1"]), ConditionWithArgs(opcode, [bytes48(PK2), b"msg2"])]
+    }
     result2 = pkm_pairs_for_conditions_dict(conditions_dict, TEST_COIN, b"foobar")
     assert result_aligned == result2
 
     # missing message argument
     with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
-        conditions_dict = {opcode: [ConditionWithArgs(opcode, [PK1])]}
+        conditions_dict = {opcode: [ConditionWithArgs(opcode, [bytes48(PK1)])]}
         result2 = pkm_pairs_for_conditions_dict(conditions_dict, TEST_COIN, b"foobar")
 
     with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
@@ -86,12 +88,12 @@ def test_pkm_pairs_vs_for_conditions_dict(opcode: ConditionOpcode) -> None:
 
     # extra argument
     with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
-        conditions_dict = {opcode: [ConditionWithArgs(opcode, [PK1, b"msg1", b"msg2"])]}
+        conditions_dict = {opcode: [ConditionWithArgs(opcode, [bytes48(PK1), b"msg1", b"msg2"])]}
         result2 = pkm_pairs_for_conditions_dict(conditions_dict, TEST_COIN, b"foobar")
 
     # message too long
     with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
-        conditions_dict = {opcode: [ConditionWithArgs(opcode, [PK1, b"m" * 1025])]}
+        conditions_dict = {opcode: [ConditionWithArgs(opcode, [bytes48(PK1), b"m" * 1025])]}
         result2 = pkm_pairs_for_conditions_dict(conditions_dict, TEST_COIN, b"foobar")
 
 
@@ -213,7 +215,9 @@ class TestPkmPairsForConditionDict:
     def test_agg_sig_unsafe_restriction(self) -> None:
         ASU = ConditionOpcode.AGG_SIG_UNSAFE
 
-        conds = {ASU: [ConditionWithArgs(ASU, [PK1, b"msg1"]), ConditionWithArgs(ASU, [PK2, b"msg2"])]}
+        conds = {
+            ASU: [ConditionWithArgs(ASU, [bytes48(PK1), b"msg1"]), ConditionWithArgs(ASU, [bytes48(PK2), b"msg2"])]
+        }
         tuples = pkm_pairs_for_conditions_dict(conds, TEST_COIN, b"msg10")
         assert tuples == [(bytes48(PK1), b"msg1"), (bytes48(PK2), b"msg2")]
 


### PR DESCRIPTION
`ConditionOpcode`s can be more than 1 byte now (as we introduced multi-byte, unknown, condition codes with cost, in the hard-fork).

Leaving them streamable in their current form (as a single byte) seems risky. It turns out that we no longer need them to be streamable anyway. This is a hold-over from the times when the multi-threaded block validation passed `ConditionWithArgs` across the process boundary.