### PR TITLE
Add traceback to front-end error responses

### DIFF
--- a/chia/rpc/util.py
+++ b/chia/rpc/util.py
@@ -27,7 +27,7 @@ def wrap_http_handler(f) -> Callable:
             tb = traceback.format_exc()
             log.warning(f"Error while handling message: {tb}")
             if len(e.args) > 0:
-                res_object = {"success": False, "error": f"{e.args[0]}"}
+                res_object = {"success": False, "error": f"{e.args[0]}", "traceback": f"{tb}"}
             else:
                 res_object = {"success": False, "error": f"{e}"}
 


### PR DESCRIPTION
We often get issue submissions where users capture some relevant log output from the front end error message, but not the log message from the backend containing the backend stack trace.  This change would make it much more likely that while debugging we get all of the relevant info in a single log entry.