### PR TITLE
override class variables in limits tests in order to speed up test

### DIFF
--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1863,6 +1863,10 @@ async def test_get_coin_records_rpc_limits(
     api: WalletRpcApi = cast(WalletRpcApi, rpc_server.rpc_api)
     store = wallet_node.wallet_state_manager.coin_store
 
+    # Adjust the limits for faster testing
+    WalletRpcApi.max_get_coin_records_limit = uint32(5)
+    WalletRpcApi.max_get_coin_records_filter_items = uint32(5)
+
     max_coins = api.max_get_coin_records_limit * 10
     coin_records = [
         WalletCoinRecord(


### PR DESCRIPTION
`test_get_coin_records_rpc_limits` was very slow on slower systems as it generated and inserted 10k records one at a time. Here the insert is rather slow, especially on a pi4 or slow CI runner.

Change the limit for the test to a much smaller number.

