### PR TITLE
try again a few times if the temporary DB file can't be removed

### DIFF
--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -5,6 +5,7 @@ import gc
 import logging
 import signal
 import sqlite3
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from secrets import token_bytes
@@ -173,8 +174,24 @@ async def setup_full_node(
     await service.wait_closed()
     if not reuse_db and db_path.exists():
         # TODO: remove (maybe) when fixed https://github.com/python/cpython/issues/97641
+
+        # 3.11 switched to using functools.lru_cache for the statement cache.
+        # See #87028. This introduces a reference cycle involving the connection
+        # object, so the connection object no longer gets immediately
+        # deallocated, not until, for example, gc.collect() is called to break
+        # the cycle.
         gc.collect()
-        db_path.unlink()
+        for _ in range(10):
+            try:
+                db_path.unlink()
+                break
+            except PermissionError as e:
+                print(f"db_path.unlink(): {e}")
+                time.sleep(0.1)
+                # filesystem operations are async on windows
+                # [WinError 32] The process cannot access the file because it is
+                # being used by another process
+                pass
 
 
 async def setup_crawler(


### PR DESCRIPTION
during simulation shutdown.

### Purpose:

The purpose is to get less noise in the errors reported on test failures, alternatively improve flakiness of tests.

### Current Behavior:

Sometimes our tests fail with an error that looks like this:
```
_ ERROR at teardown of TestFullSync.test_sync_bad_peak_while_synced[Mode.SOFT_FORK3-2] _
[gw1] win32 -- Python 3.11.4 D:\a\chia-blockchain\chia-blockchain\venv\scripts\python.exe
venv\Lib\site-packages\pytest_asyncio\plugin.py:302: in finalizer
    event_loop.run_until_complete(async_finalizer())
C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\asyncio\base_events.py:653: in run_until_complete
    return future.result()
venv\Lib\site-packages\pytest_asyncio\plugin.py:294: in async_finalizer
    await gen_obj.__anext__()
tests\conftest.py:348: in three_nodes
    async for _ in setup_n_nodes(blockchain_constants, 3, db_version=db_version, self_hostname=self_hostname):
chia\simulator\setup_nodes.py:137: in setup_n_nodes
    await _teardown_nodes(node_iters)
chia\simulator\setup_nodes.py:66: in _teardown_nodes
    await sublist_awaitable
C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\asyncio\tasks.py:605: in _wait_for_one
    return f.result()  # May raise f.exception().
chia\simulator\setup_services.py:174: in setup_full_node
    db_path.unlink()
C:\hostedtoolcache\windows\Python\3.11.4\x64\Lib\pathlib.py:1147: in unlink
    os.unlink(self)
E   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpzyl7kp3j\\blockchain_test_0.db'
```

It doesn't look like the root cause of the test failure, but it's not trivial to tell from the output.

### New Behavior:

The new behavior in sqlite for python 3.11 won't close the DB file until we call `gc.collect()` at the end. On windows, filesystem operations are asynchronous, so attempting to delete the file immediately after closing it may be too soon. If it fails with a `PermissionsError` wait a bit and try again.

This is believed to improve reliability of successful removal. It also means that even if it fails after 10 attempts, it won't raise the exception, but just leave the temporary file behind.