### PR TITLE
Add extra_conditions to special offer making

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -1170,6 +1170,7 @@ class DataLayerWallet:
         solver: Solver,
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Offer:
         dl_wallet = None
         for wallet in wallet_state_manager.wallets.values():
@@ -1199,8 +1200,10 @@ class DataLayerWallet:
                 sign=False,
                 add_pending_singleton=False,
                 announce_new_state=True,
+                extra_conditions=extra_conditions,
             )
             fee_left_to_pay = uint64(0)
+            extra_conditions = tuple()
 
             assert txs[0].spend_bundle is not None
             dl_spend: CoinSpend = next(

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -806,6 +806,7 @@ class NFTWallet:
         driver_dict: Dict[bytes32, PuzzleInfo],
         tx_config: TXConfig,
         fee: uint64,
+        extra_conditions: Tuple[Condition, ...],
     ) -> Offer:
         # First, let's take note of all the royalty enabled NFTs
         royalty_nft_asset_dict: Dict[bytes32, int] = {}
@@ -956,6 +957,7 @@ class NFTWallet:
                         fee=fee,
                         coins=offered_coins_by_asset[asset],
                         puzzle_announcements_to_consume=announcements_to_assert,
+                        extra_conditions=extra_conditions,
                     )
                     txs = [tx]
                 elif asset not in fungible_asset_dict:
@@ -972,6 +974,7 @@ class NFTWallet:
                             for price in trade_prices
                             if math.floor(price[0] * (offered_royalty_percentages[asset] / 10000)) != 0
                         ],
+                        extra_conditions=extra_conditions,
                     )
                 else:
                     payments = royalty_payments[asset] if asset in royalty_payments else []
@@ -982,9 +985,11 @@ class NFTWallet:
                         fee=fee_left_to_pay,
                         coins=offered_coins_by_asset[asset],
                         puzzle_announcements_to_consume=announcements_to_assert,
+                        extra_conditions=extra_conditions,
                     )
                 all_transactions.extend(txs)
                 fee_left_to_pay = uint64(0)
+                extra_conditions = tuple()
 
                 # Then, adding in the spends for the royalty offer mod
                 if asset in fungible_asset_dict:

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -506,7 +506,12 @@ class TradeManager:
             )
 
             potential_special_offer: Optional[Offer] = await self.check_for_special_offer_making(
-                offer_dict_no_ints, driver_dict, tx_config, solver, fee
+                offer_dict_no_ints,
+                driver_dict,
+                tx_config,
+                solver,
+                fee,
+                extra_conditions,
             )
 
             if potential_special_offer is not None:
@@ -822,6 +827,7 @@ class TradeManager:
         tx_config: TXConfig,
         solver: Solver,
         fee: uint64 = uint64(0),
+        extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> Optional[Offer]:
         for puzzle_info in driver_dict.values():
             if (
@@ -831,7 +837,7 @@ class TradeManager:
                 == AssetType.ROYALTY_TRANSFER_PROGRAM.value
             ):
                 return await NFTWallet.make_nft1_offer(
-                    self.wallet_state_manager, offer_dict, driver_dict, tx_config, fee
+                    self.wallet_state_manager, offer_dict, driver_dict, tx_config, fee, extra_conditions
                 )
             elif (
                 puzzle_info.check_type(
@@ -843,7 +849,7 @@ class TradeManager:
                 and puzzle_info.also()["updater_hash"] == ACS_MU_PH  # type: ignore
             ):
                 return await DataLayerWallet.make_update_offer(
-                    self.wallet_state_manager, offer_dict, driver_dict, solver, tx_config, fee
+                    self.wallet_state_manager, offer_dict, driver_dict, solver, tx_config, fee, extra_conditions
                 )
         return None
 


### PR DESCRIPTION
Missed one area in which extra_conditions could have been piped through but wasn't.  This resulted in NFT and DL offers telling you they would expire when, in fact, they wouldn't.  This PR fixes that.