### PR TITLE
correct --insecure flag to cancel_offer command line

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -580,7 +580,7 @@ def take_offer_cmd(
 def cancel_offer_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: str, insecure: bool, fee: str) -> None:
     from .wallet_funcs import cancel_offer
 
-    asyncio.run(cancel_offer(wallet_rpc_port, fingerprint, Decimal(fee), id, insecure))
+    asyncio.run(cancel_offer(wallet_rpc_port, fingerprint, Decimal(fee), id, not insecure))
 
 
 @wallet_cmd.command("check", short_help="Check wallet DB integrity", help=check_help_text)


### PR DESCRIPTION
### Purpose:

There was a typo in a recent refactor where the `--insecure` flag was inverted.
Here: ca1a53e42f64b4de3007f6801d67819d97fe0cde

The command line takes an option called *insecure* (to make the default "secure"). But the underlying function in `wallet_funcs.py` takes a bool called `secure`. The command line option needs to be inverted.

See `cancel_offer()` here: https://github.com/Chia-Network/chia-blockchain/blob/release/2.0.0/chia/cmds/wallet_funcs.py#L766-L768

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The `--insecure` flag has the opposite meaning, along with the default being the opposite

### New Behavior:

The `--insecure` flag's behavior is restored

### Testing Notes:

This was discovered while adding unit tests to the CLI in `main`. https://github.com/Chia-Network/chia-blockchain/pull/15886