### PR TITLE
Add `extra_conditions` as an option to transaction endpoints

### DIFF
--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -288,6 +288,24 @@ def tx_config_args(func: Callable[..., None]) -> Callable[..., None]:
     )(coin_selection_args(func))
 
 
+def timelock_args(func: Callable[..., None]) -> Callable[..., None]:
+    return click.option(
+        "--valid-at",
+        help="UNIX timestamp at which the associated transactions become valid",
+        type=int,
+        required=False,
+        default=None,
+    )(
+        click.option(
+            "--expires-at",
+            help="UNIX timestamp at which the associated transactions expire",
+            type=int,
+            required=False,
+            default=None,
+        )(func)
+    )
+
+
 @streamable
 @dataclasses.dataclass(frozen=True)
 class CMDCoinSelectionConfigLoader(Streamable):

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -46,6 +46,7 @@ from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64, uint128
+from chia.wallet.conditions import Condition
 from chia.wallet.derive_keys import find_owner_sk
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_synthetic_public_key
 from chia.wallet.sign_coin_spends import sign_coin_spends
@@ -398,6 +399,7 @@ class PoolWallet:
         fee: uint64 = uint64(0),
         p2_singleton_delay_time: Optional[uint64] = None,
         p2_singleton_delayed_ph: Optional[bytes32] = None,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Tuple[TransactionRecord, bytes32, bytes32]:
         """
         A "plot NFT", or pool wallet, represents the idea of a set of plots that all pay to
@@ -435,6 +437,7 @@ class PoolWallet:
             p2_singleton_delay_time,
             p2_singleton_delayed_ph,
             tx_config,
+            extra_conditions=extra_conditions,
         )
 
         if spend_bundle is None:
@@ -644,6 +647,7 @@ class PoolWallet:
         delay_time: uint64,
         delay_ph: bytes32,
         tx_config: TXConfig,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Tuple[SpendBundle, bytes32, bytes32]:
         """
         Creates the initial singleton, which includes spending an origin coin, the launcher, and creating a singleton
@@ -702,6 +706,7 @@ class PoolWallet:
             False,
             announcement_set,
             origin_id=launcher_parent.name(),
+            extra_conditions=extra_conditions,
         )
         assert create_launcher_tx_record is not None and create_launcher_tx_record.spend_bundle is not None
 

--- a/chia/rpc/util.py
+++ b/chia/rpc/util.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import logging
 import traceback
-from typing import Any, Callable, Coroutine, Dict, List, Optional
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple
 
 import aiohttp
 
 from chia.types.blockchain_format.coin import Coin
 from chia.util.json_util import obj_to_response
+from chia.wallet.conditions import Condition, conditions_from_json_dicts
 from chia.wallet.util.tx_config import TXConfig, TXConfigLoader
 
 log = logging.getLogger(__name__)
@@ -63,6 +64,11 @@ def tx_endpoint(
             config=self.service.wallet_state_manager.config,
             logged_in_fingerprint=self.service.logged_in_fingerprint,
         )
