### PR TITLE
fix deep reorgs in full node

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: [ 3.9 ]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.33.0
+      BLOCKS_AND_PLOTS_VERSION: 0.34.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -113,7 +113,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.name }}
-      BLOCKS_AND_PLOTS_VERSION: 0.33.0
+      BLOCKS_AND_PLOTS_VERSION: 0.34.0
 
     steps:
       - name: Configure git

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import logging
+from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from chiabip158 import PyBIP158
@@ -13,10 +14,9 @@ from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
-from chia.consensus.find_fork_point import find_fork_point_in_chain
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
+from chia.full_node.mempool_check_conditions import mempool_check_time_locks
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
@@ -27,11 +27,60 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.util import cached_bls
 from chia.util.condition_tools import pkm_pairs
 from chia.util.errors import Err
-from chia.util.generator_tools import tx_removals_and_additions
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
 
+# from chia.consensus.find_fork_point import find_fork_point_in_chain
+
 log = logging.getLogger(__name__)
+
+#  peak->  o
+#  main    |
+#  chain   o  o <- peak_height  \ additions and removals
+#          |  |    peak_hash    | from these blocks are
+#          o  o                 / recorded
+#          \ /
+#           o <- fork_height
+#           |    this block is shared by the main chain
+#           o    and the fork
+#           :
+
+
+@dataclass
+class ForkInfo:
+    # defines the last block shared by the fork and the main chain. additions
+    # and removals are from the block following this height up to and including
+    # the peak_height
+    fork_height: int
+    # the ForkInfo object contain all additions and removals made by blocks
+    # starting at fork_height+1 up to and including peak_height.
+    # When validating the block at height 0, the peak_height is -1, that's why
+    # it needs to be signed
+    peak_height: int
+    # the header hash of the peak block of this fork
+    peak_hash: bytes32
+    # The additions include coinbase additions
+    # coin, creation-height, timestamp
+    additions_since_fork: Dict[bytes32, Tuple[Coin, uint32, uint64]] = field(default_factory=dict)
+    # coin-id
+    removals_since_fork: Set[bytes32] = field(default_factory=set)
+
+    def include_spends(self, npc_result: Optional[NPCResult], block: FullBlock) -> None:
+        height = block.height
+        if npc_result is not None:
+            assert npc_result.conds is not None
+            assert block.foliage_transaction_block is not None
+            timestamp = block.foliage_transaction_block.timestamp
+            for spend in npc_result.conds.spends:
+                self.removals_since_fork.add(bytes32(spend.coin_id))
+                for puzzle_hash, amount, _ in spend.create_coin:
+                    coin = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
+                    self.additions_since_fork[coin.name()] = (coin, height, timestamp)
+        for coin in block.get_included_reward_coins():
+            assert block.foliage_transaction_block is not None
+            timestamp = block.foliage_transaction_block.timestamp
+            assert coin.name() not in self.additions_since_fork
+            self.additions_since_fork[coin.name()] = (coin, block.height, timestamp)
 
 
 async def validate_block_body(
@@ -43,7 +92,7 @@ async def validate_block_body(
     block: Union[FullBlock, UnfinishedBlock],
     height: uint32,
     npc_result: Optional[NPCResult],
-    fork_point_with_peak: Optional[uint32],
+    fork_info: ForkInfo,
     get_block_generator: Callable[[BlockInfo], Awaitable[Optional[BlockGenerator]]],
     *,
     validate_signature: bool = True,
@@ -55,6 +104,9 @@ async def validate_block_body(
     only if validation succeeded, and there are transactions. In other cases it returns None. The NPC result is
     the result of running the generator with the previous generators refs. It is only present for transaction
     blocks which have spent coins.
+    fork_info specifies the fork context of this block. In case the block
+        extends the main chain, it can be empty, but if the block extends a fork
+        of the main chain, the fork info is mandatory in order to validate the block.
     """
     if isinstance(block, FullBlock):
         assert height == block.height
@@ -80,6 +132,8 @@ async def validate_block_body(
         assert prev_tb.timestamp is not None
         if len(block.transactions_generator_ref_list) > 0:
             return Err.NOT_BLOCK_BUT_HAS_DATA, None
+
+        assert fork_info.peak_height == height - 1
 
         return None, None  # This means the block is valid
 
@@ -286,79 +340,9 @@ async def validate_block_body(
 
     # 15. Check if removals exist and were not previously spent. (unspent_db + diff_store + this_block)
     # The fork point is the last block in common between the peak chain and the chain of `block`
-    if peak is None or height == 0:
-        fork_h: int = -1
-    elif fork_point_with_peak is not None:
-        fork_h = fork_point_with_peak
-    else:
-        prev_br = await blocks.get_block_record_from_db(block.prev_header_hash)
-        assert prev_br is not None
-        fork_h = await find_fork_point_in_chain(blocks, peak, prev_br)
 
-    # Get additions and removals since (after) fork_h but not including this block
-    # The values include: the coin that was added, the height of the block in which it was confirmed, and the
-    # timestamp of the block in which it was confirmed
-    additions_since_fork: Dict[bytes32, Tuple[Coin, uint32, uint64]] = {}  # This includes coinbase additions
-    removals_since_fork: Set[bytes32] = set()
-
-    # For height 0, there are no additions and removals before this block, so we can skip
-    if height > 0:
-        # First, get all the blocks in the fork > fork_h, < block.height
-        prev_block: Optional[FullBlock] = await block_store.get_full_block(block.prev_header_hash)
-        reorg_blocks: Dict[uint32, FullBlock] = {}
-        curr: Optional[FullBlock] = prev_block
-        assert curr is not None
-        while curr.height > fork_h:
-            if curr.height == 0:
-                break
-            curr = await block_store.get_full_block(curr.prev_header_hash)
-            assert curr is not None
-            reorg_blocks[curr.height] = curr
-        if fork_h != -1:
-            assert len(reorg_blocks) == height - fork_h - 1
-
-        curr = prev_block
-        assert curr is not None
-        while curr.height > fork_h:
-            # Coin store doesn't contain coins from fork, we have to run generator for each block in fork
-            if curr.transactions_generator is not None:
-                # These blocks are in the past and therefore assumed to be valid, so get_block_generator won't raise
-                curr_block_generator: Optional[BlockGenerator] = await get_block_generator(curr)
-                assert curr_block_generator is not None and curr.transactions_info is not None
-                curr_npc_result = get_name_puzzle_conditions(
-                    curr_block_generator,
-                    min(constants.MAX_BLOCK_COST_CLVM, curr.transactions_info.cost),
-                    mempool_mode=False,
-                    height=curr.height,
-                    constants=constants,
-                )
-                removals_in_curr, additions_in_curr = tx_removals_and_additions(curr_npc_result.conds)
-            else:
-                removals_in_curr = []
-                additions_in_curr = []
-
-            for c_name in removals_in_curr:
-                assert c_name not in removals_since_fork
-                removals_since_fork.add(c_name)
-            for c in additions_in_curr:
-                coin_name = c.name()
-                assert coin_name not in additions_since_fork
-                assert curr.foliage_transaction_block is not None
-                additions_since_fork[coin_name] = (c, curr.height, curr.foliage_transaction_block.timestamp)
-
-            for coinbase_coin in curr.get_included_reward_coins():
-                coin_name = coinbase_coin.name()
-                assert coin_name not in additions_since_fork
-                assert curr.foliage_transaction_block is not None
-                additions_since_fork[coin_name] = (
-                    coinbase_coin,
-                    curr.height,
-                    curr.foliage_transaction_block.timestamp,
-                )
-            if curr.height == 0:
-                break
-            curr = reorg_blocks[uint32(curr.height - 1)]
-            assert curr is not None
+    assert fork_info.fork_height < height
+    assert fork_info.peak_height == height - 1
 
     removal_coin_records: Dict[bytes32, CoinRecord] = {}
     # the removed coins we need to look up from the DB
@@ -379,7 +363,7 @@ async def validate_block_body(
         else:
             # This check applies to both coins created before fork (pulled from coin_store),
             # and coins created after fork (additions_since_fork)
-            if rem in removals_since_fork:
+            if rem in fork_info.removals_since_fork:
                 # This coin was spent in the fork
                 return Err.DOUBLE_SPEND_IN_FORK, None
             removals_from_db.append(rem)
@@ -390,10 +374,10 @@ async def validate_block_body(
     # can't find in the DB, but also coins that were spent after the fork point
     look_in_fork: List[bytes32] = []
     for unspent in unspent_records:
-        if unspent.confirmed_block_index <= fork_h:
+        if unspent.confirmed_block_index <= fork_info.fork_height:
             # Spending something in the current chain, confirmed before fork
             # (We ignore all coins confirmed after fork)
-            if unspent.spent == 1 and unspent.spent_block_index <= fork_h:
+            if unspent.spent == 1 and unspent.spent_block_index <= fork_info.fork_height:
                 # Check for coins spent in an ancestor block
                 return Err.DOUBLE_SPEND, None
             removal_coin_records[unspent.name] = unspent
@@ -411,11 +395,11 @@ async def validate_block_body(
 
     for rem in look_in_fork:
         # This coin is not in the current heaviest chain, so it must be in the fork
-        if rem not in additions_since_fork:
+        if rem not in fork_info.additions_since_fork:
             # Check for spending a coin that does not exist in this fork
             log.error(f"Err.UNKNOWN_UNSPENT: COIN ID: {rem} NPC RESULT: {npc_result}")
             return Err.UNKNOWN_UNSPENT, None
-        new_coin, confirmed_height, confirmed_timestamp = additions_since_fork[rem]
+        new_coin, confirmed_height, confirmed_timestamp = fork_info.additions_since_fork[rem]
         new_coin_record: CoinRecord = CoinRecord(
             new_coin,
             confirmed_height,

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -293,7 +293,7 @@ async def validate_block_body(
     else:
         prev_br = await blocks.get_block_record_from_db(block.prev_header_hash)
         assert prev_br is not None
-        fork_h = find_fork_point_in_chain(blocks, peak, prev_br)
+        fork_h = await find_fork_point_in_chain(blocks, peak, prev_br)
 
     # Get additions and removals since (after) fork_h but not including this block
     # The values include: the coin that was added, the height of the block in which it was confirmed, and the

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -848,6 +848,16 @@ class Blockchain(BlockchainInterface):
             return ret
         return await self.block_store.get_block_record(header_hash)
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            b = self.__block_records.get(h)
+            if b is not None:
+                ret.append(b.prev_hash)
+            else:
+                ret.append(await self.block_store.get_prev_hash(h))
+        return ret
+
     async def contains_block_from_db(self, header_hash: bytes32) -> bool:
         ret = header_hash in self.__block_records
         if ret:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -232,14 +232,18 @@ class Blockchain(BlockchainInterface):
         """
 
         genesis: bool = block.height == 0
-        if self.contains_block(block.header_hash):
+        header_hash: bytes32 = block.header_hash
+
+        if await self.contains_block_from_db(header_hash):
             return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
 
-        if not self.contains_block(block.prev_header_hash) and not genesis:
-            return AddBlockResult.DISCONNECTED_BLOCK, Err.INVALID_PREV_BLOCK_HASH, None
+        prev_block = await self.get_block_record_from_db(block.prev_header_hash)
+        if not genesis:
+            if prev_block is None:
+                return AddBlockResult.DISCONNECTED_BLOCK, Err.INVALID_PREV_BLOCK_HASH, None
 
-        if not genesis and (self.block_record(block.prev_header_hash).height + 1) != block.height:
-            return AddBlockResult.INVALID_BLOCK, Err.INVALID_HEIGHT, None
+            if prev_block.height + 1 != block.height:
+                return AddBlockResult.INVALID_BLOCK, Err.INVALID_HEIGHT, None
 
         npc_result: Optional[NPCResult] = pre_validation_result.npc_result
         required_iters = pre_validation_result.required_iters
@@ -264,6 +268,11 @@ class Blockchain(BlockchainInterface):
         if error_code is not None:
             return AddBlockResult.INVALID_BLOCK, error_code, None
 
+        # block_to_block_record() require the previous block in the cache
+        if not genesis:
+            assert prev_block is not None
+            self.add_block_record(prev_block)
+
         block_record = block_to_block_record(
             self.constants,
             self,
@@ -274,7 +283,6 @@ class Blockchain(BlockchainInterface):
         # Always add the block to the database
         async with self.block_store.db_wrapper.writer():
             try:
-                header_hash: bytes32 = block.header_hash
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 records, state_change_summary = await self._reconsider_peak(
@@ -295,7 +303,7 @@ class Blockchain(BlockchainInterface):
             except BaseException as e:
                 self.block_store.rollback_cache_block(header_hash)
                 log.error(
-                    f"Error while adding block {block.header_hash} height {block.height},"
+                    f"Error while adding block {header_hash} height {block.height},"
                     f" rolling back: {traceback.format_exc()} {e}"
                 )
                 raise
@@ -835,9 +843,17 @@ class Blockchain(BlockchainInterface):
         return records
 
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
-        if header_hash in self.__block_records:
-            return self.__block_records[header_hash]
+        ret = self.__block_records.get(header_hash)
+        if ret is not None:
+            return ret
         return await self.block_store.get_block_record(header_hash)
+
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        ret = header_hash in self.__block_records
+        if ret:
+            return True
+
+        return (await self.block_store.get_block_record(header_hash)) is not None
 
     def remove_block_record(self, header_hash: bytes32) -> None:
         sbr = self.block_record(header_hash)
@@ -918,10 +934,10 @@ class Blockchain(BlockchainInterface):
                 curr = prev
 
             peak: Optional[BlockRecord] = self.get_peak()
-            if self.contains_block(curr.prev_header_hash) and peak is not None:
+            previous_block_hash = curr.prev_header_hash
+            prev_block_record = await self.get_block_record_from_db(previous_block_hash)
+            if prev_block_record is not None and peak is not None:
                 # Then we look up blocks up to fork point one at a time, backtracking
-                previous_block_hash = curr.prev_header_hash
-                prev_block_record = await self.block_store.get_block_record(previous_block_hash)
                 prev_block = await self.block_store.get_full_block(previous_block_hash)
                 assert prev_block is not None
                 assert prev_block_record is not None

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -378,7 +378,7 @@ class Blockchain(BlockchainInterface):
         elif fork_point_with_peak is not None:
             fork_height = fork_point_with_peak
         else:
-            fork_height = find_fork_point_in_chain(self, block_record, peak)
+            fork_height = await find_fork_point_in_chain(self, block_record, peak)
 
         if block_record.prev_hash != peak.header_hash:
             for coin_record in await self.coin_store.rollback_to_block(fork_height):
@@ -941,7 +941,7 @@ class Blockchain(BlockchainInterface):
                 prev_block = await self.block_store.get_full_block(previous_block_hash)
                 assert prev_block is not None
                 assert prev_block_record is not None
-                fork = find_fork_point_in_chain(self, peak, prev_block_record)
+                fork = await find_fork_point_in_chain(self, peak, prev_block_record)
                 curr_2: Optional[FullBlock] = prev_block
                 assert curr_2 is not None and isinstance(curr_2, FullBlock)
                 reorg_chain[curr_2.height] = curr_2

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -64,6 +64,9 @@ class BlockchainInterface:
         # ignoring hinting error until we handle our interfaces more formally
         return  # type: ignore[return-value]
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        return  # type: ignore[return-value]
+
     async def get_header_blocks_in_range(
         self, start: int, stop: int, tx_filter: bool = True
     ) -> Dict[bytes32, HeaderBlock]:

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -41,6 +41,9 @@ class BlockchainInterface:
         # ignoring hinting error until we handle our interfaces more formally
         return  # type: ignore[return-value]
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        return  # type: ignore[return-value]
+
     def remove_block_record(self, header_hash: bytes32) -> None:
         pass
 

--- a/chia/consensus/find_fork_point.py
+++ b/chia/consensus/find_fork_point.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockchainInterface
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
+from chia.util.ints import uint32
 
 
 def unwrap(block: Optional[BlockRecord]) -> BlockRecord:
@@ -40,3 +42,50 @@ async def find_fork_point_in_chain(
 
     # First block is the same
     return 0
+
+
+async def lookup_fork_chain(
+    blocks: BlockchainInterface,
+    block_1: Tuple[uint32, bytes32],
+    block_2: Tuple[uint32, bytes32],
+) -> Tuple[Dict[uint32, bytes32], bytes32]:
+    """Tries to find height where new chain (block_2) diverged from block_1.
+    The inputs are (height, header-hash)-tuples.
+    Returns two values:
+        1. The height to hash map of block_2's chain down to, but not
+           including, the fork height
+        2. The header hash of the block at the fork height
+    """
+    height_1 = int(block_1[0])
+    bh_1 = block_1[1]
+    height_2 = int(block_2[0])
+    bh_2 = block_2[1]
+
+    ret: Dict[uint32, bytes32] = {}
+
+    while height_1 > height_2:
+        [bh_1] = await blocks.prev_block_hash([bh_1])
+        height_1 -= 1
+
+    while height_2 > height_1:
+        ret[uint32(height_2)] = bh_2
+        [bh_2] = await blocks.prev_block_hash([bh_2])
+        height_2 -= 1
+
+    assert height_1 == height_2
+
+    height = height_2
+    while height > 0:
+        if bh_1 == bh_2:
+            return (ret, bh_2)
+        ret[uint32(height)] = bh_2
+        [bh_1, bh_2] = await blocks.prev_block_hash([bh_1, bh_2])
+        height -= 1
+
+    if bh_1 == bh_2:
+        return (ret, bh_2)
+
+    ret[uint32(0)] = bh_2
+    # TODO: if we would pass in the consensus constants, we could return the
+    # GENESIS_CHALLENGE hash here, instead of zeros
+    return (ret, bytes32([0] * 32))

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -197,9 +197,9 @@ async def pre_validate_blocks_multiprocessing(
     num_sub_slots_found = 0
     num_blocks_seen = 0
     if blocks[0].height > 0:
-        if not block_records.contains_block(blocks[0].prev_header_hash):
+        curr = await block_records.get_block_record_from_db(blocks[0].prev_header_hash)
+        if curr is None:
             return [PreValidationResult(uint16(Err.INVALID_PREV_BLOCK_HASH.value), None, None, False)]
-        curr = block_records.block_record(blocks[0].prev_header_hash)
         num_sub_slots_to_look_for = 3 if curr.overflow else 2
         while (
             curr.sub_epoch_summary_included is None
@@ -212,7 +212,8 @@ async def pre_validate_blocks_multiprocessing(
             recent_blocks[curr.header_hash] = curr
             if curr.is_transaction_block:
                 num_blocks_seen += 1
-            curr = block_records.block_record(curr.prev_hash)
+            curr = await block_records.get_block_record_from_db(curr.prev_hash)
+            assert curr is not None
         recent_blocks[curr.header_hash] = curr
     block_record_was_present = []
     for block in blocks:
@@ -221,10 +222,18 @@ async def pre_validate_blocks_multiprocessing(
     diff_ssis: List[Tuple[uint64, uint64]] = []
     for block in blocks:
         if block.height != 0:
-            assert block_records.contains_block(block.prev_header_hash)
             if prev_b is None:
-                prev_b = block_records.block_record(block.prev_header_hash)
+                prev_b = await block_records.get_block_record_from_db(block.prev_header_hash)
+            assert prev_b is not None
 
+        # get_next_sub_slot_iters_and_difficulty() requires prev_b.prev_hash to
+        # be in the block record cache.
+        if prev_b is not None and prev_b.height != 0 and not block_records.contains_block(prev_b.prev_hash):
+            return [PreValidationResult(uint16(Err.INVALID_PREV_BLOCK_HASH.value), None, None, False)]
+        if prev_b is not None and not block_records.contains_block(block.prev_header_hash):
+            # the call to block_to_block_record() requires the previous
+            # block is in the cache
+            block_records.add_block_record(prev_b)
         sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
             constants, len(block.finished_sub_slots) > 0, prev_b, block_records
         )
@@ -253,6 +262,10 @@ async def pre_validate_blocks_multiprocessing(
         )
 
         try:
+            if prev_b is not None and not block_records.contains_block(block.prev_header_hash):
+                # the call to block_to_block_record() requires the previous
+                # block is in the cache
+                block_records.add_block_record(prev_b)
             block_rec = block_to_block_record(
                 constants,
                 block_records,

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -342,6 +342,21 @@ class BlockStore:
             ret.append(all_blocks[hh])
         return ret
 
+    async def get_prev_hash(self, header_hash: bytes32) -> bytes32:
+        """
+        Returns the header hash preceeding the input header hash.
+        Throws an exception if the block is not present
+        """
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute(
+                "SELECT prev_hash FROM full_blocks WHERE header_hash=?",
+                (header_hash,),
+            ) as cursor:
+                row = await cursor.fetchone()
+                if row is None:
+                    raise KeyError("missing block in chain")
+                return bytes32(row[0])
+
     async def get_block_bytes_by_hash(self, header_hashes: List[bytes32]) -> List[bytes]:
         """
         Returns a list of Full Blocks block blobs, ordered by the same order in which header_hashes are passed in.

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1197,7 +1197,7 @@ class FullNode:
 
         blocks_to_validate: List[FullBlock] = []
         for i, block in enumerate(all_blocks):
-            if not self.blockchain.contains_block(block.header_hash):
+            if not await self.blockchain.contains_block_from_db(block.header_hash):
                 blocks_to_validate = all_blocks[i:]
                 break
         if len(blocks_to_validate) == 0:
@@ -1253,7 +1253,8 @@ class FullNode:
                 if error is not None:
                     self.log.error(f"Error: {error}, Invalid block from peer: {peer.get_peer_logging()} ")
                 return False, agg_state_change_summary, error
-            block_record = self.blockchain.block_record(block.header_hash)
+            block_record = await self.blockchain.get_block_record_from_db(block.header_hash)
+            assert block_record is not None
             if block_record.sub_epoch_summary_included is not None:
                 if self.weight_proof_handler is not None:
                     await self.weight_proof_handler.create_prev_sub_epoch_segments()
@@ -1424,7 +1425,7 @@ class FullNode:
             # This is a reorg
             fork_hash: Optional[bytes32] = self.blockchain.height_to_hash(state_change_summary.fork_height)
             assert fork_hash is not None
-            fork_block = self.blockchain.block_record(fork_hash)
+            fork_block = await self.blockchain.get_block_record_from_db(fork_hash)
 
         fns_peak_result: FullNodeStorePeakResult = self.full_node_store.new_peak(
             record,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -547,7 +547,8 @@ class FullNode:
             )
             if first is None or not isinstance(first, full_node_protocol.RespondBlock):
                 self.sync_store.batch_syncing.remove(peer.peer_node_id)
-                raise ValueError(f"Error short batch syncing, could not fetch block at height {start_height}")
+                self.log.error(f"Error short batch syncing, could not fetch block at height {start_height}")
+                return False
             if not self.blockchain.contains_block(first.block.prev_header_hash):
                 self.log.info("Batch syncing stopped, this is a deep chain")
                 self.sync_store.batch_syncing.remove(peer.peer_node_id)
@@ -726,6 +727,10 @@ class FullNode:
                 return None
 
             if request.height < curr_peak_height + self.config["sync_blocks_behind_threshold"]:
+                # TODO: We get here if we encountered a heavier peak with a
+                # lower height than ours. We don't seem to handle this case
+                # right now. This ends up requesting the block at *our* peak
+                # height.
                 # This case of being behind but not by so much
                 if await self.short_sync_batch(peer, uint32(max(curr_peak_height - 6, 0)), request.height):
                     return None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -15,6 +15,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, U
 
 from blspy import AugSchemeMPL
 
+from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_creation import unfinished_block_to_full_block
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain import AddBlockResult, Blockchain, BlockchainMutexPriority, StateChangeSummary
@@ -1051,6 +1052,16 @@ class FullNode:
         )
         batch_size = self.constants.MAX_BLOCK_COUNT_PER_REQUESTS
 
+        # normally "fork_point" or "fork_height" refers to the first common
+        # block between the main chain and the fork. Here "fork_point_height"
+        # seems to refer to the first diverging block
+        if fork_point_height == 0:
+            fork_info = ForkInfo(-1, -1, bytes32([0] * 32))
+        else:
+            fork_hash = self.blockchain.height_to_hash(uint32(fork_point_height - 1))
+            assert fork_hash is not None
+            fork_info = ForkInfo(fork_point_height - 1, fork_point_height - 1, fork_hash)
+
         async def fetch_block_batches(
             batch_queue: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]]
         ) -> None:
@@ -1086,7 +1097,6 @@ class FullNode:
         async def validate_block_batches(
             inner_batch_queue: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]]
         ) -> None:
-            advanced_peak: bool = False
             while True:
                 res: Optional[Tuple[WSChiaConnection, List[FullBlock]]] = await inner_batch_queue.get()
                 if res is None:
@@ -1096,7 +1106,10 @@ class FullNode:
                 start_height = blocks[0].height
                 end_height = blocks[-1].height
                 success, state_change_summary, err = await self.add_block_batch(
-                    blocks, peer, None if advanced_peak else uint32(fork_point_height), summaries
+                    blocks,
+                    peer,
+                    fork_info,
+                    summaries,
                 )
                 if success is False:
                     await peer.close(600)
@@ -1108,7 +1121,6 @@ class FullNode:
                 self.log.info(f"Added blocks {start_height} to {end_height}")
                 peak: Optional[BlockRecord] = self.blockchain.get_peak()
                 if state_change_summary is not None:
-                    advanced_peak = True
                     assert peak is not None
                     # Hints must be added to the DB. The other post-processing tasks are not required when syncing
                     hints_to_add, _ = get_hints_and_subscription_coin_ids(
@@ -1189,7 +1201,7 @@ class FullNode:
         self,
         all_blocks: List[FullBlock],
         peer: WSChiaConnection,
-        fork_point: Optional[uint32],
+        fork_info: Optional[ForkInfo],
         wp_summaries: Optional[List[SubEpochSummary]] = None,
     ) -> Tuple[bool, Optional[StateChangeSummary], Optional[Err]]:
         # Precondition: All blocks must be contiguous blocks, index i+1 must be the parent of index i
@@ -1197,9 +1209,38 @@ class FullNode:
 
         blocks_to_validate: List[FullBlock] = []
         for i, block in enumerate(all_blocks):
-            if not await self.blockchain.contains_block_from_db(block.header_hash):
+            header_hash = block.header_hash
+            if not await self.blockchain.contains_block_from_db(header_hash):
                 blocks_to_validate = all_blocks[i:]
                 break
+
+            if fork_info is None:
+                continue
+            # the below section updates the fork_info object, if
+            # there is one.
+
+            # TODO: it seems unnecessary to request overlapping block ranges
+            # when syncing
+            if block.height <= fork_info.peak_height:
+                continue
+
+            # we have already validated this block once, no need to do it again.
+            # however, if this block is not part of the main chain, we need to
+            # update the fork context with its additions and removals
+            if self.blockchain.height_to_hash(block.height) == header_hash:
+                # we're on the main chain, just fast-forward the fork height
+                fork_info.fork_height = block.height
+                fork_info.peak_height = block.height
+                fork_info.peak_hash = header_hash
+                fork_info.additions_since_fork == {}
+                fork_info.removals_since_fork == set()
+            else:
+                # We have already validated the block, but if it's not part of the
+                # main chain, we still need to re-run it to update the additions and
+                # removals in fork_info.
+                await self.blockchain.advance_fork_info(block, fork_info)
+                await self.blockchain.run_single_block(block, fork_info)
+
         if len(blocks_to_validate) == 0:
             return True, None, None
 
@@ -1229,9 +1270,8 @@ class FullNode:
         for i, block in enumerate(blocks_to_validate):
             assert pre_validation_results[i].required_iters is not None
             state_change_summary: Optional[StateChangeSummary]
-            advanced_peak = agg_state_change_summary is not None
             result, error, state_change_summary = await self.blockchain.add_block(
-                block, pre_validation_results[i], None if advanced_peak else fork_point
+                block, pre_validation_results[i], fork_info
             )
 
             if result == AddBlockResult.NEW_PEAK:
@@ -1573,6 +1613,7 @@ class FullNode:
         block: FullBlock,
         peer: Optional[WSChiaConnection] = None,
         raise_on_disconnected: bool = False,
+        fork_info: Optional[ForkInfo] = None,
     ) -> Optional[Message]:
         """
         Add a full block from a peer full node (or ourselves).
@@ -1675,7 +1716,7 @@ class FullNode:
                     )
                     assert result_to_validate.required_iters == pre_validation_results[0].required_iters
                     (added, error_code, state_change_summary) = await self.blockchain.add_block(
-                        block, result_to_validate, None
+                        block, result_to_validate, fork_info
                     )
                 if added == AddBlockResult.ALREADY_HAVE_BLOCK:
                     return None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -931,8 +931,9 @@ class FullNode:
             self.log.info("Waiting to receive peaks from peers.")
 
             # Wait until we have 3 peaks or up to a max of 30 seconds
+            max_iterations = int(self.config.get("max_sync_wait", 30)) * 10
             peaks = []
-            for i in range(300):
+            for i in range(max_iterations):
                 peaks = [peak.header_hash for peak in self.sync_store.get_peak_of_each_peer().values()]
                 if len(self.sync_store.get_peers_that_have_peak(peaks)) < 3:
                     if self._shut_down:

--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -129,6 +129,10 @@ async def setup_simulators_and_wallets(
     disable_capabilities: Optional[List[Capability]] = None,
 ) -> AsyncIterator[Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]]:
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
+        if config_overrides is None:
+            config_overrides = {}
+        if "full_node.max_sync_wait" not in config_overrides:
+            config_overrides["full_node.max_sync_wait"] = 1
         async with setup_simulators_and_wallets_inner(
             db_version,
             consensus_constants,

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -59,6 +59,9 @@ class BlockCache(BlockchainInterface):
     def contains_block(self, header_hash: bytes32) -> bool:
         return header_hash in self._block_records
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        return header_hash in self._block_records
+
     def contains_height(self, height: uint32) -> bool:
         return height in self._height_to_hash
 

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -77,6 +77,12 @@ class BlockCache(BlockchainInterface):
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
         return self._block_records[header_hash]
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            ret.append(self._block_records[h].prev_hash)
+        return ret
+
     def remove_block_record(self, header_hash: bytes32):
         del self._block_records[header_hash]
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -417,6 +417,10 @@ full_node:
   # timeout for weight proof request
   weight_proof_timeout: &weight_proof_timeout 360
 
+  # when the full node enters sync-mode, we wait until we have collected peaks
+  # from at least 3 peers, or until we've waitied this many seconds
+  max_sync_wait: 30
+
   # when enabled, the full node will print a pstats profile to the root_dir/profile every second
   # analyze with chia/utils/profiler.py
   enable_profiler: False

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -215,6 +215,12 @@ class WalletBlockchain(BlockchainInterface):
         # blockchain_interface
         return self._block_records.get(header_hash)
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            ret.append(self._block_records[h].prev_hash)
+        return ret
+
     def add_block_record(self, block_record: BlockRecord) -> None:
         self._block_records[block_record.header_hash] = block_record
 

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -132,7 +132,7 @@ class WalletBlockchain(BlockchainInterface):
             if block_record.prev_hash == self._peak.header_hash:
                 fork_height: int = self._peak.height
             else:
-                fork_height = find_fork_point_in_chain(self, block_record, self._peak)
+                fork_height = await find_fork_point_in_chain(self, block_record, self._peak)
             await self._rollback_to_height(fork_height)
             curr_record: BlockRecord = block_record
             latest_timestamp = self._latest_timestamp

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -193,6 +193,11 @@ class WalletBlockchain(BlockchainInterface):
     def contains_block(self, header_hash: bytes32) -> bool:
         return header_hash in self._block_records
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        # the wallet doesn't have the blockchain DB, this implements the
+        # blockchain_interface
+        return header_hash in self._block_records
+
     def contains_height(self, height: uint32) -> bool:
         return height in self._height_to_hash
 
@@ -200,12 +205,15 @@ class WalletBlockchain(BlockchainInterface):
         return self._height_to_hash[height]
 
     def try_block_record(self, header_hash: bytes32) -> Optional[BlockRecord]:
-        if self.contains_block(header_hash):
-            return self.block_record(header_hash)
-        return None
+        return self._block_records.get(header_hash)
 
     def block_record(self, header_hash: bytes32) -> BlockRecord:
         return self._block_records[header_hash]
+
+    async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
+        # the wallet doesn't have the blockchain DB, this implements the
+        # blockchain_interface
+        return self._block_records.get(header_hash)
 
     def add_block_record(self, block_record: BlockRecord) -> None:
         self._block_records[block_record.header_hash] = block_record

--- a/tests/blockchain/blockchain_test_utils.py
+++ b/tests/blockchain/blockchain_test_utils.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.types.full_block import FullBlock
 from chia.util.errors import Err
-from chia.util.ints import uint32, uint64
+from chia.util.ints import uint64
 
 
 async def check_block_store_invariant(bc: Blockchain):
@@ -44,7 +45,7 @@ async def _validate_and_add_block(
     expected_result: Optional[AddBlockResult] = None,
     expected_error: Optional[Err] = None,
     skip_prevalidation: bool = False,
-    fork_point_with_peak: Optional[uint32] = None,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     # Tries to validate and add the block, and checks that there are no errors in the process and that the
     # block is added to the peak.
@@ -81,7 +82,7 @@ async def _validate_and_add_block(
         result,
         err,
         _,
-    ) = await blockchain.add_block(block, results, fork_point_with_peak=fork_point_with_peak)
+    ) = await blockchain.add_block(block, results, fork_info=fork_info)
     await check_block_store_invariant(blockchain)
 
     if expected_error is None and expected_result != AddBlockResult.INVALID_BLOCK:
@@ -107,11 +108,15 @@ async def _validate_and_add_block(
 
 
 async def _validate_and_add_block_multi_error(
-    blockchain: Blockchain, block: FullBlock, expected_errors: List[Err], skip_prevalidation: bool = False
+    blockchain: Blockchain,
+    block: FullBlock,
+    expected_errors: List[Err],
+    skip_prevalidation: bool = False,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     # Checks that the blockchain returns one of the expected errors
     try:
-        await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation)
+        await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation, fork_info=fork_info)
     except Exception as e:
         assert isinstance(e, AssertionError)
         assert e.args[0] in expected_errors
@@ -121,11 +126,15 @@ async def _validate_and_add_block_multi_error(
 
 
 async def _validate_and_add_block_multi_error_or_pass(
-    blockchain: Blockchain, block: FullBlock, expected_errors: List[Err], skip_prevalidation: bool = False
+    blockchain: Blockchain,
+    block: FullBlock,
+    expected_errors: List[Err],
+    skip_prevalidation: bool = False,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     # Checks that the blockchain returns one of the expected errors, also allows block to be added.
     try:
-        await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation)
+        await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation, fork_info=fork_info)
     except AssertionError as e:
         assert e.args[0] in expected_errors
 
@@ -134,13 +143,16 @@ async def _validate_and_add_block_multi_result(
     blockchain: Blockchain,
     block: FullBlock,
     expected_result: List[AddBlockResult],
-    skip_prevalidation: Optional[bool] = None,
+    skip_prevalidation: bool = False,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     try:
-        if skip_prevalidation is not None:
-            await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation)
-        else:
-            await _validate_and_add_block(blockchain, block)
+        await _validate_and_add_block(
+            blockchain,
+            block,
+            skip_prevalidation=skip_prevalidation,
+            fork_info=fork_info,
+        )
     except Exception as e:
         assert isinstance(e, AssertionError)
         assert "Block was not added" in e.args[0]
@@ -150,7 +162,10 @@ async def _validate_and_add_block_multi_result(
 
 
 async def _validate_and_add_block_no_error(
-    blockchain: Blockchain, block: FullBlock, skip_prevalidation: Optional[bool] = None
+    blockchain: Blockchain,
+    block: FullBlock,
+    skip_prevalidation: bool = False,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     # adds a block and ensures that there is no error. However, does not ensure that block extended the peak of
     # the blockchain
@@ -163,4 +178,5 @@ async def _validate_and_add_block_no_error(
             AddBlockResult.ADDED_AS_ORPHAN,
         ],
         skip_prevalidation=skip_prevalidation,
+        fork_info=fork_info,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,11 +249,15 @@ def default_10000_blocks(bt, consensus_mode):
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
-    return persistent_blocks(10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000")
+    return persistent_blocks(
+        10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000", dummy_block_references=True
+    )
 
 
+# this long reorg chain shares the first 500 blocks with "default_10000_blocks"
+# and has heavier weight blocks
 @pytest.fixture(scope="session")
-def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
+def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
     version = ""
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
@@ -261,12 +265,33 @@ def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        758,
+        4500,
         f"test_blocks_long_reorg_{saved_blocks_version}{version}.db",
         bt,
-        block_list_input=default_1500_blocks[:320],
+        block_list_input=default_10000_blocks[:500],
         seed=b"reorg_blocks",
         time_per_block=8,
+        dummy_block_references=True,
+    )
+
+
+# this long reorg chain shares the first 500 blocks with "default_10000_blocks"
+# and has the same weight blocks
+@pytest.fixture(scope="session")
+def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
+    version = ""
+    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        version = "_hardfork"
+
+    from tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(
+        4500,
+        f"test_blocks_long_reorg_light_{saved_blocks_version}{version}.db",
+        bt,
+        block_list_input=default_10000_blocks[:500],
+        seed=b"reorg_blocks2",
+        dummy_block_references=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,7 +250,11 @@ def default_10000_blocks(bt, consensus_mode):
         version = "_hardfork"
 
     return persistent_blocks(
-        10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000", dummy_block_references=True
+        10000,
+        f"test_blocks_10000_{saved_blocks_version}{version}.db",
+        bt,
+        seed=b"10000",
+        dummy_block_references=True,
     )
 
 
@@ -272,6 +276,7 @@ def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
         seed=b"reorg_blocks",
         time_per_block=8,
         dummy_block_references=True,
+        include_transactions=True,
     )
 
 
@@ -292,6 +297,7 @@ def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
         block_list_input=default_10000_blocks[:500],
         seed=b"reorg_blocks2",
         dummy_block_references=True,
+        include_transactions=True,
     )
 
 

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -298,7 +298,7 @@ class TestFullNodeStore:
             assert peak_here is not None
             if peak_here.header_hash == block.header_hash:
                 sb = blockchain.block_record(block.header_hash)
-                fork = find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
+                fork = await find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
                 if fork > 0:
                     fork_block = blockchain.height_to_block_record(uint32(fork))
                 else:
@@ -375,7 +375,7 @@ class TestFullNodeStore:
             assert peak_here is not None
             if peak_here.header_hash == blocks[-1].header_hash:
                 sb = blockchain.block_record(blocks[-1].header_hash)
-                fork = find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
+                fork = await find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
                 if fork > 0:
                     fork_block = blockchain.height_to_block_record(uint32(fork))
                 else:

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2162,3 +2162,68 @@ async def test_long_reorg(
         assert peak.height > chain_1_height
     else:
         assert peak.height < chain_1_height
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("light_blocks", [True, False])
+@pytest.mark.parametrize(
+    "chain_length",
+    [
+        0,
+        # TODO: understand why this breaks
+        #    900
+    ],
+)
+async def test_long_reorg_nodes(
+    light_blocks: bool,
+    chain_length: int,
+    setup_two_nodes_and_wallet,
+    default_10000_blocks: List[FullBlock],
+    test_long_reorg_blocks: List[FullBlock],
+    test_long_reorg_blocks_light: List[FullBlock],
+    self_hostname: str,
+):
+    nodes, wallets, bt = setup_two_nodes_and_wallet
+    server_1 = nodes[0].full_node.server
+    server_2 = nodes[1].full_node.server
+    full_node_1 = nodes[0]
+    full_node_2 = nodes[1]
+
+    blocks = default_10000_blocks[: 1600 - chain_length]
+
+    if light_blocks:
+        reorg_blocks = test_long_reorg_blocks_light[: 2000 - chain_length]
+    else:
+        reorg_blocks = test_long_reorg_blocks[: 1500 - chain_length]
+
+    # full node 1 has the original chain
+    for block_batch in to_batches(blocks, 64):
+        b = block_batch.entries[0]
+        if (b.height % 128) == 0:
+            print(f"main chain: {b.height:4} weight: {b.weight}")
+        await full_node_1.full_node.add_block_batch(block_batch.entries, get_dummy_connection(NodeType.FULL_NODE), None)
+
+    # full node 2 has the reorg-chain
+    for block_batch in to_batches(reorg_blocks[:-1], 64):
+        b = block_batch.entries[0]
+        if (b.height % 128) == 0:
+            print(f"reorg chain: {b.height:4} weight: {b.weight}")
+        await full_node_2.full_node.add_block_batch(block_batch.entries, get_dummy_connection(NodeType.FULL_NODE), None)
+
+    await connect_and_get_peer(server_1, server_2, self_hostname)
+
+    await full_node_2.full_node.add_block(reorg_blocks[-1])
+
+    # node 1 will wait 30 seonds before it starts syncing. It would be nice to
+    # be able to configure this delay to be shorter
+
+    def check_nodes_in_sync():
+        try:
+            p1 = full_node_2.full_node.blockchain.get_peak()
+            p2 = full_node_1.full_node.blockchain.get_peak()
+            return p1 == p2
+        except Exception as e:
+            print(f"e: {e}")
+            return False
+
+    await time_out_assert(200, check_nodes_in_sync)

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2214,9 +2214,6 @@ async def test_long_reorg_nodes(
 
     await full_node_2.full_node.add_block(reorg_blocks[-1])
 
-    # node 1 will wait 30 seonds before it starts syncing. It would be nice to
-    # be able to configure this delay to be shorter
-
     def check_nodes_in_sync():
         try:
             p1 = full_node_2.full_node.blockchain.get_peak()

--- a/tests/plot_sync/util.py
+++ b/tests/plot_sync/util.py
@@ -29,6 +29,9 @@ class WSChiaConnectionDummy:
     async def send_message(self, message: Message) -> None:
         self.last_sent_message = message
 
+    def get_peer_logging(self) -> PeerInfo:
+        return self.peer_info
+
 
 def get_dummy_connection(node_type: NodeType, peer_id: Optional[bytes32] = None) -> WSChiaConnectionDummy:
     return WSChiaConnectionDummy(node_type, bytes32(token_bytes(32)) if peer_id is None else peer_id)

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -25,7 +25,7 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int) -> T
 
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
-    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2)
+    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2, single_threaded=True)
     assert bc1.get_peak() is None
     return bc1, wrapper, db_path
 
@@ -36,12 +36,14 @@ def persistent_blocks(
     bt: BlockTools,
     seed: bytes = b"",
     empty_sub_slots: int = 0,
+    *,
     normalized_to_identity_cc_eos: bool = False,
     normalized_to_identity_icc_eos: bool = False,
     normalized_to_identity_cc_sp: bool = False,
     normalized_to_identity_cc_ip: bool = False,
     block_list_input: Optional[List[FullBlock]] = None,
     time_per_block: Optional[float] = None,
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
@@ -81,10 +83,11 @@ def persistent_blocks(
         bt,
         block_list_input,
         time_per_block,
-        normalized_to_identity_cc_eos,
-        normalized_to_identity_icc_eos,
-        normalized_to_identity_cc_sp,
-        normalized_to_identity_cc_ip,
+        normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
+        normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
+        normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
+        normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
 
 
@@ -96,10 +99,12 @@ def new_test_db(
     bt: BlockTools,
     block_list_input: List[FullBlock],
     time_per_block: Optional[float],
+    *,
     normalized_to_identity_cc_eos: bool = False,  # CC_EOS,
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
@@ -112,6 +117,7 @@ def new_test_db(
         normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
     block_bytes_list: List[bytes] = []
     for block in blocks:

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -44,6 +44,7 @@ def persistent_blocks(
     block_list_input: Optional[List[FullBlock]] = None,
     time_per_block: Optional[float] = None,
     dummy_block_references: bool = False,
+    include_transactions: bool = False,
 ) -> List[FullBlock]:
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
@@ -88,6 +89,7 @@ def persistent_blocks(
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
         dummy_block_references=dummy_block_references,
+        include_transactions=include_transactions,
     )
 
 
@@ -105,6 +107,7 @@ def new_test_db(
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
     dummy_block_references: bool = False,
+    include_transactions: bool = False,
 ) -> List[FullBlock]:
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
@@ -118,6 +121,7 @@ def new_test_db(
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
         dummy_block_references=dummy_block_references,
+        include_transactions=include_transactions,
     )
     block_bytes_list: List[bytes] = []
     for block in blocks:


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

### Purpose:

The node is currently having a hard time with deep reorgs. The issue can be split in 2 parts:

1. Some parts of block validation require some previous blocks to be loaded in the block record cache in the blockchain object. When performing a reorg deeper than the cache size, those block records may not be in the cache and fail.

2. When validating coin spends on the forked chain, we re-run blocks in order to compute the additions and removals for the fork of the chain. This is done very inefficiently, causing the same blocks to be run many times.

When validating blocks on the fork of the chain (before accepting it and updating our peak) we need to be able to pick up block records (and generators) from blocks that are not in the main chain. This requires looking them up from the database. One case of interest, that has previously not been covered by a test, is when a block reference points into the forked chain (i.e. a block not in the main chain).

### Current Behavior:

In a long/deep reorg, the node may fail with `KeyError` while looking up block records that are not in the cache.

### New Behavior:

Long/deep reorgs work as expected.

# Changes

Update `BlockTools` to make reorg test blockchains use block references and transactions.

## commits

* add feature to BlockTools to allow including block references to previous generators in test chains. Use a longer chain, with block generators, in the long_reorg test add new test block chain fixture for reorgs with lighter weight blocks, this covers reorgs to greater block heights than the current peak

* add feature to BlockTools to include transactions in every transaction block, to exercise more parts of our validation logic in simulations

Allow block validation to pull blocks from the database, that currently *only* pull from the cache.

## commits

* update block validation to pull block dependencies from the database
* transition find_fork_point_in_chain() to be async and pull blocks from the database

Preserve the state of the fork across block validations. This is done in `ForkInfo`, by preserving all additions and removals of the fork. The "fix reorg performance" commit is the big one that passes around information about the fork that's currently being validated (if any).

## commits

* introduce new function, lookup_fork_chain(), similar to find_fork_point_in_chain(), but return the whole sequence of block hashes
* optimize find_fork_point_in_chain() to just look up prev_hash from the database, avoiding parsing and constructing a whole BlockRecord object for block traversed
* fix reorg performance issue by preserving additions and removals across block validations (instead of re-computing them from scratch for every block)
* update get_block_generator() to use new lookup_fork_chain()

Extend the existing long reorg test to be even longer (to be deeper than the block cache size).
Also add tests on the `FullNode` object including one with two nodes syncing via the network protocol.

## commits

* update test_long_reorg to use the new, longer, test chains with block generators and block references
* add new test_long_reorg operating on full node
* add test with two nodes with a deep fork, where one syncs to the other
* make the timeout for collecting 3 peaks configurable. Set it to 1 seconds in the simulation tests to avoid waiting on CI
* bump test chains used on CI

# Benchmark

I profiled the new reorg logic via `test_long_reorg_nodes()` and the `Blockchain.py` `test_long_reorg()` tests.

## test_long_reorg_nodes()

![full-node-test-long-reorg](https://github.com/Chia-Network/chia-blockchain/assets/661450/5c84b0e6-41dc-4f48-9c36-62dc5b99ca6c)

## test_long_reorg()

![blockchain-test-long-reorg](https://github.com/Chia-Network/chia-blockchain/assets/661450/66f2e4dd-eb52-47f2-9c2e-5c4983323a22)

# future improvements

There are still some significant performance improvements to be made to the `get_block_generator()` function. If the fork chain's height-to-hash map would be recorded in the `ForkInfo` object, it could avoid the (expensive) call to `lookup_fork_chain()` entirely.