### PR TITLE
Add timelock information to Trades and Transactions

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -25,7 +25,7 @@ from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.streamable import Streamable, streamable
-from chia.wallet.conditions import Condition, UnknownCondition
+from chia.wallet.conditions import Condition, UnknownCondition, parse_timelock_info
 from chia.wallet.db_wallet.db_wallet_puzzles import (
     ACS_MU,
     ACS_MU_PH,
@@ -355,6 +355,7 @@ class DataLayerWallet:
             trade_id=None,
             type=uint32(TransactionType.INCOMING_TX.value),
             name=full_spend.name(),
+            valid_times=parse_timelock_info(extra_conditions),
         )
         singleton_record = SingletonRecord(
             coin_id=Coin(launcher_coin.name(), full_puzzle.get_tree_hash(), uint64(1)).name(),
@@ -608,6 +609,7 @@ class DataLayerWallet:
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=singleton_record.coin_id,
+            valid_times=parse_timelock_info(extra_conditions),
         )
         assert dl_tx.spend_bundle is not None
         if fee > 0:
@@ -822,6 +824,7 @@ class DataLayerWallet:
                 trade_id=None,
                 type=uint32(TransactionType.OUTGOING_TX.value),
                 name=mirror_bundle.name(),
+                valid_times=parse_timelock_info(extra_conditions),
             )
         ]
 

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -46,7 +46,7 @@ from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64, uint128
-from chia.wallet.conditions import Condition
+from chia.wallet.conditions import Condition, ConditionValidTimes, parse_timelock_info
 from chia.wallet.derive_keys import find_owner_sk
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_synthetic_public_key
 from chia.wallet.sign_coin_spends import sign_coin_spends
@@ -460,6 +460,7 @@ class PoolWallet:
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=spend_bundle.name(),
+            valid_times=parse_timelock_info(extra_conditions),
         )
         await standard_wallet.push_transaction(standard_wallet_record)
         p2_singleton_puzzle_hash: bytes32 = launcher_id_to_p2_puzzle_hash(
@@ -632,6 +633,7 @@ class PoolWallet:
             memos=[],
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=signed_spend_bundle.name(),
+            valid_times=ConditionValidTimes(),
         )
 
         await self.publish_transactions(tx_record, fee_tx)
@@ -913,6 +915,7 @@ class PoolWallet:
             trade_id=None,
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=full_spend.name(),
+            valid_times=ConditionValidTimes(),
         )
 
         await self.publish_transactions(absorb_transaction, fee_tx)

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -3928,6 +3928,7 @@ class WalletRpcApi:
             parsed_request.min_amount_to_claim,
             tx_config,
             fee=parsed_request.fee,
+            extra_conditions=extra_conditions,
         )
         for tx in txs:
             await self.service.wallet_state_manager.add_pending_transaction(tx)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -33,7 +33,7 @@ from chia.wallet.cat_wallet.cat_utils import (
 )
 from chia.wallet.cat_wallet.lineage_store import CATLineageStore
 from chia.wallet.coin_selection import select_coins
-from chia.wallet.conditions import Condition, UnknownCondition
+from chia.wallet.conditions import Condition, ConditionValidTimes, UnknownCondition, parse_timelock_info
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.outer_puzzles import AssetType
@@ -170,6 +170,7 @@ class CATWallet:
             type=uint32(TransactionType.INCOMING_TX.value),
             name=bytes32(token_bytes()),
             memos=[],
+            valid_times=ConditionValidTimes(),
         )
         chia_tx = dataclasses.replace(chia_tx, spend_bundle=spend_bundle)
         await self.standard_wallet.push_transaction(chia_tx)
@@ -833,6 +834,7 @@ class CATWallet:
                 type=uint32(TransactionType.OUTGOING_TX.value),
                 name=spend_bundle.name(),
                 memos=list(compute_memos(spend_bundle).items()),
+                valid_times=parse_timelock_info(extra_conditions),
             )
         ]
 
@@ -855,6 +857,7 @@ class CATWallet:
                     type=chia_tx.type,
                     name=chia_tx.name,
                     memos=[],
+                    valid_times=parse_timelock_info(extra_conditions),
                 )
             )
 

--- a/chia/wallet/conditions.py
+++ b/chia/wallet/conditions.py
@@ -1210,7 +1210,7 @@ ABSOLUTE_PROPERTIES: Set[str] = {"min_time", "max_time", "min_height", "max_heig
 ALL_PROPERTIES: Set[str] = SECONDS_PROPERTIES | HEIGHT_PROPERTIES
 
 
-def parse_timelock_info(conditions: List[Condition]) -> ConditionValidTimes:
+def parse_timelock_info(conditions: Iterable[Condition]) -> ConditionValidTimes:
     valid_times: ConditionValidTimes = ConditionValidTimes()
     properties: Set[str] = ALL_PROPERTIES.copy()
     for condition in conditions:

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -20,7 +20,7 @@ from chia.types.coin_spend import CoinSpend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.ints import uint32, uint64, uint128
-from chia.wallet.conditions import Condition
+from chia.wallet.conditions import Condition, ConditionValidTimes, parse_timelock_info
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk_unhardened
 from chia.wallet.did_wallet import did_wallet_puzzles
@@ -618,6 +618,7 @@ class DIDWallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=bytes32(token_bytes()),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=parse_timelock_info(extra_conditions),
         )
         await self.wallet_state_manager.add_pending_transaction(did_record)
 
