### PR TITLE
simplify db connection helper (more simply)

### DIFF
--- a/tests/util/db_connection.py
+++ b/tests/util/db_connection.py
@@ -10,12 +10,10 @@ from chia.util.db_wrapper import DBWrapper2
 
 @asynccontextmanager
 async def DBConnection(db_version: int) -> AsyncIterator[DBWrapper2]:
-    db_path = Path(tempfile.NamedTemporaryFile().name)
-    if db_path.exists():
-        db_path.unlink()
-    _db_wrapper = await DBWrapper2.create(database=db_path, reader_count=4, db_version=db_version)
-    try:
-        yield _db_wrapper
-    finally:
-        await _db_wrapper.close()
-        db_path.unlink()
+    with tempfile.TemporaryDirectory() as directory:
+        db_path = Path(directory).joinpath("db.sqlite")
+        _db_wrapper = await DBWrapper2.create(database=db_path, reader_count=4, db_version=db_version)
+        try:
+            yield _db_wrapper
+        finally:
+            await _db_wrapper.close()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Similar to https://github.com/Chia-Network/chia-blockchain/pull/15550 but smaller.  It doesn't move the temporary directory for the db into the pytest provided directory but does eliminate the various race conditions of the existing code.  It also leaves cleanup to the stdlib `tempfile` module.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The existing code has a few layers of issues.

* We are trying to create a fresh SQLite db file but we create a temporary file and SQLite expects the file to not exist so we need to delete the temporary file which is both extra required action and induces a technical race on the file system between deleting the temporary file and then SQLite creating a file of the same.
* The existence check followed by deletion is itself a technical race with the filesystem.
* The created temporary file object is not stored and when it gets torn down it will delete the file on disk and the timing of this depends on the Python GC introducing a practical race with our file deletion code.
* Using the temporary file that has to be removed leaves us implementing the final cleanup ourselves.

### New Behavior:

The temporary directory is created and it and its contents are cleaned up by the Python `tempfile` code.  SQLite has a clean place that nothing else is likely to use to create a fresh file itself.  We need no custom file cleanup code, just to close the db wrapper so the file is not in use.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
