### PR TITLE
Block tools compute cost

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -112,9 +112,8 @@ from chia.util.config import (
     save_config,
 )
 from chia.util.default_root import DEFAULT_ROOT_PATH
-from chia.util.errors import Err
 from chia.util.hash import std_hash
-from chia.util.ints import uint8, uint16, uint32, uint64, uint128
+from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.keychain import Keychain, bytes_to_mnemonic
 from chia.util.prev_transaction_block import get_prev_transaction_block
 from chia.util.ssl_check import fix_ssl
@@ -1810,46 +1809,56 @@ def compute_cost_table() -> List[int]:
 CONDITION_COSTS = compute_cost_table()
 
 
-def compute_cost_test(
-    generator: BlockGenerator, cost_per_byte: int, hard_fork: bool = False
-) -> Tuple[Optional[uint16], uint64]:
-    try:
-        block_program_args = Program.to([[bytes(g) for g in generator.generator_refs]])
-        clvm_cost, result = GENERATOR_MOD._run(
-            INFINITE_COST, MEMPOOL_MODE | ALLOW_BACKREFS, generator.program, block_program_args
-        )
-        size_cost = len(bytes(generator.program)) * cost_per_byte
-        condition_cost = 0
+def conditions_cost(conds: Program, hard_fork: bool) -> uint64:
+    condition_cost = 0
+    for cond in conds.as_iter():
+        condition = cond.first().as_atom()
+        if condition in [ConditionOpcode.AGG_SIG_UNSAFE, ConditionOpcode.AGG_SIG_ME]:
+            condition_cost += ConditionCost.AGG_SIG.value
+        elif condition == ConditionOpcode.CREATE_COIN:
+            condition_cost += ConditionCost.CREATE_COIN.value
+        # after the 2.0 hard fork, two byte conditions (with no leading 0)
+        # have costs. Account for that.
+        elif hard_fork and len(condition) == 2 and condition[0] != 0:
+            condition_cost += CONDITION_COSTS[condition[1]]
+        elif hard_fork and condition == ConditionOpcode.SOFTFORK.value:
+            arg = cond.rest().first().as_int()
+            condition_cost += arg * 10000
+        elif hard_fork and condition in [
+            ConditionOpcode.AGG_SIG_PARENT,
+            ConditionOpcode.AGG_SIG_PUZZLE,
+            ConditionOpcode.AGG_SIG_AMOUNT,
+            ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT,
+            ConditionOpcode.AGG_SIG_PARENT_AMOUNT,
+            ConditionOpcode.AGG_SIG_PARENT_PUZZLE,
+        ]:
+            condition_cost += ConditionCost.AGG_SIG.value
+    return uint64(condition_cost)
 