@@ -714,6 +715,7 @@ class DIDWallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=bytes32(token_bytes()),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=parse_timelock_info(extra_conditions),
         )
         await self.wallet_state_manager.add_pending_transaction(did_record)
         return did_record
@@ -834,6 +836,7 @@ class DIDWallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=bytes32(token_bytes()),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=ConditionValidTimes(),
         )
         await self.wallet_state_manager.add_pending_transaction(did_record)
         return spend_bundle
@@ -915,6 +918,7 @@ class DIDWallet:
             type=uint32(TransactionType.INCOMING_TX.value),
             name=bytes32(token_bytes()),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=parse_timelock_info(extra_conditions),
         )
         attest_str: str = f"{self.get_my_DID()}:{bytes(message_spend_bundle).hex()}:{coin.parent_coin_info.hex()}:"
         attest_str += f"{self.did_info.current_inner.get_tree_hash().hex()}:{coin.amount}"
@@ -1043,6 +1047,7 @@ class DIDWallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=bytes32(token_bytes()),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=ConditionValidTimes(),
         )
         await self.wallet_state_manager.add_pending_transaction(did_record)
         new_did_info = DIDInfo(
@@ -1284,6 +1289,7 @@ class DIDWallet:
             type=uint32(TransactionType.INCOMING_TX.value),
             name=bytes32(token_bytes()),
             memos=[],
+            valid_times=ConditionValidTimes(),
         )
         regular_record = dataclasses.replace(tx_record, spend_bundle=None)
         await self.wallet_state_manager.add_pending_transaction(regular_record)

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -23,7 +23,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint32, uint64, uint128
-from chia.wallet.conditions import Condition, UnknownCondition
+from chia.wallet.conditions import Condition, UnknownCondition, parse_timelock_info
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.did_wallet import did_wallet_puzzles
 from chia.wallet.did_wallet.did_info import DIDInfo
@@ -689,6 +689,7 @@ class NFTWallet:
                 type=uint32(TransactionType.OUTGOING_TX.value),
                 name=spend_bundle.name(),
                 memos=list(compute_memos(spend_bundle).items()),
+                valid_times=parse_timelock_info(extra_conditions),
             ),
         ]
 

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -17,7 +17,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
-from chia.wallet.conditions import Condition
+from chia.wallet.conditions import Condition, ConditionValidTimes, parse_conditions_non_consensus, parse_timelock_info
 from chia.wallet.db_wallet.db_wallet_puzzles import ACS_MU_PH
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.outer_puzzles import AssetType
@@ -255,6 +255,7 @@ class TradeManager:
                 continue
 
             cancellation_additions: List[Coin] = []
+            valid_times: ConditionValidTimes = parse_timelock_info(extra_conditions)
             for coin in Offer.from_bytes(trade.offer).get_cancellation_coins():
                 wallet = await self.wallet_state_manager.get_wallet_for_coin(coin.name())
 
@@ -329,6 +330,7 @@ class TradeManager:
                         type=uint32(TransactionType.INCOMING_TX.value),
                         name=cancellation_additions[0].name(),
                         memos=[],
+                        valid_times=valid_times,
                     )
                 )
 
@@ -397,6 +399,7 @@ class TradeManager:
             trade_id=created_offer.name(),
             status=uint32(TradeStatus.PENDING_ACCEPT.value),
             sent_to=[],
+            valid_times=parse_timelock_info(extra_conditions),
         )
 
         if success is True and trade_offer is not None and not validate_only:
@@ -617,6 +620,13 @@ class TradeManager:
             additions_dict.update({id: hc.coin for id, hc in hinted_coins.items()})
         removals: List[Coin] = final_spend_bundle.removals()
         additions: List[Coin] = list(a for a in additions_dict.values() if a not in removals)
+        valid_times: ConditionValidTimes = parse_timelock_info(
+            parse_conditions_non_consensus(
+                condition
+                for spend in final_spend_bundle.coin_spends
+                for condition in spend.puzzle_reveal.to_program().run(spend.solution.to_program()).as_iter()
+            )
+        )
         all_fees = uint64(final_spend_bundle.fees())
 
         txs = []
@@ -649,6 +659,7 @@ class TradeManager:
                             type=uint32(TransactionType.INCOMING_TRADE.value),
                             name=std_hash(final_spend_bundle.name() + addition.name()),
                             memos=[(coin_id, [hint]) for coin_id, hint in hint_dict.items()],
