### PR TITLE
Update chia_rs to 0.2.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ dependencies = [
     "chiapos==2.0.0",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
-    "chia_rs==0.2.9",
+    "chia_rs==0.2.10",
     "clvm-tools-rs==0.1.34",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.4",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
Update chia_rs to 0.2.10 for fixes related to allowing backrefs

Full fix also requires https://github.com/Chia-Network/chia-blockchain/pull/15937 to be targeted to release/2.0.0