### PR TITLE
Add new RPC to get block spends with conditions

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -32,7 +32,6 @@ from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, SpendInfo
 from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle_conditions import SpendBundleConditions
-from chia.util.condition_tools import parse_sexp_to_conditions
 from chia.util.errors import Err
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.puzzles.load_clvm import load_serialized_clvm_maybe_recompile

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -190,10 +190,7 @@ def get_spends_for_block_with_conditions(
         coin = Coin(parent.atom, puzzle_hash, int_from_bytes(amount.atom))
         coin_spend = CoinSpend(coin, puzzle, solution)
         conditions = conditions_for_solution(puzzle, solution, DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM)
-        spends.append({
-            "coin_spend": coin_spend,
-            "conditions": [{'opcode': condition.opcode, 'vars': [[var.hex() for var in condition.vars]]} for condition in conditions]
-        })
+        spends.append(CoinSpendWithConditions(coin_spend, conditions))
 
     return spends
 

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from chia_rs import (
     AGG_SIG_ARGS,
@@ -32,6 +32,7 @@ from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, SpendInfo
 from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle_conditions import SpendBundleConditions
+from chia.util.condition_tools import parse_sexp_to_conditions
 from chia.util.errors import Err
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.puzzles.load_clvm import load_serialized_clvm_maybe_recompile
@@ -43,22 +44,8 @@ DESERIALIZE_MOD = load_serialized_clvm_maybe_recompile(
 log = logging.getLogger(__name__)
 
 
-def get_name_puzzle_conditions(
-    generator: BlockGenerator,
-    max_cost: int,
-    *,
-    mempool_mode: bool,
-    height: uint32,
-    constants: ConsensusConstants,
-) -> NPCResult:
-    run_block = run_block_generator
-
-    flags = 0
-    if mempool_mode:
-        flags = flags | MEMPOOL_MODE
-
-    if height >= constants.SOFT_FORK2_HEIGHT:
-        flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+def get_flags_for_height_and_constants(height: int, constants: ConsensusConstants) -> int:
+    flags = ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 
     if height >= constants.SOFT_FORK3_HEIGHT:
         # the soft-fork initiated with 2.0. To activate end of October 2023
@@ -92,6 +79,22 @@ def get_name_puzzle_conditions(
             | AGG_SIG_ARGS
             | ALLOW_BACKREFS
         )
+    
+    return flags
+
+def get_name_puzzle_conditions(
+    generator: BlockGenerator,
+    max_cost: int,
+    *,
+    mempool_mode: bool,
+    height: uint32,
+    constants: ConsensusConstants,
+) -> NPCResult:
+    run_block = run_block_generator
+    flags = get_flags_for_height_and_constants(height, constants)
+
+    if mempool_mode:
+        flags = flags | MEMPOOL_MODE
 
     if height >= constants.HARD_FORK_FIX_HEIGHT:
         run_block = run_block_generator2
@@ -132,7 +135,7 @@ def get_puzzle_and_solution_for_coin(generator: BlockGenerator, coin: Coin, flag
         raise ValueError(f"Failed to get puzzle and solution for coin {coin}, error: {e}") from e
 
 
-def get_spends_for_block(generator: BlockGenerator) -> List[CoinSpend]:
+def get_spends_for_block(generator: BlockGenerator, height: int, constants: ConsensusConstants) -> List[CoinSpend]:
     args = bytearray(b"\xff")
     args += bytes(DESERIALIZE_MOD)
     args += b"\xff"
@@ -143,7 +146,7 @@ def get_spends_for_block(generator: BlockGenerator) -> List[CoinSpend]:
         bytes(generator.program),
         bytes(args),
         DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
-        0,
+        get_flags_for_height_and_constants(height, constants),
     )
 
     spends: List[CoinSpend] = []
@@ -156,6 +159,45 @@ def get_spends_for_block(generator: BlockGenerator) -> List[CoinSpend]:
 
     return spends
 
+def get_spends_for_block_with_conditions(generator: BlockGenerator, height: int, constants: ConsensusConstants) -> List[Dict[str, Any]]:
+    args = bytearray(b"\xff")
+    args += bytes(DESERIALIZE_MOD)
+    args += b"\xff"
+    args += bytes(Program.to([bytes(a) for a in generator.generator_refs]))
+    args += b"\x80\x80"
+
+    flags = get_flags_for_height_and_constants(height, constants)
+
+    _, ret = run_chia_program(
+        bytes(generator.program),
+        bytes(args),
+        DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+        flags,
+    )
+
+    spends = []
+
+    for spend in Program.to(ret).first().as_iter():
+        parent, puzzle, amount, solution = spend.as_iter()
+        puzzle_hash = puzzle.get_tree_hash()
+        _, r = run_chia_program(
+            puzzle.as_bin(),
+            solution.as_bin(),
+            DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+            flags,
+        )
+        spends.append({
+            "coin": {
+                "amount": int_from_bytes(amount.atom),
+                "parent_coin_info": parent.atom,
+                "puzzle_hash": puzzle_hash,
+            },
+            "puzzle": puzzle,
+            "solution": solution,
+            "conditions": Program.to(r),
+        })
+
+    return spends
 
 def mempool_check_time_locks(
     removal_coin_records: Dict[bytes32, CoinRecord],

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -45,6 +45,9 @@ log = logging.getLogger(__name__)
 
 def get_flags_for_height_and_constants(height: int, constants: ConsensusConstants) -> int:
     flags = ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+    
+    if height >= constants.SOFT_FORK2_HEIGHT:
+        flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 
     if height >= constants.SOFT_FORK3_HEIGHT:
         # the soft-fork initiated with 2.0. To activate end of October 2023

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from chia_rs import (
     AGG_SIG_ARGS,

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -503,7 +503,16 @@ class FullNodeRpcApi:
             block_generator, full_block.height, self.service.constants
         )
 
-        return {"block_spends_with_conditions": spends_with_conditions}
+        return {
+            "block_spends_with_conditions": [
+                {
+                    "coin_spend": spend_with_conditions.coin_spend,
+                    "conditions": [
+                        {
+                            'opcode': condition.opcode,
+                            'vars': [var.hex() for var in condition.vars]
+                        } for condition in spend_with_conditions.conditions]
+                    } for spend_with_conditions in spends_with_conditions]}
 
     async def get_block_record_by_height(self, request: Dict[str, Any]) -> EndpointResult:
         if "height" not in request:

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -508,11 +508,13 @@ class FullNodeRpcApi:
                 {
                     "coin_spend": spend_with_conditions.coin_spend,
                     "conditions": [
-                        {
-                            'opcode': condition.opcode,
-                            'vars': [var.hex() for var in condition.vars]
-                        } for condition in spend_with_conditions.conditions]
-                    } for spend_with_conditions in spends_with_conditions]}
+                        {"opcode": condition.opcode, "vars": [var.hex() for var in condition.vars]}
+                        for condition in spend_with_conditions.conditions
+                    ],
+                }
+                for spend_with_conditions in spends_with_conditions
+            ]
+        }
 
     async def get_block_record_by_height(self, request: Dict[str, Any]) -> EndpointResult:
         if "height" not in request:

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -21,7 +21,7 @@ from chia.server.outbound_message import NodeType
 from chia.types.blockchain_format.proof_of_space import calculate_prefix_bits
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.types.coin_spend import CoinSpend, CoinSpendWithConditions
+from chia.types.coin_spend import CoinSpend
 from chia.types.full_block import FullBlock
 from chia.types.generator_types import BlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -487,7 +487,7 @@ class FullNodeRpcApi:
 
         return {"block_spends": spends}
 