+                            valid_times=valid_times,
                         )
                     )
                 else:  # This is change
@@ -696,6 +707,7 @@ class TradeManager:
                     type=uint32(TransactionType.OUTGOING_TRADE.value),
                     name=std_hash(final_spend_bundle.name() + removal_tree_hash),
                     memos=[(coin_id, [hint]) for coin_id, hint in hint_dict.items()],
+                    valid_times=valid_times,
                 )
             )
 
@@ -772,6 +784,7 @@ class TradeManager:
             trade_id=complete_offer.name(),
             status=uint32(TradeStatus.PENDING_CONFIRM.value),
             sent_to=[],
+            valid_times=parse_timelock_info(extra_conditions),
         )
 
         await self.save_trade(trade_record, offer)
@@ -794,6 +807,7 @@ class TradeManager:
             type=uint32(TransactionType.OUTGOING_TRADE.value),
             name=final_spend_bundle.name(),
             memos=[],
+            valid_times=ConditionValidTimes(),
         )
         await self.wallet_state_manager.add_pending_transaction(push_tx)
         for tx in tx_records:

--- a/chia/wallet/trade_record.py
+++ b/chia/wallet/trade_record.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint8, uint32, uint64
 from chia.util.streamable import Streamable, streamable
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
+
+_T_TradeRecord = TypeVar("_T_TradeRecord", bound="TradeRecordOld")
 
 
 @streamable
 @dataclass(frozen=True)
-class TradeRecord(Streamable):
+class TradeRecordOld(Streamable):
     """
     Used for storing transaction data and status in wallets.
     """
@@ -47,10 +50,18 @@ class TradeRecord(Streamable):
         return formatted
 
     @classmethod
-    def from_json_dict_convenience(cls, record: Dict[str, Any], offer: str = "") -> "TradeRecord":
+    def from_json_dict_convenience(
+        cls: Type[_T_TradeRecord], record: Dict[str, Any], offer: str = ""
+    ) -> _T_TradeRecord:
         new_record = record.copy()
         new_record["status"] = TradeStatus[record["status"]].value
         del new_record["summary"]
         del new_record["pending"]
         new_record["offer"] = offer
         return cls.from_json_dict(new_record)
+
+
+@streamable
+@dataclass(frozen=True)
+class TradeRecord(TradeRecordOld):
+    valid_times: ConditionValidTimes

--- a/chia/wallet/trading/trade_status.py
+++ b/chia/wallet/trading/trade_status.py
@@ -10,3 +10,4 @@ class TradeStatus(Enum):
     CANCELLED = 3
     CONFIRMED = 4
     FAILED = 5
+    EXPIRED = 6

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -145,7 +145,7 @@ class TradeStore:
             try:
                 await conn.execute("CREATE TABLE trade_record_times(trade_id blob PRIMARY KEY, valid_times blob)")
                 async with await conn.execute("SELECT trade_id from trade_records") as cursor:
-                    trade_ids: List[bytes32] = [bytes32.from_hexstr(row) for row in await cursor.fetchall()]
+                    trade_ids: List[bytes32] = [bytes32.from_hexstr(row[0]) for row in await cursor.fetchall()]
                     await conn.executemany(
                         "INSERT INTO trade_record_times (trade_id, valid_times) VALUES(?, ?)",
                         [(id, bytes(ConditionValidTimes())) for id in trade_ids],

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Dict, Generic, List, Optional, Tuple, Type, TypeVar
 
 from chia.consensus.coinbase import farmer_parent_id, pool_parent_id
 from chia.types.blockchain_format.coin import Coin
@@ -12,9 +12,11 @@ from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32, uint64
 from chia.util.streamable import Streamable, streamable
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.util.transaction_type import TransactionType
 
 T = TypeVar("T")
+_T_TransactionRecord = TypeVar("_T_TransactionRecord", bound="TransactionRecordOld")
 
 minimum_send_attempts = 6
 
@@ -27,7 +29,7 @@ class ItemAndTransactionRecords(Generic[T]):
 
 @streamable
 @dataclass(frozen=True)
-class TransactionRecord(Streamable):
+class TransactionRecordOld(Streamable):
     """
     Used for storing transaction data and status in wallets.
     """
@@ -81,7 +83,7 @@ class TransactionRecord(Streamable):
         return {coin_id: ms for coin_id, ms in self.memos}
 
     @classmethod
-    def from_json_dict_convenience(cls, modified_tx_input: Dict):
+    def from_json_dict_convenience(cls: Type[_T_TransactionRecord], modified_tx_input: Dict) -> _T_TransactionRecord:
         modified_tx = modified_tx_input.copy()
         if "to_address" in modified_tx:
             modified_tx["to_puzzle_hash"] = decode_puzzle_hash(modified_tx["to_address"]).hex()
@@ -127,3 +129,9 @@ class TransactionRecord(Streamable):
 
     def hint_dict(self) -> Dict[bytes32, bytes32]:
         return {coin_id: bytes32(memos[0]) for coin_id, memos in self.memos if len(memos) > 0 and len(memos[0]) == 32}
+
+
+@streamable
+@dataclass(frozen=True)
+class TransactionRecord(TransactionRecordOld):
+    valid_times: ConditionValidTimes

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -24,7 +24,7 @@ from chia.wallet.cat_wallet.cat_info import CATCoinData, CRCATInfo
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD, construct_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.coin_selection import select_coins
-from chia.wallet.conditions import Condition, UnknownCondition
+from chia.wallet.conditions import Condition, ConditionValidTimes, UnknownCondition, parse_timelock_info
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.payment import Payment
@@ -248,6 +248,7 @@ class CRCATWallet(CATWallet):
                     type=uint32(TransactionType.INCOMING_CRCAT_PENDING),
                     name=coin.name(),
                     memos=list(memos.items()),
+                    valid_times=ConditionValidTimes(),
                 )
                 await self.wallet_state_manager.tx_store.add_transaction_record(tx_record)
             else:  # pragma: no cover