-        return await func(self, request, *args, tx_config=tx_config, **kwargs)
+
+        extra_conditions: Tuple[Condition, ...] = tuple()
+        if "extra_conditions" in request:
+            extra_conditions = tuple(conditions_from_json_dicts(request["extra_conditions"]))
+
+        return await func(self, request, *args, tx_config=tx_config, extra_conditions=extra_conditions, **kwargs)
 
     return rpc_endpoint

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -42,6 +42,7 @@ from chia.util.ws_message import WsRpcMessage, create_payload_dict
 from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_info import CRCATInfo
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
+from chia.wallet.conditions import Condition
 from chia.wallet.derive_keys import (
     MAX_POOL_WALLETS,
     master_sk_to_farmer_sk,
@@ -628,7 +629,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def create_new_wallet(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         wallet_state_manager = self.service.wallet_state_manager
 
@@ -817,6 +821,7 @@ class WalletRpcApi:
                             fee,
                             request.get("p2_singleton_delay_time", None),
                             delayed_address,
+                            extra_conditions=extra_conditions,
                         )
                     except Exception as e:
                         raise ValueError(str(e))
@@ -1006,7 +1011,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def send_transaction(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before sending transactions")
@@ -1038,6 +1046,7 @@ class WalletRpcApi:
                 fee,
                 memos=memos,
                 puzzle_decorator_override=request.get("puzzle_decorator", None),
+                extra_conditions=extra_conditions,
             )
             await wallet.push_transaction(tx)
 
@@ -1070,7 +1079,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def spend_clawback_coins(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         """Spend clawback coins that were sent (to claw them back) or received (to claim them).
 
@@ -1105,7 +1117,7 @@ class WalletRpcApi:
                     tx_id_list.extend(
                         (
                             await self.service.wallet_state_manager.spend_clawback_coins(
-                                coins, tx_fee, tx_config, request.get("force", False)
+                                coins, tx_fee, tx_config, request.get("force", False), extra_conditions=extra_conditions
                             )
                         )
                     )
@@ -1116,7 +1128,7 @@ class WalletRpcApi:
             tx_id_list.extend(
                 (
                     await self.service.wallet_state_manager.spend_clawback_coins(
-                        coins, tx_fee, tx_config, request.get("force", False)
+                        coins, tx_fee, tx_config, request.get("force", False), extra_conditions=extra_conditions
                     )
                 )
             )
@@ -1141,7 +1153,12 @@ class WalletRpcApi:
             return {}
 
     @tx_endpoint
-    async def select_coins(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def select_coins(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before selecting coins")
 
@@ -1353,7 +1370,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def send_notification(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         tx: TransactionRecord = await self.service.wallet_state_manager.notification_manager.send_new_notification(
             bytes32.from_hexstr(request["target"]),
@@ -1361,6 +1381,7 @@ class WalletRpcApi:
             uint64(request["amount"]),
             tx_config,
             request.get("fee", uint64(0)),
+            extra_conditions=extra_conditions,
         )
         await self.service.wallet_state_manager.add_pending_transaction(tx)
         return {"tx": tx.to_json_dict_convenience(self.service.config)}
@@ -1517,7 +1538,11 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def cat_spend(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG, hold_lock: bool = True
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+        hold_lock: bool = True,
     ) -> EndpointResult:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
@@ -1580,6 +1605,7 @@ class WalletRpcApi:
                     cat_discrepancy=cat_discrepancy,
                     coins=coins,
                     memos=memos if memos else None,
+                    extra_conditions=extra_conditions,
                 )
                 for tx in txs:
                     await wallet.standard_wallet.push_transaction(tx)
@@ -1592,6 +1618,7 @@ class WalletRpcApi:
                 cat_discrepancy=cat_discrepancy,
                 coins=coins,
                 memos=memos if memos else None,
+                extra_conditions=extra_conditions,
             )
             for tx in txs:
                 await wallet.standard_wallet.push_transaction(tx)
@@ -1621,7 +1648,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def create_offer_for_ids(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         offer: Dict[str, int] = request["offer"]
         fee: uint64 = uint64(request.get("fee", 0))
@@ -1664,6 +1694,7 @@ class WalletRpcApi:
                 solver=solver,
                 fee=fee,
                 validate_only=validate_only,
+                extra_conditions=extra_conditions,
             )
         if result[0]:
             success, trade_record, error = result
@@ -1739,7 +1770,12 @@ class WalletRpcApi:
         }
 
     @tx_endpoint
-    async def take_offer(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def take_offer(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         offer_hex: str = request["offer"]
 
         ###
@@ -1778,6 +1814,7 @@ class WalletRpcApi:
                 tx_config,
                 fee=fee,
                 solver=solver,
+                extra_conditions=extra_conditions,
             )
         return {"trade_record": trade_record.to_json_dict_convenience()}
 
@@ -1833,17 +1870,29 @@ class WalletRpcApi:
         return {"total": total, "my_offers_count": my_offers_count, "taken_offers_count": taken_offers_count}
 
     @tx_endpoint
-    async def cancel_offer(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def cancel_offer(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         wsm = self.service.wallet_state_manager
         secure = request["secure"]
         trade_id = bytes32.from_hexstr(request["trade_id"])
         fee: uint64 = uint64(request.get("fee", 0))
         async with self.service.wallet_state_manager.lock:
-            await wsm.trade_manager.cancel_pending_offers([bytes32(trade_id)], tx_config, fee=fee, secure=secure)
+            await wsm.trade_manager.cancel_pending_offers(
+                [bytes32(trade_id)], tx_config, fee=fee, secure=secure, extra_conditions=extra_conditions
+            )
         return {}
 
     @tx_endpoint
-    async def cancel_offers(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def cancel_offers(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         secure = request["secure"]
         batch_fee: uint64 = uint64(request.get("batch_fee", 0))
         batch_size = request.get("batch_size", 5)
@@ -1882,7 +1931,9 @@ class WalletRpcApi:
                         continue
 
             async with self.service.wallet_state_manager.lock:
-                await trade_mgr.cancel_pending_offers(list(records.keys()), tx_config, batch_fee, secure, records)
+                await trade_mgr.cancel_pending_offers(
+                    list(records.keys()), tx_config, batch_fee, secure, records, extra_conditions=extra_conditions
+                )
             log.info(f"Cancelled offers {start} to {end} ...")
             # If fewer records were returned than requested, we're done
             if len(trades) < batch_size:
@@ -1909,7 +1960,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def did_update_recovery_ids(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
         wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=DIDWallet)
@@ -1925,14 +1979,19 @@ class WalletRpcApi:
             update_success = await wallet.update_recovery_list(recovery_list, new_amount_verifications_required)
             # Update coin with new ID info
             if update_success:
-                spend_bundle = await wallet.create_update_spend(tx_config, fee=uint64(request.get("fee", 0)))
+                spend_bundle = await wallet.create_update_spend(
+                    tx_config, fee=uint64(request.get("fee", 0)), extra_conditions=extra_conditions
+                )
                 if spend_bundle is not None:
                     success = True
         return {"success": success}
 
     @tx_endpoint
     async def did_message_spend(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
         wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=DIDWallet)
@@ -1943,7 +2002,9 @@ class WalletRpcApi:
         for pa in request.get("puzzle_announcements", []):
             puzzle_announcements.add(bytes.fromhex(pa))
 
-        spend_bundle = await wallet.create_message_spend(tx_config, coin_announcements, puzzle_announcements)
+        spend_bundle = await wallet.create_message_spend(
+            tx_config, coin_announcements, puzzle_announcements, extra_conditions=extra_conditions
+        )
         return {"success": True, "spend_bundle": spend_bundle}
 
     async def did_get_info(self, request: Dict[str, Any]) -> EndpointResult:
@@ -2175,7 +2236,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def did_update_metadata(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
         wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=DIDWallet)
@@ -2186,7 +2250,9 @@ class WalletRpcApi:
             update_success = await wallet.update_metadata(metadata)
             # Update coin with new ID info
             if update_success:
-                spend_bundle = await wallet.create_update_spend(tx_config, uint64(request.get("fee", 0)))
+                spend_bundle = await wallet.create_update_spend(
+                    tx_config, uint64(request.get("fee", 0)), extra_conditions=extra_conditions
+                )
                 if spend_bundle is not None:
                     return {"wallet_id": wallet_id, "success": True, "spend_bundle": spend_bundle}
                 else:
@@ -2274,7 +2340,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def did_create_attest(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
         wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=DIDWallet)
@@ -2287,6 +2356,7 @@ class WalletRpcApi:
                 bytes32.from_hexstr(request["puzhash"]),
                 pubkey,
                 tx_config,
+                extra_conditions=extra_conditions,
             )
         if info is not None and spend_bundle is not None:
             return {
@@ -2342,7 +2412,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def did_transfer_did(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
@@ -2355,6 +2428,7 @@ class WalletRpcApi:
                 uint64(request.get("fee", 0)),
                 request.get("with_recovery_info", True),
                 tx_config,
+                extra_conditions=extra_conditions,
             )
 
         return {
@@ -2367,7 +2441,12 @@ class WalletRpcApi:
     # NFT Wallet
     ##########################################################################################
     @tx_endpoint
-    async def nft_mint_nft(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def nft_mint_nft(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         log.debug("Got minting RPC request: %s", request)
         wallet_id = uint32(request["wallet_id"])
         assert self.service.wallet_state_manager
@@ -2426,6 +2505,7 @@ class WalletRpcApi:
             royalty_amount,
             did_id,
             fee,
+            extra_conditions=extra_conditions,
         )
         nft_id = None
         assert spend_bundle is not None
@@ -2478,7 +2558,12 @@ class WalletRpcApi:
         return {"wallet_id": wallet_id, "success": True, "nft_list": nft_info_list}
 
     @tx_endpoint
-    async def nft_set_nft_did(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def nft_set_nft_did(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
         nft_wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=NFTWallet)
         did_id = request.get("did_id", b"")
@@ -2491,12 +2576,21 @@ class WalletRpcApi:
             return {"success": False, "error": "The NFT doesn't support setting a DID."}
 
         fee = uint64(request.get("fee", 0))
-        spend_bundle = await nft_wallet.set_nft_did(nft_coin_info, did_id, tx_config, fee=fee)
+        spend_bundle = await nft_wallet.set_nft_did(
+            nft_coin_info,
+            did_id,
+            tx_config,
+            fee=fee,
+            extra_conditions=extra_conditions,
+        )
         return {"wallet_id": wallet_id, "success": True, "spend_bundle": spend_bundle}
 
     @tx_endpoint
     async def nft_set_did_bulk(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         """
         Bulk set DID for NFTs across different wallets.
@@ -2547,9 +2641,15 @@ class WalletRpcApi:
         for wallet_id, nft_list in nft_dict.items():
             nft_wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=NFTWallet)
             if not first:
-                tx_list.extend(await nft_wallet.set_bulk_nft_did(nft_list, did_id, tx_config))
+                tx_list.extend(
+                    await nft_wallet.set_bulk_nft_did(nft_list, did_id, tx_config, extra_conditions=extra_conditions)
+                )
             else:
-                tx_list.extend(await nft_wallet.set_bulk_nft_did(nft_list, did_id, tx_config, fee, nft_ids))
+                tx_list.extend(
+                    await nft_wallet.set_bulk_nft_did(
+                        nft_list, did_id, tx_config, fee, nft_ids, extra_conditions=extra_conditions
+                    )
+                )
             for coin in nft_list:
                 coin_ids.append(coin.coin.name())
             first = False
@@ -2582,7 +2682,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def nft_transfer_bulk(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         """
         Bulk transfer NFTs to an address.
@@ -2628,9 +2731,17 @@ class WalletRpcApi:
         for wallet_id, nft_list in nft_dict.items():
             nft_wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=NFTWallet)
             if not first:
-                tx_list.extend(await nft_wallet.bulk_transfer_nft(nft_list, puzzle_hash, tx_config))
+                tx_list.extend(
+                    await nft_wallet.bulk_transfer_nft(
+                        nft_list, puzzle_hash, tx_config, extra_conditions=extra_conditions
+                    )
+                )
             else:
-                tx_list.extend(await nft_wallet.bulk_transfer_nft(nft_list, puzzle_hash, tx_config, fee))
+                tx_list.extend(
+                    await nft_wallet.bulk_transfer_nft(
+                        nft_list, puzzle_hash, tx_config, fee, extra_conditions=extra_conditions
+                    )
+                )
             for coin in nft_list:
                 coin_ids.append(coin.coin.name())
             first = False
@@ -2717,7 +2828,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def nft_transfer_nft(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
         address = request["target_address"]
@@ -2745,6 +2859,7 @@ class WalletRpcApi:
                 fee=fee,
                 new_owner=b"",
                 new_did_inner_hash=b"",
+                extra_conditions=extra_conditions,
             )
             spend_bundle: Optional[SpendBundle] = None
             for tx in txs:
@@ -2825,7 +2940,12 @@ class WalletRpcApi:
         return {"success": True, "nft_info": nft_info}
 
     @tx_endpoint
-    async def nft_add_uri(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def nft_add_uri(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         wallet_id = uint32(request["wallet_id"])
         # Note metadata updater can only add one uri for one field per spend.
         # If you want to add multiple uris for one field, you need to spend multiple times.
@@ -2840,7 +2960,9 @@ class WalletRpcApi:
         nft_coin_info = await nft_wallet.get_nft_coin_by_id(nft_coin_id)
 
         fee = uint64(request.get("fee", 0))
-        spend_bundle = await nft_wallet.update_metadata(nft_coin_info, key, uri, tx_config, fee=fee)
+        spend_bundle = await nft_wallet.update_metadata(
+            nft_coin_info, key, uri, tx_config, fee=fee, extra_conditions=extra_conditions
+        )
         return {"wallet_id": wallet_id, "success": True, "spend_bundle": spend_bundle}
 
     async def nft_calculate_royalties(self, request: Dict[str, Any]) -> EndpointResult:
@@ -2853,7 +2975,12 @@ class WalletRpcApi:
         )
 
     @tx_endpoint
-    async def nft_mint_bulk(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def nft_mint_bulk(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
         wallet_id = uint32(request["wallet_id"])
@@ -2947,6 +3074,7 @@ class WalletRpcApi:
                 did_lineage_parent=did_lineage_parent,
                 fee=fee,
                 tx_config=tx_config,
+                extra_conditions=extra_conditions,
             )
         else:
             sb = await nft_wallet.mint_from_xch(
@@ -2958,6 +3086,7 @@ class WalletRpcApi:
                 xch_change_ph=xch_change_ph,
                 fee=fee,
                 tx_config=tx_config,
+                extra_conditions=extra_conditions,
             )
         nft_id_list = []
         for cs in sb.coin_spends:
@@ -3058,7 +3187,11 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def create_signed_transaction(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG, hold_lock: bool = True
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+        hold_lock: bool = True,
     ) -> EndpointResult:
         if "wallet_id" in request:
             wallet_id = uint32(request["wallet_id"])
@@ -3146,6 +3279,7 @@ class WalletRpcApi:
                     memos=memos_0,
                     coin_announcements_to_consume=coin_announcements,
                     puzzle_announcements_to_consume=puzzle_announcements,
+                    extra_conditions=extra_conditions,
                 )
                 signed_tx = tx.to_json_dict_convenience(self.service.config)
 
@@ -3164,6 +3298,7 @@ class WalletRpcApi:
                     memos=[memos_0] + [output.memos for output in additional_outputs],
                     coin_announcements_to_consume=coin_announcements,
                     puzzle_announcements_to_consume=puzzle_announcements,
+                    extra_conditions=extra_conditions,
                 )
                 signed_txs = [tx.to_json_dict_convenience(self.service.config) for tx in txs]
 
@@ -3179,7 +3314,12 @@ class WalletRpcApi:
     # Pool Wallet
     ##########################################################################################
     @tx_endpoint
-    async def pw_join_pool(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def pw_join_pool(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         fee = uint64(request.get("fee", 0))
         wallet_id = uint32(request["wallet_id"])
         wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=PoolWallet)
@@ -3207,7 +3347,12 @@ class WalletRpcApi:
             return {"total_fee": total_fee, "transaction": tx, "fee_transaction": fee_tx}
 
     @tx_endpoint
-    async def pw_self_pool(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def pw_self_pool(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         # Leaving a pool requires two state transitions.
         # First we transition to PoolSingletonState.LEAVING_POOL
         # Then we transition to FARMING_TO_POOL or SELF_POOLING
@@ -3224,7 +3369,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def pw_absorb_rewards(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         """Perform a sweep of the p2_singleton rewards controlled by the pool wallet singleton"""
         if await self.service.wallet_state_manager.synced() is False:
@@ -3257,7 +3405,12 @@ class WalletRpcApi:
     # DataLayer Wallet
     ##########################################################################################
     @tx_endpoint
-    async def create_new_dl(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def create_new_dl(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         """Initialize the DataLayer Wallet (only one can exist)"""
         if self.service.wallet_state_manager is None:
             raise ValueError("The wallet service is not currently initialized")
@@ -3271,7 +3424,10 @@ class WalletRpcApi:
         try:
             async with self.service.wallet_state_manager.lock:
                 dl_tx, std_tx, launcher_id = await dl_wallet.generate_new_reporter(
-                    bytes32.from_hexstr(request["root"]), tx_config, fee=request.get("fee", uint64(0))
+                    bytes32.from_hexstr(request["root"]),
+                    tx_config,
+                    fee=request.get("fee", uint64(0)),
+                    extra_conditions=extra_conditions,
                 )
                 await self.service.wallet_state_manager.add_pending_transaction(dl_tx)
                 await self.service.wallet_state_manager.add_pending_transaction(std_tx)
@@ -3344,7 +3500,12 @@ class WalletRpcApi:
         return {"singletons": records_json}
 
     @tx_endpoint
-    async def dl_update_root(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def dl_update_root(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         """Get the singleton record for the latest singleton of a launcher ID"""
         if self.service.wallet_state_manager is None:
             raise ValueError("The wallet service is not currently initialized")
@@ -3356,6 +3517,7 @@ class WalletRpcApi:
                 bytes32.from_hexstr(request["new_root"]),
                 tx_config,
                 fee=uint64(request.get("fee", 0)),
+                extra_conditions=extra_conditions,
             )
             for record in records:
                 await self.service.wallet_state_manager.add_pending_transaction(record)
@@ -3363,7 +3525,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def dl_update_multiple(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         """Update multiple singletons with new merkle roots"""
         if self.service.wallet_state_manager is None:
@@ -3376,7 +3541,10 @@ class WalletRpcApi:
             tx_records: List[TransactionRecord] = []
             for launcher, root in request["updates"].items():
                 records = await wallet.create_update_state_spend(
-                    bytes32.from_hexstr(launcher), bytes32.from_hexstr(root), tx_config
+                    bytes32.from_hexstr(launcher),
+                    bytes32.from_hexstr(root),
+                    tx_config,
+                    extra_conditions=extra_conditions,
                 )
                 tx_records.extend(records)
             # Now that we have all the txs, we need to aggregate them all into just one spend
@@ -3434,7 +3602,12 @@ class WalletRpcApi:
         return {"mirrors": mirrors_json}
 
     @tx_endpoint
-    async def dl_new_mirror(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def dl_new_mirror(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         """Add a new on chain message for a specific singleton"""
         if self.service.wallet_state_manager is None:
             raise ValueError("The wallet service is not currently initialized")
@@ -3447,6 +3620,7 @@ class WalletRpcApi:
                 [bytes(url, "utf8") for url in request["urls"]],
                 tx_config,
                 fee=request.get("fee", uint64(0)),
+                extra_conditions=extra_conditions,
             )
             for tx in txs:
                 await self.service.wallet_state_manager.add_pending_transaction(tx)
@@ -3457,7 +3631,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def dl_delete_mirror(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         """Remove an existing mirror for a specific singleton"""
         if self.service.wallet_state_manager is None:
@@ -3471,6 +3648,7 @@ class WalletRpcApi:
                 self.service.get_full_node_peer(),
                 tx_config,
                 fee=request.get("fee", uint64(0)),
+                extra_conditions=extra_conditions,
             )
             for tx in txs:
                 await self.service.wallet_state_manager.add_pending_transaction(tx)
@@ -3483,7 +3661,12 @@ class WalletRpcApi:
     # Verified Credential
     ##########################################################################################
     @tx_endpoint
-    async def vc_mint(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def vc_mint(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         """
         Mint a verified credential using the assigned DID
         :param request: We require 'did_id' that will be minting the VC and options for a new 'target_address' as well
@@ -3507,7 +3690,9 @@ class WalletRpcApi:
             puzhash = decode_puzzle_hash(parsed_request.target_address)
 
         vc_wallet: VCWallet = await self.service.wallet_state_manager.get_or_create_vc_wallet()
-        vc_record, tx_list = await vc_wallet.launch_new_vc(did_id, tx_config, puzhash, parsed_request.fee)
+        vc_record, tx_list = await vc_wallet.launch_new_vc(
+            did_id, tx_config, puzhash, parsed_request.fee, extra_conditions=extra_conditions
+        )
         for tx in tx_list:
             await self.service.wallet_state_manager.add_pending_transaction(tx)
         return {
@@ -3563,7 +3748,12 @@ class WalletRpcApi:
         }
 
     @tx_endpoint
-    async def vc_spend(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def vc_spend(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         """
         Spend a verified credential
         :param request: Required 'vc_id' launcher id of the vc we wish to spend. Optional paramaters for a 'new_puzhash'
@@ -3592,6 +3782,7 @@ class WalletRpcApi:
             parsed_request.new_puzhash,
             new_proof_hash=parsed_request.new_proof_hash,
             provider_inner_puzhash=parsed_request.provider_inner_puzhash,
+            extra_conditions=extra_conditions,
         )
         for tx in txs:
             await self.service.wallet_state_manager.add_pending_transaction(tx)
@@ -3634,7 +3825,12 @@ class WalletRpcApi:
         return {"proofs": vc_proofs.key_value_pairs}
 
     @tx_endpoint
-    async def vc_revoke(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    async def vc_revoke(
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+    ) -> EndpointResult:
         """
         Revoke an on chain VC provided the correct DID is available
         :param request: required 'vc_parent_id' for the VC coin. Standard transaction params 'fee' & 'reuse_puzhash'.
@@ -3655,6 +3851,7 @@ class WalletRpcApi:
             self.service.get_full_node_peer(),
             tx_config,
             parsed_request.fee,
+            extra_conditions=extra_conditions,
         )
         for tx in txs:
             await self.service.wallet_state_manager.add_pending_transaction(tx)
@@ -3665,7 +3862,10 @@ class WalletRpcApi:
 
     @tx_endpoint
     async def crcat_approve_pending(
-        self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG
+        self,
+        request: Dict[str, Any],
+        tx_config: TXConfig = DEFAULT_TX_CONFIG,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
         """
         Moving any "pending approval" CR-CATs into the spendable balance of the wallet

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -340,6 +340,7 @@ class NFTWallet:
         did_id: Optional[bytes] = None,
         fee: uint64 = uint64(0),
         push_tx: bool = True,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Optional[SpendBundle]:
         """
         This must be called under the wallet state manager lock
@@ -403,6 +404,7 @@ class NFTWallet:
             False,
             announcement_set,
             origin_id=origin.name(),
+            extra_conditions=extra_conditions,
         )
         genesis_launcher_solution = Program.to([eve_fullpuz_hash, amount, []])
 
@@ -494,6 +496,7 @@ class NFTWallet:
         uri: str,
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Optional[SpendBundle]:
         uncurried_nft = UncurriedNFT.uncurry(*nft_coin_info.full_puzzle.uncurry())
         assert uncurried_nft is not None
@@ -511,6 +514,7 @@ class NFTWallet:
             fee,
             {nft_coin_info.coin},
             metadata_update=(key, uri),
+            extra_conditions=extra_conditions,
         )
         for tx in txs:
             await self.wallet_state_manager.add_pending_transaction(tx)
@@ -622,6 +626,7 @@ class NFTWallet:
         coin_announcements_to_consume: Optional[Set[Announcement]] = None,
         puzzle_announcements_to_consume: Optional[Set[Announcement]] = None,
         ignore_max_send_amount: bool = False,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
         **kwargs: Unpack[GSTOptionalArgs],
     ) -> List[TransactionRecord]:
         nft_coin: Optional[NFTCoinInfo] = kwargs.get("nft_coin", None)
@@ -655,6 +660,7 @@ class NFTWallet:
             new_did_inner_hash=new_did_inner_hash,
             trade_prices_list=trade_prices_list,
             metadata_update=metadata_update,
+            extra_conditions=extra_conditions,
         )
         spend_bundle = await self.sign(unsigned_spend_bundle)
         spend_bundle = SpendBundle.aggregate([spend_bundle] + additional_bundles)
