### PR TITLE
Update to chiapos 2.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ dependencies = [
     "boto3==1.26.161",  # AWS S3 for DL s3 plugin
     "chiavdf==1.0.10",  # timelord and vdf verification
     "chiabip158==1.2",  # bip158-style wallet filters
-    "chiapos==2.0.1",  # proof of space
+    "chiapos==2.0.2",  # proof of space
     "clvm==0.9.7",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
     "chia_rs==0.2.10",


### PR DESCRIPTION
Update to chiapos 2.0.2 to fix the timeout issues with GPU harvesting.