### PR TITLE
Fix issue with GUI and `chia plotters` when making compressed plots

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -865,15 +865,12 @@ class WebSocketServer:
         # Options only applicable for cudaplot
         if plot_type == "cudaplot":
             device_index = request.get("device", None)
-            no_direct_downloads = request.get("no_direct_downloads", False)
             t1 = request.get("t", None)  # Temp directory
             t2 = request.get("t2", None)  # Temp2 directory
 
             if device_index is not None and str(device_index).isdigit():
                 command_args.append("--device")
                 command_args.append(str(device_index))
-            if no_direct_downloads:
-                command_args.append("--no-direct-downloads")
             if t1 is not None:
                 command_args.append("-t")
                 command_args.append(t1)

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -365,7 +365,7 @@ def plot_bladebit(args, chia_root_path, root_path):
     if "device" in args and str(args.device).isdigit():
         call_args.append("--device")
         call_args.append(str(args.device))
-    if "no_direct_downloads" in args and args.no_direct_downloads is not None:
+    if "no_direct_downloads" in args and args.no_direct_downloads:
         call_args.append("--no-direct-downloads")
 
     call_args.append(args.finaldir)

--- a/chia/plotters/bladebit.py
+++ b/chia/plotters/bladebit.py
@@ -365,8 +365,6 @@ def plot_bladebit(args, chia_root_path, root_path):
     if "device" in args and str(args.device).isdigit():
         call_args.append("--device")
         call_args.append(str(args.device))
-    if "no_direct_downloads" in args and args.no_direct_downloads:
-        call_args.append("--no-direct-downloads")
 
     call_args.append(args.finaldir)
 

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -51,7 +51,6 @@ class Options(Enum):
     BLADEBIT_NO_T2_DIRECT = 36
     COMPRESSION = 37
     BLADEBIT_DEVICE_INDEX = 38
-    BLADEBIT_NO_DIRECT_DOWNLOADS = 39
     CUDA_TMP_DIR = 40
 
 
@@ -113,7 +112,6 @@ bladebit_cuda_plotter_options = [
     Options.FINAL_DIR,
     Options.COMPRESSION,
     Options.BLADEBIT_DEVICE_INDEX,
-    Options.BLADEBIT_NO_DIRECT_DOWNLOADS,
 ]
 
 bladebit_ram_plotter_options = [
@@ -465,13 +463,6 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
                 type=int,
                 help="The CUDA device index",
                 default=0,
-            )
-        if option is Options.BLADEBIT_NO_DIRECT_DOWNLOADS:
-            parser.add_argument(
-                "--no-direct-downloads",
-                action="store_true",
-                help="Don't allocate host tables using pinned buffers",
-                default=False,
             )
 
 


### PR DESCRIPTION
Don't use `no-direct-downloads` at all for `cudaplot`.

Will not set it when using `chia plotters` and will also not set it from the GUI despite the checkbox
Fixes https://github.com/Chia-Network/chia-blockchain/issues/16233 