### PR TITLE
Rework Bladebit artifact logic, CI cleanup, release simulation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -53,7 +53,7 @@ jobs:
         id: pip-cache
         shell: bash
         run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pip
         uses: actions/cache@v3

--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -7,7 +7,9 @@ on:
         description: 'Tagged release testing scenario'
         required: false
         type: choice
+        default: ''
         options:
+        - ''
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -2,12 +2,12 @@ name: 📦🚀 Build Installer - Linux DEB ARM64
 
 on:
   workflow_dispatch:
-  inputs:
-    release_type:
-      description: 'Tagged release testing scenario'
-      required: false
-      type: choice
-      options:
+    inputs:
+      release_type:
+        description: 'Tagged release testing scenario'
+        required: false
+        type: choice
+        options:
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -71,9 +71,9 @@ jobs:
       run: |
         REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
         REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
-        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.release_type }}" =~ $REG_B ]]; then
           echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
-        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.release_type }}" =~ $REG_RC ]]; then
           echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/build-linux-arm64-installer.yml
+++ b/.github/workflows/build-linux-arm64-installer.yml
@@ -2,6 +2,15 @@ name: 📦🚀 Build Installer - Linux DEB ARM64
 
 on:
   workflow_dispatch:
+  inputs:
+    release_type:
+      description: 'Tagged release testing scenario'
+      required: false
+      type: choice
+      options:
+        - 9.9.9-b1
+        - 9.9.9-rc1
+        - 9.9.9
   push:
     paths-ignore:
     - '**.md'
@@ -56,6 +65,18 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check tag type
+      id: check_tag_type
+      shell: bash
+      run: |
+        REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
+        REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+          echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+          echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
+        fi
+
     # Create our own venv outside of the git directory JUST for getting the ACTUAL version so that install can't break it
     - name: Get version number
       id: version_number
@@ -63,7 +84,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
+        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Test for secrets access
@@ -74,10 +95,10 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> $GITHUB_OUTPUT
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> "$GITHUB_OUTPUT"
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> $GITHUB_OUTPUT
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> "$GITHUB_OUTPUT"
       env:
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
         GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
@@ -87,34 +108,64 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/madmax"
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot-*-arm64' -O $GITHUB_WORKSPACE/madmax/chia_plot
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot_k34-*-arm64' -O $GITHUB_WORKSPACE/madmax/chia_plot_k34
-        chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot"
-        chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot_k34"
+        mkdir "$GITHUB_WORKSPACE"/madmax
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-*-arm64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-*-arm64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
 
-    - name: Get latest bladebit plotter
-      if: '!github.event.release.prerelease'
+    - name: Get latest bladebit plotter for Full Release
+      if: "github.event.release && !github.event.release.prerelease"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
       run: |
-        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/bladebit"
-        cd "$GITHUB_WORKSPACE/bladebit"
-        gh release download -R Chia-Network/bladebit $LATEST_BLADEBIT -p 'bladebit*-ubuntu-arm64.tar.gz'
+        LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
+        gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-ubuntu-arm64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
         cd "$OLDPWD"
 
-    - name: Get latest prerelease bladebit plotter
-      if: env.PRE_RELEASE == 'true'
+    - name: Get latest beta bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'beta'"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
       run: |
-        LATEST_PRERELEASE=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease)) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/bladebit"
-        cd "$GITHUB_WORKSPACE/bladebit"
-        gh release download -R Chia-Network/bladebit $LATEST_PRERELEASE -p 'bladebit*ubuntu-arm64.tar.gz'
+        LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
+        gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-ubuntu-arm64.tar.gz'
+        ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+        ls bladebit* | xargs -I{} chmod +x {}
+        cd "$OLDPWD"
+
+    - name: Get latest RC bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'rc'"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
+        gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-ubuntu-arm64.tar.gz'
+        ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+        ls bladebit* | xargs -I{} chmod +x {}
+        cd "$OLDPWD"
+
+    - name: Get latest bladebit plotter for Dev
+      if: "!github.event.release"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
+        gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-ubuntu-arm64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
         cd "$OLDPWD"
@@ -131,7 +182,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "GUI_REF=${gui_ref}" >> $GITHUB_OUTPUT
+        echo "GUI_REF=${gui_ref}" >> "$GITHUB_OUTPUT"
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -178,7 +229,7 @@ jobs:
       run: |
         GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
         CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-        echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >>$GITHUB_ENV
+        echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >> "$GITHUB_ENV"
         aws s3 cp "$GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb" "s3://download.chia.net/dev/chia-blockchain_${CHIA_DEV_BUILD}_arm64.deb"
         aws s3 cp "$GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb" "s3://download.chia.net/dev/chia-blockchain-cli_${CHIA_DEV_BUILD}-1_arm64.deb"
 
@@ -187,10 +238,10 @@ jobs:
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
-        sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256
-        sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.sha256
-        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
+        ls "$GITHUB_WORKSPACE"/build_scripts/final_installer/
+        sha256sum "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb > "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256
+        sha256sum "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb > "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.sha256
+        ls "$GITHUB_WORKSPACE"/build_scripts/final_installer/
 
     - name: Create torrent
       if: env.FULL_RELEASE == 'true'
@@ -198,38 +249,31 @@ jobs:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb
-        gh release upload $RELEASE_TAG $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb -o "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb -o "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb
+        gh release upload $RELEASE_TAG "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent
 
     - name: Upload Dev Installer
       if: steps.check_secrets.outputs.HAS_AWS_SECRET && github.ref == 'refs/heads/main'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download.chia.net/latest-dev/chia-blockchain_arm64_latest_dev.deb
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain_arm64_latest_dev.deb.sha256
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb s3://download.chia.net/latest-dev/chia-blockchain-cli_arm64_latest_dev.deb
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain-cli_arm64_latest_dev.deb.sha256
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download.chia.net/latest-dev/chia-blockchain_arm64_latest_dev.deb
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain_arm64_latest_dev.deb.sha256
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb s3://download.chia.net/latest-dev/chia-blockchain-cli_arm64_latest_dev.deb
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain-cli_arm64_latest_dev.deb.sha256
 
     - name: Upload Release Files
       if: steps.check_secrets.outputs.HAS_AWS_SECRET && env.FULL_RELEASE == 'true'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent s3://download.chia.net/torrents/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.sha256 s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.torrent s3://download.chia.net/torrents/
-
-    - name: Get tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      id: tag-name
-      run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.sha256 s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_arm64.deb.torrent s3://download.chia.net/torrents/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.sha256 s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_arm64.deb.torrent s3://download.chia.net/torrents/
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'
@@ -245,7 +289,7 @@ jobs:
     - name: Mark installer complete
       if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
       run: |