@@ -701,6 +707,7 @@ class NFTWallet:
         trade_prices_list: Optional[Program] = None,
         metadata_update: Optional[Tuple[str, str]] = None,
         nft_coin: Optional[NFTCoinInfo] = None,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Tuple[SpendBundle, Optional[TransactionRecord]]:
         if nft_coin is None:
             if coins is None or not len(coins) == 1:
@@ -730,7 +737,6 @@ class NFTWallet:
             announcement_to_make = None
             chia_tx = None
 
-        extra_conditions: List[Condition] = []
         unft = UncurriedNFT.uncurry(*nft_coin.full_puzzle.uncurry())
         assert unft is not None
         if unft.supports_did:
@@ -743,7 +749,8 @@ class NFTWallet:
                 )
                 if derivation_record is not None:
                     new_owner = unft.owner_did
-            extra_conditions.append(
+            extra_conditions = (
+                *extra_conditions,
                 UnknownCondition(
                     opcode=Program.to(-10),
                     args=[
@@ -751,17 +758,18 @@ class NFTWallet:
                         Program.to(trade_prices_list),
                         Program.to(new_did_inner_hash),
                     ],
-                )
+                ),
             )
         if metadata_update is not None:
-            extra_conditions.append(
+            extra_conditions = (
+                *extra_conditions,
                 UnknownCondition(
                     opcode=Program.to(-24),
                     args=[
                         NFT_METADATA_UPDATER,
                         Program.to(metadata_update),
                     ],
-                )
+                ),
             )
 
         innersol: Program = self.standard_wallet.make_solution(
@@ -1107,6 +1115,7 @@ class NFTWallet:
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
         announcement_ids: List[bytes32] = [],
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> List[TransactionRecord]:
         self.log.debug("Setting NFT DID with parameters: nft=%s did=%s", nft_list, did_id)
         did_inner_hash = b""
@@ -1127,6 +1136,7 @@ class NFTWallet:
             puzzle_hashes_to_sign = [unft.p2_puzzle.get_tree_hash()]
             if not first:
                 fee = uint64(0)
+                extra_conditions = tuple()
             nft_tx_record.extend(
                 await self.generate_signed_transaction(
                     [uint64(nft_coin_info.coin.amount)],
@@ -1136,6 +1146,7 @@ class NFTWallet:
                     {nft_coin_info.coin},
                     new_owner=did_id,
                     new_did_inner_hash=did_inner_hash,
+                    extra_conditions=extra_conditions,
                 )
             )
             first = False
@@ -1158,6 +1169,7 @@ class NFTWallet:
         puzzle_hash: bytes32,
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> List[TransactionRecord]:
         self.log.debug("Transfer NFTs %s to %s", nft_list, puzzle_hash.hex())
         nft_tx_record = []
@@ -1167,6 +1179,7 @@ class NFTWallet:
         for nft_coin_info in nft_list:
             if not first:
                 fee = uint64(0)
+                extra_conditions = tuple()
             nft_tx_record.extend(
                 await self.generate_signed_transaction(
                     [uint64(nft_coin_info.coin.amount)],
@@ -1176,6 +1189,7 @@ class NFTWallet:
                     fee=fee,
                     new_owner=b"",
                     new_did_inner_hash=b"",
+                    extra_conditions=extra_conditions,
                 )
             )
             first = False
@@ -1197,6 +1211,7 @@ class NFTWallet:
         did_id: bytes,
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> SpendBundle:
         self.log.debug("Setting NFT DID with parameters: nft=%s did=%s", nft_coin_info, did_id)
         unft = UncurriedNFT.uncurry(*nft_coin_info.full_puzzle.uncurry())
@@ -1218,6 +1233,7 @@ class NFTWallet:
             new_owner=did_id,
             new_did_inner_hash=did_inner_hash,
             additional_bundles=additional_bundles,
+            extra_conditions=extra_conditions,
         )
         spend_bundle = SpendBundle.aggregate([x.spend_bundle for x in nft_tx_record if x.spend_bundle is not None])
         if spend_bundle:
