### PR TITLE
`chia show keys --show-mnemonic-seed`: Also show farmer private key

### DIFF
--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -174,6 +174,7 @@ def show_keys(
 
         if show_mnemonic:
             key["master_sk"] = bytes(sk).hex()
+            key["farmer_sk"] = bytes(master_sk_to_farmer_sk(sk)).hex()
             key["wallet_sk"] = bytes(master_sk_to_wallet_sk(sk, uint32(0))).hex()
             key["mnemonic"] = bytes_to_mnemonic(key_data.entropy)
         return key
@@ -194,6 +195,7 @@ def show_keys(
             print(f"First wallet address{' (non-observer)' if key['non_observer'] else ''}: {key['wallet_address']}")
             if show_mnemonic:
                 print("Master private key (m):", key["master_sk"])
+                print("Farmer private key (m/12381/8444/0/0):", key["farmer_sk"])
                 print("First wallet secret key (m/12381/8444/2/0):", key["wallet_sk"])
                 print("  Mnemonic seed (24 secret words):")
                 print(key["mnemonic"])


### PR DESCRIPTION
Technically, the farmer process alone doesn't need the master secret key, but only the farmer secret key. This change therefore makes it easier to retrieve this derived secret key.