-        curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "${{ steps.tag-name.outputs.TAG_NAME }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/success/build-arm
+        curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "$RELEASE_TAG"}' ${{ secrets.GLUE_API_URL }}/api/v1/$RFC_REPO/$RELEASE_TAG/success/build-arm
 
     - name: Clean up on self hosted runner
       run: |

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -7,7 +7,9 @@ on:
         description: 'Tagged release testing scenario'
         required: false
         type: choice
+        default: ''
         options:
+        - ''
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -2,6 +2,15 @@ name: 📦🚀 Build Installer - Linux DEB AMD64
 
 on:
   workflow_dispatch:
+  inputs:
+    release_type:
+      description: 'Tagged release testing scenario'
+      required: false
+      type: choice
+      options:
+        - 9.9.9-b1
+        - 9.9.9-rc1
+        - 9.9.9
   push:
     paths-ignore:
     - '**.md'
@@ -56,6 +65,18 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check tag type
+      id: check_tag_type
+      shell: bash
+      run: |
+        REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
+        REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+          echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+          echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
+        fi
+
     # Create our own venv outside of the git directory JUST for getting the ACTUAL version so that install can't break it
     - name: Get version number
       id: version_number
@@ -63,7 +84,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >>$GITHUB_OUTPUT
+        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Test for secrets access
@@ -74,10 +95,10 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> "$GITHUB_OUTPUT"
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >>$GITHUB_OUTPUT
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> "$GITHUB_OUTPUT"
       env:
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
         GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
@@ -87,34 +108,64 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/madmax"
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot-*-x86-64' -O $GITHUB_WORKSPACE/madmax/chia_plot
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot_k34-*-x86-64' -O $GITHUB_WORKSPACE/madmax/chia_plot_k34
-        chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot"
-        chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot_k34"
+        mkdir "$GITHUB_WORKSPACE"/madmax"
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot"
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34"
 
-    - name: Get latest bladebit plotter
-      if: '!github.event.release.prerelease'
+    - name: Get latest bladebit plotter for Full Release
+      if: "github.event.release && !github.event.release.prerelease"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
       run: |
-        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/bladebit"
-        cd "$GITHUB_WORKSPACE/bladebit"
-        gh release download -R Chia-Network/bladebit $LATEST_BLADEBIT -p 'bladebit*-ubuntu-x86-64.tar.gz'
+        LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-ubuntu-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
         cd "$OLDPWD"
 
-    - name: Get latest prerelease bladebit plotter
-      if: env.PRE_RELEASE == 'true'
+    - name: Get latest beta bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'beta'"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
       run: |
-        LATEST_PRERELEASE=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease)) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/bladebit"
-        cd "$GITHUB_WORKSPACE/bladebit"
-        gh release download -R Chia-Network/bladebit $LATEST_PRERELEASE -p 'bladebit*ubuntu-x86-64.tar.gz'
+        LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-ubuntu-x86-64.tar.gz'
+        ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+        ls bladebit* | xargs -I{} chmod +x {}
+        cd "$OLDPWD"
+
+    - name: Get latest RC bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'rc'"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-ubuntu-x86-64.tar.gz'
+        ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+        ls bladebit* | xargs -I{} chmod +x {}
+        cd "$OLDPWD"
+
+    - name: Get latest bladebit plotter for Dev
+      if: "!github.event.release"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-ubuntu-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
         cd "$OLDPWD"
@@ -131,7 +182,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "GUI_REF=${gui_ref}" >>$GITHUB_OUTPUT
+        echo "GUI_REF=${gui_ref}" >> "$GITHUB_OUTPUT"
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -178,19 +229,19 @@ jobs:
       run: |
         GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
         CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-        echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >>$GITHUB_ENV
-        aws s3 cp "$GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb" "s3://download.chia.net/dev/chia-blockchain_${CHIA_DEV_BUILD}_amd64.deb"
-        aws s3 cp "$GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb" "s3://download.chia.net/dev/chia-blockchain-cli_${CHIA_DEV_BUILD}-1_amd64.deb"
+        echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >> "$GITHUB_ENV"
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb" "s3://download.chia.net/dev/chia-blockchain_${CHIA_DEV_BUILD}_amd64.deb"
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb" "s3://download.chia.net/dev/chia-blockchain-cli_${CHIA_DEV_BUILD}-1_amd64.deb"
 
     - name: Create Checksums
       if: env.FULL_RELEASE == 'true' || github.ref == 'refs/heads/main'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
-        sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.sha256
-        sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.sha256
-        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
+        ls "$GITHUB_WORKSPACE"/build_scripts/final_installer/
+        sha256sum "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb > "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.sha256
+        sha256sum "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb > "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.sha256
+        ls "$GITHUB_WORKSPACE"/build_scripts/final_installer/
 
     - name: Create .deb torrent
       if: env.FULL_RELEASE == 'true'
@@ -198,38 +249,31 @@ jobs:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb
-        gh release upload $RELEASE_TAG $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.torrent
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb -o "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb -o "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.torrent --webseed https://download.chia.net/install/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb
+        gh release upload $RELEASE_TAG "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.torrent
 
     - name: Upload Dev Installer
       if: steps.check_secrets.outputs.HAS_AWS_SECRET && github.ref == 'refs/heads/main'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb s3://download.chia.net/latest-dev/chia-blockchain_amd64_latest_dev.deb
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain_amd64_latest_dev.deb.sha256
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb s3://download.chia.net/latest-dev/chia-blockchain-cli_amd64_latest_dev.deb
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain-cli_amd64_latest_dev.deb.sha256
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb s3://download.chia.net/latest-dev/chia-blockchain_amd64_latest_dev.deb
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain_amd64_latest_dev.deb.sha256
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb s3://download.chia.net/latest-dev/chia-blockchain-cli_amd64_latest_dev.deb
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.sha256 s3://download.chia.net/latest-dev/chia-blockchain-cli_amd64_latest_dev.deb.sha256
 
     - name: Upload Release Files
       if: steps.check_secrets.outputs.HAS_AWS_SECRET && env.FULL_RELEASE == 'true'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.sha256 s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.torrent s3://download.chia.net/torrents/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.sha256 s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.torrent s3://download.chia.net/torrents/
-
-    - name: Get tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      id: tag-name
-      run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >>$GITHUB_OUTPUT
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >>$GITHUB_OUTPUT
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.sha256 s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb.torrent s3://download.chia.net/torrents/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.sha256 s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb.torrent s3://download.chia.net/torrents/
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'
@@ -245,7 +289,7 @@ jobs:
     - name: Mark installer complete
       if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
       run: |
-        curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "${{ steps.tag-name.outputs.TAG_NAME }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/success/build-linux-deb
+        curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "$RELEASE_TAG"}' ${{ secrets.GLUE_API_URL }}/api/v1/$RFC_REPO/$RELEASE_TAG/success/build-linux-deb
 
     - name: Remove working files to exclude from cache
       run: |

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -108,11 +108,11 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/madmax"
+        mkdir "$GITHUB_WORKSPACE"/madmax
         gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot
         gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
