### PR TITLE
Update nft_wallet.py

### DIFF
--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -399,6 +399,7 @@ class NFTWallet:
             False,
             announcement_set,
             origin_id=origin.name(),
+            reuse_puzhash=reuse_puzhash,
         )
         genesis_launcher_solution = Program.to([eve_fullpuz_hash, amount, []])
 


### PR DESCRIPTION
Fixed issue reuse_puzhash for mint NFT
Purpose:
Reuse_puzhash parameter of mint nft cli /rpc allow us the reuse xch address instead of generative new address 

Current Behavior:
Even have --reuse in the cli parameter, still generate new address 

New Behavior:
Will reuse address if you have --reuse

Testing Notes:
Tested in mainnet