### PR TITLE
Always use at least one worker for `chia plots check`

### DIFF
--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -240,7 +240,7 @@ def check_plots(
                 )
                 bad_plots_list.append(plot_path)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1,context_count)) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, context_count)) as executor:
             logger_lock = Lock()
             futures = []
             for plot_path, plot_info in plot_manager.plots.items():

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -240,7 +240,7 @@ def check_plots(
                 )
                 bad_plots_list.append(plot_path)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=context_count) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=(max(1,context_count)) as executor:
             logger_lock = Lock()
             futures = []
             for plot_path, plot_info in plot_manager.plots.items():

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -240,7 +240,7 @@ def check_plots(
                 )
                 bad_plots_list.append(plot_path)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=(max(1,context_count)) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1,context_count)) as executor:
             logger_lock = Lock()
             futures = []
             for plot_path, plot_info in plot_manager.plots.items():


### PR DESCRIPTION
If the config has `parallel_decompressor_count: 0` which is the default setting and typical for people with uncompressed plots, we try to create a thread pool with 0 workers.

Make sure we use at least 1 worker

It does seem somewhat incorrect to use this setting when there are only uncompressed plots, but using 1 worker, in this case, isn't any worse than prior releases.

Fixes #16098