-    async def get_block_spends_with_conditions(self, request: Dict[str, CoinSpendWithConditions]) -> EndpointResult:
+    async def get_block_spends_with_conditions(self, request: Dict[str, Any]) -> EndpointResult:
         if "header_hash" not in request:
             raise ValueError("No header_hash in request")
         header_hash = bytes32.from_hexstr(request["header_hash"])

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple, TypedDict, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from chia.consensus.block_record import BlockRecord
 from chia.full_node.signage_point import SignagePoint
 from chia.rpc.rpc_client import RpcClient
-from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, cast
 
 from chia.consensus.block_record import BlockRecord
 from chia.full_node.signage_point import SignagePoint
 from chia.rpc.rpc_client import RpcClient
+from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
@@ -205,6 +206,14 @@ class FullNodeRpcClient(RpcClient):
             for block_spend in response["block_spends"]:
                 block_spends.append(CoinSpend.from_json_dict(block_spend))
             return block_spends
+        except Exception:
+            return None
+
+    async def get_block_spends_with_conditions(self, header_hash: bytes32) -> Optional[List[Dict[str, Any]]]:
+        try:
+            response: List[Dict[str, Any]] = await self.fetch("get_block_spends_with_conditions", {"header_hash": header_hash.hex()})
+
+            return response["block_spends_with_conditions"]
         except Exception:
             return None
 

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -211,10 +211,11 @@ class FullNodeRpcClient(RpcClient):
     async def get_block_spends_with_conditions(self, header_hash: bytes32) -> Optional[List[CoinSpendWithConditions]]:
         try:
             response = await self.fetch("get_block_spends_with_conditions", {"header_hash": header_hash.hex()})
