### PR TITLE
explicitly convert G1Element to bytes before passing it to Program.to()

### DIFF
--- a/tests/clvm/test_puzzles.py
+++ b/tests/clvm/test_puzzles.py
@@ -194,7 +194,7 @@ class TestPuzzles(TestCase):
             G1Element.from_bytes_unchecked(hidden_public_key), hidden_puzzle
         )
         solution = p2_delegated_puzzle_or_hidden_puzzle.solution_for_hidden_puzzle(
-            G1Element.from_bytes_unchecked(hidden_public_key), hidden_puzzle, Program.to(0)
+            hidden_public_key, hidden_puzzle, Program.to(0)
         )
 
         do_test_spend(puzzle, solution, payments, key_lookup)

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -503,9 +503,9 @@ async def test_same_sb_twice_with_eligible_coin() -> None:
         [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 2],
     ]
     sb1 = spend_bundle_from_conditions(sb1_conditions)
-    sb2_conditions = [
+    sb2_conditions: List[List[object]] = [
         [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 3],
-        [ConditionOpcode.AGG_SIG_UNSAFE, G1Element(), IDENTITY_PUZZLE_HASH],
+        [ConditionOpcode.AGG_SIG_UNSAFE, bytes(G1Element()), IDENTITY_PUZZLE_HASH],
     ]
     sb2 = spend_bundle_from_conditions(sb2_conditions, TEST_COIN2)
     sb = SpendBundle.aggregate([sb1, sb2])
@@ -527,12 +527,12 @@ async def test_sb_twice_with_eligible_coin_and_different_spends_order() -> None:
         [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 2],
     ]
     sb1 = spend_bundle_from_conditions(sb1_conditions)
-    sb2_conditions = [
+    sb2_conditions: List[List[object]] = [
         [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 3],
-        [ConditionOpcode.AGG_SIG_UNSAFE, G1Element(), IDENTITY_PUZZLE_HASH],
+        [ConditionOpcode.AGG_SIG_UNSAFE, bytes(G1Element()), IDENTITY_PUZZLE_HASH],
     ]
     sb2 = spend_bundle_from_conditions(sb2_conditions, TEST_COIN2)
-    sb3_conditions = [[ConditionOpcode.AGG_SIG_UNSAFE, G1Element(), IDENTITY_PUZZLE_HASH]]
+    sb3_conditions = [[ConditionOpcode.AGG_SIG_UNSAFE, bytes(G1Element()), IDENTITY_PUZZLE_HASH]]
     sb3 = spend_bundle_from_conditions(sb3_conditions, TEST_COIN3)
     sb = SpendBundle.aggregate([sb1, sb2, sb3])
     sb_name = sb.name()
@@ -945,10 +945,10 @@ async def test_create_bundle_from_mempool_on_max_cost() -> None:
     # This test exercises the path where an item's inclusion would exceed the
     # maximum cumulative cost, so it gets skipped as a result
     async def make_and_send_big_cost_sb(coin: Coin) -> None:
-        conditions = []
+        conditions: List[List[object]] = []
         g1 = G1Element()
         for _ in range(2436):
-            conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, g1, IDENTITY_PUZZLE_HASH])
+            conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, bytes(g1), IDENTITY_PUZZLE_HASH])
         conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, coin.amount - 1])
         # Create a spend bundle with a big enough cost that gets it close to the limit
         _, _, res = await generate_and_add_spendbundle(mempool_manager, conditions, coin)
@@ -1036,7 +1036,7 @@ async def test_assert_before_expiration(
 def make_test_spendbundle(coin: Coin, *, fee: int = 0, eligible_spend: bool = False) -> SpendBundle:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, uint64(coin.amount - fee)]]
     if not eligible_spend:
-        conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, G1Element(), IDENTITY_PUZZLE_HASH])
+        conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, bytes(G1Element()), IDENTITY_PUZZLE_HASH])
     return spend_bundle_from_conditions(conditions, coin)
 
 
