### PR TITLE
wallet: Fix comment in `WalletNode.validate_received_state_from_peer`

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1302,8 +1302,7 @@ class WalletNode:
         fork_height: Optional[uint32],
     ) -> bool:
         """
-        Returns all state that is valid and included in the blockchain proved by the weight proof. If return_old_states
-        is False, only new states that are not in the coin_store are returned.
+        Returns True if the coin_state is valid and included in the blockchain proved by the weight proof.
         """
         if peer.closed:
             return False


### PR DESCRIPTION
### Purpose:

Just fix an outdated comment (`return_old_states` doesn't longer exist).


### New Behavior:

No change in behaviour.