### PR TITLE
Better timestamps on simulated chains

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: [ 3.9 ]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.32.0
+      BLOCKS_AND_PLOTS_VERSION: 0.33.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -113,7 +113,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.name }}
-      BLOCKS_AND_PLOTS_VERSION: 0.32.0
+      BLOCKS_AND_PLOTS_VERSION: 0.33.0
 
     steps:
       - name: Configure git

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -793,6 +793,9 @@ class BlockTools:
                             assert full_block.foliage_transaction_block is not None
                         elif guarantee_transaction_block:
                             continue
+                        # print(f"{full_block.height}: difficulty {difficulty} "
+                        #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
@@ -1081,6 +1084,9 @@ class BlockTools:
                             assert full_block.foliage_transaction_block is not None
                         elif guarantee_transaction_block:
                             continue
+                        # print(f"{full_block.height}: difficulty {difficulty} "
+                        #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
 
                         block_list.append(full_block)

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1706,6 +1706,11 @@ def get_full_block_and_block_record(
     current_time: bool = False,
     block_time_residual: float = 0.0,
 ) -> Tuple[FullBlock, BlockRecord, float, uint64]:
+    # we're simulating time between blocks here. The more VDF iterations the
+    # blocks advances, the longer it should have taken (and vice versa). This
+    # formula is meant to converge at 1024 iters per the specified
+    # time_per_block (which defaults to 18.75 seconds)
+    time_per_block *= (((sub_slot_iters / 1024) - 1) * 0.2) + 1
     time_delta, block_time_residual = round_timestamp(time_per_block, block_time_residual)
     if current_time is True:
         timestamp = uint64(max(int(time.time()), last_timestamp + time_delta))

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -757,7 +757,12 @@ class BlockTools:
                         if not use_timestamp_residual:
                             self._block_time_residual = 0.0
 
-                        full_block, block_record, self._block_time_residual = get_full_block_and_block_record(
+                        (
+                            full_block,
+                            block_record,
+                            self._block_time_residual,
+                            new_timestamp,
+                        ) = get_full_block_and_block_record(
                             constants,
                             blocks,
                             sub_slot_start_total_iters,
@@ -793,10 +798,9 @@ class BlockTools:
                             previous_generator = None
                             keep_going_until_tx_block = False
                             assert full_block.foliage_transaction_block is not None
-                            last_timestamp = full_block.foliage_transaction_block.timestamp
-                        else:
-                            if guarantee_transaction_block:
-                                continue
+                        elif guarantee_transaction_block:
+                            continue
+                        last_timestamp = new_timestamp
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
                             compressor_arg = detect_potential_template_generator(
@@ -1043,7 +1047,12 @@ class BlockTools:
                         if not use_timestamp_residual:
                             self._block_time_residual = 0.0
 
-                        full_block, block_record, self._block_time_residual = get_full_block_and_block_record(
+                        (
+                            full_block,
+                            block_record,
+                            self._block_time_residual,
+                            new_timestamp,
+                        ) = get_full_block_and_block_record(
                             constants,
                             blocks,
                             sub_slot_start_total_iters,
@@ -1082,9 +1091,9 @@ class BlockTools:
                             previous_generator = None
                             keep_going_until_tx_block = False
                             assert full_block.foliage_transaction_block is not None
-                            last_timestamp = full_block.foliage_transaction_block.timestamp
                         elif guarantee_transaction_block:
                             continue
+                        last_timestamp = new_timestamp
 
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
@@ -1696,7 +1705,7 @@ def get_full_block_and_block_record(
     normalized_to_identity_cc_ip: bool = False,
     current_time: bool = False,
     block_time_residual: float = 0.0,
-) -> Tuple[FullBlock, BlockRecord, float]:
+) -> Tuple[FullBlock, BlockRecord, float, uint64]:
     time_delta, block_time_residual = round_timestamp(time_per_block, block_time_residual)
     if current_time is True:
         timestamp = uint64(max(int(time.time()), last_timestamp + time_delta))
@@ -1752,7 +1761,7 @@ def get_full_block_and_block_record(
         normalized_to_identity_cc_ip,
     )
 
-    return full_block, block_record, block_time_residual
+    return full_block, block_record, block_time_residual, timestamp
 
 
 # these are the costs of unknown conditions, as defined chia_rs here:

--- a/tests/farmer_harvester/test_filter_prefix_bits.py
+++ b/tests/farmer_harvester/test_filter_prefix_bits.py
@@ -32,7 +32,7 @@ from tests.core.test_farmer_harvester_rpc import wait_for_plot_sync
 # this test
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN])
 @pytest.mark.parametrize(
-    argnames=["filter_prefix_bits", "should_pass"], argvalues=[(9, 33), (8, 66), (7, 138), (6, 265), (5, 607)]
+    argnames=["filter_prefix_bits", "should_pass"], argvalues=[(9, 34), (8, 89), (7, 162), (6, 295), (5, 579)]
 )
 def test_filter_prefix_bits_on_blocks(
     default_10000_blocks: List[FullBlock], filter_prefix_bits: uint8, should_pass: int

--- a/tools/generate_chain.py
+++ b/tools/generate_chain.py
@@ -105,7 +105,6 @@ def main(length: int, fill_rate: int, profile: bool, block_refs: bool, output: O
                 pool_reward_puzzle_hash=pool_puzzlehash,
                 keep_going_until_tx_block=True,
                 genesis_timestamp=uint64(1234567890),
-                use_timestamp_residual=True,
             )
 
             unspent_coins: List[Coin] = []
@@ -164,7 +163,6 @@ def main(length: int, fill_rate: int, profile: bool, block_refs: bool, output: O
                         keep_going_until_tx_block=True,
                         transaction_data=SpendBundle.aggregate(spend_bundles),
                         previous_generator=block_references,
-                        use_timestamp_residual=True,
                     )
                     prev_tx_block = b
                     prev_block = blocks[-2]


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

### Purpose:

This updates the `BlockTools` logic to generate more authentic simulated chains, and also lets us generate the long chains faster.

The highlights are:

* The (simulated) timestamps on blocks are proportional to the number of iterations between the blocks
* The logic to support tracking of sub-second simulated time is simplified to just use `float`, instead of integer seconds + residual

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The timestamp between two transaction blocks is always 18 seconds, regardless of there being non-tx blocks in between
The timestamp between blocks is irrespective of the number of actual VDF iterations between the blocks. This effectively simulates a timelord that speeds up over time, making it increasingly expensive to generate the chain.

### New Behavior:

The timestamp between two transaction blocks is (by default) 18.75 seconds for each block (including non-TX blocks). This time delta is scaled by the number of iterations.
The simulated chain does not simulate a timelord that speeds up over time. The cost of generating the chain is linear to the number of blocks.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I generated the chains, including the 10000 block one with the debug output to verify.