### PR TITLE
fix typo in PendingTxCache

### DIFF
--- a/chia/full_node/pending_tx_cache.py
+++ b/chia/full_node/pending_tx_cache.py
@@ -87,7 +87,7 @@ class PendingTxCache:
             self._cache_cost -= removed_item.cost
             to_evict[1].pop(first_in)
             if to_evict[1] == {}:
-                self._by_height.pop()
+                self._by_height.popitem()
 
     def drain(self, up_to_height: uint32) -> Dict[bytes32, MempoolItem]:
         ret: Dict[bytes32, MempoolItem] = {}

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -198,6 +198,20 @@ class TestPendingTxCache:
         tx = c.drain(101)
         assert tx == {items[-2].spend_bundle_name: items[-2], items[-1].spend_bundle_name: items[-1]}
 
+    def test_add_eviction(self):
+        c = PendingTxCache(160)
+        item = make_item(1, assert_height=100)
+        c.add(item)
+
+        for i in range(3):
+            item = make_item(i + 1, assert_height=50)
+            c.add(item)
+
+        txs = c.drain(161)
+        assert len(txs) == 2
+        for name, tx in txs.items():
+            assert tx.assert_height == 50
+
     def test_item_limit(self):
         c = PendingTxCache(1000000, 2)
         # each item has cost 80


### PR DESCRIPTION
when evicting the last MempoolItem of an assert-height level. add test coverage, we `pop()` from the `SortedDict`. This fails unconditionally because we're not passing in the required `key` argument.

The intention was to call `popitem()`, which pops the last item.

Kyle discovered this while experimenting with new linting.