### PR TITLE
Fix CAT --> CR-CAT wallet conversion

### DIFF
--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -167,15 +167,17 @@ class CRCATWallet(CATWallet):
         replace_self = cls()
         replace_self.standard_wallet = cat_wallet.standard_wallet
         replace_self.log = logging.getLogger(cat_wallet.get_name())
+        replace_self.log.info(f"Converting CAT wallet {cat_wallet.id()} to CR-CAT wallet")
         replace_self.wallet_state_manager = cat_wallet.wallet_state_manager
         replace_self.info = CRCATInfo(
             cat_wallet.cat_info.limitations_program_hash, None, authorized_providers, proofs_checker
         )
-        replace_self.wallet_info = await cat_wallet.wallet_state_manager.user_store.update_wallet(
+        await cat_wallet.wallet_state_manager.user_store.update_wallet(
             WalletInfo(
                 cat_wallet.id(), cat_wallet.get_name(), uint8(WalletType.CRCAT.value), bytes(replace_self.info).hex()
             )
         )
+        replace_self.wallet_info = await cat_wallet.wallet_state_manager.user_store.get_wallet_by_id(cat_wallet.id())
 
         cat_wallet.wallet_state_manager.wallets[cat_wallet.id()] = replace_self
 

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -177,7 +177,9 @@ class CRCATWallet(CATWallet):
                 cat_wallet.id(), cat_wallet.get_name(), uint8(WalletType.CRCAT.value), bytes(replace_self.info).hex()
             )
         )
-        replace_self.wallet_info = await cat_wallet.wallet_state_manager.user_store.get_wallet_by_id(cat_wallet.id())
+        updated_wallet_info = await cat_wallet.wallet_state_manager.user_store.get_wallet_by_id(cat_wallet.id())
+        assert updated_wallet_info is not None
+        replace_self.wallet_info = updated_wallet_info
 
         cat_wallet.wallet_state_manager.wallets[cat_wallet.id()] = replace_self
 


### PR DESCRIPTION
### Purpose:
When converting a CAT wallet to a CR-CAT wallet, the `convert_to_cr` method attempts to set the converted wallet's `wallet_info` property, but the `update_wallet` function doesn't return anything. The resulting CR-CAT wallet has its wallet_info set to None, causing issues when querying the wallet through subsequent RPCs.


### Current Behavior:
After conversion, calling an RPC like `get_wallet_balance` will fail.


### New Behavior:
After conversion, the CR-CAT wallet can be queried using RPCs like `get_wallet_balance`


### Testing Notes:
Manually tested

