### PR TITLE
Fix timelord-install.sh for CentOS\RHEL

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -82,7 +82,9 @@ elif [ "$(uname)" = "Linux" ] && type dnf || yum; then
 	echo "Found RedHat."
 
 	if [ "$INSTALL_PYTHON_DEV" ]; then
-		PYTHON_DEV_DEPENDENCY="$PYTHON_VERSION"-devel
+		yumcmd="sudo yum install "$PYTHON_VERSION"-devel gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
+  	else
+		yumcmd="sudo yum install gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
 	fi
 
 elif [ "$(uname)" = "Darwin" ]; then
@@ -109,8 +111,8 @@ else
 	elif [ -e venv/bin/python ] && test "$RHEL_BASED"; then
 		echo "Installing chiavdf dependencies on RedHat/CentOS/Fedora"
 		# Install remaining needed development tools - assumes venv and prior run of install.sh
-		echo "yum install gcc gcc-c++ gmp-devel $PYTHON_DEV_DEPENDENCY libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y" | tr -s ' '
-		sudo yum install gcc gcc-c++ gmp-devel "$PYTHON_DEV_DEPENDENCY" libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y | tr -s ' '
+		echo "$yumcmd"
+		${yumcmd}
 		echo "Installing chiavdf from source on RedHat/CentOS/Fedora"
 		echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
 		venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"

--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -76,13 +76,20 @@ symlink_vdf_bench() {
 if [ "$(uname)" = "Linux" ] && type apt-get; then
 	UBUNTU_DEBIAN=true
 	echo "Found Ubuntu/Debian."
+
 elif [ "$(uname)" = "Linux" ] && type dnf || yum; then
 	RHEL_BASED=true
 	echo "Found RedHat."
+
+	if [ "$INSTALL_PYTHON_DEV" ]; then
+		PYTHON_DEV_DEPENDENCY="$PYTHON_VERSION"-devel
+	fi
+
 elif [ "$(uname)" = "Darwin" ]; then
 	MACOS=true
 	echo "Found MacOS."
 fi
+
 
 if [ -e "$THE_PATH" ]; then
 	echo "$THE_PATH"
@@ -102,8 +109,8 @@ else
 	elif [ -e venv/bin/python ] && test "$RHEL_BASED"; then
 		echo "Installing chiavdf dependencies on RedHat/CentOS/Fedora"
 		# Install remaining needed development tools - assumes venv and prior run of install.sh
-		echo "yum install gcc gcc-c++ gmp-devel $PYTHON_DEV_DEPENDENCY libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
-		sudo yum install gcc gcc-c++ gmp-devel "$PYTHON_DEV_DEPENDENCY" libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y
+		echo "yum install gcc gcc-c++ gmp-devel $PYTHON_DEV_DEPENDENCY libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y" | tr -s ' '
+		sudo yum install gcc gcc-c++ gmp-devel "$PYTHON_DEV_DEPENDENCY" libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y | tr -s ' '
 		echo "Installing chiavdf from source on RedHat/CentOS/Fedora"
 		echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
 		venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"

--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -82,7 +82,7 @@ elif [ "$(uname)" = "Linux" ] && type dnf || yum; then
 	echo "Found RedHat."
 
 	if [ "$INSTALL_PYTHON_DEV" ]; then
-		yumcmd="sudo yum install "$PYTHON_VERSION"-devel gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
+		yumcmd="sudo yum install $PYTHON_VERSION-devel gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
   	else
 		yumcmd="sudo yum install gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
 	fi


### PR DESCRIPTION

### Purpose:

This pull request fixes the issue were the install-timelord.sh fails on CentOS and RHEL


### Current Behavior:

When running the install-timelord.sh on CentOS\RHEL the install fails because the name of the python development package that the script tries to install is wrong. For CentOS\RHEL the name is "python3-devel"

If you chose to not to install the python3 development package using the "-n" option  --> "install-timelord.sh -n"
This causes the yum command to have a double space in the command and then yum throws an error and the script aborts.

### New Behavior:

The package name is updated only for CentOS/RHEL, the Package name for other OSes is not changed. The double space issues in the yum command has been fixed.

This results in the expected behavior.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

tested by running install-timelord.sh on CentOS 9 system with and without the -n switch

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
