### PR TITLE
add fee for cat creation

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -655,6 +655,7 @@ class WalletRpcApi:
                             {"identifier": "genesis_by_id"},
                             uint64(request["amount"]),
                             tx_config,
+                            fee,
                             name,
                         )
                         asset_id = cat_wallet.get_asset_id()

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -677,11 +677,12 @@ class WalletRpcClient(RpcClient):
         )
 
     # CATS
-    async def create_new_cat_and_wallet(self, amount: uint64, test: bool = False) -> Dict:
+    async def create_new_cat_and_wallet(self, amount: uint64, fee: uint64 = uint64(0), test: bool = False) -> Dict:
         request: Dict[str, Any] = {
             "wallet_type": "cat_wallet",
             "mode": "new",
             "amount": amount,
+            "fee": fee,
             "test": test,
         }
         return await self.fetch("create_new_wallet", request)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -88,6 +88,7 @@ class CATWallet:
         cat_tail_info: Dict[str, Any],
         amount: uint64,
         tx_config: TXConfig,
+        fee: uint64 = uint64(0),
         name: Optional[str] = None,
     ) -> "CATWallet":
         self = CATWallet()
@@ -119,6 +120,7 @@ class CATWallet:
                 cat_tail_info,
                 amount,
                 tx_config,
+                fee,
             )
             assert self.cat_info.limitations_program_hash != empty_bytes
         except Exception:
@@ -157,7 +159,7 @@ class CATWallet:
             created_at_time=uint64(int(time.time())),
             to_puzzle_hash=(await self.convert_puzzle_hash(cat_coin.puzzle_hash)),
             amount=uint64(cat_coin.amount),
-            fee_amount=uint64(0),
+            fee_amount=fee,
             confirmed=False,
             sent=uint32(10),
             spend_bundle=None,

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -79,9 +79,9 @@ class GenesisById(LimitationsProgram):
 
     @classmethod
     async def generate_issuance_bundle(
-        cls, wallet, _: Dict, amount: uint64, tx_config: TXConfig
+        cls, wallet, _: Dict, amount: uint64, tx_config: TXConfig, fee: uint64 = uint64(0)
     ) -> Tuple[TransactionRecord, SpendBundle]:
-        coins = await wallet.standard_wallet.select_coins(amount, tx_config.coin_selection_config)
+        coins = await wallet.standard_wallet.select_coins(amount + fee, tx_config.coin_selection_config)
 
         origin = coins.copy().pop()
         origin_id = origin.name()
@@ -97,7 +97,7 @@ class GenesisById(LimitationsProgram):
         minted_cat_puzzle_hash: bytes32 = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), cat_inner).get_tree_hash()
 
         tx_record: TransactionRecord = await wallet.standard_wallet.generate_signed_transaction(
-            amount, minted_cat_puzzle_hash, tx_config, uint64(0), coins, origin_id=origin_id
+            amount, minted_cat_puzzle_hash, tx_config, fee, coins, origin_id=origin_id
         )
         assert tx_record.spend_bundle is not None
 

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -80,6 +80,7 @@ class CRCATWallet(CATWallet):
         cat_tail_info: Dict[str, Any],
         amount: uint64,
         tx_config: TXConfig,
+        fee: uint64 = uint64(0),
         name: Optional[str] = None,
     ) -> "CATWallet":  # pragma: no cover
         raise NotImplementedError("create_new_cat_wallet is a legacy method and is not available on CR-CAT wallets")

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -81,6 +81,7 @@ class TestCATWallet:
                 {"identifier": "genesis_by_id"},
                 uint64(100),
                 DEFAULT_TX_CONFIG,
+                fee=uint64(10),
             )
             # The next 2 lines are basically a noop, it just adds test coverage
             cat_wallet = await CATWallet.create(wallet_node.wallet_state_manager, wallet, cat_wallet.wallet_info)
@@ -93,6 +94,9 @@ class TestCATWallet:
         await time_out_assert(20, cat_wallet.get_confirmed_balance, 100)
         await time_out_assert(20, cat_wallet.get_spendable_balance, 100)
         await time_out_assert(20, cat_wallet.get_unconfirmed_balance, 100)
+        await time_out_assert(20, wallet.get_confirmed_balance, funds - 110)
+        await time_out_assert(20, wallet.get_spendable_balance, funds - 110)
+        await time_out_assert(20, wallet.get_unconfirmed_balance, funds - 110)
 
         # Test migration
         all_lineage = await cat_wallet.lineage_store.get_all_lineage_proofs()

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -952,8 +952,8 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
             },
         )
 
-    # Creates a CAT wallet with 100 mojos and a CAT with 20 mojos
-    await client.create_new_cat_and_wallet(uint64(100), test=True)
+    # Creates a CAT wallet with 100 mojos and a CAT with 20 mojos and fee=10
+    await client.create_new_cat_and_wallet(uint64(100), fee=uint64(10), test=True)
     await time_out_assert(20, client.get_synced)
 
     res = await client.create_new_cat_and_wallet(uint64(20), test=True)


### PR DESCRIPTION
When creating new CATs there is no option to set a fee for the transaction. This PR adds the option to specify a fee for the transaction