### PR TITLE
Made `chia peers -c` more   a e s t h e t i c .

### DIFF
--- a/chia/cmds/peer.py
+++ b/chia/cmds/peer.py
@@ -26,9 +26,7 @@ from chia.cmds.peer_funcs import peer_async
 @click.option(
     "-r", "--remove-connection", help="Remove a Node by the first 8 characters of NodeID", type=str, default=""
 )
-@click.option(
-    "-j", "--json", "json_output", help="Output in JSON format", is_flag=True, type=bool, default=False
-)
+@click.option("-j", "--json", "json_output", help="Output in JSON format", is_flag=True, type=bool, default=False)
 @click.argument("node_type", type=click.Choice(list(NODE_TYPES.keys())), nargs=1, required=True)
 @click.pass_context
 def peer_cmd(

--- a/chia/cmds/peer.py
+++ b/chia/cmds/peer.py
@@ -20,6 +20,9 @@ from chia.cmds.peer_funcs import peer_async
     default=None,
 )
 @click.option(
+    "-w", "--wide", help="Display wide output with additional columns", is_flag=True, type=bool, default=False
+)
+@click.option(
     "-c", "--connections", help="List connections to the specified service", is_flag=True, type=bool, default=False
 )
 @click.option("-a", "--add-connection", help="Connect specified Chia service to ip:port", type=str, default="")
@@ -32,6 +35,7 @@ from chia.cmds.peer_funcs import peer_async
 def peer_cmd(
     ctx: click.Context,
     rpc_port: Optional[int],
+    wide: bool,
     connections: bool,
     add_connection: str,
     remove_connection: str,
@@ -49,5 +53,6 @@ def peer_cmd(
             add_connection,
             remove_connection,
             json_output,
+            wide,
         )
     )

--- a/chia/cmds/peer.py
+++ b/chia/cmds/peer.py
@@ -13,7 +13,7 @@ from chia.cmds.peer_funcs import peer_async
     "-p",
     "--rpc-port",
     help=(
-        "Set the port where the farmer, wallet, full node or harvester "
+        "Set the port where the farmer, wallet, full node, or harvester "
         "is hosting the RPC interface. See the rpc_port in config.yaml"
     ),
     type=int,
@@ -26,6 +26,9 @@ from chia.cmds.peer_funcs import peer_async
 @click.option(
     "-r", "--remove-connection", help="Remove a Node by the first 8 characters of NodeID", type=str, default=""
 )
+@click.option(
+    "-j", "--json", "json_output", help="Output in JSON format", is_flag=True, type=bool, default=False
+)
 @click.argument("node_type", type=click.Choice(list(NODE_TYPES.keys())), nargs=1, required=True)
 @click.pass_context
 def peer_cmd(
@@ -35,6 +38,7 @@ def peer_cmd(
     add_connection: str,
     remove_connection: str,
     node_type: str,
+    json_output: bool,
 ) -> None:
     import asyncio
 
@@ -46,5 +50,6 @@ def peer_cmd(
             connections,
             add_connection,
             remove_connection,
+            json_output,
         )
     )

--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -136,10 +136,10 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
     # Print the table rows
     for con in connections:
         last_connect = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(con["last_message_time"]))
-        peak_height = con.get("peak_height", "No Info")
+        peak_height = con.get("peak_height") or "No Info"
         mib_up_down_str = f"{con['bytes_written'] / (1024 * 1024):.1f}/{con['bytes_read'] / (1024 * 1024):.1f}"
         ports_str = f"{con['peer_port']}/{con['peer_server_port']}"
-        connection_peak_hash = con.get("peak_hash", "No Info")
+        connection_peak_hash = con.get("peak_hash") or "No Info"
         if connection_peak_hash and connection_peak_hash.startswith(("0x", "0X")):
             connection_peak_hash = f"{connection_peak_hash[2:10]}…"
 

--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, List, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from chia.cmds.cmds_util import NODE_TYPES, get_any_service_client
 from chia.rpc.rpc_client import RpcClient
@@ -85,8 +85,12 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
     hash_width = 10  # Fixed width for peak hash
 
     # Header definition
