### PR TITLE
Drop macos-10.14 support

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         python-version: [3.9]
         os:
-          - runs-on: macos-10.14
+          - runs-on: macos-11
             name: intel
             file-suffix: ""
             mac-package-name: "Chia-darwin-x64"

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -64,6 +64,7 @@ jobs:
         uses: Chia-Network/actions/setjobenv@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MACOSX_DEPLOYMENT_TARGET: 11
 
       - name: Test for secrets access
         id: check_secrets

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -33,7 +33,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: macos-10.14
+              intel: macos-11
               arm: [macos, arm64]
           - name: Windows
             matrix: windows

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -69,3 +69,4 @@ jobs:
 
     - name: Check Wheel Availability
       run: python build_scripts/check_dependency_artifacts.py
+      

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -69,4 +69,3 @@ jobs:
 
     - name: Check Wheel Availability
       run: python build_scripts/check_dependency_artifacts.py
-      


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Dropping Mojave after 2.0.0


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
currently uses macos-10.14


### New Behavior:
macos-11


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
