### PR TITLE
RPM: Change the --depends to a Recommends: tag on the specific compat package

### DIFF
--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -68,7 +68,9 @@ fpm -s dir -t rpm \
   --version "$CHIA_INSTALLER_VERSION" \
   --architecture "$REDHAT_PLATFORM" \
   --description "Chia is a modern cryptocurrency built from scratch, designed to be efficient, decentralized, and secure." \
-  --depends /usr/lib64/libcrypt.so.1 \
+  --rpm-tag 'Recommends: libxcrypt-compat' \
+  --rpm-tag '%define _build_id_links none' \
+  --rpm-tag '%undefine _missing_build_ids_terminate_build' \
   .
 # CLI only rpm done
 cp -r dist/daemon ../chia-blockchain-gui/packages/gui


### PR DESCRIPTION
Removes dependency on a specific lib/file, which is apparently not actually supported, and we just got lucky with it working before. Instead, adding a recommended dependency on the package that provides that library on newer OSes (older ones have it by default). When the package exists, the package is installed, if not (older systems) its just skipped.

Tested installation on:
* Rocky 8
* Rocky 9
* Fedora 37
* Fedora 38

Fixes the CLI rpm. The UI rpm requires a fix in the GUI repo, and then an updated pin in this repo (see https://github.com/Chia-Network/chia-blockchain-gui/pull/2124)