### PR TITLE
Increase peak timeout due to slow runners

### DIFF
--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -434,7 +434,7 @@ class TestFullSync:
             PeerInfo(self_hostname, uint16(server_1._port)), on_connect=full_node_2.full_node.on_connect
         )
         await time_out_assert(60, full_node_1.full_node.sync_store.get_long_sync, True)
-        await time_out_assert(60, full_node_1.full_node.sync_store.get_long_sync, False)
+        await time_out_assert(250, full_node_1.full_node.sync_store.get_long_sync, False)
         peak = full_node_2.full_node.blockchain.get_peak()
         wp = await full_node_2.full_node.weight_proof_handler.get_proof_of_weight(peak.header_hash)
         assert full_node_1.full_node.in_bad_peak_cache(wp) is True


### PR DESCRIPTION
On the Windows CI runners, 60 seconds resulted in almost 100% failure. Increase to 250 seconds results in 100% success.