### PR TITLE
Delete unconfirmed Clawback TX

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1660,6 +1660,19 @@ class WalletStateManager:
                                 else:
                                     for rem_coin in tx_record.removals:
                                         if rem_coin == coin_state.coin:
+                                            if tx_record.type == TransactionType.OUTGOING_CLAWBACK.value:
+                                                # Check if the coin is spent by the current wallet
+                                                coin_spend = await fetch_coin_spend_for_coin_state(coin_state, peer)
+                                                new_coins = set(compute_spend_hints_and_additions(coin_spend).keys())
+                                                # Check if the new coin belongs to the current wallet.
+                                                # Otherwise, we should remove the TX.
+                                                need_remove: bool = True
+                                                for added_coin in tx_record.additions:
+                                                    if added_coin.name() in new_coins:
+                                                        need_remove = False
+                                                        break
+                                                if need_remove:
+                                                    await self.tx_store.delete_transaction_record(tx_record.name)
                                             confirmed_tx_records.append(tx_record)
 
                             for tx_record in confirmed_tx_records:

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -776,6 +776,7 @@ class TestWalletSimulator:
         wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
         wallet_2 = wallet_node_2.wallet_state_manager.main_wallet
         api_1 = WalletRpcApi(wallet_node_1)
+        api_2 = WalletRpcApi(wallet_node_2)
         if trusted:
             wallet_node_1.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
             wallet_node_2.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}
@@ -838,6 +839,9 @@ class TestWalletSimulator:
         assert resp["success"]
         assert len(resp["transaction_ids"]) == 1
         resp = await api_1.spend_clawback_coins(dict({"coin_ids": [clawback_coin_id_2.hex()], "fee": 0}))
+        assert resp["success"]
+        assert len(resp["transaction_ids"]) == 1
+        resp = await api_2.spend_clawback_coins(dict({"coin_ids": [clawback_coin_id_1.hex()], "fee": 0}))
         assert resp["success"]
         assert len(resp["transaction_ids"]) == 1
         expected_confirmed_balance += await full_node_api.farm_blocks_to_wallet(count=num_blocks, wallet=wallet_1)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
When users claim and clawback the same coin concurrently, both TX will be marked as confirmed which is confusing for the users.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Set TX to confirmed


### New Behavior:
Delete the TX if it is impossible to be confirmed


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
