### PR TITLE
Fix `chia farm summary` aborting early if no local full node present

### DIFF
--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -89,7 +89,10 @@ async def summary(
     root_path: Path = DEFAULT_ROOT_PATH,
 ) -> None:
     harvesters_summary = await get_harvesters_summary(farmer_rpc_port, root_path)
-    blockchain_state = await get_blockchain_state(rpc_port, root_path)
+    try:
+        blockchain_state = await get_blockchain_state(rpc_port, root_path)
+    except Exception:
+        blockchain_state = None
     farmer_running = False if harvesters_summary is None else True  # harvesters uses farmer rpc too
 
     wallet_not_ready: bool = False

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -10,6 +12,7 @@ from chia.rpc.farmer_rpc_client import FarmerRpcClient
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.errors import CliRpcConnectionError
 from chia.util.misc import format_bytes, format_minutes
 from chia.util.network import is_localhost
 
@@ -89,18 +92,26 @@ async def summary(
     root_path: Path = DEFAULT_ROOT_PATH,
 ) -> None:
     harvesters_summary = await get_harvesters_summary(farmer_rpc_port, root_path)
+    blockchain_state = None
     try:
         blockchain_state = await get_blockchain_state(rpc_port, root_path)
+    except CliRpcConnectionError:
+        pass
     except Exception:
-        blockchain_state = None
+        print("Error while trying to get blockchain state!", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+
     farmer_running = False if harvesters_summary is None else True  # harvesters uses farmer rpc too
 
     wallet_not_ready: bool = False
     amounts = None
     try:
         amounts = await get_wallets_stats(wallet_rpc_port, root_path)
-    except Exception:
+    except CliRpcConnectionError:
         wallet_not_ready = True
+    except Exception:
+        print("Error while trying to get wallet stats!", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
     wallet_not_running: bool = True if amounts is None else False
 
     print("Farming status: ", end="")


### PR DESCRIPTION
Before 2.0, even if no local full node was present, `chia farm summary` would still show useful information:

	$ chia farm summary
	Farming status: Not available
	Local Harvester
	   1 plots of size: 101.320 GiB on-disk, 101.400 GiBe (effective)
	Plot count for all harvesters: 1
	Total size of plots: 101.320 GiB, 101.400 GiBe (effective)
	Estimated network space: Unknown
	Expected time to win: Unknown
	For details on farmed rewards and fees you should run 'chia start wallet' and 'chia wallet show'

However, since 2.0, that is no longer the case. `chia farm summary` simply aborts with an exception:

	$ chia farm summary
	Error: Connection error: ClientConnectorError: Cannot connect to host localhost:8555 ssl:<ssl.SSLContext object at 0x7fe0edd533c0> [Connect call failed ('127.0.0.1', 8555)]
	Check if full node rpc is running at 8555
	This is normal if full node is still starting up

This fixes this particular regression which is rather annoying for farmers farming to a remote node.

Fixes #16164. Related to issue #9615, but that issue is wider in scope.