### PR TITLE
fix mypy warnings from latest version

### DIFF
--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -198,6 +198,8 @@ def validate_unfinished_header_block(
                         icc_iters_proof,
                         sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.output,
                     )
+                    if icc_iters_committed is None:
+                        return None, ValidationError(Err.INVALID_ICC_EOS_VDF)
                     if sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf != dataclasses.replace(
                         target_vdf_info,
                         number_of_iterations=icc_iters_committed,

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import Any
+from typing import Any, Dict
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
@@ -80,7 +80,7 @@ class ConsensusConstants:
     # number of consecutive plot ids required to be distinct
     UNIQUE_PLOTS_WINDOW: uint8
 
-    def replace(self, **changes: object) -> "ConsensusConstants":
+    def replace(self, **changes: Any) -> "ConsensusConstants":
         return dataclasses.replace(self, **changes)
 
     def replace_str_to_bytes(self, **changes: Any) -> "ConsensusConstants":
@@ -88,7 +88,7 @@ class ConsensusConstants:
         Overrides str (hex) values with bytes.
         """
 
-        filtered_changes = {}
+        filtered_changes: Dict[str, Any] = {}
         for k, v in changes.items():
             if not hasattr(self, k):
                 # NETWORK_TYPE used to be present in default config, but has been removed

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1255,7 +1255,7 @@ def validate_recent_blocks(
             if not adjusted:
                 assert prev_block_record is not None
                 prev_block_record = dataclasses.replace(
-                    prev_block_record, deficit=deficit % constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK
+                    prev_block_record, deficit=uint8(deficit % constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK)
                 )
                 sub_blocks.add_block_record(prev_block_record)
                 adjusted = True

--- a/chia/seeder/crawl_store.py
+++ b/chia/seeder/crawl_store.py
@@ -11,6 +11,7 @@ from typing import Dict, List
 import aiosqlite
 
 from chia.seeder.peer_record import PeerRecord, PeerReliability
+from chia.util.ints import uint32, uint64
 
 log = logging.getLogger(__name__)
 
@@ -157,7 +158,7 @@ class CrawlStore:
         age_timestamp = int(max(peer.last_try_timestamp, peer.connected_timestamp))
         if age_timestamp == 0:
             age_timestamp = now - 1000
-        replaced = dataclasses.replace(peer, try_count=peer.try_count + 1, last_try_timestamp=now)
+        replaced = dataclasses.replace(peer, try_count=uint32(peer.try_count + 1), last_try_timestamp=uint64(now))
         reliability = await self.get_peer_reliability(peer.peer_id)
         if reliability is None:
             reliability = PeerReliability(peer.peer_id)
@@ -169,7 +170,7 @@ class CrawlStore:
         age_timestamp = int(max(peer.last_try_timestamp, peer.connected_timestamp))
         if age_timestamp == 0:
             age_timestamp = now - 1000
-        replaced = dataclasses.replace(peer, connected=True, connected_timestamp=now, tls_version=tls_version)
+        replaced = dataclasses.replace(peer, connected=True, connected_timestamp=uint64(now), tls_version=tls_version)
         reliability = await self.get_peer_reliability(peer.peer_id)
         if reliability is None:
             reliability = PeerReliability(peer.peer_id)

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -483,7 +483,7 @@ class Timelord:
                     log.warning(f"SP: Do not have correct challenge {rc_challenge.hex()} has {rc_info.challenge}")
                     # This proof is on an outdated challenge, so don't use it
                     continue
-                iters_from_sub_slot_start = cc_info.number_of_iterations + self.last_state.get_last_ip()
+                iters_from_sub_slot_start = uint64(cc_info.number_of_iterations + self.last_state.get_last_ip())
                 response = timelord_protocol.NewSignagePointVDF(
                     signage_point_index,
                     dataclasses.replace(cc_info, number_of_iterations=iters_from_sub_slot_start),
@@ -756,7 +756,7 @@ class Timelord:
             log.debug("Collected end of subslot vdfs.")
             self.iters_finished.add(iter_to_look_for)
             self.last_active_time = time.time()
-            iters_from_sub_slot_start = cc_vdf.number_of_iterations + self.last_state.get_last_ip()
+            iters_from_sub_slot_start = uint64(cc_vdf.number_of_iterations + self.last_state.get_last_ip())
             cc_vdf = dataclasses.replace(cc_vdf, number_of_iterations=iters_from_sub_slot_start)
             if icc_ip_vdf is not None:
                 if self.last_state.peak is not None:

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -206,7 +206,7 @@ class WalletTransactionStore:
             record = TransactionRecord.from_bytes(row[0])
             if include_accepted_txs:
                 # Reset the "sent" state for peers that have replied about this transaction. Retain errors.
-                record = dataclasses.replace(record, sent=1, sent_to=filter_ok_mempool_status(record.sent_to))
+                record = dataclasses.replace(record, sent=uint32(1), sent_to=filter_ok_mempool_status(record.sent_to))
                 await self.add_transaction_record(record)
                 self.tx_submitted[record.name] = current_time, 1
                 records.append(record)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -577,7 +577,7 @@ class TestBlockHeaderValidation:
                             block.finished_sub_slots[
                                 -1
                             ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf,
-                            number_of_iterations=10000000,
+                            number_of_iterations=uint64(10000000),
                         )
                     ),
                 )
@@ -614,7 +614,7 @@ class TestBlockHeaderValidation:
                             block.finished_sub_slots[
                                 -1
                             ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf,
-                            challenge=bytes([0] * 32),
+                            challenge=bytes32([0] * 32),
                         )
                     ),
                 )

--- a/tests/clvm/coin_store.py
+++ b/tests/clvm/coin_store.py
@@ -113,7 +113,7 @@ class CoinStore:
         for spent_coin in removals:
             coin_name = spent_coin.name()
             coin_record = self._db[coin_name]
-            self._db[coin_name] = replace(coin_record, spent_block_index=now.height)
+            self._db[coin_name] = replace(coin_record, spent_block_index=uint32(now.height))
         return additions, spend_bundle.coin_spends
 
     def coins_for_puzzle_hash(self, puzzle_hash: bytes32) -> Iterator[Coin]:

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -440,10 +440,12 @@ async def test_farmer_get_harvester_plots_endpoints(
     await wait_for_plot_sync(receiver, last_sync_id)
 
     for page_size in [1, int(total_count / 2), total_count - 1, total_count, total_count + 1, 100]:
-        request = dataclasses.replace(request, page_size=uint32(page_size))
+        # we know that the concrete type of request has a page_size field, but
+        # the type is a Protocol that doesn't, so mypy is right in complaining
+        request = dataclasses.replace(request, page_size=uint32(page_size))  # type: ignore[call-arg]
         expected_page_count = ceil(total_count / page_size)
         for page in range(expected_page_count):
-            request = dataclasses.replace(request, page=uint32(page))
+            request = dataclasses.replace(request, page=uint32(page))  # type: ignore[call-arg]
             await wait_for_synced_receiver(farmer_service._api.farmer, harvester_id)
             page_result = await endpoint(farmer_rpc_client, request)
             offset = page * page_size

--- a/tests/wallet/test_transaction_store.py
+++ b/tests/wallet/test_transaction_store.py
@@ -17,14 +17,19 @@ from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.wallet_transaction_store import WalletTransactionStore, filter_ok_mempool_status
 from tests.util.db_connection import DBConnection
 
-coin_1 = Coin(token_bytes(32), token_bytes(32), uint64(12312))
-coin_2 = Coin(token_bytes(32), token_bytes(32), uint64(1234))
-coin_3 = Coin(token_bytes(32), token_bytes(32), uint64(12312 - 1234))
+
+def rand_hash() -> bytes32:
+    return bytes32(token_bytes(32))
+
+
+coin_1 = Coin(rand_hash(), rand_hash(), uint64(12312))
+coin_2 = Coin(rand_hash(), rand_hash(), uint64(1234))
+coin_3 = Coin(rand_hash(), rand_hash(), uint64(12312 - 1234))
 
 tr1 = TransactionRecord(
     uint32(0),  # confirmed height
     uint64(1000),  # created_at_time
-    bytes32(token_bytes(32)),  # to_puzzle_hash
+    rand_hash(),  # to_puzzle_hash
     uint64(1234),  # amount
     uint64(12),  # fee_amount
     False,  # confirmed
@@ -34,9 +39,9 @@ tr1 = TransactionRecord(
     [coin_1],  # removals
     uint32(1),  # wallet_id
     [],  # List[Tuple[str, uint8, Optional[str]]] sent_to
-    bytes32(token_bytes(32)),  # trade_id
+    rand_hash(),  # trade_id
     uint32(TransactionType.OUTGOING_TX),  # type
-    bytes32(token_bytes(32)),  # name
+    rand_hash(),  # name
     [],  # List[Tuple[bytes32, List[bytes]]] memos
 )
 
@@ -80,9 +85,7 @@ async def test_increment_sent_noop() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        assert (
-            await store.increment_sent(bytes32(token_bytes(32)), "peer1", MempoolInclusionStatus.PENDING, None) is False
-        )
+        assert await store.increment_sent(rand_hash(), "peer1", MempoolInclusionStatus.PENDING, None) is False
 
 
 @pytest.mark.asyncio
@@ -146,7 +149,7 @@ async def test_tx_reorged_update() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr = dataclasses.replace(tr1, sent=2, sent_to=[("peer1", uint8(1), None), ("peer2", uint8(1), None)])
+        tr = dataclasses.replace(tr1, sent=uint32(2), sent_to=[("peer1", uint8(1), None), ("peer2", uint8(1), None)])
         await store.add_transaction_record(tr)
         tr = await store.get_transaction_record(tr.name)
         assert tr.sent == 2
@@ -163,7 +166,7 @@ async def test_tx_reorged_add() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr = dataclasses.replace(tr1, sent=2, sent_to=[("peer1", uint8(1), None), ("peer2", uint8(1), None)])
+        tr = dataclasses.replace(tr1, sent=uint32(2), sent_to=[("peer1", uint8(1), None), ("peer2", uint8(1), None)])
 
         await store.get_transaction_record(tr.name) is None
         await store.tx_reorged(tr)
@@ -177,8 +180,8 @@ async def test_get_tx_record() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32))
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32))
+        tr2 = dataclasses.replace(tr1, name=rand_hash())
+        tr3 = dataclasses.replace(tr1, name=rand_hash())
 
         assert await store.get_transaction_record(tr1.name) is None
         await store.add_transaction_record(tr1)
@@ -217,10 +220,10 @@ async def test_get_farming_rewards() -> None:
                 test_trs.append(
                     dataclasses.replace(
                         tr1,
-                        name=token_bytes(32),
+                        name=rand_hash(),
                         confirmed=conf,
                         confirmed_at_height=uint32(100 if conf else 0),
-                        type=type,
+                        type=uint32(type.value),
                     )
                 )
 
@@ -239,7 +242,7 @@ async def test_get_all_unconfirmed() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(100))
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(100))
         await store.add_transaction_record(tr1)
         await store.add_transaction_record(tr2)
 
@@ -251,9 +254,9 @@ async def test_get_unconfirmed_for_wallet() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(100))
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32), wallet_id=2)
-        tr4 = dataclasses.replace(tr2, name=token_bytes(32), wallet_id=2)
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(100))
+        tr3 = dataclasses.replace(tr1, name=rand_hash(), wallet_id=uint32(2))
+        tr4 = dataclasses.replace(tr2, name=rand_hash(), wallet_id=uint32(2))
         await store.add_transaction_record(tr1)
         await store.add_transaction_record(tr2)
         await store.add_transaction_record(tr3)
@@ -268,18 +271,18 @@ async def test_transaction_count_for_wallet() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), wallet_id=2)
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), wallet_id=uint32(2))
 
         # 5 transactions in wallet_id 1
         await store.add_transaction_record(tr1)
-        await store.add_transaction_record(dataclasses.replace(tr1, name=token_bytes(32)))
-        await store.add_transaction_record(dataclasses.replace(tr1, name=token_bytes(32)))
-        await store.add_transaction_record(dataclasses.replace(tr1, name=token_bytes(32)))
-        await store.add_transaction_record(dataclasses.replace(tr1, name=token_bytes(32)))
+        await store.add_transaction_record(dataclasses.replace(tr1, name=rand_hash()))
+        await store.add_transaction_record(dataclasses.replace(tr1, name=rand_hash()))
+        await store.add_transaction_record(dataclasses.replace(tr1, name=rand_hash()))
+        await store.add_transaction_record(dataclasses.replace(tr1, name=rand_hash()))
 
         # 2 transactions in wallet_id 2
         await store.add_transaction_record(tr2)
-        await store.add_transaction_record(dataclasses.replace(tr2, name=token_bytes(32)))
+        await store.add_transaction_record(dataclasses.replace(tr2, name=rand_hash()))
 
         assert await store.get_transaction_count_for_wallet(1) == 5
         assert await store.get_transaction_count_for_wallet(2) == 2
@@ -318,7 +321,9 @@ async def test_all_transactions_for_wallet() -> None:
                 TransactionType.INCOMING_TRADE,
                 TransactionType.OUTGOING_TRADE,
             ]:
-                test_trs.append(dataclasses.replace(tr1, name=token_bytes(32), wallet_id=wallet_id, type=type))
+                test_trs.append(
+                    dataclasses.replace(tr1, name=rand_hash(), wallet_id=uint32(wallet_id), type=uint32(type.value))
+                )
 
         for tr in test_trs:
             await store.add_transaction_record(tr)
@@ -355,7 +360,7 @@ async def test_get_all_transactions() -> None:
         test_trs: List[TransactionRecord] = []
         assert await store.get_all_transactions() == []
         for wallet_id in [1, 2, 3, 4]:
-            test_trs.append(dataclasses.replace(tr1, name=token_bytes(32), wallet_id=wallet_id))
+            test_trs.append(dataclasses.replace(tr1, name=rand_hash(), wallet_id=uint32(wallet_id)))
 
         for tr in test_trs:
             await store.add_transaction_record(tr)
@@ -372,7 +377,7 @@ async def test_get_transaction_above() -> None:
         test_trs: List[TransactionRecord] = []
         assert await store.get_transaction_above(uint32(0)) == []
         for height in range(10):
-            test_trs.append(dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(height)))
+            test_trs.append(dataclasses.replace(tr1, name=rand_hash(), confirmed_at_height=uint32(height)))
 
         for tr in test_trs:
             await store.add_transaction_record(tr)
@@ -387,9 +392,9 @@ async def test_get_tx_by_trade_id() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), trade_id=token_bytes(32))
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32), trade_id=token_bytes(32))
-        tr4 = dataclasses.replace(tr1, name=token_bytes(32))
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), trade_id=rand_hash())
+        tr3 = dataclasses.replace(tr1, name=rand_hash(), trade_id=rand_hash())
+        tr4 = dataclasses.replace(tr1, name=rand_hash())
 
         assert await store.get_transactions_by_trade_id(tr1.trade_id) == []
         await store.add_transaction_record(tr1)
@@ -421,7 +426,7 @@ async def test_rollback_to_block() -> None:
 
         test_trs: List[TransactionRecord] = []
         for height in range(10):
-            test_trs.append(dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(height)))
+            test_trs.append(dataclasses.replace(tr1, name=rand_hash(), confirmed_at_height=uint32(height)))
 
         for tr in test_trs:
             await store.add_transaction_record(tr)
@@ -440,11 +445,11 @@ async def test_delete_unconfirmed() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True)
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, wallet_id=2)
-        tr4 = dataclasses.replace(tr1, name=token_bytes(32), wallet_id=2)
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True)
+        tr3 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, wallet_id=uint32(2))
+        tr4 = dataclasses.replace(tr1, name=rand_hash(), wallet_id=uint32(2))
         tr5 = dataclasses.replace(
-            tr1, name=token_bytes(32), wallet_id=2, type=uint32(TransactionType.INCOMING_CLAWBACK_RECEIVE.value)
+            tr1, name=rand_hash(), wallet_id=uint32(2), type=uint32(TransactionType.INCOMING_CLAWBACK_RECEIVE.value)
         )
 
         await store.add_transaction_record(tr1)
@@ -465,12 +470,12 @@ async def test_get_transactions_between_confirmed() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(1))
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(2))
-        tr4 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(3))
-        tr5 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(4))
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(1))
+        tr3 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(2))
+        tr4 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(3))
+        tr5 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(4))
         tr6 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed_at_height=uint32(5), type=uint32(TransactionType.COINBASE_REWARD.value)
+            tr1, name=rand_hash(), confirmed_at_height=uint32(5), type=uint32(TransactionType.COINBASE_REWARD.value)
         )
 
         await store.add_transaction_record(tr1)
@@ -547,29 +552,29 @@ async def test_get_transactions_between_relevance() -> None:
         store = await WalletTransactionStore.create(db_wrapper)
 
         t1 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=False, confirmed_at_height=uint32(2), created_at_time=1000
+            tr1, name=rand_hash(), confirmed=False, confirmed_at_height=uint32(2), created_at_time=uint64(1000)
         )
         t2 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=False, confirmed_at_height=uint32(2), created_at_time=999
+            tr1, name=rand_hash(), confirmed=False, confirmed_at_height=uint32(2), created_at_time=uint64(999)
         )
         t3 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=False, confirmed_at_height=uint32(1), created_at_time=1000
+            tr1, name=rand_hash(), confirmed=False, confirmed_at_height=uint32(1), created_at_time=uint64(1000)
         )
         t4 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=False, confirmed_at_height=uint32(1), created_at_time=999
+            tr1, name=rand_hash(), confirmed=False, confirmed_at_height=uint32(1), created_at_time=uint64(999)
         )
 
         t5 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(2), created_at_time=1000
+            tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(2), created_at_time=uint64(1000)
         )
         t6 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(2), created_at_time=999
+            tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(2), created_at_time=uint64(999)
         )
         t7 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(1), created_at_time=1000
+            tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(1), created_at_time=uint64(1000)
         )
         t8 = dataclasses.replace(
-            tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(1), created_at_time=999
+            tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(1), created_at_time=uint64(999)
         )
 
         await store.add_transaction_record(t1)
@@ -645,13 +650,13 @@ async def test_get_transactions_between_to_puzzle_hash() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        ph1 = token_bytes(32)
-        ph2 = token_bytes(32)
+        ph1 = rand_hash()
+        ph2 = rand_hash()
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(1), to_puzzle_hash=ph1)
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(2), to_puzzle_hash=ph1)
-        tr4 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(3), to_puzzle_hash=ph2)
-        tr5 = dataclasses.replace(tr1, name=token_bytes(32), confirmed_at_height=uint32(4), to_puzzle_hash=ph2)
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), confirmed_at_height=uint32(1), to_puzzle_hash=ph1)
+        tr3 = dataclasses.replace(tr1, name=rand_hash(), confirmed_at_height=uint32(2), to_puzzle_hash=ph1)
+        tr4 = dataclasses.replace(tr1, name=rand_hash(), confirmed_at_height=uint32(3), to_puzzle_hash=ph2)
+        tr5 = dataclasses.replace(tr1, name=rand_hash(), confirmed_at_height=uint32(4), to_puzzle_hash=ph2)
 
         await store.add_transaction_record(tr1)
         await store.add_transaction_record(tr2)
@@ -683,9 +688,9 @@ async def test_get_not_sent() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
 
-        tr2 = dataclasses.replace(tr1, name=token_bytes(32), confirmed=True, confirmed_at_height=uint32(1))
-        tr3 = dataclasses.replace(tr1, name=token_bytes(32))
-        tr4 = dataclasses.replace(tr1, name=token_bytes(32))
+        tr2 = dataclasses.replace(tr1, name=rand_hash(), confirmed=True, confirmed_at_height=uint32(1))
+        tr3 = dataclasses.replace(tr1, name=rand_hash())
+        tr4 = dataclasses.replace(tr1, name=rand_hash())
 
         await store.add_transaction_record(tr1)
         await store.add_transaction_record(tr2)


### PR DESCRIPTION
The main theme of these changes are that types are validated in `dataclasses.replace()` calls.

I think it's reasonable to land this despite the parts of the patch missing test coverage. Its main objective is to correct mypy rules.