-        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot"
-        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34"
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
 
     - name: Get latest bladebit plotter for Full Release
       if: "github.event.release && !github.event.release.prerelease"
@@ -121,8 +121,8 @@ jobs:
       shell: bash
       run: |
         LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-ubuntu-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
@@ -135,8 +135,8 @@ jobs:
       shell: bash
       run: |
         LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-ubuntu-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
@@ -149,8 +149,8 @@ jobs:
       shell: bash
       run: |
         LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-ubuntu-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
@@ -163,8 +163,8 @@ jobs:
       shell: bash
       run: |
         LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-ubuntu-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -230,8 +230,8 @@ jobs:
         GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
         CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
         echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >> "$GITHUB_ENV"
-        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb" "s3://download.chia.net/dev/chia-blockchain_${CHIA_DEV_BUILD}_amd64.deb"
-        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb" "s3://download.chia.net/dev/chia-blockchain-cli_${CHIA_DEV_BUILD}-1_amd64.deb"
+        aws s3 cp "$GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_amd64.deb" "s3://download.chia.net/dev/chia-blockchain_${CHIA_DEV_BUILD}_amd64.deb"
+        aws s3 cp "$GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_amd64.deb" "s3://download.chia.net/dev/chia-blockchain-cli_${CHIA_DEV_BUILD}-1_amd64.deb"
 
     - name: Create Checksums
       if: env.FULL_RELEASE == 'true' || github.ref == 'refs/heads/main'

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -71,9 +71,9 @@ jobs:
       run: |
         REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
         REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
-        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.release_type }}" =~ $REG_B ]]; then
           echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
-        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.release_type }}" =~ $REG_RC ]]; then
           echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -2,12 +2,12 @@ name: 📦🚀 Build Installer - Linux DEB AMD64
 
 on:
   workflow_dispatch:
-  inputs:
-    release_type:
-      description: 'Tagged release testing scenario'
-      required: false
-      type: choice
-      options:
+    inputs:
+      release_type:
+        description: 'Tagged release testing scenario'
+        required: false
+        type: choice
+        options:
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -7,7 +7,9 @@ on:
         description: 'Tagged release testing scenario'
         required: false
         type: choice
+        default: ''
         options:
+        - ''
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -2,12 +2,12 @@ name: 📦🚀 Build Installer - Linux RPM AMD64
 
 on:
   workflow_dispatch:
-  inputs:
-    release_type:
-      description: 'Tagged release testing scenario'
-      required: false
-      type: choice
-      options:
+    inputs:
+      release_type:
+        description: 'Tagged release testing scenario'
+        required: false
+        type: choice
+        options:
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -2,6 +2,15 @@ name: 📦🚀 Build Installer - Linux RPM AMD64
 
 on:
   workflow_dispatch:
+  inputs:
+    release_type:
+      description: 'Tagged release testing scenario'
+      required: false
+      type: choice
+      options:
+        - 9.9.9-b1
+        - 9.9.9-rc1
+        - 9.9.9
   push:
     paths-ignore:
     - '**.md'
@@ -52,6 +61,18 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check tag type
+      id: check_tag_type
+      shell: bash
+      run: |
+        REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
+        REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+          echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+          echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
+        fi
+
     - uses: Chia-Network/actions/enforce-semver@main
       if: env.FULL_RELEASE == 'true'
 
@@ -62,7 +83,7 @@ jobs:
         python3 -m venv ../venv
         . ../venv/bin/activate
         pip3 install setuptools_scm
-        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >>$GITHUB_OUTPUT
+        echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Test for secrets access
@@ -73,10 +94,10 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> "$GITHUB_OUTPUT"
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >>$GITHUB_OUTPUT
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> "$GITHUB_OUTPUT"
       env:
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
         GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
@@ -86,34 +107,64 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/madmax"
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot-*-x86-64' -O $GITHUB_WORKSPACE/madmax/chia_plot
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot_k34-*-x86-64' -O $GITHUB_WORKSPACE/madmax/chia_plot_k34
-        chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot"
-        chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot_k34"
+        mkdir "$GITHUB_WORKSPACE"/madmax"
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot"
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34"
 
-    - name: Get latest bladebit plotter
-      if: '!github.event.release.prerelease'
+    - name: Get latest bladebit plotter for Full Release
+      if: "github.event.release && !github.event.release.prerelease"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
       run: |
-        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/bladebit"
-        cd "$GITHUB_WORKSPACE/bladebit"
-        gh release download -R Chia-Network/bladebit $LATEST_BLADEBIT -p 'bladebit*-centos-x86-64.tar.gz'
+        LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-centos-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
         cd "$OLDPWD"
 
-    - name: Get latest prerelease bladebit plotter
-      if: env.PRE_RELEASE == 'true'
+    - name: Get latest beta bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'beta'"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
       run: |
-        LATEST_PRERELEASE=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease)) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE/bladebit"
-        cd "$GITHUB_WORKSPACE/bladebit"
-        gh release download -R Chia-Network/bladebit $LATEST_PRERELEASE -p 'bladebit*centos-x86-64.tar.gz'
+        LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-centos-x86-64.tar.gz'
+        ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+        ls bladebit* | xargs -I{} chmod +x {}
+        cd "$OLDPWD"
+
+    - name: Get latest RC bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'rc'"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-centos-x86-64.tar.gz'
+        ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+        ls bladebit* | xargs -I{} chmod +x {}
+        cd "$OLDPWD"
+
+    - name: Get latest bladebit plotter for Dev
+      if: "!github.event.release"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE"/bladebit"
+        cd "$GITHUB_WORKSPACE"/bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-centos-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
         cd "$OLDPWD"
@@ -130,7 +181,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "GUI_REF=${gui_ref}" >>$GITHUB_OUTPUT
+        echo "GUI_REF=${gui_ref}" >> "$GITHUB_OUTPUT"
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -177,20 +228,20 @@ jobs:
       run: |
           GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
           CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-          echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >>$GITHUB_ENV
-          ls $GITHUB_WORKSPACE/build_scripts/final_installer/
-          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/dev/chia-blockchain-${CHIA_DEV_BUILD}-1.x86_64.rpm
-          aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/dev/chia-blockchain-cli-${CHIA_DEV_BUILD}-1.x86_64.rpm
+          echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >> "$GITHUB_ENV"
+          ls "$GITHUB_WORKSPACE"/build_scripts/final_installer/
+          aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/dev/chia-blockchain-${CHIA_DEV_BUILD}-1.x86_64.rpm
+          aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/dev/chia-blockchain-cli-${CHIA_DEV_BUILD}-1.x86_64.rpm
 
     - name: Create Checksums
       if: env.FULL_RELEASE == 'true' || github.ref == 'refs/heads/main'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
