### PR TITLE
Warn if running `install-plotter.sh` as root

### DIFF
--- a/install-plotter.sh
+++ b/install-plotter.sh
@@ -166,11 +166,6 @@ if [ "$VIRTUAL_ENV" = "" ]; then
   exit 1
 fi
 
-if [ "$(id -u)" = 0 ]; then
-  echo "ERROR: Plotter can not be installed or run by the root user."
-  exit 1
-fi
-
 OS=""
 ARCH="x86-64"
 if [ "$(uname)" = "Linux" ]; then

--- a/install-plotter.sh
+++ b/install-plotter.sh
@@ -166,6 +166,10 @@ if [ "$VIRTUAL_ENV" = "" ]; then
   exit 1
 fi
 
+if [ "$(id -u)" = 0 ]; then
+  echo "WARN: Plotter should not be installed or run by the root user."
+fi
+
 OS=""
 ARCH="x86-64"
 if [ "$(uname)" = "Linux" ]; then


### PR DESCRIPTION
Confirmed to work on
- Fedora 35
- Ubuntu 22.04
- MacOS 13