### PR TITLE
remove CHIP-13 and SOFT_FORK4

### DIFF
--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -210,8 +210,6 @@ async def run_add_block_benchmark(version: int) -> None:
                 deficit,
                 deficit == 16,
                 prev_transaction_height,
-                bytes32([0] * 32),
-                bytes32([0] * 32),
                 timestamp if is_transaction else None,
                 prev_transaction_block if prev_transaction_block != bytes32([0] * 32) else None,
                 None if fees == 0 else fees,

--- a/chia/cmds/db_validate_func.py
+++ b/chia/cmds/db_validate_func.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from chia.consensus.block_record import BlockRecord
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.full_node.block_store import BlockRecordDB
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.util.config import load_config
@@ -103,7 +103,7 @@ def validate_v2(in_path: Path, *, validate_blocks: bool) -> None:
 
                 if validate_blocks:
                     block = FullBlock.from_bytes(zstd.decompress(row[4]))
-                    block_record: BlockRecordDB = BlockRecordDB.from_bytes(row[5])
+                    block_record = BlockRecord.from_bytes(row[5])
                     actual_header_hash = block.header_hash
                     actual_prev_hash = block.prev_header_hash
                     if actual_header_hash != hh:

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -19,7 +19,6 @@ from chia.full_node.coin_store import CoinStore
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.proof_of_space import calculate_prefix_bits, get_plot_id, passes_plot_filter
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
 from chia.types.coin_record import CoinRecord
 from chia.types.full_block import FullBlock