-    header = f"{'Type':<{type_width}}│{'IP':<{ip_width}}│{'Ports':<{port_width}}│{'NodeID':<{node_id_width}}│{'Last Connect':<{last_connect_width}}│{'MiB ↑/↓':<{mib_up_down_width}}│{'Height':<{height_width}}│{'Peak Hash':<{hash_width}}"
-    table_width = len(header)
+    header = (
+        f"{'Type':<{type_width}}│{'IP':<{ip_width}}│{'Ports':<{port_width}}│"
+        f"{'NodeID':<{node_id_width}}│{'Last Connect':<{last_connect_width}}│"
+        f"{'MiB ↑/↓':<{mib_up_down_width}}│{'Height':<{height_width}}│"
+        f"{'Peak Hash':<{hash_width}}"
+    )
 
     # Print the table header
     print(
@@ -139,7 +143,12 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
         if connection_peak_hash and connection_peak_hash.startswith(("0x", "0X")):
             connection_peak_hash = f"{connection_peak_hash[2:10]}…"
 
-        row_str = f"│{NodeType(con['type']).name:<{type_width}}│{con['peer_host']:<{ip_width}}│{ports_str:<{port_width}}│{con['node_id'][:8]}… │{last_connect:<{last_connect_width}}│{mib_up_down_str:<{mib_up_down_width}}│{peak_height:<{height_width}}│{connection_peak_hash:<{hash_width}}│"
+        row_str = (
+            f"│{NodeType(con['type']).name:<{type_width}}│{con['peer_host']:<{ip_width}}│{ports_str:<{port_width}}│"
+            f"{con['node_id'][:8]}… │{last_connect:<{last_connect_width}}│{mib_up_down_str:<{mib_up_down_width}}│"
+            f"{peak_height:<{height_width}}│{connection_peak_hash:<{hash_width}}│"
+        )
+
         print(row_str)
 
     print(

--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, List, Dict, Optional
 
 from chia.cmds.cmds_util import NODE_TYPES, get_any_service_client
 from chia.rpc.rpc_client import RpcClient
@@ -50,28 +50,20 @@ async def remove_node_connection(rpc_client: RpcClient, remove_connection: str) 
     print(result_txt)
 
 
-def bytes_to_str(data):
-    if isinstance(data, bytes):
-        try:
-            return data.decode("utf-8")
-        except UnicodeDecodeError:
-            # If bytes cannot be decoded as UTF-8, return a representation of the bytes
-            return data.hex()
-    if isinstance(data, dict):
-        return {key: bytes_to_str(value) for key, value in data.items()}
-    if isinstance(data, list):
-        return [bytes_to_str(element) for element in data]
-    return data
+def bytes_to_str(data: List[Dict[Any, Any]]) -> List[Dict[Any, Any]]:
+    new_data = []
+    for item in data:
+        new_item = {key: value.hex() if isinstance(value, bytes) else value for key, value in item.items()}
+        new_data.append(new_item)
+    return new_data
 
 
 async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any], json_output: bool = False) -> None:
     import time
 
     from chia.server.outbound_message import NodeType
-    from chia.util.network import is_trusted_peer
 
-    connections = await rpc_client.get_connections()
-    connections = bytes_to_str(connections)
+    connections = bytes_to_str(await rpc_client.get_connections())
     if json_output:
         # Print the connections in JSON format
         print(json.dumps(connections, indent=4))

--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from chia.cmds.cmds_util import NODE_TYPES, get_any_service_client
 from chia.rpc.rpc_client import RpcClient
 
-import json
 
 async def add_node_connection(rpc_client: RpcClient, add_connection: str) -> None:
     if ":" not in add_connection:
@@ -49,10 +49,11 @@ async def remove_node_connection(rpc_client: RpcClient, remove_connection: str) 
                 result_txt = f"NodeID {remove_connection}... not found"
     print(result_txt)
 
+
 def bytes_to_str(data):
     if isinstance(data, bytes):
         try:
-            return data.decode('utf-8')
+            return data.decode("utf-8")
         except UnicodeDecodeError:
             # If bytes cannot be decoded as UTF-8, return a representation of the bytes
             return data.hex()
@@ -61,6 +62,7 @@ def bytes_to_str(data):
     if isinstance(data, list):
         return [bytes_to_str(element) for element in data]
     return data
+
 
 async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any], json_output: bool = False) -> None:
     import time
@@ -75,12 +77,18 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
         print(json.dumps(connections, indent=4))
         return
     # Determine the width of each column
-    type_width = max(len(NodeType(con['type']).name) for con in connections) + 1
-    ip_width = max(len(con['peer_host']) for con in connections) + 1
+    type_width = max(len(NodeType(con["type"]).name) for con in connections) + 1
+    ip_width = max(len(con["peer_host"]) for con in connections) + 1
     port_width = max(len(f"{con['peer_port']}/{con['peer_server_port']}") for con in connections) + 1
     node_id_width = 10  # Fixed width for node ID
     last_connect_width = 20  # Fixed width for last connect
