### PR TITLE
demote log level for TIMESTAMP_TOO_FAR_IN_FUTURE errors

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -70,7 +70,7 @@ from chia.util.config import PEER_DB_PATH_KEY_DEPRECATED, process_config_start_m
 from chia.util.db_synchronous import db_synchronous_on
 from chia.util.db_version import lookup_db_version, set_db_version_async
 from chia.util.db_wrapper import DBWrapper2, manage_connection
-from chia.util.errors import ConsensusError, Err, ValidationError
+from chia.util.errors import ConsensusError, Err, TimestampError, ValidationError
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.limited_semaphore import LimitedSemaphore
 from chia.util.path import path_from_root
@@ -1645,6 +1645,8 @@ class FullNode:
                     if Err(pre_validation_results[0].error) == Err.INVALID_PREV_BLOCK_HASH:
                         added = AddBlockResult.DISCONNECTED_BLOCK
                         error_code: Optional[Err] = Err.INVALID_PREV_BLOCK_HASH
+                    elif Err(pre_validation_results[0].error) == Err.TIMESTAMP_TOO_FAR_IN_FUTURE:
+                        raise TimestampError()
                     else:
                         raise ValueError(
                             f"Failed to validate block {header_hash} height "
@@ -1825,7 +1827,10 @@ class FullNode:
             start_header_time = time.time()
             _, header_error = await self.blockchain.validate_unfinished_block_header(block)
             if header_error is not None:
-                raise ConsensusError(header_error)
+                if header_error == Err.TIMESTAMP_TOO_FAR_IN_FUTURE:
+                    raise TimestampError()
+                else:
+                    raise ConsensusError(header_error)
             validate_time = time.time() - start_header_time
             self.log.log(
                 logging.WARNING if validate_time > 2 else logging.DEBUG,

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -27,7 +27,7 @@ from chia.server.rate_limits import RateLimiter
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.api_decorators import get_metadata
-from chia.util.errors import ApiError, Err, ProtocolError
+from chia.util.errors import ApiError, Err, ProtocolError, TimestampError
 from chia.util.ints import int16, uint8, uint16
 from chia.util.log_exceptions import log_exceptions
 
@@ -411,6 +411,8 @@ class WSChiaConnection:
                         )
                     else:
                         return None
+                except TimestampError:
+                    raise
                 except Exception as e:
                     tb = traceback.format_exc()
                     self.log.error(f"Exception: {e}, {self.get_peer_logging()}. {tb}")
@@ -436,6 +438,8 @@ class WSChiaConnection:
             #     await self.send_message(response_message)
         except TimeoutError:
             self.log.error(f"Timeout error for: {message_type}")
+        except TimestampError:
+            self.log.info("Received block with timestamp too far into the future")
         except Exception as e:
             if not self.closed:
                 tb = traceback.format_exc()

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -195,9 +195,16 @@ class ValidationError(Exception):
         self.error_msg = error_msg
 
 
+class TimestampError(Exception):
+    def __init__(self) -> None:
+        self.code = Err.TIMESTAMP_TOO_FAR_IN_FUTURE
+        super().__init__(f"Error code: {self.code}")
+
+
 class ConsensusError(Exception):
     def __init__(self, code: Err, errors: List[Any] = []):
         super().__init__(f"Error code: {code.name} {errors}")
+        self.code = code
         self.errors = errors
 
 


### PR DESCRIPTION
### Purpose:

This patch aims to match the log level with the attention needed from the user.

### Current Behavior:

When a node receives an unfinished block with a timestamp that's more than 2 minutes *ahead* of its own clock, it's rejected with a `ConsensusError` exception, printing a very serious looking error to the log. We expect to receive more of these invalid blocks while transitioning to more 1.8 full nodes.

Prior to version 1.8.0 the upper timestamp limit was 5 minutes, now it's 2. This means that a sizeable part of the network still forwards blocks more than 2 minutes ahead of wall-clock.

### New Behavior:

Instead of printing the stack trace at `ERROR` log level, print a message at `INFO` log level describing the validation failure.

### Testing Notes:

I'm running this locally and have two instances printed to my log so far:
```
2023-08-17T22:09:41.847 full_node full_node_server        : INFO     Received block with timestamp too far into the future
2023-08-17T23:11:12.479 full_node full_node_server        : INFO     Received block with timestamp too far into the future
```