-            block_spends = []
+            block_spends: List[CoinSpendWithConditions] = []
             for block_spend in response["block_spends_with_conditions"]:
                 block_spends.append(CoinSpendWithConditions.from_json_dict(block_spend))
             return block_spends
+
         except Exception:
             return None
 

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -7,7 +7,7 @@ from chia.full_node.signage_point import SignagePoint
 from chia.rpc.rpc_client import RpcClient
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, CoinSpendWithConditions
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
@@ -208,11 +208,13 @@ class FullNodeRpcClient(RpcClient):
         except Exception:
             return None
 
-    async def get_block_spends_with_conditions(self, header_hash: bytes32) -> Optional[List[Dict[str, Any]]]:
+    async def get_block_spends_with_conditions(self, header_hash: bytes32) -> Optional[List[CoinSpendWithConditions]]:
         try:
             response = await self.fetch("get_block_spends_with_conditions", {"header_hash": header_hash.hex()})
-            block_spends_with_conditions: List[Dict[str, Any]] = response["block_spends_with_conditions"]
-            return block_spends_with_conditions
+            block_spends = []
+            for block_spend in response["block_spends_with_conditions"]:
+                block_spends.append(CoinSpendWithConditions.from_json_dict(block_spend))
+            return block_spends
         except Exception:
             return None
 

--- a/chia/rpc/full_node_rpc_client.py
+++ b/chia/rpc/full_node_rpc_client.py
@@ -211,9 +211,9 @@ class FullNodeRpcClient(RpcClient):
 
     async def get_block_spends_with_conditions(self, header_hash: bytes32) -> Optional[List[Dict[str, Any]]]:
         try:
-            response: List[Dict[str, Any]] = await self.fetch("get_block_spends_with_conditions", {"header_hash": header_hash.hex()})
-
-            return response["block_spends_with_conditions"]
+            response = await self.fetch("get_block_spends_with_conditions", {"header_hash": header_hash.hex()})
+            block_spends_with_conditions: List[Dict[str, Any]] = response["block_spends_with_conditions"]
+            return block_spends_with_conditions
         except Exception:
             return None
 

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -88,8 +88,12 @@ class CoinSpendWithConditions:
     coin_spend: CoinSpend
     conditions: List[ConditionWithArgs]
 
-    def from_json_dict(dict: Dict[str, Any]):
+    @staticmethod
+    def from_json_dict(dict: Dict[str, Any]) -> CoinSpendWithConditions:
         return CoinSpendWithConditions(
             CoinSpend.from_json_dict(dict["coin_spend"]),
-            [ConditionWithArgs(bytes.fromhex(condition["opcode"][2:]), [[bytes.fromhex(v)for v in var] for var in condition["vars"]]) for condition in dict["conditions"]]
+            [ConditionWithArgs(
+                ConditionOpcode(bytes.fromhex(condition["opcode"][2:])),
+                [bytes.fromhex(var) for var in condition["vars"]]
+            ) for condition in dict["conditions"]]
         )

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -11,6 +11,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.condition_opcodes import ConditionOpcode
+from chia.types.condition_with_args import ConditionWithArgs
 from chia.util.errors import Err, ValidationError
 from chia.util.streamable import Streamable, streamable
 
