### PR TITLE
Add config option to set rpc timeout and use it for simulator tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate matrix configuration
         id: configure
         run: |
-          python tests/build-job-matrix.py --per directory --verbose > matrix.json
+          python tests/build-job-matrix.py --per file --only cmds/test_sim.py --duplicates 50 --verbose > matrix.json
           cat matrix.json
           echo configuration=$(cat matrix.json) >> "$GITHUB_OUTPUT"
           echo matrix_mode=${{ ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate matrix configuration
         id: configure
         run: |
-          python tests/build-job-matrix.py --per file --only cmds/test_sim.py --duplicates 50 --verbose > matrix.json
+          python tests/build-job-matrix.py --per directory --verbose > matrix.json
           cat matrix.json
           echo configuration=$(cat matrix.json) >> "$GITHUB_OUTPUT"
           echo matrix_mode=${{ ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> "$GITHUB_OUTPUT"

--- a/chia/rpc/rpc_client.py
+++ b/chia/rpc/rpc_client.py
@@ -47,12 +47,12 @@ class RpcClient:
         ca_crt_path, ca_key_path = private_ssl_ca_paths(root_path, net_config)
         crt_path = root_path / net_config["daemon_ssl"]["private_crt"]
         key_path = root_path / net_config["daemon_ssl"]["private_key"]
-
+        timeout = net_config.get("rpc_timeout", 300)
         self = cls(
             hostname=self_hostname,
             port=port,
             url=f"https://{self_hostname}:{str(port)}/",
-            session=aiohttp.ClientSession(),
+            session=aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)),
             ssl_context=ssl_context_for_client(ca_crt_path, ca_key_path, crt_path, key_path),
         )
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -4,6 +4,7 @@ min_mainnet_k_size: 32
 ping_interval: 120
 self_hostname: &self_hostname "localhost"
 prefer_ipv6: False
+rpc_timeout: 300
 daemon_port: 55400
 daemon_max_message_size: 50000000 # maximum size of RPC message in bytes
 daemon_heartbeat: 300 # sets the heartbeat for ping/ping interval and timeouts

--- a/tests/cmds/test_sim.py
+++ b/tests/cmds/test_sim.py
@@ -7,6 +7,7 @@ import pytest
 from click.testing import CliRunner, Result
 
 from chia.cmds.chia import cli
+from chia.util.config import lock_and_load_config, save_config
 from chia.util.default_root import SIMULATOR_ROOT_PATH
 
 mnemonic = (  # ignore any secret warnings
@@ -40,6 +41,12 @@ def test_every_simulator_command() -> None:
     assert f"Farming & Prefarm reward address: {address}" in start_result.output
     assert "chia_full_node_simulator: started" in start_result.output
     assert "Genesis block generated, exiting." in start_result.output
+
+    config_dir = SIMULATOR_ROOT_PATH.joinpath(simulator_name)
+    with lock_and_load_config(config_dir, "config.yaml") as config:
+        config["rpc_timeout"] = 600
+        save_config(config_dir, "config.yaml", config)
+
     try:
         # run all tests
         run_all_tests(runner, address, simulator_name)


### PR DESCRIPTION
Add "global" config option `rpc_timeout` to configure the RPC client session timeout and use this for running the simulator tests. Set the default timeout to 300s (5 mins) - this matches the current default in aiohttp

This is primarily to fix flaky tests where the simulator commands end up taking more than 5 mins to reply to the RPC request. However, the config setting may have some use in other contexts.

This is a different strategy than the fix here: https://github.com/Chia-Network/chia-blockchain/pull/15618