### PR TITLE
cudaplot fix

### DIFF
--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -365,7 +365,7 @@ def plot_bladebit(args, chia_root_path, root_path):
         call_args.append("--no-t2-direct")
     if "device" in args and str(args.device).isdigit():
         call_args.append("--device")
-        call_args.append(args.device)
+        call_args.append(str(args.device))
     if "no_direct_downloads" in args and args.no_direct_downloads is not None:
         call_args.append("--no-direct-downloads")
 

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -101,6 +101,8 @@ bladebit_cuda_plotter_options = [
     Options.FARMERKEY,
     Options.POOLKEY,
     Options.POOLCONTRACT,
+    Options.TMP_DIR,
+    Options.TMP_DIR2,
     Options.ID,
     Options.BLADEBIT_WARMSTART,
     Options.BLADEBIT_NONUMA,


### PR DESCRIPTION
Fixed an issue where `chia plotters bladebit cudaplot ...` command fails with an error.
This is caused by:
- `--device` option was set as an `int` where it should be `str`
- Lack of  `-t` and `-2` flags support

You can test the behavior by running
`chia plotters bladebit cudaplot -n 1 -d <Final dir> -r 0 --compress 0 --device 0 -t <Tmp dir>`
with bladebit 3 installed. (If you install from source, put the bladebit_cuda(.exe) binary under `venv/bin/`)
Before this PR, the above command fails. After this PR, plotting will begin.