### PR TITLE
Support calling get_routes via wss

### DIFF
--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -188,7 +188,7 @@ class RpcServer:
             hostname=self_hostname,
             port=rpc_port,
             max_request_body_size=max_request_body_size,
-            routes=[web.post(route, wrap_http_handler(func)) for (route, func) in self.get_routes().items()],
+            routes=[web.post(route, wrap_http_handler(func)) for (route, func) in self._get_routes().items()],
             ssl_context=self.ssl_context,
             prefer_ipv6=self.prefer_ipv6,
         )
@@ -246,21 +246,21 @@ class RpcServer:
             raise RuntimeError("RpcServer is not started")
         return self.webserver.listen_port
 
-    def get_routes(self) -> Dict[str, Endpoint]:
+    def _get_routes(self) -> Dict[str, Endpoint]:
         return {
             **self.rpc_api.get_routes(),
             "/get_connections": self.get_connections,
             "/open_connection": self.open_connection,
             "/close_connection": self.close_connection,
             "/stop_node": self.stop_node,
-            "/get_routes": self._get_routes,
+            "/get_routes": self.get_routes,
             "/healthz": self.healthz,
         }
 
-    async def _get_routes(self, request: Dict[str, Any]) -> EndpointResult:
+    async def get_routes(self, request: Dict[str, Any]) -> EndpointResult:
         return {
             "success": True,
-            "routes": list(self.get_routes().keys()),
+            "routes": list(self._get_routes().keys()),
         }
 
     async def get_connections(self, request: Dict[str, Any]) -> EndpointResult:


### PR DESCRIPTION
### Purpose:
The `get_routes` method acts as both an endpoint router and an API endpoint in its own right. Calling `get_routes` as an endpoint has worked properly over https, but fails when called by the daemon over a websocket connection (note: the daemon's implementation of `get_routes` actually does work when called over a websocket because the daemon is _not_ built on top of RpcServer; chia services built on top of RpcServer fail).

The http/wss asymmetry is due to how RpcServer defines the `get_routes` method -- the method signature is not compatible with the websocket API calling convention. Specifically, websocket callable APIs are expected to be async and accept an optional `data` dictionary. RpcServer has an existing `_get_routes` method which is compatible with the websocket calling convention, so this change simply switches up the existing method names to make get_routes callable over a websocket connection.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
`get_routes` is callable when called over https for chia services, but fails when called by the daemon over its websocket connection.

### New Behavior:
`get_routes` is callable over https for chia services, and is also callable by the daemon over its websocket connection


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
The following calls work:

Using `chia rpc` CLI
```
$ chia rpc endpoints farmer
```

```
$ chia rpc endpoints daemon
```

Calling `get_routes` over https
```
curl --insecure --cert ~/.chia/mainnet/config/ssl/full_node/private_full_node.crt \ (release/2.0.0|✚1⚑18)
--key ~/.chia/mainnet/config/ssl/full_node/private_full_node.key \
-d '{}' -H "Content-Type: application/json" -X POST https://localhost:8555/get_routes
```

Calling `get_routes` over wss
```
wscat -n --cert ~/.chia/mainnet/config/ssl/daemon/private_daemon.crt --key ~/.chia/mainnet/config/ssl/daemon/private_daemon.key -c wss://0.0.0.0:55400
Connected (press CTRL+C to quit)
> {"ack": false, "command": "register_service", "data": {"service": "testing"}, "destination": "daemon", "origin": "testing", "request_id": "xyz"}
< {"ack": true, "command": "register_service", "data": {"success": true}, "destination": "testing", "origin": "daemon", "request_id": "xyz"}
> {"ack": false, "command": "get_routes", "data": "{}", "destination": "chia_full_node", "origin": "testing", "request_id": "abc"}
< {"ack": true, "command": "get_routes", "data": {"routes": ["/get_blockchain_state", "/get_block", "/get_blocks", "/get_block_count_metrics", "/get_block_record_by_height", "/get_block_record", "/get_block_records", "/get_block_spends", "/get_unfinished_block_headers", "/get_network_space", "/get_additions_and_removals", "/get_initial_freeze_period", "/get_network_info", "/get_recent_signage_point_or_eos", "/get_coin_records_by_puzzle_hash", "/get_coin_records_by_puzzle_hashes", "/get_coin_record_by_name", "/get_coin_records_by_names", "/get_coin_records_by_parent_ids", "/get_coin_records_by_hint", "/push_tx", "/get_puzzle_and_solution", "/get_all_mempool_tx_ids", "/get_all_mempool_items", "/get_mempool_item_by_tx_id", "/get_fee_estimate", "/get_connections", "/open_connection", "/close_connection", "/stop_node", "/get_routes", "/healthz"], "success": true}, "destination": "testing", "origin": "chia_full_node", "request_id": "abc"}
```