-        sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256
-        sha256sum $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm > $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256
-        ls $GITHUB_WORKSPACE/build_scripts/final_installer/
+        ls "$GITHUB_WORKSPACE"/build_scripts/final_installer/
+        sha256sum "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm > "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256
+        sha256sum "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm > "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256
+        ls "$GITHUB_WORKSPACE"/build_scripts/final_installer/
 
     - name: Create .rpm torrent
       if: env.FULL_RELEASE == 'true'
@@ -198,38 +249,31 @@ jobs:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent --webseed https://download.chia.net/install/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm -o $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent --webseed https://download.chia.net/install/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm
-        gh release upload $RELEASE_TAG $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm -o "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent --webseed https://download.chia.net/install/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm -o "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent --webseed https://download.chia.net/install/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm
+        gh release upload $RELEASE_TAG "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent
 
     - name: Upload Dev Installer
       if: steps.check_secrets.outputs.HAS_AWS_SECRET && github.ref == 'refs/heads/main'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/latest-dev/chia-blockchain-1.x86_64_latest_dev.rpm
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/latest-dev/chia-blockchain-1.x86_64_latest_dev.rpm.sha256
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/latest-dev/chia-blockchain-cli-1.x86_64_latest_dev.rpm
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/latest-dev/chia-blockchain-cli-1.x86_64_latest_dev.rpm.sha256
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/latest-dev/chia-blockchain-1.x86_64_latest_dev.rpm
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/latest-dev/chia-blockchain-1.x86_64_latest_dev.rpm.sha256
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/latest-dev/chia-blockchain-cli-1.x86_64_latest_dev.rpm
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/latest-dev/chia-blockchain-cli-1.x86_64_latest_dev.rpm.sha256
 
     - name: Upload Release Files
       if: steps.check_secrets.outputs.HAS_AWS_SECRET && env.FULL_RELEASE == 'true'
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent s3://download.chia.net/torrents/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/install/
-        aws s3 cp $GITHUB_WORKSPACE/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent s3://download.chia.net/torrents/
-
-    - name: Get tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      id: tag-name
-      run: |
-          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >>$GITHUB_OUTPUT
-          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >>$GITHUB_OUTPUT
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent s3://download.chia.net/torrents/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.sha256 s3://download.chia.net/install/
+        aws s3 cp "$GITHUB_WORKSPACE"/build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm.torrent s3://download.chia.net/torrents/
 
     - name: Upload release artifacts
       if: env.RELEASE == 'true'
@@ -246,7 +290,7 @@ jobs:
     - name: Mark installer complete
       if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
       run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "${{ steps.tag-name.outputs.TAG_NAME }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/success/build-linux-rpm
+          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "$RELEASE_TAG"}' ${{ secrets.GLUE_API_URL }}/api/v1/$RFC_REPO/$RELEASE_TAG/success/build-linux-rpm
 
     - name: Remove working files to exclude from cache
       run: |

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -67,9 +67,9 @@ jobs:
       run: |
         REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
         REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
-        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.release_type }}" =~ $REG_B ]]; then
           echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
-        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.release_type }}" =~ $REG_RC ]]; then
           echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -107,11 +107,11 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/madmax"
+        mkdir "$GITHUB_WORKSPACE"/madmax
         gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot
         gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-*-x86-64' -O "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
-        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot"
-        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34"
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot
+        chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
 
     - name: Get latest bladebit plotter for Full Release
       if: "github.event.release && !github.event.release.prerelease"
@@ -120,8 +120,8 @@ jobs:
       shell: bash
       run: |
         LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-centos-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
@@ -134,8 +134,8 @@ jobs:
       shell: bash
       run: |
         LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-centos-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
@@ -148,8 +148,8 @@ jobs:
       shell: bash
       run: |
         LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-centos-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}
@@ -162,8 +162,8 @@ jobs:
       shell: bash
       run: |
         LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
-        mkdir "$GITHUB_WORKSPACE"/bladebit"
-        cd "$GITHUB_WORKSPACE"/bladebit"
+        mkdir "$GITHUB_WORKSPACE"/bladebit
+        cd "$GITHUB_WORKSPACE"/bladebit
         gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-centos-x86-64.tar.gz'
         ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
         ls bladebit* | xargs -I{} chmod +x {}

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -7,7 +7,9 @@ on:
         description: 'Tagged release testing scenario'
         required: false
         type: choice
+        default: ''
         options:
+        - ''
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -47,7 +47,7 @@ jobs:
             file-suffix: ""
             mac-package-name: "Chia-darwin-x64"
             glue-name: "build-macos"
-            bladebit-suffix: macos-${{ matrix.os.name }}.tar.gz
+            bladebit-suffix: macos-x86-64.tar.gz
           - runs-on: [MacOS, ARM64]
             name: m1
             file-suffix: "-arm64"
