### PR TITLE
extend tests being parametrised by soft-fork

### DIFF
--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -143,7 +143,7 @@ async def setup_n_nodes(
 async def setup_simulators_and_wallets(
     simulator_count: int,
     wallet_count: int,
-    dic: Dict[str, int],
+    consensus_constants: ConsensusConstants,
     spam_filter_after_n_txs: int = 200,
     xch_spam_amount: int = 1000000,
     *,
@@ -156,7 +156,7 @@ async def setup_simulators_and_wallets(
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         res = await setup_simulators_and_wallets_inner(
             db_version,
-            dic,
+            consensus_constants,
             initial_num_public_keys,
             key_seed,
             keychain1,
@@ -186,7 +186,7 @@ async def setup_simulators_and_wallets(
 async def setup_simulators_and_wallets_service(
     simulator_count: int,
     wallet_count: int,
-    dic: Dict[str, int],
+    consensus_constants: ConsensusConstants,
     spam_filter_after_n_txs: int = 200,
     xch_spam_amount: int = 1000000,
     *,
@@ -201,7 +201,7 @@ async def setup_simulators_and_wallets_service(
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         res = await setup_simulators_and_wallets_inner(
             db_version,
-            dic,
+            consensus_constants,
             initial_num_public_keys,
             key_seed,
             keychain1,
@@ -222,7 +222,7 @@ async def setup_simulators_and_wallets_service(
 
 async def setup_simulators_and_wallets_inner(
     db_version: int,
-    dic: Dict[str, int],
+    consensus_constants: ConsensusConstants,
     initial_num_public_keys: int,
     key_seed: Optional[bytes32],
     keychain1: Keychain,
@@ -245,13 +245,10 @@ async def setup_simulators_and_wallets_inner(
         AsyncGenerator[Union[Service[FullNode, FullNodeSimulator], Service[WalletNode, WalletNodeAPI]], None]
     ] = []
     bt_tools: List[BlockTools] = []
-    consensus_constants: ConsensusConstants = constants_for_dic(dic)
     for index in range(0, simulator_count):
         db_name = f"blockchain_test_{index}_sim_and_wallets.db"
         bt_tools.append(
-            await create_block_tools_async(
-                consensus_constants, const_dict=dic, keychain=keychain1, config_overrides=config_overrides
-            )
+            await create_block_tools_async(consensus_constants, keychain=keychain1, config_overrides=config_overrides)
         )  # block tools modifies constants
         sim = cast(
             AsyncGenerator[Service[FullNode, FullNodeSimulator], None],
@@ -275,7 +272,7 @@ async def setup_simulators_and_wallets_inner(
             seed = key_seed
         if index > (len(bt_tools) - 1):
             wallet_bt_tools = await create_block_tools_async(
-                consensus_constants, const_dict=dic, keychain=keychain2, config_overrides=config_overrides
+                consensus_constants, keychain=keychain2, config_overrides=config_overrides
             )  # block tools modifies constants
         else:
             wallet_bt_tools = bt_tools[index]

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1375,7 +1375,7 @@ class TestBlockHeaderValidation:
         reason="Skipped ConsensusMode.SOFT_FORK4 temporarily until adding more pool plots.",
     )
     @pytest.mark.asyncio
-    async def test_pool_target_contract(self, empty_blockchain, bt, consensus_mode: ConsensusMode):
+    async def test_pool_target_contract(self, empty_blockchain, bt):
         # 20c invalid pool target with contract
         blocks_initial = bt.get_consecutive_blocks(2)
         await _validate_and_add_block(empty_blockchain, blocks_initial[0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,23 +350,23 @@ def pytest_collection_modifyitems(session, config: pytest.Config, items: List[py
 
 
 @pytest_asyncio.fixture(scope="function")
-async def node_with_params(request):
+async def node_with_params(request, blockchain_constants: ConsensusConstants):
     params = {}
     if request:
         params = request.param
-    async for (sims, wallets, bt) in setup_simulators_and_wallets(1, 0, {}, **params):
+    async for (sims, wallets, bt) in setup_simulators_and_wallets(1, 0, blockchain_constants, **params):
         yield sims[0]
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_nodes(db_version: int, self_hostname, blockchain_constants):
+async def two_nodes(db_version: int, self_hostname, blockchain_constants: ConsensusConstants):
     async for _ in setup_two_nodes(blockchain_constants, db_version=db_version, self_hostname=self_hostname):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup_two_nodes_fixture(db_version: int):
-    async for _ in setup_simulators_and_wallets(2, 0, {}, db_version=db_version):
+async def setup_two_nodes_fixture(db_version: int, blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(2, 0, blockchain_constants, db_version=db_version):
         yield _
 
 
@@ -407,7 +407,7 @@ async def wallet_nodes(blockchain_constants, consensus_mode):
     async_gen = setup_simulators_and_wallets(
         2,
         1,
-        {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 400000000, "SOFT_FORK4_HEIGHT": constants.SOFT_FORK4_HEIGHT},
+        blockchain_constants.replace(MEMPOOL_BLOCK_BUFFER=1, MAX_BLOCK_COST_CLVM=400000000),
     )
     nodes, wallets, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
@@ -423,14 +423,14 @@ async def wallet_nodes(blockchain_constants, consensus_mode):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup_four_nodes(db_version):
-    async for _ in setup_simulators_and_wallets(4, 0, {}, db_version=db_version):
+async def setup_four_nodes(db_version, blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(4, 0, blockchain_constants, db_version=db_version):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_nodes_sim_and_wallets():
-    async for _ in setup_simulators_and_wallets(2, 0, {}):
+async def two_nodes_sim_and_wallets(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(2, 0, blockchain_constants):
         yield _
 
 
@@ -449,104 +449,108 @@ async def two_nodes_sim_and_wallets():
     ],
 )
 async def two_nodes_sim_and_wallets_services(blockchain_constants, consensus_mode):
-    async for _ in setup_simulators_and_wallets_service(
-        2, 0, {"SOFT_FORK4_HEIGHT": blockchain_constants.SOFT_FORK4_HEIGHT}
-    ):
+    async for _ in setup_simulators_and_wallets_service(2, 0, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def one_wallet_and_one_simulator_services():
-    async for _ in setup_simulators_and_wallets_service(1, 1, {}):
+async def one_wallet_and_one_simulator_services(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets_service(1, 1, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_node_100_pk():
-    async for _ in setup_simulators_and_wallets(1, 1, {}, initial_num_public_keys=100):
+async def wallet_node_100_pk(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(1, 1, blockchain_constants, initial_num_public_keys=100):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def simulator_and_wallet() -> AsyncIterator[
-    Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]
-]:
-    async for _ in setup_simulators_and_wallets(simulator_count=1, wallet_count=1, dic={}):
+async def simulator_and_wallet(
+    blockchain_constants: ConsensusConstants,
+) -> AsyncIterator[Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]]:
+    async for _ in setup_simulators_and_wallets(1, 1, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_wallet_nodes(request):
+async def two_wallet_nodes(request, blockchain_constants: ConsensusConstants):
     params = {}
     if request and request.param_index > 0:
         params = request.param
-    async for _ in setup_simulators_and_wallets(1, 2, {}, **params):
+    async for _ in setup_simulators_and_wallets(1, 2, blockchain_constants, **params):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_wallet_nodes_services() -> AsyncIterator[
+async def two_wallet_nodes_services(
+    blockchain_constants: ConsensusConstants,
+) -> AsyncIterator[
     Tuple[List[Service[FullNode, FullNodeSimulator]], List[Service[WalletNode, WalletNodeAPI]], BlockTools]
 ]:
-    async for _ in setup_simulators_and_wallets_service(1, 2, {}):
+    async for _ in setup_simulators_and_wallets_service(1, 2, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_wallet_nodes_custom_spam_filtering(spam_filter_after_n_txs, xch_spam_amount):
-    async for _ in setup_simulators_and_wallets(1, 2, {}, spam_filter_after_n_txs, xch_spam_amount):
+async def two_wallet_nodes_custom_spam_filtering(
+    spam_filter_after_n_txs, xch_spam_amount, blockchain_constants: ConsensusConstants
+):
+    async for _ in setup_simulators_and_wallets(1, 2, blockchain_constants, spam_filter_after_n_txs, xch_spam_amount):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def three_sim_two_wallets():
-    async for _ in setup_simulators_and_wallets(3, 2, {}):
+async def three_sim_two_wallets(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(3, 2, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup_two_nodes_and_wallet():
-    async for _ in setup_simulators_and_wallets(2, 1, {}, db_version=2):
+async def setup_two_nodes_and_wallet(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(2, 1, blockchain_constants, db_version=2):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup_two_nodes_and_wallet_fast_retry():
+async def setup_two_nodes_and_wallet_fast_retry(blockchain_constants: ConsensusConstants):
     async for _ in setup_simulators_and_wallets(
-        1, 1, {}, config_overrides={"wallet.tx_resend_timeout_secs": 1}, db_version=2
+        1, 1, blockchain_constants, config_overrides={"wallet.tx_resend_timeout_secs": 1}, db_version=2
     ):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def three_wallet_nodes():
-    async for _ in setup_simulators_and_wallets(1, 3, {}):
+async def three_wallet_nodes(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(1, 3, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_two_node_simulator():
-    async for _ in setup_simulators_and_wallets(2, 1, {}):
+async def wallet_two_node_simulator(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(2, 1, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def wallet_nodes_mempool_perf(bt):
     key_seed = bt.farmer_master_sk_entropy
-    async for _ in setup_simulators_and_wallets(2, 1, {}, key_seed=key_seed):
+    async for _ in setup_simulators_and_wallets(2, 1, bt.constants, key_seed=key_seed):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def two_nodes_two_wallets_with_same_keys(bt) -> AsyncIterator[SimulatorsAndWallets]:
     key_seed = bt.farmer_master_sk_entropy
-    async for _ in setup_simulators_and_wallets(2, 2, {}, key_seed=key_seed):
+    async for _ in setup_simulators_and_wallets(2, 2, bt.constants, key_seed=key_seed):
         yield _
 
 
 @pytest_asyncio.fixture(scope="module")
-async def wallet_nodes_perf():
-    async_gen = setup_simulators_and_wallets(1, 1, {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 11000000000})
+async def wallet_nodes_perf(blockchain_constants: ConsensusConstants):
+    async_gen = setup_simulators_and_wallets(
+        1, 1, blockchain_constants, config_overrides={"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 11000000000}
+    )
     nodes, wallets, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     server_1 = full_node_1.full_node.server
@@ -559,8 +563,8 @@ async def wallet_nodes_perf():
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_nodes_mainnet(db_version):
-    async_gen = setup_simulators_and_wallets(2, 1, {}, db_version=db_version)
+async def wallet_nodes_mainnet(db_version, blockchain_constants: ConsensusConstants):
+    async_gen = setup_simulators_and_wallets(2, 1, blockchain_constants, db_version=db_version)
     nodes, wallets, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     full_node_2 = nodes[1]
@@ -575,20 +579,24 @@ async def wallet_nodes_mainnet(db_version):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def three_nodes_two_wallets():
-    async for _ in setup_simulators_and_wallets(3, 2, {}):
+async def three_nodes_two_wallets(blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(3, 2, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def one_node() -> AsyncIterator[Tuple[List[Service], List[FullNodeSimulator], BlockTools]]:
-    async for _ in setup_simulators_and_wallets_service(1, 0, {}):
+async def one_node(
+    blockchain_constants: ConsensusConstants,
+) -> AsyncIterator[Tuple[List[Service], List[FullNodeSimulator], BlockTools]]:
+    async for _ in setup_simulators_and_wallets_service(1, 0, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def one_node_one_block() -> AsyncIterator[Tuple[Union[FullNodeAPI, FullNodeSimulator], ChiaServer, BlockTools]]:
-    async_gen = setup_simulators_and_wallets(1, 0, {})
+async def one_node_one_block(
+    blockchain_constants: ConsensusConstants,
+) -> AsyncIterator[Tuple[Union[FullNodeAPI, FullNodeSimulator], ChiaServer, BlockTools]]:
+    async_gen = setup_simulators_and_wallets(1, 0, blockchain_constants)
     nodes, _, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     server_1 = full_node_1.full_node.server
@@ -617,8 +625,8 @@ async def one_node_one_block() -> AsyncIterator[Tuple[Union[FullNodeAPI, FullNod
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_nodes_one_block():
-    async_gen = setup_simulators_and_wallets(2, 0, {})
+async def two_nodes_one_block(blockchain_constants: ConsensusConstants):
+    async_gen = setup_simulators_and_wallets(2, 0, blockchain_constants)
     nodes, _, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     full_node_2 = nodes[1]
@@ -632,7 +640,7 @@ async def two_nodes_one_block():
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=reward_ph,
         pool_reward_puzzle_hash=reward_ph,
-        genesis_timestamp=10000,
+        genesis_timestamp=uint64(10000),
         time_per_block=10,
     )
     assert blocks[0].height == 0
@@ -651,6 +659,7 @@ async def two_nodes_one_block():
 @pytest_asyncio.fixture(scope="function")
 async def farmer_one_harvester_simulator_wallet(
     tmp_path: Path,
+    blockchain_constants: ConsensusConstants,
 ) -> AsyncIterator[
     Tuple[
         Service[Harvester, HarvesterAPI],
@@ -660,7 +669,7 @@ async def farmer_one_harvester_simulator_wallet(
         BlockTools,
     ]
 ]:
-    async for sim_and_wallet in setup_simulators_and_wallets_service(1, 1, {}):
+    async for sim_and_wallet in setup_simulators_and_wallets_service(1, 1, blockchain_constants):
         nodes, wallets, bt = sim_and_wallet
         async for farmer_harvester in setup_farmer_multi_harvester(bt, 1, tmp_path, bt.constants, start_services=True):
             harvester_services, farmer_service, _ = farmer_harvester

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -563,22 +563,6 @@ async def wallet_nodes_perf(blockchain_constants: ConsensusConstants):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def wallet_nodes_mainnet(db_version, blockchain_constants: ConsensusConstants):
-    async_gen = setup_simulators_and_wallets(2, 1, blockchain_constants, db_version=db_version)
-    nodes, wallets, bt = await async_gen.__anext__()
-    full_node_1 = nodes[0]
-    full_node_2 = nodes[1]
-    server_1 = full_node_1.full_node.server
-    server_2 = full_node_2.full_node.server
-    wallet_a = bt.get_pool_wallet_tool()
-    wallet_receiver = WalletTool(full_node_1.full_node.constants)
-    yield full_node_1, full_node_2, server_1, server_2, wallet_a, wallet_receiver, bt
-
-    async for _ in async_gen:
-        yield _
-
-
-@pytest_asyncio.fixture(scope="function")
 async def three_nodes_two_wallets(blockchain_constants: ConsensusConstants):
     async for _ in setup_simulators_and_wallets(3, 2, blockchain_constants):
         yield _

--- a/tests/core/daemon/config.py
+++ b/tests/core/daemon/config.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
 
+job_timeout = 50
 install_timelord = True
 checkout_blocks_and_plots = True

--- a/tests/core/daemon/test_daemon.py
+++ b/tests/core/daemon/test_daemon.py
@@ -382,7 +382,7 @@ async def test_daemon_simulation(self_hostname, daemon_simulation):
     data = {"service": service_name}
     payload = create_payload("register_service", data, service_name, "daemon")
     await ws.send_str(payload)
-    message_queue = asyncio.Queue()
+    message_queue: asyncio.Queue = asyncio.Queue()
 
     async def reader(ws, queue):
         while True:

--- a/tests/core/data_layer/config.py
+++ b/tests/core/data_layer/config.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
 parallel = 4
-job_timeout = 60
+job_timeout = 80
 checkout_blocks_and_plots = True

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -55,6 +55,7 @@ from chia.util.vdf_prover import get_vdf_info_and_proof
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block, _validate_and_add_block_no_error
+from tests.conftest import ConsensusMode
 from tests.connection_utils import add_dummy_connection, connect_and_get_peer
 from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.make_block_generator import make_spend_bundle
@@ -105,7 +106,9 @@ async def get_block_path(full_node: FullNodeAPI):
 class TestFullNodeBlockCompression:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("tx_size", [3000000000000])
-    async def test_block_compression(self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, self_hostname):
+    async def test_block_compression(
+        self, setup_two_nodes_and_wallet, empty_blockchain, tx_size, self_hostname, consensus_mode
+    ):
         nodes, wallets, bt = setup_two_nodes_and_wallet
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -165,7 +168,12 @@ class TestFullNodeBlockCompression:
         # Confirm generator is not compressed
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
-        assert detect_potential_template_generator(uint32(5), program) is not None
+        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+            # after the hard fork we don't use this compression mechanism
+            # anymore, we use CLVM backrefs in the encoding instead
+            assert detect_potential_template_generator(uint32(5), program) is None
+        else:
+            assert detect_potential_template_generator(uint32(5), program) is not None
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         # Send another tx
@@ -195,7 +203,12 @@ class TestFullNodeBlockCompression:
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
         assert detect_potential_template_generator(uint32(6), program) is None
-        assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
+        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+            # after the hard fork we don't use this compression mechanism
+            # anymore, we use CLVM backrefs in the encoding instead
+            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
+        else:
+            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
 
         # Farm two empty blocks
         await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -270,7 +283,12 @@ class TestFullNodeBlockCompression:
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
         assert detect_potential_template_generator(uint32(9), program) is None
-        assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
+        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+            # after the hard fork we don't use this compression mechanism
+            # anymore, we use CLVM backrefs in the encoding instead
+            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
+        else:
+            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
 
         # Creates a standard_transaction and an anyone-can-spend tx
         tr: TransactionRecord = await wallet.generate_signed_transaction(
@@ -359,7 +377,12 @@ class TestFullNodeBlockCompression:
         # Confirm generator is not compressed
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
-        assert detect_potential_template_generator(uint32(11), program) is not None
+        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+            # after the hard fork we don't use this compression mechanism
+            # anymore, we use CLVM backrefs in the encoding instead
+            assert detect_potential_template_generator(uint32(11), program) is None
+        else:
+            assert detect_potential_template_generator(uint32(11), program) is not None
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         height = full_node_1.full_node.blockchain.get_peak().height
@@ -367,7 +390,13 @@ class TestFullNodeBlockCompression:
         blockchain = empty_blockchain
         all_blocks: List[FullBlock] = await full_node_1.get_all_full_blocks()
         assert height == len(all_blocks) - 1
-        assert full_node_1.full_node.full_node_store.previous_generator is not None
+
+        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+            # after the hard fork we don't use this compression mechanism
+            # anymore, we use CLVM backrefs in the encoding instead
+            assert full_node_1.full_node.full_node_store.previous_generator is None
+        else:
+            assert full_node_1.full_node.full_node_store.previous_generator is not None
         if test_reorgs:
             reog_blocks = bt.get_consecutive_blocks(14)
             for r in range(0, len(reog_blocks), 3):

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -168,12 +168,13 @@ class TestFullNodeBlockCompression:
         # Confirm generator is not compressed
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
+        template = detect_potential_template_generator(uint32(5), program)
         if consensus_mode == ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
-            assert detect_potential_template_generator(uint32(5), program) is None
+            assert template is None
         else:
-            assert detect_potential_template_generator(uint32(5), program) is not None
+            assert template is not None
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         # Send another tx
@@ -203,12 +204,13 @@ class TestFullNodeBlockCompression:
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
         assert detect_potential_template_generator(uint32(6), program) is None
+        num_blocks = len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list)
         if consensus_mode == ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
-            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
+            assert num_blocks == 0
         else:
-            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
+            assert num_blocks > 0
 
         # Farm two empty blocks
         await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -283,12 +285,13 @@ class TestFullNodeBlockCompression:
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
         assert detect_potential_template_generator(uint32(9), program) is None
+        num_blocks = len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list)
         if consensus_mode == ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
-            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
+            assert num_blocks == 0
         else:
-            assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) > 0
+            assert num_blocks > 0
 
         # Creates a standard_transaction and an anyone-can-spend tx
         tr: TransactionRecord = await wallet.generate_signed_transaction(
@@ -377,12 +380,13 @@ class TestFullNodeBlockCompression:
         # Confirm generator is not compressed
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
+        template = detect_potential_template_generator(uint32(11), program)
         if consensus_mode == ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
-            assert detect_potential_template_generator(uint32(11), program) is None
+            assert template is None
         else:
-            assert detect_potential_template_generator(uint32(11), program) is not None
+            assert template is not None
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         height = full_node_1.full_node.blockchain.get_peak().height
@@ -391,12 +395,13 @@ class TestFullNodeBlockCompression:
         all_blocks: List[FullBlock] = await full_node_1.get_all_full_blocks()
         assert height == len(all_blocks) - 1
 
+        template = full_node_1.full_node.full_node_store.previous_generator
         if consensus_mode == ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
-            assert full_node_1.full_node.full_node_store.previous_generator is None
+            assert template is None
         else:
-            assert full_node_1.full_node.full_node_store.previous_generator is not None
+            assert template is not None
         if test_reorgs:
             reog_blocks = bt.get_consecutive_blocks(14)
             for r in range(0, len(reog_blocks), 3):

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -16,6 +16,7 @@ import pytest_asyncio
 from _pytest.fixtures import SubRequest
 from blspy import G1Element
 
+from chia.consensus.constants import ConsensusConstants
 from chia.full_node.full_node import FullNode
 from chia.pools.pool_puzzles import SINGLETON_LAUNCHER_HASH
 from chia.pools.pool_wallet_info import PoolSingletonState, PoolWalletInfo
@@ -97,11 +98,10 @@ OneWalletNodeAndRpc = Tuple[WalletRpcClient, Any, FullNodeSimulator, int, BlockT
 
 @pytest_asyncio.fixture(scope="function")
 async def one_wallet_node_and_rpc(
-    trusted: bool,
-    self_hostname: str,
+    trusted: bool, self_hostname: str, blockchain_constants: ConsensusConstants
 ) -> AsyncIterator[OneWalletNodeAndRpc]:
     rmtree(get_pool_plot_dir(), ignore_errors=True)
-    async for nodes in setup_simulators_and_wallets_service(1, 1, {}):
+    async for nodes in setup_simulators_and_wallets_service(1, 1, blockchain_constants):
         full_nodes, wallets, bt = nodes
         full_node_api: FullNodeSimulator = full_nodes[0]._api
         wallet_service = wallets[0]

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -39,6 +39,7 @@ from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_node_api import WalletNodeAPI
+from tests.conftest import ConsensusMode
 
 # TODO: Compare deducted fees in all tests against reported total_fee
 
@@ -405,12 +406,13 @@ class TestPoolWalletRpc:
                             assert owner_sk is not None
                             assert owner_sk[0] != auth_sk
 
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
+        reason="the pooling test only creates one plot, and cannot pass CHIP-13 rules",
+    )
     @pytest.mark.asyncio
     async def test_absorb_self(
-        self,
-        one_wallet_node_and_rpc: OneWalletNodeAndRpc,
-        fee: uint64,
-        self_hostname: str,
+        self, one_wallet_node_and_rpc: OneWalletNodeAndRpc, fee: uint64, self_hostname: str
     ) -> None:
         client, wallet_node, full_node_api, total_block_rewards, _ = one_wallet_node_and_rpc
         bt = full_node_api.bt
@@ -486,12 +488,13 @@ class TestPoolWalletRpc:
             tx1 = await client.get_transactions(1)
             assert (250_000_000_000 + fee) in [tx.amount for tx in tx1]
 
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
+        reason="the pooling test only creates one plot, and cannot pass CHIP-13 rules",
+    )
     @pytest.mark.asyncio
     async def test_absorb_self_multiple_coins(
-        self,
-        one_wallet_node_and_rpc: OneWalletNodeAndRpc,
-        fee: uint64,
-        self_hostname: str,
+        self, one_wallet_node_and_rpc: OneWalletNodeAndRpc, fee: uint64, self_hostname: str
     ) -> None:
         client, wallet_node, full_node_api, total_block_rewards, _ = one_wallet_node_and_rpc
         bt = full_node_api.bt
@@ -558,12 +561,13 @@ class TestPoolWalletRpc:
             assert pool_bal["confirmed_wallet_balance"] == pool_expected_confirmed_balance
             assert main_bal["confirmed_wallet_balance"] == main_expected_confirmed_balance  # 10499999999999
 
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
+        reason="the pooling test only creates one plot, and cannot pass CHIP-13 rules",
+    )
     @pytest.mark.asyncio
     async def test_absorb_pooling(
-        self,
-        one_wallet_node_and_rpc: OneWalletNodeAndRpc,
-        fee: uint64,
-        self_hostname: str,
+        self, one_wallet_node_and_rpc: OneWalletNodeAndRpc, fee: uint64, self_hostname: str
     ) -> None:
         client, wallet_node, full_node_api, total_block_rewards, _ = one_wallet_node_and_rpc
         bt = full_node_api.bt

--- a/tests/wallet/cat_wallet/config.py
+++ b/tests/wallet/cat_wallet/config.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
 
-parallel = False
 job_timeout = 90
 checkout_blocks_and_plots = True

--- a/tests/wallet/cat_wallet/config.py
+++ b/tests/wallet/cat_wallet/config.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
 parallel = False
-job_timeout = 50
+job_timeout = 90
 checkout_blocks_and_plots = True

--- a/tests/wallet/cat_wallet/test_cat_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_cat_lifecycle.py
@@ -25,6 +25,7 @@ from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.tails import DelegatedLimitations, EverythingWithSig, GenesisById, GenesisByPuzhash
 from tests.clvm.benchmark_costs import cost_of_spend_bundle
 from tests.clvm.test_puzzles import secret_exponent_for_index
+from tests.conftest import ConsensusMode
 
 acs = Program.to(1)
 acs_ph = acs.get_tree_hash()
@@ -91,8 +92,9 @@ async def do_spend(
 
 
 class TestCATLifecycle:
-    @pytest.mark.asyncio()
-    async def test_cat_mod(self, cost_logger):
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.asyncio
+    async def test_cat_mod(self, cost_logger, consensus_mode):
         async with sim_and_client() as (sim, sim_client):
             tail = Program.to([])
             checker_solution = Program.to([])
@@ -260,8 +262,9 @@ class TestCATLifecycle:
                 cost_log_msg="ACS burn + Cat Spend (Mint) + create one child (TAIL: ())",
             )
 
-    @pytest.mark.asyncio()
-    async def test_complex_spend(self, cost_logger):
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.asyncio
+    async def test_complex_spend(self, cost_logger, consensus_mode):
         async with sim_and_client() as (sim, sim_client):
             tail = Program.to([])
             checker_solution = Program.to([])
@@ -354,8 +357,9 @@ class TestCATLifecycle:
                 cost_log_msg="Cat Eve Spend x2 (mint & melt) + Cat Spend x2 (mint & melt) - one child each (TAIL: ())",
             )
 
-    @pytest.mark.asyncio()
-    async def test_genesis_by_id(self, cost_logger):
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.asyncio
+    async def test_genesis_by_id(self, cost_logger, consensus_mode):
         async with sim_and_client() as (sim, sim_client):
             standard_acs = Program.to(1)
             standard_acs_ph: bytes32 = standard_acs.get_tree_hash()
@@ -395,8 +399,9 @@ class TestCATLifecycle:
                 cost_log_msg="Cat Eve Spend - create one child (TAIL: genesis_by_id)",
             )
 
-    @pytest.mark.asyncio()
-    async def test_genesis_by_puzhash(self, cost_logger):
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.asyncio
+    async def test_genesis_by_puzhash(self, cost_logger, consensus_mode):
         async with sim_and_client() as (sim, sim_client):
             standard_acs = Program.to(1)
             standard_acs_ph: bytes32 = standard_acs.get_tree_hash()
@@ -436,8 +441,9 @@ class TestCATLifecycle:
                 cost_log_msg="Cat Eve Spend - create one child (TAIL: genesis_by_puzhash)",
             )
 
-    @pytest.mark.asyncio()
-    async def test_everything_with_signature(self, cost_logger):
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.asyncio
+    async def test_everything_with_signature(self, cost_logger, consensus_mode):
         async with sim_and_client() as (sim, sim_client):
             sk = PrivateKey.from_bytes(secret_exponent_for_index(1).to_bytes(32, "big"))
             tail: Program = EverythingWithSig.construct([Program.to(sk.get_g1())])
@@ -547,8 +553,9 @@ class TestCATLifecycle:
                 cost_log_msg="ACS Burn + Cat Spend (Mint) - create one child (TAIL: everything_with_signature)",
             )
 
-    @pytest.mark.asyncio()
-    async def test_delegated_tail(self, cost_logger):
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.asyncio
+    async def test_delegated_tail(self, cost_logger, consensus_mode):
         async with sim_and_client() as (sim, sim_client):
             standard_acs = Program.to(1)
             standard_acs_ph: bytes32 = standard_acs.get_tree_hash()

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -36,6 +36,7 @@ from chia.wallet.util.tx_config import DEFAULT_COIN_SELECTION_CONFIG, DEFAULT_TX
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_interested_store import WalletInterestedStore
+from tests.conftest import ConsensusMode
 
 
 class TestCATWallet:
@@ -666,10 +667,8 @@ class TestCATWallet:
                 assert b"Markus Walburg" in [v for v_list in memos.values() for v in v_list]
                 assert list(memos.keys())[0] in [a.name() for a in tx.spend_bundle.additions()]
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_cat_max_amount_send(self, self_hostname, two_wallet_nodes, trusted):
         num_blocks = 3
@@ -780,14 +779,9 @@ class TestCATWallet:
                 DEFAULT_TX_CONFIG,
             )
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
-    @pytest.mark.parametrize(
-        "autodiscovery",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
+    @pytest.mark.parametrize("autodiscovery", [True, False])
     @pytest.mark.asyncio
     async def test_cat_hint(self, self_hostname, two_wallet_nodes, trusted, autodiscovery):
         num_blocks = 3

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -31,7 +31,7 @@ from chia.wallet.vc_wallet.cr_cat_drivers import ProofsChecker
 from chia.wallet.vc_wallet.cr_cat_wallet import CRCATWallet
 from chia.wallet.vc_wallet.vc_store import VCProofs
 from chia.wallet.wallet_node import WalletNode
-from tests.conftest import SOFTFORK_HEIGHTS
+from tests.conftest import SOFTFORK_HEIGHTS, ConsensusMode
 from tests.wallet.vc_wallet.test_vc_wallet import mint_cr_cat
 
 
@@ -64,6 +64,7 @@ async def claim_pending_approval_balance(
 # We do not test aggregation in a number of cases because it's not correlated with a lot of these parameters.
 # So to avoid the overhead of start up for identical tests, we only change the softfork param for the tests that use it.
 # To pin down the behavior that we intend to eventually deprecate, it only gets one test case.
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "wallets_prefarm_services,trusted,reuse_puzhash,credential_restricted,active_softfork_height",
@@ -80,10 +81,7 @@ async def claim_pending_approval_balance(
     indirect=["wallets_prefarm_services"],
 )
 async def test_cat_trades(
-    wallets_prefarm_services,
-    reuse_puzhash: bool,
-    credential_restricted: bool,
-    active_softfork_height: uint32,
+    wallets_prefarm_services, reuse_puzhash: bool, credential_restricted: bool, active_softfork_height: uint32
 ):
     (
         [wallet_node_maker, initial_maker_balance],
@@ -919,6 +917,7 @@ class TestCATTrades:
 
         await time_out_assert(15, get_trade_and_status, TradeStatus.CANCELLED, trade_manager_maker, trade_make)
 
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
     @pytest.mark.asyncio
     async def test_trade_conflict(self, three_wallets_prefarm):
         (

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -371,7 +371,7 @@ async def test_cat_trades(
     await time_out_assert(15, new_cat_wallet_taker.get_unconfirmed_balance, TAKER_NEW_CAT_BALANCE)
 
     await full_node.process_transaction_records(records=tx_records)
-    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=15)
+    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=30)
 
     await time_out_assert(15, wallet_maker.get_confirmed_balance, MAKER_CHIA_BALANCE)
     await time_out_assert(15, wallet_maker.get_unconfirmed_balance, MAKER_CHIA_BALANCE)
@@ -464,7 +464,7 @@ async def test_cat_trades(
     await time_out_assert(15, cat_wallet_taker.get_unconfirmed_balance, TAKER_CAT_BALANCE)
 
     await full_node.process_transaction_records(records=tx_records)
-    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=15)
+    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=30)
 
     await time_out_assert(15, wallet_maker.get_confirmed_balance, MAKER_CHIA_BALANCE)
     await time_out_assert(15, wallet_maker.get_unconfirmed_balance, MAKER_CHIA_BALANCE)
@@ -513,7 +513,7 @@ async def test_cat_trades(
     await time_out_assert(15, cat_wallet_taker.get_unconfirmed_balance, TAKER_CAT_BALANCE)
 
     await full_node.process_transaction_records(records=tx_records)
-    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=15)
+    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=30)
 
     if credential_restricted:
         await claim_pending_approval_balance(
@@ -595,7 +595,7 @@ async def test_cat_trades(
     await time_out_assert(15, cat_wallet_taker.get_unconfirmed_balance, TAKER_CAT_BALANCE)
 
     await full_node.process_transaction_records(records=tx_records)
-    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=15)
+    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=30)
 
     if credential_restricted:
         await claim_pending_approval_balance(
@@ -656,7 +656,7 @@ async def test_cat_trades(
     await time_out_assert(15, cat_wallet_taker.get_unconfirmed_balance, TAKER_CAT_BALANCE)
 
     await full_node.process_transaction_records(records=tx_records)
-    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=15)
+    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=30)
 
     await time_out_assert(15, new_cat_wallet_maker.get_confirmed_balance, MAKER_NEW_CAT_BALANCE)
     await time_out_assert(15, new_cat_wallet_maker.get_unconfirmed_balance, MAKER_NEW_CAT_BALANCE)
@@ -701,7 +701,7 @@ async def test_cat_trades(
     await time_out_assert(15, cat_wallet_taker.get_unconfirmed_balance, TAKER_CAT_BALANCE)
 
     await full_node.process_transaction_records(records=tx_records)
-    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=15)
+    await full_node.wait_for_wallets_synced(wallet_nodes=[wallet_node_maker, wallet_node_taker], timeout=30)
 
     if credential_restricted:
         await claim_pending_approval_balance(

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -14,6 +14,7 @@ from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.util.merkle_utils import build_merkle_tree, simplify_merkle_proof
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
+from tests.conftest import ConsensusMode
 
 
 async def is_singleton_confirmed_and_root(dl_wallet: DataLayerWallet, lid: bytes32, root: bytes32) -> bool:
@@ -37,10 +38,8 @@ def get_parent_branch(value: bytes32, proof: Tuple[int, List[bytes32]]) -> Tuple
     return branch, new_proof
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
 @pytest.mark.asyncio
 async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     (
@@ -302,10 +301,8 @@ async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> Non
     await time_out_assert(15, get_trade_and_status, TradeStatus.CANCELLED, trade_manager, offer)
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
 @pytest.mark.asyncio
 async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
     (

--- a/tests/wallet/db_wallet/test_dl_wallet.py
+++ b/tests/wallet/db_wallet/test_dl_wallet.py
@@ -19,6 +19,7 @@ from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.db_wallet.db_wallet_puzzles import create_mirror_puzzle
 from chia.wallet.util.merkle_tree import MerkleTree
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
+from tests.conftest import ConsensusMode
 
 pytestmark = pytest.mark.data_layer
 
@@ -142,10 +143,8 @@ class TestDLWallet:
         owned_launcher_ids = sorted(singleton.launcher_id for singleton in owned_singletons)
         assert owned_launcher_ids == sorted(expected_launcher_ids)
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_tracking_non_owned(
         self, self_hostname: str, two_wallet_nodes: SimulatorsAndWallets, trusted: bool

--- a/tests/wallet/nft_wallet/config.py
+++ b/tests/wallet/nft_wallet/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 70
+job_timeout = 115
 checkout_blocks_and_plots = True

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -25,6 +25,7 @@ from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
+from tests.conftest import ConsensusMode
 
 # from clvm_tools.binutils import disassemble
 
@@ -50,16 +51,10 @@ async def get_nft_count(wallet: NFTWallet) -> int:
     return await wallet.get_nft_count()
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
-@pytest.mark.parametrize(
-    "zero_royalties",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
+@pytest.mark.parametrize("zero_royalties", [True, False])
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_nft_offer_sell_nft(
     self_hostname: str, two_wallet_nodes: Any, trusted: Any, zero_royalties: bool
 ) -> None:
@@ -210,16 +205,10 @@ async def test_nft_offer_sell_nft(
     await time_out_assert(20, wallet_taker.get_confirmed_balance, expected_taker_balance)
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
-@pytest.mark.parametrize(
-    "zero_royalties",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
+@pytest.mark.parametrize("zero_royalties", [True, False])
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_nft_offer_request_nft(
     self_hostname: str, two_wallet_nodes: Any, trusted: Any, zero_royalties: bool
 ) -> None:
@@ -368,16 +357,10 @@ async def test_nft_offer_request_nft(
     await time_out_assert(20, wallet_taker.get_confirmed_balance, expected_taker_balance)
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
-@pytest.mark.parametrize(
-    "zero_royalties",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
+@pytest.mark.parametrize("zero_royalties", [True, False])
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_nft_offer_sell_did_to_did(
     self_hostname: str, two_wallet_nodes: Any, trusted: Any, zero_royalties: bool
 ) -> None:
@@ -549,16 +532,10 @@ async def test_nft_offer_sell_did_to_did(
     await time_out_assert(20, wallet_taker.get_confirmed_balance, expected_taker_balance)
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
-@pytest.mark.parametrize(
-    "zero_royalties",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
+@pytest.mark.parametrize("zero_royalties", [True, False])
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_nft_offer_sell_nft_for_cat(
     self_hostname: str, two_wallet_nodes: Any, trusted: Any, zero_royalties: bool
 ) -> None:
@@ -752,10 +729,10 @@ async def test_nft_offer_sell_nft_for_cat(
     await time_out_assert(20, cat_wallet_taker.get_confirmed_balance, expected_taker_cat_balance)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.parametrize("trusted", [True, False])
 @pytest.mark.parametrize("test_change", [True, False])
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_nft_offer_request_nft_for_cat(
     self_hostname: str, two_wallet_nodes: Any, trusted: bool, test_change: bool
 ) -> None:
@@ -1200,10 +1177,8 @@ async def test_nft_offer_sell_cancel_in_batch(self_hostname: str, two_wallet_nod
     await time_out_assert(15, get_trade_and_status, TradeStatus.CANCELLED, trade_manager_maker, trade_make)
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
 @pytest.mark.parametrize(
     "royalty_pts",
     [
@@ -1215,7 +1190,6 @@ async def test_nft_offer_sell_cancel_in_batch(self_hostname: str, two_wallet_nod
     ],
 )
 @pytest.mark.asyncio
-# @pytest.mark.skip
 async def test_complex_nft_offer(
     self_hostname: str, two_wallet_nodes: Any, trusted: Any, royalty_pts: Tuple[int, int, int]
 ) -> None:

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -22,6 +22,7 @@ from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.debug_spend_bundle import disassemble
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
+from tests.conftest import ConsensusMode
 from tests.wallet.nft_wallet.test_nft_1_offers import mempool_not_empty
 
 
@@ -476,20 +477,12 @@ async def test_nft_offer_with_metadata_update(self_hostname: str, two_wallet_nod
     assert await nft_wallet_taker.get_nft_count() == 1
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [False],
-)
-@pytest.mark.parametrize(
-    "reuse_puzhash",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [False])
+@pytest.mark.parametrize("reuse_puzhash", [True, False])
 @pytest.mark.asyncio
 async def test_nft_offer_nft_for_cat(
-    self_hostname: str,
-    two_wallet_nodes: Any,
-    trusted: Any,
-    reuse_puzhash: bool,
+    self_hostname: str, two_wallet_nodes: Any, trusted: Any, reuse_puzhash: bool
 ) -> None:
     full_nodes, wallets, _ = two_wallet_nodes
     full_node_api: FullNodeSimulator = full_nodes[0]

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -29,6 +29,7 @@ from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_state_manager import WalletStateManager
+from tests.conftest import ConsensusMode
 
 
 async def get_nft_count(wallet: NFTWallet) -> int:
@@ -176,10 +177,8 @@ async def test_nft_wallet_creation_automatically(self_hostname: str, two_wallet_
     assert await nft_wallet_1.get_nft_count() == 1
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
 @pytest.mark.asyncio
 async def test_nft_wallet_creation_and_transfer(self_hostname: str, two_wallet_nodes: Any, trusted: Any) -> None:
     num_blocks = 2
@@ -1519,10 +1518,8 @@ async def test_nft_bulk_transfer(two_wallet_nodes: Any, trusted: Any) -> None:
     assert coins[2].owner_did is None
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+@pytest.mark.parametrize("trusted", [True, False])
 @pytest.mark.asyncio
 async def test_nft_set_did(self_hostname: str, two_wallet_nodes: Any, trusted: Any) -> None:
     num_blocks = 3

--- a/tests/wallet/rpc/config.py
+++ b/tests/wallet/rpc/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
-job_timeout = 40
+job_timeout = 90

--- a/tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -15,16 +15,15 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.db_wallet.db_wallet_puzzles import create_mirror_puzzle
+from tests.conftest import ConsensusMode
 from tests.util.rpc import validate_get_routes
 
 log = logging.getLogger(__name__)
 
 
 class TestWalletRpc:
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_wallet_make_transaction(
         self, two_wallet_nodes_services: SimulatorsAndWalletsServices, trusted: bool, self_hostname: str

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -60,6 +60,7 @@ from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_coin_store import GetCoinRecords
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_protocol import WalletProtocol
+from tests.conftest import ConsensusMode
 from tests.wallet.test_wallet_coin_store import (
     get_coin_records_amount_filter_tests,
     get_coin_records_amount_range_tests,
@@ -289,6 +290,7 @@ def update_verify_signature_request(request: Dict[str, Any], prefix_hex_values: 
     return updated_request
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -336,6 +338,7 @@ async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment
     await time_out_assert(20, get_confirmed_balance, generated_funds - tx_amount, client, 1)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_push_transactions(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -365,6 +368,7 @@ async def test_push_transactions(wallet_rpc_environment: WalletRpcTestEnvironmen
     assert tx.confirmed
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_balance(wallet_rpc_environment: WalletRpcTestEnvironment):
     env = wallet_rpc_environment
@@ -381,6 +385,7 @@ async def test_get_balance(wallet_rpc_environment: WalletRpcTestEnvironment):
     await assert_get_balance(wallet_rpc_client, wallet_node, cat_wallet)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_farmed_amount(wallet_rpc_environment: WalletRpcTestEnvironment):
     env = wallet_rpc_environment
@@ -405,6 +410,7 @@ async def test_get_farmed_amount(wallet_rpc_environment: WalletRpcTestEnvironmen
     assert get_farmed_amount_result == expected_result
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_farmed_amount_with_fee(wallet_rpc_environment: WalletRpcTestEnvironment):
     env = wallet_rpc_environment
@@ -433,6 +439,7 @@ async def test_get_farmed_amount_with_fee(wallet_rpc_environment: WalletRpcTestE
     assert result["fee_amount"] == fee_amount
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_timestamp_for_height(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -446,6 +453,7 @@ async def test_get_timestamp_for_height(wallet_rpc_environment: WalletRpcTestEnv
     uint64(await client.get_timestamp_for_height(uint32(1)))
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.parametrize(
     "output_args, fee, select_coin, is_cat",
     [
@@ -549,6 +557,7 @@ async def test_create_signed_transaction(
             assert found
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_create_signed_transaction_with_coin_announcement(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -580,6 +589,7 @@ async def test_create_signed_transaction_with_coin_announcement(wallet_rpc_envir
     await assert_push_tx_error(client_node, tx_res)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_create_signed_transaction_with_puzzle_announcement(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -611,6 +621,7 @@ async def test_create_signed_transaction_with_puzzle_announcement(wallet_rpc_env
     await assert_push_tx_error(client_node, tx_res)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_create_signed_transaction_with_excluded_coins(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -658,6 +669,7 @@ async def test_create_signed_transaction_with_excluded_coins(wallet_rpc_environm
     await it_throws_an_error_when_all_spendable_coins_are_excluded()
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_spend_clawback_coins(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -764,6 +776,7 @@ async def test_spend_clawback_coins(wallet_rpc_environment: WalletRpcTestEnviron
     assert resp["transaction_ids"] == []
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_send_transaction_multi(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -813,6 +826,7 @@ async def test_send_transaction_multi(wallet_rpc_environment: WalletRpcTestEnvir
         assert key in [a.name() for a in spend_bundle.additions()]
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_transactions(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -890,6 +904,7 @@ async def test_get_transactions(wallet_rpc_environment: WalletRpcTestEnvironment
     assert len(all_transactions) == 1
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_transaction_count(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -912,6 +927,7 @@ async def test_get_transaction_count(wallet_rpc_environment: WalletRpcTestEnviro
     )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -1068,6 +1084,7 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert len(selected_coins) > 0
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -1282,6 +1299,7 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_coin_records_by_names(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -1335,6 +1353,7 @@ async def test_get_coin_records_by_names(wallet_rpc_environment: WalletRpcTestEn
         await client.get_coin_records_by_names(coin_ids, include_spent_coins=False)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -1468,6 +1487,7 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert next_did_coin.puzzle_hash == last_did_coin.puzzle_hash
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_nft_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -1560,6 +1580,7 @@ async def test_nft_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     }
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_key_and_address_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -1689,6 +1710,7 @@ async def test_key_and_address_endpoints(wallet_rpc_environment: WalletRpcTestEn
     assert len(await client.get_public_keys()) == 0
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_select_coins_rpc(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -1809,10 +1831,9 @@ async def test_select_coins_rpc(wallet_rpc_environment: WalletRpcTestEnvironment
         )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
-async def test_get_coin_records_rpc(
-    wallet_rpc_environment: WalletRpcTestEnvironment,
-) -> None:
+async def test_get_coin_records_rpc(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
     env: WalletRpcTestEnvironment = wallet_rpc_environment
     wallet_node: WalletNode = env.wallet_1.node
     client: WalletRpcClient = env.wallet_1.rpc_client
@@ -1857,10 +1878,9 @@ async def test_get_coin_records_rpc(
             await run_test_case(f"{name}-{i}", request, expected_total_count, expected_records)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
-async def test_get_coin_records_rpc_limits(
-    wallet_rpc_environment: WalletRpcTestEnvironment,
-) -> None:
+async def test_get_coin_records_rpc_limits(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
     env: WalletRpcTestEnvironment = wallet_rpc_environment
     wallet_node: WalletNode = env.wallet_1.node
     client: WalletRpcClient = env.wallet_1.rpc_client
@@ -1929,10 +1949,9 @@ async def test_get_coin_records_rpc_limits(
             assert expected_record in response["coin_records"]
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
-async def test_get_coin_records_rpc_failures(
-    wallet_rpc_environment: WalletRpcTestEnvironment,
-) -> None:
+async def test_get_coin_records_rpc_failures(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
     env: WalletRpcTestEnvironment = wallet_rpc_environment
     client: WalletRpcClient = env.wallet_1.rpc_client
     rpc_server: Optional[RpcServer] = wallet_rpc_environment.wallet_1.service.rpc_server
@@ -1976,6 +1995,7 @@ async def test_get_coin_records_rpc_failures(
             await api.get_coin_records(json_dict)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -2200,6 +2220,7 @@ async def test_get_auto_claim(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert res["batch_size"] == 50
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_set_wallet_resync_on_startup(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -2295,6 +2316,7 @@ async def test_set_wallet_resync_on_startup(wallet_rpc_environment: WalletRpcTes
     await wallet_node_2._await_closed()
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_set_wallet_resync_on_startup_disable(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -2334,6 +2356,7 @@ async def test_set_wallet_resync_on_startup_disable(wallet_rpc_environment: Wall
     await wallet_node_2._await_closed()
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_set_wallet_resync_schema(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -2362,6 +2385,7 @@ async def test_set_wallet_resync_schema(wallet_rpc_environment: WalletRpcTestEnv
     assert await wallet_node.reset_sync_db(db_path, fingerprint)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_cat_spend_run_tail(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
@@ -2439,6 +2463,7 @@ async def test_cat_spend_run_tail(wallet_rpc_environment: WalletRpcTestEnvironme
     await time_out_assert(20, get_confirmed_balance, 0, client, cat_wallet_id)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_balances(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -663,6 +663,7 @@ class TestWalletSync:
     """
 
     @pytest.mark.asyncio
+    @pytest.mark.skip("this test is non-deterministic and is temporarily disabled")
     @pytest.mark.parametrize(
         "spam_filter_after_n_txs, xch_spam_amount, dust_value",
         [

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -33,6 +33,7 @@ from chia.wallet.util.wallet_types import CoinType
 from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX
 from chia.wallet.wallet_node import WalletNode, get_wallet_db_path
 from chia.wallet.wallet_state_manager import WalletStateManager
+from tests.conftest import ConsensusMode
 
 
 class TestWalletSimulator:
@@ -186,6 +187,7 @@ class TestWalletSimulator:
         assert await wallet.get_confirmed_balance() == expected_confirmed_balance
         assert await wallet.get_unconfirmed_balance() == expected_confirmed_balance
 
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
     @pytest.mark.parametrize(
         "trusted",
         [True, False],
@@ -419,10 +421,8 @@ class TestWalletSimulator:
         interested_coins = await wallet_node_2.wallet_state_manager.interested_store.get_interested_coin_ids()
         assert merkle_coin.name() not in set(interested_coins)
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_wallet_clawback_sent_self(
         self,
@@ -507,10 +507,8 @@ class TestWalletSimulator:
         assert txs["transactions"][0]["memos"] != txs["transactions"][1]["memos"]
         assert list(txs["transactions"][0]["memos"].values())[0] == b"Test".hex()
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_wallet_clawback_claim_manual(
         self,
@@ -601,10 +599,8 @@ class TestWalletSimulator:
         assert len(txs["transactions"]) == 1
         assert txs["transactions"][0]["confirmed"]
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_wallet_clawback_reorg(
         self,
@@ -761,10 +757,8 @@ class TestWalletSimulator:
         assert len(resp["coin_records"]) == 1
         assert resp["coin_records"][0]["id"][2:] == merkle_coin.name().hex()
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_clawback_resync(
         self,
@@ -959,10 +953,8 @@ class TestWalletSimulator:
         # Check unspent coins
         assert len(await wallet_node_1.wallet_state_manager.coin_store.get_all_unspent_coins()) == 6
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_wallet_coinbase_reorg(
         self,
@@ -1000,10 +992,8 @@ class TestWalletSimulator:
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=5)
         assert await wallet.get_confirmed_balance() == permanent_funds
 
-    @pytest.mark.parametrize(
-        "trusted",
-        [True, False],
-    )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
+    @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.asyncio
     async def test_wallet_send_to_three_peers(
         self,

--- a/tests/wallet/test_wallet_blockchain.py
+++ b/tests/wallet/test_wallet_blockchain.py
@@ -11,10 +11,12 @@ from chia.types.weight_proof import WeightProof
 from chia.util.generator_tools import get_block_header
 from chia.wallet.key_val_store import KeyValStore
 from chia.wallet.wallet_blockchain import WalletBlockchain
+from tests.conftest import ConsensusMode
 from tests.util.db_connection import DBConnection
 
 
 class TestWalletBlockchain:
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
     @pytest.mark.asyncio
     async def test_wallet_blockchain(self, simulator_and_wallet, default_1000_blocks):
         [full_node_api], [(wallet_node, _)], bt = simulator_and_wallet

--- a/tests/wallet/test_wallet_node.py
+++ b/tests/wallet/test_wallet_node.py
@@ -18,6 +18,7 @@ from chia.util.config import load_config
 from chia.util.ints import uint16, uint32, uint128
 from chia.util.keychain import Keychain, KeyData, generate_mnemonic
 from chia.wallet.wallet_node import Balance, WalletNode
+from tests.conftest import ConsensusMode
 from tests.util.misc import CoinGenerator
 
 
@@ -311,6 +312,7 @@ async def test_unique_puzzle_hash_subscriptions(simulator_and_wallet: Simulators
     assert len(set(puzzle_hashes)) == len(puzzle_hashes)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.asyncio
 async def test_get_balance(
     simulator_and_wallet: SimulatorsAndWallets, self_hostname: str, default_400_blocks: List[FullBlock]


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

Currently, only a few of our test fixtures are parameterized by soft-fork and hard-fork activation. They primarily test the full node. However, the fixtures we use to test wallets, and multiple nodes, are not parameterized. This makes for a blind-spot in our testing (missing a bug that was instead found by manual testing ahead of the 2.0 release).

In order to parameterize these fixtures, the underlying functions used to set up the simulation environment also need to be changed to take a full `ConsensusConstants` object, indicating the mode we're testing. Specifically, these functions:
* `setup_simulators_and_wallets()`
* `setup_simulators_and_wallets_service()`
* `setup_simulators_and_wallets_inner()`

Instead of taking an "overrides" dictionary, the caller can override the constants before passing it in. However, there's only one instance where a caller actually does override constants (and it's not a particularly convenient interface).

A consequence of parameterizing is that we end up running a lot more tests in CI. This needs to be mitigated by disabling the parameterization for some tests and also to bump the timeouts.