### PR TITLE
Remove extra check in send_transaction_multi for chia coins split

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1059,9 +1059,6 @@ class WalletRpcApi:
         }
 
     async def send_transaction_multi(self, request) -> EndpointResult:
-        if await self.service.wallet_state_manager.synced() is False:
-            raise ValueError("Wallet needs to be fully synced before sending transactions")
-
         wallet_id = uint32(request["wallet_id"])
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This removes a sync check from the wallet rpc `send_transaction_multi`


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
N/A


### New Behavior:
N/A


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Applicable test coverage exists, however this issue is hard to replicate and just happens, and this is the best way to fix it

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