@@ -158,10 +158,10 @@ jobs:
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
           ASSETS=$(gh release view "$LATEST_RELEASE" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
-            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+            if ! echo "$ASSETS" | grep -q 'bladebit.*-${{ matrix.os.bladebit-suffix }}'; then
               LATEST_RELEASE=v2.0.1
             fi
-          gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
+          gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-${{ matrix.os.bladebit-suffix }}'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
@@ -176,10 +176,10 @@ jobs:
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
           ASSETS=$(gh release view "$LATEST_BETA" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
-            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+            if ! echo "$ASSETS" | grep -q 'bladebit.*-${{ matrix.os.bladebit-suffix }}'; then
               LATEST_BETA=v2.0.1
             fi
-          gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
+          gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-${{ matrix.os.bladebit-suffix }}'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
@@ -194,10 +194,10 @@ jobs:
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
           ASSETS=$(gh release view "$LATEST_RC" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
-            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+            if ! echo "$ASSETS" | grep -q 'bladebit.*-${{ matrix.os.bladebit-suffix }}'; then
               LATEST_RC=v2.0.1
             fi
-          gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
+          gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-${{ matrix.os.bladebit-suffix }}'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
@@ -212,10 +212,10 @@ jobs:
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
           ASSETS=$(gh release view "$LATEST_BLADEBIT" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
-            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+            if ! echo "$ASSETS" | grep -q 'bladebit.*-${{ matrix.os.bladebit-suffix }}'; then
               LATEST_BLADEBIT=v2.0.1
             fi
-          gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
+          gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-${{ matrix.os.bladebit-suffix }}'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -47,7 +47,7 @@ jobs:
             file-suffix: ""
             mac-package-name: "Chia-darwin-x64"
             glue-name: "build-macos"
-            bladebit-suffix: macos-x86-64.tar.gz
+            bladebit-suffix: macos-${{ matrix.os.name }}.tar.gz
           - runs-on: [MacOS, ARM64]
             name: m1
             file-suffix: "-arm64"
@@ -157,7 +157,11 @@ jobs:
           LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
-          gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-macos-x86-64.tar.gz'
+          ASSETS=$(gh release view "$LATEST_RELEASE" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
+            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+              LATEST_RELEASE=v2.0.1
+            fi
+          gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
@@ -171,7 +175,11 @@ jobs:
           LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
-          gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-macos-x86-64.tar.gz'
+          ASSETS=$(gh release view "$LATEST_BETA" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
+            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+              LATEST_BETA=v2.0.1
+            fi
+          gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
@@ -185,7 +193,11 @@ jobs:
           LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
-          gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-macos-x86-64.tar.gz'
+          ASSETS=$(gh release view "$LATEST_RC" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
+            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+              LATEST_RC=v2.0.1
+            fi
+          gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
@@ -199,7 +211,11 @@ jobs:
           LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
           mkdir "$GITHUB_WORKSPACE"/bladebit
           cd "$GITHUB_WORKSPACE"/bladebit
-          gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-macos-x86-64.tar.gz'
+          ASSETS=$(gh release view "$LATEST_BLADEBIT" --repo Chia-Network/bladebit --json assets -q '.assets[].name')
+            if ! echo "$ASSETS" | grep -q 'bladebit.*macos-${{ matrix.os.name }}'; then
+              LATEST_BLADEBIT=v2.0.1
+            fi
+          gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-macos-${{ matrix.os.name }}.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -80,9 +80,9 @@ jobs:
         run: |
           REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
           REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
-          if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+          if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.release_type }}" =~ $REG_B ]]; then
             echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+          elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.release_type }}" =~ $REG_RC ]]; then
             echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -2,6 +2,15 @@ name: 📦🚀 Build Installers - MacOS
 
 on:
   workflow_dispatch:
+  inputs:
+    release_type:
+      description: 'Tagged release testing scenario'
+      required: false
+      type: choice
+      options:
+        - 9.9.9-b1
+        - 9.9.9-rc1
+        - 9.9.9
   push:
     paths-ignore:
     - '**.md'
@@ -65,6 +74,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check tag type
+        id: check_tag_type
+        shell: bash
+        run: |
+          REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
+          REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
+          if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+            echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+            echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Test for secrets access
         id: check_secrets
         shell: bash
@@ -74,13 +95,13 @@ jobs:
           unset HAS_GLUE_SECRET
 
           if [ -n "$APPLE_SECRET" ]; then HAS_APPLE_SECRET='true' ; fi
-          echo HAS_APPLE_SECRET=${HAS_APPLE_SECRET} >>$GITHUB_OUTPUT
+          echo HAS_APPLE_SECRET=${HAS_APPLE_SECRET} >> "$GITHUB_OUTPUT"
 
           if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-          echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
+          echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> "$GITHUB_OUTPUT"
 
           if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-          echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >>$GITHUB_OUTPUT
+          echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> "$GITHUB_OUTPUT"
         env:
           APPLE_SECRET: "${{ secrets.APPLE_DEV_ID_APP }}"
           AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
@@ -92,7 +113,7 @@ jobs:
           python3 -m venv ../venv
           . ../venv/bin/activate
           pip install setuptools_scm
-          echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> $GITHUB_OUTPUT
+          echo "CHIA_INSTALLER_VERSION=$(python3 ./build_scripts/installer-version.py)" >> "$GITHUB_OUTPUT"
           deactivate
 
       - name: Setup Python environment
@@ -119,40 +140,66 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-          mkdir "$GITHUB_WORKSPACE/madmax"
-          gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot-'$LATEST_MADMAX'-macos-${{ matrix.os.name }}'
-          mv chia_plot-$LATEST_MADMAX-macos-${{ matrix.os.name }} $GITHUB_WORKSPACE/madmax/chia_plot
-          gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot_k34-'$LATEST_MADMAX'-macos-${{ matrix.os.name }}'
-          mv chia_plot_k34-$LATEST_MADMAX-macos-${{ matrix.os.name }} $GITHUB_WORKSPACE/madmax/chia_plot_k34
-          chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot"
-          chmod +x "$GITHUB_WORKSPACE/madmax/chia_plot_k34"
+          mkdir "$GITHUB_WORKSPACE"/madmax"
+          gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-'$LATEST_MADMAX'-macos-${{ matrix.os.name }}'
+          mv chia_plot-$LATEST_MADMAX-macos-${{ matrix.os.name }} "$GITHUB_WORKSPACE"/madmax/chia_plot
+          gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-'$LATEST_MADMAX'-macos-${{ matrix.os.name }}'
+          mv chia_plot_k34-$LATEST_MADMAX-macos-${{ matrix.os.name }} "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
+          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot"
+          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34"
 
-      - name: Get latest bladebit plotter
-        if: '!github.event.release.prerelease'
+      - name: Get latest bladebit plotter for Full Release
+        if: "github.event.release && !github.event.release.prerelease"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          mkdir "$GITHUB_WORKSPACE/bladebit"
-          cd "$GITHUB_WORKSPACE/bladebit"
-          gh api repos/Chia-Network/bladebit/releases --jq '.[] | select(.prerelease == false) | .tag_name' | while read tag; do
-              echo "Attempting to download bladebit artifact for macOS from release ${tag}...";
-              gh release download -R Chia-Network/bladebit $tag -p 'bladebit*macos-x86-64.tar.gz' && break
-          done
+          LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
+          mkdir "$GITHUB_WORKSPACE"/bladebit"
+          cd "$GITHUB_WORKSPACE"/bladebit"
+          gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-macos-x86-64.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
 
-      - name: Get latest prerelease bladebit plotter
-        if: env.PRE_RELEASE == 'true'
+      - name: Get latest beta bladebit plotter
+        if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'beta'"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          mkdir "$GITHUB_WORKSPACE/bladebit"
-          cd "$GITHUB_WORKSPACE/bladebit"
-          gh api repos/Chia-Network/bladebit/releases --jq '.[] | select(.prerelease == true) | .tag_name' | while read tag; do
-              echo "Attempting to download bladebit artifact for macOS from release ${tag}...";
-              gh release download -R Chia-Network/bladebit $tag -p 'bladebit*macos-x86-64.tar.gz' && break
-          done
+          LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
+          mkdir "$GITHUB_WORKSPACE"/bladebit"
+          cd "$GITHUB_WORKSPACE"/bladebit"
+          gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-macos-x86-64.tar.gz'
+          ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+          ls bladebit* | xargs -I{} chmod +x {}
+          cd "$OLDPWD"
+
+      - name: Get latest RC bladebit plotter
+        if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'rc'"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
+          mkdir "$GITHUB_WORKSPACE"/bladebit"
+          cd "$GITHUB_WORKSPACE"/bladebit"
+          gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-macos-x86-64.tar.gz'
+          ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
+          ls bladebit* | xargs -I{} chmod +x {}
+          cd "$OLDPWD"
+
+      - name: Get latest bladebit plotter for Dev
+        if: "!github.event.release"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
+          mkdir "$GITHUB_WORKSPACE"/bladebit"
+          cd "$GITHUB_WORKSPACE"/bladebit"
+          gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-macos-x86-64.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
           cd "$OLDPWD"
@@ -174,7 +221,7 @@ jobs:
         run: |
           gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
           echo "${gui_ref}"
-          echo "GUI_REF=${gui_ref}" >> $GITHUB_OUTPUT
+          echo "GUI_REF=${gui_ref}" >> "$GITHUB_OUTPUT"
           echo "rm -rf ./chia-blockchain-gui"
           rm -rf ./chia-blockchain-gui
 
@@ -234,7 +281,7 @@ jobs:
         run: |
           GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
           CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-          echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >>$GITHUB_ENV
+          echo "CHIA_DEV_BUILD=$CHIA_DEV_BUILD" >> "$GITHUB_ENV"
           aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/Chia-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}${{ matrix.os.file-suffix }}.dmg s3://download.chia.net/dev/Chia-${CHIA_DEV_BUILD}${{ matrix.os.file-suffix }}.dmg
 
       - name: Create torrent
@@ -268,13 +315,6 @@ jobs:
           aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/Chia-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}${{ matrix.os.file-suffix }}.dmg.sha256 s3://download.chia.net/install/
           aws s3 cp ${{ github.workspace }}/build_scripts/final_installer/Chia-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}${{ matrix.os.file-suffix }}.dmg.torrent s3://download.chia.net/torrents/
 
