### PR TITLE
setup_simulators_and_wallets() with constants

### DIFF
--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -16,7 +16,7 @@ from chia.harvester.harvester_api import HarvesterAPI
 from chia.protocols.shared_protocol import Capability
 from chia.server.server import ChiaServer
 from chia.server.start_service import Service
-from chia.simulator.block_tools import BlockTools, create_block_tools_async, test_constants
+from chia.simulator.block_tools import BlockTools, create_block_tools_async
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.keyring import TempKeyring
 from chia.simulator.setup_services import (
@@ -53,10 +53,6 @@ def cleanup_keyring(keyring: TempKeyring) -> None:
 
 
 log = logging.getLogger(__name__)
-
-
-def constants_for_dic(dic: Dict[str, int]) -> ConsensusConstants:
-    return test_constants.replace(**dic)
 
 
 async def _teardown_nodes(node_aiters: List[AsyncGenerator[Any, None]]) -> None:
@@ -143,7 +139,7 @@ async def setup_n_nodes(
 async def setup_simulators_and_wallets(
     simulator_count: int,
     wallet_count: int,
-    dic: Dict[str, int],
+    constants: ConsensusConstants,
     spam_filter_after_n_txs: int = 200,
     xch_spam_amount: int = 1000000,
     *,
@@ -156,7 +152,7 @@ async def setup_simulators_and_wallets(
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         res = await setup_simulators_and_wallets_inner(
             db_version,
-            dic,
+            constants,
             initial_num_public_keys,
             key_seed,
             keychain1,
@@ -186,7 +182,7 @@ async def setup_simulators_and_wallets(
 async def setup_simulators_and_wallets_service(
     simulator_count: int,
     wallet_count: int,
-    dic: Dict[str, int],
+    constants: ConsensusConstants,
     spam_filter_after_n_txs: int = 200,
     xch_spam_amount: int = 1000000,
     *,
@@ -201,7 +197,7 @@ async def setup_simulators_and_wallets_service(
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         res = await setup_simulators_and_wallets_inner(
             db_version,
-            dic,
+            constants,
             initial_num_public_keys,
             key_seed,
             keychain1,
@@ -222,7 +218,7 @@ async def setup_simulators_and_wallets_service(
 
 async def setup_simulators_and_wallets_inner(
     db_version: int,
-    dic: Dict[str, int],
+    constants: ConsensusConstants,
     initial_num_public_keys: int,
     key_seed: Optional[bytes32],
     keychain1: Keychain,
@@ -245,13 +241,10 @@ async def setup_simulators_and_wallets_inner(
         AsyncGenerator[Union[Service[FullNode, FullNodeSimulator], Service[WalletNode, WalletNodeAPI]], None]
     ] = []
     bt_tools: List[BlockTools] = []
-    consensus_constants: ConsensusConstants = constants_for_dic(dic)
     for index in range(0, simulator_count):
         db_name = f"blockchain_test_{index}_sim_and_wallets.db"
         bt_tools.append(
-            await create_block_tools_async(
-                consensus_constants, const_dict=dic, keychain=keychain1, config_overrides=config_overrides
-            )
+            await create_block_tools_async(constants, keychain=keychain1, config_overrides=config_overrides)
         )  # block tools modifies constants
         sim = cast(
             AsyncGenerator[Service[FullNode, FullNodeSimulator], None],
@@ -275,7 +268,7 @@ async def setup_simulators_and_wallets_inner(
             seed = key_seed
         if index > (len(bt_tools) - 1):
             wallet_bt_tools = await create_block_tools_async(
-                consensus_constants, const_dict=dic, keychain=keychain2, config_overrides=config_overrides
+                constants, keychain=keychain2, config_overrides=config_overrides
             )  # block tools modifies constants
         else:
             wallet_bt_tools = bt_tools[index]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,19 +354,19 @@ async def node_with_params(request):
     params = {}
     if request:
         params = request.param
-    async for (sims, wallets, bt) in setup_simulators_and_wallets(1, 0, {}, **params):
+    async for (sims, wallets, bt) in setup_simulators_and_wallets(1, 0, test_constants, **params):
         yield sims[0]
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_nodes(db_version: int, self_hostname, blockchain_constants):
+async def two_nodes(db_version: int, self_hostname, blockchain_constants: ConsensusConstants):
     async for _ in setup_two_nodes(blockchain_constants, db_version=db_version, self_hostname=self_hostname):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def setup_two_nodes_fixture(db_version: int):
-    async for _ in setup_simulators_and_wallets(2, 0, {}, db_version=db_version):
+async def setup_two_nodes_fixture(db_version: int, blockchain_constants: ConsensusConstants):
+    async for _ in setup_simulators_and_wallets(2, 0, blockchain_constants, db_version=db_version):
         yield _
 
 
@@ -407,7 +407,7 @@ async def wallet_nodes(blockchain_constants, consensus_mode):
     async_gen = setup_simulators_and_wallets(
         2,
         1,
-        {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 400000000, "SOFT_FORK4_HEIGHT": constants.SOFT_FORK4_HEIGHT},
+        blockchain_constants.replace(MEMPOOL_BLOCK_BUFFER=1, MAX_BLOCK_COST_CLVM=400000000),
     )
     nodes, wallets, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
@@ -424,13 +424,13 @@ async def wallet_nodes(blockchain_constants, consensus_mode):
 
 @pytest_asyncio.fixture(scope="function")
 async def setup_four_nodes(db_version):
-    async for _ in setup_simulators_and_wallets(4, 0, {}, db_version=db_version):
+    async for _ in setup_simulators_and_wallets(4, 0, test_constants, db_version=db_version):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def two_nodes_sim_and_wallets():
-    async for _ in setup_simulators_and_wallets(2, 0, {}):
+    async for _ in setup_simulators_and_wallets(2, 0, test_constants):
         yield _
 
 
@@ -449,21 +449,19 @@ async def two_nodes_sim_and_wallets():
     ],
 )
 async def two_nodes_sim_and_wallets_services(blockchain_constants, consensus_mode):
-    async for _ in setup_simulators_and_wallets_service(
-        2, 0, {"SOFT_FORK4_HEIGHT": blockchain_constants.SOFT_FORK4_HEIGHT}
-    ):
+    async for _ in setup_simulators_and_wallets_service(2, 0, blockchain_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def one_wallet_and_one_simulator_services():
-    async for _ in setup_simulators_and_wallets_service(1, 1, {}):
+    async for _ in setup_simulators_and_wallets_service(1, 1, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def wallet_node_100_pk():
-    async for _ in setup_simulators_and_wallets(1, 1, {}, initial_num_public_keys=100):
+    async for _ in setup_simulators_and_wallets(1, 1, test_constants, initial_num_public_keys=100):
         yield _
 
 
@@ -471,7 +469,7 @@ async def wallet_node_100_pk():
 async def simulator_and_wallet() -> AsyncIterator[
     Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]
 ]:
-    async for _ in setup_simulators_and_wallets(simulator_count=1, wallet_count=1, dic={}):
+    async for _ in setup_simulators_and_wallets(1, 1, test_constants):
         yield _
 
 
@@ -480,7 +478,7 @@ async def two_wallet_nodes(request):
     params = {}
     if request and request.param_index > 0:
         params = request.param
-    async for _ in setup_simulators_and_wallets(1, 2, {}, **params):
+    async for _ in setup_simulators_and_wallets(1, 2, test_constants, **params):
         yield _
 
 
@@ -488,65 +486,70 @@ async def two_wallet_nodes(request):
 async def two_wallet_nodes_services() -> AsyncIterator[
     Tuple[List[Service[FullNode, FullNodeSimulator]], List[Service[WalletNode, WalletNodeAPI]], BlockTools]
 ]:
-    async for _ in setup_simulators_and_wallets_service(1, 2, {}):
+    async for _ in setup_simulators_and_wallets_service(1, 2, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
-async def two_wallet_nodes_custom_spam_filtering(spam_filter_after_n_txs, xch_spam_amount):
-    async for _ in setup_simulators_and_wallets(1, 2, {}, spam_filter_after_n_txs, xch_spam_amount):
+async def two_wallet_nodes_custom_spam_filtering(
+    spam_filter_after_n_txs,
+    xch_spam_amount,
+):
+    async for _ in setup_simulators_and_wallets(1, 2, test_constants, spam_filter_after_n_txs, xch_spam_amount):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def three_sim_two_wallets():
-    async for _ in setup_simulators_and_wallets(3, 2, {}):
+    async for _ in setup_simulators_and_wallets(3, 2, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes_and_wallet():
-    async for _ in setup_simulators_and_wallets(2, 1, {}, db_version=2):
+    async for _ in setup_simulators_and_wallets(2, 1, test_constants, db_version=2):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def setup_two_nodes_and_wallet_fast_retry():
     async for _ in setup_simulators_and_wallets(
-        1, 1, {}, config_overrides={"wallet.tx_resend_timeout_secs": 1}, db_version=2
+        1, 1, test_constants, config_overrides={"wallet.tx_resend_timeout_secs": 1}, db_version=2
     ):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def three_wallet_nodes():
-    async for _ in setup_simulators_and_wallets(1, 3, {}):
+    async for _ in setup_simulators_and_wallets(1, 3, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def wallet_two_node_simulator():
-    async for _ in setup_simulators_and_wallets(2, 1, {}):
+    async for _ in setup_simulators_and_wallets(2, 1, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def wallet_nodes_mempool_perf(bt):
     key_seed = bt.farmer_master_sk_entropy
-    async for _ in setup_simulators_and_wallets(2, 1, {}, key_seed=key_seed):
+    async for _ in setup_simulators_and_wallets(2, 1, bt.constants, key_seed=key_seed):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def two_nodes_two_wallets_with_same_keys(bt) -> AsyncIterator[SimulatorsAndWallets]:
     key_seed = bt.farmer_master_sk_entropy
-    async for _ in setup_simulators_and_wallets(2, 2, {}, key_seed=key_seed):
+    async for _ in setup_simulators_and_wallets(2, 2, bt.constants, key_seed=key_seed):
         yield _
 
 
 @pytest_asyncio.fixture(scope="module")
 async def wallet_nodes_perf():
-    async_gen = setup_simulators_and_wallets(1, 1, {"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 11000000000})
+    async_gen = setup_simulators_and_wallets(
+        1, 1, test_constants, config_overrides={"MEMPOOL_BLOCK_BUFFER": 1, "MAX_BLOCK_COST_CLVM": 11000000000}
+    )
     nodes, wallets, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     server_1 = full_node_1.full_node.server
@@ -560,7 +563,7 @@ async def wallet_nodes_perf():
 
 @pytest_asyncio.fixture(scope="function")
 async def wallet_nodes_mainnet(db_version):
-    async_gen = setup_simulators_and_wallets(2, 1, {}, db_version=db_version)
+    async_gen = setup_simulators_and_wallets(2, 1, test_constants, db_version=db_version)
     nodes, wallets, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     full_node_2 = nodes[1]
@@ -576,19 +579,19 @@ async def wallet_nodes_mainnet(db_version):
 
 @pytest_asyncio.fixture(scope="function")
 async def three_nodes_two_wallets():
-    async for _ in setup_simulators_and_wallets(3, 2, {}):
+    async for _ in setup_simulators_and_wallets(3, 2, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def one_node() -> AsyncIterator[Tuple[List[Service], List[FullNodeSimulator], BlockTools]]:
-    async for _ in setup_simulators_and_wallets_service(1, 0, {}):
+    async for _ in setup_simulators_and_wallets_service(1, 0, test_constants):
         yield _
 
 
 @pytest_asyncio.fixture(scope="function")
 async def one_node_one_block() -> AsyncIterator[Tuple[Union[FullNodeAPI, FullNodeSimulator], ChiaServer, BlockTools]]:
-    async_gen = setup_simulators_and_wallets(1, 0, {})
+    async_gen = setup_simulators_and_wallets(1, 0, test_constants)
     nodes, _, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     server_1 = full_node_1.full_node.server
@@ -618,7 +621,7 @@ async def one_node_one_block() -> AsyncIterator[Tuple[Union[FullNodeAPI, FullNod
 
 @pytest_asyncio.fixture(scope="function")
 async def two_nodes_one_block():
-    async_gen = setup_simulators_and_wallets(2, 0, {})
+    async_gen = setup_simulators_and_wallets(2, 0, test_constants)
     nodes, _, bt = await async_gen.__anext__()
     full_node_1 = nodes[0]
     full_node_2 = nodes[1]
@@ -632,7 +635,7 @@ async def two_nodes_one_block():
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=reward_ph,
         pool_reward_puzzle_hash=reward_ph,
-        genesis_timestamp=10000,
+        genesis_timestamp=uint64(10000),
         time_per_block=10,
     )
     assert blocks[0].height == 0
@@ -660,7 +663,7 @@ async def farmer_one_harvester_simulator_wallet(
         BlockTools,
     ]
 ]:
-    async for sim_and_wallet in setup_simulators_and_wallets_service(1, 1, {}):
+    async for sim_and_wallet in setup_simulators_and_wallets_service(1, 1, test_constants):
         nodes, wallets, bt = sim_and_wallet
         async for farmer_harvester in setup_farmer_multi_harvester(bt, 1, tmp_path, bt.constants, start_services=True):
             harvester_services, farmer_service, _ = farmer_harvester

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -21,7 +21,7 @@ from chia.pools.pool_puzzles import SINGLETON_LAUNCHER_HASH
 from chia.pools.pool_wallet_info import PoolSingletonState, PoolWalletInfo
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.server.start_service import Service
-from chia.simulator.block_tools import BlockTools, get_plot_dir
+from chia.simulator.block_tools import BlockTools, get_plot_dir, test_constants
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.setup_nodes import setup_simulators_and_wallets_service
 from chia.simulator.simulator_protocol import ReorgProtocol
@@ -96,12 +96,9 @@ OneWalletNodeAndRpc = Tuple[WalletRpcClient, Any, FullNodeSimulator, int, BlockT
 
 
 @pytest_asyncio.fixture(scope="function")
-async def one_wallet_node_and_rpc(
-    trusted: bool,
-    self_hostname: str,
-) -> AsyncIterator[OneWalletNodeAndRpc]:
+async def one_wallet_node_and_rpc(trusted: bool, self_hostname: str) -> AsyncIterator[OneWalletNodeAndRpc]:
     rmtree(get_pool_plot_dir(), ignore_errors=True)
-    async for nodes in setup_simulators_and_wallets_service(1, 1, {}):
+    async for nodes in setup_simulators_and_wallets_service(1, 1, test_constants):
         full_nodes, wallets, bt = nodes
         full_node_api: FullNodeSimulator = full_nodes[0]._api
         wallet_service = wallets[0]


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

simplify setup_simulators_and_wallets() and setup_simulators_and_wallets_service() to pass in the consensus constants directly.

The underlying functions that our test fixtures use, `setup_simulators_and_wallets()` and `setup_simulators_and_wallets_service()` implicitly use `test_constants` as their consensus constants. They take a dictionary that allows a caller to patch up specific constants for specific tests (which we only use in one place, and it's not convenient).

Long term, all our fixtures that set up nodes and wallets need to be parameterized by `ConsensusMode`, which means the fixture need to be able to specify which constants to construct the nodes and wallets with. This patch is a step along that way, to make it possible to specify exactly which constants to use from the caller.

There is no (intentional) change in behavior. This prepares for a gradual transition to increased parameterization of our test fixtures.