### PR TITLE
Invoke python instead of python3 consistently in pre-commit flows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     hooks:
     -   id: check-sql
         name: Validate SQL statements
-        entry: ./activated.py python3 -m tests.check_sql_statements
+        entry: ./activated.py python -m tests.check_sql_statements
         language: system
         pass_filenames: false
 -   repo: local
     hooks:
     -   id: init_py_files
         name: __init__.py files
-        entry: ./activated.py python3 tests/build-init-files.py -v --root .
+        entry: ./activated.py python tests/build-init-files.py -v --root .
         language: system
         pass_filenames: false
 -   repo: local


### PR DESCRIPTION
On Windows, `python.exe` is safely assumed to exist in venv's `Scripts` folder.