### PR TITLE
fix initial-config for testnet fork points heights

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -72,16 +72,16 @@ network_overrides: &network_overrides
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
       SOFT_FORK2_HEIGHT: 0
-      SOFT_FORK3_HEIGHT: 2960728
       # planned 2.0 release is July 26, height 2965036 on testnet
       # 1 week later
-      HARD_FORK_HEIGHT": 2997292
+      SOFT_FORK3_HEIGHT: 2997292
+      HARD_FORK_HEIGHT: 2997292
       # another 2 weeks later
-      PLOT_FILTER_128_HEIGHT": 3061804
+      PLOT_FILTER_128_HEIGHT: 3061804
       # 3 years later
-      PLOT_FILTER_64_HEIGHT": 8010796
+      PLOT_FILTER_64_HEIGHT: 8010796
       # 3 years later
-      PLOT_FILTER_32_HEIGHT": 13056556
+      PLOT_FILTER_32_HEIGHT: 13056556
   config:
     mainnet:
       address_prefix: "xch"


### PR DESCRIPTION
fix typo in `initial-config.yaml` and bump soft-fork 3 activation height on testnet