### PR TITLE
Must force a flush here so reloaded cache doesn't have bogus values

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -286,8 +286,6 @@ class Blockchain(BlockchainInterface):
                 self.add_block_record(block_record)
                 if state_change_summary is not None:
                     self.__height_map.rollback(state_change_summary.fork_height)
-                    # Must force a flush here so reloaded cache doesn't have bogus values
-                    await self.__height_map.maybe_flush(True)
 
                 for fetched_block_record in records:
                     self.__height_map.update_height(
@@ -309,7 +307,7 @@ class Blockchain(BlockchainInterface):
             self._peak_height = block_record.height
 
         # This is done outside the try-except in case it fails, since we do not want to revert anything if it does
-        await self.__height_map.maybe_flush()
+        await self.__height_map.maybe_flush(True)
 
         if state_change_summary is not None:
             # new coin records added

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -286,6 +286,9 @@ class Blockchain(BlockchainInterface):
                 self.add_block_record(block_record)
                 if state_change_summary is not None:
                     self.__height_map.rollback(state_change_summary.fork_height)
+                    # Must force a flush here so reloaded cache doesn't have bogus values
+                    await self.__height_map.maybe_flush(True)
+
                 for fetched_block_record in records:
                     self.__height_map.update_height(
                         fetched_block_record.height,

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -287,7 +287,7 @@ class Blockchain(BlockchainInterface):
                 if state_change_summary is not None:
                     self.__height_map.rollback(state_change_summary.fork_height)
                     # Must force a flush here so reloaded cache doesn't have bogus values
-                    await self.__height_map.maybe_flush(False)
+                    await self.__height_map.maybe_flush(True)
 
                 for fetched_block_record in records:
                     self.__height_map.update_height(

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -287,7 +287,7 @@ class Blockchain(BlockchainInterface):
                 if state_change_summary is not None:
                     self.__height_map.rollback(state_change_summary.fork_height)
                     # Must force a flush here so reloaded cache doesn't have bogus values
-                    await self.__height_map.maybe_flush(True)
+                    await self.__height_map.maybe_flush(False)
 
                 for fetched_block_record in records:
                     self.__height_map.update_height(

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -209,8 +209,6 @@ class BlockHeightMap:
         for height in heights_to_delete:
             del self.__sub_epoch_summaries[height]
         del self.__height_to_hash[(fork_height + 1) * 32 :]
-        # Must force a flush here so reloaded cache doesn't have bogus values
-        await self.maybe_flush(True)
 
     def get_ses(self, height: uint32) -> SubEpochSummary:
         return SubEpochSummary.from_bytes(self.__sub_epoch_summaries[height])

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -128,7 +128,7 @@ class BlockHeightMap:
             self.__sub_epoch_summaries[height] = bytes(ses)
 
     async def maybe_flush(self, bForce: bool = False) -> None:
-        if self.__dirty < 1000 and !bForce:
+        if self.__dirty < 1000 and not bForce:
             return
 
         assert (len(self.__height_to_hash) % 32) == 0

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -127,8 +127,8 @@ class BlockHeightMap:
         if ses is not None:
             self.__sub_epoch_summaries[height] = bytes(ses)
 
-    async def maybe_flush(self) -> None:
-        if self.__dirty < 1000:
+    async def maybe_flush(self, bForce: bool = False) -> None:
+        if self.__dirty < 1000 and !bForce:
             return
 
         assert (len(self.__height_to_hash) % 32) == 0
@@ -209,6 +209,8 @@ class BlockHeightMap:
         for height in heights_to_delete:
             del self.__sub_epoch_summaries[height]
         del self.__height_to_hash[(fork_height + 1) * 32 :]
+        # Must force a flush here so reloaded cache doesn't have bogus values
+        await self.maybe_flush(True)
 
     def get_ses(self, height: uint32) -> SubEpochSummary:
         return SubEpochSummary.from_bytes(self.__sub_epoch_summaries[height])

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -47,7 +47,7 @@ class TestFullSync:
             PeerInfo(self_hostname, uint16(server_1._port)), on_connect=full_node_2.full_node.on_connect
         )
 
-        timeout_seconds = 250
+        timeout_seconds = 350
 
         # The second node should eventually catch up to the first one
         await time_out_assert(

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -47,7 +47,7 @@ class TestFullSync:
             PeerInfo(self_hostname, uint16(server_1._port)), on_connect=full_node_2.full_node.on_connect
         )
 
-        timeout_seconds = 350
+        timeout_seconds = 750
 
         # The second node should eventually catch up to the first one
         await time_out_assert(


### PR DESCRIPTION
### Purpose:

Ensure cache coherency of height to hash

### Current Behavior:

Node could return orphaned blocks due to reorgs

### New Behavior:

Reorgs flush out height to hash cache

### Testing Notes:

Must force reorg, restart, then query block
