### PR TITLE
Add new option to set sqlite soft_heap_limit in config

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -307,12 +307,16 @@ class FullNode:
         db_sync = db_synchronous_on(self.config.get("db_sync", "auto"))
         self.log.info(f"opening blockchain DB: synchronous={db_sync}")
 
+        # 0 turns off the soft limit and is the default value if the pragma is not used
+        soft_heap_limit = self.config.get("db_soft_heap_limit_bytes", 0)
+
         self._db_wrapper = await DBWrapper2.create(
             self.db_path,
             db_version=db_version,
             reader_count=4,
             log_path=sql_log_path,
             synchronous=db_sync,
+            soft_heap_limit=soft_heap_limit,
         )
 
         if self.db_wrapper.db_version != 2:

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -145,6 +145,7 @@ class DBWrapper2:
         synchronous: Optional[str] = None,
         foreign_keys: bool = False,
         row_factory: Optional[Type[aiosqlite.Row]] = None,
+        soft_heap_limit: Optional[int] = None,
     ) -> DBWrapper2:
         if log_path is None:
             log_file = None
@@ -155,6 +156,9 @@ class DBWrapper2:
         await (await write_connection.execute(f"pragma journal_mode={journal_mode}")).close()
         if synchronous is not None:
             await (await write_connection.execute(f"pragma synchronous={synchronous}")).close()
+
+        if soft_heap_limit is not None:
+            await (await write_connection.execute(f"pragma soft_heap_limit={soft_heap_limit}")).close()
 
         await (await write_connection.execute(f"pragma foreign_keys={'ON' if foreign_keys else 'OFF'}")).close()
 

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -145,7 +145,7 @@ class DBWrapper2:
         synchronous: Optional[str] = None,
         foreign_keys: bool = False,
         row_factory: Optional[Type[aiosqlite.Row]] = None,
-        soft_heap_limit: Optional[int] = None,
+        soft_heap_limit: int = 0,
     ) -> DBWrapper2:
         if log_path is None:
             log_file = None
@@ -157,8 +157,7 @@ class DBWrapper2:
         if synchronous is not None:
             await (await write_connection.execute(f"pragma synchronous={synchronous}")).close()
 
-        if soft_heap_limit is not None:
-            await (await write_connection.execute(f"pragma soft_heap_limit={soft_heap_limit}")).close()
+        await (await write_connection.execute(f"pragma soft_heap_limit={soft_heap_limit}")).close()
 
         await (await write_connection.execute(f"pragma foreign_keys={'ON' if foreign_keys else 'OFF'}")).close()
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -349,6 +349,11 @@ full_node:
   # configurable
   db_readers: 4
 
+  # set the sqlite soft heap limit to limit total memory usage of sqlite
+  # useful on lower RAM devices - 0 is the default and turns off the limit
+  # a good value for 4GB systems is around 1073741824 bytes
+  db_soft_heap_limit_bytes: 0
+
   # Run multiple nodes with different databases by changing the database_path
   database_path: db/blockchain_v2_CHALLENGE.sqlite
   # peer_db_path is deprecated and has been replaced by peers_file_path

--- a/tests/core/test_db_options.py
+++ b/tests/core/test_db_options.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 import pytest
 
 from chia.util.db_wrapper import DBWrapper2
@@ -10,19 +8,17 @@ from tests.util.temp_file import TempFile
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "soft_heap_limit, expected",
+    "soft_heap_limit",
     [
-        (None, 0),
-        (0, 0),
-        (500, 500),
-        (1073741824, 1073741824),
-        (107374182400, 107374182400),
-        (145, 145),
-        (None, 145),
-        (0, 0),
+        0,
+        500,
+        1073741824,
+        107374182400,
+        145,
+        0,
     ],
 )
-async def test_db_soft_heap_limit(soft_heap_limit: Optional[int], expected: int) -> None:
+async def test_db_soft_heap_limit(soft_heap_limit: int) -> None:
     with TempFile() as db_file:
         db_wrapper = await DBWrapper2.create(
             database=db_file, reader_count=1, db_version=2, soft_heap_limit=soft_heap_limit
@@ -34,4 +30,4 @@ async def test_db_soft_heap_limit(soft_heap_limit: Optional[int], expected: int)
 
         await db_wrapper.close()
         assert limit is not None
-        assert limit[0] == expected
+        assert limit[0] == soft_heap_limit

--- a/tests/core/test_db_options.py
+++ b/tests/core/test_db_options.py
@@ -19,7 +19,6 @@ from tests.util.temp_file import TempFile
         (107374182400, 107374182400),
         (145, 145),
         (None, 145),
-        (-300, 145),
         (0, 0),
     ],
 )

--- a/tests/core/test_db_options.py
+++ b/tests/core/test_db_options.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from chia.util.db_wrapper import DBWrapper2
+from tests.util.temp_file import TempFile
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "soft_heap_limit, expected",
+    [
+        (None, 0),
+        (0, 0),
+        (500, 500),
+        (1073741824, 1073741824),
+        (107374182400, 107374182400),
+        (145, 145),
+        (None, 145),
+        (-300, 145),
+        (0, 0),
+    ],
+)
+async def test_db_soft_heap_limit(soft_heap_limit: Optional[int], expected: int) -> None:
+    with TempFile() as db_file:
+        db_wrapper = await DBWrapper2.create(
+            database=db_file, reader_count=1, db_version=2, soft_heap_limit=soft_heap_limit
+        )
+
+        async with db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute("pragma soft_heap_limit") as cursor:
+                limit = await cursor.fetchone()
+
+        await db_wrapper.close()
+        assert limit is not None
+        assert limit[0] == expected


### PR DESCRIPTION
Add an option to set the SQLite `soft_heap_limit` in config.

The default value for this is 0 which means no set limit

This may be helpful on lower RAM systems (eg 4GB ) where SQLite seems to be using more memory due to fetching full blocks from the DB for Chip-13 verification. It's unknown what impact on performance this may have.

For 4GB systems, a limit of either 1GB or 1GiB does reduce overall memory usage of the full node in empirical testing.