### PR TITLE
Parallel CI

### DIFF
--- a/tests/core/cmds/config.py
+++ b/tests/core/cmds/config.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-parallel = True

--- a/tests/core/consensus/config.py
+++ b/tests/core/consensus/config.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-parallel = True

--- a/tests/core/custom_types/config.py
+++ b/tests/core/custom_types/config.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-parallel = True

--- a/tests/generator/config.py
+++ b/tests/generator/config.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-parallel = True

--- a/tests/simulation/config.py
+++ b/tests/simulation/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 job_timeout = 60
+parallel = False
 install_timelord = True
 checkout_blocks_and_plots = True

--- a/tests/testconfig.py
+++ b/tests/testconfig.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     Oses = Literal["macos", "ubuntu", "windows"]
 
 # Defaults are conservative.
-parallel: Union[bool, int, Literal["auto"]] = False
+parallel: Union[bool, int, Literal["auto"]] = True
 checkout_blocks_and_plots = False
 install_timelord = False
 check_resource_usage = False

--- a/tests/wallet/cat_wallet/config.py
+++ b/tests/wallet/cat_wallet/config.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
 
+parallel = False
 job_timeout = 50
 checkout_blocks_and_plots = True


### PR DESCRIPTION
### Purpose:

Speed up CI and catch tests that don't support being run in parallel, before landing them.

### Current Behavior:

Most tests run with `-n 0`

### New Behavior:

Most test run with `-n 2`