### PR TITLE
Extend sign APIs for customized puzzle

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -28,7 +28,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
-from chia.types.signing_mode import SigningMode
+from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
@@ -88,7 +88,7 @@ from chia.wallet.vc_wallet.cr_cat_drivers import ProofsChecker
 from chia.wallet.vc_wallet.cr_cat_wallet import CRCATWallet
 from chia.wallet.vc_wallet.vc_store import VCProofs
 from chia.wallet.vc_wallet.vc_wallet import VCWallet
-from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
+from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_coin_store import CoinRecordOrder, GetCoinRecords, unspent_range
 from chia.wallet.wallet_info import WalletInfo
@@ -1447,17 +1447,27 @@ class WalletRpcApi:
         :return:
         """
         puzzle_hash: bytes32 = decode_puzzle_hash(request["address"])
-        is_hex = request.get("is_hex", False)
+        is_hex: bool = request.get("is_hex", False)
         if isinstance(is_hex, str):
-            is_hex = bool(is_hex)
+            is_hex = True if is_hex.lower() == "true" else False
+        safe_mode: bool = request.get("safe_mode", True)
+        if isinstance(safe_mode, str):
+            safe_mode = True if safe_mode.lower() == "true" else False
+        mode: SigningMode = SigningMode.CHIP_0002
+        if is_hex and safe_mode:
+            mode = SigningMode.CHIP_0002_HEX_INPUT
+        elif not is_hex and not safe_mode:
+            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT
+        elif is_hex and not safe_mode:
+            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT
         pubkey, signature = await self.service.wallet_state_manager.main_wallet.sign_message(
-            request["message"], puzzle_hash, is_hex
+            request["message"], puzzle_hash, mode
         )
         return {
             "success": True,
             "pubkey": str(pubkey),
             "signature": str(signature),
-            "signing_mode": SigningMode.CHIP_0002.value,
+            "signing_mode": mode.value,
         }
 
     async def sign_message_by_id(self, request: Dict[str, Any]) -> EndpointResult:
@@ -1468,9 +1478,19 @@ class WalletRpcApi:
         """
         entity_id: bytes32 = decode_puzzle_hash(request["id"])
         selected_wallet: Optional[WalletProtocol[Any]] = None
-        is_hex = request.get("is_hex", False)
+        is_hex: bool = request.get("is_hex", False)
         if isinstance(is_hex, str):
-            is_hex = bool(is_hex)
+            is_hex = True if is_hex.lower() == "true" else False
+        safe_mode: bool = request.get("safe_mode", True)
+        if isinstance(safe_mode, str):
+            safe_mode = True if safe_mode.lower() == "true" else False
+        mode: SigningMode = SigningMode.CHIP_0002
+        if is_hex and safe_mode:
+            mode = SigningMode.CHIP_0002_HEX_INPUT
+        elif not is_hex and not safe_mode:
+            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT
+        elif is_hex and not safe_mode:
+            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT
         if is_valid_address(request["id"], {AddressType.DID}, self.service.config):
             for wallet in self.service.wallet_state_manager.wallets.values():
                 if wallet.type() == WalletType.DECENTRALIZED_ID.value:
@@ -1482,7 +1502,7 @@ class WalletRpcApi:
             if selected_wallet is None:
                 return {"success": False, "error": f"DID for {entity_id.hex()} doesn't exist."}
             assert isinstance(selected_wallet, DIDWallet)
-            pubkey, signature = await selected_wallet.sign_message(request["message"], is_hex)
+            pubkey, signature = await selected_wallet.sign_message(request["message"], mode)
             latest_coin_id = (await selected_wallet.get_coin()).name()
         elif is_valid_address(request["id"], {AddressType.NFT}, self.service.config):
             target_nft: Optional[NFTCoinInfo] = None
@@ -1498,7 +1518,7 @@ class WalletRpcApi:
                 return {"success": False, "error": f"NFT for {entity_id.hex()} doesn't exist."}
 
             assert isinstance(selected_wallet, NFTWallet)
-            pubkey, signature = await selected_wallet.sign_message(request["message"], target_nft, is_hex)
+            pubkey, signature = await selected_wallet.sign_message(request["message"], target_nft, mode)
             latest_coin_id = target_nft.coin.name()
         else:
             return {"success": False, "error": f'Unknown ID type, {request["id"]}'}
