### PR TITLE
max_coin_amount should default to None in walllet send command

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -170,7 +170,7 @@ def get_transactions_cmd(
     help="Ignore coins worth more then this much XCH or CAT units",
     type=str,
     required=False,
-    default="0",
+    default=None,
 )
 @click.option(
     "--exclude-coin",
@@ -201,7 +201,7 @@ def send_cmd(
     address: str,
     override: bool,
     min_coin_amount: str,
-    max_coin_amount: str,
+    max_coin_amount: Optional[str],
     coins_to_exclude: Sequence[str],
     reuse: bool,
     clawback_time: int,

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -264,7 +264,7 @@ async def send(
     address: str,
     override: bool,
     min_coin_amount: str,
-    max_coin_amount: str,
+    max_coin_amount: Optional[str],
     excluded_coin_ids: Sequence[str],
     reuse_puzhash: Optional[bool],
     clawback_time_lock: int,


### PR DESCRIPTION
Using CLI to send a transaction is failing because max_coin_amount is defaulting to 0. This means `select_coins` produces no spendable coins since it is looking for coins with value between min_amount=0, max_amount=0.

Update the wallet's `send_cmd` to use `Optional[str]` as max_coin_amount's type, so if it is unspecified then we default to None and TXConfig will use the calculated max amount correctly.
