### PR TITLE
Code Cleanup: Fix overly broad exception handler

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -948,10 +948,11 @@ class WalletRpcApi:
             if record is None:
                 log.error(f"Cannot find coin record for type {tx['type']} transaction {tx['name']}")
                 continue
-            if record.metadata is None:
-                log.error(f"Cannot find metadata for coin {coin.name().hex()}")
+            try:
+                tx["metadata"] = record.parsed_metadata().to_json_dict()
+            except ValueError as e:
+                log.exception(f"Could not parse coin record metadata: {type(e).__name__} {e}")
                 continue
-            tx["metadata"] = record.parsed_metadata().to_json_dict()
             tx["metadata"]["coin_id"] = coin.name().hex()
             tx["metadata"]["spent"] = record.spent
         return {

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -937,21 +937,23 @@ class WalletRpcApi:
         tx_list = []
         # Format for clawback transactions
         for tr in transactions:
-            try:
-                tx = (await self._convert_tx_puzzle_hash(tr)).to_json_dict_convenience(self.service.config)
-                tx_list.append(tx)
-                if tx["type"] not in CLAWBACK_INCOMING_TRANSACTION_TYPES:
-                    continue
-                coin: Coin = tr.additions[0]
-                record: Optional[WalletCoinRecord] = await self.service.wallet_state_manager.coin_store.get_coin_record(
-                    coin.name()
-                )
-                assert record is not None, f"Cannot find coin record for type {tx['type']} transaction {tx['name']}"
-                tx["metadata"] = record.parsed_metadata().to_json_dict()
-                tx["metadata"]["coin_id"] = coin.name().hex()
-                tx["metadata"]["spent"] = record.spent
-            except Exception:
-                log.exception(f"Failed to get transaction {tr.name}.")
+            tx = (await self._convert_tx_puzzle_hash(tr)).to_json_dict_convenience(self.service.config)
+            tx_list.append(tx)
+            if tx["type"] not in CLAWBACK_INCOMING_TRANSACTION_TYPES:
+                continue
+            coin: Coin = tr.additions[0]
+            record: Optional[WalletCoinRecord] = await self.service.wallet_state_manager.coin_store.get_coin_record(
+                coin.name()
+            )
+            if record is None:
+                log.error(f"Cannot find coin record for type {tx['type']} transaction {tx['name']}")
+                continue
+            if record.metadata is None:
+                log.error(f"Cannot find metadata for coin {coin.name().hex()}")
+                continue
+            tx["metadata"] = record.parsed_metadata().to_json_dict()
+            tx["metadata"]["coin_id"] = coin.name().hex()
+            tx["metadata"]["spent"] = record.spent
         return {
             "transactions": tx_list,
             "wallet_id": wallet_id,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -951,7 +951,7 @@ class WalletRpcApi:
             try:
                 tx["metadata"] = record.parsed_metadata().to_json_dict()
             except ValueError as e:
-                log.exception(f"Could not parse coin record metadata: {type(e).__name__} {e}")
+                log.error(f"Could not parse coin record metadata: {type(e).__name__} {e}")
                 continue
             tx["metadata"]["coin_id"] = coin.name().hex()
             tx["metadata"]["spent"] = record.spent


### PR DESCRIPTION
Previously code was a little strange IMO - but primarily, it was eating and ignoring all exceptions, which generally is a bad idea.

And since the idea here was if there is some problem getting the extra clawback info we would just continue, using exceptions here seems the wrong idea.

I think this PR represents better code flow. Any real exceptions will get raised as expected, while typical parsing errors for clawback items are ignored and not displayed

There is a test for this code that is flaky and it is difficult to determine why because this hides and ignores all exceptions