### PR TITLE
fix waiting for co-routines in plotters_util.py

### DIFF
--- a/chia/plotters/plotters_util.py
+++ b/chia/plotters/plotters_util.py
@@ -82,13 +82,17 @@ async def run_plotter(root_path, plotter, args, progress_dict):
         try:
             await asyncio.wait(
                 [
-                    _read_stream(
-                        process.stdout,
-                        process_stdout_line,
+                    asyncio.create_task(
+                        _read_stream(
+                            process.stdout,
+                            process_stdout_line,
+                        )
                     ),
-                    _read_stream(
-                        process.stderr,
-                        process_stderr_line,
+                    asyncio.create_task(
+                        _read_stream(
+                            process.stderr,
+                            process_stderr_line,
+                        )
                     ),
                 ]
             )


### PR DESCRIPTION
### Purpose:

Fix an error running `chia plotters` by following the advice from the error message:

```
use tasks explicitly
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

running `chia plotters ...` fails with:

```
Exception while plotting: Passing coroutines is forbidden, use tasks explicitly. <class 'TypeError'>
Traceback: Traceback (most recent call last):
  File "/home/arvid/dev/chia-blockchain/chia/plotters/bladebit.py", line 380, in plot_bladebit
    asyncio.run(run_plotter(chia_root_path, args.plotter, call_args, progress))
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/arvid/dev/chia-blockchain/chia/plotters/plotters_util.py", line 83, in run_plotter
    await asyncio.wait(
  File "/usr/lib/python3.11/asyncio/tasks.py", line 415, in wait
    raise TypeError("Passing coroutines is forbidden, use tasks explicitly.")
TypeError: Passing coroutines is forbidden, use tasks explicitly.

sys:1: RuntimeWarning: coroutine '_read_stream' was never awaited
```

### New Behavior:

`chia plotters ...` works
