### PR TITLE
introduce SOFT_FORK4_HEIGHT and tie CHIP-13 to it

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -66,7 +66,7 @@ async def validate_block_body(
     # from the database too (BlockStore). In `BlockHeaderValidation` we don't have access to the database,
     # just the cache. This check makes sure we retrieve blocks from the database and perform the check with them,
     # in case they were missing from the cache.
-    if height >= constants.SOFT_FORK3_HEIGHT:
+    if height >= constants.SOFT_FORK4_HEIGHT:
         curr_optional_block_record: Optional[BlockRecord] = await blocks.get_block_record_from_db(
             block.prev_header_hash
         )

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -497,7 +497,7 @@ def validate_unfinished_header_block(
         return None, ValidationError(Err.INVALID_POSPACE)
 
     # 5c. Check plot id is not present within last `NUM_DISTINCT_CONSECUTIVE_PLOT_IDS` blocks.
-    if height >= constants.SOFT_FORK3_HEIGHT:
+    if height >= constants.SOFT_FORK4_HEIGHT:
         curr_optional_block_record: Optional[BlockRecord] = prev_b
         plot_id = get_plot_id(header_block.reward_chain_block.proof_of_space)
         curr_sp = cc_sp_hash

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -65,6 +65,9 @@ class ConsensusConstants:
     # soft fork initiated in 2.0 release
     SOFT_FORK3_HEIGHT: uint32
 
+    # soft fork initiated in 2.1 release
+    SOFT_FORK4_HEIGHT: uint32
+
     # the hard fork planned with the 2.0 release
     # this is the block with the first plot filter adjustment
     HARD_FORK_HEIGHT: uint32

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -57,6 +57,8 @@ default_kwargs = {
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
     # October 23, 2023
     "SOFT_FORK3_HEIGHT": 4410000,
+    # December 4, 2023
+    "SOFT_FORK4_HEIGHT": 4603536,
     # June 2024
     "HARD_FORK_HEIGHT": 5496000,
     # June 2027

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -74,6 +74,8 @@ def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None
     # these numbers are supposed to match initial-config.yaml
     if "SOFT_FORK3_HEIGHT" not in overrides:
         overrides["SOFT_FORK3_HEIGHT"] = 2997292
+    if "SOFT_FORK4_HEIGHT" not in overrides:
+        overrides["SOFT_FORK4_HEIGHT"] = 2997292
     if "HARD_FORK_HEIGHT" not in overrides:
         overrides["HARD_FORK_HEIGHT"] = 2997292
     if "PLOT_FILTER_128_HEIGHT" not in overrides:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -729,7 +729,7 @@ class BlockTools:
                                     continue
                         assert latest_block.header_hash in blocks
                         plot_id = get_plot_id(proof_of_space)
-                        if latest_block.height + 1 >= constants.SOFT_FORK3_HEIGHT:
+                        if latest_block.height + 1 >= constants.SOFT_FORK4_HEIGHT:
                             if self.plot_id_passed_previous_filters(plot_id, cc_sp_output_hash, block_list):
                                 continue
                         additions = None
@@ -1031,7 +1031,7 @@ class BlockTools:
                             break
                         assert last_timestamp is not None
                         plot_id = get_plot_id(proof_of_space)
-                        if latest_block.height + 1 >= constants.SOFT_FORK3_HEIGHT:
+                        if latest_block.height + 1 >= constants.SOFT_FORK4_HEIGHT:
                             if self.plot_id_passed_previous_filters(plot_id, cc_sp_output_hash, block_list):
                                 continue
                         if proof_of_space.pool_contract_puzzle_hash is not None:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -72,6 +72,7 @@ network_overrides: &network_overrides
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
       SOFT_FORK3_HEIGHT: 2997292
+      SOFT_FORK4_HEIGHT: 2997292
       # planned 2.0 release is July 26, height 2965036 on testnet
       # 1 week later
       HARD_FORK_HEIGHT: 2997292

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,9 +101,10 @@ class Mode(Enum):
     PLAIN = 0
     HARD_FORK_2_0 = 1
     SOFT_FORK3 = 2
+    SOFT_FORK4 = 3
 
 
-@pytest.fixture(scope="session", params=[Mode.PLAIN, Mode.HARD_FORK_2_0, Mode.SOFT_FORK3])
+@pytest.fixture(scope="session", params=[Mode.PLAIN, Mode.HARD_FORK_2_0, Mode.SOFT_FORK3, Mode.SOFT_FORK4])
 def consensus_mode(request):
     return request.param
 
@@ -114,6 +115,8 @@ def blockchain_constants(consensus_mode) -> ConsensusConstants:
         return test_constants
     if consensus_mode == Mode.SOFT_FORK3:
         return test_constants.replace(SOFT_FORK3_HEIGHT=3)
+    if consensus_mode == Mode.SOFT_FORK4:
+        return test_constants.replace(SOFT_FORK3_HEIGHT=3, SOFT_FORK4_HEIGHT=3)
     if consensus_mode == Mode.HARD_FORK_2_0:
         return test_constants.replace(
             HARD_FORK_HEIGHT=2, PLOT_FILTER_128_HEIGHT=10, PLOT_FILTER_64_HEIGHT=15, PLOT_FILTER_32_HEIGHT=20
@@ -180,7 +183,7 @@ saved_blocks_version = "rc5"
 @pytest.fixture(scope="session")
 def default_400_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         version = "_softfork3"
 
     from tests.util.blockchain import persistent_blocks
@@ -191,7 +194,7 @@ def default_400_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def default_1000_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         version = "_softfork3"
 
     from tests.util.blockchain import persistent_blocks
@@ -202,7 +205,7 @@ def default_1000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def pre_genesis_empty_slots_1000_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         version = "_softfork3"
 
     from tests.util.blockchain import persistent_blocks
@@ -219,7 +222,7 @@ def pre_genesis_empty_slots_1000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def default_1500_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         version = "_softfork3"
 
     from tests.util.blockchain import persistent_blocks
@@ -231,7 +234,7 @@ def default_1500_blocks(bt, consensus_mode):
 def default_10000_blocks(bt, consensus_mode):
     from tests.util.blockchain import persistent_blocks
 
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         pytest.skip("Test cache not available yet")
 
     return persistent_blocks(10000, f"test_blocks_10000_{saved_blocks_version}.db", bt, seed=b"10000")
@@ -239,7 +242,7 @@ def default_10000_blocks(bt, consensus_mode):
 
 @pytest.fixture(scope="session")
 def default_20000_blocks(bt, consensus_mode):
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         pytest.skip("Test cache not available")
 
     from tests.util.blockchain import persistent_blocks
@@ -250,7 +253,7 @@ def default_20000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
     version = ""
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         version = "_softfork3"
 
     from tests.util.blockchain import persistent_blocks
@@ -268,7 +271,7 @@ def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
 @pytest.fixture(scope="session")
 def default_2000_blocks_compact(bt, consensus_mode):
     version = ""
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         version = "_softfork3"
 
     from tests.util.blockchain import persistent_blocks
@@ -289,7 +292,7 @@ def default_2000_blocks_compact(bt, consensus_mode):
 def default_10000_blocks_compact(bt, consensus_mode):
     from tests.util.blockchain import persistent_blocks
 
-    if consensus_mode == Mode.SOFT_FORK3:
+    if consensus_mode == Mode.SOFT_FORK4:
         pytest.skip("Test cache not available yet")
     return persistent_blocks(
         10000,
@@ -363,14 +366,14 @@ async def five_nodes(db_version: int, self_hostname, blockchain_constants):
 @pytest_asyncio.fixture(scope="function")
 async def wallet_nodes(blockchain_constants, consensus_mode):
     # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
-    # mode `PLAIN` and `SOFT_FORK3`.
-    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK3):
+    # mode `PLAIN` and `SOFT_FORK4`.
+    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK4):
         pytest.skip("Skipping duplicate test, the same setup is ran by Mode.PLAIN")
     constants = blockchain_constants
     async_gen = setup_simulators_and_wallets(
         2,
         1,
-        {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 400000000, "SOFT_FORK3_HEIGHT": constants.SOFT_FORK3_HEIGHT},
+        {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 400000000, "SOFT_FORK4_HEIGHT": constants.SOFT_FORK4_HEIGHT},
     )
     nodes, wallets, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
@@ -400,11 +403,11 @@ async def two_nodes_sim_and_wallets():
 @pytest_asyncio.fixture(scope="function")
 async def two_nodes_sim_and_wallets_services(blockchain_constants, consensus_mode):
     # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
-    # mode `PLAIN` and `SOFT_FORK3`.
-    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK3):
+    # mode `PLAIN` and `SOFT_FORK4`.
+    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK4):
         pytest.skip("Skipping duplicate test, the same setup is ran by Mode.PLAIN")
     async for _ in setup_simulators_and_wallets_service(
-        2, 0, {"SOFT_FORK3_HEIGHT": blockchain_constants.SOFT_FORK3_HEIGHT}
+        2, 0, {"SOFT_FORK4_HEIGHT": blockchain_constants.SOFT_FORK4_HEIGHT}
     ):
         yield _
 

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -378,7 +378,7 @@ class TestConditions:
         pre-v2-softfork, and rejects more than the announcement limit afterward.
         """
 
-        if consensus_mode != Mode.SOFT_FORK3:
+        if consensus_mode.value < Mode.SOFT_FORK3.value:
             # before softfork 3, there was no limit on the number of
             # announcements
             expect_err = None

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -27,13 +27,17 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.hash import std_hash
 from chia.util.ints import uint8
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
+from tests.conftest import Mode
 from tests.connection_utils import connect_and_get_peer
 from tests.util.rpc import validate_get_routes
 
 
 class TestRpc:
     @pytest.mark.asyncio
-    async def test1(self, two_nodes_sim_and_wallets_services, self_hostname):
+    async def test1(self, two_nodes_sim_and_wallets_services, self_hostname, consensus_mode):
+        if consensus_mode != Mode.PLAIN:
+            pytest.skip("test does not depend on consesus rules")
+
         num_blocks = 5
         nodes, _, bt = two_nodes_sim_and_wallets_services
         full_node_service_1, full_node_service_2 = nodes

--- a/tests/util/test_testnet_overrides.py
+++ b/tests/util/test_testnet_overrides.py
@@ -10,6 +10,7 @@ def test_testnet10() -> None:
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
         "SOFT_FORK3_HEIGHT": 2997292,
+        "SOFT_FORK4_HEIGHT": 2997292,
         "HARD_FORK_HEIGHT": 2997292,
         "PLOT_FILTER_128_HEIGHT": 3061804,
         "PLOT_FILTER_64_HEIGHT": 8010796,
@@ -20,6 +21,7 @@ def test_testnet10() -> None:
 def test_testnet10_existing() -> None:
     overrides: Dict[str, Any] = {
         "SOFT_FORK3_HEIGHT": 42,
+        "SOFT_FORK4_HEIGHT": 45,
         "HARD_FORK_HEIGHT": 42,
         "PLOT_FILTER_128_HEIGHT": 42,
         "PLOT_FILTER_64_HEIGHT": 42,
@@ -28,6 +30,7 @@ def test_testnet10_existing() -> None:
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
         "SOFT_FORK3_HEIGHT": 42,
+        "SOFT_FORK4_HEIGHT": 45,
         "HARD_FORK_HEIGHT": 42,
         "PLOT_FILTER_128_HEIGHT": 42,
         "PLOT_FILTER_64_HEIGHT": 42,


### PR DESCRIPTION
Note that testnet has soft-fork3, soft-fork4 and the hard-fork all activate at the same time. This is unchanged from current testnet activation heights.

There is one line missing test coverage:
```
tests/conftest.py (93.3%): Missing lines 245
```

It seems there is no test using the `default_20000_blocks` fixture.

~~This adds a lot of new test cases, it's probably a good idea to land https://github.com/Chia-Network/chia-blockchain/pull/15793 before landing this one.~~