### PR TITLE
full_node: Stop updating wallets during long sync

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1091,14 +1091,12 @@ class FullNode:
                     advanced_peak = True
                     assert peak is not None
                     # Hints must be added to the DB. The other post-processing tasks are not required when syncing
-                    hints_to_add, lookup_coin_ids = get_hints_and_subscription_coin_ids(
+                    hints_to_add, _ = get_hints_and_subscription_coin_ids(
                         state_change_summary,
                         self.subscriptions.has_coin_subscription,
                         self.subscriptions.has_ph_subscription,
                     )
                     await self.hint_store.add_hints(hints_to_add)
-                    await self.update_wallets(state_change_summary, hints_to_add, lookup_coin_ids)
-                await self.send_peak_to_wallets()
                 self.blockchain.clean_block_record(end_height - self.constants.BLOCKS_CACHE_SIZE)
 
         batch_queue_input: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]] = asyncio.Queue(
@@ -1112,17 +1110,6 @@ class FullNode:
             assert validate_task.done()
             fetch_task.cancel()  # no need to cancel validate_task, if we end up here validate_task is already done
             self.log.error(f"sync from fork point failed err: {e}")
-
-    async def send_peak_to_wallets(self) -> None:
-        peak = self.blockchain.get_peak()
-        assert peak is not None
-        msg = make_msg(
-            ProtocolMessageTypes.new_peak_wallet,
-            wallet_protocol.NewPeakWallet(
-                peak.header_hash, peak.height, peak.weight, uint32(max(peak.height - 1, uint32(0)))
-            ),
-        )
-        await self.server.send_to_all([msg], NodeType.WALLET)
 
     def get_peers_with_peak(self, peak_hash: bytes32) -> List[WSChiaConnection]:
         peer_ids: Set[bytes32] = self.sync_store.get_peers_that_have_peak([peak_hash])


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

I think its not necessary and only leads to pointless DB lookups and API calls, also from the wallet back to the node in few places like here https://github.com/Chia-Network/chia-blockchain/blob/7b9801fa7f8be84f528f8aa0d09eeb685676053a/chia/wallet/wallet_node.py#L1059 or inside `WalletNode.is_peer_synced` here https://github.com/Chia-Network/chia-blockchain/blob/7b9801fa7f8be84f528f8aa0d09eeb685676053a/chia/wallet/wallet_node.py#L1079

only to throw it away here (after even disconnecting in untrusted case) https://github.com/Chia-Network/chia-blockchain/blob/7b9801fa7f8be84f528f8aa0d09eeb685676053a/chia/wallet/wallet_node.py#L1086 because the node isn't synced.

Note that this doesn't have an impact on short syncs and we also still send a `new_peak_wallet` after connecting and there will be one right after the long sync was done in here https://github.com/Chia-Network/chia-blockchain/blob/7b9801fa7f8be84f528f8aa0d09eeb685676053a/chia/full_node/full_node.py#L1021

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The node sends new peak messages / wallet updates during long sync.

### New Behavior:

The only sends one peak update right after the long sync is done which then can trigger the wallet to start the sync. 
