### PR TITLE
bump data layer benchmark timeout for batch insert from 17 -> 18 seconds

### DIFF
--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -1394,7 +1394,7 @@ class BatchInsertBenchmarkCase:
     BatchInsertBenchmarkCase(
         pre=0,
         count=1_000,
-        limit=17,
+        limit=18,
     ),
     BatchInsertBenchmarkCase(
         pre=1_000,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This benchmark fails fairly often on CI, by a small margin:

```
=================================== FAILURES ===================================
_____________ test_benchmark_batch_insert_speed[pre=0,count=1000] ______________
tests/core/data_layer/test_data_store.py:1436: in test_benchmark_batch_insert_speed
    await data_store.insert_batch(
E   AssertionError: 17.06771757599995 seconds not less than 17 seconds ( 100 % )
=========================== short test summary info ============================
FAILED tests/core/data_layer/test_data_store.py::test_benchmark_batch_insert_speed[pre=0,count=1000] - AssertionError: 17.06771757599995 seconds not less than 17 seconds ( 100 % )
========= 1 failed, 119 passed, 6292 deselected in 1329.62s (0:22:09) ==========
```

e.g. https://github.com/Chia-Network/chia-blockchain/actions/runs/6195782805/job/16821144590?pr=16338#step:10:4077
