### PR TITLE
Do not enable seeder signal handlers in tests

### DIFF
--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -5,7 +5,6 @@ import logging
 import signal
 import sys
 import traceback
-from asyncio import AbstractEventLoop
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from ipaddress import IPv4Address, IPv6Address, ip_address
@@ -322,7 +321,6 @@ class DNSServer:
         log.info("Starting DNS server.")
         # Get a reference to the event loop as we plan to use low-level APIs.
         loop = asyncio.get_running_loop()
-        await self.setup_signal_handlers(loop)
 
         # Set up the crawl store and the peer update task.
         self.crawl_store = await CrawlStore.create(await aiosqlite.connect(self.db_path, timeout=120))
@@ -356,8 +354,9 @@ class DNSServer:
             await self.stop()
             log.info("DNS server stopped.")
 
-    async def setup_signal_handlers(self, loop: AbstractEventLoop) -> None:
+    async def setup_process_global_state(self) -> None:
         try:
+            loop = asyncio.get_running_loop()
             loop.add_signal_handler(signal.SIGINT, self._accept_signal)
             loop.add_signal_handler(signal.SIGTERM, self._accept_signal)
         except NotImplementedError:
@@ -508,6 +507,7 @@ class DNSServer:
 
 
 async def run_dns_server(dns_server: DNSServer) -> None:  # pragma: no cover
+    await dns_server.setup_process_global_state()
     async with dns_server.run():
         await dns_server.shutdown_event.wait()  # this is released on SIGINT or SIGTERM or any unhandled exception
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

There are two reasons for this.  One relates to `RuntimeError: set_wakeup_fd only works in main thread of the main interpreter` which is triggered because tooling under pytest-xdist uses threads (sometimes) as I believe is discussed in https://github.com/pytest-dev/execnet/issues/96.  The other is that it messes up pytest's own handling of signals which means `ctrl+c` and such don't work well.

It would be great at some point to bring consistency to our signal handling.  I started that awhile back in https://github.com/Chia-Network/chia-blockchain/pull/13568 and will add a note there about taking care of the seeder as well.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

Daft For:
- [x] probably going to consider this after https://github.com/Chia-Network/chia-blockchain/pull/16055