### PR TITLE
type mismatch for last_time_farmed

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -3027,7 +3027,7 @@ class WalletRpcApi:
                 last_height_farmed = height
             amount += record.amount
 
-        last_time_farmed = uint32(
+        last_time_farmed = uint64(
             await self.service.get_timestamp_for_height(last_height_farmed) if last_height_farmed > 0 else 0
         )
         assert amount == pool_reward_amount + farmer_reward_amount + fee_amount


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

There is a type mismatch when setting `last_height_farmed`:

```
last_time_farmed = uint32(
    await self.service.get_timestamp_for_height(last_height_farmed) if last_height_farmed > 0 else 0
)
```

`get_timestamp_for_height` returns uint64, so not sure when, but at some epoch-seconds that will overflow.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

non-breaking since using wider data type


### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

None - visual inspection and correctness


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
