### PR TITLE
revive test-full-sync benchmark

### DIFF
--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -1,22 +1,33 @@
 #!/bin/sh
 
+# pass in the name of the test run as the first argument
+
 run_benchmark() {
    # shellcheck disable=SC2086
-   python ./tools/test_full_sync.py run $3 --profile --test-constants "$1" &
+   python -m tools.test_full_sync run $3 --profile --test-constants "$1" &
    test_pid=$!
-   python ./tools/cpu_utilization.py $test_pid
+   python -m tools.cpu_utilization $test_pid
    mkdir -p "$2"
    mv test-full-sync.log cpu.png cpu-usage.log plot-cpu.gnuplot "$2"
-   python ./tools/test_full_sync.py analyze
+   python -m tools.test_full_sync analyze
    mv slow-batch-*.profile slow-batch-*.png "$2"
-   python ./chia/util/profiler.py profile-node >"$2/node-profile.txt"
-   mv profile-node "$2"
+   # python -m chia.util.profiler profile-node >"$2/node-profile.txt"
+   # mv profile-node "$2"
 }
 
 cd ..
 
-run_benchmark stress-test-blockchain-1500-0-refs.sqlite "$1-sync-empty" ""
-run_benchmark stress-test-blockchain-1500-0-refs.sqlite "$1-keepup-empty" --keep-up
+if [ "$1" = "" ]; then
+    TEST_NAME="node-benchmark"
+else
+    TEST_NAME=$1
+fi
 
-run_benchmark stress-test-blockchain-500-100.sqlite "$1-sync-full" ""
-run_benchmark stress-test-blockchain-500-100.sqlite "$1-keepup-full" --keep-up
+# generate the test blockchain databases by running:
+# python -m tools.generate_chain --fill-rate 0 --length 1500 --block-refs 1
+# python -m tools.generate_chain --fill-rate 100 --length 500 --block-refs 0
+run_benchmark stress-test-blockchain-1500-0-refs.sqlite "${TEST_NAME}-sync-empty" ""
+run_benchmark stress-test-blockchain-1500-0-refs.sqlite "${TEST_NAME}-keepup-empty" --keep-up
+
+run_benchmark stress-test-blockchain-500-100.sqlite "${TEST_NAME}-sync-full" ""
+run_benchmark stress-test-blockchain-500-100.sqlite "${TEST_NAME}-keepup-full" --keep-up


### PR DESCRIPTION
### Purpose:

Make it possible to run these benchmarks again

### Current Behavior:

`./tools/run_benchmarks.sh` fails to run.

### New Behavior:

`./tools/run_benchmarks.sh` works and have instructions on how to use it.

### Testing Notes:

You get this kind of output:

![cpu](https://github.com/Chia-Network/chia-blockchain/assets/661450/8f9fd885-4494-4c6b-a066-71fa946111f9)
![chia-hotspot-8-184](https://github.com/Chia-Network/chia-blockchain/assets/661450/0ea2411f-af31-433d-b961-2e4ed5cb4433)
