### PR TITLE
Make sure to sign all EXEs

### DIFF
--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -75,15 +75,15 @@ Write-Output "   ---"
 
 If ($env:HAS_SIGNING_SECRET) {
    Write-Output "   ---"
-   Write-Output "Sign App"
-   signtool.exe sign /sha1 $env:SM_CODE_SIGNING_CERT_SHA1_HASH /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\dist\win-unpacked\Chia.exe
-   signtool.exe sign /sha1 $env:SM_CODE_SIGNING_CERT_SHA1_HASH /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\dist\win-unpacked\resources\app.asar.unpacked\*.exe
-   Write-Output "   ---"
-   Write-Output "Verify signature"
-   Write-Output "   ---"
-   signtool.exe verify /v /pa .\dist\win-unpacked\Chia.exe
-   signtool.exe verify /v /pa .\dist\win-unpacked\resources\app.asar.unpacked\*.exe
-}   Else    {
+   Write-Output "Sign all EXEs"
+   Get-ChildItem ".\dist\win-unpacked" -Recurse | Where-Object { $_.Extension -eq ".exe" } | ForEach-Object {
+      $exePath = $_.FullName
+      Write-Output "Signing $exePath"
+      signtool.exe sign /sha1 $env:SM_CODE_SIGNING_CERT_SHA1_HASH /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 $exePath
+      Write-Output "Verify signature"
+      signtool.exe verify /v /pa $exePath
+  }
+}    Else    {
    Write-Output "Skipping verify signatures - no authorization to install certificates"
 }
 
@@ -94,7 +94,7 @@ Write-Output "   ---"
 
 If ($env:HAS_SIGNING_SECRET) {
    Write-Output "   ---"
-   Write-Output "Sign App"
+   Write-Output "Sign Final Installer App"
    signtool.exe sign /sha1 $env:SM_CODE_SIGNING_CERT_SHA1_HASH /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\dist\ChiaSetup-$packageVersion.exe
    Write-Output "   ---"
    Write-Output "Verify signature"

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -68,9 +68,28 @@ mv temp.json package.json
 Write-Output "   ---"
 
 Write-Output "   ---"
-Write-Output "electron-builder"
-electron-builder build --win --x64 --config.productName="Chia"
+Write-Output "electron-builder create package directory"
+electron-builder build --win --x64 --config.productName="Chia" --dev
 Get-ChildItem dist\win-unpacked\resources
+Write-Output "   ---"
+
+If ($env:HAS_SIGNING_SECRET) {
+   Write-Output "   ---"
+   Write-Output "Sign App"
+   signtool.exe sign /sha1 $env:SM_CODE_SIGNING_CERT_SHA1_HASH /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\dist\win-unpacked\Chia.exe
+   signtool.exe sign /sha1 $env:SM_CODE_SIGNING_CERT_SHA1_HASH /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 .\dist\win-unpacked\resources\app.asar.unpacked\*.exe
+   Write-Output "   ---"
+   Write-Output "Verify signature"
+   Write-Output "   ---"
+   signtool.exe verify /v /pa .\dist\win-unpacked\Chia.exe
+   signtool.exe verify /v /pa .\dist\win-unpacked\resources\app.asar.unpacked\*.exe
+}   Else    {
+   Write-Output "Skipping verify signatures - no authorization to install certificates"
+}
+
+Write-Output "   ---"
+Write-Output "electron-builder create installer"
+electron-builder build --win --x64 --config.productName="Chia" --pd ".\dist\win-unpacked"
 Write-Output "   ---"
 
 If ($env:HAS_SIGNING_SECRET) {

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -69,7 +69,7 @@ Write-Output "   ---"
 
 Write-Output "   ---"
 Write-Output "electron-builder create package directory"
-electron-builder build --win --x64 --config.productName="Chia" --dev
+electron-builder build --win --x64 --config.productName="Chia" --dir
 Get-ChildItem dist\win-unpacked\resources
 Write-Output "   ---"
 


### PR DESCRIPTION
Make sure to sign all EXEs inside the installer
Previously this was handled by electron builder, but now needs to be done separately

Run electron-builder with `--dir` option to create the unpacked directory with all EXEs
Sign them
Run electron-build again with `--pd` option to create the installer
Sign that
