### PR TITLE
`@pytest.mark.limit_consensus_modes`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 asyncio_mode = strict
 markers =
-    plain_consensus_only
+    limit_consensus_modes
     benchmark
     data_layer: Mark as a data layer related test.
     test_mark_a1: used in testing test utilities

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 asyncio_mode = strict
 markers =
+    plain_consensus_only
     benchmark
     data_layer: Mark as a data layer related test.
     test_mark_a1: used in testing test utilities

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -142,7 +142,7 @@ class TestGenesisBlock:
 
 
 class TestBlockHeaderValidation:
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_long_chain(self, empty_blockchain, default_1000_blocks):
         blocks = default_1000_blocks
@@ -3612,7 +3612,7 @@ async def test_reorg_flip_flop(empty_blockchain, bt):
 @pytest.mark.parametrize("unique_plots_window", [1, 2])
 @pytest.mark.parametrize("bt_respects_soft_fork4", [True, False])
 @pytest.mark.parametrize("soft_fork4_height", [0, 10, 10000])
-@pytest.mark.plain_consensus_only
+@pytest.mark.limit_consensus_modes
 @pytest.mark.asyncio
 async def test_soft_fork4_activation(
     blockchain_constants, bt_respects_soft_fork4, soft_fork4_height, db_version, unique_plots_window

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -142,7 +142,7 @@ class TestGenesisBlock:
 
 
 class TestBlockHeaderValidation:
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_long_chain(self, empty_blockchain, default_1000_blocks):
         blocks = default_1000_blocks

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -142,11 +142,9 @@ class TestGenesisBlock:
 
 
 class TestBlockHeaderValidation:
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_long_chain(self, empty_blockchain, default_1000_blocks, consensus_mode: Mode):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_long_chain(self, empty_blockchain, default_1000_blocks):
         blocks = default_1000_blocks
         for block in blocks:
             if (
@@ -3614,15 +3612,14 @@ async def test_reorg_flip_flop(empty_blockchain, bt):
 @pytest.mark.parametrize("unique_plots_window", [1, 2])
 @pytest.mark.parametrize("bt_respects_soft_fork4", [True, False])
 @pytest.mark.parametrize("soft_fork4_height", [0, 10, 10000])
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
 async def test_soft_fork4_activation(
-    consensus_mode, blockchain_constants, bt_respects_soft_fork4, soft_fork4_height, db_version, unique_plots_window
+    blockchain_constants, bt_respects_soft_fork4, soft_fork4_height, db_version, unique_plots_window
 ):
     # We don't run Mode.SOFT_FORK4, since this is already parametrized by this test.
     # Additionally, Mode.HARD_FORK_2_0 mode is incopatible with this test, since plot filter size would be zero,
     # blocks won't ever be produced (we'll pass every consecutive plot filter, hence no block would pass CHIP-13).
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("Skipped test")
     with TempKeyring() as keychain:
         bt = await create_block_tools_async(
             constants=blockchain_constants.replace(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,11 +333,12 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Func
     # https://github.com/pytest-dev/pytest/issues/3730#issuecomment-567142496
     removed = []
     kept = []
+    plain_consensus_only_problems: List[str] = []
     for item in items:
         if item.get_closest_marker("plain_consensus_only"):
             mode = item.callspec.params.get("consensus_mode")
             if mode is None:
-                raise Exception(f"@pytest.mark.plain_consensus_only used without consensus_mode: {item.name}")
+                plain_consensus_only_problems.append(item.name)
             if mode != Mode.PLAIN:
                 removed.append(item)
                 continue
@@ -346,6 +347,10 @@ def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Func
     if removed:
         config.hook.pytest_deselected(items=removed)
         items[:] = kept
+
+    if len(plain_consensus_only_problems) > 0:
+        name_lines = "\n".join(f"    {line}" for line in plain_consensus_only_problems)
+        raise Exception(f"@pytest.mark.plain_consensus_only used without consensus_mode:\n{name_lines}")
 
 
 @pytest.fixture(name="plain_consensus_only")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -435,12 +435,13 @@ async def two_nodes_sim_and_wallets():
         yield _
 
 
-# Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
-# mode `PLAIN` and `SOFT_FORK4`.
-# TODO: plain and also fork4
-@pytest.mark.plain_consensus_only(reason="the same setup is ran by Mode.PLAIN")
 @pytest_asyncio.fixture(scope="function")
 async def two_nodes_sim_and_wallets_services(blockchain_constants, consensus_mode):
+    # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
+    # mode `PLAIN` and `SOFT_FORK4`.
+    # TODO: translate to @pytest.mark.plain_consensus_only
+    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK4):
+        pytest.skip("Skipping duplicate test, the same setup is ran by Mode.PLAIN")
     async for _ in setup_simulators_and_wallets_service(
         2, 0, {"SOFT_FORK4_HEIGHT": blockchain_constants.SOFT_FORK4_HEIGHT}
     ):
@@ -696,9 +697,11 @@ async def farmer_three_harvester_not_started(
 # fixture, to test all versions of the database schema. This doesn't work
 # because of a hack in shutting down the full node, which means you cannot run
 # more than one simulations per process.
-@pytest.mark.plain_consensus_only(reason="This test only supports one running at a time.")
 @pytest_asyncio.fixture(scope="function")
-async def daemon_simulation(bt, get_b_tools, get_b_tools_1):
+async def daemon_simulation(consensus_mode, bt, get_b_tools, get_b_tools_1):
+    # TODO: translate to @pytest.mark.plain_consensus_only
+    if consensus_mode != Mode.PLAIN:
+        pytest.skip("Skipping this run. This test only supports one running at a time.")
     async for _ in setup_full_system_connect_to_deamon(
         test_constants_modified,
         bt,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,12 +397,12 @@ async def five_nodes(db_version: int, self_hostname, blockchain_constants):
         yield _
 
 
+# Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
+# mode `PLAIN` and `SOFT_FORK4`.
+# TODO: plain and also fork4
+@pytest.mark.plain_consensus_only(reason="the same setup is ran by Mode.PLAIN")
 @pytest_asyncio.fixture(scope="function")
 async def wallet_nodes(blockchain_constants, consensus_mode):
-    # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
-    # mode `PLAIN` and `SOFT_FORK4`.
-    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK4):
-        pytest.skip("Skipping duplicate test, the same setup is ran by Mode.PLAIN")
     constants = blockchain_constants
     async_gen = setup_simulators_and_wallets(
         2,
@@ -434,12 +434,12 @@ async def two_nodes_sim_and_wallets():
         yield _
 
 
+# Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
+# mode `PLAIN` and `SOFT_FORK4`.
+# TODO: plain and also fork4
+@pytest.mark.plain_consensus_only(reason="the same setup is ran by Mode.PLAIN")
 @pytest_asyncio.fixture(scope="function")
 async def two_nodes_sim_and_wallets_services(blockchain_constants, consensus_mode):
-    # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
-    # mode `PLAIN` and `SOFT_FORK4`.
-    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK4):
-        pytest.skip("Skipping duplicate test, the same setup is ran by Mode.PLAIN")
     async for _ in setup_simulators_and_wallets_service(
         2, 0, {"SOFT_FORK4_HEIGHT": blockchain_constants.SOFT_FORK4_HEIGHT}
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -977,7 +977,6 @@ def cost_logger_fixture() -> Iterator[CostLogger]:
     print(cost_logger.log_cost_statistics())
 
 
-@pytest.mark.plain_consensus_only(reason="This test only supports one running at a time.")
 @pytest_asyncio.fixture(scope="function")
 async def simulation(bt):
     async for _ in setup_full_system(test_constants_modified, bt, db_version=1):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,12 +397,13 @@ async def five_nodes(db_version: int, self_hostname, blockchain_constants):
         yield _
 
 
-# Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
-# mode `PLAIN` and `SOFT_FORK4`.
-# TODO: plain and also fork4
-@pytest.mark.plain_consensus_only(reason="the same setup is ran by Mode.PLAIN")
 @pytest_asyncio.fixture(scope="function")
 async def wallet_nodes(blockchain_constants, consensus_mode):
+    # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
+    # mode `PLAIN` and `SOFT_FORK4`.
+    # TODO: translate to @pytest.mark.plain_consensus_only
+    if consensus_mode not in (Mode.PLAIN, Mode.SOFT_FORK4):
+        pytest.skip("Skipping duplicate test, the same setup is ran by Mode.PLAIN")
     constants = blockchain_constants
     async_gen = setup_simulators_and_wallets(
         2,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -356,11 +356,6 @@ def pytest_collection_modifyitems(session, config: pytest.Config, items: List[py
         raise Exception(f"@pytest.mark.limit_consensus_modes used without consensus_mode:\n{name_lines}")
 
 
-@pytest.fixture(name="limit_consensus_modes")
-def limit_consensus_modes_fixture(consensus_mode: Mode) -> Mode:
-    return consensus_mode
-
-
 @pytest_asyncio.fixture(scope="function")
 async def node_with_params(request):
     params = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -690,7 +690,7 @@ async def farmer_three_harvester_not_started(
 # fixture, to test all versions of the database schema. This doesn't work
 # because of a hack in shutting down the full node, which means you cannot run
 # more than one simulations per process.
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="This test only supports one running at a time.")
 @pytest_asyncio.fixture(scope="function")
 async def daemon_simulation(bt, get_b_tools, get_b_tools_1):
     async for _ in setup_full_system_connect_to_deamon(
@@ -972,7 +972,7 @@ def cost_logger_fixture() -> Iterator[CostLogger]:
     print(cost_logger.log_cost_statistics())
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="This test only supports one running at a time.")
 @pytest_asyncio.fixture(scope="function")
 async def simulation(bt):
     async for _ in setup_full_system(test_constants_modified, bt, db_version=1):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,6 +329,30 @@ if os.getenv("_PYTEST_RAISE", "0") != "0":
         raise excinfo.value
 
 
+def pytest_collection_modifyitems(config, items):
+    # https://github.com/pytest-dev/pytest/issues/3730#issuecomment-567142496
+    removed = []
+    kept = []
+    for item in items:
+        if item.get_closest_marker("plain_consensus_only"):
+            mode = item.callspec.params.get("consensus_mode")
+            if mode is None:
+                raise Exception("@pytest.mark.plain_consensus_only used without consensus_mode")
+            if mode != Mode.PLAIN:
+                removed.append(item)
+                continue
+
+        kept.append(item)
+    if removed:
+        config.hook.pytest_deselected(items=removed)
+        items[:] = kept
+
+
+@pytest.fixture(name="plain_consensus_only")
+def plain_consensus_only_fixture(consensus_mode: Mode) -> Mode:
+    return consensus_mode
+
+
 @pytest_asyncio.fixture(scope="function")
 async def node_with_params(request):
     params = {}
@@ -666,10 +690,9 @@ async def farmer_three_harvester_not_started(
 # fixture, to test all versions of the database schema. This doesn't work
 # because of a hack in shutting down the full node, which means you cannot run
 # more than one simulations per process.
+@pytest.mark.plain_consensus_only
 @pytest_asyncio.fixture(scope="function")
-async def daemon_simulation(consensus_mode, bt, get_b_tools, get_b_tools_1):
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("Skipping this run. This test only supports one running at a time.")
+async def daemon_simulation(bt, get_b_tools, get_b_tools_1):
     async for _ in setup_full_system_connect_to_deamon(
         test_constants_modified,
         bt,
@@ -949,10 +972,9 @@ def cost_logger_fixture() -> Iterator[CostLogger]:
     print(cost_logger.log_cost_statistics())
 
 
+@pytest.mark.plain_consensus_only
 @pytest_asyncio.fixture(scope="function")
-async def simulation(consensus_mode, bt):
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("Skipping this run. This test only supports one running at a time.")
+async def simulation(bt):
     async for _ in setup_full_system(test_constants_modified, bt, db_version=1):
         yield _
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,15 +333,15 @@ def pytest_collection_modifyitems(session, config: pytest.Config, items: List[py
     # https://github.com/pytest-dev/pytest/issues/3730#issuecomment-567142496
     removed = []
     kept = []
-    plain_consensus_only_problems: List[str] = []
+    limit_consensus_modes_problems: List[str] = []
     for item in items:
         # if 'postgres' in getattr(item, 'fixturenames', ()):
         #     item.add_marker("slow")
 
-        if item.get_closest_marker("plain_consensus_only"):
+        if item.get_closest_marker("limit_consensus_modes"):
             mode = item.callspec.params.get("consensus_mode")
             if mode is None:
-                plain_consensus_only_problems.append(item.name)
+                limit_consensus_modes_problems.append(item.name)
             if mode != Mode.PLAIN:
                 removed.append(item)
                 continue
@@ -351,13 +351,13 @@ def pytest_collection_modifyitems(session, config: pytest.Config, items: List[py
         config.hook.pytest_deselected(items=removed)
         items[:] = kept
 
-    if len(plain_consensus_only_problems) > 0:
-        name_lines = "\n".join(f"    {line}" for line in plain_consensus_only_problems)
-        raise Exception(f"@pytest.mark.plain_consensus_only used without consensus_mode:\n{name_lines}")
+    if len(limit_consensus_modes_problems) > 0:
+        name_lines = "\n".join(f"    {line}" for line in limit_consensus_modes_problems)
+        raise Exception(f"@pytest.mark.limit_consensus_modes used without consensus_mode:\n{name_lines}")
 
 
-@pytest.fixture(name="plain_consensus_only")
-def plain_consensus_only_fixture(consensus_mode: Mode) -> Mode:
+@pytest.fixture(name="limit_consensus_modes")
+def limit_consensus_modes_fixture(consensus_mode: Mode) -> Mode:
     return consensus_mode
 
 
@@ -405,7 +405,7 @@ async def five_nodes(db_version: int, self_hostname, blockchain_constants):
     # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
     # mode `PLAIN` and `SOFT_FORK4`.
     # TODO: plain... and also soft fork 4
-    params=[pytest.param(None, marks=pytest.mark.plain_consensus_only(reason="the same setup is ran by Mode.PLAIN"))],
+    params=[pytest.param(None, marks=pytest.mark.limit_consensus_modes(reason="the same setup is ran by Mode.PLAIN"))],
 )
 async def wallet_nodes(blockchain_constants, consensus_mode):
     constants = blockchain_constants
@@ -444,7 +444,7 @@ async def two_nodes_sim_and_wallets():
     # Since the constants are identical for `Mode.PLAIN` and `Mode.HARD_FORK_2_0`, we will only run in
     # mode `PLAIN` and `SOFT_FORK4`.
     # TODO: plain... and also soft fork 4
-    params=[pytest.param(None, marks=pytest.mark.plain_consensus_only(reason="the same setup is ran by Mode.PLAIN"))],
+    params=[pytest.param(None, marks=pytest.mark.limit_consensus_modes(reason="the same setup is ran by Mode.PLAIN"))],
 )
 async def two_nodes_sim_and_wallets_services(blockchain_constants, consensus_mode):
     async for _ in setup_simulators_and_wallets_service(
@@ -706,7 +706,7 @@ async def farmer_three_harvester_not_started(
     scope="function",
     params=[
         pytest.param(
-            None, marks=pytest.mark.plain_consensus_only(reason="This test only supports one running at a time.")
+            None, marks=pytest.mark.limit_consensus_modes(reason="This test only supports one running at a time.")
         )
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,7 +329,7 @@ if os.getenv("_PYTEST_RAISE", "0") != "0":
         raise excinfo.value
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Function]):
     # https://github.com/pytest-dev/pytest/issues/3730#issuecomment-567142496
     removed = []
     kept = []
@@ -337,7 +337,7 @@ def pytest_collection_modifyitems(config, items):
         if item.get_closest_marker("plain_consensus_only"):
             mode = item.callspec.params.get("consensus_mode")
             if mode is None:
-                raise Exception("@pytest.mark.plain_consensus_only used without consensus_mode")
+                raise Exception(f"@pytest.mark.plain_consensus_only used without consensus_mode: {item.name}")
             if mode != Mode.PLAIN:
                 removed.append(item)
                 continue

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -1861,7 +1861,7 @@ async def test_get_sync_status(
         assert sync_status["target_generation"] == 3
 
 
-@pytest.mark.plain_consensus_only(reason="does not depend on consensus rules")
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.parametrize(argnames="layer", argvalues=list(InterfaceLayer))
 @pytest.mark.asyncio
 async def test_clear_pending_roots(

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -1861,7 +1861,7 @@ async def test_get_sync_status(
         assert sync_status["target_generation"] == 3
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="does not depend on consensus rules")
 @pytest.mark.parametrize(argnames="layer", argvalues=list(InterfaceLayer))
 @pytest.mark.asyncio
 async def test_clear_pending_roots(

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -43,7 +43,6 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_node_api import WalletNodeAPI
-from tests.conftest import Mode
 
 pytestmark = pytest.mark.data_layer
 nodes = Tuple[WalletNode, FullNodeSimulator]
@@ -1862,6 +1861,7 @@ async def test_get_sync_status(
         assert sync_status["target_generation"] == 3
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.parametrize(argnames="layer", argvalues=list(InterfaceLayer))
 @pytest.mark.asyncio
 async def test_clear_pending_roots(
@@ -1870,11 +1870,7 @@ async def test_clear_pending_roots(
     tmp_path: Path,
     layer: InterfaceLayer,
     bt: BlockTools,
-    consensus_mode: Mode,
 ) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("Skipped test - does not depend on Consensus rules")
-
     wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
         self_hostname, one_wallet_and_one_simulator_services
     )

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -30,7 +30,6 @@ from chia.util.db_wrapper import get_host_parameter_limit
 from chia.util.full_block_utils import GeneratorBlockInfo
 from chia.util.ints import uint8, uint32, uint64
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
-from tests.conftest import Mode
 from tests.util.db_connection import DBConnection
 
 log = logging.getLogger(__name__)
@@ -46,13 +45,11 @@ def use_plot_filter_info(request: SubRequest) -> bool:
     return cast(bool, request.param)
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
 async def test_block_store(
-    tmp_dir: Path, db_version: int, bt: BlockTools, consensus_mode: Mode, use_cache: bool, use_plot_filter_info: bool
+    tmp_dir: Path, db_version: int, bt: BlockTools, use_cache: bool, use_plot_filter_info: bool
 ) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
-
     assert sqlite3.threadsafety >= 1
 
     blocks = bt.get_consecutive_blocks(
@@ -145,14 +142,13 @@ async def test_block_store(
             assert br.header_hash == b.header_hash
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, consensus_mode: Mode, use_cache: bool) -> None:
+async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, use_cache: bool) -> None:
     """
     This test was added because the store was deadlocking in certain situations, when fetching and
     adding blocks repeatedly. The issue was patched.
     """
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(db_version) as wrapper, DBConnection(db_version) as wrapper_2:
@@ -179,10 +175,9 @@ async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, consensu
         await asyncio.gather(*tasks)
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_rollback(bt: BlockTools, tmp_dir: Path, consensus_mode: Mode, use_cache: bool) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
+async def test_rollback(bt: BlockTools, tmp_dir: Path, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(2) as db_wrapper:
@@ -226,12 +221,9 @@ async def test_rollback(bt: BlockTools, tmp_dir: Path, consensus_mode: Mode, use
                 count += 1
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_count_compactified_blocks(
-    bt: BlockTools, tmp_dir: Path, db_version: int, consensus_mode: Mode, use_cache: bool
-) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
+async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(db_version) as db_wrapper:
@@ -250,11 +242,7 @@ async def test_count_compactified_blocks(
 
 
 @pytest.mark.asyncio
-async def test_count_uncompactified_blocks(
-    bt: BlockTools, tmp_dir: Path, db_version: int, consensus_mode: Mode, use_cache: bool
-) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
+async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
 
     async with DBConnection(db_version) as db_wrapper:
@@ -272,12 +260,9 @@ async def test_count_uncompactified_blocks(
         assert count == 10
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_replace_proof(
-    bt: BlockTools, tmp_dir: Path, db_version: int, consensus_mode: Mode, use_cache: bool
-) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
+async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
 
     def rand_bytes(num: int) -> bytes:
@@ -322,10 +307,9 @@ async def test_replace_proof(
             assert b.challenge_chain_ip_proof == proof
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_get_generator(bt: BlockTools, db_version: int, consensus_mode: Mode, use_cache: bool) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
+async def test_get_generator(bt: BlockTools, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
 
     def generator(i: int) -> SerializedProgram:
@@ -363,12 +347,9 @@ async def test_get_generator(bt: BlockTools, db_version: int, consensus_mode: Mo
         assert await store.get_generator(blocks[7].header_hash) == new_blocks[7].transactions_generator
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_get_blocks_by_hash(
-    tmp_dir: Path, bt: BlockTools, db_version: int, consensus_mode: Mode, use_cache: bool
-) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
+async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int, use_cache: bool) -> None:
     assert sqlite3.threadsafety >= 1
     blocks = bt.get_consecutive_blocks(10)
 
@@ -405,12 +386,9 @@ async def test_get_blocks_by_hash(
             await store.get_block_bytes_by_hash([bytes32.from_bytes(b"yolo" * 8)] * (get_host_parameter_limit() + 1))
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_get_block_bytes_in_range(
-    tmp_dir: Path, bt: BlockTools, db_version: int, consensus_mode: Mode, use_cache: bool
-) -> None:
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
+async def test_get_block_bytes_in_range(tmp_dir: Path, bt: BlockTools, db_version: int, use_cache: bool) -> None:
     assert sqlite3.threadsafety >= 1
     blocks = bt.get_consecutive_blocks(10)
 

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -45,7 +45,7 @@ def use_plot_filter_info(request: SubRequest) -> bool:
     return cast(bool, request.param)
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_block_store(
     tmp_dir: Path, db_version: int, bt: BlockTools, use_cache: bool, use_plot_filter_info: bool
@@ -142,7 +142,7 @@ async def test_block_store(
             assert br.header_hash == b.header_hash
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, use_cache: bool) -> None:
     """
@@ -175,7 +175,7 @@ async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, use_cach
         await asyncio.gather(*tasks)
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_rollback(bt: BlockTools, tmp_dir: Path, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -221,7 +221,7 @@ async def test_rollback(bt: BlockTools, tmp_dir: Path, use_cache: bool) -> None:
                 count += 1
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -241,7 +241,7 @@ async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_versi
         assert count == 0
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -261,7 +261,7 @@ async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_ver
         assert count == 10
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -308,7 +308,7 @@ async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int, use
             assert b.challenge_chain_ip_proof == proof
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_get_generator(bt: BlockTools, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -348,7 +348,7 @@ async def test_get_generator(bt: BlockTools, db_version: int, use_cache: bool) -
         assert await store.get_generator(blocks[7].header_hash) == new_blocks[7].transactions_generator
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int, use_cache: bool) -> None:
     assert sqlite3.threadsafety >= 1
@@ -387,7 +387,7 @@ async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int
             await store.get_block_bytes_by_hash([bytes32.from_bytes(b"yolo" * 8)] * (get_host_parameter_limit() + 1))
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_get_block_bytes_in_range(tmp_dir: Path, bt: BlockTools, db_version: int, use_cache: bool) -> None:
     assert sqlite3.threadsafety >= 1

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -45,7 +45,7 @@ def use_plot_filter_info(request: SubRequest) -> bool:
     return cast(bool, request.param)
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_block_store(
     tmp_dir: Path, db_version: int, bt: BlockTools, use_cache: bool, use_plot_filter_info: bool
@@ -142,7 +142,7 @@ async def test_block_store(
             assert br.header_hash == b.header_hash
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, use_cache: bool) -> None:
     """
@@ -175,7 +175,7 @@ async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, use_cach
         await asyncio.gather(*tasks)
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_rollback(bt: BlockTools, tmp_dir: Path, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -221,7 +221,7 @@ async def test_rollback(bt: BlockTools, tmp_dir: Path, use_cache: bool) -> None:
                 count += 1
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -241,6 +241,7 @@ async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_versi
         assert count == 0
 
 
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -260,7 +261,7 @@ async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_ver
         assert count == 10
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -307,7 +308,7 @@ async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int, use
             assert b.challenge_chain_ip_proof == proof
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_get_generator(bt: BlockTools, db_version: int, use_cache: bool) -> None:
     blocks = bt.get_consecutive_blocks(10)
@@ -347,7 +348,7 @@ async def test_get_generator(bt: BlockTools, db_version: int, use_cache: bool) -
         assert await store.get_generator(blocks[7].header_hash) == new_blocks[7].transactions_generator
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int, use_cache: bool) -> None:
     assert sqlite3.threadsafety >= 1
@@ -386,7 +387,7 @@ async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int
             await store.get_block_bytes_by_hash([bytes32.from_bytes(b"yolo" * 8)] * (get_host_parameter_limit() + 1))
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_get_block_bytes_in_range(tmp_dir: Path, bt: BlockTools, db_version: int, use_cache: bool) -> None:
     assert sqlite3.threadsafety >= 1

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -409,7 +409,6 @@ class TestCoinStoreWithBlocks:
 
             b.shut_down()
 
-    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_get_coin_states(self, db_version: int) -> None:
         async with DBConnection(db_version) as db_wrapper:

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -51,7 +51,7 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 
 
 class TestCoinStoreWithBlocks:
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_basic_coin_store(self, db_version: int, softfork_height: uint32, bt: BlockTools) -> None:
         wallet_a = WALLET_A
@@ -163,7 +163,7 @@ class TestCoinStoreWithBlocks:
                     should_be_included_prev = should_be_included.copy()
                     should_be_included = set()
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_set_spent(self, db_version: int, bt: BlockTools) -> None:
         blocks = bt.get_consecutive_blocks(9, [])
@@ -207,7 +207,7 @@ class TestCoinStoreWithBlocks:
                         assert record.spent
                         assert record.spent_block_index == block.height
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_num_unspent(self, bt: BlockTools, db_version: int) -> None:
         blocks = bt.get_consecutive_blocks(37, [])
@@ -240,7 +240,7 @@ class TestCoinStoreWithBlocks:
 
         assert test_excercised
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_rollback(self, db_version: int, bt: BlockTools) -> None:
         blocks = bt.get_consecutive_blocks(20)
@@ -379,7 +379,7 @@ class TestCoinStoreWithBlocks:
             finally:
                 b.shut_down()
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_get_puzzle_hash(self, tmp_dir: Path, db_version: int, bt: BlockTools) -> None:
         async with DBConnection(db_version) as db_wrapper:

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -51,7 +51,7 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 
 
 class TestCoinStoreWithBlocks:
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_basic_coin_store(self, db_version: int, softfork_height: uint32, bt: BlockTools) -> None:
         wallet_a = WALLET_A
@@ -163,7 +163,7 @@ class TestCoinStoreWithBlocks:
                     should_be_included_prev = should_be_included.copy()
                     should_be_included = set()
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_set_spent(self, db_version: int, bt: BlockTools) -> None:
         blocks = bt.get_consecutive_blocks(9, [])
@@ -207,7 +207,7 @@ class TestCoinStoreWithBlocks:
                         assert record.spent
                         assert record.spent_block_index == block.height
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_num_unspent(self, bt: BlockTools, db_version: int) -> None:
         blocks = bt.get_consecutive_blocks(37, [])
@@ -240,7 +240,7 @@ class TestCoinStoreWithBlocks:
 
         assert test_excercised
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_rollback(self, db_version: int, bt: BlockTools) -> None:
         blocks = bt.get_consecutive_blocks(20)
@@ -379,7 +379,7 @@ class TestCoinStoreWithBlocks:
             finally:
                 b.shut_down()
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_get_puzzle_hash(self, tmp_dir: Path, db_version: int, bt: BlockTools) -> None:
         async with DBConnection(db_version) as db_wrapper:
@@ -409,7 +409,7 @@ class TestCoinStoreWithBlocks:
 
             b.shut_down()
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_get_coin_states(self, db_version: int) -> None:
         async with DBConnection(db_version) as db_wrapper:

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -23,7 +23,6 @@ from chia.util.generator_tools import tx_removals_and_additions
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
-from tests.conftest import Mode
 from tests.util.db_connection import DBConnection
 
 constants = test_constants
@@ -52,13 +51,9 @@ def get_future_reward_coins(block: FullBlock) -> Tuple[Coin, Coin]:
 
 
 class TestCoinStoreWithBlocks:
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_basic_coin_store(
-        self, db_version: int, softfork_height: uint32, bt: BlockTools, consensus_mode: Mode
-    ) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_basic_coin_store(self, db_version: int, softfork_height: uint32, bt: BlockTools) -> None:
         wallet_a = WALLET_A
         reward_ph = wallet_a.get_new_puzzlehash()
 
@@ -168,11 +163,9 @@ class TestCoinStoreWithBlocks:
                     should_be_included_prev = should_be_included.copy()
                     should_be_included = set()
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_set_spent(self, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_set_spent(self, db_version: int, bt: BlockTools) -> None:
         blocks = bt.get_consecutive_blocks(9, [])
 
         async with DBConnection(db_version) as db_wrapper:
@@ -214,11 +207,9 @@ class TestCoinStoreWithBlocks:
                         assert record.spent
                         assert record.spent_block_index == block.height
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_num_unspent(self, bt: BlockTools, db_version: int, consensus_mode: Mode) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_num_unspent(self, bt: BlockTools, db_version: int) -> None:
         blocks = bt.get_consecutive_blocks(37, [])
 
         expect_unspent = 0
@@ -249,11 +240,9 @@ class TestCoinStoreWithBlocks:
 
         assert test_excercised
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_rollback(self, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_rollback(self, db_version: int, bt: BlockTools) -> None:
         blocks = bt.get_consecutive_blocks(20)
 
         async with DBConnection(db_version) as db_wrapper:
@@ -390,11 +379,9 @@ class TestCoinStoreWithBlocks:
             finally:
                 b.shut_down()
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_get_puzzle_hash(self, tmp_dir: Path, db_version: int, bt: BlockTools, consensus_mode: Mode) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_get_puzzle_hash(self, tmp_dir: Path, db_version: int, bt: BlockTools) -> None:
         async with DBConnection(db_version) as db_wrapper:
             num_blocks = 20
             farmer_ph = bytes32(32 * b"0")
@@ -422,11 +409,9 @@ class TestCoinStoreWithBlocks:
 
             b.shut_down()
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_get_coin_states(self, db_version: int, consensus_mode: Mode) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_get_coin_states(self, db_version: int) -> None:
         async with DBConnection(db_version) as db_wrapper:
             crs = [
                 CoinRecord(

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -64,7 +64,7 @@ async def empty_blockchain_with_original_constants(
 
 
 class TestFullNodeStore:
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     @pytest.mark.parametrize("normalized_to_identity", [False, True])
     async def test_basic_store(
@@ -936,7 +936,7 @@ class TestFullNodeStore:
                 for block in blocks[-2:]:
                     await _validate_and_add_block_no_error(blockchain, block)
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_long_chain_slots(
         self,

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -64,7 +64,7 @@ async def empty_blockchain_with_original_constants(
 
 
 class TestFullNodeStore:
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     @pytest.mark.parametrize("normalized_to_identity", [False, True])
     async def test_basic_store(
@@ -936,7 +936,7 @@ class TestFullNodeStore:
                 for block in blocks[-2:]:
                     await _validate_and_add_block_no_error(blockchain, block)
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_long_chain_slots(
         self,

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -26,7 +26,6 @@ from chia.util.block_cache import BlockCache
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block, _validate_and_add_block_no_error
-from tests.conftest import Mode
 from tests.util.blockchain import create_blockchain
 
 log = logging.getLogger(__name__)
@@ -65,17 +64,15 @@ async def empty_blockchain_with_original_constants(
 
 
 class TestFullNodeStore:
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
     @pytest.mark.parametrize("normalized_to_identity", [False, True])
     async def test_basic_store(
         self,
         empty_blockchain: Blockchain,
         custom_block_tools: BlockTools,
-        consensus_mode: Mode,
         normalized_to_identity: bool,
     ) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
         blockchain = empty_blockchain
         blocks = custom_block_tools.get_consecutive_blocks(
             10,
@@ -939,15 +936,13 @@ class TestFullNodeStore:
                 for block in blocks[-2:]:
                     await _validate_and_add_block_no_error(blockchain, block)
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
     async def test_long_chain_slots(
         self,
         empty_blockchain_with_original_constants: Blockchain,
         default_1000_blocks: List[FullBlock],
-        consensus_mode: Mode,
     ) -> None:
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
         blockchain = empty_blockchain_with_original_constants
         store = FullNodeStore(blockchain.constants)
         peak = None

--- a/tests/core/mempool/test_mempool_performance.py
+++ b/tests/core/mempool/test_mempool_performance.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 
 class TestMempoolPerformance:
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="benchmark")
     @pytest.mark.asyncio
     @pytest.mark.benchmark
     async def test_mempool_update_performance(

--- a/tests/core/mempool/test_mempool_performance.py
+++ b/tests/core/mempool/test_mempool_performance.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 
 class TestMempoolPerformance:
-    @pytest.mark.plain_consensus_only(reason="benchmark")
+    @pytest.mark.limit_consensus_modes(reason="benchmark")
     @pytest.mark.asyncio
     @pytest.mark.benchmark
     async def test_mempool_update_performance(

--- a/tests/core/mempool/test_mempool_performance.py
+++ b/tests/core/mempool/test_mempool_performance.py
@@ -36,14 +36,12 @@ log = logging.getLogger(__name__)
 
 
 class TestMempoolPerformance:
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
     @pytest.mark.benchmark
     async def test_mempool_update_performance(
-        self, request, wallet_nodes_mempool_perf, default_400_blocks, self_hostname, consensus_mode: Mode
+        self, request, wallet_nodes_mempool_perf, default_400_blocks, self_hostname
     ):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run benchmarks in PLAIN mode")
-
         blocks = default_400_blocks
         full_nodes, wallets, bt = wallet_nodes_mempool_perf
         wallet_node = wallets[0][0]

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -33,7 +33,7 @@ from tests.util.rpc import validate_get_routes
 
 
 class TestRpc:
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="does not depend on consensus rules")
     @pytest.mark.asyncio
     async def test1(self, two_nodes_sim_and_wallets_services, self_hostname):
         num_blocks = 5

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -33,7 +33,7 @@ from tests.util.rpc import validate_get_routes
 
 
 class TestRpc:
-    @pytest.mark.plain_consensus_only(reason="does not depend on consensus rules")
+    @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
     @pytest.mark.asyncio
     async def test1(self, two_nodes_sim_and_wallets_services, self_hostname):
         num_blocks = 5

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -33,11 +33,9 @@ from tests.util.rpc import validate_get_routes
 
 
 class TestRpc:
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test1(self, two_nodes_sim_and_wallets_services, self_hostname, consensus_mode):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("test does not depend on consesus rules")
-
+    async def test1(self, two_nodes_sim_and_wallets_services, self_hostname):
         num_blocks = 5
         nodes, _, bt = two_nodes_sim_and_wallets_services
         full_node_service_1, full_node_service_2 = nodes

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -28,7 +28,6 @@ from chia.simulator.time_out_assert import time_out_assert
 from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
 from chia.util.ints import uint16, uint32
 from chia.util.misc import VersionedBlob
-from tests.conftest import Mode
 from tests.plotting.util import get_test_plots
 
 log = logging.getLogger(__name__)
@@ -170,11 +169,9 @@ def trigger_remove_plot(_: Path, plot_path: str):
     remove_plot(Path(plot_path))
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
-async def test_plot_refreshing(environment, consensus_mode: Mode):
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("plot refreshing is not dependent on consensus. This test does not support parallel execution")
-
+async def test_plot_refreshing(environment):
     env: Environment = environment
     expected_result = PlotRefreshResult()
     dir_duplicates: Directory = Directory(get_plot_dir().resolve() / "duplicates", env.dir_1.plots)

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -169,7 +169,7 @@ def trigger_remove_plot(_: Path, plot_path: str):
     remove_plot(Path(plot_path))
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="not dependent on consensus, does not support parallel execution")
 @pytest.mark.asyncio
 async def test_plot_refreshing(environment):
     env: Environment = environment

--- a/tests/plotting/test_plot_manager.py
+++ b/tests/plotting/test_plot_manager.py
@@ -169,7 +169,7 @@ def trigger_remove_plot(_: Path, plot_path: str):
     remove_plot(Path(plot_path))
 
 
-@pytest.mark.plain_consensus_only(reason="not dependent on consensus, does not support parallel execution")
+@pytest.mark.limit_consensus_modes(reason="not dependent on consensus, does not support parallel execution")
 @pytest.mark.asyncio
 async def test_plot_refreshing(environment):
     env: Environment = environment

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -60,7 +60,7 @@ async def extra_node(self_hostname):
 
 
 class TestSimulation:
-    @pytest.mark.plain_consensus_only(reason="This test only supports one running at a time.")
+    @pytest.mark.limit_consensus_modes(reason="This test only supports one running at a time.")
     @pytest.mark.asyncio
     async def test_simulation_1(self, simulation, extra_node, self_hostname):
         node1, node2, _, _, _, _, _, _, _, sanitizer_server = simulation

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -60,6 +60,7 @@ async def extra_node(self_hostname):
 
 
 class TestSimulation:
+    @pytest.mark.plain_consensus_only(reason="This test only supports one running at a time.")
     @pytest.mark.asyncio
     async def test_simulation_1(self, simulation, extra_node, self_hostname):
         node1, node2, _, _, _, _, _, _, _, sanitizer_server = simulation

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -34,7 +34,6 @@ from chia.wallet.util.tx_config import DEFAULT_COIN_SELECTION_CONFIG, DEFAULT_TX
 from chia.wallet.util.wallet_sync_utils import PeerRequestException
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_weight_proof_handler import get_wp_fork_point
-from tests.conftest import Mode
 from tests.connection_utils import disconnect_all, disconnect_all_and_reconnect
 from tests.weight_proof.test_weight_proof import load_blocks_dont_validate
 
@@ -54,11 +53,9 @@ log = getLogger(__name__)
 
 
 class TestWalletSync:
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_request_block_headers(self, simulator_and_wallet, default_1000_blocks, consensus_mode: Mode):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_request_block_headers(self, simulator_and_wallet, default_1000_blocks):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
         [full_node_api], [(wallet_node, _)], bt = simulator_and_wallet
 
@@ -158,11 +155,9 @@ class TestWalletSync:
         ],
         indirect=True,
     )
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_basic_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname, consensus_mode: Mode):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_basic_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -212,14 +207,10 @@ class TestWalletSync:
         ],
         indirect=True,
     )
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_almost_recent(
-        self, two_wallet_nodes, default_400_blocks, self_hostname, blockchain_constants, consensus_mode: Mode
-    ):
+    async def test_almost_recent(self, two_wallet_nodes, default_400_blocks, self_hostname, blockchain_constants):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -299,13 +290,9 @@ class TestWalletSync:
         for wallet_node, wallet_server in wallets:
             await time_out_assert(100, wallet_height_at_least, True, wallet_node, 199)
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_long_sync_wallet(
-        self, two_wallet_nodes, default_1000_blocks, default_400_blocks, self_hostname, consensus_mode: Mode
-    ):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_long_sync_wallet(self, two_wallet_nodes, default_1000_blocks, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -351,11 +338,9 @@ class TestWalletSync:
                 600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) + num_blocks - 5 - 1
             )
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_wallet_reorg_sync(self, two_wallet_nodes, default_400_blocks, self_hostname, consensus_mode: Mode):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_wallet_reorg_sync(self, two_wallet_nodes, default_400_blocks, self_hostname):
         num_blocks = 5
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
@@ -410,13 +395,9 @@ class TestWalletSync:
             await time_out_assert(60, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
             await time_out_assert(60, wallet.get_confirmed_balance, 0)
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_wallet_reorg_get_coinbase(
-        self, two_wallet_nodes, default_400_blocks, self_hostname, consensus_mode: Mode
-    ):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_wallet_reorg_get_coinbase(self, two_wallet_nodes, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
         full_node_api = full_nodes[0]
         full_node_server = full_node_api.full_node.server
@@ -1342,13 +1323,9 @@ class TestWalletSync:
             assert not wallet_node.db_flaky
             await time_out_assert(30, wallet.get_confirmed_balance, 1_000_000_000_000)
 
+    @pytest.mark.plain_consensus_only
     @pytest.mark.asyncio
-    async def test_bad_peak_mismatch(
-        self, two_wallet_nodes, default_1000_blocks, self_hostname, blockchain_constants, consensus_mode
-    ):
-        if consensus_mode != Mode.PLAIN:
-            pytest.skip("only run in PLAIN mode to save time")
-
+    async def test_bad_peak_mismatch(self, two_wallet_nodes, default_1000_blocks, self_hostname, blockchain_constants):
         full_nodes, wallets, bt = two_wallet_nodes
         wallet_node, wallet_server = wallets[0]
         full_node_api = full_nodes[0]
@@ -1400,13 +1377,11 @@ class TestWalletSync:
         log.info(f"height {wallet_node.wallet_state_manager.blockchain.get_peak_height()}")
 
 
+@pytest.mark.plain_consensus_only
 @pytest.mark.asyncio
 async def test_long_sync_untrusted_break(
-    setup_two_nodes_and_wallet, default_1000_blocks, default_400_blocks, self_hostname, caplog, consensus_mode: Mode
+    setup_two_nodes_and_wallet, default_1000_blocks, default_400_blocks, self_hostname, caplog
 ):
-    if consensus_mode != Mode.PLAIN:
-        pytest.skip("only run in PLAIN mode to save time")
-
     full_nodes, [(wallet_node, wallet_server)], bt = setup_two_nodes_and_wallet
     trusted_full_node_api = full_nodes[0]
     trusted_full_node_server = trusted_full_node_api.full_node.server

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -53,7 +53,7 @@ log = getLogger(__name__)
 
 
 class TestWalletSync:
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_request_block_headers(self, simulator_and_wallet, default_1000_blocks):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
@@ -155,7 +155,7 @@ class TestWalletSync:
         ],
         indirect=True,
     )
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_basic_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -207,7 +207,7 @@ class TestWalletSync:
         ],
         indirect=True,
     )
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_almost_recent(self, two_wallet_nodes, default_400_blocks, self_hostname, blockchain_constants):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
@@ -290,7 +290,7 @@ class TestWalletSync:
         for wallet_node, wallet_server in wallets:
             await time_out_assert(100, wallet_height_at_least, True, wallet_node, 199)
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_long_sync_wallet(self, two_wallet_nodes, default_1000_blocks, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -338,7 +338,7 @@ class TestWalletSync:
                 600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) + num_blocks - 5 - 1
             )
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_wallet_reorg_sync(self, two_wallet_nodes, default_400_blocks, self_hostname):
         num_blocks = 5
@@ -395,7 +395,7 @@ class TestWalletSync:
             await time_out_assert(60, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
             await time_out_assert(60, wallet.get_confirmed_balance, 0)
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_wallet_reorg_get_coinbase(self, two_wallet_nodes, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -1323,7 +1323,7 @@ class TestWalletSync:
             assert not wallet_node.db_flaky
             await time_out_assert(30, wallet.get_confirmed_balance, 1_000_000_000_000)
 
-    @pytest.mark.plain_consensus_only
+    @pytest.mark.plain_consensus_only(reason="save time")
     @pytest.mark.asyncio
     async def test_bad_peak_mismatch(self, two_wallet_nodes, default_1000_blocks, self_hostname, blockchain_constants):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -1377,7 +1377,7 @@ class TestWalletSync:
         log.info(f"height {wallet_node.wallet_state_manager.blockchain.get_peak_height()}")
 
 
-@pytest.mark.plain_consensus_only
+@pytest.mark.plain_consensus_only(reason="save time")
 @pytest.mark.asyncio
 async def test_long_sync_untrusted_break(
     setup_two_nodes_and_wallet, default_1000_blocks, default_400_blocks, self_hostname, caplog

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -53,7 +53,7 @@ log = getLogger(__name__)
 
 
 class TestWalletSync:
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_request_block_headers(self, simulator_and_wallet, default_1000_blocks):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
@@ -155,7 +155,7 @@ class TestWalletSync:
         ],
         indirect=True,
     )
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_basic_sync_wallet(self, two_wallet_nodes, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -207,7 +207,7 @@ class TestWalletSync:
         ],
         indirect=True,
     )
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_almost_recent(self, two_wallet_nodes, default_400_blocks, self_hostname, blockchain_constants):
         # Tests the edge case of receiving funds right before the recent blocks  in weight proof
@@ -290,7 +290,7 @@ class TestWalletSync:
         for wallet_node, wallet_server in wallets:
             await time_out_assert(100, wallet_height_at_least, True, wallet_node, 199)
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_long_sync_wallet(self, two_wallet_nodes, default_1000_blocks, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -338,7 +338,7 @@ class TestWalletSync:
                 600, wallet_height_at_least, True, wallet_node, len(default_1000_blocks) + num_blocks - 5 - 1
             )
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_wallet_reorg_sync(self, two_wallet_nodes, default_400_blocks, self_hostname):
         num_blocks = 5
@@ -395,7 +395,7 @@ class TestWalletSync:
             await time_out_assert(60, get_tx_count, 0, wallet_node.wallet_state_manager, 1)
             await time_out_assert(60, wallet.get_confirmed_balance, 0)
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_wallet_reorg_get_coinbase(self, two_wallet_nodes, default_400_blocks, self_hostname):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -1323,7 +1323,7 @@ class TestWalletSync:
             assert not wallet_node.db_flaky
             await time_out_assert(30, wallet.get_confirmed_balance, 1_000_000_000_000)
 
-    @pytest.mark.plain_consensus_only(reason="save time")
+    @pytest.mark.limit_consensus_modes(reason="save time")
     @pytest.mark.asyncio
     async def test_bad_peak_mismatch(self, two_wallet_nodes, default_1000_blocks, self_hostname, blockchain_constants):
         full_nodes, wallets, bt = two_wallet_nodes
@@ -1377,7 +1377,7 @@ class TestWalletSync:
         log.info(f"height {wallet_node.wallet_state_manager.blockchain.get_peak_height()}")
 
 
-@pytest.mark.plain_consensus_only(reason="save time")
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.asyncio
 async def test_long_sync_untrusted_break(
     setup_two_nodes_and_wallet, default_1000_blocks, default_400_blocks, self_hostname, caplog


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

- reduce the copy paste code around limiting otherwise parametrized consensus modes
- avoid actually executing the test cases just to skip them
- clean up these extraneous skip statuses from the test results, build logs, and local developer test runs
- _maybe_ also avoid the fixture setups for these skipped tests (i haven't checked into this in detail yet) (a quick check seems to suggest that fixture setups are being avoided)

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

```python
consensus_mode: Mode
```

and

```python
if consensus_mode != Mode.PLAIN:
    pytest.skip("only run in PLAIN mode to save time")
```

### New Behavior:

```python
@pytest.mark.limit_consensus_modes(reason="save time")
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

`main`:
> `<testsuites tests="16538" failures="0" errors="0" skipped="991" time="134501.239">`

this:
> `<testsuites tests="15874" failures="0" errors="0" skipped="327" time="126181.596">`

Non-skipped test counts match.

```
>>> (16538 - 991) == (15874 - 327)
True
```

Regarding the missed coverage, all three lines are in test framework code intended to notify us in the case that this mark is applied without the `consensus_mode` fixture being in use by the test.  I did exercise that at some point, but we often don't have test code for our test frameworks.

https://github.com/Chia-Network/chia-blockchain/pull/16148/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R342

https://github.com/Chia-Network/chia-blockchain/pull/16148/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R354-R356

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
### Draft For:
- [x] review total test counts to make sure this doesn't lose any non-skipped tests https://github.com/Chia-Network/chia-blockchain/pull/16149
- [ ] should we auto-apply to benchmarks?
