### PR TITLE
Simplify BlockStore and CoinStore

### DIFF
--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -20,10 +20,12 @@ from chia.consensus.full_block_to_block_record import header_block_to_sub_block_
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.simulator.block_tools import BlockTools
+from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.full_block import FullBlock
+from chia.types.spend_bundle import SpendBundle
 from chia.util.db_wrapper import get_host_parameter_limit
 from chia.util.full_block_utils import GeneratorBlockInfo
 from chia.util.ints import uint8, uint32, uint64
@@ -52,7 +54,24 @@ async def test_block_store(
         pytest.skip("only run in PLAIN mode to save time")
 
     assert sqlite3.threadsafety >= 1
-    blocks = bt.get_consecutive_blocks(10)
+
+    blocks = bt.get_consecutive_blocks(
+        3,
+        guarantee_transaction_block=True,
+        farmer_reward_puzzle_hash=bt.pool_ph,
+        pool_reward_puzzle_hash=bt.pool_ph,
+        time_per_block=10,
+    )
+    wt: WalletTool = bt.get_pool_wallet_tool()
+    tx: SpendBundle = wt.generate_signed_transaction(
+        uint64(10), wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+    )
+    blocks = bt.get_consecutive_blocks(
+        10,
+        block_list_input=blocks,
+        guarantee_transaction_block=True,
+        transaction_data=tx,
+    )
 
     async with DBConnection(db_version) as db_wrapper, DBConnection(db_version) as db_wrapper_2:
         # Use a different file for the blockchain
@@ -91,6 +110,18 @@ async def test_block_store(
             await store.set_in_chain([(block_record.header_hash,)])
             await store.set_peak(block_record.header_hash)
             await store.set_peak(block_record.header_hash)
+
+            assert await store.get_full_block_bytes(block.header_hash) == bytes(block)
+            buf = await store.get_full_block_bytes(block.header_hash)
+            assert buf is not None
+            assert FullBlock.from_bytes(buf) == block
+
+            assert await store.get_full_blocks_at([block.height]) == [block]
+            if block.transactions_generator is not None:
+                assert await store.get_generators_at([block.height]) == [block.transactions_generator]
+            else:
+                with pytest.raises(ValueError, match="GENERATOR_REF_HAS_NO_GENERATOR"):
+                    await store.get_generators_at([block.height])
 
         assert len(await store.get_full_blocks_at([uint32(1)])) == 1
         assert len(await store.get_full_blocks_at([uint32(0)])) == 1
@@ -316,18 +347,17 @@ async def test_get_generator(bt: BlockTools, db_version: int, consensus_mode: Mo
             await store.set_peak(block_record.header_hash)
             new_blocks.append(block)
 
-        if db_version == 2:
-            expected_generators = list(map(lambda x: x.transactions_generator, new_blocks[1:10]))
-            generators = await store.get_generators_at([uint32(x) for x in range(1, 10)])
-            assert generators == expected_generators
+        expected_generators = list(map(lambda x: x.transactions_generator, new_blocks[1:10]))
+        generators = await store.get_generators_at([uint32(x) for x in range(1, 10)])
+        assert generators == expected_generators
 
-            # test out-of-order heights
-            expected_generators = list(map(lambda x: x.transactions_generator, [new_blocks[i] for i in [4, 8, 3, 9]]))
-            generators = await store.get_generators_at([uint32(4), uint32(8), uint32(3), uint32(9)])
-            assert generators == expected_generators
+        # test out-of-order heights
+        expected_generators = list(map(lambda x: x.transactions_generator, [new_blocks[i] for i in [4, 8, 3, 9]]))
+        generators = await store.get_generators_at([uint32(4), uint32(8), uint32(3), uint32(9)])
+        assert generators == expected_generators
 
-            with pytest.raises(KeyError):
-                await store.get_generators_at([uint32(100)])
+        with pytest.raises(KeyError):
+            await store.get_generators_at([uint32(100)])
 
         assert await store.get_generator(blocks[2].header_hash) == new_blocks[2].transactions_generator
         assert await store.get_generator(blocks[4].header_hash) == new_blocks[4].transactions_generator

--- a/tests/core/full_node/stores/test_hint_store.py
+++ b/tests/core/full_node/stores/test_hint_store.py
@@ -98,13 +98,9 @@ class TestHintStore:
                 cursor = await conn.execute("SELECT COUNT(*) FROM hints")
                 rows = await cursor.fetchall()
 
-            if db_wrapper.db_version == 2:
-                # even though we inserted the pair multiple times, there's only one
-                # entry in the DB
-                assert rows[0][0] == 1
-            else:
-                # we get one copy for each duplicate
-                assert rows[0][0] == 4
+            # even though we inserted the pair multiple times, there's only one
+            # entry in the DB
+            assert rows[0][0] == 1
 
     @pytest.mark.asyncio
     async def test_hints_in_blockchain(self, wallet_nodes):  # noqa: F811

--- a/tests/core/full_node/test_block_height_map.py
+++ b/tests/core/full_node/test_block_height_map.py
@@ -34,62 +34,35 @@ async def new_block(
     ses: Optional[SubEpochSummary],
 ):
     async with db.writer_maybe_transaction() as conn:
-        if db.db_version == 2:
-            cursor = await conn.execute(
-                "INSERT INTO full_blocks VALUES(?, ?, ?, ?)",
-                (
-                    block_hash,
-                    parent,
-                    height,
-                    # sub epoch summary
-                    None if ses is None else bytes(ses),
-                ),
-            )
-            await cursor.close()
-            if is_peak:
-                cursor = await conn.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, block_hash))
-                await cursor.close()
-        else:
-            cursor = await conn.execute(
-                "INSERT INTO block_records VALUES(?, ?, ?, ?, ?)",
-                (
-                    block_hash.hex(),
-                    parent.hex(),
-                    height,
-                    # sub epoch summary
-                    None if ses is None else bytes(ses),
-                    is_peak,
-                ),
-            )
+        cursor = await conn.execute(
+            "INSERT INTO full_blocks VALUES(?, ?, ?, ?)",
+            (
+                block_hash,
+                parent,
+                height,
+                # sub epoch summary
+                None if ses is None else bytes(ses),
+            ),
+        )
+        await cursor.close()
+        if is_peak:
+            cursor = await conn.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, block_hash))
             await cursor.close()
 
 
 async def setup_db(db: DBWrapper2):
     async with db.writer_maybe_transaction() as conn:
