### PR TITLE
fix testnet10 sync-from-scratch

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -495,11 +495,18 @@ async def validate_block_body(
     if npc_result is not None:
         assert npc_result.conds is not None
 
+        block_timestamp: uint64
+        if height < constants.SOFT_FORK2_HEIGHT:
+            # this does not happen on mainnet. testnet10 only
+            block_timestamp = block.foliage_transaction_block.timestamp  # pragma: no cover
+        else:
+            block_timestamp = prev_transaction_block_timestamp
+
         error = mempool_check_time_locks(
             removal_coin_records,
             npc_result.conds,
             prev_transaction_block_height,
-            prev_transaction_block_timestamp,
+            block_timestamp,
         )
         if error:
             return error, None

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -62,6 +62,9 @@ class ConsensusConstants:
     MAX_GENERATOR_REF_LIST_SIZE: uint32
     POOL_SUB_SLOT_ITERS: uint64
 
+    # soft fork initiated in 1.8.0 release
+    SOFT_FORK2_HEIGHT: uint32
+
     # soft fork initiated in 2.0 release
     SOFT_FORK3_HEIGHT: uint32
 

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -55,6 +55,7 @@ default_kwargs = {
     "MAX_GENERATOR_SIZE": 1000000,
     "MAX_GENERATOR_REF_LIST_SIZE": 512,  # Number of references allowed in the block generator ref list
     "POOL_SUB_SLOT_ITERS": 37600000000,  # iters limit * NUM_SPS
+    "SOFT_FORK2_HEIGHT": 0,
     # November 14, 2023
     "SOFT_FORK3_HEIGHT": 4510000,
     # December 4, 2023

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -55,7 +55,8 @@ def get_name_puzzle_conditions(
     if mempool_mode:
         flags = flags | MEMPOOL_MODE
 
-    flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+    if height >= constants.SOFT_FORK2_HEIGHT:
+        flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 
     if height >= constants.SOFT_FORK3_HEIGHT:
         # the soft-fork initiated with 2.0. To activate end of October 2023

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -72,6 +72,8 @@ def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None
         return
     # activate softforks immediately on testnet
     # these numbers are supposed to match initial-config.yaml
+    if "SOFT_FORK2_HEIGHT" not in overrides:
+        overrides["SOFT_FORK2_HEIGHT"] = 3000000
     if "SOFT_FORK3_HEIGHT" not in overrides:
         overrides["SOFT_FORK3_HEIGHT"] = 2997292
     if "SOFT_FORK4_HEIGHT" not in overrides:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -71,6 +71,7 @@ network_overrides: &network_overrides
       GENESIS_PRE_FARM_POOL_PUZZLE_HASH: d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
+      SOFT_FORK2_HEIGHT: 3000000
       SOFT_FORK3_HEIGHT: 2997292
       SOFT_FORK4_HEIGHT: 2997292
       # planned 2.0 release is July 26, height 2965036 on testnet

--- a/tests/util/test_testnet_overrides.py
+++ b/tests/util/test_testnet_overrides.py
@@ -9,6 +9,7 @@ def test_testnet10() -> None:
     overrides: Dict[str, Any] = {}
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
+        "SOFT_FORK2_HEIGHT": 3000000,
         "SOFT_FORK3_HEIGHT": 2997292,
         "SOFT_FORK4_HEIGHT": 2997292,
         "HARD_FORK_HEIGHT": 2997292,
@@ -29,6 +30,7 @@ def test_testnet10_existing() -> None:
     }
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
+        "SOFT_FORK2_HEIGHT": 3000000,
         "SOFT_FORK3_HEIGHT": 42,
         "SOFT_FORK4_HEIGHT": 45,
         "HARD_FORK_HEIGHT": 42,


### PR DESCRIPTION
soft-fork2 was not a smooth softfork on testnet (but it was on mainnet).
This re-introduces the minimum logic for supporting syncing on testnet10.

The height 3000000 was picked arbitrarily assuming that there would be no violations of soft-fork2 past that height.

I would prefer to scrap testnet10 and start testnet11 instead of landing this PR.

I successfully synced testnet10 from scratch (up to block 3035527)