### PR TITLE
Add valid_times to Offer object

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -613,7 +613,7 @@ async def print_trade_record(record: TradeRecord, wallet_client: WalletRpcClient
     if summaries:
         print("Summary:")
         offer = Offer.from_bytes(record.offer)
-        offered, requested, _ = offer.summary()
+        offered, requested, _, _ = offer.summary()
         outbound_balances: Dict[str, int] = offer.get_pending_amounts()
         fees: Decimal = Decimal(offer.fees())
         cat_name_resolver = wallet_client.cat_asset_id_to_name
@@ -701,7 +701,7 @@ async def take_offer(
             print("Please enter a valid offer file or hex blob")
             return
 
-        offered, requested, _ = offer.summary()
+        offered, requested, _, _ = offer.summary()
         cat_name_resolver = wallet_client.cat_asset_id_to_name
         network_xch = AddressType.XCH.hrp(config).upper()
         print("Summary:")

--- a/chia/rpc/util.py
+++ b/chia/rpc/util.py
@@ -8,7 +8,7 @@ import aiohttp
 
 from chia.types.blockchain_format.coin import Coin
 from chia.util.json_util import obj_to_response
-from chia.wallet.conditions import Condition, ConditionValidTimes, conditions_from_json_dicts
+from chia.wallet.conditions import Condition, ConditionValidTimes, conditions_from_json_dicts, parse_timelock_info
 from chia.wallet.util.tx_config import TXConfig, TXConfigLoader
 
 log = logging.getLogger(__name__)
@@ -69,6 +69,16 @@ def tx_endpoint(
         if "extra_conditions" in request:
             extra_conditions = tuple(conditions_from_json_dicts(request["extra_conditions"]))
         extra_conditions = (*extra_conditions, *ConditionValidTimes.from_json_dict(request).to_conditions())
+
+        valid_times: ConditionValidTimes = parse_timelock_info(extra_conditions)
+        if (
+            valid_times.max_secs_after_created is not None
+            or valid_times.min_secs_since_created is not None
+            or valid_times.max_blocks_after_created is not None
+            or valid_times.min_blocks_since_created is not None
+        ):
+            raise ValueError("Relative timelocks are not currently supported in the RPC")
+
         return await func(self, request, *args, tx_config=tx_config, extra_conditions=extra_conditions, **kwargs)
 
     return rpc_endpoint

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1739,7 +1739,17 @@ class WalletRpcApi:
                     "requested": requested,
                     "fees": offer.fees(),
                     "infos": infos,
-                    "valid_times": valid_times,
+                    "valid_times": {
+                        k: v
+                        for k, v in valid_times.to_json_dict().items()
+                        if k
+                        not in (
+                            "max_secs_after_created",
+                            "min_secs_since_created",
+                            "max_blocks_after_created",
+                            "min_blocks_since_created",
+                        )
+                    },
                 },
                 "id": offer.name(),
             }

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1730,11 +1730,17 @@ class WalletRpcApi:
         ###
 
         offer = Offer.from_bech32(offer_hex)
-        offered, requested, infos = offer.summary()
+        offered, requested, infos, valid_times = offer.summary()
 
         if request.get("advanced", False):
             response = {
-                "summary": {"offered": offered, "requested": requested, "fees": offer.fees(), "infos": infos},
+                "summary": {
+                    "offered": offered,
+                    "requested": requested,
+                    "fees": offer.fees(),
+                    "infos": infos,
+                    "valid_times": valid_times,
+                },
                 "id": offer.name(),
             }
         else:

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -886,7 +886,17 @@ class TradeManager:
             "requested": requested,
             "fees": offer.fees(),
             "infos": infos,
-            "valid_times": valid_times,
+            "valid_times": {
+                k: v
+                for k, v in valid_times.to_json_dict().items()
+                if k
+                not in (
+                    "max_secs_after_created",
+                    "min_secs_since_created",
+                    "max_blocks_after_created",
+                    "min_blocks_since_created",
+                )
+            },
         }
 
     async def check_for_final_modifications(

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -880,8 +880,14 @@ class TradeManager:
             ):
                 return await DataLayerWallet.get_offer_summary(offer)
         # Otherwise just return the same thing as the RPC normally does
