### PR TITLE
Adjust harvester warning to 8 seconds from 5

### DIFF
--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -252,7 +252,7 @@ class HarvesterAPI:
             time_taken = time.time() - start
             if time_taken > 8:
                 self.harvester.log.warning(
-                    f"Looking up qualities on {filename} took: {time_taken}. This should be below 5 seconds"
+                    f"Looking up qualities on {filename} took: {time_taken}. This should be below 8 seconds"
                     f" to minimize risk of losing rewards."
                 )
             else:

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -250,7 +250,7 @@ class HarvesterAPI:
         for filename_sublist_awaitable in asyncio.as_completed(awaitables):
             filename, sublist = await filename_sublist_awaitable
             time_taken = time.time() - start
-            if time_taken > 5:
+            if time_taken > 8:
                 self.harvester.log.warning(
                     f"Looking up qualities on {filename} took: {time_taken}. This should be below 5 seconds"
                     f" to minimize risk of losing rewards."

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -172,9 +172,9 @@ def check_plots(
                     quality_start_time = int(round(time() * 1000))
                     for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):
                         quality_spent_time = int(round(time() * 1000)) - quality_start_time
-                        if quality_spent_time > 5000:
+                        if quality_spent_time > 8000:
                             log.warning(
-                                f"\tLooking up qualities took: {quality_spent_time} ms. This should be below 5 seconds "
+                                f"\tLooking up qualities took: {quality_spent_time} ms. This should be below 8 seconds "
                                 f"to minimize risk of losing rewards. Filepath: {plot_path}"
                             )
                         else:


### PR DESCRIPTION
Due to compressed farming, harvester latency is naturally higher - Adjusting the warning to be 8 seconds from 5 seconds.