### PR TITLE
allow `_ProactorBasePipeTransport.__del__` failures in tests

### DIFF
--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -1933,7 +1933,11 @@ async def test_clear_pending_roots(
             cleared_root = json.loads(stdout)
             stderr = await process.stderr.read()
             assert process.returncode == 0
-            assert stderr == b""
+            if sys.version_info >= (3, 10, 6):
+                assert stderr == b""
+            else:
+                # https://github.com/python/cpython/issues/92841
+                assert stderr == b"" or b"_ProactorBasePipeTransport.__del__" in stderr
         elif layer == InterfaceLayer.client:
             client = await DataLayerRpcClient.create(
                 self_hostname=self_hostname,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Ignores the issues such as reported in https://github.com/Chia-Network/chia-blockchain/issues/12009 and https://github.com/Chia-Network/chia-blockchain/issues/15637 that are showing up in the DataLayer CLI testing.  I believe these are being caused by https://github.com/python/cpython/issues/92841 which was fixed in 3.10.6 and not backported to 3.8 or 3.9.  This does not fix the issue during runtime.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
