### PR TITLE
Fix add_vc_proofs over daemon/walletconnect

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -3869,7 +3869,8 @@ class WalletRpcApi:
         """
         vc_wallet: VCWallet = await self.service.wallet_state_manager.get_or_create_vc_wallet()
 
-        await vc_wallet.store.add_vc_proofs(VCProofs(request["proofs"]))
+        proofs = request["proofs"]
+        await vc_wallet.store.add_vc_proofs(VCProofs(json.loads(proofs) if isinstance(proofs, str) else proofs))
 
         return {}
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1403,7 +1403,7 @@ class WalletRpcClient(RpcClient):
         )
         return [TransactionRecord.from_json_dict_convenience(tx) for tx in response["transactions"]]
 
-    async def vc_add_proofs(self, proofs: Dict[str, Any]) -> None:
+    async def vc_add_proofs(self, proofs: Union[Dict[str, Any], str]) -> None:
         await self.fetch("vc_add_proofs", {"proofs": proofs})
 
     async def vc_get_proofs_for_root(self, root: bytes32) -> Dict[str, Any]:

--- a/tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/tests/wallet/vc_wallet/test_vc_wallet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Awaitable, Callable, List, Optional
 
+import json
 import pytest
 from blspy import G2Element
 from typing_extensions import Literal
@@ -213,6 +214,16 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
     vc_records, fetched_proofs = await client_0.vc_get_list()
     assert len(vc_records) == 1
     assert fetched_proofs[proof_root.hex()] == proofs.key_value_pairs
+
+    # Add proofs to DB (String input)
+    proofs = {'criminal': True}
+    proofs_str = json.dumps(proofs)
+    await client_0.vc_add_proofs(proofs_str)
+    await client_0.vc_add_proofs(proofs_str)  # Doing it again just to make sure it doesn't care
+    assert await client_0.vc_get_proofs_for_root(proof_root) == proofs
+    vc_records, fetched_proofs = await client_0.vc_get_list()
+    assert len(vc_records) == 1
+    assert fetched_proofs[proof_root.hex()] == proofs
 
     await mint_cr_cat(1, wallet_0, wallet_node_0, client_0, full_node_api, [did_id])
     await full_node_api.farm_blocks_to_wallet(count=1, wallet=wallet_0)


### PR DESCRIPTION
### Purpose:

Bugfix of addVCProofs WalletConnect call. Currently it doesn't work because an error is thrown.

### Current Behavior:

- When calling addVCProofs using the HTTP RPC it parses the proofs into a Python dictionary which gets passed into a VCProofs class.
- When calling addVCProofs using WalletConnect it parses the proofs into a string which throws an error when passed into a VCProofs class.


### New Behavior:

- When calling addVCProofs using the HTTP RPC it parses the proofs into a Python dictionary which gets passed into a VCProofs class.
- When calling addVCProofs using WalletConnect it parses the proofs into a Python dictionary which gets passed into a VCProofs class.

