### PR TITLE
consistently use `CliRunner.invoke(catch_exceptions=False)`

### DIFF
--- a/tests/cmds/test_sim.py
+++ b/tests/cmds/test_sim.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from shutil import rmtree
 
 import pytest
-from click.testing import CliRunner, Result
+from click.testing import CliRunner
 
 from chia.cmds.chia import cli
 from chia.util.default_root import SIMULATOR_ROOT_PATH
@@ -35,7 +35,11 @@ def test_every_simulator_command() -> None:
     simulator_name = get_profile_path(starting_str)
     runner: CliRunner = CliRunner()
     address = std_farming_address
-    start_result: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "create", "-bm", mnemonic])
+    start_result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "create", "-bm", mnemonic],
+        catch_exceptions=False,
+    )
     assert start_result.exit_code == 0
     assert f"Farming & Prefarm reward address: {address}" in start_result.output
     assert "chia_full_node_simulator: started" in start_result.output
@@ -53,8 +57,10 @@ def test_custom_farming_address() -> None:
     address = burn_address
     starting_str = "ci_address_test"
     simulator_name = get_profile_path(starting_str)
-    start_result: Result = runner.invoke(
-        cli, ["dev", "sim", "-n", simulator_name, "create", "-bm", mnemonic, "--reward-address", address]
+    start_result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "create", "-bm", mnemonic, "--reward-address", address],
+        catch_exceptions=False,
     )
     assert start_result.exit_code == 0
     assert f"Farming & Prefarm reward address: {address}" in start_result.output
@@ -70,7 +76,11 @@ def test_custom_farming_address() -> None:
 
 def stop_simulator(runner: CliRunner, simulator_name: str) -> None:
     """Stop simulator."""
-    result: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "stop", "-d"])
+    result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "stop", "-d"],
+        catch_exceptions=False,
+    )
     assert result.exit_code == 0
     assert "chia_full_node_simulator: Stopped\nDaemon stopped\n" == result.output
     rmtree(SIMULATOR_ROOT_PATH / simulator_name)
@@ -84,7 +94,11 @@ def run_all_tests(runner: CliRunner, address: str, simulator_name: str) -> None:
 
 def _test_sim_status(runner: CliRunner, address: str, simulator_name: str) -> None:
     # show everything
-    result: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "status", "--show-key", "-cia"])
+    result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "status", "--show-key", "-cia"],
+        catch_exceptions=False,
+    )
     assert result.exit_code == 0
     # asserts are grouped by arg
     assert (
@@ -107,29 +121,47 @@ def _test_sim_status(runner: CliRunner, address: str, simulator_name: str) -> No
 
 def _test_farm_and_revert_block(runner: CliRunner, address: str, simulator_name: str) -> None:
     # make 5 blocks
-    five_blocks_result: Result = runner.invoke(
-        cli, ["dev", "sim", "-n", simulator_name, "farm", "-b", "5", "-a", address]
+    five_blocks_result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "farm", "-b", "5", "-a", address],
+        catch_exceptions=False,
     )
     assert five_blocks_result.exit_code == 0
     assert "Farmed 5 Transaction blocks" in five_blocks_result.output
 
     # check that height increased
-    five_blocks_check: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "status"])
+    five_blocks_check = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "status"],
+        catch_exceptions=False,
+    )
     assert five_blocks_check.exit_code == 0
     assert "Height:          6" in five_blocks_check.output
 
     # do a reorg, 3 blocks back, 2 blocks forward, height now 8
-    reorg_result: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "revert", "-b", "3", "-n", "2"])
+    reorg_result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "revert", "-b", "3", "-n", "2"],
+        catch_exceptions=False,
+    )
     assert reorg_result.exit_code == 0
     assert "Block: 3 and above " in reorg_result.output and "Block Height is now: 8" in reorg_result.output
 
     # check that height changed by 2
-    reorg_check: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "status"])
+    reorg_check = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "status"],
+        catch_exceptions=False,
+    )
     assert reorg_check.exit_code == 0
     assert "Height:          8" in reorg_check.output
 
     # do a forceful reorg 4 blocks back