-    mib_up_down_width = max(len(f"{con['bytes_written'] / (1024 * 1024):.1f}/{con['bytes_read'] / (1024 * 1024):.1f}") for con in connections) + 1
+    mib_up_down_width = (
+        max(
+            len(f"{con['bytes_written'] / (1024 * 1024):.1f}/{con['bytes_read'] / (1024 * 1024):.1f}")
+            for con in connections
+        )
+        + 1
+    )
     height_width = max(len(str(con.get("peak_height", "No Info"))) for con in connections) + 1
     hash_width = 10  # Fixed width for peak hash
 
@@ -89,10 +97,45 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
     table_width = len(header)
 
     # Print the table header
-    print("╭" + "─" * (type_width) + "┬" + "─" * (ip_width) + "┬" + "─" * (port_width) + "┬" + "─" * (node_id_width) + "┬" + "─" * (last_connect_width) + "┬" + "─" * (mib_up_down_width) + "┬" + "─" * (height_width) + "┬" + "─" * (hash_width) + "╮")
+    print(
+        "╭"
+        + "─" * (type_width)
+        + "┬"
+        + "─" * (ip_width)
+        + "┬"
+        + "─" * (port_width)
+        + "┬"
+        + "─" * (node_id_width)
+        + "┬"
+        + "─" * (last_connect_width)
+        + "┬"
+        + "─" * (mib_up_down_width)
+        + "┬"
+        + "─" * (height_width)
+        + "┬"
+        + "─" * (hash_width)
+        + "╮"
+    )
     print(f"│{header}│")
-    print("├" + "─" * (type_width) + "┼" + "─" * (ip_width) + "┼" + "─" * (port_width) + "┼" + "─" * (node_id_width) + "┼" + "─" * (last_connect_width) + "┼" + "─" * (mib_up_down_width) + "┼" + "─" * (height_width) + "┼" + "─" * (hash_width) + "┤")
-
+    print(
+        "├"
+        + "─" * (type_width)
+        + "┼"
+        + "─" * (ip_width)
+        + "┼"
+        + "─" * (port_width)
+        + "┼"
+        + "─" * (node_id_width)
+        + "┼"
+        + "─" * (last_connect_width)
+        + "┼"
+        + "─" * (mib_up_down_width)
+        + "┼"
+        + "─" * (height_width)
+        + "┼"
+        + "─" * (hash_width)
+        + "┤"
+    )
 
     # Print the table rows
     for con in connections:
@@ -104,12 +147,28 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
         if connection_peak_hash and connection_peak_hash.startswith(("0x", "0X")):
             connection_peak_hash = f"{connection_peak_hash[2:10]}…"
 
-        row_str = (
-            f"│{NodeType(con['type']).name:<{type_width}}│{con['peer_host']:<{ip_width}}│{ports_str:<{port_width}}│{con['node_id'][:8]}… │{last_connect:<{last_connect_width}}│{mib_up_down_str:<{mib_up_down_width}}│{peak_height:<{height_width}}│{connection_peak_hash:<{hash_width}}│"
-        )
+        row_str = f"│{NodeType(con['type']).name:<{type_width}}│{con['peer_host']:<{ip_width}}│{ports_str:<{port_width}}│{con['node_id'][:8]}… │{last_connect:<{last_connect_width}}│{mib_up_down_str:<{mib_up_down_width}}│{peak_height:<{height_width}}│{connection_peak_hash:<{hash_width}}│"
         print(row_str)
 
