### PR TITLE
Fix black pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
         name: black
         entry: ./activated.py black
         language: system
-        types: [python]
+        require_serial: true
+        types_or: [python, pyi]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:


### PR DESCRIPTION
https://github.com/psf/black/blob/d9c249c25a77f75e70278aab9ec65c10ce08b0a8/.pre-commit-hooks.yaml#L9

https://pre-commit.com/#hooks-require_serial

It seems that perhaps the cache was being busted by parallel executions of black by pre-commit.  Thanks for noticing and bringing it up @xdustinface.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