@@ -1243,6 +1259,7 @@ class NFTWallet:
         did_coin: Optional[Coin] = None,
         did_lineage_parent: Optional[bytes32] = None,
         fee: Optional[uint64] = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> SpendBundle:
         """
         Minting NFTs from the DID linked wallet, also used for bulk minting NFTs.
@@ -1475,6 +1492,7 @@ class NFTWallet:
             coin_announcements=did_coin_announcement,
             coin_announcements_to_assert=did_announcements,
             puzzle_announcements_to_assert=puzzle_assertions,
+            conditions=extra_conditions,
         )
         did_inner_sol: Program = Program.to([1, did_p2_solution])
         did_full_puzzle: Program = chia.wallet.singleton.create_singleton_puzzle(
@@ -1524,6 +1542,7 @@ class NFTWallet:
         xch_coins: Optional[Set[Coin]] = None,
         xch_change_ph: Optional[bytes32] = None,
         fee: Optional[uint64] = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> SpendBundle:
         """
         Minting NFTs from a single XCH spend using intermediate launcher puzzle
@@ -1695,6 +1714,7 @@ class NFTWallet:
                     coin_announcements=xch_announcement if len(xch_coins) > 1 else None,
                     coin_announcements_to_assert=coin_announcements,
                     puzzle_announcements_to_assert=puzzle_assertions,
