### PR TITLE
Bump chia-blockchain-gui to 2.1.1-rc1

### DIFF
--- a/build_scripts/build_windows-1-gui.ps1
+++ b/build_scripts/build_windows-1-gui.ps1
@@ -22,6 +22,9 @@ $Env:NODE_OPTIONS = "--max-old-space-size=3000"
 
 Write-Output "lerna clean -y"
 npx lerna clean -y
+# Do core first, so that electron is already done there to avoid a race condition
+Write-Output "npm ci --workspace @chia-network/core"
+npm ci --workspace @chia-network/core
 Write-Output "npm ci"
 npm ci
 # Audit fix does not currently work with Lerna. See https://github.com/lerna/lerna/issues/1663


### PR DESCRIPTION
## What's Changed
* Downgrade electron to 25.9.0 by @ChiaMineJP in https://github.com/Chia-Network/chia-blockchain-gui/pull/2192


**Full Changelog**: https://github.com/Chia-Network/chia-blockchain-gui/compare/2.1.0...2.1.1-rc1