-        for res in result.first().as_iter():
-            res = res.rest()  # skip parent coind id
-            res = res.rest()  # skip puzzle hash
-            res = res.rest()  # skip amount
-            for cond in res.first().as_iter():
-                condition = cond.first().as_atom()
-                if condition in [ConditionOpcode.AGG_SIG_UNSAFE, ConditionOpcode.AGG_SIG_ME]:
-                    condition_cost += ConditionCost.AGG_SIG.value
-                elif condition == ConditionOpcode.CREATE_COIN:
-                    condition_cost += ConditionCost.CREATE_COIN.value
-                # after the 2.0 hard fork, two byte conditions (with no leading 0)
-                # have costs. Account for that.
-                elif hard_fork and len(condition) == 2 and condition[0] != 0:
-                    condition_cost += CONDITION_COSTS[condition[1]]
-                elif hard_fork and condition == ConditionOpcode.SOFTFORK.value:
-                    arg = cond.rest().first().as_int()
-                    condition_cost += arg * 10000
-                elif hard_fork and condition in [
-                    ConditionOpcode.AGG_SIG_PARENT,
-                    ConditionOpcode.AGG_SIG_PUZZLE,
-                    ConditionOpcode.AGG_SIG_AMOUNT,
-                    ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT,
-                    ConditionOpcode.AGG_SIG_PARENT_AMOUNT,
-                    ConditionOpcode.AGG_SIG_PARENT_PUZZLE,
-                ]:
-                    condition_cost += ConditionCost.AGG_SIG.value
-        return None, uint64(clvm_cost + size_cost + condition_cost)
-    except Exception:
-        return uint16(Err.GENERATOR_RUNTIME_ERROR.value), uint64(0)
+
+def compute_cost_test(generator: BlockGenerator, cost_per_byte: int, hard_fork: bool = False) -> uint64:
+    # this function cannot *validate* the block or any of the transactions. We
+    # deliberately create invalid blocks as parts of the tests, and we still
+    # need to be able to compute the cost of it
+
+    condition_cost = 0
+    clvm_cost = 0
+
+    flags = MEMPOOL_MODE
+    if hard_fork:
+        flags |= ALLOW_BACKREFS
+    block_program_args = Program.to([[bytes(g) for g in generator.generator_refs]])
+    clvm_cost, result = GENERATOR_MOD._run(INFINITE_COST, flags, generator.program, block_program_args)
+
+    for res in result.first().as_iter():
+        res = res.rest()  # skip parent coin id
+        res = res.rest()  # skip puzzle hash
+        res = res.rest()  # skip amount
+        condition_cost += conditions_cost(res.first(), hard_fork)
+
+    size_cost = len(bytes(generator.program)) * cost_per_byte
+
+    return uint64(clvm_cost + size_cost + condition_cost)
 
 
 def create_test_foliage(
@@ -1944,10 +1953,9 @@ def create_test_foliage(
         # Calculate the cost of transactions
         if block_generator is not None:
             generator_block_heights_list = block_generator.block_height_list
-            err, cost = compute_cost_test(
+            cost = compute_cost_test(
                 block_generator, constants.COST_PER_BYTE, hard_fork=height >= constants.HARD_FORK_HEIGHT
             )
-            assert err is None
 
             removal_amount = 0
             addition_amount = 0

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2098,21 +2098,23 @@ class TestGeneratorConditions:
         # CREATE_COIN
         puzzle_hash = "abababababababababababababababab"
 
+        generator_base_cost = 20470
+
         # this max cost is exactly enough for the create coin condition
         npc_result = generator_condition_tester(
             f'(51 "{puzzle_hash}" 10) ',
-            max_cost=20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value,
+            max_cost=generator_base_cost + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value,
             height=softfork_height,
         )
         assert npc_result.error is None
-        assert npc_result.cost == 20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value
+        assert npc_result.cost == generator_base_cost + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value
         assert len(npc_result.conds.spends) == 1
         assert len(npc_result.conds.spends[0].create_coin) == 1
 
         # if we subtract one from max cost, this should fail
         npc_result = generator_condition_tester(
             f'(51 "{puzzle_hash}" 10) ',
-            max_cost=20470 + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value - 1,
+            max_cost=generator_base_cost + 95 * COST_PER_BYTE + ConditionCost.CREATE_COIN.value - 1,
             height=softfork_height,
         )
         assert npc_result.error in [Err.BLOCK_COST_EXCEEDS_MAX.value, Err.INVALID_BLOCK_COST.value]
@@ -2121,20 +2123,22 @@ class TestGeneratorConditions:
         # AGG_SIG_ME
         pubkey = "abababababababababababababababababababababababab"
 
+        generator_base_cost = 20512
+
         # this max cost is exactly enough for the AGG_SIG condition
         npc_result = generator_condition_tester(
             f'(49 "{pubkey}" "foobar") ',
-            max_cost=20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value,
+            max_cost=generator_base_cost + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value,
             height=softfork_height,
         )
         assert npc_result.error is None
-        assert npc_result.cost == 20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value
+        assert npc_result.cost == generator_base_cost + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value
         assert len(npc_result.conds.spends) == 1
 
         # if we subtract one from max cost, this should fail
         npc_result = generator_condition_tester(
             f'(49 "{pubkey}" "foobar") ',
-            max_cost=20512 + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value - 1,
+            max_cost=generator_base_cost + 117 * COST_PER_BYTE + ConditionCost.AGG_SIG.value - 1,
             height=softfork_height,
         )
         assert npc_result.error in [Err.BLOCK_COST_EXCEEDS_MAX.value, Err.INVALID_BLOCK_COST.value]


### PR DESCRIPTION
### Purpose:

the `compute_cost_test()` function is used when building blocks for our tests. It's special in that it allows invalid blocks, because our tests wants to create those.

This patch simplifies it by splitting it into two functions (reducing indentation). It also makes it propagate any exceptions, to give much clearer error messages. This function is never supposed to fail in the tests, and failing is a sign of a bug that needs to be addressed. Seeing the full stack trace and error message is very helpful.

### Current Behavior:

When `compute_cost_test()` fails, the message seen in the test log is an assertion failure that `err is not None`

### New Behavior:

When `compute_cost_test()` fails, the message seen in the test log is the exception type, message and stack trace.