+                    conditions=extra_conditions,
                 )
                 primary_announcement_hash = Announcement(xch_coin.name(), message).name()
                 first = False

--- a/chia/wallet/vc_wallet/vc_drivers.py
+++ b/chia/wallet/vc_wallet/vc_drivers.py
@@ -10,6 +10,7 @@ from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.util.hash import std_hash
 from chia.util.ints import uint64
 from chia.util.streamable import Streamable, streamable
+from chia.wallet.conditions import Condition
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
 from chia.wallet.puzzles.singleton_top_layer_v1_1 import (
@@ -337,6 +338,7 @@ class VerifiedCredential(Streamable):
         new_inner_puzzle_hash: bytes32,
         memos: List[bytes32],
         fee: uint64 = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Tuple[Program, List[CoinSpend], _T_VerifiedCredential]:
         """
         Launch a VC.
@@ -408,6 +410,7 @@ class VerifiedCredential(Streamable):
                 [52, fee],
                 [61, std_hash(launcher_coin.name() + launcher_solution.get_tree_hash())],
                 [61, std_hash(second_launcher_coin.name() + launch_dpuz.get_tree_hash())],
+                *[cond.to_program() for cond in extra_conditions],
             ]
         )
 

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -203,7 +203,7 @@ class Wallet:
         coin_announcements_to_assert: Optional[Set[bytes32]] = None,
         puzzle_announcements: Optional[Set[bytes]] = None,
         puzzle_announcements_to_assert: Optional[Set[bytes32]] = None,
-        conditions: List[Condition] = [],
+        conditions: Tuple[Condition, ...] = tuple(),
         fee: uint64 = uint64(0),
     ) -> Program:
         assert fee >= 0
@@ -277,6 +277,7 @@ class Wallet:
         memos: Optional[List[bytes]] = None,
         negative_change_allowed: bool = False,
         puzzle_decorator_override: Optional[List[Dict[str, Any]]] = None,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> List[CoinSpend]:
         """
         Generates a unsigned transaction in form of List(Puzzle, Solutions)
@@ -371,6 +372,7 @@ class Wallet:
                     coin_announcements={message},
                     coin_announcements_to_assert=coin_announcements_bytes,
                     puzzle_announcements_to_assert=puzzle_announcements_bytes,
+                    conditions=extra_conditions,
                 )
                 solution = decorator_manager.solve(inner_puzzle, target_primary, solution)
                 primary_announcement_hash = Announcement(coin.name(), message).name()
