### PR TITLE
Fix glitch NFT wallet test

### DIFF
--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -998,6 +998,8 @@ async def test_nft_transfer_nft_with_did(self_hostname: str, two_wallet_nodes: A
 
     assert len(wallet_1.wallet_state_manager.wallets) == 1, "NFT wallet shouldn't exist yet"
     assert len(wallet_0.wallet_state_manager.wallets) == 3
+    await full_node_api.wait_for_wallet_synced(wallet_node_0, 20)
+    await full_node_api.wait_for_wallet_synced(wallet_node_1, 20)
     # transfer DID to the other wallet
     tx = await did_wallet.transfer_did(ph1, uint64(0), True, DEFAULT_TX_CONFIG)
     assert tx
@@ -1005,7 +1007,8 @@ async def test_nft_transfer_nft_with_did(self_hostname: str, two_wallet_nodes: A
     await time_out_assert_not_none(30, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle.name())
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
-
+    await full_node_api.wait_for_wallet_synced(wallet_node_0, 20)
+    await full_node_api.wait_for_wallet_synced(wallet_node_1, 20)
     await time_out_assert(15, len, 2, wallet_0.wallet_state_manager.wallets)
     # Transfer NFT, wallet will be deleted
     resp = await api_0.nft_transfer_nft(

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1001,6 +1001,7 @@ async def test_nft_transfer_nft_with_did(self_hostname: str, two_wallet_nodes: A
     # transfer DID to the other wallet
     tx = await did_wallet.transfer_did(ph1, uint64(0), True, DEFAULT_TX_CONFIG)
     assert tx
+    await time_out_assert_not_none(30, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle.name())
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))
 

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1001,6 +1001,7 @@ async def test_nft_transfer_nft_with_did(self_hostname: str, two_wallet_nodes: A
     # transfer DID to the other wallet
     tx = await did_wallet.transfer_did(ph1, uint64(0), True, DEFAULT_TX_CONFIG)
     assert tx
+    assert tx.spend_bundle is not None
     await time_out_assert_not_none(30, full_node_api.full_node.mempool_manager.get_spendbundle, tx.spend_bundle.name())
     for i in range(1, num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph1))


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
test_nft_transfer_nft_with_did may fail because the spend bundle is not in the mempool before farming a new block.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
No check of the spend bundle


### New Behavior:

Add a check to ensure the spend bundle is in the mempool.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
