### PR TITLE
report bad `@pytest.mark.limit_consensus_modes()` use with fixtureless tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,9 +340,15 @@ def pytest_collection_modifyitems(session, config: pytest.Config, items: List[py
     for item in items:
         limit_consensus_modes_marker = item.get_closest_marker("limit_consensus_modes")
         if limit_consensus_modes_marker is not None:
-            mode = item.callspec.params.get("consensus_mode")
+            callspec = getattr(item, "callspec", None)
+            if callspec is None:
+                limit_consensus_modes_problems.append(item.name)
+                continue
+
+            mode = callspec.params.get("consensus_mode")
             if mode is None:
                 limit_consensus_modes_problems.append(item.name)
+                continue
 
             modes = limit_consensus_modes_marker.kwargs.get("allowed", [ConsensusMode.PLAIN])
             if mode not in modes:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

exception

### New Behavior:

helpful message

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