-    forced_reorg_result: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "revert", "-b", "4", "-fd"])
+    forced_reorg_result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "revert", "-b", "4", "-fd"],
+        catch_exceptions=False,
+    )
     assert forced_reorg_result.exit_code == 0
     assert (
         "Block: 8 and above were successfully deleted" in forced_reorg_result.output
@@ -137,12 +169,20 @@ def _test_farm_and_revert_block(runner: CliRunner, address: str, simulator_name:
     )
 
     # check that height changed by 4
-    forced_reorg_check: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "status"])
+    forced_reorg_check = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "status"],
+        catch_exceptions=False,
+    )
     assert forced_reorg_check.exit_code == 0
     assert "Height:          4" in forced_reorg_check.output
 
     # test chain reset to genesis
-    genesis_reset_result: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "revert", "-fd", "--reset"])
+    genesis_reset_result = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "revert", "-fd", "--reset"],
+        catch_exceptions=False,
+    )
     assert genesis_reset_result.exit_code == 0
     assert (
         "Block: 2 and above were successfully deleted" in genesis_reset_result.output
@@ -150,6 +190,10 @@ def _test_farm_and_revert_block(runner: CliRunner, address: str, simulator_name:
     )
 
     # check that height changed to 1
-    genesis_reset_check: Result = runner.invoke(cli, ["dev", "sim", "-n", simulator_name, "status"])
+    genesis_reset_check = runner.invoke(
+        cli,
+        ["dev", "sim", "-n", simulator_name, "status"],
+        catch_exceptions=False,
+    )
     assert genesis_reset_check.exit_code == 0
     assert "Height:          1" in genesis_reset_check.output

--- a/tests/fee_estimation/cmdline_test.py
+++ b/tests/fee_estimation/cmdline_test.py
@@ -27,5 +27,5 @@ def test_show_fee_info(
 ) -> None:
     _, _, _ = one_node_one_block
     runner = CliRunner()
-    result = runner.invoke(cli, ["show", "-f"])
+    result = runner.invoke(cli, ["show", "-f"], catch_exceptions=False)
     assert result.exit_code == 0

--- a/tests/pools/test_pool_cmdline.py
+++ b/tests/pools/test_pool_cmdline.py
@@ -30,10 +30,10 @@ class TestPoolNFTCommands:
 
     def test_plotnft_show(self):
         runner = CliRunner()
-        result: Result = runner.invoke(show_cmd, [])
+        result = runner.invoke(show_cmd, [], catch_exceptions=False)
         assert result.exit_code == 0
 
     def test_validate_fee_cmdline(self):
         runner = CliRunner()
-        result: Result = runner.invoke(create_cmd, ["create", "-s", "local", "--fee", "0.005"])
+        result = runner.invoke(create_cmd, ["create", "-s", "local", "--fee", "0.005"], catch_exceptions=False)
         assert result.exit_code != 0

--- a/tests/util/test_dump_keyring.py
+++ b/tests/util/test_dump_keyring.py
@@ -52,7 +52,7 @@ class KeyringCase:
 def test_keyring_dump_empty(empty_keyring: Keychain, case: KeyringCase) -> None:
     keyring_path = empty_keyring.keyring_wrapper.keyring.keyring_path
     runner = CliRunner()
-    result = runner.invoke(dump, [*case.args, os.fspath(keyring_path)])
+    result = runner.invoke(dump, [*case.args, os.fspath(keyring_path)], catch_exceptions=False)
 
     regex = re.escape(output_prefix.format(path=keyring_path)) + case.regex
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

As is we can get cryptic failures in CI when the invoked command raises a general exception.  This will result in a traceback instead which pinpoints the issue.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

https://github.com/Chia-Network/chia-blockchain/actions/runs/6400404960/job/17388447814#step:17:79
```
tests/cmds/test_sim.py:39: in test_every_simulator_command
    assert start_result.exit_code == 0
E   AssertionError: assert 1 == 0
E    +  where 1 = <Result KeyError('port')>.exit_code
```

### New Behavior:

```
<snip>
../../chia/cmds/sim_funcs.py:281: in async_config_wizard
    config = create_chia_directory(root_path, fingerprint, farming_address, plot_directory, auto_farm, docker_mode)
../../chia/cmds/sim_funcs.py:94: in create_chia_directory
    config["full_node"]["wallet_peer"]["port"] = config["wallet"]["port"]
E   KeyError: 'port'
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Coverage failing for skipped tests and one misnamed test file which is being addressed in https://github.com/Chia-Network/chia-blockchain/pull/16524.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