@@ -693,6 +694,7 @@ class CRCATWallet(CATWallet):
                 type=uint32(TransactionType.OUTGOING_TX.value),
                 name=signed_spend_bundle.name(),
                 memos=list(compute_memos(signed_spend_bundle).items()),
+                valid_times=parse_timelock_info(extra_conditions),
             )
             for i, payment in enumerate(payments)
         ]
@@ -709,6 +711,7 @@ class CRCATWallet(CATWallet):
         max_coin_amount: Optional[uint64] = None,
         excluded_coin_amounts: Optional[List[uint64]] = None,
         reuse_puzhash: Optional[bool] = None,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> List[TransactionRecord]:
         # Select the relevant CR-CAT coins
         crcat_records: Set[WalletCoinRecord] = await self.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(
@@ -798,6 +801,7 @@ class CRCATWallet(CATWallet):
             puzzle_announcements=set(crcat.expected_announcement() for crcat, _ in crcats_and_puzhashes),
             coin_announcements={nonce},
             coin_announcements_to_consume=set(expected_announcements),
+            extra_conditions=extra_conditions,
         )
         claim_bundle = SpendBundle.aggregate(
             [claim_bundle, *(tx.spend_bundle for tx in vc_txs if tx.spend_bundle is not None)]
@@ -821,6 +825,7 @@ class CRCATWallet(CATWallet):
                 type=uint32(TransactionType.INCOMING_TX.value),
                 name=claim_bundle.name(),
                 memos=list(compute_memos(claim_bundle).items()),
+                valid_times=parse_timelock_info(extra_conditions),
             ),
             *(dataclasses.replace(tx, spend_bundle=None) for tx in vc_txs),
             *((dataclasses.replace(chia_tx, spend_bundle=None),) if chia_tx is not None else []),

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -21,7 +21,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
 from chia.util.streamable import Streamable
-from chia.wallet.conditions import Condition, UnknownCondition
+from chia.wallet.conditions import Condition, UnknownCondition, parse_timelock_info
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.payment import Payment
 from chia.wallet.puzzle_drivers import Solver
@@ -216,6 +216,7 @@ class VCWallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=spend_bundle.name(),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=parse_timelock_info(extra_conditions),
         )
 
         return vc_record, [tx]
@@ -356,6 +357,7 @@ class VCWallet:
                 type=uint32(TransactionType.OUTGOING_TX.value),
                 name=spend_bundle.name(),
                 memos=list(compute_memos(spend_bundle).items()),
+                valid_times=parse_timelock_info(extra_conditions),
             )
         )
         return tx_list
@@ -434,6 +436,7 @@ class VCWallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=final_bundle.name(),
             memos=list(compute_memos(final_bundle).items()),
