### PR TITLE
`@pytest.mark.limit_consensus_modes()` in DataLayer RPC tests

### DIFF
--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -1849,6 +1849,7 @@ async def test_make_and_cancel_offer_not_secure_clears_pending_roots(
     await offer_setup.maker.api.insert(request={"id": offer_setup.maker.id.hex(), "key": "ab", "value": "cd"})
 
 
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.asyncio
 async def test_get_sync_status(
     self_hostname: str, one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices, tmp_path: Path
@@ -2002,6 +2003,7 @@ async def test_clear_pending_roots(
         assert cleared_root == {"success": True, "root": pending_root.marshal()}
 
 
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.asyncio
 async def test_issue_15955_deadlock(
     self_hostname: str, one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices, tmp_path: Path
@@ -2058,6 +2060,7 @@ async def test_issue_15955_deadlock(
 
 
 @pytest.mark.parametrize("retain", [True, False])
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.asyncio
 async def test_unsubscribe_removes_files(
     self_hostname: str,
@@ -2103,6 +2106,7 @@ async def test_unsubscribe_removes_files(
 
 
 @pytest.mark.parametrize(argnames="layer", argvalues=list(InterfaceLayer))
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.asyncio
 async def test_wallet_log_in_changes_active_fingerprint(
     self_hostname: str,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Let's save some test time that isn't doing any useful consensus fork testing.  I'm sure there are more, but this is a useful start.

```
============================ slowest 10 durations =============================
155.50s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.HARD_FORK_2_0-False]
125.81s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.SOFT_FORK3-False]
123.62s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.HARD_FORK_2_0-True]
122.81s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.PLAIN-True]
120.82s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.SOFT_FORK3-True]
117.98s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.PLAIN-False]
116.68s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.SOFT_FORK4-False]
116.36s call     tests/core/data_layer/test_data_rpc.py::test_unsubscribe_removes_files[ConsensusMode.SOFT_FORK4-True]
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
