### PR TITLE
add _run() method to Program

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -108,10 +108,13 @@ class Program(SExp):
     def get_tree_hash(self) -> bytes32:
         return bytes32(tree_hash(bytes(self)))
 
-    def run_with_cost(self, max_cost: int, args) -> Tuple[int, "Program"]:
+    def _run(self, max_cost: int, flags: int, args) -> Tuple[int, "Program"]:
         prog_args = Program.to(args)
-        cost, r = run_chia_program(self.as_bin(), prog_args.as_bin(), max_cost, 0)
+        cost, r = run_chia_program(self.as_bin(), prog_args.as_bin(), max_cost, flags)
         return cost, Program.to(r)
+
+    def run_with_cost(self, max_cost: int, args) -> Tuple[int, "Program"]:
+        return self._run(max_cost, 0, args)
 
     def run(self, args) -> "Program":
         cost, r = self.run_with_cost(INFINITE_COST, args)


### PR DESCRIPTION
### Purpose:

1. Make it possible to pass in `flags` when running a `Program` (currently only possible with `SerializedProgram`)
2. Make `Program` and `SerializedProgram` have more similar interfaces.