-        offered, requested, infos = offer.summary()
-        return {"offered": offered, "requested": requested, "fees": offer.fees(), "infos": infos}
+        offered, requested, infos, valid_times = offer.summary()
+        return {
+            "offered": offered,
+            "requested": requested,
+            "fees": offer.fees(),
+            "infos": infos,
+            "valid_times": valid_times,
+        }
 
     async def check_for_final_modifications(
         self, offer: Offer, solver: Solver, tx_config: TXConfig

--- a/chia/wallet/trade_record.py
+++ b/chia/wallet/trade_record.py
@@ -38,7 +38,7 @@ class TradeRecordOld(Streamable):
         formatted["status"] = TradeStatus(self.status).name
         offer_to_summarize: bytes = self.offer if self.taken_offer is None else self.taken_offer
         offer = Offer.from_bytes(offer_to_summarize)
-        offered, requested, infos = offer.summary()
+        offered, requested, infos, _ = offer.summary()
         formatted["summary"] = {
             "offered": offered,
             "requested": requested,

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -150,6 +150,7 @@ class Offer:
             if max_cost < 0:
                 raise ValidationError(Err.BLOCK_COST_EXCEEDS_MAX, "compute_additions for CoinSpend")
         object.__setattr__(self, "_additions", adds)
+        object.__setattr__(self, "_conditions", None)
 
     def conditions(self) -> List[Condition]:
         if self._conditions is None:

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -161,9 +161,9 @@ class Offer:
                     cost, conds = cs.puzzle_reveal.run_with_cost(max_cost, cs.solution)
                     max_cost -= cost
                     conditions[cs.coin] = parse_conditions_non_consensus(conds.as_iter())
-                except Exception:
+                except Exception:  # pragma: no cover
                     continue
-                if max_cost < 0:
+                if max_cost < 0:  # pragma: no cover
                     raise ValidationError(Err.BLOCK_COST_EXCEEDS_MAX, "computing conditions for CoinSpend")
             object.__setattr__(self, "_conditions", conditions)
         assert self._conditions is not None, "self._conditions is None"

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -16,6 +16,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import bech32_decode, bech32_encode, convertbits
 from chia.util.errors import Err, ValidationError
 from chia.util.ints import uint64
+from chia.wallet.conditions import Condition, ConditionValidTimes, parse_conditions_non_consensus, parse_timelock_info
 from chia.wallet.outer_puzzles import (
     construct_puzzle,
     create_asset_id,
@@ -77,6 +78,7 @@ class Offer:
     _additions: Dict[Coin, List[Coin]] = field(init=False)
     _offered_coins: Dict[Optional[bytes32], List[Coin]] = field(init=False)
     _final_spend_bundle: Optional[SpendBundle] = field(init=False)
+    _conditions: Optional[Dict[Coin, List[Condition]]] = field(init=False)
 
     @staticmethod
     def ph() -> bytes32:
@@ -148,6 +150,26 @@ class Offer:
             if max_cost < 0:
                 raise ValidationError(Err.BLOCK_COST_EXCEEDS_MAX, "compute_additions for CoinSpend")
         object.__setattr__(self, "_additions", adds)
+
+    def conditions(self) -> List[Condition]:
+        if self._conditions is None:
+            conditions: Dict[Coin, List[Condition]] = {}
+            max_cost = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM
+            for cs in self._bundle.coin_spends:
+                try:
+                    cost, conds = cs.puzzle_reveal.run_with_cost(max_cost, cs.solution)
+                    max_cost -= cost
+                    conditions[cs.coin] = parse_conditions_non_consensus(conds.as_iter())
+                except Exception:
+                    continue
+                if max_cost < 0:
+                    raise ValidationError(Err.BLOCK_COST_EXCEEDS_MAX, "computing conditions for CoinSpend")
+            object.__setattr__(self, "_conditions", conditions)
+        assert self._conditions is not None, "self._conditions is None"
+        return [c for conditions in self._conditions.values() for c in conditions]
+
+    def valid_times(self) -> ConditionValidTimes:
+        return parse_timelock_info(self.conditions())
 
     def additions(self) -> List[Coin]:
         return [c for additions in self._additions.values() for c in additions]
@@ -270,7 +292,7 @@ class Offer:
         return arbitrage_dict
 
     # This is a method mostly for the UI that creates a JSON summary of the offer
-    def summary(self) -> Tuple[Dict[str, int], Dict[str, int], Dict[str, Dict[str, Any]]]:
+    def summary(self) -> Tuple[Dict[str, int], Dict[str, int], Dict[str, Dict[str, Any]], ConditionValidTimes]:
         offered_amounts: Dict[Optional[bytes32], int] = self.get_offered_amounts()
         requested_amounts: Dict[Optional[bytes32], int] = self.get_requested_amounts()
 
@@ -287,7 +309,7 @@ class Offer:
         for key, value in self.driver_dict.items():
             driver_dict[key.hex()] = value.info
 
-        return keys_to_strings(offered_amounts), keys_to_strings(requested_amounts), driver_dict
+        return keys_to_strings(offered_amounts), keys_to_strings(requested_amounts), driver_dict, self.valid_times()
 
     # Also mostly for the UI, returns a dictionary of assets and how much of them is pended for this offer
     # This method is also imperfect for sufficiently complex spends

--- a/tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -21,6 +21,7 @@ from chia.wallet.cat_wallet.cat_utils import (
     construct_cat_puzzle,
     unsigned_spend_bundle_for_spendable_cats,
 )
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.payment import Payment
 from chia.wallet.puzzle_drivers import PuzzleInfo
@@ -288,6 +289,7 @@ class TestOfferLifecycle:
                 },
                 {"xch": 900, str_to_tail_hash("red").hex(): 350},
                 driver_dict_as_infos,
+                ConditionValidTimes(),
             )
             assert new_offer.get_pending_amounts() == {
                 "xch": 1200,

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -42,6 +42,7 @@ from chia.util.streamable import ConversionError, InvalidTypeError
 from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD, construct_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
+from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
@@ -1308,6 +1309,14 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     await wallet_1_rpc.cancel_offers(DEFAULT_TX_CONFIG, asset_id=cat_asset_id)
     assert len([o for o in await wallet_1_rpc.get_all_offers() if o.status == TradeStatus.PENDING_ACCEPT.value]) == 0
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
+
+    with pytest.raises(ValueError, match="not currently supported"):
+        await wallet_1_rpc.create_offer_for_ids(
+            {uint32(1): -5, cat_asset_id.hex(): 1},
+            DEFAULT_TX_CONFIG,
+            driver_dict=driver_dict,
+            timelock_info=ConditionValidTimes(min_secs_since_created=uint64(1)),
+        )
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1154,13 +1154,9 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
         "infos": driver_dict,
         "fees": 1,
         "valid_times": {
-            "max_blocks_after_created": None,
             "max_height": None,
-            "max_secs_after_created": None,
             "max_time": None,
-            "min_blocks_since_created": None,
             "min_height": None,
-            "min_secs_since_created": None,
             "min_time": None,
         },
     }

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -1148,7 +1148,22 @@ async def test_offer_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment)
     assert id == offer.name()
     id, advanced_summary = await wallet_1_rpc.get_offer_summary(offer, advanced=True)
     assert id == offer.name()
-    assert summary == {"offered": {"xch": 5}, "requested": {cat_asset_id.hex(): 1}, "infos": driver_dict, "fees": 1}
+    assert summary == {
+        "offered": {"xch": 5},
+        "requested": {cat_asset_id.hex(): 1},
+        "infos": driver_dict,
+        "fees": 1,
+        "valid_times": {
+            "max_blocks_after_created": None,
+            "max_height": None,
+            "max_secs_after_created": None,
+            "max_time": None,
+            "min_blocks_since_created": None,
+            "min_height": None,
+            "min_secs_since_created": None,
+            "min_time": None,
+        },
+    }
     assert advanced_summary == summary
 
     id, valid = await wallet_1_rpc.check_offer_validity(offer)


### PR DESCRIPTION
This PR adds a property to the `Offer` driver to get the information about what times the offer will be valid for.  It also adds this information to the summary returned by the `.summary()` method and the `get_offer_summary` RPC.