### PR TITLE
Remove tx_endpoint from select_coins

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -81,7 +81,7 @@ from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.query_filter import HashFilter, TransactionTypeFilter
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
-from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, CoinSelectionConfig, CoinSelectionConfigLoader, TXConfig
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import CoinType, WalletType
 from chia.wallet.vc_wallet.cr_cat_drivers import ProofsChecker
@@ -1155,13 +1155,25 @@ class WalletRpcApi:
                 wallet.target_state = None
             return {}
 
-    @tx_endpoint
     async def select_coins(
         self,
         request: Dict[str, Any],
-        tx_config: TXConfig = DEFAULT_TX_CONFIG,
-        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> EndpointResult:
+        assert self.service.logged_in_fingerprint is not None
+        cs_config_loader: CoinSelectionConfigLoader = CoinSelectionConfigLoader.from_json_dict(request)
+
+        # Some backwards compat fill-ins
+        if cs_config_loader.excluded_coin_ids is None:
+            excluded_coins: Optional[List[Coin]] = request.get("excluded_coins")
+            if excluded_coins is not None:
+                cs_config_loader = cs_config_loader.override(
+                    excluded_coin_ids=[Coin.from_json_dict(c).name() for c in excluded_coins],
+                )
+
+        cs_config: CoinSelectionConfig = cs_config_loader.autofill(
+            constants=self.service.wallet_state_manager.constants,
+        )
+
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before selecting coins")
 
@@ -1170,7 +1182,7 @@ class WalletRpcApi:
 
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
         async with self.service.wallet_state_manager.lock:
-            selected_coins = await wallet.select_coins(amount, tx_config.coin_selection_config)
+            selected_coins = await wallet.select_coins(amount, cs_config)
 
         return {"coins": [coin.to_json_dict() for coin in selected_coins]}
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1164,7 +1164,7 @@ class WalletRpcApi:
 
         # Some backwards compat fill-ins
         if cs_config_loader.excluded_coin_ids is None:
-            excluded_coins: Optional[List[Coin]] = request.get("excluded_coins")
+            excluded_coins: Optional[List[Coin]] = request.get("excluded_coins", request.get("exclude_coins"))
             if excluded_coins is not None:
                 cs_config_loader = cs_config_loader.override(
                     excluded_coin_ids=[Coin.from_json_dict(c).name() for c in excluded_coins],


### PR DESCRIPTION
This decorator doesn't really make sense for this RPC, it only needs the `CoinSelectionArgs`.