@@ -427,6 +429,7 @@ class Wallet:
         puzzle_announcements_to_consume: Optional[Set[Announcement]] = None,
         memos: Optional[List[bytes]] = None,
         puzzle_decorator_override: Optional[List[Dict[str, Any]]] = None,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
         **kwargs: Unpack[GSTOptionalArgs],
     ) -> TransactionRecord:
         origin_id: Optional[bytes32] = kwargs.get("origin_id", None)
@@ -456,6 +459,7 @@ class Wallet:
             memos,
             negative_change_allowed,
             puzzle_decorator_override=puzzle_decorator_override,
+            extra_conditions=extra_conditions,
         )
         assert len(transaction) > 0
         self.log.info("About to sign a transaction: %s", transaction)

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -18,6 +18,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -63,6 +64,7 @@ from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_info import CATInfo, CRCATInfo
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD, CAT_MOD_HASH, construct_cat_puzzle, match_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
+from chia.wallet.conditions import Condition
 from chia.wallet.db_wallet.db_wallet_puzzles import MIRROR_PUZZLE_HASH
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import (
@@ -809,7 +811,12 @@ class WalletStateManager:
             await self.spend_clawback_coins(clawback_coins, tx_fee, tx_config)
 
     async def spend_clawback_coins(
-        self, clawback_coins: Dict[Coin, ClawbackMetadata], fee: uint64, tx_config: TXConfig, force: bool = False
+        self,
+        clawback_coins: Dict[Coin, ClawbackMetadata],
+        fee: uint64,
+        tx_config: TXConfig,
+        force: bool = False,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> List[bytes32]:
         assert len(clawback_coins) > 0
         coin_spends: List[CoinSpend] = []
@@ -850,6 +857,7 @@ class WalletStateManager:
                         )
                     ],
                     coin_announcements=None if len(coin_spends) > 0 or fee == 0 else {message},