@@ -1209,8 +1209,8 @@ def test_run_for_cost_max_cost() -> None:
 
 def test_dedup_info_nothing_to_do() -> None:
     # No eligible coins, nothing to deduplicate, item gets considered normally
-    conditions = [
-        [ConditionOpcode.AGG_SIG_UNSAFE, G1Element(), IDENTITY_PUZZLE_HASH],
+    conditions: List[List[object]] = [
+        [ConditionOpcode.AGG_SIG_UNSAFE, bytes(G1Element()), IDENTITY_PUZZLE_HASH],
         [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1],
     ]
     sb = spend_bundle_from_conditions(conditions, TEST_COIN)
@@ -1315,8 +1315,8 @@ def test_dedup_info_eligible_3rd_time_another_2nd_time_and_one_non_eligible() ->
     )
     sb1 = spend_bundle_from_conditions(initial_conditions, TEST_COIN)
     sb2 = spend_bundle_from_conditions(second_conditions, TEST_COIN2)
-    sb3_conditions = [
-        [ConditionOpcode.AGG_SIG_UNSAFE, G1Element(), IDENTITY_PUZZLE_HASH],
+    sb3_conditions: List[List[object]] = [
+        [ConditionOpcode.AGG_SIG_UNSAFE, bytes(G1Element()), IDENTITY_PUZZLE_HASH],
         [ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 4],
     ]
     sb3 = spend_bundle_from_conditions(sb3_conditions, TEST_COIN3)

--- a/tests/wallet/cat_wallet/test_cat_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_cat_lifecycle.py
@@ -440,7 +440,7 @@ class TestCATLifecycle:
     async def test_everything_with_signature(self, cost_logger):
         async with sim_and_client() as (sim, sim_client):
             sk = PrivateKey.from_bytes(secret_exponent_for_index(1).to_bytes(32, "big"))
-            tail: Program = EverythingWithSig.construct([Program.to(sk.get_g1())])
+            tail: Program = EverythingWithSig.construct([Program.to(bytes(sk.get_g1()))])
             checker_solution: Program = EverythingWithSig.solve([], {})
             cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), acs)
             cat_ph: bytes32 = cat_puzzle.get_tree_hash()
@@ -556,7 +556,7 @@ class TestCATLifecycle:
 
             starting_coin: Coin = (await sim_client.get_coin_records_by_puzzle_hash(standard_acs_ph))[0].coin
             sk = PrivateKey.from_bytes(secret_exponent_for_index(1).to_bytes(32, "big"))
-            tail: Program = DelegatedLimitations.construct([Program.to(sk.get_g1())])
+            tail: Program = DelegatedLimitations.construct([Program.to(bytes(sk.get_g1()))])
             cat_puzzle: Program = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), acs)
             cat_ph: bytes32 = cat_puzzle.get_tree_hash()
 

--- a/tests/wallet/test_debug_spend_bundle.py
+++ b/tests/wallet/test_debug_spend_bundle.py
@@ -27,7 +27,7 @@ def test_debug_spend_bundle() -> None:
     coin_bad_reveal: Coin = Coin(bytes32([0] * 32), bytes32([0] * 32), 0)
     solution = Program.to(
         [
-            [ConditionOpcode.AGG_SIG_UNSAFE, pk, msg],
+            [ConditionOpcode.AGG_SIG_UNSAFE, bytes(pk), msg],
             [ConditionOpcode.REMARK],
             [ConditionOpcode.CREATE_COIN, ACS_PH, 0],
             [ConditionOpcode.CREATE_COIN, bytes32([0] * 32), 1],


### PR DESCRIPTION
This avoids relying on a special case in clvm that explicitly looks for `blspy.G1Element` to convert it to bytes. That special case should be removed

### Purpose:

Simplify the code and make the protocol for `Program.to()` more regular and clear.

### Current Behavior:

`Program.to()` has a special case for `blspy.G1Element` here: https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py#L50C1-L51

I think that case should be removed to simplify the protocol for `Program.to()`.

### New Behavior:

With these changes, `clvm` can remove the special case.