-      - name: Get tag name
-        if: startsWith(github.ref, 'refs/tags/')
-        id: tag-name
-        run: |
-          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
-
       - name: Upload release artifacts
         if: env.RELEASE == 'true'
         env:
@@ -288,7 +328,7 @@ jobs:
       - name: Mark installer complete
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
         run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "${{ steps.tag-name.outputs.TAG_NAME }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/success/${{ matrix.os.glue-name }}
+          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "$RELEASE_TAG"}' ${{ secrets.GLUE_API_URL }}/api/v1/$RFC_REPO/$RELEASE_TAG/success/${{ matrix.os.glue-name }}
 
       # We want to delete this no matter what happened in the previous steps (failures, success, etc)
       - name: Delete signing keychain

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -140,13 +140,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-          mkdir "$GITHUB_WORKSPACE"/madmax"
+          mkdir "$GITHUB_WORKSPACE"/madmax
           gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-'$LATEST_MADMAX'-macos-${{ matrix.os.name }}'
           mv chia_plot-$LATEST_MADMAX-macos-${{ matrix.os.name }} "$GITHUB_WORKSPACE"/madmax/chia_plot
           gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-'$LATEST_MADMAX'-macos-${{ matrix.os.name }}'
           mv chia_plot_k34-$LATEST_MADMAX-macos-${{ matrix.os.name }} "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
-          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot"
-          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34"
+          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot
+          chmod +x "$GITHUB_WORKSPACE"/madmax/chia_plot_k34
 
       - name: Get latest bladebit plotter for Full Release
         if: "github.event.release && !github.event.release.prerelease"
@@ -155,8 +155,8 @@ jobs:
         shell: bash
         run: |
           LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-          mkdir "$GITHUB_WORKSPACE"/bladebit"
-          cd "$GITHUB_WORKSPACE"/bladebit"
+          mkdir "$GITHUB_WORKSPACE"/bladebit
+          cd "$GITHUB_WORKSPACE"/bladebit
           gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*-macos-x86-64.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
@@ -169,8 +169,8 @@ jobs:
         shell: bash
         run: |
           LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
-          mkdir "$GITHUB_WORKSPACE"/bladebit"
-          cd "$GITHUB_WORKSPACE"/bladebit"
+          mkdir "$GITHUB_WORKSPACE"/bladebit
+          cd "$GITHUB_WORKSPACE"/bladebit
           gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*-macos-x86-64.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
@@ -183,8 +183,8 @@ jobs:
         shell: bash
         run: |
           LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
-          mkdir "$GITHUB_WORKSPACE"/bladebit"
-          cd "$GITHUB_WORKSPACE"/bladebit"
+          mkdir "$GITHUB_WORKSPACE"/bladebit
+          cd "$GITHUB_WORKSPACE"/bladebit
           gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*-macos-x86-64.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}
@@ -197,8 +197,8 @@ jobs:
         shell: bash
         run: |
           LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
-          mkdir "$GITHUB_WORKSPACE"/bladebit"
-          cd "$GITHUB_WORKSPACE"/bladebit"
+          mkdir "$GITHUB_WORKSPACE"/bladebit
+          cd "$GITHUB_WORKSPACE"/bladebit
           gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*-macos-x86-64.tar.gz'
           ls *.tar.gz | xargs -I{} bash -c 'tar -xzf {} && rm {}'
           ls bladebit* | xargs -I{} chmod +x {}

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -2,12 +2,12 @@ name: 📦🚀 Build Installers - MacOS
 
 on:
   workflow_dispatch:
-  inputs:
-    release_type:
-      description: 'Tagged release testing scenario'
-      required: false
-      type: choice
-      options:
+    inputs:
+      release_type:
+        description: 'Tagged release testing scenario'
+        required: false
+        type: choice
+        options:
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -7,7 +7,9 @@ on:
         description: 'Tagged release testing scenario'
         required: false
         type: choice
+        default: ''
         options:
+        - ''
         - 9.9.9-b1
         - 9.9.9-rc1
         - 9.9.9

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,16 +1,16 @@
 name: 📦🚀 Build Installer - Windows 10
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
     inputs:
       release_type:
         description: 'Tagged release testing scenario'
         required: false
         type: choice
         options:
-          - 9.9.9-b1
-          - 9.9.9-rc1
-          - 9.9.9
+        - 9.9.9-b1
+        - 9.9.9-rc1
+        - 9.9.9
   push:
     paths-ignore:
     - '**.md'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,7 +1,16 @@
 name: 📦🚀 Build Installer - Windows 10
 
 on:
-  workflow_dispatch:
+    workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Tagged release testing scenario'
+        required: false
+        type: choice
+        options:
+          - 9.9.9-b1
+          - 9.9.9-rc1
+          - 9.9.9
   push:
     paths-ignore:
     - '**.md'
@@ -44,6 +53,18 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Check tag type
+      id: check_tag_type
+      shell: bash
+      run: |
+        REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
+        REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+          echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+          echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Set git urls to https instead of ssh
       run: |
         git config --global url."https://github.com/".insteadOf ssh://git@github.com/
@@ -52,7 +73,7 @@ jobs:
       id: npm-cache
       shell: bash
       run: |
-        echo "dir=$(npm config get cache)" >>$GITHUB_OUTPUT
+        echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
     - name: Cache npm
       uses: actions/cache@v3
