### PR TITLE
Bump test_mempool_update_performance benchmark duration from 0.1 to 0.15

### DIFF
--- a/tests/core/mempool/test_mempool_performance.py
+++ b/tests/core/mempool/test_mempool_performance.py
@@ -79,7 +79,7 @@ class TestMempoolPerformance:
 
         for idx, block in enumerate(blocks):
             if idx >= len(blocks) - 3:
-                duration = 0.1
+                duration = 0.15
             else:
                 duration = 0.001
 


### PR DESCRIPTION
Addresses instances like:
```FAILED tests/core/mempool/test_mempool_performance.py::TestMempoolPerformance::test_mempool_update_performance[ConsensusMode.PLAIN] - AssertionError: 0.12349152299998423 seconds not less than 0.1 seconds ( 123 % )```