### PR TITLE
fix bug in recent BlockStore optimization patch

### DIFF
--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -469,7 +469,7 @@ class BlockStore:
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT header_hash,block_record,plot_info.plot_filter_info "
-                "FROM full_blocks JOIN plot_info USING(header_hash) "
+                "FROM full_blocks LEFT JOIN plot_info USING(header_hash) "
                 f'WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)',
                 header_hashes,
             ) as cursor:
@@ -554,7 +554,7 @@ class BlockStore:
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT block_record,plot_info.plot_filter_info "
-                "FROM full_blocks JOIN plot_info USING(header_hash) "
+                "FROM full_blocks LEFT JOIN plot_info USING(header_hash) "
                 "WHERE header_hash=?",
                 (header_hash,),
             ) as cursor:
@@ -602,7 +602,7 @@ class BlockStore:
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT header_hash,block_record,plot_info.plot_filter_info "
-                "FROM full_blocks JOIN plot_info USING(header_hash) "
+                "FROM full_blocks LEFT JOIN plot_info USING(header_hash) "
                 "WHERE height >= ? AND height <= ?",
                 (start, stop),
             ) as cursor:
@@ -683,7 +683,7 @@ class BlockStore:
         async with self.db_wrapper.reader_no_transaction() as conn:
             async with conn.execute(
                 "SELECT header_hash, block_record,plot_info.plot_filter_info "
-                "FROM full_blocks JOIN plot_info USING(header_hash) "
+                "FROM full_blocks LEFT JOIN plot_info USING(header_hash) "
                 "WHERE height >= ?",
                 (peak[1] - blocks_n,),
             ) as cursor:

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -76,9 +76,7 @@ async def test_block_store(
                 # simulate an existing database, created before this column was
                 # added
                 async with db_wrapper.writer_maybe_transaction() as conn:
-                    await conn.execute(
-                        "UPDATE plot_info SET plot_filter_info=NULL WHERE header_hash=?", (block_record.header_hash,)
-                    )
+                    await conn.execute("DELETE FROM plot_info WHERE header_hash=?", (block_record.header_hash,))
 
             assert block == await store.get_full_block(block.header_hash)
             assert block == await store.get_full_block(block.header_hash)


### PR DESCRIPTION
and fix the issue with the test that allowed it through.

The problem of using a regular `JOIN` is that the `plot_info` table is populated lazily, and starts out empty. With an `INNER JOIN`, no rows will be returned.

The test would have caught this if I had deleted the rows correctly.