### PR TITLE
Make the standard wallet return `List[TransactionRecord]`

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -314,7 +314,7 @@ class DataLayerWallet:
         )
         announcement_message: bytes32 = genesis_launcher_solution.get_tree_hash()
         announcement = Announcement(launcher_coin.name(), announcement_message)
-        create_launcher_tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
+        [create_launcher_tx_record] = await self.standard_wallet.generate_signed_transaction(
             amount=uint64(1),
             puzzle_hash=SINGLETON_LAUNCHER.get_tree_hash(),
             tx_config=tx_config,
@@ -385,7 +385,7 @@ class DataLayerWallet:
         tx_config: TXConfig,
         coin_announcement: bool = True,
     ) -> TransactionRecord:
-        chia_tx = await self.standard_wallet.generate_signed_transaction(
+        [chia_tx] = await self.standard_wallet.generate_signed_transaction(
             amount=uint64(0),
             puzzle_hash=await self.standard_wallet.get_puzzle_hash(new=not tx_config.reuse_puzhash),
             tx_config=tx_config,
@@ -751,7 +751,7 @@ class DataLayerWallet:
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
     ) -> List[TransactionRecord]:
-        create_mirror_tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
+        [create_mirror_tx_record] = await self.standard_wallet.generate_signed_transaction(
             amount=amount,
             puzzle_hash=create_mirror_puzzle().get_tree_hash(),
             tx_config=tx_config,
@@ -761,7 +761,7 @@ class DataLayerWallet:
             ignore_max_send_amount=False,
             extra_conditions=extra_conditions,
         )
-        assert create_mirror_tx_record is not None and create_mirror_tx_record.spend_bundle is not None
+        assert create_mirror_tx_record.spend_bundle is not None
         return [create_mirror_tx_record]
 
     async def delete_mirror(
@@ -829,7 +829,7 @@ class DataLayerWallet:
         ]
 
         if excess_fee > 0:
-            chia_tx: TransactionRecord = await self.wallet_state_manager.main_wallet.generate_signed_transaction(
+            [chia_tx] = await self.wallet_state_manager.main_wallet.generate_signed_transaction(
                 uint64(1),
                 new_puzhash,
                 tx_config,

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -508,7 +508,7 @@ class PoolWallet:
         tx_config: TXConfig,
         coin_announcements: Optional[Set[Announcement]] = None,
     ) -> TransactionRecord:
-        fee_tx = await self.standard_wallet.generate_signed_transaction(
+        [fee_tx] = await self.standard_wallet.generate_signed_transaction(
             uint64(0),
             (await self.standard_wallet.get_new_puzzlehash()),
             tx_config,
@@ -698,7 +698,7 @@ class PoolWallet:
         announcement_message = Program.to([puzzle_hash, amount, pool_state_bytes]).get_tree_hash()
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
-        create_launcher_tx_record: Optional[TransactionRecord] = await standard_wallet.generate_signed_transaction(
+        [create_launcher_tx_record] = await standard_wallet.generate_signed_transaction(
             amount,
             genesis_launcher_puz.get_tree_hash(),
             tx_config,
@@ -710,7 +710,7 @@ class PoolWallet:
             origin_id=launcher_parent.name(),
             extra_conditions=extra_conditions,
         )
-        assert create_launcher_tx_record is not None and create_launcher_tx_record.spend_bundle is not None
+        assert create_launcher_tx_record.spend_bundle is not None
 
         genesis_launcher_solution: Program = Program.to([puzzle_hash, amount, pool_state_bytes])
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1042,7 +1042,7 @@ class WalletRpcApi:
         fee: uint64 = uint64(request.get("fee", 0))
 
         async with self.service.wallet_state_manager.lock:
-            tx: TransactionRecord = await wallet.generate_signed_transaction(
+            [tx] = await wallet.generate_signed_transaction(
                 amount,
                 puzzle_hash,
                 tx_config,
@@ -3335,7 +3335,7 @@ class WalletRpcApi:
 
         async def _generate_signed_transaction() -> EndpointResult:
             if isinstance(wallet, Wallet):
-                tx = await wallet.generate_signed_transaction(
+                [tx] = await wallet.generate_signed_transaction(
                     amount_0,
                     bytes32(puzzle_hash_0),
                     tx_config,

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -614,7 +614,7 @@ class FullNodeSimulator(FullNodeAPI):
 
                 if len(outputs_group) > 0:
                     async with wallet.wallet_state_manager.lock:
-                        tx = await wallet.generate_signed_transaction(
+                        [tx] = await wallet.generate_signed_transaction(
                             amount=outputs_group[0].amount,
                             puzzle_hash=outputs_group[0].puzzle_hash,
                             tx_config=DEFAULT_TX_CONFIG,

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -582,7 +582,7 @@ class CATWallet:
                 tx_config.coin_selection_config,
             )
             origin_id = list(chia_coins)[0].name()
-            chia_tx = await self.standard_wallet.generate_signed_transaction(
+            [chia_tx] = await self.standard_wallet.generate_signed_transaction(
                 uint64(0),
                 (await self.standard_wallet.get_puzzle_hash(not tx_config.reuse_puzhash)),
                 tx_config,
@@ -600,7 +600,7 @@ class CATWallet:
             )
             origin_id = list(chia_coins)[0].name()
             selected_amount = sum([c.amount for c in chia_coins])
-            chia_tx = await self.standard_wallet.generate_signed_transaction(
+            [chia_tx] = await self.standard_wallet.generate_signed_transaction(
                 uint64(selected_amount + amount_to_claim - fee),
                 (await self.standard_wallet.get_puzzle_hash(not tx_config.reuse_puzhash)),
                 tx_config,

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1219,7 +1219,7 @@ class DIDWallet:
         announcement_message = Program.to([did_puzzle_hash, amount, bytes(0x80)]).get_tree_hash()
         announcement_set.add(Announcement(launcher_coin.name(), announcement_message))
 
-        tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
+        [tx_record] = await self.standard_wallet.generate_signed_transaction(
             amount,
             genesis_launcher_puz.get_tree_hash(),
             tx_config,
@@ -1249,7 +1249,7 @@ class DIDWallet:
         await self.add_parent(eve_coin.parent_coin_info, eve_parent)
         await self.add_parent(eve_coin.name(), future_parent)
 
-        if tx_record is None or tx_record.spend_bundle is None:
+        if tx_record.spend_bundle is None:
             return None
 
         # Only want to save this information if the transaction is valid

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -380,7 +380,7 @@ class NFTWallet:
             "Creating transaction for launcher: %s and other coins: %s (%s)", origin, coins, announcement_set
         )
         # store the launcher transaction in the wallet state
-        tx_record: Optional[TransactionRecord] = await self.standard_wallet.generate_signed_transaction(
+        [tx_record] = await self.standard_wallet.generate_signed_transaction(
             uint64(amount),
             nft_puzzles.LAUNCHER_PUZZLE_HASH,
             tx_config,
@@ -400,7 +400,7 @@ class NFTWallet:
 
         eve_coin = Coin(launcher_coin.name(), eve_fullpuz_hash, uint64(amount))
 
-        if tx_record is None or tx_record.spend_bundle is None:
+        if tx_record.spend_bundle is None:
             self.log.error("Couldn't produce a launcher spend")
             return None
 
@@ -948,7 +948,7 @@ class NFTWallet:
                 if wallet.type() == WalletType.STANDARD_WALLET:
                     payments = royalty_payments[asset] if asset in royalty_payments else []
                     payment_sum = sum(p.amount for _, p in payments)
-                    tx = await wallet.generate_signed_transaction(
+                    [tx] = await wallet.generate_signed_transaction(
                         abs(amount),
                         OFFER_MOD_HASH,
                         tx_config,

--- a/chia/wallet/notification_manager.py
+++ b/chia/wallet/notification_manager.py
@@ -105,7 +105,7 @@ class NotificationManager:
             Program.to(None),
         )
         extra_spend_bundle = SpendBundle([notification_spend], G2Element())
-        chia_tx = await self.wallet_state_manager.main_wallet.generate_signed_transaction(
+        [chia_tx] = await self.wallet_state_manager.main_wallet.generate_signed_transaction(
             amount,
             notification_hash,
             tx_config,

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -96,7 +96,7 @@ class GenesisById(LimitationsProgram):
 
         minted_cat_puzzle_hash: bytes32 = construct_cat_puzzle(CAT_MOD, tail.get_tree_hash(), cat_inner).get_tree_hash()
 
-        tx_record: TransactionRecord = await wallet.standard_wallet.generate_signed_transaction(
+        [tx_record] = await wallet.standard_wallet.generate_signed_transaction(
             amount, minted_cat_puzzle_hash, tx_config, fee, coins, origin_id=origin_id
         )
         assert tx_record.spend_bundle is not None

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -276,7 +276,7 @@ class TradeManager:
                         selected_coins.add(coin)
                     else:
                         selected_coins = {coin}
-                    tx: TransactionRecord = await wallet.generate_signed_transaction(
+                    [tx] = await wallet.generate_signed_transaction(
                         uint64(sum([c.amount for c in selected_coins]) - fee_to_pay),
                         new_ph,
                         tx_config.override(
@@ -530,7 +530,7 @@ class TradeManager:
                     wallet = await self.wallet_state_manager.get_wallet_for_asset_id(id.hex())
                 # This should probably not switch on whether or not we're spending XCH but it has to for now
                 if wallet.type() == WalletType.STANDARD_WALLET:
-                    tx = await wallet.generate_signed_transaction(
+                    [tx] = await wallet.generate_signed_transaction(
                         abs(offer_dict[id]),
                         Offer.ph(),
                         tx_config,

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -433,7 +433,7 @@ class Wallet:
         puzzle_decorator_override: Optional[List[Dict[str, Any]]] = None,
         extra_conditions: Tuple[Condition, ...] = tuple(),
         **kwargs: Unpack[GSTOptionalArgs],
-    ) -> TransactionRecord:
+    ) -> List[TransactionRecord]:
         origin_id: Optional[bytes32] = kwargs.get("origin_id", None)
         negative_change_allowed: bool = kwargs.get("negative_change_allowed", False)
         """
@@ -478,25 +478,27 @@ class Wallet:
         else:
             assert output_amount == input_amount
 
-        return TransactionRecord(
-            confirmed_at_height=uint32(0),
-            created_at_time=now,
-            to_puzzle_hash=puzzle_hash,
-            amount=uint64(non_change_amount),
-            fee_amount=uint64(fee),
-            confirmed=False,
-            sent=uint32(0),
-            spend_bundle=spend_bundle,
-            additions=add_list,
-            removals=rem_list,
-            wallet_id=self.id(),
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_TX.value),
-            name=spend_bundle.name(),
-            memos=list(compute_memos(spend_bundle).items()),
-            valid_times=parse_timelock_info(extra_conditions),
-        )
+        return [
+            TransactionRecord(
+                confirmed_at_height=uint32(0),
+                created_at_time=now,
+                to_puzzle_hash=puzzle_hash,
+                amount=uint64(non_change_amount),
+                fee_amount=uint64(fee),
+                confirmed=False,
+                sent=uint32(0),
+                spend_bundle=spend_bundle,
+                additions=add_list,
+                removals=rem_list,
+                wallet_id=self.id(),
+                sent_to=[],
+                trade_id=None,
+                type=uint32(TransactionType.OUTGOING_TX.value),
+                name=spend_bundle.name(),
+                memos=list(compute_memos(spend_bundle).items()),
+                valid_times=parse_timelock_info(extra_conditions),
+            )
+        ]
 
     async def create_tandem_xch_tx(
         self,
@@ -505,7 +507,7 @@ class Wallet:
         announcement_to_assert: Optional[Announcement] = None,
     ) -> TransactionRecord:
         chia_coins = await self.select_coins(fee, tx_config.coin_selection_config)
-        chia_tx = await self.generate_signed_transaction(
+        [chia_tx] = await self.generate_signed_transaction(
             uint64(0),
             (await self.get_puzzle_hash(not tx_config.reuse_puzhash)),
             tx_config,

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -56,7 +56,6 @@ from chia.util.ints import uint8, uint16, uint32, uint64, uint128
 from chia.util.limited_semaphore import LimitedSemaphore
 from chia.util.recursive_replace import recursive_replace
 from chia.util.vdf_prover import get_vdf_info_and_proof
-from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block, _validate_and_add_block_no_error
 from tests.conftest import ConsensusMode
@@ -143,7 +142,7 @@ class TestFullNodeBlockCompression:
         await full_node_1.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=30)
 
         # Send a transaction to mempool
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             tx_size,
             ph,
             DEFAULT_TX_CONFIG,
@@ -182,7 +181,7 @@ class TestFullNodeBlockCompression:
         assert len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list) == 0
 
         # Send another tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             20000,
             ph,
             DEFAULT_TX_CONFIG,
@@ -225,7 +224,7 @@ class TestFullNodeBlockCompression:
         await full_node_1.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=30)
 
         # Send another 2 tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             30000,
             ph,
             DEFAULT_TX_CONFIG,
@@ -237,7 +236,7 @@ class TestFullNodeBlockCompression:
             tr.spend_bundle,
             tr.name,
         )
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             40000,
             ph,
             DEFAULT_TX_CONFIG,
@@ -250,7 +249,7 @@ class TestFullNodeBlockCompression:
             tr.name,
         )
 
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             50000,
             ph,
             DEFAULT_TX_CONFIG,
@@ -263,7 +262,7 @@ class TestFullNodeBlockCompression:
             tr.name,
         )
 
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             3000000000000,
             ph,
             DEFAULT_TX_CONFIG,
@@ -298,7 +297,7 @@ class TestFullNodeBlockCompression:
             assert num_blocks > 0
 
         # Creates a standard_transaction and an anyone-can-spend tx
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             30000,
             Program.to(1).get_tree_hash(),
             DEFAULT_TX_CONFIG,
@@ -344,7 +343,7 @@ class TestFullNodeBlockCompression:
         assert len(all_blocks[-1].transactions_generator_ref_list) == 0
 
         # Make a standard transaction and an anyone-can-spend transaction
-        tr: TransactionRecord = await wallet.generate_signed_transaction(
+        [tr] = await wallet.generate_signed_transaction(
             30000,
             Program.to(1).get_tree_hash(),
             DEFAULT_TX_CONFIG,

--- a/tests/core/full_node/test_transactions.py
+++ b/tests/core/full_node/test_transactions.py
@@ -83,7 +83,9 @@ class TestTransactions:
         await time_out_assert(20, peak_height, num_blocks, full_node_api_1)
         await time_out_assert(20, peak_height, num_blocks, full_node_api_2)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(10, ph1, DEFAULT_TX_CONFIG, 0)
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+            10, ph1, DEFAULT_TX_CONFIG, 0
+        )
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)
 
         await time_out_assert(
@@ -155,7 +157,7 @@ class TestTransactions:
         )
         await time_out_assert(20, wallet_0.wallet_state_manager.main_wallet.get_confirmed_balance, funds)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
             10, bytes32.random(seeded_random), DEFAULT_TX_CONFIG, 0
         )
         await wallet_0.wallet_state_manager.main_wallet.push_transaction(tx)

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -1436,7 +1436,7 @@ async def test_identical_spend_aggregation_e2e(simulator_and_wallet: SimulatorsA
         for _ in range(2):
             await farm_a_block(full_node_api, wallet_node, ph)
         other_recipients = [Payment(puzzle_hash=p, amount=uint64(200), memos=[]) for p in phs[1:]]
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(200), phs[0], DEFAULT_TX_CONFIG, primaries=other_recipients
         )
         assert tx.spend_bundle is not None
@@ -1453,9 +1453,9 @@ async def test_identical_spend_aggregation_e2e(simulator_and_wallet: SimulatorsA
     wallet, coins, ph = await make_setup_and_coins(full_node_api, wallet_node)
 
     # Make sure spending AB then BC would generate a conflict for the latter
-    tx_a = await wallet.generate_signed_transaction(uint64(30), ph, DEFAULT_TX_CONFIG, coins={coins[0].coin})
-    tx_b = await wallet.generate_signed_transaction(uint64(30), ph, DEFAULT_TX_CONFIG, coins={coins[1].coin})
-    tx_c = await wallet.generate_signed_transaction(uint64(30), ph, DEFAULT_TX_CONFIG, coins={coins[2].coin})
+    [tx_a] = await wallet.generate_signed_transaction(uint64(30), ph, DEFAULT_TX_CONFIG, coins={coins[0].coin})
+    [tx_b] = await wallet.generate_signed_transaction(uint64(30), ph, DEFAULT_TX_CONFIG, coins={coins[1].coin})
+    [tx_c] = await wallet.generate_signed_transaction(uint64(30), ph, DEFAULT_TX_CONFIG, coins={coins[2].coin})
     assert tx_a.spend_bundle is not None
     assert tx_b.spend_bundle is not None
     assert tx_c.spend_bundle is not None
@@ -1469,7 +1469,7 @@ async def test_identical_spend_aggregation_e2e(simulator_and_wallet: SimulatorsA
     # Make sure DE and EF would aggregate on E when E is eligible for deduplication
 
     # Create a coin with the identity puzzle hash
-    tx = await wallet.generate_signed_transaction(
+    [tx] = await wallet.generate_signed_transaction(
         uint64(200), IDENTITY_PUZZLE_HASH, DEFAULT_TX_CONFIG, coins={coins[3].coin}
     )
     assert tx.spend_bundle is not None
@@ -1493,7 +1493,7 @@ async def test_identical_spend_aggregation_e2e(simulator_and_wallet: SimulatorsA
     message = b"Identical spend aggregation test"
     e_announcement = Announcement(e_coin_id, message)
     # Create transactions D and F that consume an announcement created by E
-    tx_d = await wallet.generate_signed_transaction(
+    [tx_d] = await wallet.generate_signed_transaction(
         uint64(100),
         ph,
         DEFAULT_TX_CONFIG,
@@ -1501,7 +1501,7 @@ async def test_identical_spend_aggregation_e2e(simulator_and_wallet: SimulatorsA
         coins={coins[4].coin},
         coin_announcements_to_consume={e_announcement},
     )
-    tx_f = await wallet.generate_signed_transaction(
+    [tx_f] = await wallet.generate_signed_transaction(
         uint64(150),
         ph,
         DEFAULT_TX_CONFIG,
@@ -1534,7 +1534,7 @@ async def test_identical_spend_aggregation_e2e(simulator_and_wallet: SimulatorsA
     sb_e2 = spend_bundle_from_conditions(conditions, e_coin)
     g_coin = coins[6].coin
     g_coin_id = g_coin.name()
-    tx_g = await wallet.generate_signed_transaction(
+    [tx_g] = await wallet.generate_signed_transaction(
         uint64(13), ph, DEFAULT_TX_CONFIG, coins={g_coin}, coin_announcements_to_consume={e_announcement}
     )
     assert tx_g.spend_bundle is not None

--- a/tests/core/mempool/test_mempool_performance.py
+++ b/tests/core/mempool/test_mempool_performance.py
@@ -61,9 +61,7 @@ class TestMempoolPerformance:
         fee_amount = 2213
         await time_out_assert(60, wallet_balance_at_least, True, wallet_node, send_amount + fee_amount)
 
-        big_transaction: TransactionRecord = await wallet.generate_signed_transaction(
-            send_amount, ph, DEFAULT_TX_CONFIG, fee_amount
-        )
+        [big_transaction] = await wallet.generate_signed_transaction(send_amount, ph, DEFAULT_TX_CONFIG, fee_amount)
 
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
         assert big_transaction.spend_bundle

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -165,7 +165,7 @@ class TestSimulation:
 
         await time_out_assert(10, wallet.get_confirmed_balance, funds)
         await time_out_assert(5, wallet.get_unconfirmed_balance, funds)
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(10),
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG,
@@ -339,7 +339,7 @@ class TestSimulation:
 
         # repeating just to try to expose any flakiness
         for coin in coins:
-            tx = await wallet.generate_signed_transaction(
+            [tx] = await wallet.generate_signed_transaction(
                 amount=uint64(tx_amount),
                 puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
                 tx_config=DEFAULT_TX_CONFIG,
@@ -385,12 +385,14 @@ class TestSimulation:
         for repeat in range(repeats):
             coins = [next(coins_iter) for _ in range(tx_per_repeat)]
             transactions = [
-                await wallet.generate_signed_transaction(
-                    amount=uint64(tx_amount),
-                    puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
-                    tx_config=DEFAULT_TX_CONFIG,
-                    coins={coin},
-                )
+                (
+                    await wallet.generate_signed_transaction(
+                        amount=uint64(tx_amount),
+                        puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
+                        tx_config=DEFAULT_TX_CONFIG,
+                        coins={coin},
+                    )
+                )[0]
                 for coin in coins
             ]
             for tx in transactions:

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -159,7 +159,7 @@ async def test_wait_transaction_records_entered_mempool(
 
     # repeating just to try to expose any flakiness
     for coin in coins:
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             amount=uint64(tx_amount),
             puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             tx_config=DEFAULT_TX_CONFIG,
@@ -194,7 +194,7 @@ async def test_process_transaction_records(
 
     # repeating just to try to expose any flakiness
     for coin in coins:
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             amount=uint64(tx_amount),
             puzzle_hash=await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             tx_config=DEFAULT_TX_CONFIG,

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -524,7 +524,7 @@ class TestCATWallet:
         await time_out_assert(20, cat_wallet_2.get_unconfirmed_balance, 60)
 
         cc2_ph = await cat_wallet_2.get_new_cat_puzzle_hash()
-        tx_record = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(
+        [tx_record] = await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(
             10, cc2_ph, DEFAULT_TX_CONFIG, 0
         )
         await wallet.wallet_state_manager.add_pending_transaction(tx_record)

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -917,7 +917,7 @@ class TestDIDWallet:
             )
         ).pop()
         assert coin_1.amount % 2 == 0
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             odd_amount,
             ph1,
             DEFAULT_TX_CONFIG.override(

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -423,7 +423,7 @@ async def test_get_farmed_amount_with_fee(wallet_rpc_environment: WalletRpcTestE
     await generate_funds(full_node_api, env.wallet_1)
 
     fee_amount = 100
-    tx = await wallet.generate_signed_transaction(
+    [tx] = await wallet.generate_signed_transaction(
         amount=uint64(5),
         puzzle_hash=bytes32([0] * 32),
         tx_config=DEFAULT_TX_CONFIG,

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -186,7 +186,7 @@ class TestSimpleSyncProtocol:
 
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
-        tx_record = await wallet.generate_signed_transaction(uint64(10), puzzle_hash, DEFAULT_TX_CONFIG, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction(uint64(10), puzzle_hash, DEFAULT_TX_CONFIG, uint64(0))
         assert len(tx_record.spend_bundle.removals()) == 1
         spent_coin = tx_record.spend_bundle.removals()[0]
         assert spent_coin.puzzle_hash == puzzle_hash
@@ -200,7 +200,7 @@ class TestSimpleSyncProtocol:
 
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
-        tx_record = await wallet.generate_signed_transaction(
+        [tx_record] = await wallet.generate_signed_transaction(
             uint64(10), SINGLETON_LAUNCHER_HASH, DEFAULT_TX_CONFIG, uint64(0)
         )
         await wallet.push_transaction(tx_record)
@@ -210,7 +210,7 @@ class TestSimpleSyncProtocol:
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
         # Send a transaction to make sure the wallet is still running
-        tx_record = await wallet.generate_signed_transaction(uint64(10), junk_ph, DEFAULT_TX_CONFIG, uint64(0))
+        [tx_record] = await wallet.generate_signed_transaction(uint64(10), junk_ph, DEFAULT_TX_CONFIG, uint64(0))
         await wallet.push_transaction(tx_record)
 
         await full_node_api.process_transaction_records(records=[tx_record])
@@ -270,7 +270,7 @@ class TestSimpleSyncProtocol:
 
         coins = set()
         coins.add(coin_to_spend)
-        tx_record = await standard_wallet.generate_signed_transaction(
+        [tx_record] = await standard_wallet.generate_signed_transaction(
             uint64(10), puzzle_hash, DEFAULT_TX_CONFIG, uint64(0), coins=coins
         )
         await standard_wallet.push_transaction(tx_record)
@@ -292,7 +292,7 @@ class TestSimpleSyncProtocol:
         # Test getting notification for coin that is about to be created
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
-        tx_record = await standard_wallet.generate_signed_transaction(
+        [tx_record] = await standard_wallet.generate_signed_transaction(
             uint64(10), puzzle_hash, DEFAULT_TX_CONFIG, uint64(0)
         )
 

--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -28,7 +28,6 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.payment import Payment
-from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.tx_config import DEFAULT_COIN_SELECTION_CONFIG, DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_sync_utils import PeerRequestException
@@ -520,9 +519,7 @@ class TestWalletSync:
             payees.append(Payment(payee_ph, uint64(i + 100)))
             payees.append(Payment(payee_ph, uint64(i + 200)))
 
-        tx: TransactionRecord = await wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -733,9 +730,7 @@ class TestWalletSync:
         payees.append(Payment(payee_ph, uint64(dust_value)))
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
         await full_node_api.wait_transaction_records_entered_mempool([tx])
         await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=20)
@@ -793,9 +788,7 @@ class TestWalletSync:
             # This greatly speeds up the overall process
             if dust_remaining % 100 == 0 and dust_remaining != new_dust:
                 # construct and send tx
-                tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-                    uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-                )
+                [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
                 await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
                 # advance the chain and sync both wallets
@@ -815,9 +808,7 @@ class TestWalletSync:
         # Only need to create tx if there was new dust to be added
         if new_dust >= 1:
             # construct and send tx
-            tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-                uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-            )
+            [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
             await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
             # advance the chain and sync both wallets
@@ -864,9 +855,7 @@ class TestWalletSync:
             payees.append(Payment(payee_ph, uint64(xch_spam_amount)))
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -905,9 +894,7 @@ class TestWalletSync:
         payees.append(Payment(payee_ph, uint64(dust_value)))
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -966,9 +953,7 @@ class TestWalletSync:
                 large_dust_balance += dust_value
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -1004,9 +989,7 @@ class TestWalletSync:
         payees = [Payment(payee_ph, uint64(balance))]
 
         # construct and send tx
-        tx: TransactionRecord = await dust_wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await dust_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -1049,9 +1032,7 @@ class TestWalletSync:
             # This greatly speeds up the overall process
             if coins_remaining % 100 == 0 and coins_remaining != spam_filter_after_n_txs:
                 # construct and send tx
-                tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-                    uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-                )
+                [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
                 await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
                 await full_node_api.wait_transaction_records_entered_mempool([tx])
                 await full_node_api.wait_for_wallets_synced(
@@ -1067,9 +1048,7 @@ class TestWalletSync:
             coins_remaining -= 1
 
         # construct and send tx
-        tx: TransactionRecord = await farm_wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await farm_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -1098,9 +1077,7 @@ class TestWalletSync:
         payees = [Payment(payee_ph, uint64(1))]
 
         # construct and send tx
-        tx: TransactionRecord = await dust_wallet.generate_signed_transaction(
-            uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees
-        )
+        [tx] = await dust_wallet.generate_signed_transaction(uint64(0), ph, DEFAULT_TX_CONFIG, primaries=payees)
         await full_node_api.send_transaction(SendTransaction(tx.spend_bundle))
 
         # advance the chain and sync both wallets
@@ -1314,7 +1291,7 @@ class TestWalletSync:
 
             await time_out_assert(30, wallet.get_confirmed_balance, 2_000_000_000_000)
 
-            tx = await wallet.generate_signed_transaction(
+            [tx] = await wallet.generate_signed_transaction(
                 1_000_000_000_000, bytes32([0] * 32), DEFAULT_TX_CONFIG, memos=[ph]
             )
             await wallet_node.wallet_state_manager.add_pending_transaction(tx)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -114,7 +114,7 @@ class TestWalletSimulator:
 
         tx_amount = 10
 
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(tx_amount),
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG,
@@ -166,7 +166,7 @@ class TestWalletSimulator:
         expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet)
         tx_amount = 10
 
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(tx_amount),
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG.override(reuse_puzhash=True),
@@ -224,7 +224,7 @@ class TestWalletSimulator:
         await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
         normal_puzhash = await wallet_1.get_new_puzzlehash()
         # Transfer to normal wallet
-        tx1 = await wallet.generate_signed_transaction(
+        [tx1] = await wallet.generate_signed_transaction(
             uint64(500),
             normal_puzhash,
             DEFAULT_TX_CONFIG,
@@ -240,7 +240,7 @@ class TestWalletSimulator:
         await time_out_assert(
             20, wallet_node_2.wallet_state_manager.coin_store.count_small_unspent, 1, 1000, CoinType.CLAWBACK
         )
-        tx2 = await wallet.generate_signed_transaction(
+        [tx2] = await wallet.generate_signed_transaction(
             uint64(500),
             await wallet_1.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG,
@@ -256,7 +256,7 @@ class TestWalletSimulator:
         await time_out_assert(
             20, wallet_node_2.wallet_state_manager.coin_store.count_small_unspent, 2, 1000, CoinType.CLAWBACK
         )
-        tx3 = await wallet.generate_signed_transaction(
+        [tx3] = await wallet.generate_signed_transaction(
             uint64(500),
             normal_puzhash,
             DEFAULT_TX_CONFIG,
@@ -334,7 +334,7 @@ class TestWalletSimulator:
 
         normal_puzhash = await wallet_1.get_new_puzzlehash()
         # Transfer to normal wallet
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(500),
             normal_puzhash,
             DEFAULT_TX_CONFIG,
@@ -457,7 +457,7 @@ class TestWalletSimulator:
         expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
         normal_puzhash = await wallet.get_new_puzzlehash()
         # Transfer to normal wallet
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(500),
             normal_puzhash,
             DEFAULT_TX_CONFIG,
@@ -544,7 +544,7 @@ class TestWalletSimulator:
         expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
         normal_puzhash = await wallet_1.get_new_puzzlehash()
         # Transfer to normal wallet
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(500),
             normal_puzhash,
             DEFAULT_TX_CONFIG,
@@ -634,7 +634,7 @@ class TestWalletSimulator:
         expected_confirmed_balance = await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)
         normal_puzhash = await wallet_1.get_new_puzzlehash()
         # Transfer to normal wallet
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(500),
             normal_puzhash,
             DEFAULT_TX_CONFIG,
@@ -732,7 +732,7 @@ class TestWalletSimulator:
 
         normal_puzhash = await wallet_1.get_new_puzzlehash()
         # Transfer to normal wallet
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(500),
             normal_puzhash,
             DEFAULT_TX_CONFIG,
@@ -790,7 +790,7 @@ class TestWalletSimulator:
         wallet_2_puzhash = await wallet_2.get_new_puzzlehash()
 
         # Transfer to normal wallet
-        tx1 = await wallet_1.generate_signed_transaction(
+        [tx1] = await wallet_1.generate_signed_transaction(
             uint64(500),
             wallet_2_puzhash,
             DEFAULT_TX_CONFIG,
@@ -810,7 +810,7 @@ class TestWalletSimulator:
         await time_out_assert(
             20, wallet_node_2.wallet_state_manager.coin_store.count_small_unspent, 1, 1000, CoinType.CLAWBACK
         )
-        tx2 = await wallet_1.generate_signed_transaction(
+        [tx2] = await wallet_1.generate_signed_transaction(
             uint64(700),
             wallet_1_puzhash,
             DEFAULT_TX_CONFIG,
@@ -1040,7 +1040,7 @@ class TestWalletSimulator:
             await full_node_1.add_block(block)
             await full_node_2.add_block(block)
 
-        tx = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
+        [tx] = await wallet_0.wallet_state_manager.main_wallet.generate_signed_transaction(
             uint64(10),
             bytes32(32 * b"0"),
             DEFAULT_TX_CONFIG,
@@ -1097,7 +1097,7 @@ class TestWalletSimulator:
         assert await wallet_0.get_unconfirmed_balance() == expected_confirmed_balance
 
         tx_amount = 10
-        tx = await wallet_0.generate_signed_transaction(
+        [tx] = await wallet_0.generate_signed_transaction(
             uint64(tx_amount),
             await wallet_node_1.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG,
@@ -1119,7 +1119,7 @@ class TestWalletSimulator:
         await time_out_assert(20, wallet_1.get_confirmed_balance, 10)
 
         tx_amount = 5
-        tx = await wallet_1.generate_signed_transaction(
+        [tx] = await wallet_1.generate_signed_transaction(
             uint64(tx_amount), await wallet_0.get_new_puzzlehash(), DEFAULT_TX_CONFIG, uint64(0)
         )
         await wallet_1.push_transaction(tx)
@@ -1174,7 +1174,7 @@ class TestWalletSimulator:
 
         tx_amount = 3200000000000
         tx_fee = 10
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(tx_amount),
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG,
@@ -1243,7 +1243,7 @@ class TestWalletSimulator:
         tx_amount = 3200000000000
         tx_fee = 10
         ph_2 = await wallet_1.get_new_puzzlehash()
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(tx_amount), ph_2, DEFAULT_TX_CONFIG, uint64(tx_fee), memos=[ph_2]
         )
         tx_id = tx.name.hex()
@@ -1309,7 +1309,7 @@ class TestWalletSimulator:
         await time_out_assert(20, wallet.get_confirmed_balance, expected_confirmed_balance)
 
         primaries = [Payment(ph, uint64(1000000000 + i)) for i in range(60)]
-        tx_split_coins = await wallet.generate_signed_transaction(
+        [tx_split_coins] = await wallet.generate_signed_transaction(
             uint64(1), ph, DEFAULT_TX_CONFIG, uint64(0), primaries=primaries
         )
         assert tx_split_coins.spend_bundle is not None
@@ -1321,7 +1321,7 @@ class TestWalletSimulator:
         max_sent_amount = await wallet.get_max_send_amount()
 
         # 1) Generate transaction that is under the limit
-        transaction_record = await wallet.generate_signed_transaction(
+        [transaction_record] = await wallet.generate_signed_transaction(
             uint64(max_sent_amount - 1),
             ph,
             DEFAULT_TX_CONFIG,
@@ -1331,7 +1331,7 @@ class TestWalletSimulator:
         assert transaction_record.amount == uint64(max_sent_amount - 1)
 
         # 2) Generate transaction that is equal to limit
-        transaction_record = await wallet.generate_signed_transaction(
+        [transaction_record] = await wallet.generate_signed_transaction(
             uint64(max_sent_amount),
             ph,
             DEFAULT_TX_CONFIG,
@@ -1389,7 +1389,7 @@ class TestWalletSimulator:
         assert await wallet.get_unconfirmed_balance() == expected_confirmed_balance
         tx_amount = 3200000000000
         tx_fee = 300000000000
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(tx_amount),
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG,
@@ -1484,7 +1484,7 @@ class TestWalletSimulator:
         assert reorg_height is not None
         reorg_funds = await full_node_api.farm_blocks_to_wallet(count=reorg_block_count, wallet=wallet)
 
-        tx = await wallet.generate_signed_transaction(uint64(tx_amount), ph2, DEFAULT_TX_CONFIG, coins={coin})
+        [tx] = await wallet.generate_signed_transaction(uint64(tx_amount), ph2, DEFAULT_TX_CONFIG, coins={coin})
         assert tx.spend_bundle is not None
         await wallet.push_transaction(tx)
         await full_node_api.process_transaction_records(records=[tx])
@@ -1706,7 +1706,7 @@ class TestWalletSimulator:
         coins = await wallet.select_coins(uint64(AMOUNT_TO_SEND), DEFAULT_TX_CONFIG.coin_selection_config)
         coin_list = list(coins)
 
-        tx = await wallet.generate_signed_transaction(
+        [tx] = await wallet.generate_signed_transaction(
             uint64(AMOUNT_TO_SEND),
             await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(),
             DEFAULT_TX_CONFIG,

--- a/tests/wallet/test_wallet_retry.py
+++ b/tests/wallet/test_wallet_retry.py
@@ -63,9 +63,7 @@ async def test_wallet_tx_retry(
     await farm_blocks(full_node_1, reward_ph, 2)
     await full_node_1.wait_for_wallet_synced(wallet_node=wallet_node_1, timeout=wait_secs)
 
-    transaction: TransactionRecord = await wallet_1.generate_signed_transaction(
-        uint64(100), reward_ph, DEFAULT_TX_CONFIG
-    )
+    [transaction] = await wallet_1.generate_signed_transaction(uint64(100), reward_ph, DEFAULT_TX_CONFIG)
     sb1: Optional[SpendBundle] = transaction.spend_bundle
     assert sb1 is not None
     await wallet_1.push_transaction(transaction)


### PR DESCRIPTION
This seems like a potentially silly change on first glance, but the idea is to better conform with our other `generate_signed_transaction` methods which return a `List[TransactionRecord]` like I have changed this to.  The API still needs some work to fully conform but given how many places this function is used it seems wise to move slowly in that direction.

(Needs a coverage exception for the change to the benchmark test)