@@ -82,8 +83,7 @@ class SpendInfo(Streamable):
     puzzle: SerializedProgram
     solution: SerializedProgram
 
-@streamable
 @dataclass(frozen=True)
-class CoinSpendWithConditions(Streamable):
+class CoinSpendWithConditions:
     coin_spend: CoinSpend
-    conditions: Program
+    conditions: List[ConditionWithArgs]

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -83,6 +83,7 @@ class SpendInfo(Streamable):
     puzzle: SerializedProgram
     solution: SerializedProgram
 
+
 @dataclass(frozen=True)
 class CoinSpendWithConditions:
     coin_spend: CoinSpend
@@ -92,8 +93,11 @@ class CoinSpendWithConditions:
     def from_json_dict(dict: Dict[str, Any]) -> CoinSpendWithConditions:
         return CoinSpendWithConditions(
             CoinSpend.from_json_dict(dict["coin_spend"]),
-            [ConditionWithArgs(
-                ConditionOpcode(bytes.fromhex(condition["opcode"][2:])),
-                [bytes.fromhex(var) for var in condition["vars"]]
-            ) for condition in dict["conditions"]]
+            [
+                ConditionWithArgs(
+                    ConditionOpcode(bytes.fromhex(condition["opcode"][2:])),
+                    [bytes.fromhex(var) for var in condition["vars"]],
+                )
+                for condition in dict["conditions"]
+            ],
         )

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from clvm.casts import int_from_bytes
 
@@ -87,3 +87,9 @@ class SpendInfo(Streamable):
 class CoinSpendWithConditions:
     coin_spend: CoinSpend
     conditions: List[ConditionWithArgs]
