### PR TITLE
Wallet workaround for python issue 97641 and update anyio for issue 589

### DIFF
--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -329,8 +329,24 @@ async def setup_wallet_node(
         await service.wait_closed()
         if db_path.exists():
             # TODO: remove (maybe) when fixed https://github.com/python/cpython/issues/97641
+
+            # 3.11 switched to using functools.lru_cache for the statement cache.
+            # See #87028. This introduces a reference cycle involving the connection
+            # object, so the connection object no longer gets immediately
+            # deallocated, not until, for example, gc.collect() is called to break
+            # the cycle.
             gc.collect()
-            db_path.unlink()
+            for _ in range(10):
+                try:
+                    db_path.unlink()
+                    break
+                except PermissionError as e:
+                    print(f"db_path.unlink(): {e}")
+                    time.sleep(0.1)
+                    # filesystem operations are async on windows
+                    # [WinError 32] The process cannot access the file because it is
+                    # being used by another process
+                    pass
         keychain.delete_all_keys()
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 dependencies = [
     "aiofiles==23.2.1",  # Async IO for files
-    "anyio==3.7.1",
+    "anyio==4.0.0",
     "blspy==2.0.2",  # Signature library
     "boto3==1.28.25",  # AWS S3 for DL s3 plugin
     "chiavdf==1.0.11",  # timelord and vdf verification


### PR DESCRIPTION
Purpose:

Improve test reliability by adding Arvid's workaround for python issue 97641 to wallet

https://github.com/python/cpython/issues/97641

and updating anyio to 4.0.0 for timeout after success

https://github.com/agronholm/anyio/issues/589

Current Behavior:

ERROR tests/wallet/cat_wallet/test_cat_wallet.py::TestCATWallet::test_cat_spend[ConsensusMode.SOFT_FORK3-True] - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\Users\RUNNER~1\AppData\Local\Temp\tmpx8x4fkli\test-wallet-db-None-270976397.sqlite'
ERROR tests/wallet/cat_wallet/test_cat_wallet.py::TestCATWallet::test_cat_spend[ConsensusMode.SOFT_FORK3-False] - MemoryError
Tasks not finished etc

Plus loads of timeouts?!?

New Behavior:

This flakiness removed

Testing Notes:

Watch CI results