### PR TITLE
Use 'Completed writing plot' as the magic final words for cudaplot

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -748,7 +748,10 @@ class WebSocketServer:
         if plotter == "chiapos":
             final_words = ["Renamed final file"]
         elif plotter == "bladebit":
-            final_words = ["Finished plotting in"]
+            if "cudaplot" in config["command_args"]:
+                final_words = ["Completed writing plot"]
+            else:
+                final_words = ["Finished plotting in"]
         elif plotter == "madmax":
             temp_dir = config["temp_dir"]
             final_dir = config["final_dir"]

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -201,7 +201,6 @@ progress_bladebit_cuda = {
     "Completed Phase 1 in ": 0.8,
     "Completed Phase 2 in ": 0.9,
     "Completed Phase 3 in ": 0.95,
-    "Completed writing plot in ": 0.98,
 }
 
 progress_bladebit_ram = {


### PR DESCRIPTION
The GUI plotting with `cudaplot` creates the plot, but it is stuck at 98% as the magic words expected in the log file are not present.

BB `cudaplot` is not using the final words expected to trigger the daemon and GUI to consider the plot complete.

Adjusted to use the `Completed writing plot` magic words as the final words. Previously this was used as the 98% trigger, which is where the GUI would get stuck.

Tested locally. There are some related tests that likely need to be expanded, and this could use a refactor, but this is a minimal change for 2.0.0