### PR TITLE
add `--diff` for isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
     hooks:
     -   id: isort
         name: isort
-        entry: ./activated.py isort
+        entry: ./activated.py isort --diff
         language: system
         types: [python]
 -   repo: local


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

https://github.com/Chia-Network/chia-blockchain/actions/runs/6274090643/job/17038962616?pr=16387#step:9:136
```
isort....................................................................Failed
- hook id: isort
- duration: 1.55s
- files were modified by this hook

Fixing /home/runner/work/chia-blockchain/chia-blockchain/chia/cmds/farm_funcs.py
```

Let's make this output a little more useful so we can tell what it wanted changed.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
### Draft For:
- [ ] but this needs to be ci only... maybe?