+            valid_times=parse_timelock_info(extra_conditions),
         )
         if fee > 0:
             chia_tx: TransactionRecord = await self.wallet_state_manager.main_wallet.create_tandem_xch_tx(

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -18,7 +18,7 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
 from chia.util.streamable import Streamable
 from chia.wallet.coin_selection import select_coins
-from chia.wallet.conditions import Condition
+from chia.wallet.conditions import Condition, parse_timelock_info
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.payment import Payment
 from chia.wallet.puzzles.clawback.metadata import ClawbackMetadata
@@ -495,6 +495,7 @@ class Wallet:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=spend_bundle.name(),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=parse_timelock_info(extra_conditions),
         )
 
     async def create_tandem_xch_tx(

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -280,7 +280,7 @@ class WalletNode:
     async def reset_sync_db(self, db_path: Union[Path, str], fingerprint: int) -> bool:
         conn: aiosqlite.Connection
         # are not part of core wallet tables, but might appear later
-        ignore_tables = {"lineage_proofs_", "sqlite_"}
+        ignore_tables = {"lineage_proofs_", "sqlite_", "MIGRATED_VALID_TIMES_TXS", "MIGRATED_VALID_TIMES_TRADES"}
         required_tables = [
             "coin_record",
             "transaction_record",

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -291,6 +291,8 @@ class WalletNode:
             "all_notification_ids",
             "key_val_store",
             "trade_records",
+            "trade_record_times",
+            "tx_times",
             "pool_state_transitions",
             "singleton_records",
             "mirrors",

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -51,7 +51,7 @@ from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_info import CATCoinData, CATInfo, CRCATInfo
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD, CAT_MOD_HASH, construct_cat_puzzle, match_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
-from chia.wallet.conditions import Condition
+from chia.wallet.conditions import Condition, ConditionValidTimes, parse_timelock_info
 from chia.wallet.db_wallet.db_wallet_puzzles import MIRROR_PUZZLE_HASH
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import (
@@ -891,6 +891,7 @@ class WalletStateManager:
             type=uint32(TransactionType.OUTGOING_CLAWBACK),
             name=spend_bundle.name(),
             memos=list(compute_memos(spend_bundle).items()),
+            valid_times=parse_timelock_info(extra_conditions),
         )
         await self.add_pending_transaction(tx_record)
         # Update incoming tx to prevent double spend and mark it is pending
@@ -1329,6 +1330,7 @@ class WalletStateManager:
                         type=uint32(TransactionType.OUTGOING_CLAWBACK),
                         name=clawback_spend_bundle.name(),
                         memos=list(compute_memos(clawback_spend_bundle).items()),
+                        valid_times=ConditionValidTimes(),
                     )
                     await self.tx_store.add_transaction_record(tx_record)
             coin_record = WalletCoinRecord(
@@ -1370,6 +1372,7 @@ class WalletStateManager:
                 # Use coin ID as the TX ID to mapping with the coin table
                 name=coin_record.coin.name(),
                 memos=list(memos.items()),
+                valid_times=ConditionValidTimes(),
             )
             await self.tx_store.add_transaction_record(tx_record)
         return None
@@ -1555,6 +1558,7 @@ class WalletStateManager:
                                     type=uint32(tx_type),
                                     name=bytes32(token_bytes()),
                                     memos=[],
+                                    valid_times=ConditionValidTimes(),
                                 )
                                 await self.tx_store.add_transaction_record(tx_record)
 
@@ -1634,6 +1638,7 @@ class WalletStateManager:
                                         type=uint32(TransactionType.OUTGOING_TX.value),
                                         name=tx_name,
                                         memos=[],
+                                        valid_times=ConditionValidTimes(),
                                     )
 
                                     await self.tx_store.add_transaction_record(tx_record)
@@ -1952,6 +1957,7 @@ class WalletStateManager:
                 type=uint32(tx_type),
                 name=coin_name,
                 memos=[],
+                valid_times=ConditionValidTimes(),
             )
             if tx_record.amount > 0:
                 await self.tx_store.add_transaction_record(tx_record)

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -30,40 +30,6 @@ def filter_ok_mempool_status(sent_to: List[Tuple[str, uint8, Optional[str]]]) ->
     return new_sent_to
 
 
