### PR TITLE
block-references in BlockTools

### DIFF
--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -3135,7 +3135,7 @@ class TestReorgs:
         assert b.get_peak().height == 16
 
     @pytest.mark.asyncio
-    async def test_long_reorg(self, empty_blockchain, default_1500_blocks, test_long_reorg_blocks, bt):
+    async def test_long_reorg(self, empty_blockchain, default_10000_blocks, test_long_reorg_blocks, bt):
         # Reorg longer than a difficulty adjustment
         # Also tests higher weight chain but lower height
         b = empty_blockchain
@@ -3143,10 +3143,10 @@ class TestReorgs:
         num_blocks_chain_2_start = bt.constants.EPOCH_BLOCKS - 20
 
         assert num_blocks_chain_1 < 10000
-        blocks = default_1500_blocks[:num_blocks_chain_1]
+        blocks = default_10000_blocks[:num_blocks_chain_1]
 
         for block in blocks:
-            await _validate_and_add_block(b, block, skip_prevalidation=True)
+            await _validate_and_add_block(b, block)
         chain_1_height = b.get_peak().height
         chain_1_weight = b.get_peak().weight
         assert chain_1_height == (num_blocks_chain_1 - 1)
@@ -3156,8 +3156,10 @@ class TestReorgs:
 
         # If these assert fail, you probably need to change the fixture in test_long_reorg_blocks to create the
         # right amount of blocks at the right time
-        assert test_long_reorg_blocks[num_blocks_chain_2_start - 1] == default_1500_blocks[num_blocks_chain_2_start - 1]
-        assert test_long_reorg_blocks[num_blocks_chain_2_start] != default_1500_blocks[num_blocks_chain_2_start]
+        assert (
+            test_long_reorg_blocks[num_blocks_chain_2_start - 1] == default_10000_blocks[num_blocks_chain_2_start - 1]
+        )
+        assert test_long_reorg_blocks[num_blocks_chain_2_start] != default_10000_blocks[num_blocks_chain_2_start]
 
         for reorg_block in test_long_reorg_blocks:
             if reorg_block.height < num_blocks_chain_2_start:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,11 +263,13 @@ def default_10000_blocks(bt, consensus_mode):
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
-    return persistent_blocks(10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000")
+    return persistent_blocks(
+        10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000", dummy_block_references=True
+    )
 
 
 @pytest.fixture(scope="session")
-def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
+def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
     version = ""
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
@@ -275,12 +277,13 @@ def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        758,
+        5000,
         f"test_blocks_long_reorg_{saved_blocks_version}{version}.db",
         bt,
-        block_list_input=default_1500_blocks[:320],
+        block_list_input=default_10000_blocks[:5000],
         seed=b"reorg_blocks",
         time_per_block=8,
+        dummy_block_references=True,
     )
 
 

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -25,7 +25,7 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int) -> T
 
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
-    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2)
+    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2, single_threaded=True)
     assert bc1.get_peak() is None
     return bc1, wrapper, db_path
 
@@ -36,12 +36,14 @@ def persistent_blocks(
     bt: BlockTools,
     seed: bytes = b"",
     empty_sub_slots: int = 0,
+    *,
     normalized_to_identity_cc_eos: bool = False,
     normalized_to_identity_icc_eos: bool = False,
     normalized_to_identity_cc_sp: bool = False,
     normalized_to_identity_cc_ip: bool = False,
     block_list_input: Optional[List[FullBlock]] = None,
     time_per_block: Optional[float] = None,
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
@@ -81,10 +83,11 @@ def persistent_blocks(
         bt,
         block_list_input,
         time_per_block,
-        normalized_to_identity_cc_eos,
-        normalized_to_identity_icc_eos,
-        normalized_to_identity_cc_sp,
-        normalized_to_identity_cc_ip,
+        normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
+        normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
+        normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
+        normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
 
 
@@ -96,10 +99,12 @@ def new_test_db(
     bt: BlockTools,
     block_list_input: List[FullBlock],
     time_per_block: Optional[float],
+    *,
     normalized_to_identity_cc_eos: bool = False,  # CC_EOS,
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
@@ -112,6 +117,7 @@ def new_test_db(
         normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
     block_bytes_list: List[bytes] = []
     for block in blocks:


### PR DESCRIPTION
add feature to BlockTools to allow including block references to previous generators in test chains. Use a longer chain, with block generators, in the long_reorg test.

This is work-in-progress. It would also require updating the `test-cache` with these new test chains