@@ -66,7 +87,7 @@ jobs:
       id: pip-cache
       shell: bash
       run: |
-        echo "dir=$(pip cache dir)" >>$GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip
       uses: actions/cache@v3
@@ -95,13 +116,13 @@ jobs:
         unset HAS_GLUE_SECRET
 
         if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
-        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >>$GITHUB_OUTPUT
+        echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >> "$GITHUB_OUTPUT"
 
         if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >>$GITHUB_OUTPUT
+        echo HAS_AWS_SECRET=${HAS_AWS_SECRET} >> "$GITHUB_OUTPUT"
 
         if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_GLUE_SECRET='true' ; fi
-        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >>$GITHUB_OUTPUT
+        echo HAS_GLUE_SECRET=${HAS_GLUE_SECRET} >> "$GITHUB_OUTPUT"
       env:
         SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
@@ -124,7 +145,7 @@ jobs:
         pip3 install setuptools_scm
         CHIA_INSTALLER_VERSION=$(python ./build_scripts/installer-version.py)
         echo "$CHIA_INSTALLER_VERSION"
-        echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >>$GITHUB_OUTPUT
+        echo "CHIA_INSTALLER_VERSION=$CHIA_INSTALLER_VERSION" >> "$GITHUB_OUTPUT"
         deactivate
 
     - name: Get latest madmax plotter
@@ -133,35 +154,61 @@ jobs:
       shell: bash
       run: |
         LATEST_MADMAX=$(gh api repos/Chia-Network/chia-plotter-madmax/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir $GITHUB_WORKSPACE\\madmax
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot-*.exe' -O $GITHUB_WORKSPACE\\madmax\\chia_plot.exe
-        gh release download -R Chia-Network/chia-plotter-madmax $LATEST_MADMAX -p 'chia_plot_k34-*.exe' -O $GITHUB_WORKSPACE\\madmax\\chia_plot_k34.exe
+        mkdir "$GITHUB_WORKSPACE"\\madmax
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot-*.exe' -O "$GITHUB_WORKSPACE"\\madmax\\chia_plot.exe
+        gh release download -R Chia-Network/chia-plotter-madmax "$LATEST_MADMAX" -p 'chia_plot_k34-*.exe' -O "$GITHUB_WORKSPACE"\\madmax\\chia_plot_k34.exe
 
-    - name: Get latest bladebit plotter
-      if: '!github.event.release.prerelease'
+    - name: Get latest bladebit plotter for Full Release
+      if: "github.event.release && !github.event.release.prerelease"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |
-        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
-        mkdir $GITHUB_WORKSPACE\\bladebit
-        cd $GITHUB_WORKSPACE\\bladebit
-        gh release download -R Chia-Network/bladebit $LATEST_BLADEBIT -p 'bladebit*windows-x86-64.zip'
+        LATEST_RELEASE=$(gh api repos/Chia-Network/bladebit/releases/latest --jq 'select(.prerelease == false) | .tag_name')
+        mkdir "$GITHUB_WORKSPACE\\bladebit"
+        cd "$GITHUB_WORKSPACE\\bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_RELEASE" -p 'bladebit*windows-x86-64.zip'
         ls *.zip | xargs -I{} bash -c 'unzip {} && rm {}'
-        cd $OLDPWD
+        cd "$OLDPWD"
 
-    - name: Get latest prerelease bladebit plotter
-      if: env.PRE_RELEASE == 'true'
+    - name: Get latest beta bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'beta'"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |
-        LATEST_PRERELEASE=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease)) | first | .tag_name')
-        mkdir $GITHUB_WORKSPACE\\bladebit
-        cd $GITHUB_WORKSPACE\\bladebit
-        gh release download -R Chia-Network/bladebit $LATEST_PRERELEASE -p 'bladebit*windows-x86-64.zip'
+        LATEST_BETA=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE\\bladebit"
+        cd "$GITHUB_WORKSPACE\\bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_BETA" -p 'bladebit*windows-x86-64.zip'
         ls *.zip | xargs -I{} bash -c 'unzip {} && rm {}'
-        cd $OLDPWD
+        cd "$OLDPWD"
+
+    - name: Get latest RC bladebit plotter
+      if: "github.event.release && github.event.release.prerelease || env.TAG_TYPE == 'rc'"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_RC=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease) | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+$"))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE\\bladebit"
+        cd "$GITHUB_WORKSPACE\\bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_RC" -p 'bladebit*windows-x86-64.zip'
+        ls *.zip | xargs -I{} bash -c 'unzip {} && rm {}'
+        cd "$OLDPWD"
+
+    - name: Get latest bladebit plotter for Dev
+      if: "!github.event.release"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        LATEST_BLADEBIT=$(gh api repos/Chia-Network/bladebit/releases --jq 'map(select(.prerelease and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|rc)[0-9]+$")))) | first | .tag_name')
+        mkdir "$GITHUB_WORKSPACE\\bladebit"
+        cd "$GITHUB_WORKSPACE\\bladebit"
+        gh release download -R Chia-Network/bladebit "$LATEST_BLADEBIT" -p 'bladebit*windows-x86-64.zip'
+        ls *.zip | xargs -I{} bash -c 'unzip {} && rm {}'
+        cd "$OLDPWD"
 
     - name: Run install script
       env:
@@ -177,7 +224,7 @@ jobs:
       run: |
         gui_ref=$(git submodule status chia-blockchain-gui | sed -e 's/^ //g' -e 's/ chia-blockchain-gui.*$//g')
         echo "${gui_ref}"
-        echo "GUI_REF=${gui_ref}" >>$GITHUB_OUTPUT
+        echo "GUI_REF=${gui_ref}" >> "$GITHUB_OUTPUT"
         echo "rm -rf ./chia-blockchain-gui"
         rm -rf ./chia-blockchain-gui
 
@@ -233,7 +280,7 @@ jobs:
       run: |
         GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
         CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-        echo CHIA_DEV_BUILD=${CHIA_DEV_BUILD} >>$GITHUB_OUTPUT
+        echo CHIA_DEV_BUILD=${CHIA_DEV_BUILD} >> "$GITHUB_OUTPUT"
         echo ${CHIA_DEV_BUILD}
         pwd
         aws s3 cp chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${CHIA_INSTALLER_VERSION}.exe s3://download.chia.net/dev/ChiaSetup-${CHIA_DEV_BUILD}.exe
@@ -272,14 +319,6 @@ jobs:
         aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256 s3://download.chia.net/install/
         aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.torrent s3://download.chia.net/torrents/
 
-    - name: Get tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      id: tag-name
-      shell: bash
-      run: |
-        echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >>$GITHUB_OUTPUT
-        echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >>$GITHUB_OUTPUT
-
     - name: Upload release artifacts
       if: env.RELEASE == 'true'
       env:
