### PR TITLE
simplify a test the no longer needs to cover pre-soft-fork2 cases

### DIFF
--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -2070,21 +2070,24 @@ class TestBodyValidation:
     @pytest.mark.parametrize(
         "opcode,lock_value,expected",
         [
+            # we don't allow any birth assertions, not
+            # relative time locks on ephemeral coins. This test is only for
+            # ephemeral coins, so these cases should always fail
             # MY BIRHT HEIGHT
             (co.ASSERT_MY_BIRTH_HEIGHT, -1, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_HEIGHT, 0x100000000, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_HEIGHT, 2, rbr.INVALID_BLOCK),
-            (co.ASSERT_MY_BIRTH_HEIGHT, 3, rbr.NEW_PEAK),
+            (co.ASSERT_MY_BIRTH_HEIGHT, 3, rbr.INVALID_BLOCK),
             # MY BIRHT SECONDS
             (co.ASSERT_MY_BIRTH_SECONDS, -1, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_SECONDS, 0x10000000000000000, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_SECONDS, 10029, rbr.INVALID_BLOCK),
-            (co.ASSERT_MY_BIRTH_SECONDS, 10030, rbr.NEW_PEAK),
+            (co.ASSERT_MY_BIRTH_SECONDS, 10030, rbr.INVALID_BLOCK),
             (co.ASSERT_MY_BIRTH_SECONDS, 10031, rbr.INVALID_BLOCK),
             # SECONDS RELATIVE
             # genesis timestamp is 10000 and each block is 10 seconds
-            (co.ASSERT_SECONDS_RELATIVE, -2, rbr.NEW_PEAK),
-            (co.ASSERT_SECONDS_RELATIVE, -1, rbr.NEW_PEAK),
+            (co.ASSERT_SECONDS_RELATIVE, -2, rbr.INVALID_BLOCK),
+            (co.ASSERT_SECONDS_RELATIVE, -1, rbr.INVALID_BLOCK),
             (co.ASSERT_SECONDS_RELATIVE, 0, rbr.INVALID_BLOCK),
             (co.ASSERT_SECONDS_RELATIVE, 1, rbr.INVALID_BLOCK),
             # BEFORE SECONDS RELATIVE
@@ -2095,8 +2098,8 @@ class TestBodyValidation:
             (co.ASSERT_BEFORE_SECONDS_RELATIVE, 10, rbr.INVALID_BLOCK),
             (co.ASSERT_BEFORE_SECONDS_RELATIVE, 0x10000000000000000, rbr.INVALID_BLOCK),
             # HEIGHT RELATIVE
-            (co.ASSERT_HEIGHT_RELATIVE, -2, rbr.NEW_PEAK),
-            (co.ASSERT_HEIGHT_RELATIVE, -1, rbr.NEW_PEAK),
+            (co.ASSERT_HEIGHT_RELATIVE, -2, rbr.INVALID_BLOCK),
+            (co.ASSERT_HEIGHT_RELATIVE, -1, rbr.INVALID_BLOCK),
             (co.ASSERT_HEIGHT_RELATIVE, 0, rbr.INVALID_BLOCK),
             (co.ASSERT_HEIGHT_RELATIVE, 1, rbr.INVALID_BLOCK),
             # BEFORE HEIGHT RELATIVE
@@ -2131,17 +2134,6 @@ class TestBodyValidation:
         ],
     )
     async def test_ephemeral_timelock(self, opcode, lock_value, expected, with_garbage, bt):
-        # we don't allow any birth assertions, not
-        # relative time locks on ephemeral coins. This test is only for
-        # ephemeral coins, so these cases should always fail
-        if opcode in [
-            ConditionOpcode.ASSERT_MY_BIRTH_HEIGHT,
-            ConditionOpcode.ASSERT_MY_BIRTH_SECONDS,
-            ConditionOpcode.ASSERT_SECONDS_RELATIVE,
-            ConditionOpcode.ASSERT_HEIGHT_RELATIVE,
-        ]:
-            expected = AddBlockResult.INVALID_BLOCK
-
         async with make_empty_blockchain(bt.constants) as b:
             blocks = bt.get_consecutive_blocks(
                 3,


### PR DESCRIPTION
### Purpose:

Simplify test code

### Current Behavior:

This test used to cover consensus rules prior to soft-fork2, but as that logic was removed, this test can be simplified further.

### New Behavior:

Simpler test