@@ -1508,7 +1528,7 @@ class WalletRpcApi:
             "pubkey": str(pubkey),
             "signature": str(signature),
             "latest_coin_id": latest_coin_id.hex() if latest_coin_id is not None else None,
-            "signing_mode": SigningMode.CHIP_0002.value,
+            "signing_mode": mode.value,
         }
 
     ##########################################################################################

--- a/chia/types/signing_mode.py
+++ b/chia/types/signing_mode.py
@@ -11,9 +11,16 @@ class SigningMode(Enum):
     # BLS message augmentation scheme
     CHIP_0002 = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:CHIP-0002_"
 
+    # Same as above but with the message specified as a string of hex characters
+    CHIP_0002_HEX_INPUT = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:CHIP-0002_HEX"
+
     # Standard BLS signatures used by Chia use the BLS message augmentation scheme
     # https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-sign
     BLS_MESSAGE_AUGMENTATION_UTF8_INPUT = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:utf8input_"
 
     # Same as above but with the message specified as a string of hex characters
     BLS_MESSAGE_AUGMENTATION_HEX_INPUT = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG:hexinput_"
+
+
+# https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md#signmessage
+CHIP_0002_SIGN_MESSAGE_PREFIX = "Chia Signed Message"

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -17,6 +17,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
+from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.ints import uint32, uint64, uint128
@@ -46,7 +47,7 @@ from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import WalletType
-from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
+from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_protocol import WalletProtocol
@@ -1151,7 +1152,7 @@ class DIDWallet:
 
         return parent_info
 
-    async def sign_message(self, message: str, is_hex: bool = False) -> Tuple[G1Element, G2Element]:
+    async def sign_message(self, message: str, mode: SigningMode) -> Tuple[G1Element, G2Element]:
         if self.did_info.current_inner is None:
             raise ValueError("Missing DID inner puzzle.")
         puzzle_args = did_wallet_puzzles.uncurry_innerpuz(self.did_info.current_inner)
@@ -1161,11 +1162,17 @@ class DIDWallet:
             private = await self.wallet_state_manager.get_private_key(puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
             synthetic_pk = synthetic_secret_key.get_g1()
-            if is_hex:
-                puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message)))
+            if mode == SigningMode.CHIP_0002_HEX_INPUT:
+                hex_message: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message))).get_tree_hash()
+            elif mode == SigningMode.CHIP_0002:
+                hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
+            elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
+                hex_message = bytes(message, "utf-8")
+            elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
+                hex_message = bytes.fromhex(message)
             else:
-                puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
-            return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, puzzle.get_tree_hash())
+                raise ValueError(f"Invalid sign mode {mode.value}.")
+            return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, hex_message)
         else:
             raise ValueError("Invalid inner DID puzzle.")
 

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1164,14 +1164,12 @@ class DIDWallet:
             synthetic_pk = synthetic_secret_key.get_g1()
             if mode == SigningMode.CHIP_0002_HEX_INPUT:
                 hex_message: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message))).get_tree_hash()
-            elif mode == SigningMode.CHIP_0002:
-                hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
             elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
                 hex_message = bytes(message, "utf-8")
             elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
                 hex_message = bytes.fromhex(message)
             else:
-                raise ValueError(f"Invalid sign mode {mode.value}.")
+                hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
             return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, hex_message)
         else:
             raise ValueError("Invalid inner DID puzzle.")

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -19,6 +19,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
+from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.hash import std_hash
@@ -47,7 +48,7 @@ from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_types import WalletType
-from chia.wallet.wallet import CHIP_0002_SIGN_MESSAGE_PREFIX, Wallet
+from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_nft_store import WalletNftStore
@@ -544,7 +545,7 @@ class NFTWallet:
         else:
             return puzzle_info
 
-    async def sign_message(self, message: str, nft: NFTCoinInfo, is_hex: bool = False) -> Tuple[G1Element, G2Element]:
+    async def sign_message(self, message: str, nft: NFTCoinInfo, mode: SigningMode) -> Tuple[G1Element, G2Element]:
         uncurried_nft = UncurriedNFT.uncurry(*nft.full_puzzle.uncurry())
         if uncurried_nft is not None:
             p2_puzzle = uncurried_nft.p2_puzzle
