### PR TITLE
correct backtick usage in coverage comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,7 +241,7 @@ jobs:
             IFS=$'\n'
             for LINE in $CONTENT; do
               if [[ $LINE =~ ^(.*\.py)\ \(([0-9\.]+%)\)\:\ Missing\ lines\ (.*)$ ]]; then
-                FILE=\`"${BASH_REMATCH[1]}"\`
+                FILE="${BASH_REMATCH[1]}"
                 COVERAGE="${BASH_REMATCH[2]}"
                 MISSING="${BASH_REMATCH[3]}"
                 MISSING_TRANSFORMED="lines "
@@ -254,7 +254,7 @@ jobs:
                   fi
                 done
                 MISSING_TRANSFORMED=${MISSING_TRANSFORMED%, }
-                OUTPUT+="| [${FILE}](${BASE_URL}/${FILE}) | ${COVERAGE} | ${MISSING_TRANSFORMED} |\n"
+                OUTPUT+="| [\`${FILE}\`](${BASE_URL}/${FILE}) | ${COVERAGE} | ${MISSING_TRANSFORMED} |\n"
               elif [[ $LINE =~ ^Total:\ \ \ (.*)\ lines$ ]]; then
                 TOTAL_LINES="${BASH_REMATCH[1]} lines"
               elif [[ $LINE =~ ^Missing:\ (.*)\ lines$ ]]; then


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

unbreak the links since they should not include the backtick, only the link text.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