@@ -295,10 +334,10 @@ jobs:
             Authorization="Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}"
         }
         $data = @{
-            chia_ref='${{ steps.tag-name.outputs.TAG_NAME }}'
+            chia_ref='$RELEASE_TAG'
         }
         $json = $data | ConvertTo-Json
-        $response = Invoke-RestMethod '${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/success/build-windows' -Method Post -Body $json -ContentType 'application/json' -Headers $headers
+        $response = Invoke-RestMethod '${{ secrets.GLUE_API_URL }}/api/v1/$RFC_REPO/$RELEASE_TAG/success/build-windows' -Method Post -Body $json -ContentType 'application/json' -Headers $headers
 
     - name: Remove Windows exe and installer to exclude from cache
       run: |

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -59,9 +59,9 @@ jobs:
       run: |
         REG_B="^[0-9]+\.[0-9]+\.[0-9]+-b[0-9]+$"
         REG_RC="^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$"
-        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.tags }}" =~ $REG_B ]]; then
+        if [[ "${{ github.event.release.tag_name }}" =~ $REG_B ]] || [[ "${{ inputs.release_type }}" =~ $REG_B ]]; then
           echo "TAG_TYPE=beta" >> "$GITHUB_OUTPUT"
-        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.tags }}" =~ $REG_RC ]]; then
+        elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.release_type }}" =~ $REG_RC ]]; then
           echo "TAG_TYPE=rc" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/snyk-python-scan.yml
+++ b/.github/workflows/snyk-python-scan.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         unset HAS_SNYK_SECRET
         if [ -n "$SNYK_TOKEN" ]; then HAS_SNYK_SECRET='true' ; fi
-        echo HAS_SNYK_SECRET=${HAS_SNYK_SECRET} >> $GITHUB_OUTPUT
+        echo HAS_SNYK_SECRET=${HAS_SNYK_SECRET} >> "$GITHUB_OUTPUT"
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -10,13 +10,11 @@ jobs:
     name: Starts release process in Glue API
     runs-on: [glue-notify]
     steps:
-      - name: Get tag name
-        if: "!github.event.release.prerelease"
-        id: tag-name
-        run: |
-          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
-          echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f 2)" >> $GITHUB_OUTPUT
+      - name: Set Env
+        uses: Chia-Network/actions/setjobenv@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Start release
         if: "!github.event.release.prerelease"
         run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "${{ steps.tag-name.outputs.TAG_NAME }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/start
+          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"chia_ref": "$RELEASE_TAG"}' ${{ secrets.GLUE_API_URL }}/api/v1/$RFC_REPO/$RELEASE_TAG/start

--- a/.github/workflows/start-sync-test.yml
+++ b/.github/workflows/start-sync-test.yml
@@ -9,11 +9,11 @@ jobs:
     name: Starts Sync Test
     runs-on: ubuntu-latest
     steps:
-      - name: Get tag name
-        id: tag-name
-        run: |
-          echo "TAG_NAME=$(echo ${{ github.ref }} | cut -d'/' -f 3)" >> $GITHUB_OUTPUT
+      - name: Set Env
+        uses: Chia-Network/actions/setjobenv@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Trigger Workflow
         run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"test_ref": "${{ steps.tag-name.outputs.TAG_NAME }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/sync-test/${{ steps.tag-name.outputs.TAG_NAME }}/start
-          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"test_ref": "${{ steps.tag-name.outputs.TAG_NAME }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/sync-test/${{ steps.tag-name.outputs.TAG_NAME }}/success/deploy
+          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"test_ref": "$RELEASE_TAG"}' ${{ secrets.GLUE_API_URL }}/api/v1/sync-test/$RELEASE_TAG/start
+          curl -s -XPOST -H "Authorization: Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}" --data '{"test_ref": "$RELEASE_TAG"}' ${{ secrets.GLUE_API_URL }}/api/v1/sync-test/$RELEASE_TAG/success/deploy

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -175,7 +175,7 @@ jobs:
         apt-get install --yes git lsb-release sudo
 
     - name: Add safe git directory
-      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     # after installing git so we use that copy
     - name: Checkout Code

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -158,7 +158,7 @@ jobs:
         id: pip-cache
         shell: bash
         run: |
-          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pip
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           python tests/build-job-matrix.py --per directory --verbose > matrix.json
           cat matrix.json
-          echo configuration=$(cat matrix.json) >> $GITHUB_OUTPUT
-          echo matrix_mode=${{ ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> $GITHUB_OUTPUT
+          echo configuration=$(cat matrix.json) >> "$GITHUB_OUTPUT"
+          echo matrix_mode=${{ ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> "$GITHUB_OUTPUT"
 
     outputs:
       configuration: ${{ steps.configure.outputs.configuration }}

--- a/.github/workflows/trigger-docker-dev.yml
+++ b/.github/workflows/trigger-docker-dev.yml
@@ -28,7 +28,7 @@ jobs:
           unset HAS_SECRET
 
           if [ -n "$GLUE_ACCESS_TOKEN" ]; then HAS_SECRET='true' ; fi
-          echo HAS_SECRET=${HAS_SECRET} >> $GITHUB_OUTPUT
+          echo HAS_SECRET=${HAS_SECRET} >> "$GITHUB_OUTPUT"
         env:
           GLUE_ACCESS_TOKEN: "${{ secrets.GLUE_ACCESS_TOKEN }}"
 

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -186,7 +186,7 @@ jobs:
       run: |
         unset HAS_SECRET
         if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo HAS_SECRET=${HAS_SECRET} >> $GITHUB_OUTPUT
+        echo HAS_SECRET=${HAS_SECRET} >> "$GITHUB_OUTPUT"
       env:
         SECRET: "${{ secrets.test_pypi_password }}"
 


### PR DESCRIPTION
### Purpose:
Rework the bladebit artifact download release logic.
I've also added some expanded options for the Workflow Dispatch inputs on the build-installer workflows that allow us to simulate tagged releases.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Currently, our workflows that create blockchain installers downloads the bladebit `rc` artifacts if the blockchain event is a `pre-release`, otherwise it downloads the latest `full release`


### New Behavior:
On my fork, where I've tested this, I have the following release tags of bladebit:

- v3.0.1-beta1
- v3.0.0
- v3.0.0-rc2
- v3.0.0-rc1
- v3.0.0-beta1
- v3.0.0-alpha2
- v3.0.0-alpha1
- v2.0.1
- v2.0.1-rc1
- v2.0.0
- v2.0.0-rc1
- v2.0.0-beta1
- v2.0.0-alpha2
- v2.0.0-alpha1
- v1.2.0

The CI changes that I've made would result in the following blockchain release types fetching the corresponding bladebit release artifacts:

**full**: v3.0.0
**rc**: v3.0.0-rc2
**beta**: v3.0.1-beta1
**dev**: v3.0.1-beta1