+
+    def from_json_dict(dict: Dict[str, Any]):
+        return CoinSpendWithConditions(
+            CoinSpend.from_json_dict(dict["coin_spend"]),
+            [ConditionWithArgs(bytes.fromhex(condition["opcode"][2:]), [[bytes.fromhex(v)for v in var] for var in condition["vars"]]) for condition in dict["conditions"]]
+        )

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -81,3 +81,9 @@ def compute_additions(cs: CoinSpend, *, max_cost: int = DEFAULT_CONSTANTS.MAX_BL
 class SpendInfo(Streamable):
     puzzle: SerializedProgram
     solution: SerializedProgram
+
+@streamable
+@dataclass(frozen=True)
+class CoinSpendWithConditions(Streamable):
+    coin_spend: CoinSpend
+    conditions: Program

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import List
+from chia.types.blockchain_format.program import Program
 
 import pytest
 from blspy import AugSchemeMPL
@@ -228,6 +229,14 @@ class TestRpc:
 
             assert len(block_spends) == 3
             assert sorted(block_spends, key=lambda x: str(x)) == sorted(coin_spends, key=lambda x: str(x))
+
+            block_spends_with_conditions = await client.get_block_spends_with_conditions(block.header_hash)
+
+            assert len(block_spends_with_conditions) == 3
+            assert sorted(block_spends_with_conditions, key=lambda x: str(x)) == sorted(coin_spends, key=lambda x: str(x))
+
+            for coin_spend in block_spends_with_conditions:
+                assert isinstance(coin_spend.conditions, Program) == True
 
             memo = 32 * b"\f"
 

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import List
+from chia_rs import CoinSpend
 
 import pytest
 from blspy import AugSchemeMPL
@@ -234,8 +235,40 @@ class TestRpc:
 
             assert len(block_spends_with_conditions) == 3
 
-            for coin_spend_with_conditions in block_spends_with_conditions:
-                assert isinstance(coin_spend_with_conditions.conditions, Program) == True
+            block_spends_with_conditions = sorted(block_spends_with_conditions, key=lambda x: str(x))
+
+            coin_spend_with_conditions = block_spends_with_conditions[0]
+
+            assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000a"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 1750000000000)
+            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
+            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa0a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee54798080ff8080")
+            assert coin_spend_with_conditions.conditions == Program.to([
+                [50, bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"), bytes.fromhex("49b6f533000b967f049bb6e7b29d0b6f465ebccd5733bc75340f98dae782aa08")],
+                [51, bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"), bytes.fromhex("01977420dc00")],
+                [60, bytes.fromhex("a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee5479")]
+            ])
+
+            coin_spend_with_conditions = block_spends_with_conditions[1]
+
+            assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000b"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 1750000000000)
+            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
+            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa04f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f8080ff8080")
+            assert coin_spend_with_conditions.conditions == Program.to([
+                [50, bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"), bytes.fromhex("95df50b31bb746a37df6ab448f10436fb98bb659990c61ee6933a196f6a06465")],
+                [51, bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"), bytes.fromhex("01977420dc00")],
+                [60, bytes.fromhex("4f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f")]
+            ])
+
+            coin_spend_with_conditions = block_spends_with_conditions[2]
+
+            assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("27ae41e4649b934ca495991b7852b8550000000000000000000000000000000b"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 250000000000)
+            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
+            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff853a3529440080ffff3cffa0617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f8080ff8080")
+            assert coin_spend_with_conditions.conditions == Program.to([
+                [50, bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"), bytes.fromhex("f3dd65f1ca4b030a726182e0194174fe95ff7a66f54381cad3aab168b8e75ee7")],
+                [51, bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"), bytes.fromhex("3a35294400")],
+                [60, bytes.fromhex("617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f")]
+            ])
 
             memo = 32 * b"\f"
 

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -1,6 +1,5 @@
 # flake8: noqa: F811, F401
 from __future__ import annotations
-
 from typing import List
 from chia_rs import CoinSpend
 
@@ -235,40 +234,82 @@ class TestRpc:
 
             assert len(block_spends_with_conditions) == 3
 
-            block_spends_with_conditions = sorted(block_spends_with_conditions, key=lambda x: str(x))
+            block_spends_with_conditions = sorted(block_spends_with_conditions, key=lambda x: str(x.coin_spend))
 
             coin_spend_with_conditions = block_spends_with_conditions[0]
 
             assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000a"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 1750000000000)
             assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
             assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa0a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee54798080ff8080")
-            assert coin_spend_with_conditions.conditions == Program.to([
-                [50, bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"), bytes.fromhex("49b6f533000b967f049bb6e7b29d0b6f465ebccd5733bc75340f98dae782aa08")],
-                [51, bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"), bytes.fromhex("01977420dc00")],
-                [60, bytes.fromhex("a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee5479")]
-            ])
+            assert coin_spend_with_conditions.conditions == [
+                ConditionWithArgs(b"2", [
+                    [
+                        bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
+                        bytes.fromhex("49b6f533000b967f049bb6e7b29d0b6f465ebccd5733bc75340f98dae782aa08")
+                    ]
+                ]),
+                ConditionWithArgs(b"3", [
+                    [
+                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                        bytes.fromhex("01977420dc00")
+                    ]
+                ]),
+                ConditionWithArgs(b"<", [
+                    [
+                        bytes.fromhex("a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee5479"),
+                    ]
+                ])
+            ]
 
             coin_spend_with_conditions = block_spends_with_conditions[1]
 
             assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000b"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 1750000000000)
             assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
             assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa04f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f8080ff8080")
-            assert coin_spend_with_conditions.conditions == Program.to([
-                [50, bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"), bytes.fromhex("95df50b31bb746a37df6ab448f10436fb98bb659990c61ee6933a196f6a06465")],
-                [51, bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"), bytes.fromhex("01977420dc00")],
-                [60, bytes.fromhex("4f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f")]
-            ])
+            assert coin_spend_with_conditions.conditions == [
+                ConditionWithArgs(b"2", [
+                    [
+                        bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
+                        bytes.fromhex("95df50b31bb746a37df6ab448f10436fb98bb659990c61ee6933a196f6a06465")
+                    ]
+                ]),
+                ConditionWithArgs(b"3", [
+                    [
+                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                        bytes.fromhex("01977420dc00")
+                    ]
+                ]),
+                ConditionWithArgs(b"<", [
+                    [
+                        bytes.fromhex("4f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f"),
+                    ]
+                ])
+            ]
 
             coin_spend_with_conditions = block_spends_with_conditions[2]
 
             assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("27ae41e4649b934ca495991b7852b8550000000000000000000000000000000b"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 250000000000)
             assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
             assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff853a3529440080ffff3cffa0617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f8080ff8080")
-            assert coin_spend_with_conditions.conditions == Program.to([
-                [50, bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"), bytes.fromhex("f3dd65f1ca4b030a726182e0194174fe95ff7a66f54381cad3aab168b8e75ee7")],
-                [51, bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"), bytes.fromhex("3a35294400")],
-                [60, bytes.fromhex("617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f")]
-            ])
+            assert coin_spend_with_conditions.conditions == [
+                ConditionWithArgs(b"2", [
+                    [
+                        bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
+                        bytes.fromhex("f3dd65f1ca4b030a726182e0194174fe95ff7a66f54381cad3aab168b8e75ee7")
+                    ]
+                ]),
+                ConditionWithArgs(b"3", [
+                    [
+                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                        bytes.fromhex("3a35294400")
+                    ]
+                ]),
+                ConditionWithArgs(b"<", [
+                    [
+                        bytes.fromhex("617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f"),
+                    ]
+                ])
+            ]
 
             memo = 32 * b"\f"
 

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -1,10 +1,11 @@
 # flake8: noqa: F811, F401
 from __future__ import annotations
+
 from typing import List
-from chia_rs import CoinSpend
 
 import pytest
 from blspy import AugSchemeMPL
+from chia_rs import CoinSpend
 from clvm.casts import int_to_bytes
 
 from chia.consensus.block_record import BlockRecord
@@ -238,59 +239,116 @@ class TestRpc:
 
             coin_spend_with_conditions = block_spends_with_conditions[0]
 
-            assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000a"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 1750000000000)
-            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
-            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa0a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee54798080ff8080")
+            assert coin_spend_with_conditions.coin_spend.coin == Coin(
+                bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000a"),
+                bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"),
+                1750000000000,
+            )
+            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex(
+                "ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080"
+            )
+            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex(
+                "ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa0a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee54798080ff8080"
+            )
             assert coin_spend_with_conditions.conditions == [
-                ConditionWithArgs(b"2", [
-                    bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
-                    bytes.fromhex("49b6f533000b967f049bb6e7b29d0b6f465ebccd5733bc75340f98dae782aa08")
-                ]),
-                ConditionWithArgs(b"3", [
-                    bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
-                    bytes.fromhex("01977420dc00")
-                ]),
-                ConditionWithArgs(b"<", [
-                    bytes.fromhex("a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee5479"),
-                ])
+                ConditionWithArgs(
+                    b"2",
+                    [
+                        bytes.fromhex(
+                            "a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"
+                        ),
+                        bytes.fromhex("49b6f533000b967f049bb6e7b29d0b6f465ebccd5733bc75340f98dae782aa08"),
+                    ],
+                ),
+                ConditionWithArgs(
+                    b"3",
+                    [
+                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                        bytes.fromhex("01977420dc00"),
+                    ],
+                ),
+                ConditionWithArgs(
+                    b"<",
+                    [
+                        bytes.fromhex("a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee5479"),
+                    ],
+                ),
             ]
 
             coin_spend_with_conditions = block_spends_with_conditions[1]
 
-            assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000b"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 1750000000000)
-            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
-            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa04f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f8080ff8080")
+            assert coin_spend_with_conditions.coin_spend.coin == Coin(
+                bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000b"),
+                bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"),
+                1750000000000,
+            )
+            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex(
+                "ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080"
+            )
+            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex(
+                "ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa04f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f8080ff8080"
+            )
             assert coin_spend_with_conditions.conditions == [
-                ConditionWithArgs(b"2", [
-                    bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
-                    bytes.fromhex("95df50b31bb746a37df6ab448f10436fb98bb659990c61ee6933a196f6a06465")
-                ]),
-                ConditionWithArgs(b"3", [
-                    bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
-                    bytes.fromhex("01977420dc00")
-                ]),
-                ConditionWithArgs(b"<", [
-                    bytes.fromhex("4f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f"),
-                ])
+                ConditionWithArgs(
+                    b"2",
+                    [
+                        bytes.fromhex(
+                            "a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"
+                        ),
+                        bytes.fromhex("95df50b31bb746a37df6ab448f10436fb98bb659990c61ee6933a196f6a06465"),
+                    ],
+                ),
+                ConditionWithArgs(
+                    b"3",
+                    [
+                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                        bytes.fromhex("01977420dc00"),
+                    ],
+                ),
+                ConditionWithArgs(
+                    b"<",
+                    [
+                        bytes.fromhex("4f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f"),
+                    ],
+                ),
             ]
 
             coin_spend_with_conditions = block_spends_with_conditions[2]
 
-            assert coin_spend_with_conditions.coin_spend.coin == Coin(bytes.fromhex("27ae41e4649b934ca495991b7852b8550000000000000000000000000000000b"), bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"), 250000000000)
-            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex("ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080")
-            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff853a3529440080ffff3cffa0617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f8080ff8080")
+            assert coin_spend_with_conditions.coin_spend.coin == Coin(
+                bytes.fromhex("27ae41e4649b934ca495991b7852b8550000000000000000000000000000000b"),
+                bytes.fromhex("8488947a2213b2c2551fe019bbb708db86eab3dd5133eb57e801515e9e4ad82a"),
+                250000000000,
+            )
+            assert coin_spend_with_conditions.coin_spend.puzzle_reveal.to_program() == Program.fromhex(
+                "ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252aff018080"
+            )
+            assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex(
+                "ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff853a3529440080ffff3cffa0617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f8080ff8080"
+            )
             assert coin_spend_with_conditions.conditions == [
-                ConditionWithArgs(b"2", [
-                    bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
-                    bytes.fromhex("f3dd65f1ca4b030a726182e0194174fe95ff7a66f54381cad3aab168b8e75ee7")
-                ]),
-                ConditionWithArgs(b"3", [
-                    bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
-                    bytes.fromhex("3a35294400")
-                ]),
-                ConditionWithArgs(b"<", [
-                    bytes.fromhex("617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f"),
-                ])
+                ConditionWithArgs(
+                    b"2",
+                    [
+                        bytes.fromhex(
+                            "a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"
+                        ),
+                        bytes.fromhex("f3dd65f1ca4b030a726182e0194174fe95ff7a66f54381cad3aab168b8e75ee7"),
+                    ],
+                ),
+                ConditionWithArgs(
+                    b"3",
+                    [
+                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                        bytes.fromhex("3a35294400"),
+                    ],
+                ),
+                ConditionWithArgs(
+                    b"<",
+                    [
+                        bytes.fromhex("617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f"),
+                    ],
+                ),
             ]
 
             memo = 32 * b"\f"

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -243,21 +243,15 @@ class TestRpc:
             assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa0a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee54798080ff8080")
             assert coin_spend_with_conditions.conditions == [
                 ConditionWithArgs(b"2", [
-                    [
-                        bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
-                        bytes.fromhex("49b6f533000b967f049bb6e7b29d0b6f465ebccd5733bc75340f98dae782aa08")
-                    ]
+                    bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
+                    bytes.fromhex("49b6f533000b967f049bb6e7b29d0b6f465ebccd5733bc75340f98dae782aa08")
                 ]),
                 ConditionWithArgs(b"3", [
-                    [
-                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
-                        bytes.fromhex("01977420dc00")
-                    ]
+                    bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                    bytes.fromhex("01977420dc00")
                 ]),
                 ConditionWithArgs(b"<", [
-                    [
-                        bytes.fromhex("a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee5479"),
-                    ]
+                    bytes.fromhex("a2366d6d8e1ce7496175528f5618a13da8401b02f2bac1eaae8f28aea9ee5479"),
                 ])
             ]
 
@@ -268,21 +262,15 @@ class TestRpc:
             assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff8601977420dc0080ffff3cffa04f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f8080ff8080")
             assert coin_spend_with_conditions.conditions == [
                 ConditionWithArgs(b"2", [
-                    [
-                        bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
-                        bytes.fromhex("95df50b31bb746a37df6ab448f10436fb98bb659990c61ee6933a196f6a06465")
-                    ]
+                    bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
+                    bytes.fromhex("95df50b31bb746a37df6ab448f10436fb98bb659990c61ee6933a196f6a06465")
                 ]),
                 ConditionWithArgs(b"3", [
-                    [
-                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
-                        bytes.fromhex("01977420dc00")
-                    ]
+                    bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                    bytes.fromhex("01977420dc00")
                 ]),
                 ConditionWithArgs(b"<", [
-                    [
-                        bytes.fromhex("4f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f"),
-                    ]
+                    bytes.fromhex("4f6d4d12e97e83b2024fd0970e3b9e8a1c2e509625c15ff4145940c45b51974f"),
                 ])
             ]
 
@@ -293,21 +281,15 @@ class TestRpc:
             assert coin_spend_with_conditions.coin_spend.solution.to_program() == Program.fromhex("ff80ffff01ffff33ffa063c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575cff853a3529440080ffff3cffa0617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f8080ff8080")
             assert coin_spend_with_conditions.conditions == [
                 ConditionWithArgs(b"2", [
-                    [
-                        bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
-                        bytes.fromhex("f3dd65f1ca4b030a726182e0194174fe95ff7a66f54381cad3aab168b8e75ee7")
-                    ]
+                    bytes.fromhex("a499b52c7eba3465c3d74070a25d5ac5f5df25ed07d1c9c0c0509b00140da3e3bb60b584eaa30a1204ec0e5839f1252a"),
+                    bytes.fromhex("f3dd65f1ca4b030a726182e0194174fe95ff7a66f54381cad3aab168b8e75ee7")
                 ]),
                 ConditionWithArgs(b"3", [
-                    [
-                        bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
-                        bytes.fromhex("3a35294400")
-                    ]
+                    bytes.fromhex("63c767818f8b7cc8f3760ce34a09b7f34cd9ddf09d345c679b6897e7620c575c"),
+                    bytes.fromhex("3a35294400")
                 ]),
                 ConditionWithArgs(b"<", [
-                    [
-                        bytes.fromhex("617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f"),
-                    ]
+                    bytes.fromhex("617d9951551dc9e329fcab835f37fe4602c9ea57626cc2069228793f7007716f"),
                 ])
             ]
 

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import List
-from chia.types.blockchain_format.program import Program
 
 import pytest
 from blspy import AugSchemeMPL
@@ -20,6 +19,7 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtoco
 from chia.simulator.time_out_assert import time_out_assert
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.coin import Coin
+from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
@@ -233,10 +233,9 @@ class TestRpc:
             block_spends_with_conditions = await client.get_block_spends_with_conditions(block.header_hash)
 
             assert len(block_spends_with_conditions) == 3
-            assert sorted(block_spends_with_conditions, key=lambda x: str(x)) == sorted(coin_spends, key=lambda x: str(x))
 
-            for coin_spend in block_spends_with_conditions:
-                assert isinstance(coin_spend.conditions, Program) == True
+            for coin_spend_with_conditions in block_spends_with_conditions:
+                assert isinstance(coin_spend_with_conditions.conditions, Program) == True
 
             memo = 32 * b"\f"
 


### PR DESCRIPTION
### Purpose:

Support for conditions can change at different block heights. Calculating this is complex and easily forgotten so this RPC gets the spends with conditions that are valid for the height of the spend. This encapsulates the logic in the full node and the caller doesn't need to think about it.