### PR TITLE
fix flake8 warnings

### DIFF
--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -12,9 +12,9 @@ from chia.util.byte_types import hexstr_to_bytes
 
 
 def _serialize(node: object) -> bytes:
-    if type(node) == SerializedProgram:
+    if type(node) is SerializedProgram:
         return bytes(node)
-    if type(node) == Program:
+    if type(node) is Program:
         return bytes(node)
     else:
         ret: bytes = SExp.to(node).as_bin()

--- a/chia/util/files.py
+++ b/chia/util/files.py
@@ -70,7 +70,7 @@ async def write_file_async(
     # Create the parent directory if necessary
     os.makedirs(file_path.parent, mode=dir_mode, exist_ok=True)
 
-    mode: Literal["w+", "w+b"] = "w+" if type(data) == str else "w+b"
+    mode: Literal["w+", "w+b"] = "w+" if type(data) is str else "w+b"
     temp_file_path: Path
     async with tempfile.NamedTemporaryFile(dir=file_path.parent, mode=mode, delete=False) as f:
         # Ignoring type error since it is not obvious how to tie the type of the data

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -330,7 +330,7 @@ def recurse_jsonify(d: Any) -> Any:
         return d
     elif isinstance(d, int):
         return int(d)
-    elif d is None or type(d) == str:
+    elif d is None or type(d) is str:
         return d
     elif hasattr(d, "to_json_dict"):
         ret: Union[List[Any], Dict[str, Any], str, None, int] = d.to_json_dict()

--- a/chia/wallet/util/compute_memos.py
+++ b/chia/wallet/util/compute_memos.py
@@ -19,7 +19,7 @@ def compute_memos_for_spend(coin_spend: CoinSpend) -> Dict[bytes32, List[bytes]]
         if condition[0] == ConditionOpcode.CREATE_COIN and len(condition) >= 4:
             # If only 3 elements (opcode + 2 args), there is no memo, this is ph, amount
             coin_added = Coin(coin_spend.coin.name(), bytes32(condition[1]), int_from_bytes(condition[2]))
-            if type(condition[3]) != list:
+            if type(condition[3]) is not list:
                 # If it's not a list, it's not the correct format
                 continue
             memos[coin_added.name()] = condition[3]

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -418,12 +418,12 @@ def test_post_init_valid(test_class: Type[Any], args: Tuple[Any, ...]) -> None:
         if is_type_SpecificOptional(type_in):
             return item is None or validate_item_type(get_args(type_in)[0], item)
         if is_type_Tuple(type_in):
-            assert type(item) == tuple
+            assert type(item) is tuple
             types = get_args(type_in)
             return all(validate_item_type(tuple_type, tuple_item) for tuple_type, tuple_item in zip(types, item))
         if is_type_List(type_in):
             list_type = get_args(type_in)[0]
-            assert type(item) == list
+            assert type(item) is list
             return all(validate_item_type(list_type, list_item) for list_item in item)
         return isinstance(item, type_in)
 

--- a/tests/plot_sync/test_delta.py
+++ b/tests/plot_sync/test_delta.py
@@ -37,17 +37,17 @@ def dummy_plot(path: str) -> Plot:
 )
 def test_list_delta(delta: DeltaType) -> None:
     assert delta.empty()
-    if type(delta) == PathListDelta:
+    if type(delta) is PathListDelta:
         assert delta.additions == []
-    elif type(delta) == PlotListDelta:
+    elif type(delta) is PlotListDelta:
         assert delta.additions == {}
     else:
         assert False
     assert delta.removals == []
     assert delta.empty()
-    if type(delta) == PathListDelta:
+    if type(delta) is PathListDelta:
         delta.additions.append("0")
-    elif type(delta) == PlotListDelta:
+    elif type(delta) is PlotListDelta:
         delta.additions["0"] = dummy_plot("0")
     else:
         assert False, "Invalid delta type"

--- a/tests/plot_sync/test_receiver.py
+++ b/tests/plot_sync/test_receiver.py
@@ -94,7 +94,7 @@ def assert_error_response(plot_sync: Receiver, error_code: ErrorCodes) -> None:
 def pre_function_validate(receiver: Receiver, data: Union[List[Plot], List[str]], expected_state: State) -> None:
     if expected_state == State.loaded:
         for plot_info in data:
-            assert type(plot_info) == Plot
+            assert type(plot_info) is Plot
             assert plot_info.filename not in receiver.plots()
     elif expected_state == State.removed:
         for path in data:
@@ -113,7 +113,7 @@ def pre_function_validate(receiver: Receiver, data: Union[List[Plot], List[str]]
 def post_function_validate(receiver: Receiver, data: Union[List[Plot], List[str]], expected_state: State) -> None:
     if expected_state == State.loaded:
         for plot_info in data:
-            assert type(plot_info) == Plot
+            assert type(plot_info) is Plot
             assert plot_info.filename in receiver._current_sync.delta.valid.additions
     elif expected_state == State.removed:
         for path in data:

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -99,13 +99,13 @@ class PlotRefreshTester:
         for name in ["loaded", "removed", "processed", "remaining"]:
             try:
                 actual_value = refresh_result.__getattribute__(name)
-                if type(actual_value) == list:
+                if type(actual_value) is list:
                     expected_list = self.expected_result.__getattribute__(name)
                     if len(expected_list) != len(actual_value):
                         return
                     values_found = 0
                     for value in actual_value:
-                        if type(value) == PlotInfo:
+                        if type(value) is PlotInfo:
                             for plot_info in expected_list:
                                 if plot_info.prover.get_filename() == value.prover.get_filename():
                                     values_found += 1

--- a/tests/util/test_struct_stream.py
+++ b/tests/util/test_struct_stream.py
@@ -145,8 +145,8 @@ class TestStructStream:
             with pytest.raises(struct.error):
                 struct.pack(struct_format, upper_boundary + 1)
 
-        assert type(cls.MINIMUM) == cls
-        assert type(cls.MAXIMUM) == cls
+        assert type(cls.MINIMUM) is cls
+        assert type(cls.MAXIMUM) is cls
 
     def test_int512(self) -> None:
         # int512 is special. it uses 65 bytes to allow positive and negative

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -134,7 +134,7 @@ def run_generator(block_generator: BlockGenerator, constants: ConsensusConstants
                 continue
 
             # If only 3 elements (opcode + 2 args), there is no memo, this is ph, amount
-            if type(condition[3]) != list:
+            if type(condition[3]) is not list:
                 # If it's not a list, it's not the correct format
                 conds[op].append(ConditionWithArgs(op, [i for i in condition[1:3]]))
                 continue


### PR DESCRIPTION
addresses the following Flake8 warnings:
```
chia/types/blockchain_format/serialized_program.py:15:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
chia/types/blockchain_format/serialized_program.py:17:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
chia/util/files.py:73:42: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
chia/util/streamable.py:333:23: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
chia/wallet/util/compute_memos.py:22:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/core/util/test_streamable.py:421:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/core/util/test_streamable.py:426:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plot_sync/test_delta.py:40:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plot_sync/test_delta.py:42:10: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plot_sync/test_delta.py:48:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plot_sync/test_delta.py:50:10: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plot_sync/test_receiver.py:97:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plot_sync/test_receiver.py:116:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plotting/test_plot_manager.py:102:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/plotting/test_plot_manager.py:108:28: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/util/test_struct_stream.py:148:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/util/test_struct_stream.py:149:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tools/run_block.py:137:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
Error: Process completed with exit code 1.
```