-async def migrate_valid_timess(db_connection: aiosqlite.Connection) -> None:
-    """
-    Migrate the serialized Transaction (transaction_record column) to contain a field for valid_times.
-    """
-    log.info("Beginning migration of valid_times property in transaction_record")
-
-    start_time = time.perf_counter()
-    cursor = await db_connection.execute("SELECT transaction_record, bundle_id from transaction_record")
-    rows = await cursor.fetchall()
-    await cursor.close()
-
-    updates: List[Tuple[bytes, str]] = []
-    for row in rows:
-        updates.append(
-            (
-                bytes(
-                    TransactionRecord(
-                        **TransactionRecordOld.from_bytes(row[0]).__dict__, valid_times=ConditionValidTimes()
-                    )
-                ),
-                row[1],
-            )
-        )
-
-    try:
-        await db_connection.executemany("UPDATE transaction_record SET transaction_record=? WHERE bundle_id=?", updates)
-    except (aiosqlite.OperationalError, aiosqlite.IntegrityError):  # pragma: no cover
-        log.exception("Failed to migrate valid_times property in transaction_record")
-        raise
-
-    end_time = time.perf_counter()
-    log.info(f"Completed migration of {len(updates)} records in {end_time - start_time} seconds")
-
-
 class WalletTransactionStore:
     """
     WalletTransactionStore stores transaction history for the wallet.
@@ -118,16 +84,16 @@ class WalletTransactionStore:
                 "CREATE INDEX IF NOT EXISTS transaction_record_wallet_id on transaction_record(wallet_id)"
             )
 
-            needs_valid_times_migration: bool = False
-            cursor = await conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='MIGRATED_VALID_TIMES_TXS'"
-            )
-            if await cursor.fetchone() is None:
-                needs_valid_times_migration = True
-                await conn.execute("CREATE TABLE MIGRATED_VALID_TIMES_TXS(_ blob)")
-
-            if needs_valid_times_migration:
-                await migrate_valid_timess(conn)
+            try:
+                await conn.execute("CREATE TABLE tx_times(txid blob PRIMARY KEY, valid_times blob)")
+                async with await conn.execute("SELECT bundle_id from transaction_record") as cursor:
+                    txids: List[bytes32] = [bytes32.from_hexstr(row) for row in await cursor.fetchall()]
+                    await conn.executemany(
+                        "INSERT INTO tx_times (txid, valid_times) VALUES(?, ?)",
+                        [(id, bytes(ConditionValidTimes())) for id in txids],
+                    )
+            except aiosqlite.OperationalError:
+                pass  # ignore what is likely Duplicate table error
 
         self.tx_submitted = {}
         self.last_wallet_tx_resend_time = int(time.time())
@@ -141,7 +107,16 @@ class WalletTransactionStore:
             await conn.execute_insert(
                 "INSERT OR REPLACE INTO transaction_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
-                    bytes(record),
+                    bytes(
+                        TransactionRecordOld(
+                            spend_bundle=record.spend_bundle,
+                            **{
+                                k: v
+                                for k, v in dataclasses.asdict(record).items()
+                                if k not in ("valid_times", "spend_bundle")
+                            },
+                        )
+                    ),
                     record.name,
                     record.confirmed_at_height,
                     record.created_at_time,
@@ -153,6 +128,13 @@ class WalletTransactionStore:
                     record.wallet_id,
                     record.trade_id,
                     record.type,
+                ),
+            )
+            await conn.execute_insert(
+                "INSERT OR REPLACE INTO tx_times " "(txid, valid_times) " "VALUES(?, ?)",
+                (
+                    record.name,
+                    bytes(record.valid_times),
                 ),
             )
 
@@ -232,7 +214,7 @@ class WalletTransactionStore:
                 )
             )
         if len(rows) > 0:
-            return TransactionRecord.from_bytes(rows[0][0])
+            return (await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(rows[0][0])]))[0]
         return None
 
     # TODO: This should probably be split into separate function, one that
@@ -251,7 +233,7 @@ class WalletTransactionStore:
         records = []
 
         for row in rows:
-            record = TransactionRecord.from_bytes(row[0])
+            record = (await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0])]))[0]
             if include_accepted_txs:
                 # Reset the "sent" state for peers that have replied about this transaction. Retain errors.
                 record = dataclasses.replace(record, sent=1, sent_to=filter_ok_mempool_status(record.sent_to))
@@ -284,7 +266,7 @@ class WalletTransactionStore:
                 "SELECT transaction_record from transaction_record WHERE confirmed=1 and (type=? or type=?)",
                 (fee_int, pool_int),
             )
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def get_all_unconfirmed(self) -> List[TransactionRecord]:
         """
@@ -292,7 +274,7 @@ class WalletTransactionStore:
         """
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall("SELECT transaction_record from transaction_record WHERE confirmed=0")
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def get_unconfirmed_for_wallet(self, wallet_id: int) -> List[TransactionRecord]:
         """
@@ -302,7 +284,7 @@ class WalletTransactionStore:
             rows = await conn.execute_fetchall(
                 "SELECT transaction_record from transaction_record WHERE confirmed=0 AND wallet_id=?", (wallet_id,)
             )
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def get_transactions_between(
         self,
@@ -355,7 +337,7 @@ class WalletTransactionStore:
                 (wallet_id,),
             )
 
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def get_transaction_count_for_wallet(
         self,
@@ -400,7 +382,7 @@ class WalletTransactionStore:
                         type,
                     ),
                 )
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def get_all_transactions(self) -> List[TransactionRecord]:
         """
@@ -408,7 +390,7 @@ class WalletTransactionStore:
         """
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall("SELECT transaction_record from transaction_record")
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def get_transaction_above(self, height: int) -> List[TransactionRecord]:
         # Can be -1 (get all tx)
@@ -417,14 +399,14 @@ class WalletTransactionStore:
             rows = await conn.execute_fetchall(
                 "SELECT transaction_record from transaction_record WHERE confirmed_at_height>?", (height,)
             )
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def get_transactions_by_trade_id(self, trade_id: bytes32) -> List[TransactionRecord]:
         async with self.db_wrapper.reader_no_transaction() as conn:
             rows = await conn.execute_fetchall(
                 "SELECT transaction_record from transaction_record WHERE trade_id=?", (trade_id,)
             )
-        return [TransactionRecord.from_bytes(row[0]) for row in rows]
+        return await self._get_new_tx_records_from_old([TransactionRecordOld.from_bytes(row[0]) for row in rows])
 
     async def rollback_to_block(self, height: int):
         # Delete from storage
