### PR TITLE
fix DataLayer deadlock

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -667,7 +667,6 @@ class DataLayer:
                 )
 
                 if len(changelist) > 0:
-                    # TODO: calls update too...  inside the above transaction...
                     new_root_hash = await self.batch_insert(
                         tree_id=offer_store.store_id,
                         changelist=changelist,

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -181,10 +181,9 @@ class DataLayer:
         tree_id: bytes32,
         changelist: List[Dict[str, Any]],
     ) -> bytes32:
-        # Make sure we update based on the latest confirmed root.
-        await self._update_confirmation_status(tree_id=tree_id)
-
         async with self.data_store.transaction():
+            # Make sure we update based on the latest confirmed root.
+            await self._update_confirmation_status(tree_id=tree_id)
             pending_root: Optional[Root] = await self.data_store.get_pending_root(tree_id=tree_id)
             if pending_root is not None:
                 raise Exception("Already have a pending root waiting for confirmation.")
@@ -213,7 +212,6 @@ class DataLayer:
     ) -> TransactionRecord:
         # Make sure we update based on the latest confirmed root.
         await self._update_confirmation_status(tree_id=tree_id)
-
         pending_root: Optional[Root] = await self.data_store.get_pending_root(tree_id=tree_id)
         if pending_root is None:
             raise Exception("Latest root is already confirmed.")
@@ -233,16 +231,14 @@ class DataLayer:
         key: bytes,
         root_hash: Optional[bytes32] = None,
     ) -> bytes32:
-        await self._update_confirmation_status(tree_id=store_id)
-
         async with self.data_store.transaction():
+            await self._update_confirmation_status(tree_id=store_id)
             node = await self.data_store.get_node_by_key(tree_id=store_id, key=key, root_hash=root_hash)
             return node.hash
 
     async def get_value(self, store_id: bytes32, key: bytes, root_hash: Optional[bytes32] = None) -> Optional[bytes]:
-        await self._update_confirmation_status(tree_id=store_id)
-
         async with self.data_store.transaction():
+            await self._update_confirmation_status(tree_id=store_id)
             res = await self.data_store.get_node_by_key(tree_id=store_id, key=key, root_hash=root_hash)
             if res is None:
                 self.log.error("Failed to fetch key")
@@ -251,7 +247,6 @@ class DataLayer:
 
     async def get_keys_values(self, store_id: bytes32, root_hash: Optional[bytes32]) -> List[TerminalNode]:
         await self._update_confirmation_status(tree_id=store_id)
-
         res = await self.data_store.get_keys_values(store_id, root_hash)
         if res is None:
             self.log.error("Failed to fetch keys values")
@@ -446,7 +441,6 @@ class DataLayer:
         if singleton_record is None:
             self.log.info(f"Upload files: no on-chain record for {tree_id}.")
             return
-
         await self._update_confirmation_status(tree_id=tree_id)
 
         root = await self.data_store.get_tree_root(tree_id=tree_id)
@@ -662,13 +656,11 @@ class DataLayer:
             return changelist
 
     async def process_offered_stores(self, offer_stores: Tuple[OfferStore, ...]) -> Dict[bytes32, StoreProofs]:
-        for offer_store in offer_stores:
-            # TODO: was there any need for this to be inside?
-            await self._update_confirmation_status(tree_id=offer_store.store_id)
-
         async with self.data_store.transaction():
             our_store_proofs: Dict[bytes32, StoreProofs] = {}
             for offer_store in offer_stores:
+                await self._update_confirmation_status(tree_id=offer_store.store_id)
+
                 changelist = await self.build_offer_changelist(
                     store_id=offer_store.store_id,
                     inclusions=offer_store.inclusions,

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -7,10 +7,12 @@ import enum
 import json
 import os
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
+import anyio
 import pytest
 import pytest_asyncio
 
@@ -35,7 +37,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import save_config
-from chia.util.ints import uint16, uint32
+from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.trading.offer import Offer as TradingOffer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet import Wallet
@@ -1955,3 +1957,54 @@ async def test_clear_pending_roots(
             assert False, "unhandled parametrization"
 
         assert cleared_root == {"success": True, "root": pending_root.marshal()}
+
+
+# TODO: what should this be called?  test_deadlock_we_used_to_have()?
+@pytest.mark.asyncio
+async def test_stuff(
+    self_hostname: str, one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices, tmp_path: Path
+) -> None:
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+
+    wallet_node = wallet_rpc_api.service
+    wallet = wallet_node.wallet_state_manager.main_wallet
+
+    interval = 1
+    config = bt.config
+    config["data_layer"]["manage_data_interval"] = interval
+    bt.change_config(new_config=config)
+
+    async with init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path) as data_layer:
+        # get some xch
+        await full_node_api.farm_blocks_to_wallet(count=1, wallet=wallet)
+        await full_node_api.wait_for_wallet_synced(wallet_node)
+
+        # create a store
+        transaction_records, tree_id = await data_layer.create_store(fee=uint64(0))
+        await full_node_api.process_transaction_records(records=transaction_records)
+        await full_node_api.wait_for_wallet_synced(wallet_node)
+        assert await check_singleton_confirmed(dl=data_layer, tree_id=tree_id)
+
+        # insert a key and value
+        key = b"\x00"
+        value = b"\x01" * 10_000
+        transaction_record = await data_layer.batch_update(
+            tree_id=tree_id,
+            changelist=[{"action": "insert", "key": key, "value": value}],
+            fee=uint64(0),
+        )
+        await full_node_api.process_transaction_records(records=[transaction_record])
+        await full_node_api.wait_for_wallet_synced(wallet_node)
+        assert await check_singleton_confirmed(dl=data_layer, tree_id=tree_id)
+
+        # get the value a bunch
+        duration = 10 * interval
+        start = time.monotonic()
+        end = start + duration
+        with anyio.fail_after(2 * duration):
+            while time.monotonic() < end:
+                await asyncio.gather(
+                    *(asyncio.create_task(data_layer.get_value(store_id=tree_id, key=key)) for _ in range(10))
+                )


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

https://github.com/Chia-Network/chia-blockchain/issues/15955

There were two locks acquired in opposite orders between some RPC calls and the periodic data management task via the call to `DataLayer.fetch_and_validate()`.  They are the data store db wrapper lock for the writer connection and the `DataLayer.lock` lock.  All uses of the `DataLayer.lock` were surrounding the update check prior to handling the RPC request.  In that update check it immediately acquired the db writer connection.  As such it was already exclusive since the db wrapper only allows a single write connection.  This PR removes the `DataLayer.lock`.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Making lots of queries can easily deadlock the service.  Though, in case you care, it could still process a shutdown request normally.  `:]`

### New Behavior:

This deadlock scenario is resolved.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I initially tested by triggering the deadlock via `venv/bin/chia rpc data_layer get_keys '{"id": "b9312cc24584fa34fc69f29fdbdd625e6c4f670b30e266c4032127d0a0fe1491"}' | jq -r '.keys[]' | xargs --max-procs=10 --replace={} venv/bin/chia data get_value --id b9312cc24584fa34fc69f29fdbdd625e6c4f670b30e266c4032127d0a0fe1491 --key "{}"`.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

### Draft For:
- [x] description
- [x] tests
- [x] `TODO:`s
- [x] self consideration

### Followups For `main`:
- [x] consistently update outside the existing transaction https://github.com/Chia-Network/chia-blockchain/pull/16094
- [ ] review for potential use of read-only transactions