### PR TITLE
simulator: Increase duration limit in `test_callback` of `BlockTools`

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -267,7 +267,7 @@ class BlockTools:
         self.total_result = PlotRefreshResult()
 
         def test_callback(event: PlotRefreshEvents, update_result: PlotRefreshResult) -> None:
-            assert update_result.duration < 15
+            assert update_result.duration < 30
             if event == PlotRefreshEvents.started:
                 self.total_result = PlotRefreshResult()
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Should fix flaky runs like https://github.com/Chia-Network/chia-blockchain/actions/runs/6085504135/job/16509761625

```
----------------------------- Captured log setup ------------------------------
13:53:50 chia.plotting.manager: ERROR _refresh_callback raised:  with the traceback: Traceback (most recent call last):
  File "D:\a\chia-blockchain\chia-blockchain\venv\lib\site-packages\chia\plotting\manager.py", line 254, in _refresh_task
    self._refresh_callback(PlotRefreshEvents.done, total_result)
  File "D:\a\chia-blockchain\chia-blockchain\venv\lib\site-packages\chia\simulator\block_tools.py", line 270, in test_callback
    assert update_result.duration < 15
AssertionError
```
