### PR TITLE
add missing method to FullNodeRpcClient mock

### DIFF
--- a/tests/cmds/cmd_test_utils.py
+++ b/tests/cmds/cmd_test_utils.py
@@ -279,6 +279,13 @@ class TestWalletRpcClient(TestRpcClient):
 class TestFullNodeRpcClient(TestRpcClient):
     client_type: Type[FullNodeRpcClient] = field(init=False, default=FullNodeRpcClient)
 
+    async def get_fee_estimate(
+        self,
+        target_times: Optional[List[int]],
+        cost: Optional[int],
+    ) -> Dict[str, Any]:
+        return {}
+
     async def get_blockchain_state(self) -> Dict[str, Any]:
         response: Dict[str, Any] = {
             "peak": cast(BlockRecord, create_test_block_record()),


### PR DESCRIPTION
```
________________________________________________________________________________________ test_show_fee_info _________________________________________________________________________________________
[gw2] darwin -- Python 3.11.4 /Users/arvid/Documents/dev/3/chia-blockchain/venv/bin/python
tests/fee_estimation/cmdline_test.py:31: in test_show_fee_info
    assert result.exit_code == 0
E   assert 1 == 0
E    +  where 1 = <Result AttributeError("'TestFullNodeRpcClient' object has no attribute 'get_fee_estimate'")>.exit_code
```

I see this error sometimes