### PR TITLE
server: Drop `ChiaServer.validate_broadcast_message_type`

### DIFF
--- a/chia/protocols/protocol_state_machine.py
+++ b/chia/protocols/protocol_state_machine.py
@@ -56,12 +56,6 @@ def static_check_sent_message_response() -> None:
         raise AssertionError(f"Overlapping NO_REPLY_EXPECTED and VALID_REPLY_MESSAGE_MAP values: {overlap}")
 
 
-def message_requires_reply(sent: ProtocolMessageTypes) -> bool:
-    """Return True if message has an entry in the full node P2P message map"""
-    # If we knew the peer NodeType is FULL_NODE, we could also check `sent not in NO_REPLY_EXPECTED`
-    return sent in VALID_REPLY_MESSAGE_MAP
-
-
 def message_response_ok(sent: ProtocolMessageTypes, received: ProtocolMessageTypes) -> bool:
     """
     Check to see that peers respect protocol message types in reply.

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -430,7 +430,7 @@ class WSChiaConnection:
                 await self.send_message(response_message)
             # todo uncomment when enabling none response capability
             # check that this call needs a reply
-            # elif message_requires_reply(ProtocolMessageTypes(full_message.type)) and self.has_capability(
+            # elif self.has_capability(
             #     Capability.NONE_RESPONSE
             # ):
             #     # this peer can accept None reply's, send empty msg back, so it doesn't wait for timeout


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

I might miss the point but this validation there seems strange to me and even more strange that we disconnect/ban from the peers because we tried to initiate sending the "wrong" messages. For me it looks like even sending a message which requires a response doesn't lead to actual issues, does it? 

If there is a point in keeping the `message_requires_reply` checks i might just put it directly into `send_to_all` but seems to me like just dropping it is fine? 

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The method validates static messages to peers and disconnects from the peers if the code tries to send a message which expects a response. 

### New Behavior:

It just sends the messages.