-        if db.db_version == 2:
-            await conn.execute(
-                "CREATE TABLE IF NOT EXISTS full_blocks("
-                "header_hash blob PRIMARY KEY,"
-                "prev_hash blob,"
-                "height bigint,"
-                "sub_epoch_summary blob)"
-            )
-            await conn.execute("CREATE TABLE IF NOT EXISTS current_peak(key int PRIMARY KEY, hash blob)")
+        await conn.execute(
+            "CREATE TABLE IF NOT EXISTS full_blocks("
+            "header_hash blob PRIMARY KEY,"
+            "prev_hash blob,"
+            "height bigint,"
+            "sub_epoch_summary blob)"
+        )
+        await conn.execute("CREATE TABLE IF NOT EXISTS current_peak(key int PRIMARY KEY, hash blob)")
 
-            await conn.execute("CREATE INDEX IF NOT EXISTS height on full_blocks(height)")
-            await conn.execute("CREATE INDEX IF NOT EXISTS hh on full_blocks(header_hash)")
-        else:
-            await conn.execute(
-                "CREATE TABLE IF NOT EXISTS block_records("
-                "header_hash text PRIMARY KEY,"
-                "prev_hash text,"
-                "height bigint,"
-                "sub_epoch_summary blob,"
-                "is_peak tinyint)"
-            )
-            await conn.execute("CREATE INDEX IF NOT EXISTS height on block_records(height)")
-            await conn.execute("CREATE INDEX IF NOT EXISTS hh on block_records(header_hash)")
-            await conn.execute("CREATE INDEX IF NOT EXISTS peak on block_records(is_peak)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS height on full_blocks(height)")
+        await conn.execute("CREATE INDEX IF NOT EXISTS hh on full_blocks(header_hash)")
 
 
 # if chain_id != 0, the last block in the chain won't be considered the peak,
@@ -172,10 +145,7 @@ class TestBlockHeightMap:
             # and sub epoch summary. In this test we have a sub epoch summary
             # every 20 blocks, so we generate the 30 last blocks only
             async with db_wrapper.writer_maybe_transaction() as conn:
-                if db_version == 2:
-                    await conn.execute("DROP TABLE full_blocks")
-                else:
-                    await conn.execute("DROP TABLE block_records")
+                await conn.execute("DROP TABLE full_blocks")
             await setup_db(db_wrapper)
             await setup_chain(db_wrapper, 10000, ses_every=20, start_height=9970)
             height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)


### PR DESCRIPTION
Remove some residual database v1 support:
* simplifying the `BlockStore` and `CoinStore` classes
* removing v1 test cases from tests
* adds more tests for `BlockStore`