### PR TITLE
increase data store batch insert benchmark limit from 19s to 24s

### DIFF
--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -1399,7 +1399,7 @@ class BatchInsertBenchmarkCase:
     BatchInsertBenchmarkCase(
         pre=1_000,
         count=1_000,
-        limit=19,
+        limit=24,
     ),
 )
 @pytest.mark.benchmark


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

If we would rather inspect this and try to find out if we've made an insert regression, that would be good as well.  This may or may not be caused by the recent changes to the benchmark runners.  This is just offering an educated increase to the timeout to reflect present performance.

Run times are exceeding the limit out for the biggest parametrization of the DataLayer data store batch insert benchmark.  Based on the samples and analysis linked below I am suggesting a 24s timeout.  This allows for all of the 120 runs in the sample, from both sumo and beast, to pass except for one extreme outlier at 26.8s.

https://github.com/Chia-Network/chia-blockchain/pull/16234

https://docs.google.com/spreadsheets/d/1AnyhNvJ2ZcqDqHu-4bzTo9XRjIrhcllmEGiGRbzYY8Y/edit#gid=0


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

lots of timeouts

### New Behavior:

fewer timeouts

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