-    print("╰" + "─" * (type_width) + "┴" + "─" * (ip_width) + "┴" + "─" * (port_width) + "┴" + "─" * (node_id_width) + "┴" + "─" * (last_connect_width) + "┴" + "─" * (mib_up_down_width) + "┴" + "─" * (height_width) + "┴" + "─" * (hash_width) + "╯")
+    print(
+        "╰"
+        + "─" * (type_width)
+        + "┴"
+        + "─" * (ip_width)
+        + "┴"
+        + "─" * (port_width)
+        + "┴"
+        + "─" * (node_id_width)
+        + "┴"
+        + "─" * (last_connect_width)
+        + "┴"
+        + "─" * (mib_up_down_width)
+        + "┴"
+        + "─" * (height_width)
+        + "┴"
+        + "─" * (hash_width)
+        + "╯"
+    )
 
 
 async def peer_async(


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
The output of `chia peer -c <service>` is not cute


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
`chia peer -c full_node`
```bash
Connections:
Type      IP                                      Ports       NodeID      Last Connect      MiB Up|Dwn
FARMER    127.0.0.1                               58956/8447  c968a944... Aug 09 17:50:05      0.0|0.0
FULL_NODE 84.90.114.117                            8444/8444  25f2f273... Aug 11 00:37:15      1.2|0.3
                                                  -Height:  4052208    -Hash: a1868a19...
FULL_NODE 122.244.143.150                          8444/8444  eec7f411... Aug 11 00:37:16      1.3|0.2
                                                  -Height:  4064634    -Hash: e2010fa9...
FULL_NODE 60.142.179.206                           8444/8444  f8388b66... Aug 11 00:41:11    268.3|0.0
                                                  -Height:    44128    -Hash: f0d73be7...
FULL_NODE 114.230.221.80                           8444/8444  43a873b5... Aug 11 00:37:16      0.4|0.1
                                                  -Height:  3693154    -Hash: 02fb9303...
FULL_NODE 205.149.15.235                           8444/8444  0444b847... Aug 11 00:37:16      0.0|0.0
                                                  -Height:  4067848    -Hash: 023ac866...
FULL_NODE 37.235.198.163                           8444/8444  842f8de6... Aug 11 00:41:29      0.1|0.0
                                                  -Height:  2716700    -Hash: a38dfa7b...
FULL_NODE 23.244.123.219                           8444/8444  97f1bb4f... Aug 11 00:27:50     22.5|0.0
                                                  -Height:  1565394    -Hash: 956b780e...
WALLET    127.0.0.1                               55720/8449  235fd5b4... Aug 11 00:12:25     11.5|0.1
FULL_NODE 67.173.18.19                             8444/8444  3d9b7101... Aug 11 00:39:10      0.6|0.0
                                                  -Height:   603089    -Hash: 5024b79a...
```



### New Behavior:
`chia peer -c full_node`
```bash
╭──────────┬────────────────┬───────────┬──────────┬────────────────────┬────────┬────────┬──────────╮
│Type      │IP              │Ports      │NodeID    │Last Connect        │MiB ↑/↓ │Height  │Peak Hash │
├──────────┼────────────────┼───────────┼──────────┼────────────────────┼────────┼────────┼──────────┤
│FARMER    │127.0.0.1       │52856/8447 │ac84c226… │2023-08-11 04:45:54 │0.0/0.0 │No Info │No Info   │
│FULL_NODE │88.170.117.74   │8444/8444  │6488b5b2… │2023-08-11 05:04:40 │0.0/1.1 │4071565 │de93a8f3… │
│WALLET    │127.0.0.1       │53986/8449 │f9274840… │2023-08-11 05:04:38 │1.1/0.1 │No Info │No Info   │
│FULL_NODE │45.186.202.116  │8444/8444  │09245037… │2023-08-11 05:04:40 │0.0/0.1 │4071565 │de93a8f3… │
│FULL_NODE │121.142.71.194  │8444/8444  │8d826d90… │2023-08-11 05:04:40 │0.0/0.4 │4071565 │de93a8f3… │
│FULL_NODE │60.227.215.119  │8444/8444  │a2d04833… │2023-08-11 05:04:40 │0.0/0.1 │4071565 │de93a8f3… │
│FULL_NODE │134.249.64.11   │8444/8444  │68371fdb… │2023-08-11 05:04:40 │0.0/0.5 │4071565 │de93a8f3… │
│FULL_NODE │222.118.226.228 │8444/8444  │2b02da49… │2023-08-11 05:04:40 │0.0/0.1 │4071565 │de93a8f3… │
│FULL_NODE │46.100.173.76   │8444/8444  │dd234fca… │2023-08-11 05:04:40 │0.2/0.0 │3455958 │0f387134… │
│FULL_NODE │108.53.13.153   │8444/8444  │9e1d1595… │2023-08-11 05:04:39 │0.0/0.7 │4071565 │de93a8f3… │
│FULL_NODE │120.211.43.11   │36850/8444 │0d2bbf60… │2023-08-11 05:04:40 │0.1/0.0 │4071565 │de93a8f3… │
╰──────────┴────────────────┴───────────┴──────────┴────────────────────┴────────┴────────┴──────────╯
```

OR

`chia peer -c full_node --json`
```bash
[
    {
        "bytes_read": 67,
        "bytes_written": 17287,
        "creation_time": 1691747154.1881514,
        "last_message_time": 1691747154.1893404,
        "local_port": 8444,
...
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
