### PR TITLE
Fix comment typo

### DIFF
--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -272,7 +272,7 @@ class HarvesterAPI:
             uint32(passed),
             uint32(total_proofs_found),
             uint32(total),
-            uint64(time_taken * 1_000_000),  # nano seconds,
+            uint64(time_taken * 1_000_000),  # microseconds
         )
         pass_msg = make_msg(ProtocolMessageTypes.farming_info, farming_info)
         await peer.send_message(pass_msg)


### PR DESCRIPTION
This fixes a typo in the comment describing the computation of the recently added `lookup_time` field in the harvester->farmer protocol `FarmingInfo` message. `time_taken` is computed using `time.time()`. `time.time()` returns a timestamp in (fractional) seconds. Multiplying seconds by 1_000_000 results in microseconds, not nanoseconds.
