### PR TITLE
Rename USDS --> USDSC

### DIFF
--- a/chia/wallet/cat_wallet/cat_constants.py
+++ b/chia/wallet/cat_wallet/cat_constants.py
@@ -14,8 +14,8 @@ MARMOT = {
 
 STABLY_USDS = {
     "asset_id": "6d95dae356e32a71db5ddcb42224754a02524c615c5fc35f568c2af04774e589",
-    "name": "Stably USD",
-    "symbol": "USDS",
+    "name": "Stably USD Classic",
+    "symbol": "USDSC",
 }
 
 CHIA_HOLIDAY_TOKEN = {


### PR DESCRIPTION
### Purpose:
Rename USDS to USDSC for CAT asset ID `6d95dae356e32a71db5ddcb42224754a02524c615c5fc35f568c2af04774e589`

Note that this will not rename existing USDS wallets that have been added to the wallet DB.
