### PR TITLE
Optimize CAT coin_added

### DIFF
--- a/chia/wallet/cat_wallet/cat_info.py
+++ b/chia/wallet/cat_wallet/cat_info.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint64
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.vc_wallet.cr_cat_drivers import ProofsChecker
@@ -23,6 +24,8 @@ class CATCoinData(Streamable):
     mod_hash: bytes32
     tail_program_hash: bytes32
     inner_puzzle: Program
+    parent_coin_id: bytes32
+    amount: uint64
 
 
 # We used to store all of the lineage proofs here but it was very slow to serialize for a lot of transactions

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -15,7 +15,6 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes
@@ -350,7 +349,7 @@ class CATWallet:
         )
 
     async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: Optional[CATCoinData]
+        self, coin: Coin, height: uint32, peer: WSChiaConnection, parent_coin_data: Optional[CATCoinData]
     ) -> None:
         # TODO Use coin_data instead of calling peer API
         """Notification from wallet state manager that wallet has been received."""
@@ -364,26 +363,37 @@ class CATWallet:
 
         if lineage is None:
             try:
-                coin_state = await self.wallet_state_manager.wallet_node.get_coin_state(
-                    [coin.parent_coin_info], peer=peer
-                )
-                assert coin_state[0].coin.name() == coin.parent_coin_info
-                coin_spend = await fetch_coin_spend_for_coin_state(coin_state[0], peer)
-                await self.puzzle_solution_received(coin_spend, parent_coin=coin_state[0].coin)
+                if parent_coin_data is None:
+                    # The method is not triggered after the determine_coin_type, no pre-fetched data
+                    coin_state = await self.wallet_state_manager.wallet_node.get_coin_state(
+                        [coin.parent_coin_info], peer=peer
+                    )
+                    assert coin_state[0].coin.name() == coin.parent_coin_info
+                    coin_spend = await fetch_coin_spend_for_coin_state(coin_state[0], peer)
+                    cat_curried_args = match_cat_puzzle(uncurry_puzzle(coin_spend.puzzle_reveal.to_program()))
+                    if cat_curried_args is not None:
+                        cat_mod_hash, tail_program_hash, cat_inner_puzzle = cat_curried_args
+                        parent_coin_data = CATCoinData(
+                            cat_mod_hash.atom,
+                            tail_program_hash.atom,
+                            cat_inner_puzzle,
+                            coin_state[0].coin.parent_coin_info,
+                            uint64(coin_state[0].coin.amount),
+                        )
+                await self.puzzle_solution_received(coin, parent_coin_data)
             except Exception as e:
                 self.log.debug(f"Exception: {e}, traceback: {traceback.format_exc()}")
 
-    async def puzzle_solution_received(self, coin_spend: CoinSpend, parent_coin: Coin) -> None:
-        coin_name = coin_spend.coin.name()
-        puzzle: Program = Program.from_bytes(bytes(coin_spend.puzzle_reveal))
-        args = match_cat_puzzle(uncurry_puzzle(puzzle))
-        if args is not None:
-            mod_hash, genesis_coin_checker_hash, inner_puzzle = args
-            self.log.info(f"parent: {coin_name.hex()} inner_puzzle for parent is {inner_puzzle}")
+    async def puzzle_solution_received(self, coin: Coin, parent_coin_data: Optional[CATCoinData]) -> None:
+        coin_name = coin.parent_coin_info
+        if parent_coin_data is not None:
+            assert isinstance(parent_coin_data, CATCoinData)
+            data: CATCoinData = parent_coin_data
+            self.log.info(f"parent: {coin_name.hex()} inner_puzzle for parent is {data.inner_puzzle}")
 
             await self.add_lineage(
                 coin_name,
-                LineageProof(parent_coin.parent_coin_info, inner_puzzle.get_tree_hash(), uint64(parent_coin.amount)),
+                LineageProof(data.parent_coin_id, data.inner_puzzle.get_tree_hash(), data.amount),
             )
         else:
             # The parent is not a CAT which means we need to scrub all of its children from our DB

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -351,7 +351,6 @@ class CATWallet:
     async def coin_added(
         self, coin: Coin, height: uint32, peer: WSChiaConnection, parent_coin_data: Optional[CATCoinData]
     ) -> None:
-        # TODO Use coin_data instead of calling peer API
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"CAT wallet has been notified that {coin.name().hex()} was added")
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -720,7 +720,11 @@ class WalletStateManager:
         if cat_curried_args is not None:
             cat_mod_hash, tail_program_hash, cat_inner_puzzle = cat_curried_args
             cat_data: CATCoinData = CATCoinData(
-                bytes32(cat_mod_hash.atom), bytes32(tail_program_hash.atom), cat_inner_puzzle
+                bytes32(cat_mod_hash.atom),
+                bytes32(tail_program_hash.atom),
+                cat_inner_puzzle,
+                parent_coin_state.coin.parent_coin_info,
+                uint64(parent_coin_state.coin.amount),
             )
             return (
                 await self.handle_cat(


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This is the actual optimization for the CAT wallet based on the https://github.com/Chia-Network/chia-blockchain/pull/15735.



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
The CAT will call peer API again to get the coin state and coin spend.


### New Behavior:
The CAT will not call peer API again to get the coin state and coin spend when the CATCoinData is provided.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
unit test


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
