### PR TITLE
optimize blockchain DB for Chip-13

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -129,6 +129,17 @@ class BlockRecordDB(Streamable):
         )
 
 
+def plot_filter_from_block(block: FullBlock) -> PlotFilterInfo:
+    pos_cc_ss = block.reward_chain_block.pos_ss_cc_challenge_hash
+    cc_sp_hash: bytes32
+    if block.reward_chain_block.challenge_chain_sp_vdf is None:
+        cc_sp_hash = pos_cc_ss
+    else:
+        cc_sp_hash = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
+
+    return PlotFilterInfo(pos_cc_ss, cc_sp_hash)
+
+
 @typing_extensions.final
 @dataclasses.dataclass
 class BlockStore:
@@ -162,8 +173,15 @@ class BlockStore:
                 "is_fully_compactified tinyint,"
                 "in_main_chain tinyint,"
                 "block blob,"
-                "block_record blob)"
+                "block_record blob,"
+                "plot_filter_info blob)"
             )
+
+            # for CHIP-13, we need cheap access to these fields
+            try:
+                await conn.execute("ALTER TABLE full_blocks ADD COLUMN plot_filter_info blob")
+            except sqlite3.OperationalError:
+                pass
 
             # This is a single-row table containing the hash of the current
             # peak. The "key" field is there to make update statements simple
@@ -250,10 +268,11 @@ class BlockStore:
         ses: Optional[bytes] = (
             None if block_record.sub_epoch_summary_included is None else bytes(block_record.sub_epoch_summary_included)
         )
+        plot_filter_info = plot_filter_from_block(block)
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
-                "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO full_blocks VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     header_hash,
                     block.prev_header_hash,
@@ -263,6 +282,7 @@ class BlockStore:
                     False,  # in_main_chain
                     self.compress(block),
                     bytes(block_record_db),
+                    bytes(plot_filter_info),
                 ),
             )
 
@@ -434,13 +454,19 @@ class BlockStore:
         all_blocks: Dict[bytes32, BlockRecord] = {}
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
-                "SELECT header_hash,block_record,block FROM full_blocks "
+                "SELECT header_hash,block_record,plot_filter_info FROM full_blocks "
                 f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
                 header_hashes,
             ) as cursor:
                 for row in await cursor.fetchall():
                     block_rec_db: BlockRecordDB = BlockRecordDB.from_bytes(row[1])
-                    plot_filter_info: PlotFilterInfo = plot_filter_info_from_block(zstd.decompress(row[2]))
+                    if row[2] is None:
+                        # since we're adding this field lazily, it may not be
+                        # set. If so, fall back to the slow path
+                        plot_filter_info = await self.get_plot_filter_info(block_rec_db.header_hash)
+                    else:
+                        plot_filter_info = PlotFilterInfo.from_bytes(row[2])
+
                     all_blocks[block_rec_db.header_hash] = block_rec_db.to_block_record(
                         plot_filter_info.pos_ss_cc_challenge_hash,
                         plot_filter_info.cc_sp_hash,
@@ -512,21 +538,38 @@ class BlockStore:
     async def get_block_record(self, header_hash: bytes32) -> Optional[BlockRecord]:
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
-                "SELECT block_record,block FROM full_blocks WHERE header_hash=?",
+                "SELECT block_record,plot_filter_info FROM full_blocks WHERE header_hash=?",
                 (header_hash,),
             ) as cursor:
                 row = await cursor.fetchone()
         if row is None:
             return None
         block_record_db = BlockRecordDB.from_bytes(row[0])
-        block_bytes = zstd.decompress(row[1])
+        if row[1] is None:
+            # since we're adding this field lazily, it may not be
+            # set. If so, fall back to the slow path
+            plot_filter_info = await self.get_plot_filter_info(block_record_db.header_hash)
+        else:
+            plot_filter_info = PlotFilterInfo.from_bytes(row[1])
 
-        plot_filter_info = plot_filter_info_from_block(block_bytes)
         block_record = block_record_db.to_block_record(
             plot_filter_info.pos_ss_cc_challenge_hash,
             plot_filter_info.cc_sp_hash,
         )
         return block_record
+
+    # this is the slow-path
+    async def get_plot_filter_info(self, header_hash: bytes32) -> PlotFilterInfo:
+        block = self.block_cache.get(header_hash)
+        if block is not None:
+            return plot_filter_from_block(block)
+
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute("SELECT block FROM full_blocks WHERE header_hash=?", (header_hash,)) as cursor:
+                row = await cursor.fetchone()
+        assert row is not None
+        block_bytes = zstd.decompress(row[0])
+        return plot_filter_info_from_block(block_bytes)
 
     async def get_block_records_in_range(
         self,
@@ -541,13 +584,19 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
-                "SELECT header_hash, block_record,block FROM full_blocks WHERE height >= ? AND height <= ?",
+                "SELECT header_hash,block_record,plot_filter_info FROM full_blocks WHERE height >= ? AND height <= ?",
                 (start, stop),
             ) as cursor:
                 for row in await cursor.fetchall():
                     header_hash = bytes32(row[0])
                     block_record_db: BlockRecordDB = BlockRecordDB.from_bytes(row[1])
