### PR TITLE
Set minimum macOS version to macOS 11 for Chia.app

### DIFF
--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -64,7 +64,7 @@ else
 	echo "Not on ci or no secrets so not signing"
 	export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
-echo electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME"
+echo electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME" --config.mac.minimumSystemVersion="11"
 electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME"
 LAST_EXIT_CODE=$?
 ls -l dist/mac*/chia.app/Contents/Resources/app.asar

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -65,7 +65,7 @@ else
 	export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 echo electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME" --config.mac.minimumSystemVersion="11"
-electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME"
+electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME" --config.mac.minimumSystemVersion="11"
 LAST_EXIT_CODE=$?
 ls -l dist/mac*/chia.app/Contents/Resources/app.asar
 


### PR DESCRIPTION
This set the minimum macOS version to macOS 11 for the Chia.app

On older versions, users will see 

![Screenshot 2023-07-27 at 12 55 04 PM](https://github.com/Chia-Network/chia-blockchain/assets/30607889/1c9ce3e8-c25c-4dd1-8341-7499c94c8272)
