### PR TITLE
ban peers for 10 minutes when violating consensus rules

### DIFF
--- a/chia/protocols/protocol_timing.py
+++ b/chia/protocols/protocol_timing.py
@@ -4,3 +4,4 @@ from __future__ import annotations
 INVALID_PROTOCOL_BAN_SECONDS = 10
 API_EXCEPTION_BAN_SECONDS = 10
 INTERNAL_PROTOCOL_ERROR_BAN_SECONDS = 10  # Don't flap if our client is at fault
+CONSENSUS_ERROR_BAN_SECONDS = 600

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -18,7 +18,11 @@ from typing_extensions import Protocol, final
 from chia.cmds.init_funcs import chia_full_version_str
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.protocol_state_machine import message_response_ok
-from chia.protocols.protocol_timing import API_EXCEPTION_BAN_SECONDS, INTERNAL_PROTOCOL_ERROR_BAN_SECONDS
+from chia.protocols.protocol_timing import (
+    API_EXCEPTION_BAN_SECONDS,
+    CONSENSUS_ERROR_BAN_SECONDS,
+    INTERNAL_PROTOCOL_ERROR_BAN_SECONDS,
+)
 from chia.protocols.shared_protocol import Capability, Error, Handshake
 from chia.server.api_protocol import ApiProtocol
 from chia.server.capabilities import known_active_capabilities
@@ -27,7 +31,7 @@ from chia.server.rate_limits import RateLimiter
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
 from chia.util.api_decorators import get_metadata
-from chia.util.errors import ApiError, Err, ProtocolError, TimestampError
+from chia.util.errors import ApiError, ConsensusError, Err, ProtocolError, TimestampError
 from chia.util.ints import int16, uint8, uint16
 from chia.util.log_exceptions import log_exceptions
 
@@ -446,8 +450,12 @@ class WSChiaConnection:
                 self.log.error(f"Exception: {e} {type(e)}, closing connection {self.get_peer_logging()}. {tb}")
             else:
                 self.log.debug(f"Exception: {e} while closing connection")
+            if isinstance(e, ConsensusError):
+                ban_time = CONSENSUS_ERROR_BAN_SECONDS
+            else:
+                ban_time = API_EXCEPTION_BAN_SECONDS
             # TODO: actually throw one of the errors from errors.py and pass this to close
-            await self.close(API_EXCEPTION_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
+            await self.close(ban_time, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
         finally:
             if task_id in self.api_tasks:
                 self.api_tasks.pop(task_id)


### PR DESCRIPTION
### Purpose:

Avoid peers that may be on a separate fork stronger, than other protocol errors.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

A peer violating consensus rules is banned for 10 seconds.

### New Behavior:

A peer violating consensus rules is banned for 10 minutes.