### PR TITLE
improvements to deep re-org logic

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: [ 3.9 ]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.32.0
+      BLOCKS_AND_PLOTS_VERSION: 0.33.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: [ 3.9 ]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.33.0
+      BLOCKS_AND_PLOTS_VERSION: 0.34.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -113,7 +113,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.name }}
-      BLOCKS_AND_PLOTS_VERSION: 0.32.0
+      BLOCKS_AND_PLOTS_VERSION: 0.33.0
 
     steps:
       - name: Configure git

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -113,7 +113,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.name }}
-      BLOCKS_AND_PLOTS_VERSION: 0.33.0
+      BLOCKS_AND_PLOTS_VERSION: 0.34.0
 
     steps:
       - name: Configure git

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -293,7 +293,7 @@ async def validate_block_body(
     else:
         prev_br = await blocks.get_block_record_from_db(block.prev_header_hash)
         assert prev_br is not None
-        fork_h = find_fork_point_in_chain(blocks, peak, prev_br)
+        fork_h = await find_fork_point_in_chain(blocks, peak, prev_br)
 
     # Get additions and removals since (after) fork_h but not including this block
     # The values include: the coin that was added, the height of the block in which it was confirmed, and the

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -304,6 +304,9 @@ class Blockchain(BlockchainInterface):
         # otherwise other tasks may go look for this block before it's available
         if state_change_summary is not None:
             self._peak_height = block_record.height
+        if self._peak_height is not None:
+            assert self.__height_map.contains_height(self._peak_height)
+            assert not self.__height_map.contains_height(uint32(self._peak_height + 1))
 
         # This is done outside the try-except in case it fails, since we do not want to revert anything if it does
         await self.__height_map.maybe_flush()

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -381,7 +381,7 @@ class Blockchain(BlockchainInterface):
         elif fork_point_with_peak is not None:
             fork_height = fork_point_with_peak
         else:
-            fork_height = find_fork_point_in_chain(self, block_record, peak)
+            fork_height = await find_fork_point_in_chain(self, block_record, peak)
 
         if block_record.prev_hash != peak.header_hash:
             for coin_record in await self.coin_store.rollback_to_block(fork_height):
@@ -944,7 +944,7 @@ class Blockchain(BlockchainInterface):
                 prev_block = await self.block_store.get_full_block(previous_block_hash)
                 assert prev_block is not None
                 assert prev_block_record is not None
-                fork = find_fork_point_in_chain(self, peak, prev_block_record)
+                fork = await find_fork_point_in_chain(self, peak, prev_block_record)
                 curr_2: Optional[FullBlock] = prev_block
                 assert curr_2 is not None and isinstance(curr_2, FullBlock)
                 reorg_chain[curr_2.height] = curr_2

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -851,6 +851,16 @@ class Blockchain(BlockchainInterface):
             return ret
         return await self.block_store.get_block_record(header_hash)
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            b = self.__block_records.get(h)
+            if b is not None:
+                ret.append(b.prev_hash)
+            else:
+                ret.append(await self.block_store.get_prev_hash(h))
+        return ret
+
     async def contains_block_from_db(self, header_hash: bytes32) -> bool:
         ret = header_hash in self.__block_records
         if ret:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -232,6 +232,8 @@ class Blockchain(BlockchainInterface):
         """
 
         genesis: bool = block.height == 0
+        header_hash: bytes32 = block.header_hash
+
         if self.contains_block(block.header_hash):
             return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
 
@@ -274,7 +276,6 @@ class Blockchain(BlockchainInterface):
         # Always add the block to the database
         async with self.block_store.db_wrapper.writer():
             try:
-                header_hash: bytes32 = block.header_hash
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 records, state_change_summary = await self._reconsider_peak(
@@ -295,7 +296,7 @@ class Blockchain(BlockchainInterface):
             except BaseException as e:
                 self.block_store.rollback_cache_block(header_hash)
                 log.error(
-                    f"Error while adding block {block.header_hash} height {block.height},"
+                    f"Error while adding block {header_hash} height {block.height},"
                     f" rolling back: {traceback.format_exc()} {e}"
                 )
                 raise
@@ -838,8 +839,9 @@ class Blockchain(BlockchainInterface):
         return records
 
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
-        if header_hash in self.__block_records:
-            return self.__block_records[header_hash]
+        ret = self.__block_records.get(header_hash)
+        if ret is not None:
+            return ret
         return await self.block_store.get_block_record(header_hash)
 
     def remove_block_record(self, header_hash: bytes32) -> None:

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -64,6 +64,9 @@ class BlockchainInterface:
         # ignoring hinting error until we handle our interfaces more formally
         return  # type: ignore[return-value]
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        return  # type: ignore[return-value]
+
     async def get_header_blocks_in_range(
         self, start: int, stop: int, tx_filter: bool = True
     ) -> Dict[bytes32, HeaderBlock]:

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -41,6 +41,9 @@ class BlockchainInterface:
         # ignoring hinting error until we handle our interfaces more formally
         return  # type: ignore[return-value]
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        return  # type: ignore[return-value]
+
     def remove_block_record(self, header_hash: bytes32) -> None:
         pass
 

--- a/chia/consensus/find_fork_point.py
+++ b/chia/consensus/find_fork_point.py
@@ -23,18 +23,38 @@ async def find_fork_point_in_chain(
     Returns -1 if chains have no common ancestor
     * assumes the fork point is loaded in blocks
     """
-    while block_2.height > 0 or block_1.height > 0:
-        if block_2.height > block_1.height:
-            block_2 = unwrap(await blocks.get_block_record_from_db(block_2.prev_hash))
-        elif block_1.height > block_2.height:
-            block_1 = unwrap(await blocks.get_block_record_from_db(block_1.prev_hash))
-        else:
-            if block_2.header_hash == block_1.header_hash:
-                return block_2.height
-            block_2 = unwrap(await blocks.get_block_record_from_db(block_2.prev_hash))
-            block_1 = unwrap(await blocks.get_block_record_from_db(block_1.prev_hash))
+    height_1 = int(block_1.height)
+    height_2 = int(block_2.height)
+    bh_1 = block_1.header_hash
+    bh_2 = block_2.header_hash
 
-    if block_2 != block_1:
+    # special case for first level, since we actually already know the previous
+    # hash
+    if height_1 > height_2:
+        bh_1 = block_1.prev_hash
+        height_1 -= 1
+    elif height_2 > height_1:
+        bh_2 = block_2.prev_hash
+        height_2 -= 1
+
+    while height_1 > height_2:
+        [bh_1] = await blocks.prev_block_hash([bh_1])
+        height_1 -= 1
+
+    while height_2 > height_1:
+        [bh_2] = await blocks.prev_block_hash([bh_2])
+        height_2 -= 1
+
+    assert height_1 == height_2
+
+    height = height_2
+    while height > 0:
+        if bh_1 == bh_2:
+            return height
+        [bh_1, bh_2] = await blocks.prev_block_hash([bh_1, bh_2])
+        height -= 1
+
+    if bh_2 != bh_1:
         # All blocks are different
         return -1
 

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -197,9 +197,9 @@ async def pre_validate_blocks_multiprocessing(
     num_sub_slots_found = 0
     num_blocks_seen = 0
     if blocks[0].height > 0:
-        if not block_records.contains_block(blocks[0].prev_header_hash):
+        curr = await block_records.get_block_record_from_db(blocks[0].prev_header_hash)
+        if curr is None:
             return [PreValidationResult(uint16(Err.INVALID_PREV_BLOCK_HASH.value), None, None, False)]
-        curr = block_records.block_record(blocks[0].prev_header_hash)
         num_sub_slots_to_look_for = 3 if curr.overflow else 2
         while (
             curr.sub_epoch_summary_included is None
@@ -212,7 +212,8 @@ async def pre_validate_blocks_multiprocessing(
             recent_blocks[curr.header_hash] = curr
             if curr.is_transaction_block:
                 num_blocks_seen += 1
-            curr = block_records.block_record(curr.prev_hash)
+            curr = await block_records.get_block_record_from_db(curr.prev_hash)
+            assert curr is not None
         recent_blocks[curr.header_hash] = curr
     block_record_was_present = []
     for block in blocks:
@@ -221,10 +222,18 @@ async def pre_validate_blocks_multiprocessing(
     diff_ssis: List[Tuple[uint64, uint64]] = []
     for block in blocks:
         if block.height != 0:
-            assert block_records.contains_block(block.prev_header_hash)
             if prev_b is None:
-                prev_b = block_records.block_record(block.prev_header_hash)
+                prev_b = await block_records.get_block_record_from_db(block.prev_header_hash)
+            assert prev_b is not None
 
+        # get_next_sub_slot_iters_and_difficulty() requires prev_b.prev_hash to
+        # be in the block record cache.
+        if prev_b is not None and prev_b.height != 0 and not block_records.contains_block(prev_b.prev_hash):
+            return [PreValidationResult(uint16(Err.INVALID_PREV_BLOCK_HASH.value), None, None, False)]
+        if prev_b is not None and not block_records.contains_block(block.prev_header_hash):
+            # the call to block_to_block_record() requires the previous
+            # block is in the cache
+            block_records.add_block_record(prev_b)
         sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
             constants, len(block.finished_sub_slots) > 0, prev_b, block_records
         )
@@ -253,6 +262,10 @@ async def pre_validate_blocks_multiprocessing(
         )
 
         try:
+            if prev_b is not None and not block_records.contains_block(block.prev_header_hash):
+                # the call to block_to_block_record() requires the previous
+                # block is in the cache
+                block_records.add_block_record(prev_b)
             block_rec = block_to_block_record(
                 constants,
                 block_records,

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -342,6 +342,21 @@ class BlockStore:
             ret.append(all_blocks[hh])
         return ret
 
+    async def get_prev_hash(self, header_hash: bytes32) -> bytes32:
+        """
+        Returns the header hash preceeding the input header hash.
+        Throws an exception if the block is not present
+        """
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute(
+                "SELECT prev_hash FROM full_blocks WHERE header_hash=?",
+                (header_hash,),
+            ) as cursor:
+                row = await cursor.fetchone()
+                if row is None:
+                    raise KeyError("missing block in chain")
+                return bytes32(row[0])
+
     async def get_block_bytes_by_hash(self, header_hashes: List[bytes32]) -> List[bytes]:
         """
         Returns a list of Full Blocks block blobs, ordered by the same order in which header_hashes are passed in.

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -930,8 +930,9 @@ class FullNode:
             self.log.info("Waiting to receive peaks from peers.")
 
             # Wait until we have 3 peaks or up to a max of 30 seconds
+            max_iterations = int(self.config.get("max_sync_wait", 30)) * 10
             peaks = []
-            for i in range(300):
+            for i in range(max_iterations):
                 peaks = [peak.header_hash for peak in self.sync_store.get_peak_of_each_peer().values()]
                 if len(self.sync_store.get_peers_that_have_peak(peaks)) < 3:
                     if self._shut_down:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1202,7 +1202,7 @@ class FullNode:
 
         blocks_to_validate: List[FullBlock] = []
         for i, block in enumerate(all_blocks):
-            if not self.blockchain.contains_block(block.header_hash):
+            if not await self.blockchain.contains_block_from_db(block.header_hash):
                 blocks_to_validate = all_blocks[i:]
                 break
         if len(blocks_to_validate) == 0:
@@ -1258,7 +1258,8 @@ class FullNode:
                 if error is not None:
                     self.log.error(f"Error: {error}, Invalid block from peer: {peer.get_peer_logging()} ")
                 return False, agg_state_change_summary, error
-            block_record = self.blockchain.block_record(block.header_hash)
+            block_record = await self.blockchain.get_block_record_from_db(block.header_hash)
+            assert block_record is not None
             if block_record.sub_epoch_summary_included is not None:
                 if self.weight_proof_handler is not None:
                     await self.weight_proof_handler.create_prev_sub_epoch_segments()
@@ -1429,7 +1430,7 @@ class FullNode:
             # This is a reorg
             fork_hash: Optional[bytes32] = self.blockchain.height_to_hash(state_change_summary.fork_height)
             assert fork_hash is not None
-            fork_block = self.blockchain.block_record(fork_hash)
+            fork_block = await self.blockchain.get_block_record_from_db(fork_hash)
 
         fns_peak_result: FullNodeStorePeakResult = self.full_node_store.new_peak(
             record,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from blspy import AugSchemeMPL, G1Element, G2Element, PrivateKey
-from chia_rs import ALLOW_BACKREFS, MEMPOOL_MODE, compute_merkle_set_root
+from chia_rs import ALLOW_BACKREFS, MEMPOOL_MODE, compute_merkle_set_root, solution_generator
 from chiabip158 import PyBIP158
 from clvm.casts import int_from_bytes
 
@@ -573,12 +573,21 @@ class BlockTools:
         previous_generator: Optional[Union[CompressorArg, List[uint32]]] = None,
         genesis_timestamp: Optional[uint64] = None,
         force_plot_id: Optional[bytes32] = None,
+        dummy_block_references: bool = False,
     ) -> List[FullBlock]:
         assert num_blocks > 0
         if block_list_input is not None:
             block_list = block_list_input.copy()
         else:
             block_list = []
+
+        tx_block_heights: List[uint32] = []
+        if dummy_block_references:
+            # block references can only point to transaction blocks, so we need
+            # to record which ones are
+            for b in block_list:
+                if b.transactions_generator is not None:
+                    tx_block_heights.append(b.height)
 
         constants = self.constants
         transaction_data_included = False
@@ -752,6 +761,18 @@ class BlockTools:
                             block_generator = None
                             aggregate_signature = G2Element()
 
+                        if dummy_block_references and block_generator is None:
+                            program = SerializedProgram.from_bytes(solution_generator([]))
+                            if len(tx_block_heights) > 4:
+                                block_refs = [
+                                    tx_block_heights[1],
+                                    tx_block_heights[len(tx_block_heights) // 2],
+                                    tx_block_heights[-2],
+                                ]
+                            else:
+                                block_refs = []
+                            block_generator = BlockGenerator(program, [], block_refs)
+
                         (
                             full_block,
                             block_record,
@@ -799,6 +820,7 @@ class BlockTools:
                         last_timestamp = new_timestamp
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
+                            tx_block_heights.append(full_block.height)
                             compressor_arg = detect_potential_template_generator(
                                 full_block.height, full_block.transactions_generator
                             )
@@ -1040,6 +1062,18 @@ class BlockTools:
                             block_generator = None
                             aggregate_signature = G2Element()
 
+                        if dummy_block_references and block_generator is None:
+                            program = SerializedProgram.from_bytes(solution_generator([]))
+                            if len(tx_block_heights) > 4:
+                                block_refs = [
+                                    tx_block_heights[1],
+                                    tx_block_heights[len(tx_block_heights) // 2],
+                                    tx_block_heights[-2],
+                                ]
+                            else:
+                                block_refs = []
+                            block_generator = BlockGenerator(program, [], block_refs)
+
                         (
                             full_block,
                             block_record,
@@ -1091,6 +1125,7 @@ class BlockTools:
 
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
+                            tx_block_heights.append(full_block.height)
                             compressor_arg = detect_potential_template_generator(
                                 full_block.height, full_block.transactions_generator
                             )

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -4,7 +4,6 @@ import asyncio
 import copy
 import dataclasses
 import logging
-import math
 import os
 import random
 import shutil
@@ -207,7 +206,6 @@ class BlockTools:
         self.root_path = root_path
         self.log = log
         self.local_keychain = keychain
-        self._block_time_residual = 0.0
         self.local_sk_cache: Dict[bytes32, Tuple[PrivateKey, Any]] = {}
         self.automated_testing = automated_testing
         self.plot_dir_name = plot_dir
@@ -575,7 +573,6 @@ class BlockTools:
         previous_generator: Optional[Union[CompressorArg, List[uint32]]] = None,
         genesis_timestamp: Optional[uint64] = None,
         force_plot_id: Optional[bytes32] = None,
-        use_timestamp_residual: bool = False,
     ) -> List[FullBlock]:
         assert num_blocks > 0
         if block_list_input is not None:
@@ -625,7 +622,8 @@ class BlockTools:
         curr = latest_block
         while not curr.is_transaction_block:
             curr = blocks[curr.prev_hash]
-        last_timestamp = curr.timestamp
+        assert curr.timestamp is not None
+        last_timestamp = float(curr.timestamp)
         start_height = curr.height
 
         curr = latest_block
@@ -754,10 +752,11 @@ class BlockTools:
                             block_generator = None
                             aggregate_signature = G2Element()
 
-                        if not use_timestamp_residual:
-                            self._block_time_residual = 0.0
-
-                        full_block, block_record, self._block_time_residual = get_full_block_and_block_record(
+                        (
+                            full_block,
+                            block_record,
+                            new_timestamp,
+                        ) = get_full_block_and_block_record(
                             constants,
                             blocks,
                             sub_slot_start_total_iters,
@@ -786,17 +785,18 @@ class BlockTools:
                             seed,
                             normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
                             current_time=current_time,
-                            block_time_residual=self._block_time_residual,
                         )
                         if block_record.is_transaction_block:
                             transaction_data_included = True
                             previous_generator = None
                             keep_going_until_tx_block = False
                             assert full_block.foliage_transaction_block is not None
-                            last_timestamp = full_block.foliage_transaction_block.timestamp
-                        else:
-                            if guarantee_transaction_block:
-                                continue
+                        elif guarantee_transaction_block:
+                            continue
+                        # print(f"{full_block.height}: difficulty {difficulty} "
+                        #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"tx: {block_record.is_transaction_block}")
+                        last_timestamp = new_timestamp
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
                             compressor_arg = detect_potential_template_generator(
@@ -1040,10 +1040,11 @@ class BlockTools:
                             block_generator = None
                             aggregate_signature = G2Element()
 
-                        if not use_timestamp_residual:
-                            self._block_time_residual = 0.0
-
-                        full_block, block_record, self._block_time_residual = get_full_block_and_block_record(
+                        (
+                            full_block,
+                            block_record,
+                            new_timestamp,
+                        ) = get_full_block_and_block_record(
                             constants,
                             blocks,
                             sub_slot_start_total_iters,
@@ -1074,7 +1075,6 @@ class BlockTools:
                             overflow_rc_challenge=overflow_rc_challenge,
                             normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
                             current_time=current_time,
-                            block_time_residual=self._block_time_residual,
                         )
 
                         if block_record.is_transaction_block:
@@ -1082,9 +1082,12 @@ class BlockTools:
                             previous_generator = None
                             keep_going_until_tx_block = False
                             assert full_block.foliage_transaction_block is not None
-                            last_timestamp = full_block.foliage_transaction_block.timestamp
                         elif guarantee_transaction_block:
                             continue
+                        # print(f"{full_block.height}: difficulty {difficulty} "
+                        #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"tx: {block_record.is_transaction_block}")
+                        last_timestamp = new_timestamp
 
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
@@ -1658,11 +1661,6 @@ def get_icc(
     )
 
 
-def round_timestamp(timestamp: float, residual: float) -> Tuple[int, float]:
-    mod = math.modf(timestamp + residual)
-    return (int(mod[1]), mod[0])
-
-
 def get_full_block_and_block_record(
     constants: ConsensusConstants,
     blocks: Dict[bytes32, BlockRecord],
@@ -1673,7 +1671,7 @@ def get_full_block_and_block_record(
     slot_rc_challenge: bytes32,
     farmer_reward_puzzle_hash: bytes32,
     pool_target: PoolTarget,
-    last_timestamp: uint64,
+    last_timestamp: float,
     start_height: uint32,
     time_per_block: float,
     block_generator: Optional[BlockGenerator],
@@ -1695,13 +1693,16 @@ def get_full_block_and_block_record(
     overflow_rc_challenge: Optional[bytes32] = None,
     normalized_to_identity_cc_ip: bool = False,
     current_time: bool = False,
-    block_time_residual: float = 0.0,
 ) -> Tuple[FullBlock, BlockRecord, float]:
-    time_delta, block_time_residual = round_timestamp(time_per_block, block_time_residual)
+    # we're simulating time between blocks here. The more VDF iterations the
+    # blocks advances, the longer it should have taken (and vice versa). This
+    # formula is meant to converge at 1024 iters per the specified
+    # time_per_block (which defaults to 18.75 seconds)
+    time_per_block *= (((sub_slot_iters / 1024) - 1) * 0.2) + 1
     if current_time is True:
-        timestamp = uint64(max(int(time.time()), last_timestamp + time_delta))
+        timestamp = max(int(time.time()), last_timestamp + time_per_block)
     else:
-        timestamp = uint64(last_timestamp + time_delta)
+        timestamp = last_timestamp + time_per_block
     sp_iters = calculate_sp_iters(constants, sub_slot_iters, signage_point_index)
     ip_iters = calculate_ip_iters(constants, sub_slot_iters, signage_point_index, required_iters)
 
@@ -1719,7 +1720,7 @@ def get_full_block_and_block_record(
         get_plot_signature,
         get_pool_signature,
         signage_point,
-        timestamp,
+        uint64(timestamp),
         BlockCache(blocks),
         seed,
         block_generator,
@@ -1752,7 +1753,7 @@ def get_full_block_and_block_record(
         normalized_to_identity_cc_ip,
     )
 
-    return full_block, block_record, block_time_residual
+    return full_block, block_record, timestamp
 
 
 # these are the costs of unknown conditions, as defined chia_rs here:

--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -129,6 +129,10 @@ async def setup_simulators_and_wallets(
     disable_capabilities: Optional[List[Capability]] = None,
 ) -> AsyncIterator[Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]]:
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
+        if config_overrides is None:
+            config_overrides = {}
+        if "full_node.max_sync_wait" not in config_overrides:
+            config_overrides["full_node.max_sync_wait"] = 1
         async with setup_simulators_and_wallets_inner(
             db_version,
             consensus_constants,

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -59,6 +59,9 @@ class BlockCache(BlockchainInterface):
     def contains_block(self, header_hash: bytes32) -> bool:
         return header_hash in self._block_records
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        return header_hash in self._block_records
+
     def contains_height(self, height: uint32) -> bool:
         return height in self._height_to_hash
 

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -77,6 +77,12 @@ class BlockCache(BlockchainInterface):
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
         return self._block_records[header_hash]
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            ret.append(self._block_records[h].prev_hash)
+        return ret
+
     def remove_block_record(self, header_hash: bytes32):
         del self._block_records[header_hash]
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -417,6 +417,10 @@ full_node:
   # timeout for weight proof request
   weight_proof_timeout: &weight_proof_timeout 360
 
+  # when the full node enters sync-mode, we wait until we have collected peaks
+  # from at least 3 peers, or until we've waitied this many seconds
+  max_sync_wait: 30
+
   # when enabled, the full node will print a pstats profile to the root_dir/profile every second
   # analyze with chia/utils/profiler.py
   enable_profiler: False

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -215,6 +215,12 @@ class WalletBlockchain(BlockchainInterface):
         # blockchain_interface
         return self._block_records.get(header_hash)
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            ret.append(self._block_records[h].prev_hash)
+        return ret
+
     def add_block_record(self, block_record: BlockRecord) -> None:
         self._block_records[block_record.header_hash] = block_record
 

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -132,7 +132,7 @@ class WalletBlockchain(BlockchainInterface):
             if block_record.prev_hash == self._peak.header_hash:
                 fork_height: int = self._peak.height
             else:
-                fork_height = find_fork_point_in_chain(self, block_record, self._peak)
+                fork_height = await find_fork_point_in_chain(self, block_record, self._peak)
             await self._rollback_to_height(fork_height)
             curr_record: BlockRecord = block_record
             latest_timestamp = self._latest_timestamp

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -193,6 +193,11 @@ class WalletBlockchain(BlockchainInterface):
     def contains_block(self, header_hash: bytes32) -> bool:
         return header_hash in self._block_records
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        # the wallet doesn't have the blockchain DB, this implements the
+        # blockchain_interface
+        return header_hash in self._block_records
+
     def contains_height(self, height: uint32) -> bool:
         return height in self._height_to_hash
 
@@ -200,12 +205,15 @@ class WalletBlockchain(BlockchainInterface):
         return self._height_to_hash[height]
 
     def try_block_record(self, header_hash: bytes32) -> Optional[BlockRecord]:
-        if self.contains_block(header_hash):
-            return self.block_record(header_hash)
-        return None
+        return self._block_records.get(header_hash)
 
     def block_record(self, header_hash: bytes32) -> BlockRecord:
         return self._block_records[header_hash]
+
+    async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
+        # the wallet doesn't have the blockchain DB, this implements the
+        # blockchain_interface
+        return self._block_records.get(header_hash)
 
     def add_block_record(self, block_record: BlockRecord) -> None:
         self._block_records[block_record.header_hash] = block_record

--- a/tests/blockchain/blockchain_test_utils.py
+++ b/tests/blockchain/blockchain_test_utils.py
@@ -134,13 +134,14 @@ async def _validate_and_add_block_multi_result(
     blockchain: Blockchain,
     block: FullBlock,
     expected_result: List[AddBlockResult],
-    skip_prevalidation: Optional[bool] = None,
+    skip_prevalidation: bool = False,
 ) -> None:
     try:
-        if skip_prevalidation is not None:
-            await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation)
-        else:
-            await _validate_and_add_block(blockchain, block)
+        await _validate_and_add_block(
+            blockchain,
+            block,
+            skip_prevalidation=skip_prevalidation,
+        )
     except Exception as e:
         assert isinstance(e, AssertionError)
         assert "Block was not added" in e.args[0]
@@ -150,7 +151,7 @@ async def _validate_and_add_block_multi_result(
 
 
 async def _validate_and_add_block_no_error(
-    blockchain: Blockchain, block: FullBlock, skip_prevalidation: Optional[bool] = None
+    blockchain: Blockchain, block: FullBlock, skip_prevalidation: bool = False
 ) -> None:
     # adds a block and ensures that there is no error. However, does not ensure that block extended the peak of
     # the blockchain

--- a/tests/blockchain/config.py
+++ b/tests/blockchain/config.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
 parallel = True
-job_timeout = 60
+job_timeout = 80
 checkout_blocks_and_plots = True

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -15,7 +15,7 @@ from clvm.casts import int_to_bytes
 
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.block_rewards import calculate_base_farmer_reward
-from chia.consensus.blockchain import AddBlockResult
+from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.coinbase import create_farmer_coin
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.multiprocess_validation import PreValidationResult
@@ -55,6 +55,7 @@ from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block_multi_error,
     _validate_and_add_block_multi_result,
     _validate_and_add_block_no_error,
+    check_block_store_invariant,
 )
 from tests.conftest import ConsensusMode
 from tests.util.blockchain import create_blockchain
@@ -3131,48 +3132,120 @@ class TestReorgs:
         assert b.get_peak().height == 16
 
     @pytest.mark.asyncio
-    async def test_long_reorg(self, empty_blockchain, default_1500_blocks, test_long_reorg_blocks, bt):
+    @pytest.mark.parametrize("light_blocks", [True, False])
+    @pytest.mark.limit_consensus_modes(reason="long reorgs are too inefficient to run multiple times")
+    async def test_long_reorg(
+        self,
+        light_blocks: bool,
+        empty_blockchain: Blockchain,
+        default_10000_blocks: List[FullBlock],
+        test_long_reorg_blocks: List[FullBlock],
+        test_long_reorg_blocks_light: List[FullBlock],
+    ):
+        if light_blocks:
+            reorg_blocks = test_long_reorg_blocks_light[:2000]
+        else:
+            reorg_blocks = test_long_reorg_blocks[:1500]
+
         # Reorg longer than a difficulty adjustment
         # Also tests higher weight chain but lower height
         b = empty_blockchain
-        num_blocks_chain_1 = 3 * bt.constants.EPOCH_BLOCKS + bt.constants.MAX_SUB_SLOT_BLOCKS + 10
-        num_blocks_chain_2_start = bt.constants.EPOCH_BLOCKS - 20
+        num_blocks_chain_1 = 1600
+        num_blocks_chain_2_start = 500
 
         assert num_blocks_chain_1 < 10000
-        blocks = default_1500_blocks[:num_blocks_chain_1]
+        blocks = default_10000_blocks[:num_blocks_chain_1]
 
-        for block in blocks:
-            await _validate_and_add_block(b, block, skip_prevalidation=True)
-        chain_1_height = b.get_peak().height
-        chain_1_weight = b.get_peak().weight
+        print(f"pre-validating {len(blocks)} blocks")
+        pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
+            blocks, {}, validate_signatures=False
+        )
+
+        for i, block in enumerate(blocks):
+            assert pre_validation_results[i].error is None
+            if (block.height % 100) == 0:
+                print(f"main chain: {block.height:4} weight: {block.weight}")
+            (result, err, _) = await b.add_block(block, pre_validation_results[i])
+            await check_block_store_invariant(b)
+            assert err is None
+            assert result == AddBlockResult.NEW_PEAK
+
+        peak = b.get_peak()
+        assert peak is not None
+        chain_1_height = peak.height
+        chain_1_weight = peak.weight
         assert chain_1_height == (num_blocks_chain_1 - 1)
 
         # The reorg blocks will have less time between them (timestamp) and therefore will make difficulty go up
         # This means that the weight will grow faster, and we can get a heavier chain with lower height
 
-        # If these assert fail, you probably need to change the fixture in test_long_reorg_blocks to create the
+        # If these assert fail, you probably need to change the fixture in reorg_blocks to create the
         # right amount of blocks at the right time
-        assert test_long_reorg_blocks[num_blocks_chain_2_start - 1] == default_1500_blocks[num_blocks_chain_2_start - 1]
-        assert test_long_reorg_blocks[num_blocks_chain_2_start] != default_1500_blocks[num_blocks_chain_2_start]
+        assert reorg_blocks[num_blocks_chain_2_start - 1] == default_10000_blocks[num_blocks_chain_2_start - 1]
+        assert reorg_blocks[num_blocks_chain_2_start] != default_10000_blocks[num_blocks_chain_2_start]
 
-        for reorg_block in test_long_reorg_blocks:
-            if reorg_block.height < num_blocks_chain_2_start:
-                await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK, skip_prevalidation=True
+        b.clean_block_records()
+
+        for reorg_block in reorg_blocks:
+            if (reorg_block.height % 100) == 0:
+                peak = b.get_peak()
+                assert peak is not None
+                print(
+                    f"reorg chain: {reorg_block.height:4} "
+                    f"weight: {reorg_block.weight:7} "
+                    f"peak: {str(peak.header_hash)[:6]}"
                 )
+
+            if reorg_block.height < num_blocks_chain_2_start:
+                await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK)
             elif reorg_block.weight <= chain_1_weight:
                 await _validate_and_add_block_multi_result(
                     b,
                     reorg_block,
                     [AddBlockResult.ADDED_AS_ORPHAN, AddBlockResult.ALREADY_HAVE_BLOCK],
-                    skip_prevalidation=True,
                 )
             elif reorg_block.weight > chain_1_weight:
-                assert reorg_block.height < chain_1_height
-                await _validate_and_add_block(b, reorg_block, skip_prevalidation=True)
+                await _validate_and_add_block(b, reorg_block)
 
-        assert b.get_peak().weight > chain_1_weight
-        assert b.get_peak().height < chain_1_height
+        # TODO: understand why this version of the test doesn't work (it should be a lot faster)
+
+        # print(f"pre-validating {len(reorg_blocks)} blocks")
+        # pre_validation_results = await b.pre_validate_blocks_multiprocessing(
+        #     reorg_blocks, {}, validate_signatures=False)
+
+        # for i, reorg_block in enumerate(reorg_blocks):
+        #    if (reorg_block.height % 100) == 0:
+        #        peak = b.get_peak()
+        #        assert peak is not None
+        #        print(
+        #            f"reorg chain: {reorg_block.height:4} "
+        #            f"weight: {reorg_block.weight:7} "
+        #            f"peak: {str(peak.header_hash)[:6]}"
+        #        )
+
+        #    assert pre_validation_results[i].error is None
+        #    (result, err, _) = await b.add_block(reorg_block, pre_validation_results[i])
+        #    await check_block_store_invariant(b)
+
+        #    if reorg_block.height < num_blocks_chain_2_start:
+        #        assert err is None
+        #        assert result == AddBlockResult.ALREADY_HAVE_BLOCK
+        #    elif reorg_block.weight <= chain_1_weight:
+        #        assert err is None
+        #        assert result == AddBlockResult.ADDED_AS_ORPHAN
+        #    elif reorg_block.weight > chain_1_weight:
+        #        assert err is None
+        #        assert result == AddBlockResult.NEW_PEAK
+
+        # if these asserts fires, there was no reorg
+        peak = b.get_peak()
+        assert peak is not None
+        assert peak.weight > chain_1_weight
+
+        if light_blocks:
+            assert peak.height > chain_1_height
+        else:
+            assert peak.height < chain_1_height
 
     @pytest.mark.asyncio
     async def test_long_compact_blockchain(self, empty_blockchain, default_2000_blocks_compact):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,11 +249,15 @@ def default_10000_blocks(bt, consensus_mode):
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
-    return persistent_blocks(10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000")
+    return persistent_blocks(
+        10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000", dummy_block_references=True
+    )
 
 
+# this long reorg chain shares the first 500 blocks with "default_10000_blocks"
+# and has heavier weight blocks
 @pytest.fixture(scope="session")
-def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
+def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
     version = ""
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
@@ -261,12 +265,33 @@ def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        758,
+        4500,
         f"test_blocks_long_reorg_{saved_blocks_version}{version}.db",
         bt,
-        block_list_input=default_1500_blocks[:320],
+        block_list_input=default_10000_blocks[:500],
         seed=b"reorg_blocks",
         time_per_block=8,
+        dummy_block_references=True,
+    )
+
+
+# this long reorg chain shares the first 500 blocks with "default_10000_blocks"
+# and has the same weight blocks
+@pytest.fixture(scope="session")
+def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
+    version = ""
+    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        version = "_hardfork"
+
+    from tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(
+        4500,
+        f"test_blocks_long_reorg_light_{saved_blocks_version}{version}.db",
+        bt,
+        block_list_input=default_10000_blocks[:500],
+        seed=b"reorg_blocks2",
+        dummy_block_references=True,
     )
 
 

--- a/tests/core/full_node/config.py
+++ b/tests/core/full_node/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 parallel = True
-job_timeout = 50
+job_timeout = 80
 check_resource_usage = True
 checkout_blocks_and_plots = True
 os_skip = ["windows"]

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -298,7 +298,7 @@ class TestFullNodeStore:
             assert peak_here is not None
             if peak_here.header_hash == block.header_hash:
                 sb = blockchain.block_record(block.header_hash)
-                fork = find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
+                fork = await find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
                 if fork > 0:
                     fork_block = blockchain.height_to_block_record(uint32(fork))
                 else:
@@ -375,7 +375,7 @@ class TestFullNodeStore:
             assert peak_here is not None
             if peak_here.header_hash == blocks[-1].header_hash:
                 sb = blockchain.block_record(blocks[-1].header_hash)
-                fork = find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
+                fork = await find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
                 if fork > 0:
                     fork_block = blockchain.height_to_block_record(uint32(fork))
                 else:

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -55,6 +55,7 @@ from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
 from chia.util.limited_semaphore import LimitedSemaphore
+from chia.util.misc import to_batches
 from chia.util.recursive_replace import recursive_replace
 from chia.util.vdf_prover import get_vdf_info_and_proof
 from chia.wallet.transaction_record import TransactionRecord
@@ -66,6 +67,7 @@ from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.make_block_generator import make_spend_bundle
 from tests.core.mempool.test_mempool_performance import wallet_height_at_least
 from tests.core.node_height import node_height_at_least
+from tests.plot_sync.util import get_dummy_connection
 
 
 async def new_transaction_not_requested(incoming, new_spend):
@@ -2111,3 +2113,54 @@ async def test_wallet_sync_task_failure(
     assert "update_wallets - fork_height: 10, peak_height: 0" in caplog.text
     assert "Wallet sync task failure" not in caplog.text
     assert not full_node.wallet_sync_task.done()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("light_blocks", [True, False])
+@pytest.mark.limit_consensus_modes(reason="long reorgs are too inefficient to run multiple times")
+async def test_long_reorg(
+    light_blocks: bool,
+    one_node_one_block,
+    default_10000_blocks: List[FullBlock],
+    test_long_reorg_blocks: List[FullBlock],
+    test_long_reorg_blocks_light: List[FullBlock],
+):
+    node, server, bt = one_node_one_block
+
+    fork_point = 499
+    blocks = default_10000_blocks[:1600]
+
+    if light_blocks:
+        reorg_blocks = test_long_reorg_blocks_light[:2000]
+    else:
+        reorg_blocks = test_long_reorg_blocks[:1500]
+
+    for block_batch in to_batches(blocks, 64):
+        b = block_batch.entries[0]
+        if (b.height % 128) == 0:
+            print(f"main chain: {b.height:4} weight: {b.weight}")
+        await node.full_node.add_block_batch(block_batch.entries, get_dummy_connection(NodeType.FULL_NODE), None)
+
+    peak = node.full_node.blockchain.get_peak()
+    chain_1_height = peak.height
+    chain_1_weight = peak.weight
+
+    assert reorg_blocks[fork_point] == default_10000_blocks[fork_point]
+    assert reorg_blocks[fork_point + 1] != default_10000_blocks[fork_point + 1]
+
+    node.full_node.blockchain.clean_block_records()
+
+    for b in reorg_blocks:
+        if (b.height % 128) == 0:
+            peak = node.full_node.blockchain.get_peak()
+            print(f"reorg chain: {b.height:4} " f"weight: {b.weight:7} " f"peak: {str(peak.header_hash)[:6]}")
+        await node.full_node.add_block(b)
+
+    # if these asserts fires, there was no reorg
+    peak = node.full_node.blockchain.get_peak()
+    assert peak.weight > chain_1_weight
+
+    if light_blocks:
+        assert peak.height > chain_1_height
+    else:
+        assert peak.height < chain_1_height

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2204,9 +2204,6 @@ async def test_long_reorg_nodes(
 
     await full_node_2.full_node.add_block(reorg_blocks[-1])
 
-    # node 1 will wait 30 seonds before it starts syncing. It would be nice to
-    # be able to configure this delay to be shorter
-
     def check_nodes_in_sync():
         p1 = full_node_2.full_node.blockchain.get_peak()
         p2 = full_node_1.full_node.blockchain.get_peak()

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -125,13 +125,7 @@ class TestFullNodeBlockCompression:
         wallet_node_1 = wallets[0][0]
         wallet = wallet_node_1.wallet_state_manager.main_wallet
 
-        # Avoid retesting the slow reorg portion, not necessary more than once
-        test_reorgs = (
-            tx_size == 10000
-            and empty_blockchain.block_store.db_wrapper.db_version >= 2
-            and full_node_1.full_node.block_store.db_wrapper.db_version >= 2
-            and full_node_2.full_node.block_store.db_wrapper.db_version >= 2
-        )
+        test_reorgs = True
         _ = await connect_and_get_peer(server_1, server_2, self_hostname)
         _ = await connect_and_get_peer(server_1, server_3, self_hostname)
 

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2164,3 +2164,58 @@ async def test_long_reorg(
         assert peak.height > chain_1_height
     else:
         assert peak.height < chain_1_height
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("light_blocks", [True, False])
+@pytest.mark.parametrize("chain_length", [0, 900])
+@pytest.mark.limit_consensus_modes(reason="long reorgs are too inefficient to run multiple times")
+async def test_long_reorg_nodes(
+    light_blocks: bool,
+    chain_length: int,
+    setup_two_nodes_and_wallet,
+    default_10000_blocks: List[FullBlock],
+    test_long_reorg_blocks: List[FullBlock],
+    test_long_reorg_blocks_light: List[FullBlock],
+    self_hostname: str,
+):
+    nodes, wallets, bt = setup_two_nodes_and_wallet
+    server_1 = nodes[0].full_node.server
+    server_2 = nodes[1].full_node.server
+    full_node_1 = nodes[0]
+    full_node_2 = nodes[1]
+
+    blocks = default_10000_blocks[: 1600 - chain_length]
+
+    if light_blocks:
+        reorg_blocks = test_long_reorg_blocks_light[: 2000 - chain_length]
+    else:
+        reorg_blocks = test_long_reorg_blocks[: 1500 - chain_length]
+
+    # full node 1 has the original chain
+    for block_batch in to_batches(blocks, 64):
+        b = block_batch.entries[0]
+        if (b.height % 128) == 0:
+            print(f"main chain: {b.height:4} weight: {b.weight}")
+        await full_node_1.full_node.add_block_batch(block_batch.entries, get_dummy_connection(NodeType.FULL_NODE), None)
+
+    # full node 2 has the reorg-chain
+    for block_batch in to_batches(reorg_blocks[:-1], 64):
+        b = block_batch.entries[0]
+        if (b.height % 128) == 0:
+            print(f"reorg chain: {b.height:4} weight: {b.weight}")
+        await full_node_2.full_node.add_block_batch(block_batch.entries, get_dummy_connection(NodeType.FULL_NODE), None)
+
+    await connect_and_get_peer(server_1, server_2, self_hostname)
+
+    await full_node_2.full_node.add_block(reorg_blocks[-1])
+
+    # node 1 will wait 30 seonds before it starts syncing. It would be nice to
+    # be able to configure this delay to be shorter
+
+    def check_nodes_in_sync():
+        p1 = full_node_2.full_node.blockchain.get_peak()
+        p2 = full_node_1.full_node.blockchain.get_peak()
+        return p1 == p2
+
+    await time_out_assert(2000, check_nodes_in_sync)

--- a/tests/farmer_harvester/test_filter_prefix_bits.py
+++ b/tests/farmer_harvester/test_filter_prefix_bits.py
@@ -32,7 +32,7 @@ from tests.core.test_farmer_harvester_rpc import wait_for_plot_sync
 # this test
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN])
 @pytest.mark.parametrize(
-    argnames=["filter_prefix_bits", "should_pass"], argvalues=[(9, 33), (8, 66), (7, 138), (6, 265), (5, 607)]
+    argnames=["filter_prefix_bits", "should_pass"], argvalues=[(9, 34), (8, 89), (7, 162), (6, 295), (5, 579)]
 )
 def test_filter_prefix_bits_on_blocks(
     default_10000_blocks: List[FullBlock], filter_prefix_bits: uint8, should_pass: int

--- a/tests/plot_sync/util.py
+++ b/tests/plot_sync/util.py
@@ -29,6 +29,9 @@ class WSChiaConnectionDummy:
     async def send_message(self, message: Message) -> None:
         self.last_sent_message = message
 
+    def get_peer_logging(self) -> PeerInfo:
+        return self.peer_info
+
 
 def get_dummy_connection(node_type: NodeType, peer_id: Optional[bytes32] = None) -> WSChiaConnectionDummy:
     return WSChiaConnectionDummy(node_type, bytes32(token_bytes(32)) if peer_id is None else peer_id)

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -25,7 +25,7 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int) -> T
 
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
-    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2)
+    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2, single_threaded=True)
     assert bc1.get_peak() is None
     return bc1, wrapper, db_path
 
@@ -36,12 +36,14 @@ def persistent_blocks(
     bt: BlockTools,
     seed: bytes = b"",
     empty_sub_slots: int = 0,
+    *,
     normalized_to_identity_cc_eos: bool = False,
     normalized_to_identity_icc_eos: bool = False,
     normalized_to_identity_cc_sp: bool = False,
     normalized_to_identity_cc_ip: bool = False,
     block_list_input: Optional[List[FullBlock]] = None,
     time_per_block: Optional[float] = None,
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
@@ -81,10 +83,11 @@ def persistent_blocks(
         bt,
         block_list_input,
         time_per_block,
-        normalized_to_identity_cc_eos,
-        normalized_to_identity_icc_eos,
-        normalized_to_identity_cc_sp,
-        normalized_to_identity_cc_ip,
+        normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
+        normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
+        normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
+        normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
 
 
@@ -96,10 +99,12 @@ def new_test_db(
     bt: BlockTools,
     block_list_input: List[FullBlock],
     time_per_block: Optional[float],
+    *,
     normalized_to_identity_cc_eos: bool = False,  # CC_EOS,
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
@@ -112,6 +117,7 @@ def new_test_db(
         normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
     block_bytes_list: List[bytes] = []
     for block in blocks:

--- a/tools/generate_chain.py
+++ b/tools/generate_chain.py
@@ -105,7 +105,6 @@ def main(length: int, fill_rate: int, profile: bool, block_refs: bool, output: O
                 pool_reward_puzzle_hash=pool_puzzlehash,
                 keep_going_until_tx_block=True,
                 genesis_timestamp=uint64(1234567890),
-                use_timestamp_residual=True,
             )
 
             unspent_coins: List[Coin] = []
@@ -164,7 +163,6 @@ def main(length: int, fill_rate: int, profile: bool, block_refs: bool, output: O
                         keep_going_until_tx_block=True,
                         transaction_data=SpendBundle.aggregate(spend_bundles),
                         previous_generator=block_references,
-                        use_timestamp_residual=True,
                     )
                     prev_tx_block = b
                     prev_block = blocks[-2]


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

### Purpose:

The node is currently having a hard time with deep reorgs. Some parts of block validation require some previous blocks to be loaded in the block record cache in the blockchain object. When performing a reorg deeper than the cache size, those block records may not be in the cache and fail.

Furthermore, when validating blocks on the fork of the chain (before accepting it and updating our peak) we need to be able to pick up block records (and generators) from blocks that are not in the main chain. This requires looking them up from the database. One case of interest, that has previously not been covered by a test, is when a block reference points into the forked chain (i.e. a block not in the main chain).

The important change in this PR are the last 3 commits, (8, 9 and 10 in the list below).

The other commits are tests and minor optimizations.

### Scope

This PR introduces tests covering cases we've seen fail on testnet recently. Additionally it fixes the logic to work as intended. Now, the way it was intended to work was very inefficient, so there are still serious efficiency problems with deep reorgs. Since this patch is already pretty large, I think it makes sense to split up the work and address the performance issues in separate PRs.

### Test chains

Since this patch alters the test chains (specifically, `default_10000_blocks` and `test_long_reorg_blocks`) CI will fail some tests that use them. CI requires test chains to have been committed to the `test-cache` repository and been published in a release for it to be able to pick them up.

If the general approach in this PR is approved, I will push the updated test chains and update this PR to use them, to get CI green. Here's the PR for the new test chains: https://github.com/Chia-Network/test-cache/pull/8

### Summary of changes:

In order to test long reorgs with block references, `BlockTools` need to be updated to support creating chains with block references. To avoid this change clashing with `main` later, the first commit is pulled from `main`, which also updates `BlockTools`. For details on this change, see https://github.com/Chia-Network/chia-blockchain/pull/16326 .

commits:

1. back-port of `BlockTools` change from `main`. 

2. Introduces a feature `dummy_block_references` and updates the two test blockchains `default_10000_blocks` and `test_long_reorg_blocks` to use them. These two chains will form the foundation of the new tests exercising the long reorg logic (with block references). This commit also introduces a second `long_reorg` test chain with the same weight as the main chain it's forking from (as opposed to higher weigh).

3. Updates `test_long_reorg` in `test_blockchain.py` to make the reorg *longer* than the size of the block record cache. It also makes it use the new test chains which include block references. It also clears the block reference cache to more accurately match a real-life scenario.

4. Add a new test to `test_full_node.py` to do the same thing but at the `full_node` level, making for a more authentic test (and slower).

5. Add a new test to `test_full_node.py` which sets up two full nodes with different forks, connect them and wait for them to have synchronized. This test exposed an issue where we end up requesting a block the other peer does not have. This issue need more investigation. 

6. There was a test in `test_full_node.py` that used to be parametrized, and would only run its reorg test in one of the test runs. Since then, it appears changes to the parameters have caused the reorg test to never run. The next commit runs it unconditionally.

7. Some minor optimizations to avoid duplicate dictionary lookups and multiple computations of the header hash of blocks.

8. This makes the parts of block validation that currently *only* look in the cache, also able to fall back to pull blocks from the database. Using `async` functions instead of immediate ones.

9. This makes the `find_fork_poin_in_chain()` `async` and also able to find blocks in the database that aren't in the cache.

10. Update the version of `block-cache` blocks we pull on CI, to use the new test chains.

11. Optimize `find_fork_point_in_chain()` to mitigate some of the issue of CI taking too ling.

12. Before initiating a sync, we collect peaks from at least 3 peers, unless that takes more than 30 seconds, in which case we start syncing anyway. This commit makes this timeout configurable, and configures it to 1 second in the tests. This shaves off a 30 second wait in the tests introduced in (5). 

### Current Behavior:

In a long/deep reorg, the node may fail with `KeyError` while looking up block records that are not in the cache.

### New Behavior:

Long/deep reorgs work as expected.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

There are two new relevant tests added, one in `test_blockchain.py` and one in `test_full_node.py`. These fail without the fix.