@@ -444,3 +426,22 @@ class WalletTransactionStore:
                     ),
                 )
             ).close()
+
+    async def _get_new_tx_records_from_old(self, old_records: List[TransactionRecordOld]) -> List[TransactionRecord]:
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            cursor = await conn.execute(
+                f"SELECT valid_times from tx_times WHERE txid IN ({','.join('?' *  len(old_records))})",
+                tuple(tx.name for tx in old_records),
+            )
+            valid_times: List[ConditionValidTimes] = [
+                ConditionValidTimes.from_bytes(res[0]) for res in await cursor.fetchall()
+            ]
+            await cursor.close()
+        return [
+            TransactionRecord(
+                valid_times=vts,
+                spend_bundle=record.spend_bundle,
+                **{k: v for k, v in dataclasses.asdict(record).items() if k != "spend_bundle"},
+            )
+            for record, vts in zip(old_records, valid_times)
+        ]

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -87,7 +87,7 @@ class WalletTransactionStore:
             try:
                 await conn.execute("CREATE TABLE tx_times(txid blob PRIMARY KEY, valid_times blob)")
                 async with await conn.execute("SELECT bundle_id from transaction_record") as cursor:
-                    txids: List[bytes32] = [bytes32.from_hexstr(row) for row in await cursor.fetchall()]
+                    txids: List[bytes32] = [bytes32(row[0]) for row in await cursor.fetchall()]
                     await conn.executemany(
                         "INSERT INTO tx_times (txid, valid_times) VALUES(?, ?)",
                         [(id, bytes(ConditionValidTimes())) for id in txids],

--- a/tests/cmds/cmd_test_utils.py
+++ b/tests/cmds/cmd_test_utils.py
@@ -27,6 +27,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import load_config
 from chia.util.ints import uint8, uint16, uint32, uint64
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.nft_wallet.nft_info import NFTInfo
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.transaction_record import TransactionRecord
@@ -126,6 +127,7 @@ class TestWalletRpcClient(TestRpcClient):
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=bytes32([2] * 32),
             memos=[(bytes32([3] * 32), [bytes([4] * 32)])],
+            valid_times=ConditionValidTimes(),
         )
 
     async def get_cat_name(self, wallet_id: int) -> str:
@@ -270,6 +272,7 @@ class TestWalletRpcClient(TestRpcClient):
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=bytes32([2] * 32),
             memos=[(bytes32([3] * 32), [bytes([4] * 32)])],
+            valid_times=ConditionValidTimes(),
         )
 
 

--- a/tests/cmds/wallet/test_consts.py
+++ b/tests/cmds/wallet/test_consts.py
@@ -6,6 +6,7 @@ from chia_rs import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint8, uint32, uint64
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 
@@ -39,4 +40,5 @@ STD_TX = TransactionRecord(
     type=uint32(TransactionType.OUTGOING_TX.value),
     name=get_bytes32(2),
     memos=[(get_bytes32(3), [bytes([4] * 32)])],
+    valid_times=ConditionValidTimes(),
 )

--- a/tests/cmds/wallet/test_wallet.py
+++ b/tests/cmds/wallet/test_wallet.py
@@ -13,6 +13,7 @@ from chia.types.signing_mode import SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint8, uint32, uint64
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
@@ -121,6 +122,7 @@ def test_get_transactions(capsys: object, get_test_cli_clients: Tuple[TestRpcCli
                     type=uint32(t_type.value),
                     name=bytes32([2 + i] * 32),
                     memos=[(bytes32([3 + i] * 32), [bytes([4 + i] * 32)])],
+                    valid_times=ConditionValidTimes(),
                 )
                 l_tx_rec.append(tx_rec)
 
@@ -330,6 +332,7 @@ def test_send(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Path])
                 type=uint32(TransactionType.OUTGOING_CLAWBACK.value),
                 name=get_bytes32(2),
                 memos=[(get_bytes32(3), [bytes([4] * 32)])],
+                valid_times=ConditionValidTimes(),
             )
             return tx_rec
 
@@ -660,6 +663,7 @@ def test_make_offer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
                 coins_of_interest=[],
                 trade_id=get_bytes32(2),
                 status=uint32(TradeStatus.PENDING_ACCEPT.value),
+                valid_times=ConditionValidTimes(),
             )
 
             return created_offer, trade_offer
@@ -796,6 +800,7 @@ def test_get_offers(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
                     ],
                     trade_id=bytes32([1 + i] * 32),
                     status=uint32(TradeStatus.PENDING_ACCEPT.value),
+                    valid_times=ConditionValidTimes(),
                 )
                 records.append(trade_offer)
             return records
@@ -856,6 +861,7 @@ def test_take_offer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
                 coins_of_interest=offer.get_involved_coins(),
                 trade_id=offer.name(),
                 status=uint32(TradeStatus.PENDING_ACCEPT.value),