@@ -552,11 +553,17 @@ class NFTWallet:
             private = await self.wallet_state_manager.get_private_key(puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
             synthetic_pk = synthetic_secret_key.get_g1()
-            if is_hex:
-                puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message)))
+            if mode == SigningMode.CHIP_0002_HEX_INPUT:
+                hex_message: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message))).get_tree_hash()
+            elif mode == SigningMode.CHIP_0002:
+                hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
+            elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
+                hex_message = bytes(message, "utf-8")
+            elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
+                hex_message = bytes.fromhex(message)
             else:
-                puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
-            return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, puzzle.get_tree_hash())
+                raise ValueError(f"Invalid sign mode {mode.value}.")
+            return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, hex_message)
         else:
             raise ValueError("Invalid NFT puzzle.")
 

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -555,14 +555,12 @@ class NFTWallet:
             synthetic_pk = synthetic_secret_key.get_g1()
             if mode == SigningMode.CHIP_0002_HEX_INPUT:
                 hex_message: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message))).get_tree_hash()
-            elif mode == SigningMode.CHIP_0002:
-                hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
             elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
                 hex_message = bytes(message, "utf-8")
             elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
                 hex_message = bytes.fromhex(message)
             else:
-                raise ValueError(f"Invalid sign mode {mode.value}.")
+                hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
             return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, hex_message)
         else:
             raise ValueError("Invalid NFT puzzle.")

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -410,14 +410,12 @@ class Wallet:
         synthetic_pk = synthetic_secret_key.get_g1()
         if mode == SigningMode.CHIP_0002_HEX_INPUT:
             hex_message: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message))).get_tree_hash()
-        elif mode == SigningMode.CHIP_0002:
-            hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
         elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
             hex_message = bytes(message, "utf-8")
         elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
             hex_message = bytes.fromhex(message)
         else:
-            raise ValueError(f"Invalid sign mode {mode.value}.")
+            hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
         return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, hex_message)
 
     async def generate_signed_transaction(

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -13,6 +13,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
+from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
@@ -50,9 +51,6 @@ from chia.wallet.wallet_protocol import GSTOptionalArgs, WalletProtocol
 if TYPE_CHECKING:
     from chia.server.ws_connection import WSChiaConnection
     from chia.wallet.wallet_state_manager import WalletStateManager
-
-# https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md#signmessage
-CHIP_0002_SIGN_MESSAGE_PREFIX = "Chia Signed Message"
 
 
 class Wallet:
@@ -404,19 +402,23 @@ class Wallet:
         self.log.debug(f"Spends is {spends}")
         return spends
 
-    async def sign_message(
-        self, message: str, puzzle_hash: bytes32, is_hex: bool = False
-    ) -> Tuple[G1Element, G2Element]:
+    async def sign_message(self, message: str, puzzle_hash: bytes32, mode: SigningMode) -> Tuple[G1Element, G2Element]:
         # CHIP-0002 message signing as documented at:
         # https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md#signmessage
         private = await self.wallet_state_manager.get_private_key(puzzle_hash)
         synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
         synthetic_pk = synthetic_secret_key.get_g1()
-        if is_hex:
-            puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message)))
+        if mode == SigningMode.CHIP_0002_HEX_INPUT:
+            hex_message: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message))).get_tree_hash()
+        elif mode == SigningMode.CHIP_0002:
+            hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
+        elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
+            hex_message = bytes(message, "utf-8")
+        elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
+            hex_message = bytes.fromhex(message)
         else:
-            puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
-        return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, puzzle.get_tree_hash())
+            raise ValueError(f"Invalid sign mode {mode.value}.")
+        return synthetic_pk, AugSchemeMPL.sign(synthetic_secret_key, hex_message)
 
     async def generate_signed_transaction(
         self,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
In order to allow DApps use WalletConnect to sign customized puzzles, we need to extend existing sign APIs.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Cannot sign customized message


### New Behavior:
Allow DApp sign any message by setting safe_mode = false


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
unit test


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