@@ -61,40 +60,6 @@ async def validate_block_body(
         assert height == block.height
     prev_transaction_block_height: uint32 = uint32(0)
     prev_transaction_block_timestamp: uint64 = uint64(0)
-
-    # We repeat the ProofOfSpace check from block header validation here, because we want to fetch blocks
-    # from the database too (BlockStore). In `BlockHeaderValidation` we don't have access to the database,
-    # just the cache. This check makes sure we retrieve blocks from the database and perform the check with them,
-    # in case they were missing from the cache.
-    if height >= constants.SOFT_FORK4_HEIGHT:
-        curr_optional_block_record: Optional[BlockRecord] = await blocks.get_block_record_from_db(
-            block.prev_header_hash
-        )
-        plot_id = get_plot_id(block.reward_chain_block.proof_of_space)
-        if block.reward_chain_block.challenge_chain_sp_vdf is None:
-            # Edge case of first sp (start of slot), where sp_iters == 0
-            curr_sp: bytes32 = block.reward_chain_block.pos_ss_cc_challenge_hash
-        else:
-            curr_sp = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
-        sp_count = 1
-
-        while curr_optional_block_record is not None and sp_count < constants.UNIQUE_PLOTS_WINDOW:
-            prefix_bits = calculate_prefix_bits(constants, curr_optional_block_record.height)
-
-            if curr_optional_block_record.cc_sp_hash != curr_sp:
-                if passes_plot_filter(
-                    prefix_bits,
-                    plot_id,
-                    curr_optional_block_record.pos_ss_cc_challenge_hash,
-                    curr_optional_block_record.cc_sp_hash,
-                ):
-                    log.error(f"CHIP-0013 Block Failed at height: {height}")
-                    return Err.CHIP_0013_VALIDATION, None
-
-                sp_count += 1
-                curr_sp = curr_optional_block_record.cc_sp_hash
-            if sp_count < constants.UNIQUE_PLOTS_WINDOW:
-                curr_optional_block_record = await blocks.get_block_record_from_db(curr_optional_block_record.prev_hash)
 
     # 1. For non transaction-blocs: foliage block, transaction filter, transactions info, and generator must
     # be empty. If it is a block but not a transaction block, there is no body to validate. Check that all fields are

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -23,12 +23,7 @@ from chia.consensus.pot_iterations import (
 )
 from chia.consensus.vdf_info_computation import get_signage_point_vdf_info
 from chia.types.blockchain_format.classgroup import ClassgroupElement
-from chia.types.blockchain_format.proof_of_space import (
-    calculate_prefix_bits,
-    get_plot_id,
-    passes_plot_filter,
-    verify_and_get_quality_string,
-)
+from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import ChallengeChainSubSlot, RewardChainSubSlot, SubSlotProofs
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
@@ -495,30 +490,6 @@ def validate_unfinished_header_block(
     )
     if q_str is None:
         return None, ValidationError(Err.INVALID_POSPACE)
-
-    # 5c. Check plot id is not present within last `NUM_DISTINCT_CONSECUTIVE_PLOT_IDS` blocks.
-    if height >= constants.SOFT_FORK4_HEIGHT:
-        curr_optional_block_record: Optional[BlockRecord] = prev_b
-        plot_id = get_plot_id(header_block.reward_chain_block.proof_of_space)
-        curr_sp = cc_sp_hash
-        sp_count = 1
-
-        while curr_optional_block_record is not None and sp_count < constants.UNIQUE_PLOTS_WINDOW:
-            prefix_bits = calculate_prefix_bits(constants, curr_optional_block_record.height)
-
-            if curr_optional_block_record.cc_sp_hash != curr_sp:
-                if passes_plot_filter(
-                    prefix_bits,
-                    plot_id,
-                    curr_optional_block_record.pos_ss_cc_challenge_hash,
-                    curr_optional_block_record.cc_sp_hash,
-                ):
-                    return None, ValidationError(Err.CHIP_0013_VALIDATION, f"CHIP-0013 Block Failed: {height}")
-
-                sp_count += 1
-                curr_sp = curr_optional_block_record.cc_sp_hash
-            if sp_count < constants.UNIQUE_PLOTS_WINDOW:
-                curr_optional_block_record = blocks.try_block_record(curr_optional_block_record.prev_hash)
 
     # 6. check signage point index
     # no need to check negative values as this is uint 8

--- a/chia/consensus/block_record.py
+++ b/chia/consensus/block_record.py
@@ -69,8 +69,6 @@ class BlockRecord(Streamable):
     deficit: uint8  # A deficit of 16 is an overflow block after an infusion. Deficit of 15 is a challenge block
     overflow: bool
     prev_transaction_block_height: uint32
-    pos_ss_cc_challenge_hash: bytes32
-    cc_sp_hash: bytes32
 
     # Transaction block (present iff is_transaction_block)
     timestamp: Optional[uint64]

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -68,9 +68,6 @@ class ConsensusConstants:
     # soft fork initiated in 2.0 release
     SOFT_FORK3_HEIGHT: uint32
 
-    # soft fork initiated in 2.1 release
-    SOFT_FORK4_HEIGHT: uint32
-
     # the hard fork planned with the 2.0 release
     # this is the block with the first plot filter adjustment
     HARD_FORK_HEIGHT: uint32

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -78,9 +78,6 @@ class ConsensusConstants:
     PLOT_FILTER_64_HEIGHT: uint32
     PLOT_FILTER_32_HEIGHT: uint32
 
-    # number of consecutive plot ids required to be distinct
-    UNIQUE_PLOTS_WINDOW: uint8
-
     def replace_str_to_bytes(self, **changes: Any) -> "ConsensusConstants":
         """
         Overrides str (hex) values with bytes.

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -68,6 +68,4 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     PLOT_FILTER_64_HEIGHT=uint32(15592000),
     # June 2033
     PLOT_FILTER_32_HEIGHT=uint32(20643000),
-    # Disallow plots from passing the plot filter for more than one out of any four consecutive signage points.
-    UNIQUE_PLOTS_WINDOW=uint8(4),
 )

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -60,7 +60,6 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     # November 14, 2023
     SOFT_FORK3_HEIGHT=uint32(4510000),
     # June 2024
-    SOFT_FORK4_HEIGHT=uint32(5496000),
     HARD_FORK_HEIGHT=uint32(5496000),
     HARD_FORK_FIX_HEIGHT=uint32(5496000),
     # June 2027

--- a/chia/consensus/full_block_to_block_record.py
+++ b/chia/consensus/full_block_to_block_record.py
@@ -142,12 +142,6 @@ def header_block_to_sub_block_record(
     timestamp = block.foliage_transaction_block.timestamp if block.foliage_transaction_block is not None else None
     fees = block.transactions_info.fees if block.transactions_info is not None else None
 
-    if block.reward_chain_block.challenge_chain_sp_vdf is None:
-        # Edge case of first sp (start of slot), where sp_iters == 0
-        cc_sp_hash: bytes32 = block.reward_chain_block.pos_ss_cc_challenge_hash
-    else:
-        cc_sp_hash = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
-
     return BlockRecord(
         block.header_hash,
         block.prev_header_hash,
@@ -166,8 +160,6 @@ def header_block_to_sub_block_record(
         deficit,
         overflow,
         prev_transaction_block_height,
-        block.reward_chain_block.pos_ss_cc_challenge_hash,
-        cc_sp_hash,
         timestamp,
         prev_transaction_block_hash,
         fees,

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -77,8 +77,6 @@ def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None
         overrides["SOFT_FORK2_HEIGHT"] = 3000000
     if "SOFT_FORK3_HEIGHT" not in overrides:
         overrides["SOFT_FORK3_HEIGHT"] = 2997292
-    if "SOFT_FORK4_HEIGHT" not in overrides:
-        overrides["SOFT_FORK4_HEIGHT"] = 2997292
     if "HARD_FORK_HEIGHT" not in overrides:
         overrides["HARD_FORK_HEIGHT"] = 2997292
     if "HARD_FORK_FIX_HEIGHT" not in overrides:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -154,7 +154,6 @@ test_constants = dataclasses.replace(
     # Allows creating blockchains with timestamps up to 10 days in the future, for testing
     MAX_FUTURE_TIME2=3600 * 24 * 10,
     MEMPOOL_BLOCK_BUFFER=6,
-    UNIQUE_PLOTS_WINDOW=2,
     # we deliberately make this different from HARD_FORK_HEIGHT in the
     # tests, to ensure they operate independently (which they need to do for
     # testnet10)

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -73,7 +73,6 @@ network_overrides: &network_overrides
       MIN_PLOT_SIZE: 18
       SOFT_FORK2_HEIGHT: 3000000
       SOFT_FORK3_HEIGHT: 2997292
-      SOFT_FORK4_HEIGHT: 2997292
       # planned 2.0 release is July 26, height 2965036 on testnet
       # 1 week later
       HARD_FORK_HEIGHT: 2997292

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -53,7 +53,6 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
 from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block,
     _validate_and_add_block_multi_error,
-    _validate_and_add_block_multi_error_or_pass,
     _validate_and_add_block_multi_result,
     _validate_and_add_block_no_error,
 )
@@ -1367,14 +1366,6 @@ class TestBlockHeaderValidation:
                 return None
             attempts += 1
 
-    @pytest.mark.limit_consensus_modes(
-        allowed=[
-            ConsensusMode.PLAIN,
-            ConsensusMode.HARD_FORK_2_0,
-            ConsensusMode.SOFT_FORK3,
-        ],
-        reason="Skipped ConsensusMode.SOFT_FORK4 temporarily until adding more pool plots.",
-    )
     @pytest.mark.asyncio
     async def test_pool_target_contract(self, empty_blockchain, bt):
         # 20c invalid pool target with contract
@@ -3612,66 +3603,3 @@ async def test_reorg_flip_flop(empty_blockchain, bt):
 
     for block in chain_b[40:]:
         await _validate_and_add_block(b, block)
-
-
-@pytest.mark.parametrize("unique_plots_window", [1, 2])
-@pytest.mark.parametrize("bt_respects_soft_fork4", [True, False])
-@pytest.mark.parametrize("soft_fork4_height", [0, 10, 10000])
-@pytest.mark.limit_consensus_modes
-@pytest.mark.asyncio
-async def test_soft_fork4_activation(
-    blockchain_constants, bt_respects_soft_fork4, soft_fork4_height, db_version, unique_plots_window
-):
-    # We don't run ConsensusMode.SOFT_FORK4, since this is already parametrized by this test.
-    # Additionally, ConsensusMode.HARD_FORK_2_0 mode is incopatible with this test, since
-    # plot filter size would be zero, blocks won't ever be produced (we'll pass every
-    # consecutive plot filter, hence no block would pass CHIP-13).
-    with TempKeyring() as keychain:
-        bt = await create_block_tools_async(
-            constants=dataclasses.replace(
-                blockchain_constants,
-                SOFT_FORK4_HEIGHT=(0 if bt_respects_soft_fork4 else 10000),
-                UNIQUE_PLOTS_WINDOW=unique_plots_window,
-            ),
-            keychain=keychain,
-        )
-        blockchain_constants = dataclasses.replace(
-            bt.constants,
-            SOFT_FORK3_HEIGHT=0,
-            SOFT_FORK4_HEIGHT=soft_fork4_height,
-        )
-        b, db_wrapper, db_path = await create_blockchain(blockchain_constants, db_version)
-        blocks = bt.get_consecutive_blocks(25)
-        for height, block in enumerate(blocks):
-            await _validate_and_add_block_multi_error_or_pass(b, block, [Err.CHIP_0013_VALIDATION])
-            peak = b.get_peak()
-            assert peak is not None
-            if peak.height != height:
-                break
-
-        peak = b.get_peak()
-        assert peak is not None
-
-        # We expect to add all blocks here (25 blocks), either because `unique_plots_window`=1 means we're not
-        # checking any extra plot filter, or `unique_plots_window`=True means `BlockTools` produced blocks
-        # that respect CHIP-13.
-        if bt_respects_soft_fork4 or unique_plots_window == 1:
-            assert peak.height == 24
-        else:
-            # Here we have `bt_respects_soft_fork4`=False, which means the produced blocks by `BlockTools` will not
-            # respect the CHIP-13 condition. We expect not adding blocks at some point after the soft fork 3
-            # activation height (`soft_fork4_height`).
-            if soft_fork4_height == 0:
-                # We're not adding all blocks, since at some point `BlockTools` will break the CHIP-13 condition with
-                # very high likelyhood.
-                assert peak.height < 24
-            elif soft_fork4_height == 10:
-                # We're not adding all blocks, but we've added all of them until the soft fork 3 activated (height 10)
-                assert peak.height < 24 and peak.height >= 9
-            else:
-                # Soft fork 3 will activate in the future (height 100), so we're adding all blocks.
-                assert peak.height == 24
-
-        await db_wrapper.close()
-        b.shut_down()
-        db_path.unlink()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,12 +104,11 @@ class ConsensusMode(Enum):
     PLAIN = 0
     HARD_FORK_2_0 = 1
     SOFT_FORK3 = 2
-    SOFT_FORK4 = 3
 
 
 @pytest.fixture(
     scope="session",
-    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3, ConsensusMode.SOFT_FORK4],
+    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
 )
 def consensus_mode(request):
     return request.param
@@ -121,8 +120,6 @@ def blockchain_constants(consensus_mode) -> ConsensusConstants:
         return test_constants
     if consensus_mode == ConsensusMode.SOFT_FORK3:
         return dataclasses.replace(test_constants, SOFT_FORK3_HEIGHT=3)
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        return dataclasses.replace(test_constants, SOFT_FORK3_HEIGHT=3, SOFT_FORK4_HEIGHT=3)
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         return dataclasses.replace(
             test_constants,
@@ -197,8 +194,6 @@ saved_blocks_version = "rc5"
 @pytest.fixture(scope="session")
 def default_400_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        version = "_softfork3"
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
@@ -210,8 +205,6 @@ def default_400_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def default_1000_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        version = "_softfork3"
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
@@ -223,8 +216,6 @@ def default_1000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def pre_genesis_empty_slots_1000_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        version = "_softfork3"
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
@@ -242,8 +233,6 @@ def pre_genesis_empty_slots_1000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def default_1500_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        version = "_softfork3"
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
@@ -256,9 +245,6 @@ def default_1500_blocks(bt, consensus_mode):
 def default_10000_blocks(bt, consensus_mode):
     from tests.util.blockchain import persistent_blocks
 
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        pytest.skip("Test cache not available yet")
-
     version = ""
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
@@ -269,8 +255,6 @@ def default_10000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
     version = ""
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        version = "_softfork3"
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
@@ -289,8 +273,6 @@ def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
 @pytest.fixture(scope="session")
 def default_2000_blocks_compact(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        version = "_softfork3"
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
@@ -311,9 +293,6 @@ def default_2000_blocks_compact(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def default_10000_blocks_compact(bt, consensus_mode):
     from tests.util.blockchain import persistent_blocks
-
-    if consensus_mode == ConsensusMode.SOFT_FORK4:
-        pytest.skip("Test cache not available yet")
 
     version = ""
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
@@ -415,20 +394,7 @@ async def five_nodes(db_version: int, self_hostname, blockchain_constants):
         yield _
 
 
-@pytest_asyncio.fixture(
-    scope="function",
-    # Since the constants are identical for `ConsensusMode.PLAIN` and
-    # `ConsensusMode.HARD_FORK_2_0`, we will only run in mode `PLAIN` and `SOFT_FORK4`.
-    params=[
-        pytest.param(
-            None,
-            marks=pytest.mark.limit_consensus_modes(
-                allowed=[ConsensusMode.PLAIN, ConsensusMode.SOFT_FORK4],
-                reason="the same setup is ran by ConsensusMode.PLAIN",
-            ),
-        )
-    ],
-)
+@pytest_asyncio.fixture(scope="function")
 async def wallet_nodes(blockchain_constants, consensus_mode):
     constants = blockchain_constants
     async with setup_simulators_and_wallets(
@@ -451,20 +417,7 @@ async def setup_four_nodes(db_version, blockchain_constants: ConsensusConstants)
         yield _
 
 
-@pytest_asyncio.fixture(
-    scope="function",
-    # Since the constants are identical for `ConsensusMode.PLAIN` and
-    # `ConsensusMode.HARD_FORK_2_0`, we will only run in mode `PLAIN` and `SOFT_FORK4`.
-    params=[
-        pytest.param(
-            None,
-            marks=pytest.mark.limit_consensus_modes(
-                allowed=[ConsensusMode.PLAIN, ConsensusMode.SOFT_FORK4],
-                reason="the same setup is ran by ConsensusMode.PLAIN",
-            ),
-        )
-    ],
-)
+@pytest_asyncio.fixture(scope="function")
 async def two_nodes_sim_and_wallets_services(blockchain_constants, consensus_mode):
     async with setup_simulators_and_wallets_service(2, 0, blockchain_constants) as _:
         yield _

--- a/tests/core/full_node/full_sync/test_full_sync.py
+++ b/tests/core/full_node/full_sync/test_full_sync.py
@@ -417,6 +417,7 @@ class TestFullSync:
         assert duration > 5
 
     @pytest.mark.limit_consensus_modes(reason="save time")
+    @pytest.mark.skip("This feature depends on (now removed) CHIP-13")
     @pytest.mark.asyncio
     async def test_bad_peak_in_cache(
         self, two_nodes, default_400_blocks, blockchain_constants, self_hostname, consensus_mode
@@ -443,6 +444,7 @@ class TestFullSync:
         assert full_node_1.full_node.in_bad_peak_cache(wp) is True
 
     @pytest.mark.limit_consensus_modes(reason="save time")
+    @pytest.mark.skip("This feature depends on (now removed) CHIP-13")
     @pytest.mark.asyncio
     async def test_skip_bad_peak_validation(
         self, two_nodes, default_400_blocks, blockchain_constants, self_hostname, consensus_mode

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -947,8 +947,8 @@ class TestFullNodeProtocol:
                 if force_high_fee:
                     successful_bundle = spend_bundle
             else:
-                assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(5000000 * group_size)
-                assert full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(5000000 * group_size) > 0
+                assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(10500000 * group_size)
+                assert full_node_1.full_node.mempool_manager.mempool.get_min_fee_rate(10500000 * group_size) > 0
                 assert not force_high_fee
                 not_included_tx += 1
         assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(10000000 * group_size)

--- a/tests/pools/test_pool_rpc.py
+++ b/tests/pools/test_pool_rpc.py
@@ -39,7 +39,6 @@ from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_node_api import WalletNodeAPI
-from tests.conftest import ConsensusMode
 
 # TODO: Compare deducted fees in all tests against reported total_fee
 
@@ -406,10 +405,6 @@ class TestPoolWalletRpc:
                             assert owner_sk is not None
                             assert owner_sk[0] != auth_sk
 
-    @pytest.mark.limit_consensus_modes(
-        allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
-        reason="the pooling test only creates one plot, and cannot pass CHIP-13 rules",
-    )
     @pytest.mark.asyncio
     async def test_absorb_self(
         self, one_wallet_node_and_rpc: OneWalletNodeAndRpc, fee: uint64, self_hostname: str
@@ -488,10 +483,6 @@ class TestPoolWalletRpc:
             tx1 = await client.get_transactions(1)
             assert (250_000_000_000 + fee) in [tx.amount for tx in tx1]
 
-    @pytest.mark.limit_consensus_modes(
-        allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
-        reason="the pooling test only creates one plot, and cannot pass CHIP-13 rules",
-    )
     @pytest.mark.asyncio
     async def test_absorb_self_multiple_coins(
         self, one_wallet_node_and_rpc: OneWalletNodeAndRpc, fee: uint64, self_hostname: str
@@ -561,10 +552,6 @@ class TestPoolWalletRpc:
             assert pool_bal["confirmed_wallet_balance"] == pool_expected_confirmed_balance
             assert main_bal["confirmed_wallet_balance"] == main_expected_confirmed_balance  # 10499999999999
 
-    @pytest.mark.limit_consensus_modes(
-        allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
-        reason="the pooling test only creates one plot, and cannot pass CHIP-13 rules",
-    )
     @pytest.mark.asyncio
     async def test_absorb_pooling(
         self, one_wallet_node_and_rpc: OneWalletNodeAndRpc, fee: uint64, self_hostname: str

--- a/tests/util/test_full_block_utils.py
+++ b/tests/util/test_full_block_utils.py
@@ -23,12 +23,7 @@ from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock
-from chia.util.full_block_utils import (
-    block_info_from_block,
-    generator_from_block,
-    header_block_from_block,
-    plot_filter_info_from_block,
-)
+from chia.util.full_block_utils import block_info_from_block, generator_from_block, header_block_from_block
 from chia.util.generator_tools import get_block_header
 from chia.util.ints import uint8, uint32, uint64, uint128
 
@@ -263,13 +258,6 @@ async def test_parser():
         assert block.transactions_generator == bi.transactions_generator
         assert block.prev_header_hash == bi.prev_header_hash
         assert block.transactions_generator_ref_list == bi.transactions_generator_ref_list
-        pfi = plot_filter_info_from_block(block_bytes)
-        assert pfi.pos_ss_cc_challenge_hash == block.reward_chain_block.pos_ss_cc_challenge_hash
-        if block.reward_chain_block.challenge_chain_sp_vdf is None:
-            expected_cc_sp_hash: bytes32 = block.reward_chain_block.pos_ss_cc_challenge_hash
-        else:
-            expected_cc_sp_hash = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
-        assert pfi.cc_sp_hash == expected_cc_sp_hash
         # this doubles the run-time of this test, with questionable utility
         # assert gen == FullBlock.from_bytes(block_bytes).transactions_generator
 

--- a/tests/util/test_testnet_overrides.py
+++ b/tests/util/test_testnet_overrides.py
@@ -11,7 +11,6 @@ def test_testnet10() -> None:
     assert overrides == {
         "SOFT_FORK2_HEIGHT": 3000000,
         "SOFT_FORK3_HEIGHT": 2997292,
-        "SOFT_FORK4_HEIGHT": 2997292,
         "HARD_FORK_HEIGHT": 2997292,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 3061804,
@@ -23,7 +22,6 @@ def test_testnet10() -> None:
 def test_testnet10_existing() -> None:
     overrides: Dict[str, Any] = {
         "SOFT_FORK3_HEIGHT": 42,
-        "SOFT_FORK4_HEIGHT": 45,
         "HARD_FORK_HEIGHT": 42,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 42,
@@ -34,7 +32,6 @@ def test_testnet10_existing() -> None:
     assert overrides == {
         "SOFT_FORK2_HEIGHT": 3000000,
         "SOFT_FORK3_HEIGHT": 42,
-        "SOFT_FORK4_HEIGHT": 45,
         "HARD_FORK_HEIGHT": 42,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 42,


### PR DESCRIPTION
The existing implementation of CHIP-13 only looks at signage points in winning blocks, if we want a correct CHIP-13 implementation, we need to look at the complete sequence of signage points, including ones that have no winning proof of space

CHIP-13 that only looks at signage points that has made it into blocks is problematic, since withholding a block or not affect consensus for future blocks.

If we decide to land this, testnet10 will need to be considered. Soft-fork4 already activated in testnet10, but most space appear to be on a fork that has not activated chip-13, so we could probably just move back to that chain.