### PR TITLE
wallet: Drop `is_peer_synced` / More cache usage

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -48,24 +48,6 @@ class PeerRequestException(Exception):
     pass
 
 
-async def fetch_last_tx_from_peer(height: uint32, peer: WSChiaConnection) -> Optional[HeaderBlock]:
-    request_height: int = height
-    while True:
-        if request_height == -1:
-            return None
-        response: Optional[List[HeaderBlock]] = await request_header_blocks(
-            peer, uint32(request_height), uint32(request_height)
-        )
-        if response is not None and len(response) > 0:
-            if response[0].is_transaction_block:
-                return response[0]
-        elif request_height < height:
-            # The peer might be slightly behind others but still synced, so we should allow fetching one more TX block
-            break
-        request_height = request_height - 1
-    return None
-
-
 async def subscribe_to_phs(
     puzzle_hashes: List[bytes32],
     peer: WSChiaConnection,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1003,13 +1003,12 @@ class WalletNode:
         a transaction block
         """
         cache = self.get_cache_for_peer(peer)
-        cached_timestamp = cache.get_height_timestamp(height)
-        if cached_timestamp is not None:
-            return cached_timestamp
-
         last_tx_block = None
         request_height: int = height
         while request_height >= 0:
+            cached_timestamp = cache.get_height_timestamp(uint32(request_height))
+            if cached_timestamp is not None:
+                return cached_timestamp
             response: Optional[List[HeaderBlock]] = await request_header_blocks(
                 peer, uint32(request_height), uint32(request_height)
             )

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -52,8 +52,12 @@ class WalletNodeAPI:
                 peer for peer in full_node_connections if not self.wallet_node.is_trusted(peer) and not peer.closed
             ]
 
-            # Check for untrusted peers first to avoid calling is_peer_synced if not required
-            if len(untrusted_peers) > 0 and await self.wallet_node.is_peer_synced(peer, peak.height):
+            # Check for untrusted peers to avoid fetching the timestamp if not required
+            if len(untrusted_peers) > 0:
+                timestamp = await self.wallet_node.get_timestamp_for_height_from_peer(peak.height, peer)
+            else:
+                timestamp = None
+            if timestamp is not None and self.wallet_node.is_timestamp_in_sync(timestamp):
                 self.log.info("Connected to a a synced trusted peer, disconnecting from all untrusted nodes.")
                 # Stop peer discovery/connect tasks first
                 if self.wallet_node.wallet_peers is not None:

--- a/tests/wallet/test_wallet_node.py
+++ b/tests/wallet/test_wallet_node.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import sys
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -15,7 +17,7 @@ from chia.simulator.time_out_assert import time_out_assert
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.util.config import load_config
-from chia.util.ints import uint16, uint32, uint128
+from chia.util.ints import uint16, uint32, uint64, uint128
 from chia.util.keychain import Keychain, KeyData, generate_mnemonic
 from chia.wallet.wallet_node import Balance, WalletNode
 from tests.util.misc import CoinGenerator
@@ -301,6 +303,56 @@ def test_update_last_used_fingerprint(root_path_populated_with_config: Path) -> 
 
     assert path.exists() is True
     assert path.read_text() == "9876543210"
+
+
+@pytest.mark.parametrize("testing", [True, False])
+@pytest.mark.parametrize("offset", [0, 550, 650])
+def test_timestamp_in_sync(root_path_populated_with_config: Path, testing: bool, offset: int) -> None:
+    root_path: Path = root_path_populated_with_config
+    config: Dict[str, Any] = load_config(root_path, "config.yaml", "wallet")
+    wallet_node = WalletNode(config, root_path, test_constants)
+    now = time.time()
+    wallet_node.config["testing"] = testing
+
+    expected = testing or offset < 600
+    assert wallet_node.is_timestamp_in_sync(uint64(now - offset)) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_timestamp_for_height_from_peer(
+    simulator_and_wallet: SimulatorsAndWallets, self_hostname: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
+
+    async def get_timestamp(height: int) -> Optional[uint64]:
+        return await wallet_node.get_timestamp_for_height_from_peer(uint32(height), full_node_peer)
+
+    await wallet_server.start_client(PeerInfo(self_hostname, uint16(full_node_api.server._port)), None)
+    wallet = wallet_node.wallet_state_manager.main_wallet
+    await full_node_api.farm_rewards_to_wallet(1, wallet)
+    full_node_peer = list(wallet_server.all_connections.values())[0]
+    # There should be no timestamp available for height 10
+    assert await get_timestamp(10) is None
+    # The timestamp at peak height should match the one from the full node block_store.
+    peak = await wallet_node.wallet_state_manager.blockchain.get_peak_block()
+    assert peak is not None
+    timestamp_at_peak = await get_timestamp(peak.height)
+    block_at_peak = (await full_node_api.full_node.block_store.get_full_blocks_at([peak.height]))[0]
+    assert block_at_peak.foliage_transaction_block is not None
+    assert timestamp_at_peak == block_at_peak.foliage_transaction_block.timestamp
+    # Clear the cache and add the peak back with a modified timestamp
+    cache = wallet_node.get_cache_for_peer(full_node_peer)
+    cache.clear_after_height(0)
+    modified_foliage_transaction_block = dataclasses.replace(
+        block_at_peak.foliage_transaction_block, timestamp=timestamp_at_peak + 1
+    )
+    modified_peak = dataclasses.replace(peak, foliage_transaction_block=modified_foliage_transaction_block)
+    cache.add_to_blocks(modified_peak)
+    # Now the call should make use of the cached, modified block
+    assert await get_timestamp(peak.height) == timestamp_at_peak + 1
+    # After the clearing the cache it should fetch the actual timestamp again
+    cache.clear_after_height(0)
+    assert await get_timestamp(peak.height) == timestamp_at_peak
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Drop `is_peer_synced` and use the here introduced `WalletNode.get_timestamp_for_height_from_peer` to fetch the timestamp during peak processing for more usage of the timestamp caching and also i wanted to split out `WalletNode.timstamp_in_sync` logic for the wallet protocol update which already contains the last transaction block timestamp in the peak message.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The wallet fetches the block/timestamp twice from the full node for each peak.

### New Behavior:

The wallet fetches the block/timestamp only once and uses the cache after. 

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I added a test for `WalletNode.is_timestamp_in_sync` and `WalletNode.get_timestamp_for_height_from_peer`.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