+                valid_times=ConditionValidTimes(),
             )
 
     inst_rpc_client = TakeOfferRpcClient()  # pylint: disable=no-value-for-parameter
@@ -905,6 +911,7 @@ def test_cancel_offer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
                 coins_of_interest=offer.get_involved_coins(),
                 trade_id=offer.name(),
                 status=uint32(TradeStatus.PENDING_ACCEPT.value),
+                valid_times=ConditionValidTimes(),
             )
 
         async def cancel_offer(

--- a/tests/wallet/test_transaction_store.py
+++ b/tests/wallet/test_transaction_store.py
@@ -11,7 +11,8 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32, uint64
-from chia.wallet.transaction_record import TransactionRecord, minimum_send_attempts
+from chia.wallet.conditions import ConditionValidTimes
+from chia.wallet.transaction_record import TransactionRecord, TransactionRecordOld, minimum_send_attempts
 from chia.wallet.util.query_filter import TransactionTypeFilter
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.wallet_transaction_store import WalletTransactionStore, filter_ok_mempool_status
@@ -38,6 +39,7 @@ tr1 = TransactionRecord(
     uint32(TransactionType.OUTGOING_TX),  # type
     bytes32(token_bytes(32)),  # name
     [],  # List[Tuple[bytes32, List[bytes]]] memos
+    ConditionValidTimes(),
 )
 
 
@@ -738,3 +740,69 @@ async def test_transaction_record_is_valid() -> None:
     assert dataclasses.replace(tr1, sent_to=invalid_attempts + [mempool_success]).is_valid()
     assert dataclasses.replace(tr1, sent_to=invalid_attempts + [low_fee]).is_valid()
     assert dataclasses.replace(tr1, sent_to=invalid_attempts + [close_to_zero]).is_valid()
+
+
+@pytest.mark.asyncio
+async def test_valid_times_migration() -> None:
+    async with DBConnection(1) as db_wrapper:
+        async with db_wrapper.writer_maybe_transaction() as conn:
+            await conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS transaction_record("
+                    " transaction_record blob,"
+                    " bundle_id text PRIMARY KEY,"
+                    " confirmed_at_height bigint,"
+                    " created_at_time bigint,"
+                    " to_puzzle_hash text,"
+                    " amount blob,"
+                    " fee_amount blob,"
+                    " confirmed int,"
+                    " sent int,"
+                    " wallet_id bigint,"
+                    " trade_id text,"
+                    " type int)"
+                )
+            )
+
+        old_record = TransactionRecordOld(
+            confirmed_at_height=uint32(0),
+            created_at_time=uint64(1000000000),
+            to_puzzle_hash=bytes32([0] * 32),
+            amount=uint64(0),
+            fee_amount=uint64(0),
+            confirmed=False,
+            sent=uint32(10),
+            spend_bundle=None,
+            additions=[],
+            removals=[],
+            wallet_id=uint32(1),
+            sent_to=[],
+            trade_id=None,
+            type=uint32(TransactionType.INCOMING_TX.value),
+            name=bytes32([0] * 32),
+            memos=[],
+        )
+
+        async with db_wrapper.writer_maybe_transaction() as conn:
+            await conn.execute_insert(
+                "INSERT OR REPLACE INTO transaction_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    bytes(old_record),
+                    old_record.name,
+                    old_record.confirmed_at_height,
+                    old_record.created_at_time,
+                    old_record.to_puzzle_hash.hex(),
+                    bytes(old_record.amount),
+                    bytes(old_record.fee_amount),
+                    int(old_record.confirmed),
+                    old_record.sent,
+                    old_record.wallet_id,
+                    old_record.trade_id,
+                    old_record.type,
+                ),
+            )
+
+        store = await WalletTransactionStore.create(db_wrapper)
+        rec = await store.get_transaction_record(old_record.name)
+        assert rec is not None
+        assert rec.valid_times == ConditionValidTimes()

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -22,6 +22,7 @@ from chia.types.coin_spend import compute_additions
 from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint16, uint32, uint64
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from chia.wallet.payment import Payment
 from chia.wallet.transaction_record import TransactionRecord
@@ -1469,6 +1470,7 @@ class TestWalletSimulator:
             type=uint32(TransactionType.OUTGOING_TX.value),
             name=name,
             memos=list(compute_memos(stolen_sb).items()),
+            valid_times=ConditionValidTimes(),
         )
         await wallet.push_transaction(stolen_tx)
 


### PR DESCRIPTION
A previous PR added the ability to throw in extra conditions to all of the transaction endpoints.  This includes timelock conditions that could potentially invalidate a transaction after it has already successfully made it into the mempool.  To help with UX in this scenario, this PR adds an extra field to `TransactionRecord` and `TradeRecord` that describes all of the various timelock restrictions on the transaction.  This will help a UI for example describe to the user that if their transaction is not confirmed, it is expired.

(I also removed some unused TradeStore functions for test coverage purposes)