### PR TITLE
increase windows pytest threads to 3

### DIFF
--- a/tests/build-job-matrix.py
+++ b/tests/build-job-matrix.py
@@ -104,7 +104,7 @@ for path in test_paths:
     process_count = {
         "macos": {False: 0, True: 4}.get(conf["parallel"], conf["parallel"]),
         "ubuntu": {False: 0, True: 4}.get(conf["parallel"], conf["parallel"]),
-        "windows": {False: 0, True: 2}.get(conf["parallel"], conf["parallel"]),
+        "windows": {False: 0, True: 3}.get(conf["parallel"], conf["parallel"]),
     }
     pytest_parallel_args = {os: f" -n {count}" for os, count in process_count.items()}
 


### PR DESCRIPTION
Experiment in increasing windows pytest thread count to 3