+                    conditions=extra_conditions,
                 )
                 coin_spend: CoinSpend = generate_clawback_spend_bundle(coin, metadata, inner_puzzle, inner_solution)
                 coin_spends.append(coin_spend)

--- a/tests/cmds/test_timelock_args.py
+++ b/tests/cmds/test_timelock_args.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import click
+from click.testing import CliRunner
+
+from chia.cmds.cmds_util import timelock_args
+
+
+def test_timelock_args() -> None:
+    @click.command()
+    @timelock_args
+    def test_cmd(
+        valid_at: Optional[int],
+        expires_at: Optional[int],
+    ) -> None:
+        print(valid_at)
+        print(expires_at)
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        test_cmd,
+        [
+            "--valid-at",
+            "0",
+            "--expires-at",
+            "0",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert "0\n0\n" == result.output
+
+    result = runner.invoke(
+        test_cmd,
+        [
+            "--valid-at",
+            "4294967295",
+            "--expires-at",
+            "4294967295",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert "4294967295\n4294967295\n" == result.output
+
+    result = runner.invoke(
+        test_cmd,
+        [],
+        catch_exceptions=False,
+    )
+
+    assert "None\nNone\n" == result.output


### PR DESCRIPTION
Most transactions have the ability to include any of our consensus conditions alongside the ones returned from their standard spend.  We currently don't expose that functionality but this PR adds it as an option to every transaction endpoint (similar to TXConfig).  This implicitly creates support for things like expiring offers and pre-signed transactions.  Further work is needed to make this information displayed in the wallet state manager somehow (PRs in the pipeline)