-                    plot_filter_info: PlotFilterInfo = plot_filter_info_from_block(zstd.decompress(row[2]))
+                    if row[2] is None:
+                        # since we're adding this field lazily, it may not be
+                        # set. If so, fall back to the slow path
+                        plot_filter_info = await self.get_plot_filter_info(header_hash)
+                    else:
+                        plot_filter_info = PlotFilterInfo.from_bytes(row[2])
+
                     block_record = block_record_db.to_block_record(
                         plot_filter_info.pos_ss_cc_challenge_hash,
                         plot_filter_info.cc_sp_hash,
@@ -614,13 +663,19 @@ class BlockStore:
         ret: Dict[bytes32, BlockRecord] = {}
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
-                "SELECT header_hash, block_record,block FROM full_blocks WHERE height >= ?",
+                "SELECT header_hash, block_record,plot_filter_info FROM full_blocks WHERE height >= ?",
                 (peak[1] - blocks_n,),
             ) as cursor:
                 for row in await cursor.fetchall():
                     header_hash = bytes32(row[0])
                     block_record_db: BlockRecordDB = BlockRecordDB.from_bytes(row[1])
-                    plot_filter_info: PlotFilterInfo = plot_filter_info_from_block(zstd.decompress(row[2]))
+                    if row[2] is None:
+                        # since we're adding this field lazily, it may not be
+                        # set. If so, fall back to the slow path
+                        plot_filter_info = await self.get_plot_filter_info(header_hash)
+                    else:
+                        plot_filter_info = PlotFilterInfo.from_bytes(row[2])
+
                     block_record = block_record_db.to_block_record(
                         plot_filter_info.pos_ss_cc_challenge_hash,
                         plot_filter_info.cc_sp_hash,

--- a/chia/util/full_block_utils.py
+++ b/chia/util/full_block_utils.py
@@ -14,6 +14,7 @@ from chia.types.blockchain_format.foliage import TransactionsInfo
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32
+from chia.util.streamable import Streamable, streamable
 
 
 def skip_list(buf: memoryview, skip_item: Callable[[memoryview], memoryview]) -> memoryview:
@@ -325,8 +326,9 @@ def header_block_from_block(
     return header_block
 
 
+@streamable
 @dataclass(frozen=True)
-class PlotFilterInfo:
+class PlotFilterInfo(Streamable):
     pos_ss_cc_challenge_hash: bytes32
     cc_sp_hash: bytes32
 

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -77,7 +77,7 @@ async def test_block_store(
                 # added
                 async with db_wrapper.writer_maybe_transaction() as conn:
                     await conn.execute(
-                        "UPDATE full_blocks SET plot_filter_info=NULL WHERE header_hash=?", (block_record.header_hash,)
+                        "UPDATE plot_info SET plot_filter_info=NULL WHERE header_hash=?", (block_record.header_hash,)
                     )
 
             assert block == await store.get_full_block(block.header_hash)
@@ -438,7 +438,7 @@ async def test_get_plot_filer_info(
                 # added
                 async with db_wrapper.writer_maybe_transaction() as conn:
                     await conn.execute(
-                        "UPDATE full_blocks SET plot_filter_info=NULL WHERE header_hash=?", (block.header_hash,)
+                        "UPDATE plot_info SET plot_filter_info=NULL WHERE header_hash=?", (block.header_hash,)
                     )
 
             blocks.append(block)


### PR DESCRIPTION
This patch is meant to improve performance pulling `BlockRecord`s from the `BlockStore` database table.
Currently, sqlite appears to allocate a very large buffer. Over time this memory usage may cause swapping and stalled disk I/O, delaying proof lookups.

Another issue with the current code is that we look up blocks from the database even when we have them in the cache.

This memory usage of sqlite isn't measured by the benchmark, but there is a slight time improvement of not having to load the full blocks into memory as well.

| function | before | after | after / before |
| --- | --- | --- | --- |
| get_block_records_by_hash | 2.6470s | 2.4786s | 93.6 % |
| get_block_record | 3.4475s | 2.4806s | 72 % |
| get_block_records_in_range | 0.5901s | 0.3550s | 60 % |

# This patch
```
19.5477s, add_full_block
2.0765s, get_block_info
1.1192s, get_generator
5.5172s, get_full_block
2.0444s, get_full_block_bytes
0.9421s, get_generators_at
5.5845s, get_full_blocks_at
2.4786s, get_block_records_by_hash
1.7986s, get_block_bytes_by_hash
5.5716s, get_blocks_by_hash
2.4806s, get_block_record
0.3550s, get_block_records_in_range
0.0034s, get_block_records_close_to_peak
4.4870s, is_fully_compactified
13.2819s, get_random_not_compactified
all tests completed in 67.2883s
database size: 96.518 MB
```

# main

```
14.9223s, add_full_block
2.0637s, get_block_info
1.0842s, get_generator
5.4009s, get_full_block
1.6925s, get_full_block_bytes
0.3226s, get_generators_at
5.0399s, get_full_blocks_at
2.6470s, get_block_records_by_hash
1.8506s, get_block_bytes_by_hash
5.5557s, get_blocks_by_hash
3.4475s, get_block_record
0.5901s, get_block_records_in_range
0.0091s, get_block_records_close_to_peak
3.5308s, is_fully_compactified
13.8417s, get_random_not_compactified
all tests completed in 61.9986s
database size: 93.503 MB
```