### PR TITLE
use unhashable interface before from_json_dict

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -251,14 +251,14 @@ def function_to_convert_one_item(f_type: Type[Any]) -> ConvertFunctionType:
         convert_inner_func = function_to_convert_one_item(inner_type)
         # Ignoring for now as the proper solution isn't obvious
         return lambda items: convert_list(convert_inner_func, items)  # type: ignore[arg-type]
+    elif f_type.__name__ in unhashable_types:
+        # Type is unhashable (bls type), so cast from hex string
+        return lambda item: convert_unhashable_type(f_type, item)
     elif hasattr(f_type, "from_json_dict"):
         return lambda item: f_type.from_json_dict(item)
     elif issubclass(f_type, bytes):
         # Type is bytes, data is a hex string or bytes
         return lambda item: convert_byte_type(f_type, item)
-    elif f_type.__name__ in unhashable_types:
-        # Type is unhashable (bls type), so cast from hex string
-        return lambda item: convert_unhashable_type(f_type, item)
     else:
         # Type is a primitive, cast with correct class
         return lambda item: convert_primitive(f_type, item)

--- a/tests/core/util/test_streamable.py
+++ b/tests/core/util/test_streamable.py
@@ -202,21 +202,41 @@ class ConvertUnhashableTypeFailures(Streamable):
 
 
 @pytest.mark.parametrize(
-    "input_dict, error",
+    "input_dict, error, error_msg",
     [
-        pytest.param({"a": 0}, InvalidTypeError, id="a: no string and no bytes"),
-        pytest.param({"a": []}, InvalidTypeError, id="a: no string and no bytes"),
-        pytest.param({"a": {}}, InvalidTypeError, id="a: no string and no bytes"),
-        pytest.param({"a": "invalid"}, ConversionError, id="a: invalid hex string"),
-        pytest.param({"a": "00" * (G1Element.SIZE - 1)}, ConversionError, id="a: hex string too short"),
-        pytest.param({"a": "00" * (G1Element.SIZE + 1)}, ConversionError, id="a: hex string too long"),
-        pytest.param({"a": b"\00" * (G1Element.SIZE - 1)}, ConversionError, id="a: bytes too short"),
-        pytest.param({"a": b"\00" * (G1Element.SIZE + 1)}, ConversionError, id="a: bytes too long"),
-        pytest.param({"a": b"\00" * G1Element.SIZE}, ConversionError, id="a: invalid g1 element"),
+        pytest.param({"a": 0}, InvalidTypeError, "Invalid type: Expected str, Actual: int"),
+        pytest.param({"a": []}, InvalidTypeError, "Invalid type: Expected str, Actual: list"),
+        pytest.param({"a": {}}, InvalidTypeError, "Invalid type: Expected str, Actual: dict"),
+        pytest.param({"a": "invalid"}, ConversionError, "non-hexadecimal number found in fromhex() arg at position 0"),
+        pytest.param(
+            {"a": "00" * (G1Element.SIZE - 1)},
+            ConversionError,
+            "from type bytes to G1Element: ValueError: Length of bytes object not equal to G1Element::SIZE",
+        ),
+        pytest.param(
+            {"a": "00" * (G1Element.SIZE + 1)},
+            ConversionError,
+            "from type bytes to G1Element: ValueError: Length of bytes object not equal to G1Element::SIZE",
+        ),
+        pytest.param(
+            {"a": b"\00" * (G1Element.SIZE - 1)},
+            ConversionError,
+            "from type bytes to G1Element: ValueError: Length of bytes object not equal to G1Element::SIZE",
+        ),
+        pytest.param(
+            {"a": b"\00" * (G1Element.SIZE + 1)},
+            ConversionError,
+            "from type bytes to G1Element: ValueError: Length of bytes object not equal to G1Element::SIZE",
+        ),
+        pytest.param(
+            {"a": b"\00" * G1Element.SIZE},
+            ConversionError,
+            "from type bytes to G1Element: ValueError: Given G1 non-infinity element must start with 0b10",
+        ),
     ],
 )
-def test_convert_unhashable_type_failures(input_dict: Dict[str, Any], error: Any) -> None:
-    with pytest.raises(error):
+def test_convert_unhashable_type_failures(input_dict: Dict[str, Any], error: Any, error_msg: str) -> None:
+    with pytest.raises(error, match=re.escape(error_msg)):
         streamable_from_dict(ConvertUnhashableTypeFailures, input_dict)
 
 


### PR DESCRIPTION
and improve test for streamable_from_dict

### Purpose:

Simplify the code and make the protocol for To/From Json dict clearer (in the long run).

### Current Behavior:

The current requirements for a type to support the to/from json dict protocol are poorly understood and defined by the code.
We have the concept of "unhashable", which essentially means types from `blspy` which are treated one way. Then we have a few primitives and types that implement `from_json_dict()`. Apparently we currently support passing in *bytes* to construct unhashable types (even though all other paths suggest the input is expected to be a Json dict.

If an unhashable type were to implement `from_json_dict()` (which definitely only expects a string as input), we would no longer be able to construct that type from bytes. 

In the long run, I think we should stop supporting bytes as input, be strict about the Json-dict input (i.e. python Dict, List, int and string). We should also remove the special case for unhashable types and require any type implementing this protocol to have `to_json_dict()` and `from_json_dict()`. This is why I would like to add these functions to the BLS types, i.e. the unhashable types.

### New Behavior:

This patch alters the order, to check for a type being "unhashable" first, before checking for `from_json_dict()` to work around this limitation. With this change, unhashable types that implement `from_json_dict()` still pass the tests, which expects to be able to pass in *bytes* instead of strings.

### Testing Notes:

the tests for `streamable_from_dict()` are updated to check for the specific error we expect