### PR TITLE
stop using `pkg_resources.get_distribution()` in `pyinstaller.spec`

### DIFF
--- a/build_scripts/pyinstaller.spec
+++ b/build_scripts/pyinstaller.spec
@@ -5,8 +5,6 @@ import pathlib
 import platform
 import sysconfig
 
-from pkg_resources import get_distribution
-
 from PyInstaller.utils.hooks import collect_submodules, copy_metadata
 
 THIS_IS_WINDOWS = platform.system().lower().startswith("win")
@@ -51,7 +49,7 @@ keyring_imports = collect_submodules("keyring.backends")
 # keyring uses entrypoints to read keyring.backends from metadata file entry_points.txt.
 keyring_datas = copy_metadata("keyring")[0]
 
-version_data = copy_metadata(get_distribution("chia-blockchain"))[0]
+version_data = copy_metadata("chia-blockchain")[0]
 
 block_cipher = None
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This never should have worked, but it did because down the call stack PyInstaller ended up using `pkg_resources` which was ok with it.  `pkg_resources` is deprecated and PyInstaller 6 stopped using it.  6 was accidentally installed and exposed this issue.  We need to stop using `pkg_resources` anyways.  So, here we are.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
