### PR TITLE
correct netspace calculation

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -12,6 +12,7 @@ from chia.full_node.full_node import FullNode
 from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin, get_spends_for_block
 from chia.rpc.rpc_server import Endpoint, EndpointResult
 from chia.server.outbound_message import NodeType
+from chia.types.blockchain_format.proof_of_space import calculate_prefix_bits
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
@@ -558,10 +559,11 @@ class FullNodeRpcApi:
             raise ValueError(f"Older block {older_block_hex} not found")
         delta_weight = newer_block.weight - older_block.weight
 
+        plot_filter_size = calculate_prefix_bits(self.service.constants, newer_block.height)
         delta_iters = newer_block.total_iters - older_block.total_iters
         weight_div_iters = delta_weight / delta_iters
         additional_difficulty_constant = self.service.constants.DIFFICULTY_CONSTANT_FACTOR
-        eligible_plots_filter_multiplier = 2**self.service.constants.NUMBER_ZERO_BITS_PLOT_FILTER
+        eligible_plots_filter_multiplier = 2**plot_filter_size
         network_space_bytes_estimate = (
             UI_ACTUAL_SPACE_CONSTANT_FACTOR
             * weight_div_iters


### PR DESCRIPTION
for blocks beyond the plot filter size reduction.

The computation of netspace estimate looks at twp blocks. If one block is before a filter change and the second is is after a filter change, this is likely not right. This patch just takes the filter size from the second block