### PR TITLE
Fix deep reorgs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -60,7 +60,7 @@ jobs:
         python-version: [ "3.10" ]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.33.0
+      BLOCKS_AND_PLOTS_VERSION: 0.38.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -113,7 +113,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.name }}
-      BLOCKS_AND_PLOTS_VERSION: 0.33.0
+      BLOCKS_AND_PLOTS_VERSION: 0.38.0
 
     steps:
       - name: Configure git

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -293,7 +293,7 @@ async def validate_block_body(
     else:
         prev_br = await blocks.get_block_record_from_db(block.prev_header_hash)
         assert prev_br is not None
-        fork_h = find_fork_point_in_chain(blocks, peak, prev_br)
+        fork_h = await find_fork_point_in_chain(blocks, peak, prev_br)
 
     # Get additions and removals since (after) fork_h but not including this block
     # The values include: the coin that was added, the height of the block in which it was confirmed, and the

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import logging
+from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from chiabip158 import PyBIP158
@@ -13,10 +14,9 @@ from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
-from chia.consensus.find_fork_point import find_fork_point_in_chain
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
+from chia.full_node.mempool_check_conditions import mempool_check_time_locks
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
@@ -27,11 +27,58 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.util import cached_bls
 from chia.util.condition_tools import pkm_pairs
 from chia.util.errors import Err
-from chia.util.generator_tools import tx_removals_and_additions
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
 
 log = logging.getLogger(__name__)
+
+#  peak->  o
+#  main    |
+#  chain   o  o <- peak_height  \ additions and removals
+#          |  |    peak_hash    | from these blocks are
+#          o  o                 / recorded
+#          \ /
+#           o <- fork_height
+#           |    this block is shared by the main chain
+#           o    and the fork
+#           :
+
+
+@dataclass
+class ForkInfo:
+    # defines the last block shared by the fork and the main chain. additions
+    # and removals are from the block following this height up to and including
+    # the peak_height
+    fork_height: int
+    # the ForkInfo object contain all additions and removals made by blocks
+    # starting at fork_height+1 up to and including peak_height.
+    # When validating the block at height 0, the peak_height is -1, that's why
+    # it needs to be signed
+    peak_height: int
+    # the header hash of the peak block of this fork
+    peak_hash: bytes32
+    # The additions include coinbase additions
+    # coin, creation-height, timestamp
+    additions_since_fork: Dict[bytes32, Tuple[Coin, uint32, uint64]] = field(default_factory=dict)
+    # coin-id
+    removals_since_fork: Set[bytes32] = field(default_factory=set)
+
+    def include_spends(self, npc_result: Optional[NPCResult], block: FullBlock) -> None:
+        height = block.height
+        if npc_result is not None:
+            assert npc_result.conds is not None
+            assert block.foliage_transaction_block is not None
+            timestamp = block.foliage_transaction_block.timestamp
+            for spend in npc_result.conds.spends:
+                self.removals_since_fork.add(bytes32(spend.coin_id))
+                for puzzle_hash, amount, _ in spend.create_coin:
+                    coin = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
+                    self.additions_since_fork[coin.name()] = (coin, height, timestamp)
+        for coin in block.get_included_reward_coins():
+            assert block.foliage_transaction_block is not None
+            timestamp = block.foliage_transaction_block.timestamp
+            assert coin.name() not in self.additions_since_fork
+            self.additions_since_fork[coin.name()] = (coin, block.height, timestamp)
 
 
 async def validate_block_body(
@@ -43,7 +90,7 @@ async def validate_block_body(
     block: Union[FullBlock, UnfinishedBlock],
     height: uint32,
     npc_result: Optional[NPCResult],
-    fork_point_with_peak: Optional[uint32],
+    fork_info: ForkInfo,
     get_block_generator: Callable[[BlockInfo], Awaitable[Optional[BlockGenerator]]],
     *,
     validate_signature: bool = True,
@@ -55,6 +102,9 @@ async def validate_block_body(
     only if validation succeeded, and there are transactions. In other cases it returns None. The NPC result is
     the result of running the generator with the previous generators refs. It is only present for transaction
     blocks which have spent coins.
+    fork_info specifies the fork context of this block. In case the block
+        extends the main chain, it can be empty, but if the block extends a fork
+        of the main chain, the fork info is mandatory in order to validate the block.
     """
     if isinstance(block, FullBlock):
         assert height == block.height
@@ -80,6 +130,8 @@ async def validate_block_body(
         assert prev_tb.timestamp is not None
         if len(block.transactions_generator_ref_list) > 0:
             return Err.NOT_BLOCK_BUT_HAS_DATA, None
+
+        assert fork_info.peak_height == height - 1
 
         return None, None  # This means the block is valid
 
@@ -286,79 +338,9 @@ async def validate_block_body(
 
     # 15. Check if removals exist and were not previously spent. (unspent_db + diff_store + this_block)
     # The fork point is the last block in common between the peak chain and the chain of `block`
-    if peak is None or height == 0:
-        fork_h: int = -1
-    elif fork_point_with_peak is not None:
-        fork_h = fork_point_with_peak
-    else:
-        prev_br = await blocks.get_block_record_from_db(block.prev_header_hash)
-        assert prev_br is not None
-        fork_h = await find_fork_point_in_chain(blocks, peak, prev_br)
 
-    # Get additions and removals since (after) fork_h but not including this block
-    # The values include: the coin that was added, the height of the block in which it was confirmed, and the
-    # timestamp of the block in which it was confirmed
-    additions_since_fork: Dict[bytes32, Tuple[Coin, uint32, uint64]] = {}  # This includes coinbase additions
-    removals_since_fork: Set[bytes32] = set()
-
-    # For height 0, there are no additions and removals before this block, so we can skip
-    if height > 0:
-        # First, get all the blocks in the fork > fork_h, < block.height
-        prev_block: Optional[FullBlock] = await block_store.get_full_block(block.prev_header_hash)
-        reorg_blocks: Dict[uint32, FullBlock] = {}
-        curr: Optional[FullBlock] = prev_block
-        assert curr is not None
-        while curr.height > fork_h:
-            if curr.height == 0:
-                break
-            curr = await block_store.get_full_block(curr.prev_header_hash)
-            assert curr is not None
-            reorg_blocks[curr.height] = curr
-        if fork_h != -1:
-            assert len(reorg_blocks) == height - fork_h - 1
-
-        curr = prev_block
-        assert curr is not None
-        while curr.height > fork_h:
-            # Coin store doesn't contain coins from fork, we have to run generator for each block in fork
-            if curr.transactions_generator is not None:
-                # These blocks are in the past and therefore assumed to be valid, so get_block_generator won't raise
-                curr_block_generator: Optional[BlockGenerator] = await get_block_generator(curr)
-                assert curr_block_generator is not None and curr.transactions_info is not None
-                curr_npc_result = get_name_puzzle_conditions(
-                    curr_block_generator,
-                    min(constants.MAX_BLOCK_COST_CLVM, curr.transactions_info.cost),
-                    mempool_mode=False,
-                    height=curr.height,
-                    constants=constants,
-                )
-                removals_in_curr, additions_in_curr = tx_removals_and_additions(curr_npc_result.conds)
-            else:
-                removals_in_curr = []
-                additions_in_curr = []
-
-            for c_name in removals_in_curr:
-                assert c_name not in removals_since_fork
-                removals_since_fork.add(c_name)
-            for c in additions_in_curr:
-                coin_name = c.name()
-                assert coin_name not in additions_since_fork
-                assert curr.foliage_transaction_block is not None
-                additions_since_fork[coin_name] = (c, curr.height, curr.foliage_transaction_block.timestamp)
-
-            for coinbase_coin in curr.get_included_reward_coins():
-                coin_name = coinbase_coin.name()
-                assert coin_name not in additions_since_fork
-                assert curr.foliage_transaction_block is not None
-                additions_since_fork[coin_name] = (
-                    coinbase_coin,
-                    curr.height,
-                    curr.foliage_transaction_block.timestamp,
-                )
-            if curr.height == 0:
-                break
-            curr = reorg_blocks[uint32(curr.height - 1)]
-            assert curr is not None
+    assert fork_info.fork_height < height
+    assert fork_info.peak_height == height - 1
 
     removal_coin_records: Dict[bytes32, CoinRecord] = {}
     # the removed coins we need to look up from the DB
@@ -379,7 +361,7 @@ async def validate_block_body(
         else:
             # This check applies to both coins created before fork (pulled from coin_store),
             # and coins created after fork (additions_since_fork)
-            if rem in removals_since_fork:
+            if rem in fork_info.removals_since_fork:
                 # This coin was spent in the fork
                 return Err.DOUBLE_SPEND_IN_FORK, None
             removals_from_db.append(rem)
@@ -390,10 +372,10 @@ async def validate_block_body(
     # can't find in the DB, but also coins that were spent after the fork point
     look_in_fork: List[bytes32] = []
     for unspent in unspent_records:
-        if unspent.confirmed_block_index <= fork_h:
+        if unspent.confirmed_block_index <= fork_info.fork_height:
             # Spending something in the current chain, confirmed before fork
             # (We ignore all coins confirmed after fork)
-            if unspent.spent == 1 and unspent.spent_block_index <= fork_h:
+            if unspent.spent == 1 and unspent.spent_block_index <= fork_info.fork_height:
                 # Check for coins spent in an ancestor block
                 return Err.DOUBLE_SPEND, None
             removal_coin_records[unspent.name] = unspent
@@ -411,11 +393,11 @@ async def validate_block_body(
 
     for rem in look_in_fork:
         # This coin is not in the current heaviest chain, so it must be in the fork
-        if rem not in additions_since_fork:
+        if rem not in fork_info.additions_since_fork:
             # Check for spending a coin that does not exist in this fork
             log.error(f"Err.UNKNOWN_UNSPENT: COIN ID: {rem} NPC RESULT: {npc_result}")
             return Err.UNKNOWN_UNSPENT, None
-        new_coin, confirmed_height, confirmed_timestamp = additions_since_fork[rem]
+        new_coin, confirmed_height, confirmed_timestamp = fork_info.additions_since_fork[rem]
         new_coin_record: CoinRecord = CoinRecord(
             new_coin,
             confirmed_height,

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -232,14 +232,18 @@ class Blockchain(BlockchainInterface):
         """
 
         genesis: bool = block.height == 0
-        if self.contains_block(block.header_hash):
+        header_hash: bytes32 = block.header_hash
+
+        if await self.contains_block_from_db(header_hash):
             return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
 
-        if not self.contains_block(block.prev_header_hash) and not genesis:
-            return AddBlockResult.DISCONNECTED_BLOCK, Err.INVALID_PREV_BLOCK_HASH, None
+        prev_block = await self.get_block_record_from_db(block.prev_header_hash)
+        if not genesis:
+            if prev_block is None:
+                return AddBlockResult.DISCONNECTED_BLOCK, Err.INVALID_PREV_BLOCK_HASH, None
 
-        if not genesis and (self.block_record(block.prev_header_hash).height + 1) != block.height:
-            return AddBlockResult.INVALID_BLOCK, Err.INVALID_HEIGHT, None
+            if prev_block.height + 1 != block.height:
+                return AddBlockResult.INVALID_BLOCK, Err.INVALID_HEIGHT, None
 
         npc_result: Optional[NPCResult] = pre_validation_result.npc_result
         required_iters = pre_validation_result.required_iters
@@ -264,6 +268,11 @@ class Blockchain(BlockchainInterface):
         if error_code is not None:
             return AddBlockResult.INVALID_BLOCK, error_code, None
 
+        # block_to_block_record() require the previous block in the cache
+        if not genesis:
+            assert prev_block is not None
+            self.add_block_record(prev_block)
+
         block_record = block_to_block_record(
             self.constants,
             self,
@@ -279,7 +288,6 @@ class Blockchain(BlockchainInterface):
         try:
             # Always add the block to the database
             async with self.block_store.db_wrapper.writer():
-                header_hash: bytes32 = block.header_hash
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 records, state_change_summary = await self._reconsider_peak(
@@ -311,7 +319,7 @@ class Blockchain(BlockchainInterface):
             self.block_store.rollback_cache_block(header_hash)
             self._peak_height = previous_peak_height
             log.error(
-                f"Error while adding block {block.header_hash} height {block.height},"
+                f"Error while adding block {header_hash} height {block.height},"
                 f" rolling back: {traceback.format_exc()} {e}"
             )
             raise
@@ -848,9 +856,17 @@ class Blockchain(BlockchainInterface):
         return records
 
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
-        if header_hash in self.__block_records:
-            return self.__block_records[header_hash]
+        ret = self.__block_records.get(header_hash)
+        if ret is not None:
+            return ret
         return await self.block_store.get_block_record(header_hash)
+
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        ret = header_hash in self.__block_records
+        if ret:
+            return True
+
+        return (await self.block_store.get_block_record(header_hash)) is not None
 
     def remove_block_record(self, header_hash: bytes32) -> None:
         sbr = self.block_record(header_hash)
@@ -931,10 +947,10 @@ class Blockchain(BlockchainInterface):
                 curr = prev
 
             peak: Optional[BlockRecord] = self.get_peak()
-            if self.contains_block(curr.prev_header_hash) and peak is not None:
+            previous_block_hash = curr.prev_header_hash
+            prev_block_record = await self.get_block_record_from_db(previous_block_hash)
+            if prev_block_record is not None and peak is not None:
                 # Then we look up blocks up to fork point one at a time, backtracking
-                previous_block_hash = curr.prev_header_hash
-                prev_block_record = await self.block_store.get_block_record(previous_block_hash)
                 prev_block = await self.block_store.get_full_block(previous_block_hash)
                 assert prev_block is not None
                 assert prev_block_record is not None

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -13,14 +13,14 @@ from multiprocessing.context import BaseContext
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-from chia.consensus.block_body_validation import validate_block_body
+from chia.consensus.block_body_validation import ForkInfo, validate_block_body
 from chia.consensus.block_header_validation import validate_unfinished_header_block
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
-from chia.consensus.find_fork_point import find_fork_point_in_chain
+from chia.consensus.find_fork_point import find_fork_point_in_chain, lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.multiprocess_validation import (
     PreValidationResult,
@@ -203,11 +203,74 @@ class Blockchain(BlockchainInterface):
     async def get_full_block(self, header_hash: bytes32) -> Optional[FullBlock]:
         return await self.block_store.get_full_block(header_hash)
 
+    async def advance_fork_info(
+        self, block: FullBlock, fork_info: ForkInfo, additional_blocks: Dict[bytes32, FullBlock]
+    ) -> None:
+        """
+        This function is used to advance the peak_height of fork_info given the
+        full block extending the chain. block is required to be the next block on
+        top of fork_info.peak_height. If the block is part of the main chain,
+        the fork_height will set to the same as the peak, making the fork_info
+        represent an empty fork chain.
+        If the block is part of a fork, we need to compute the additions and
+        removals, to update the fork_info object. This is an expensive operation.
+        """
+
+        assert fork_info.peak_height <= block.height - 1
+        assert fork_info.peak_hash != block.header_hash
+
+        if fork_info.peak_hash == block.prev_header_hash:
+            assert fork_info.peak_height == block.height - 1
+            return
+
+        # note that we're not technically finding a fork here, we just traverse
+        # from the current block down to the fork's current peak
+        chain, peak_hash = await lookup_fork_chain(
+            self,
+            (uint32(fork_info.peak_height), fork_info.peak_hash),
+            (uint32(block.height - 1), block.prev_header_hash),
+        )
+        # the ForkInfo object is expected to be valid, just having its peak
+        # behind the current block
+        assert peak_hash == fork_info.peak_hash
+        assert len(chain) == block.height - fork_info.peak_height - 1
+
+        for height in range(fork_info.peak_height + 1, block.height):
+            fork_block: Optional[FullBlock] = await self.block_store.get_full_block(chain[uint32(height)])
+            assert fork_block is not None
+            await self.run_single_block(fork_block, fork_info, additional_blocks)
+
+    async def run_single_block(
+        self, block: FullBlock, fork_info: ForkInfo, additional_blocks: Dict[bytes32, FullBlock]
+    ) -> None:
+        assert fork_info.peak_height == block.height - 1
+        assert block.height == 0 or fork_info.peak_hash == block.prev_header_hash
+
+        npc: Optional[NPCResult] = None
+        if block.transactions_generator is not None:
+            block_generator: Optional[BlockGenerator] = await self.get_block_generator(block, additional_blocks)
+            assert block_generator is not None
+            assert block.transactions_info is not None
+            assert block.foliage_transaction_block is not None
+            npc = get_name_puzzle_conditions(
+                block_generator,
+                block.transactions_info.cost,
+                mempool_mode=False,
+                height=block.height,
+                constants=self.constants,
+            )
+            assert npc.error is None
+
+        fork_info.include_spends(npc, block)
+
+        fork_info.peak_height = block.height
+        fork_info.peak_hash = block.header_hash
+
     async def add_block(
         self,
         block: FullBlock,
         pre_validation_result: PreValidationResult,
-        fork_point_with_peak: Optional[uint32] = None,
+        fork_info: Optional[ForkInfo] = None,
     ) -> Tuple[AddBlockResult, Optional[Err], Optional[StateChangeSummary]]:
         """
         This method must be called under the blockchain lock
@@ -219,7 +282,8 @@ class Blockchain(BlockchainInterface):
         Args:
             block: The FullBlock to be validated.
             pre_validation_result: A result of successful pre validation
-            fork_point_with_peak: The fork point, for efficiency reasons, if None, it will be recomputed
+            fork_info: Information about the fork chain this block is part of,
+               to make validation more efficient. This is an in-out parameter.
 
         Returns:
             The result of adding the block to the blockchain (NEW_PEAK, ADDED_AS_ORPHAN, INVALID_BLOCK,
@@ -231,25 +295,105 @@ class Blockchain(BlockchainInterface):
                 - A list of NPCResult for any new transaction block added to the chain
         """
 
+        if block.height == 0 and block.prev_header_hash != self.constants.GENESIS_CHALLENGE:
+            return AddBlockResult.INVALID_BLOCK, Err.INVALID_PREV_BLOCK_HASH, None
+
+        peak = self.get_peak()
         genesis: bool = block.height == 0
-        header_hash: bytes32 = block.header_hash
+        extending_main_chain: bool = genesis or peak is None or (block.prev_header_hash == peak.header_hash)
 
-        if await self.contains_block_from_db(header_hash):
-            return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
+        # first check if this block is disconnected from the currently known
+        # blocks. We can only accept blocks that are connected to another block
+        # we know of.
+        prev_block: Optional[BlockRecord] = None
+        if not extending_main_chain:
+            prev_block = await self.get_block_record_from_db(block.prev_header_hash)
+            if not genesis:
+                if prev_block is None:
+                    return AddBlockResult.DISCONNECTED_BLOCK, Err.INVALID_PREV_BLOCK_HASH, None
 
-        prev_block = await self.get_block_record_from_db(block.prev_header_hash)
-        if not genesis:
-            if prev_block is None:
-                return AddBlockResult.DISCONNECTED_BLOCK, Err.INVALID_PREV_BLOCK_HASH, None
-
-            if prev_block.height + 1 != block.height:
-                return AddBlockResult.INVALID_BLOCK, Err.INVALID_HEIGHT, None
+                if prev_block.height + 1 != block.height:
+                    return AddBlockResult.INVALID_BLOCK, Err.INVALID_HEIGHT, None
 
         npc_result: Optional[NPCResult] = pre_validation_result.npc_result
         required_iters = pre_validation_result.required_iters
         if pre_validation_result.error is not None:
             return AddBlockResult.INVALID_BLOCK, Err(pre_validation_result.error), None
         assert required_iters is not None
+
+        header_hash: bytes32 = block.header_hash
+
+        # maybe fork_info should be mandatory to pass in, but we have a lot of
+        # tests that make sure the Blockchain object can handle any blocks,
+        # including orphaned ones, without any fork context
+        if fork_info is None:
+            # remember that this fork_info object is temporary and won't be
+            # returned to the caller. It means we can save time by not updating
+            # it once the block validates
+            temporary_fork_info = True
+
+            if await self.contains_block_from_db(header_hash):
+                # this means we have already seen and validated this block.
+                return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
+            elif extending_main_chain:
+                # this is the common and efficient case where we extend the main
+                # chain. The fork_info can be empty
+                prev_height = block.height - 1
+                fork_info = ForkInfo(prev_height, prev_height, block.prev_header_hash)
+            else:
+                assert peak is not None
+                # the block is extending a fork, and we don't have any fork_info
+                # for it. This can potentially be quite expensive and we should
+                # try to avoid getting here
+
+                # first, collect all the block hashes of the forked chain
+                # the block we're trying to add doesn't exist in the chain yet,
+                # so we need to start traversing from its prev_header_hash
+                fork_chain, fork_hash = await lookup_fork_chain(
+                    self, (peak.height, peak.header_hash), (uint32(block.height - 1), block.prev_header_hash)
+                )
+                # now we know how long the fork is, and can compute the fork
+                # height.
+                fork_height = block.height - len(fork_chain) - 1
+                fork_info = ForkInfo(fork_height, fork_height, fork_hash)
+
+                # now run all the blocks of the fork to compute the additions
+                # and removals. They are recorded in the fork_info object
+                for height in range(fork_info.fork_height + 1, block.height):
+                    fork_block: Optional[FullBlock] = await self.block_store.get_full_block(fork_chain[uint32(height)])
+                    assert fork_block is not None
+                    assert fork_block.height - 1 == fork_info.peak_height
+                    assert fork_block.height == 0 or fork_block.prev_header_hash == fork_info.peak_hash
+                    await self.run_single_block(fork_block, fork_info, {})
+
+        else:
+            temporary_fork_info = False
+            if extending_main_chain:
+                fork_info.fork_height = block.height - 1
+                fork_info.peak_height = block.height - 1
+                fork_info.peak_hash = block.prev_header_hash
+                fork_info.additions_since_fork == {}
+                fork_info.removals_since_fork == set()
+
+            if await self.contains_block_from_db(header_hash):
+                # We have already validated the block, but if it's not part of the
+                # main chain, we still need to re-run it to update the additions and
+                # removals in fork_info.
+                await self.advance_fork_info(block, fork_info, {})
+                fork_info.include_spends(npc_result, block)
+                fork_info.peak_height = int(block.height)
+                fork_info.peak_hash = header_hash
+
+                return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
+
+            if fork_info.peak_hash != block.prev_header_hash:
+                await self.advance_fork_info(block, fork_info, {})
+
+        # if these prerequisites of the fork_info aren't met, the fork_info
+        # object is invalid for this block. If the caller would have passed in
+        # None, a valid fork_info would have been computed
+        assert fork_info.peak_height == block.height - 1
+        assert block.height == 0 or fork_info.peak_hash == block.prev_header_hash
 
         error_code, _ = await validate_block_body(
             self.constants,
@@ -260,7 +404,7 @@ class Blockchain(BlockchainInterface):
             block,
             block.height,
             npc_result,
-            fork_point_with_peak,
+            fork_info,
             self.get_block_generator,
             # If we did not already validate the signature, validate it now
             validate_signature=not pre_validation_result.validated_signature,
@@ -268,9 +412,17 @@ class Blockchain(BlockchainInterface):
         if error_code is not None:
             return AddBlockResult.INVALID_BLOCK, error_code, None
 
+        # commit the additions and removals from this block into the ForkInfo, in
+        # case we're validating blocks on a fork, the next block validation will
+        # need to know of these additions and removals
+        if not temporary_fork_info:
+            assert fork_info.peak_height == block.height - 1
+            fork_info.include_spends(npc_result, block)
+            fork_info.peak_height = int(block.height)
+            fork_info.peak_hash = header_hash
+
         # block_to_block_record() require the previous block in the cache
-        if not genesis:
-            assert prev_block is not None
+        if not genesis and prev_block is not None:
             self.add_block_record(prev_block)
 
         block_record = block_to_block_record(
@@ -291,7 +443,7 @@ class Blockchain(BlockchainInterface):
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 records, state_change_summary = await self._reconsider_peak(
-                    block_record, genesis, fork_point_with_peak, npc_result
+                    block_record, genesis, fork_info, npc_result
                 )
 
                 # Then update the memory cache. It is important that this is not cancelled and does not throw
@@ -339,7 +491,7 @@ class Blockchain(BlockchainInterface):
         self,
         block_record: BlockRecord,
         genesis: bool,
-        fork_point_with_peak: Optional[uint32],
+        fork_info: ForkInfo,
         npc_result: Optional[NPCResult],
     ) -> Tuple[List[BlockRecord], Optional[StateChangeSummary]]:
         """
@@ -382,17 +534,8 @@ class Blockchain(BlockchainInterface):
             # This is not a heavier block than the heaviest we have seen, so we don't change the coin set
             return [], None
 
-        # Finds the fork. if the block is just being appended, it will return the peak
-        # If no blocks in common, returns -1, and reverts all blocks
-        if block_record.prev_hash == peak.header_hash:
-            fork_height: int = peak.height
-        elif fork_point_with_peak is not None:
-            fork_height = fork_point_with_peak
-        else:
-            fork_height = await find_fork_point_in_chain(self, block_record, peak)
-
         if block_record.prev_hash != peak.header_hash:
-            for coin_record in await self.coin_store.rollback_to_block(fork_height):
+            for coin_record in await self.coin_store.rollback_to_block(fork_info.fork_height):
                 rolled_back_state[coin_record.name] = coin_record
 
         # Collects all blocks from fork point to new peak
@@ -400,7 +543,7 @@ class Blockchain(BlockchainInterface):
         curr = block_record.header_hash
 
         # Backtracks up to the fork point, pulling all the required blocks from DB (that will soon be in the chain)
-        while fork_height < 0 or curr != self.height_to_hash(uint32(fork_height)):
+        while fork_info.fork_height < 0 or curr != self.height_to_hash(uint32(fork_info.fork_height)):
             fetched_full_block: Optional[FullBlock] = await self.block_store.get_full_block(curr)
             fetched_block_record: Optional[BlockRecord] = await self.block_store.get_block_record(curr)
             assert fetched_full_block is not None
@@ -446,14 +589,18 @@ class Blockchain(BlockchainInterface):
 
         # we made it to the end successfully
         # Rollback sub_epoch_summaries
-        await self.block_store.rollback(fork_height)
+        await self.block_store.rollback(fork_info.fork_height)
         await self.block_store.set_in_chain([(br.header_hash,) for br in records_to_add])
 
         # Changes the peak to be the new peak
         await self.block_store.set_peak(block_record.header_hash)
 
         return records_to_add, StateChangeSummary(
-            block_record, uint32(max(fork_height, 0)), list(rolled_back_state.values()), npc_results, reward_coins
+            block_record,
+            uint32(max(fork_info.fork_height, 0)),
+            list(rolled_back_state.values()),
+            npc_results,
+            reward_coins,
         )
 
     async def get_tx_removals_and_additions(
@@ -639,6 +786,8 @@ class Blockchain(BlockchainInterface):
             else self.block_record(block.prev_header_hash).height
         )
 
+        fork_info = ForkInfo(prev_height, prev_height, block.prev_header_hash)
+
         error_code, cost_result = await validate_block_body(
             self.constants,
             self,
@@ -648,7 +797,7 @@ class Blockchain(BlockchainInterface):
             block,
             uint32(prev_height + 1),
             npc_result,
-            None,
+            fork_info,
             self.get_block_generator,
             validate_signature=False,  # Signature was already validated before calling this method, no need to validate
         )

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -861,6 +861,20 @@ class Blockchain(BlockchainInterface):
             return ret
         return await self.block_store.get_block_record(header_hash)
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        """
+        Given a list of block header hashes, returns the previous header hashes
+        for each block, in the order they were passed in.
+        """
+        ret = []
+        for h in header_hashes:
+            b = self.__block_records.get(h)
+            if b is not None:
+                ret.append(b.prev_hash)
+            else:
+                ret.append(await self.block_store.get_prev_hash(h))
+        return ret
+
     async def contains_block_from_db(self, header_hash: bytes32) -> bool:
         ret = header_hash in self.__block_records
         if ret:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -389,7 +389,7 @@ class Blockchain(BlockchainInterface):
         elif fork_point_with_peak is not None:
             fork_height = fork_point_with_peak
         else:
-            fork_height = find_fork_point_in_chain(self, block_record, peak)
+            fork_height = await find_fork_point_in_chain(self, block_record, peak)
 
         if block_record.prev_hash != peak.header_hash:
             for coin_record in await self.coin_store.rollback_to_block(fork_height):
@@ -954,7 +954,7 @@ class Blockchain(BlockchainInterface):
                 prev_block = await self.block_store.get_full_block(previous_block_hash)
                 assert prev_block is not None
                 assert prev_block_record is not None
-                fork = find_fork_point_in_chain(self, peak, prev_block_record)
+                fork = await find_fork_point_in_chain(self, peak, prev_block_record)
                 curr_2: Optional[FullBlock] = prev_block
                 assert curr_2 is not None and isinstance(curr_2, FullBlock)
                 reorg_chain[curr_2.height] = curr_2

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -20,7 +20,7 @@ from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
-from chia.consensus.find_fork_point import find_fork_point_in_chain, lookup_fork_chain
+from chia.consensus.find_fork_point import lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.multiprocess_validation import (
     PreValidationResult,
@@ -1098,55 +1098,38 @@ class Blockchain(BlockchainInterface):
             result = await self.block_store.get_generators_at(block.transactions_generator_ref_list)
         else:
             # First tries to find the blocks in additional_blocks
-            reorg_chain: Dict[uint32, FullBlock] = {}
             curr = block
             additional_height_dict = {}
             while curr.prev_header_hash in additional_blocks:
                 prev: FullBlock = additional_blocks[curr.prev_header_hash]
                 additional_height_dict[prev.height] = prev
-                if isinstance(curr, FullBlock):
-                    assert curr.height == prev.height + 1
-                reorg_chain[prev.height] = prev
                 curr = prev
 
             peak: Optional[BlockRecord] = self.get_peak()
-            previous_block_hash = curr.prev_header_hash
-            prev_block_record = await self.get_block_record_from_db(previous_block_hash)
+            prev_block_record = await self.get_block_record_from_db(curr.prev_header_hash)
+            reorg_chain: Dict[uint32, bytes32] = {}
             if prev_block_record is not None and peak is not None:
                 # Then we look up blocks up to fork point one at a time, backtracking
-                prev_block = await self.block_store.get_full_block(previous_block_hash)
-                assert prev_block is not None
-                assert prev_block_record is not None
-                fork = await find_fork_point_in_chain(self, peak, prev_block_record)
-                curr_2: Optional[FullBlock] = prev_block
-                assert curr_2 is not None and isinstance(curr_2, FullBlock)
-                reorg_chain[curr_2.height] = curr_2
-                while curr_2.height > fork and curr_2.height > 0:
-                    curr_2 = await self.block_store.get_full_block(curr_2.prev_header_hash)
-                    assert curr_2 is not None
-                    reorg_chain[curr_2.height] = curr_2
+                height_to_hash, _ = await lookup_fork_chain(
+                    self,
+                    (peak.height, peak.header_hash),
+                    (prev_block_record.height, prev_block_record.header_hash),
+                )
+                reorg_chain.update(height_to_hash)
 
             for ref_height in block.transactions_generator_ref_list:
-                if ref_height in reorg_chain:
-                    ref_block = reorg_chain[ref_height]
-                    assert ref_block is not None
+                if ref_height in additional_height_dict:
+                    ref_block = additional_height_dict[ref_height]
                     if ref_block.transactions_generator is None:
                         raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
                     result.append(ref_block.transactions_generator)
+                elif ref_height in reorg_chain:
+                    gen = await self.block_store.get_generator(reorg_chain[ref_height])
+                    if gen is None:
+                        raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
+                    result.append(gen)
                 else:
-                    if ref_height in additional_height_dict:
-                        ref_block = additional_height_dict[ref_height]
-                        assert ref_block is not None
-                        if ref_block.transactions_generator is None:
-                            raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
-                        result.append(ref_block.transactions_generator)
-                    else:
-                        header_hash = self.height_to_hash(ref_height)
-                        if header_hash is None:
-                            raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
-                        gen = await self.block_store.get_generator(header_hash)
-                        if gen is None:
-                            raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
-                        result.append(gen)
+                    [gen] = await self.block_store.get_generators_at([ref_height])
+                    result.append(gen)
         assert len(result) == len(ref_list)
         return BlockGenerator(block.transactions_generator, result, [])

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -64,6 +64,9 @@ class BlockchainInterface:
         # ignoring hinting error until we handle our interfaces more formally
         return  # type: ignore[return-value]
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        return  # type: ignore[return-value]
+
     async def get_header_blocks_in_range(
         self, start: int, stop: int, tx_filter: bool = True
     ) -> Dict[bytes32, HeaderBlock]:

--- a/chia/consensus/blockchain_interface.py
+++ b/chia/consensus/blockchain_interface.py
@@ -41,6 +41,9 @@ class BlockchainInterface:
         # ignoring hinting error until we handle our interfaces more formally
         return  # type: ignore[return-value]
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        return  # type: ignore[return-value]
+
     def remove_block_record(self, header_hash: bytes32) -> None:
         pass
 

--- a/chia/consensus/find_fork_point.py
+++ b/chia/consensus/find_fork_point.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Tuple, Union
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
 from chia.util.ints import uint32
-
-
-def unwrap(block: Optional[BlockRecord]) -> BlockRecord:
-    if block is None:
-        raise KeyError("missing block in chain")
-    return block
 
 
 async def find_fork_point_in_chain(
@@ -25,18 +19,38 @@ async def find_fork_point_in_chain(
     Returns -1 if chains have no common ancestor
     * assumes the fork point is loaded in blocks
     """
-    while block_2.height > 0 or block_1.height > 0:
-        if block_2.height > block_1.height:
-            block_2 = unwrap(await blocks.get_block_record_from_db(block_2.prev_hash))
-        elif block_1.height > block_2.height:
-            block_1 = unwrap(await blocks.get_block_record_from_db(block_1.prev_hash))
-        else:
-            if block_2.header_hash == block_1.header_hash:
-                return block_2.height
-            block_2 = unwrap(await blocks.get_block_record_from_db(block_2.prev_hash))
-            block_1 = unwrap(await blocks.get_block_record_from_db(block_1.prev_hash))
+    height_1 = int(block_1.height)
+    height_2 = int(block_2.height)
+    bh_1 = block_1.header_hash
+    bh_2 = block_2.header_hash
 
-    if block_2 != block_1:
+    # special case for first level, since we actually already know the previous
+    # hash
+    if height_1 > height_2:
+        bh_1 = block_1.prev_hash
+        height_1 -= 1
+    elif height_2 > height_1:
+        bh_2 = block_2.prev_hash
+        height_2 -= 1
+
+    while height_1 > height_2:
+        [bh_1] = await blocks.prev_block_hash([bh_1])
+        height_1 -= 1
+
+    while height_2 > height_1:
+        [bh_2] = await blocks.prev_block_hash([bh_2])
+        height_2 -= 1
+
+    assert height_1 == height_2
+
+    height = height_2
+    while height > 0:
+        if bh_1 == bh_2:
+            return height
+        [bh_1, bh_2] = await blocks.prev_block_hash([bh_1, bh_2])
+        height -= 1
+
+    if bh_2 != bh_1:
         # All blocks are different
         return -1
 

--- a/chia/consensus/find_fork_point.py
+++ b/chia/consensus/find_fork_point.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockchainInterface
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
+from chia.util.ints import uint32
 
 
 def unwrap(block: Optional[BlockRecord]) -> BlockRecord:
@@ -40,3 +42,50 @@ async def find_fork_point_in_chain(
 
     # First block is the same
     return 0
+
+
+async def lookup_fork_chain(
+    blocks: BlockchainInterface,
+    block_1: Tuple[uint32, bytes32],
+    block_2: Tuple[uint32, bytes32],
+) -> Tuple[Dict[uint32, bytes32], bytes32]:
+    """Tries to find height where new chain (block_2) diverged from block_1.
+    The inputs are (height, header-hash)-tuples.
+    Returns two values:
+        1. The height to hash map of block_2's chain down to, but not
+           including, the fork height
+        2. The header hash of the block at the fork height
+    """
+    height_1 = int(block_1[0])
+    bh_1 = block_1[1]
+    height_2 = int(block_2[0])
+    bh_2 = block_2[1]
+
+    ret: Dict[uint32, bytes32] = {}
+
+    while height_1 > height_2:
+        [bh_1] = await blocks.prev_block_hash([bh_1])
+        height_1 -= 1
+
+    while height_2 > height_1:
+        ret[uint32(height_2)] = bh_2
+        [bh_2] = await blocks.prev_block_hash([bh_2])
+        height_2 -= 1
+
+    assert height_1 == height_2
+
+    height = height_2
+    while height > 0:
+        if bh_1 == bh_2:
+            return (ret, bh_2)
+        ret[uint32(height)] = bh_2
+        [bh_1, bh_2] = await blocks.prev_block_hash([bh_1, bh_2])
+        height -= 1
+
+    if bh_1 == bh_2:
+        return (ret, bh_2)
+
+    ret[uint32(0)] = bh_2
+    # TODO: if we would pass in the consensus constants, we could return the
+    # GENESIS_CHALLENGE hash here, instead of zeros
+    return (ret, bytes32([0] * 32))

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1115,6 +1115,10 @@ class FullNode:
                     extending_main_chain: bool = peak is None or (
                         peak.header_hash == blocks[0].prev_header_hash or peak.header_hash == blocks[0].header_hash
                     )
+                    # if we're simply extending the main chain, it's important
+                    # *not* to pass in a ForkInfo object, as it can potentially
+                    # accrue a large state (with no value, since we can validate
+                    # against the CoinStore)
                     if not extending_main_chain:
                         if fork_point_height == 0:
                             fork_info = ForkInfo(-1, -1, bytes32([0] * 32))

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -29,6 +29,7 @@ from typing import (
 
 from chia_rs import AugSchemeMPL
 
+from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_creation import unfinished_block_to_full_block
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain import AddBlockResult, Blockchain, BlockchainMutexPriority, StateChangeSummary
@@ -1051,6 +1052,10 @@ class FullNode:
         )
         batch_size = self.constants.MAX_BLOCK_COUNT_PER_REQUESTS
 
+        # normally "fork_point" or "fork_height" refers to the first common
+        # block between the main chain and the fork. Here "fork_point_height"
+        # seems to refer to the first diverging block
+
         async def fetch_block_batches(
             batch_queue: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]]
         ) -> None:
@@ -1089,7 +1094,8 @@ class FullNode:
         async def validate_block_batches(
             inner_batch_queue: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]]
         ) -> None:
-            advanced_peak: bool = False
+            fork_info: Optional[ForkInfo] = None
+
             while True:
                 res: Optional[Tuple[WSChiaConnection, List[FullBlock]]] = await inner_batch_queue.get()
                 if res is None:
@@ -1098,8 +1104,30 @@ class FullNode:
                 peer, blocks = res
                 start_height = blocks[0].height
                 end_height = blocks[-1].height
+
+                # in case we're validating a reorg fork (i.e. not extending the
+                # main chain), we need to record the coin set from that fork in
+                # fork_info. Otherwise validation is very expensive, especially
+                # for deep reorgs
+                peak: Optional[BlockRecord]
+                if fork_info is None:
+                    peak = self.blockchain.get_peak()
+                    extending_main_chain: bool = peak is None or (
+                        peak.header_hash == blocks[0].prev_header_hash or peak.header_hash == blocks[0].header_hash
+                    )
+                    if not extending_main_chain:
+                        if fork_point_height == 0:
+                            fork_info = ForkInfo(-1, -1, bytes32([0] * 32))
+                        else:
+                            fork_hash = self.blockchain.height_to_hash(uint32(fork_point_height - 1))
+                            assert fork_hash is not None
+                            fork_info = ForkInfo(fork_point_height - 1, fork_point_height - 1, fork_hash)
+
                 success, state_change_summary, err = await self.add_block_batch(
-                    blocks, peer.get_peer_logging(), None if advanced_peak else uint32(fork_point_height), summaries
+                    blocks,
+                    peer.get_peer_logging(),
+                    fork_info,
+                    summaries,
                 )
                 if success is False:
                     await peer.close(600)
@@ -1109,9 +1137,8 @@ class FullNode:
                         raise ValidationError(err, f"Failed to validate block batch {start_height} to {end_height}")
                     raise ValueError(f"Failed to validate block batch {start_height} to {end_height}")
                 self.log.info(f"Added blocks {start_height} to {end_height}")
-                peak: Optional[BlockRecord] = self.blockchain.get_peak()
+                peak = self.blockchain.get_peak()
                 if state_change_summary is not None:
-                    advanced_peak = True
                     assert peak is not None
                     # Hints must be added to the DB. The other post-processing tasks are not required when syncing
                     hints_to_add, _ = get_hints_and_subscription_coin_ids(
@@ -1197,17 +1224,50 @@ class FullNode:
         self,
         all_blocks: List[FullBlock],
         peer_info: PeerInfo,
-        fork_point: Optional[uint32],
+        fork_info: Optional[ForkInfo],
         wp_summaries: Optional[List[SubEpochSummary]] = None,
     ) -> Tuple[bool, Optional[StateChangeSummary], Optional[Err]]:
         # Precondition: All blocks must be contiguous blocks, index i+1 must be the parent of index i
         # Returns a bool for success, as well as a StateChangeSummary if the peak was advanced
 
+        block_dict: Dict[bytes32, FullBlock] = {}
+        for block in all_blocks:
+            block_dict[block.header_hash] = block
+
         blocks_to_validate: List[FullBlock] = []
         for i, block in enumerate(all_blocks):
-            if not await self.blockchain.contains_block_from_db(block.header_hash):
+            header_hash = block.header_hash
+            if not await self.blockchain.contains_block_from_db(header_hash):
                 blocks_to_validate = all_blocks[i:]
                 break
+
+            if fork_info is None:
+                continue
+            # the below section updates the fork_info object, if
+            # there is one.
+
+            # TODO: it seems unnecessary to request overlapping block ranges
+            # when syncing
+            if block.height <= fork_info.peak_height:
+                continue
+
+            # we have already validated this block once, no need to do it again.
+            # however, if this block is not part of the main chain, we need to
+            # update the fork context with its additions and removals
+            if self.blockchain.height_to_hash(block.height) == header_hash:
+                # we're on the main chain, just fast-forward the fork height
+                fork_info.fork_height = block.height
+                fork_info.peak_height = block.height
+                fork_info.peak_hash = header_hash
+                fork_info.additions_since_fork == {}
+                fork_info.removals_since_fork == set()
+            else:
+                # We have already validated the block, but if it's not part of the
+                # main chain, we still need to re-run it to update the additions and
+                # removals in fork_info.
+                await self.blockchain.advance_fork_info(block, fork_info, block_dict)
+                await self.blockchain.run_single_block(block, fork_info, block_dict)
+
         if len(blocks_to_validate) == 0:
             return True, None, None
 
@@ -1235,9 +1295,8 @@ class FullNode:
         for i, block in enumerate(blocks_to_validate):
             assert pre_validation_results[i].required_iters is not None
             state_change_summary: Optional[StateChangeSummary]
-            advanced_peak = agg_state_change_summary is not None
             result, error, state_change_summary = await self.blockchain.add_block(
-                block, pre_validation_results[i], None if advanced_peak else fork_point
+                block, pre_validation_results[i], fork_info
             )
 
             if result == AddBlockResult.NEW_PEAK:
@@ -1580,6 +1639,7 @@ class FullNode:
         block: FullBlock,
         peer: Optional[WSChiaConnection] = None,
         raise_on_disconnected: bool = False,
+        fork_info: Optional[ForkInfo] = None,
     ) -> Optional[Message]:
         """
         Add a full block from a peer full node (or ourselves).
@@ -1682,7 +1742,7 @@ class FullNode:
                     )
                     assert result_to_validate.required_iters == pre_validation_results[0].required_iters
                     (added, error_code, state_change_summary) = await self.blockchain.add_block(
-                        block, result_to_validate, None
+                        block, result_to_validate, fork_info
                     )
                 if added == AddBlockResult.ALREADY_HAVE_BLOCK:
                     return None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1205,7 +1205,7 @@ class FullNode:
 
         blocks_to_validate: List[FullBlock] = []
         for i, block in enumerate(all_blocks):
-            if not self.blockchain.contains_block(block.header_hash):
+            if not await self.blockchain.contains_block_from_db(block.header_hash):
                 blocks_to_validate = all_blocks[i:]
                 break
         if len(blocks_to_validate) == 0:
@@ -1259,7 +1259,8 @@ class FullNode:
                 if error is not None:
                     self.log.error(f"Error: {error}, Invalid block from peer: {peer_info} ")
                 return False, agg_state_change_summary, error
-            block_record = self.blockchain.block_record(block.header_hash)
+            block_record = await self.blockchain.get_block_record_from_db(block.header_hash)
+            assert block_record is not None
             if block_record.sub_epoch_summary_included is not None:
                 if self.weight_proof_handler is not None:
                     await self.weight_proof_handler.create_prev_sub_epoch_segments()
@@ -1428,7 +1429,7 @@ class FullNode:
             # This is a reorg
             fork_hash: Optional[bytes32] = self.blockchain.height_to_hash(state_change_summary.fork_height)
             assert fork_hash is not None
-            fork_block = self.blockchain.block_record(fork_hash)
+            fork_block = await self.blockchain.get_block_record_from_db(fork_hash)
 
         fns_peak_result: FullNodeStorePeakResult = self.full_node_store.new_peak(
             record,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
+from random import Random
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from chia_rs import (
@@ -185,6 +186,27 @@ def compute_additions_unchecked(sb: SpendBundle) -> List[Coin]:
             amount = int_from_bytes(next(atoms).atom)
             ret.append(Coin(parent_id, puzzle_hash, amount))
     return ret
+
+
+def make_spend_bundle(coins: List[Coin], wallet: WalletTool, rng: Random) -> Tuple[SpendBundle, List[Coin]]:
+    """
+    makes a new spend bundle (block generator) spending some of the coins in the
+    list of coins. The list will be updated to have spent coins removed and new
+    coins appended.
+    """
+    new_coins: List[Coin] = []
+    spend_bundles: List[SpendBundle] = []
+    to_spend = rng.sample(coins, min(5, len(coins)))
+    receiver = wallet.get_new_puzzlehash()
+    for c in to_spend:
+        bundle = wallet.generate_signed_transaction(uint64(c.amount // 2), receiver, c)
+        new_coins.extend(bundle.additions())
+        spend_bundles.append(bundle)
+        coins.remove(c)
+
+    coins.extend(new_coins)
+
+    return SpendBundle.aggregate(spend_bundles), new_coins
 
 
 class BlockTools:
@@ -585,6 +607,7 @@ class BlockTools:
         genesis_timestamp: Optional[uint64] = None,
         force_plot_id: Optional[bytes32] = None,
         dummy_block_references: bool = False,
+        include_transactions: bool = False,
     ) -> List[FullBlock]:
         assert num_blocks > 0
         if block_list_input is not None:
@@ -604,6 +627,29 @@ class BlockTools:
         transaction_data_included = False
         if time_per_block is None:
             time_per_block = float(constants.SUB_SLOT_TIME_TARGET) / float(constants.SLOT_BLOCKS_TARGET)
+
+        available_coins: List[Coin] = []
+        pending_rewards: List[Coin] = []
+        wallet: Optional[WalletTool] = None
+        rng: Optional[Random] = None
+        if include_transactions:
+            # when we generate transactions in the chain, the caller cannot also
+            # have ownership of the rewards and control the transactions
+            assert farmer_reward_puzzle_hash is None
+            assert pool_reward_puzzle_hash is None
+            assert transaction_data is None
+
+            for b in block_list:
+                for coin in b.get_included_reward_coins():
+                    if coin.puzzle_hash == self.farmer_ph:
+                        available_coins.append(coin)
+            print(
+                f"found {len(available_coins)} reward coins in existing chain."
+                "for simplicity, we assume the rewards are all unspent in the original chain"
+            )
+            wallet = self.get_farmer_wallet_tool()
+            rng = Random()
+            rng.seed(seed)
 
         if farmer_reward_puzzle_hash is None:
             farmer_reward_puzzle_hash = self.farmer_ph
@@ -737,6 +783,13 @@ class BlockTools:
                         if transaction_data is not None:
                             additions = compute_additions_unchecked(transaction_data)
                             removals = transaction_data.removals()
+                        elif include_transactions:
+                            assert wallet is not None
+                            assert rng is not None
+                            transaction_data, additions = make_spend_bundle(available_coins, wallet, rng)
+                            removals = transaction_data.removals()
+                            transaction_data_included = False
+
                         assert last_timestamp is not None
                         if proof_of_space.pool_contract_puzzle_hash is not None:
                             if pool_reward_puzzle_hash is not None:
@@ -830,12 +883,23 @@ class BlockTools:
                             assert full_block.foliage_transaction_block is not None
                         elif guarantee_transaction_block:
                             continue
-                        # print(f"{full_block.height}: difficulty {difficulty} "
+                        # print(f"{full_block.height:4}: difficulty {difficulty} "
                         #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"additions: {len(additions) if block_record.is_transaction_block else 0:2} "
+                        #     f"removals: {len(removals) if block_record.is_transaction_block else 0:2} "
                         #     f"refs: {len(full_block.transactions_generator_ref_list):3} "
                         #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
                         block_list.append(full_block)
+
+                        if include_transactions:
+                            for coin in full_block.get_included_reward_coins():
+                                if coin.puzzle_hash == self.farmer_ph:
+                                    pending_rewards.append(coin)
+                            if full_block.is_transaction_block():
+                                available_coins.extend(pending_rewards)
+                                pending_rewards = []
+
                         if full_block.transactions_generator is not None:
                             tx_block_heights.append(full_block.height)
                             compressor_arg = detect_potential_template_generator(
@@ -1001,6 +1065,12 @@ class BlockTools:
             if transaction_data is not None:
                 additions = compute_additions_unchecked(transaction_data)
                 removals = transaction_data.removals()
+            elif include_transactions:
+                assert wallet is not None
+                assert rng is not None
+                transaction_data, additions = make_spend_bundle(available_coins, wallet, rng)
+                removals = transaction_data.removals()
+                transaction_data_included = False
             sub_slots_finished += 1
             self.log.info(
                 f"Sub slot finished. blocks included: {blocks_added_this_sub_slot} blocks_per_slot: "
@@ -1140,13 +1210,24 @@ class BlockTools:
                             assert full_block.foliage_transaction_block is not None
                         elif guarantee_transaction_block:
                             continue
-                        # print(f"{full_block.height}: difficulty {difficulty} "
+                        # print(f"{full_block.height:4}: difficulty {difficulty} "
                         #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"additions: {len(additions) if block_record.is_transaction_block else 0:2} "
+                        #     f"removals: {len(removals) if block_record.is_transaction_block else 0:2} "
                         #     f"refs: {len(full_block.transactions_generator_ref_list):3} "
                         #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
 
                         block_list.append(full_block)
+
+                        if include_transactions:
+                            for coin in full_block.get_included_reward_coins():
+                                if coin.puzzle_hash == self.farmer_ph:
+                                    pending_rewards.append(coin)
+                            if full_block.is_transaction_block():
+                                available_coins.extend(pending_rewards)
+                                pending_rewards = []
+
                         if full_block.transactions_generator is not None:
                             tx_block_heights.append(full_block.height)
                             compressor_arg = detect_potential_template_generator(

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -23,6 +23,7 @@ from chia_rs import (
     G2Element,
     PrivateKey,
     compute_merkle_set_root,
+    solution_generator,
 )
 from chiabip158 import PyBIP158
 from clvm.casts import int_from_bytes
@@ -583,12 +584,21 @@ class BlockTools:
         previous_generator: Optional[Union[CompressorArg, List[uint32]]] = None,
         genesis_timestamp: Optional[uint64] = None,
         force_plot_id: Optional[bytes32] = None,
+        dummy_block_references: bool = False,
     ) -> List[FullBlock]:
         assert num_blocks > 0
         if block_list_input is not None:
             block_list = block_list_input.copy()
         else:
             block_list = []
+
+        tx_block_heights: List[uint32] = []
+        if dummy_block_references:
+            # block references can only point to transaction blocks, so we need
+            # to record which ones are
+            for b in block_list:
+                if b.transactions_generator is not None:
+                    tx_block_heights.append(b.height)
 
         constants = self.constants
         transaction_data_included = False
@@ -762,6 +772,23 @@ class BlockTools:
                             block_generator = None
                             aggregate_signature = G2Element()
 
+                        if dummy_block_references:
+                            if block_generator is None:
+                                program = SerializedProgram.from_bytes(solution_generator([]))
+                                block_generator = BlockGenerator(program, [], [])
+
+                            if len(tx_block_heights) > 4:
+                                block_refs = [
+                                    tx_block_heights[1],
+                                    tx_block_heights[len(tx_block_heights) // 2],
+                                    tx_block_heights[-2],
+                                ]
+                            else:
+                                block_refs = []
+                            block_generator = dataclasses.replace(
+                                block_generator, block_height_list=block_generator.block_height_list + block_refs
+                            )
+
                         (
                             full_block,
                             block_record,
@@ -805,10 +832,12 @@ class BlockTools:
                             continue
                         # print(f"{full_block.height}: difficulty {difficulty} "
                         #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"refs: {len(full_block.transactions_generator_ref_list):3} "
                         #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
+                            tx_block_heights.append(full_block.height)
                             compressor_arg = detect_potential_template_generator(
                                 full_block.height, full_block.transactions_generator
                             )
@@ -1050,6 +1079,23 @@ class BlockTools:
                             block_generator = None
                             aggregate_signature = G2Element()
 
+                        if dummy_block_references:
+                            if block_generator is None:
+                                program = SerializedProgram.from_bytes(solution_generator([]))
+                                block_generator = BlockGenerator(program, [], [])
+
+                            if len(tx_block_heights) > 4:
+                                block_refs = [
+                                    tx_block_heights[1],
+                                    tx_block_heights[len(tx_block_heights) // 2],
+                                    tx_block_heights[-2],
+                                ]
+                            else:
+                                block_refs = []
+                            block_generator = dataclasses.replace(
+                                block_generator, block_height_list=block_generator.block_height_list + block_refs
+                            )
+
                         (
                             full_block,
                             block_record,
@@ -1096,11 +1142,13 @@ class BlockTools:
                             continue
                         # print(f"{full_block.height}: difficulty {difficulty} "
                         #     f"time: {new_timestamp - last_timestamp:0.2f} "
+                        #     f"refs: {len(full_block.transactions_generator_ref_list):3} "
                         #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
 
                         block_list.append(full_block)
                         if full_block.transactions_generator is not None:
+                            tx_block_heights.append(full_block.height)
                             compressor_arg = detect_potential_template_generator(
                                 full_block.height, full_block.transactions_generator
                             )

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -77,6 +77,12 @@ class BlockCache(BlockchainInterface):
     async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
         return self._block_records[header_hash]
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            ret.append(self._block_records[h].prev_hash)
+        return ret
+
     def remove_block_record(self, header_hash: bytes32) -> None:
         del self._block_records[header_hash]
 

--- a/chia/util/block_cache.py
+++ b/chia/util/block_cache.py
@@ -59,6 +59,9 @@ class BlockCache(BlockchainInterface):
     def contains_block(self, header_hash: bytes32) -> bool:
         return header_hash in self._block_records
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        return header_hash in self._block_records
+
     def contains_height(self, height: uint32) -> bool:
         return height in self._height_to_hash
 

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -215,6 +215,12 @@ class WalletBlockchain(BlockchainInterface):
         # blockchain_interface
         return self._block_records.get(header_hash)
 
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret = []
+        for h in header_hashes:
+            ret.append(self._block_records[h].prev_hash)
+        return ret
+
     def add_block_record(self, block_record: BlockRecord) -> None:
         self._block_records[block_record.header_hash] = block_record
 

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -132,7 +132,7 @@ class WalletBlockchain(BlockchainInterface):
             if block_record.prev_hash == self._peak.header_hash:
                 fork_height: int = self._peak.height
             else:
-                fork_height = find_fork_point_in_chain(self, block_record, self._peak)
+                fork_height = await find_fork_point_in_chain(self, block_record, self._peak)
             await self._rollback_to_height(fork_height)
             curr_record: BlockRecord = block_record
             latest_timestamp = self._latest_timestamp

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -193,6 +193,11 @@ class WalletBlockchain(BlockchainInterface):
     def contains_block(self, header_hash: bytes32) -> bool:
         return header_hash in self._block_records
 
+    async def contains_block_from_db(self, header_hash: bytes32) -> bool:
+        # the wallet doesn't have the blockchain DB, this implements the
+        # blockchain_interface
+        return header_hash in self._block_records
+
     def contains_height(self, height: uint32) -> bool:
         return height in self._height_to_hash
 
@@ -200,12 +205,15 @@ class WalletBlockchain(BlockchainInterface):
         return self._height_to_hash[height]
 
     def try_block_record(self, header_hash: bytes32) -> Optional[BlockRecord]:
-        if self.contains_block(header_hash):
-            return self.block_record(header_hash)
-        return None
+        return self._block_records.get(header_hash)
 
     def block_record(self, header_hash: bytes32) -> BlockRecord:
         return self._block_records[header_hash]
+
+    async def get_block_record_from_db(self, header_hash: bytes32) -> Optional[BlockRecord]:
+        # the wallet doesn't have the blockchain DB, this implements the
+        # blockchain_interface
+        return self._block_records.get(header_hash)
 
     def add_block_record(self, block_record: BlockRecord) -> None:
         self._block_records[block_record.header_hash] = block_record

--- a/tests/blockchain/blockchain_test_utils.py
+++ b/tests/blockchain/blockchain_test_utils.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.types.full_block import FullBlock
 from chia.util.errors import Err
-from chia.util.ints import uint32, uint64
+from chia.util.ints import uint64
 
 
 async def check_block_store_invariant(bc: Blockchain):
@@ -44,7 +45,7 @@ async def _validate_and_add_block(
     expected_result: Optional[AddBlockResult] = None,
     expected_error: Optional[Err] = None,
     skip_prevalidation: bool = False,
-    fork_point_with_peak: Optional[uint32] = None,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     # Tries to validate and add the block, and checks that there are no errors in the process and that the
     # block is added to the peak.
@@ -81,7 +82,7 @@ async def _validate_and_add_block(
         result,
         err,
         _,
-    ) = await blockchain.add_block(block, results, fork_point_with_peak=fork_point_with_peak)
+    ) = await blockchain.add_block(block, results, fork_info=fork_info)
     await check_block_store_invariant(blockchain)
 
     if expected_error is None and expected_result != AddBlockResult.INVALID_BLOCK:
@@ -107,11 +108,15 @@ async def _validate_and_add_block(
 
 
 async def _validate_and_add_block_multi_error(
-    blockchain: Blockchain, block: FullBlock, expected_errors: List[Err], skip_prevalidation: bool = False
+    blockchain: Blockchain,
+    block: FullBlock,
+    expected_errors: List[Err],
+    skip_prevalidation: bool = False,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     # Checks that the blockchain returns one of the expected errors
     try:
-        await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation)
+        await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation, fork_info=fork_info)
     except Exception as e:
         assert isinstance(e, AssertionError)
         assert e.args[0] in expected_errors
@@ -124,13 +129,16 @@ async def _validate_and_add_block_multi_result(
     blockchain: Blockchain,
     block: FullBlock,
     expected_result: List[AddBlockResult],
-    skip_prevalidation: Optional[bool] = None,
+    skip_prevalidation: bool = False,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     try:
-        if skip_prevalidation is not None:
-            await _validate_and_add_block(blockchain, block, skip_prevalidation=skip_prevalidation)
-        else:
-            await _validate_and_add_block(blockchain, block)
+        await _validate_and_add_block(
+            blockchain,
+            block,
+            skip_prevalidation=skip_prevalidation,
+            fork_info=fork_info,
+        )
     except Exception as e:
         assert isinstance(e, AssertionError)
         assert "Block was not added" in e.args[0]
@@ -140,7 +148,10 @@ async def _validate_and_add_block_multi_result(
 
 
 async def _validate_and_add_block_no_error(
-    blockchain: Blockchain, block: FullBlock, skip_prevalidation: Optional[bool] = None
+    blockchain: Blockchain,
+    block: FullBlock,
+    skip_prevalidation: bool = False,
+    fork_info: Optional[ForkInfo] = None,
 ) -> None:
     # adds a block and ensures that there is no error. However, does not ensure that block extended the peak of
     # the blockchain
@@ -153,4 +164,5 @@ async def _validate_and_add_block_no_error(
             AddBlockResult.ADDED_AS_ORPHAN,
         ],
         skip_prevalidation=skip_prevalidation,
+        fork_info=fork_info,
     )

--- a/tests/blockchain/config.py
+++ b/tests/blockchain/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 60
+job_timeout = 70
 checkout_blocks_and_plots = True

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -16,7 +16,7 @@ from clvm.casts import int_to_bytes
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.block_rewards import calculate_base_farmer_reward
-from chia.consensus.blockchain import AddBlockResult
+from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.coinbase import create_farmer_coin
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.multiprocess_validation import PreValidationResult
@@ -56,6 +56,7 @@ from tests.blockchain.blockchain_test_utils import (
     _validate_and_add_block_multi_error,
     _validate_and_add_block_multi_result,
     _validate_and_add_block_no_error,
+    check_block_store_invariant,
 )
 from tests.conftest import ConsensusMode
 from tests.util.blockchain import create_blockchain
@@ -3133,48 +3134,144 @@ class TestReorgs:
         assert b.get_peak().height == 16
 
     @pytest.mark.anyio
-    async def test_long_reorg(self, empty_blockchain, default_1500_blocks, test_long_reorg_blocks, bt):
+    @pytest.mark.parametrize("light_blocks", [True, False])
+    async def test_long_reorg(
+        self,
+        light_blocks: bool,
+        empty_blockchain: Blockchain,
+        default_10000_blocks: List[FullBlock],
+        test_long_reorg_blocks: List[FullBlock],
+        test_long_reorg_blocks_light: List[FullBlock],
+    ):
+        if light_blocks:
+            reorg_blocks = test_long_reorg_blocks_light[:1650]
+        else:
+            reorg_blocks = test_long_reorg_blocks[:1200]
+
         # Reorg longer than a difficulty adjustment
         # Also tests higher weight chain but lower height
         b = empty_blockchain
-        num_blocks_chain_1 = 3 * bt.constants.EPOCH_BLOCKS + bt.constants.MAX_SUB_SLOT_BLOCKS + 10
-        num_blocks_chain_2_start = bt.constants.EPOCH_BLOCKS - 20
+        num_blocks_chain_1 = 1600
+        num_blocks_chain_2_start = 500
 
         assert num_blocks_chain_1 < 10000
-        blocks = default_1500_blocks[:num_blocks_chain_1]
+        blocks = default_10000_blocks[:num_blocks_chain_1]
 
-        for block in blocks:
-            await _validate_and_add_block(b, block, skip_prevalidation=True)
-        chain_1_height = b.get_peak().height
-        chain_1_weight = b.get_peak().weight
+        print(f"pre-validating {len(blocks)} blocks")
+        pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
+            blocks, {}, validate_signatures=False
+        )
+
+        for i, block in enumerate(blocks):
+            assert pre_validation_results[i].error is None
+            if (block.height % 100) == 0:
+                print(f"main chain: {block.height:4} weight: {block.weight}")
+            (result, err, _) = await b.add_block(block, pre_validation_results[i])
+            await check_block_store_invariant(b)
+            assert err is None
+            assert result == AddBlockResult.NEW_PEAK
+
+        peak = b.get_peak()
+        assert peak is not None
+        chain_1_height = peak.height
+        chain_1_weight = peak.weight
         assert chain_1_height == (num_blocks_chain_1 - 1)
 
         # The reorg blocks will have less time between them (timestamp) and therefore will make difficulty go up
         # This means that the weight will grow faster, and we can get a heavier chain with lower height
 
-        # If these assert fail, you probably need to change the fixture in test_long_reorg_blocks to create the
+        # If these assert fail, you probably need to change the fixture in reorg_blocks to create the
         # right amount of blocks at the right time
-        assert test_long_reorg_blocks[num_blocks_chain_2_start - 1] == default_1500_blocks[num_blocks_chain_2_start - 1]
-        assert test_long_reorg_blocks[num_blocks_chain_2_start] != default_1500_blocks[num_blocks_chain_2_start]
+        assert reorg_blocks[num_blocks_chain_2_start - 1] == default_10000_blocks[num_blocks_chain_2_start - 1]
+        assert reorg_blocks[num_blocks_chain_2_start] != default_10000_blocks[num_blocks_chain_2_start]
 
-        for reorg_block in test_long_reorg_blocks:
-            if reorg_block.height < num_blocks_chain_2_start:
-                await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK, skip_prevalidation=True
+        b.clean_block_records()
+
+        first_peak = b.get_peak()
+        fork_info: Optional[ForkInfo] = None
+        for reorg_block in reorg_blocks:
+            if (reorg_block.height % 100) == 0:
+                peak = b.get_peak()
+                assert peak is not None
+                print(
+                    f"reorg chain: {reorg_block.height:4} "
+                    f"weight: {reorg_block.weight:7} "
+                    f"peak: {str(peak.header_hash)[:6]}"
                 )
+
+            if reorg_block.height < num_blocks_chain_2_start:
+                await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK)
             elif reorg_block.weight <= chain_1_weight:
-                await _validate_and_add_block_multi_result(
-                    b,
-                    reorg_block,
-                    [AddBlockResult.ADDED_AS_ORPHAN, AddBlockResult.ALREADY_HAVE_BLOCK],
-                    skip_prevalidation=True,
+                if fork_info is None:
+                    fork_info = ForkInfo(reorg_block.height - 1, reorg_block.height - 1, reorg_block.prev_header_hash)
+                await _validate_and_add_block(
+                    b, reorg_block, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info
                 )
             elif reorg_block.weight > chain_1_weight:
-                assert reorg_block.height < chain_1_height
-                await _validate_and_add_block(b, reorg_block, skip_prevalidation=True)
+                await _validate_and_add_block(
+                    b, reorg_block, expected_result=AddBlockResult.NEW_PEAK, fork_info=fork_info
+                )
 
-        assert b.get_peak().weight > chain_1_weight
-        assert b.get_peak().height < chain_1_height
+        # if these asserts fires, there was no reorg
+        peak = b.get_peak()
+        assert peak is not None
+        assert first_peak != peak
+        assert peak is not None
+        assert peak.weight > chain_1_weight
+        second_peak = peak
+
+        if light_blocks:
+            assert peak.height > chain_1_height
+        else:
+            assert peak.height < chain_1_height
+
+        chain_2_weight = peak.weight
+
+        # now reorg back to the original chain
+        # this exercises the case where we have some of the blocks in the DB already
+        b.clean_block_records()
+
+        if light_blocks:
+            blocks = default_10000_blocks[num_blocks_chain_2_start - 100 : 1800]
+        else:
+            blocks = default_10000_blocks[num_blocks_chain_2_start - 100 : 2600]
+
+        # the block validation requires previous block records to be in the
+        # cache
+        br = await b.get_block_record_from_db(blocks[0].prev_header_hash)
+        for i in range(200):
+            assert br is not None
+            b.add_block_record(br)
+            br = await b.get_block_record_from_db(br.prev_hash)
+        assert br is not None
+        b.add_block_record(br)
+
+        # start the fork point a few blocks back, to test that the blockchain
+        # can catch up
+        fork_block = default_10000_blocks[num_blocks_chain_2_start - 200]
+        fork_info = ForkInfo(fork_block.height, fork_block.height, fork_block.header_hash)
+        for block in blocks:
+            if (block.height % 128) == 0:
+                peak = b.get_peak()
+                assert peak is not None
+                print(
+                    f"original chain: {block.height:4} "
+                    f"weight: {block.weight:7} "
+                    f"peak: {str(peak.header_hash)[:6]}"
+                )
+            if block.height <= chain_1_height:
+                expect = AddBlockResult.ALREADY_HAVE_BLOCK
+            elif block.weight < chain_2_weight:
+                expect = AddBlockResult.ADDED_AS_ORPHAN
+            else:
+                expect = AddBlockResult.NEW_PEAK
+            await _validate_and_add_block(b, block, fork_info=fork_info, expected_result=expect)
+
+        # if these asserts fires, there was no reorg back to the original chain
+        peak = b.get_peak()
+        assert peak is not None
+        assert peak.header_hash != second_peak
+        assert peak.weight > chain_2_weight
 
     @pytest.mark.anyio
     async def test_long_compact_blockchain(self, empty_blockchain, default_2000_blocks_compact):

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -3185,6 +3185,9 @@ class TestReorgs:
         assert reorg_blocks[num_blocks_chain_2_start - 1] == default_10000_blocks[num_blocks_chain_2_start - 1]
         assert reorg_blocks[num_blocks_chain_2_start] != default_10000_blocks[num_blocks_chain_2_start]
 
+        # one aspect of this test is to make sure we can reorg blocks that are
+        # not in the cache. We need to explicitly prune the cache to get that
+        # effect.
         b.clean_block_records()
 
         first_peak = b.get_peak()

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -7,12 +7,13 @@ import random
 import time
 from contextlib import asynccontextmanager
 from dataclasses import replace
-from typing import List
+from typing import List, Optional
 
 import pytest
 from chia_rs import AugSchemeMPL, G2Element
 from clvm.casts import int_to_bytes
 
+from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.block_rewards import calculate_base_farmer_reward
 from chia.consensus.blockchain import AddBlockResult
@@ -3369,15 +3370,16 @@ async def test_reorg_new_ref(empty_blockchain, bt):
     blocks_reorg_chain = bt.get_consecutive_blocks(4, blocks_reorg_chain, seed=b"2")
 
     for i, block in enumerate(blocks_reorg_chain):
-        fork_point_with_peak = None
+        fork_info: Optional[ForkInfo] = None
         if i < 10:
             expected = AddBlockResult.ALREADY_HAVE_BLOCK
         elif i < 20:
             expected = AddBlockResult.ADDED_AS_ORPHAN
         else:
             expected = AddBlockResult.NEW_PEAK
-            fork_point_with_peak = uint32(1)
-        await _validate_and_add_block(b, block, expected_result=expected, fork_point_with_peak=fork_point_with_peak)
+            if fork_info is None:
+                fork_info = ForkInfo(blocks[1].height, blocks[1].height, blocks[1].header_hash)
+        await _validate_and_add_block(b, block, expected_result=expected, fork_info=fork_info)
     assert b.get_peak().height == 20
 
 
@@ -3425,9 +3427,10 @@ async def test_reorg_stale_fork_height(empty_blockchain, bt):
     for block in blocks[:5]:
         await _validate_and_add_block(b, block, expected_result=AddBlockResult.NEW_PEAK)
 
-    # fake the fork_height to make every new block look like a reorg
+    # fake the fork_info to make every new block look like a reorg
+    fork_info = ForkInfo(blocks[1].height, blocks[1].height, blocks[1].header_hash)
     for block in blocks[5:]:
-        await _validate_and_add_block(b, block, expected_result=AddBlockResult.NEW_PEAK, fork_point_with_peak=2)
+        await _validate_and_add_block(b, block, expected_result=AddBlockResult.NEW_PEAK, fork_info=fork_info)
     assert b.get_peak().height == 13
 
 
@@ -3579,17 +3582,15 @@ async def test_reorg_flip_flop(empty_blockchain, bt):
             block1, block2 = b1, b2
         counter += 1
 
-        fork_height = 2 if counter > 3 else None
-
         preval: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
             [block1], {}, validate_signatures=False
         )
-        result, err, _ = await b.add_block(block1, preval[0], fork_point_with_peak=fork_height)
+        result, err, _ = await b.add_block(block1, preval[0])
         assert not err
         preval: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
             [block2], {}, validate_signatures=False
         )
-        result, err, _ = await b.add_block(block2, preval[0], fork_point_with_peak=fork_height)
+        result, err, _ = await b.add_block(block2, preval[0])
         assert not err
 
     assert b.get_peak().height == 39

--- a/tests/blockchain/test_lookup_fork_chain.py
+++ b/tests/blockchain/test_lookup_fork_chain.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Dict, List
 
 import pytest
 
 from benchmarks.utils import rand_hash
+from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockchainInterface
-from chia.consensus.find_fork_point import lookup_fork_chain
+from chia.consensus.find_fork_point import find_fork_point_in_chain, lookup_fork_chain
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32
 
@@ -80,12 +82,18 @@ async def test_no_fork() -> None:
     assert chain == {}
     assert fork_hash == A
 
+    fork_height = await find_fork_point_in_chain(test_chain, BR(42, A, B), BR(42, A, B))
+    assert fork_height == 42
+
 
 @pytest.mark.anyio
 async def test_fork_left() -> None:
     chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(42), A), (uint32(41), F))
     assert chain == {uint32(40): E, uint32(41): F}
     assert fork_hash == D
+
+    fork_height = await find_fork_point_in_chain(test_chain, BR(42, A, B), BR(41, F, E))
+    assert fork_height == 39
 
 
 @pytest.mark.anyio
@@ -94,12 +102,18 @@ async def test_fork_left_short() -> None:
     assert chain == {uint32(40): E, uint32(41): F}
     assert fork_hash == D
 
+    fork_height = await find_fork_point_in_chain(test_chain, BR(41, B, C), BR(41, F, E))
+    assert fork_height == 39
+
 
 @pytest.mark.anyio
 async def test_fork_right() -> None:
     chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(41), F), (uint32(42), A))
     assert chain == {uint32(40): C, uint32(41): B, uint32(42): A}
     assert fork_hash == D
+
+    fork_height = await find_fork_point_in_chain(test_chain, BR(41, F, E), BR(42, A, B))
+    assert fork_height == 39
 
 
 @pytest.mark.anyio
@@ -108,12 +122,18 @@ async def test_fork_right_short() -> None:
     assert chain == {uint32(40): C, uint32(41): B}
     assert fork_hash == D
 
+    fork_height = await find_fork_point_in_chain(test_chain, BR(41, F, E), BR(41, B, C))
+    assert fork_height == 39
+
 
 @pytest.mark.anyio
 async def test_linear_long() -> None:
     chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(39), D), (uint32(42), A))
     assert chain == {uint32(40): C, uint32(41): B, uint32(42): A}
     assert fork_hash == D
+
+    fork_height = await find_fork_point_in_chain(test_chain, BR(39, D, G), BR(42, A, B))
+    assert fork_height == 39
 
 
 @pytest.mark.anyio
@@ -122,12 +142,18 @@ async def test_linear_short() -> None:
     assert chain == {}
     assert fork_hash == D
 
+    fork_height = await find_fork_point_in_chain(test_chain, BR(42, A, B), BR(39, D, G))
+    assert fork_height == 39
+
 
 @pytest.mark.anyio
 async def test_no_shared_left() -> None:
     chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(1), F), (uint32(1), B))
     assert chain == {uint32(0): C, uint32(1): B}
     assert fork_hash == bytes32([0] * 32)
+
+    fork_height = await find_fork_point_in_chain(test_chain, BR(1, F, E), BR(1, B, C))
+    assert fork_height == -1
 
 
 @pytest.mark.anyio
@@ -136,6 +162,9 @@ async def test_no_shared_right() -> None:
     assert chain == {uint32(0): E, uint32(1): F}
     assert fork_hash == bytes32([0] * 32)
 
+    fork_height = await find_fork_point_in_chain(test_chain, BR(1, B, C), BR(1, F, E))
+    assert fork_height == -1
+
 
 @pytest.mark.anyio
 async def test_root_shared_left() -> None:
@@ -143,9 +172,15 @@ async def test_root_shared_left() -> None:
     assert chain == {uint32(1): C, uint32(2): B}
     assert fork_hash == D
 
+    fork_height = await find_fork_point_in_chain(test_chain, BR(2, F, E), BR(2, B, C))
+    assert fork_height == 0
+
 
 @pytest.mark.anyio
 async def test_root_shared_right() -> None:
     chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(2), B), (uint32(2), F))
     assert chain == {uint32(1): E, uint32(2): F}
     assert fork_hash == D
+
+    fork_height = await find_fork_point_in_chain(test_chain, BR(2, B, C), BR(2, F, E))
+    assert fork_height == 0

--- a/tests/blockchain/test_lookup_fork_chain.py
+++ b/tests/blockchain/test_lookup_fork_chain.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pytest
+
+from benchmarks.utils import rand_hash
+from chia.consensus.blockchain_interface import BlockchainInterface
+from chia.consensus.find_fork_point import lookup_fork_chain
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint32
+
+
+class DummyChain:
+    _chain: Dict[bytes32, bytes32]
+
+    def __init__(self) -> None:
+        self._chain = {}
+
+    def add_block(self, h: bytes32, prev: bytes32) -> None:
+        self._chain[h] = prev
+
+    async def prev_block_hash(self, header_hashes: List[bytes32]) -> List[bytes32]:
+        ret: List[bytes32] = []
+        for h in header_hashes:
+            ret.append(self._chain[h])
+        return ret
+
+
+A = rand_hash()
+B = rand_hash()
+C = rand_hash()
+D = rand_hash()
+E = rand_hash()
+F = rand_hash()
+G = rand_hash()
+H = rand_hash()
+
+dummy_chain = DummyChain()
+dummy_chain.add_block(G, H)
+dummy_chain.add_block(D, G)
+dummy_chain.add_block(C, D)
+dummy_chain.add_block(B, C)
+dummy_chain.add_block(A, B)
+dummy_chain.add_block(E, D)
+dummy_chain.add_block(F, E)
+
+test_chain: BlockchainInterface = dummy_chain  # type: ignore[assignment]
+
+#    A
+#    |
+#    v
+#    B     F
+#    |     |
+#    v     v
+#    C     E
+#     \   /
+#      v v
+#       D
+#       |
+#       v
+#       G
+
+
+@dataclass
+class FakeBlockRecord:
+    height: uint32
+    header_hash: bytes32
+    prev_hash: bytes32
+
+
+def BR(height: int, header_hash: bytes32, prev_hash: bytes32) -> BlockRecord:
+    ret = FakeBlockRecord(uint32(height), header_hash, prev_hash)
+    return ret  # type: ignore[return-value]
+
+
+@pytest.mark.anyio
+async def test_no_fork() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(42), A), (uint32(42), A))
+    assert chain == {}
+    assert fork_hash == A
+
+
+@pytest.mark.anyio
+async def test_fork_left() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(42), A), (uint32(41), F))
+    assert chain == {uint32(40): E, uint32(41): F}
+    assert fork_hash == D
+
+
+@pytest.mark.anyio
+async def test_fork_left_short() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(41), B), (uint32(41), F))
+    assert chain == {uint32(40): E, uint32(41): F}
+    assert fork_hash == D
+
+
+@pytest.mark.anyio
+async def test_fork_right() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(41), F), (uint32(42), A))
+    assert chain == {uint32(40): C, uint32(41): B, uint32(42): A}
+    assert fork_hash == D
+
+
+@pytest.mark.anyio
+async def test_fork_right_short() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(41), F), (uint32(41), B))
+    assert chain == {uint32(40): C, uint32(41): B}
+    assert fork_hash == D
+
+
+@pytest.mark.anyio
+async def test_linear_long() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(39), D), (uint32(42), A))
+    assert chain == {uint32(40): C, uint32(41): B, uint32(42): A}
+    assert fork_hash == D
+
+
+@pytest.mark.anyio
+async def test_linear_short() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(42), A), (uint32(39), D))
+    assert chain == {}
+    assert fork_hash == D
+
+
+@pytest.mark.anyio
+async def test_no_shared_left() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(1), F), (uint32(1), B))
+    assert chain == {uint32(0): C, uint32(1): B}
+    assert fork_hash == bytes32([0] * 32)
+
+
+@pytest.mark.anyio
+async def test_no_shared_right() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(1), B), (uint32(1), F))
+    assert chain == {uint32(0): E, uint32(1): F}
+    assert fork_hash == bytes32([0] * 32)
+
+
+@pytest.mark.anyio
+async def test_root_shared_left() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(2), F), (uint32(2), B))
+    assert chain == {uint32(1): C, uint32(2): B}
+    assert fork_hash == D
+
+
+@pytest.mark.anyio
+async def test_root_shared_right() -> None:
+    chain, fork_hash = await lookup_fork_chain(test_chain, (uint32(2), B), (uint32(2), F))
+    assert chain == {uint32(1): E, uint32(2): F}
+    assert fork_hash == D

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,7 +237,7 @@ def softfork_height(request) -> int:
     return request.param
 
 
-saved_blocks_version = "rc5"
+saved_blocks_version = "2.0"
 
 
 @pytest.fixture(scope="session")
@@ -299,7 +299,11 @@ def default_10000_blocks(bt, consensus_mode):
         version = "_hardfork"
 
     return persistent_blocks(
-        10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000", dummy_block_references=True
+        10000,
+        f"test_blocks_10000_{saved_blocks_version}{version}.db",
+        bt,
+        seed=b"10000",
+        dummy_block_references=True,
     )
 
 
@@ -321,6 +325,7 @@ def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
         seed=b"reorg_blocks",
         time_per_block=8,
         dummy_block_references=True,
+        include_transactions=True,
     )
 
 
@@ -341,6 +346,7 @@ def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
         block_list_input=default_10000_blocks[:500],
         seed=b"reorg_blocks2",
         dummy_block_references=True,
+        include_transactions=True,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,11 +298,15 @@ def default_10000_blocks(bt, consensus_mode):
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
-    return persistent_blocks(10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000")
+    return persistent_blocks(
+        10000, f"test_blocks_10000_{saved_blocks_version}{version}.db", bt, seed=b"10000", dummy_block_references=True
+    )
 
 
+# this long reorg chain shares the first 500 blocks with "default_10000_blocks"
+# and has heavier weight blocks
 @pytest.fixture(scope="session")
-def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
+def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
     version = ""
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
@@ -310,12 +314,33 @@ def test_long_reorg_blocks(bt, consensus_mode, default_1500_blocks):
     from tests.util.blockchain import persistent_blocks
 
     return persistent_blocks(
-        758,
+        4500,
         f"test_blocks_long_reorg_{saved_blocks_version}{version}.db",
         bt,
-        block_list_input=default_1500_blocks[:320],
+        block_list_input=default_10000_blocks[:500],
         seed=b"reorg_blocks",
         time_per_block=8,
+        dummy_block_references=True,
+    )
+
+
+# this long reorg chain shares the first 500 blocks with "default_10000_blocks"
+# and has the same weight blocks
+@pytest.fixture(scope="session")
+def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
+    version = ""
+    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        version = "_hardfork"
+
+    from tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(
+        4500,
+        f"test_blocks_long_reorg_light_{saved_blocks_version}{version}.db",
+        bt,
+        block_list_input=default_10000_blocks[:500],
+        seed=b"reorg_blocks2",
+        dummy_block_references=True,
     )
 
 

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -289,7 +289,7 @@ async def test_basic_store(
         assert peak_here is not None
         if peak_here.header_hash == block.header_hash:
             sb = blockchain.block_record(block.header_hash)
-            fork = find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
+            fork = await find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
             if fork > 0:
                 fork_block = blockchain.height_to_block_record(uint32(fork))
             else:
@@ -366,7 +366,7 @@ async def test_basic_store(
         assert peak_here is not None
         if peak_here.header_hash == blocks[-1].header_hash:
             sb = blockchain.block_record(blocks[-1].header_hash)
-            fork = find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
+            fork = await find_fork_point_in_chain(blockchain, peak, blockchain.block_record(sb.header_hash))
             if fork > 0:
                 fork_block = blockchain.height_to_block_record(uint32(fork))
             else:

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2169,6 +2169,8 @@ async def test_long_reorg(
     blocks = default_10000_blocks[:1600]
 
     if light_blocks:
+        # if the blocks have lighter weight, we need more height to compensate,
+        # to force a reorg
         reorg_blocks = test_long_reorg_blocks_light[:1650]
     else:
         reorg_blocks = test_long_reorg_blocks[:1200]
@@ -2187,6 +2189,9 @@ async def test_long_reorg(
     assert reorg_blocks[fork_point] == default_10000_blocks[fork_point]
     assert reorg_blocks[fork_point + 1] != default_10000_blocks[fork_point + 1]
 
+    # one aspect of this test is to make sure we can reorg blocks that are
+    # not in the cache. We need to explicitly prune the cache to get that
+    # effect.
     node.full_node.blockchain.clean_block_records()
 
     fork_info: Optional[ForkInfo] = None
@@ -2205,6 +2210,9 @@ async def test_long_reorg(
     chain_2_weight = peak.weight
     chain_2_peak = peak.header_hash
 
+    # if the reorg chain has lighter blocks, once we've re-orged onto it, we
+    # have a greater block height. If the reorg chain has heavier blocks, we
+    # end up with a lower height than the original chain (but greater weight)
     if light_blocks:
         assert peak.height > chain_1_height
     else:

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2234,19 +2234,27 @@ async def test_long_reorg(
 
 
 @pytest.mark.anyio
-@pytest.mark.limit_consensus_modes(reason="this test is too slow (for now)")
+@pytest.mark.parametrize("light_blocks", [True, False])
+@pytest.mark.parametrize("chain_length", [0, 100])
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
 async def test_long_reorg_nodes(
+    light_blocks: bool,
+    chain_length: int,
     three_nodes,
     default_10000_blocks: List[FullBlock],
     test_long_reorg_blocks: List[FullBlock],
+    test_long_reorg_blocks_light: List[FullBlock],
     self_hostname: str,
     seeded_random: random.Random,
 ):
     full_node_1, full_node_2, full_node_3 = three_nodes
 
-    blocks = default_10000_blocks[:1600]
+    blocks = default_10000_blocks[: 1600 - chain_length]
 
-    reorg_blocks = test_long_reorg_blocks[:1200]
+    if light_blocks:
+        reorg_blocks = test_long_reorg_blocks_light[: 1600 - chain_length]
+    else:
+        reorg_blocks = test_long_reorg_blocks[: 1200 - chain_length]
 
     # full node 1 has the original chain
     for block_batch in to_batches(blocks, 64):
@@ -2274,7 +2282,7 @@ async def test_long_reorg_nodes(
         p2 = full_node_1.full_node.blockchain.get_peak()
         return p1 == p2
 
-    await time_out_assert(120, check_nodes_in_sync)
+    await time_out_assert(100, check_nodes_in_sync)
     peak = full_node_2.full_node.blockchain.get_peak()
     print(f"peak: {str(peak.header_hash)[:6]}")
 
@@ -2295,20 +2303,20 @@ async def test_long_reorg_nodes(
 
     print("connecting node 3")
     await connect_and_get_peer(full_node_3.full_node.server, full_node_1.full_node.server, self_hostname)
-    # await connect_and_get_peer(full_node_3.full_node.server, full_node_2.full_node.server, self_hostname)
+    await connect_and_get_peer(full_node_3.full_node.server, full_node_2.full_node.server, self_hostname)
 
     def check_nodes_in_sync2():
         p1 = full_node_1.full_node.blockchain.get_peak()
-        # p2 = full_node_2.full_node.blockchain.get_peak()
+        p2 = full_node_2.full_node.blockchain.get_peak()
         p3 = full_node_3.full_node.blockchain.get_peak()
-        return p1 == p3
+        return p1 == p3 and p1 == p2
 
-    await time_out_assert(2000, check_nodes_in_sync2)
+    await time_out_assert(900, check_nodes_in_sync2)
 
     p1 = full_node_1.full_node.blockchain.get_peak()
-    # p2 = full_node_2.full_node.blockchain.get_peak()
+    p2 = full_node_2.full_node.blockchain.get_peak()
     p3 = full_node_3.full_node.blockchain.get_peak()
 
     assert p1.header_hash == blocks[-1].header_hash
-    # assert p2.header_hash == blocks[-1].header_hash
+    assert p2.header_hash == blocks[-1].header_hash
     assert p3.header_hash == blocks[-1].header_hash

--- a/tests/plot_sync/util.py
+++ b/tests/plot_sync/util.py
@@ -28,6 +28,9 @@ class WSChiaConnectionDummy:
     async def send_message(self, message: Message) -> None:
         self.last_sent_message = message
 
+    def get_peer_logging(self) -> PeerInfo:
+        return self.peer_info
+
 
 def get_dummy_connection(node_type: NodeType, peer_id: bytes32) -> WSChiaConnectionDummy:
     return WSChiaConnectionDummy(node_type, peer_id)

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -40,6 +40,7 @@ def persistent_blocks(
     block_list_input: Optional[List[FullBlock]] = None,
     time_per_block: Optional[float] = None,
     dummy_block_references: bool = False,
+    include_transactions: bool = False,
 ) -> List[FullBlock]:
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
@@ -84,6 +85,7 @@ def persistent_blocks(
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
         dummy_block_references=dummy_block_references,
+        include_transactions=include_transactions,
     )
 
 
@@ -101,6 +103,7 @@ def new_test_db(
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
     dummy_block_references: bool = False,
+    include_transactions: bool = False,
 ) -> List[FullBlock]:
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
@@ -114,6 +117,7 @@ def new_test_db(
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
         dummy_block_references=dummy_block_references,
+        include_transactions=include_transactions,
     )
     block_bytes_list: List[bytes] = []
     for block in blocks:

--- a/tests/util/blockchain.py
+++ b/tests/util/blockchain.py
@@ -21,7 +21,7 @@ async def create_blockchain(constants: ConsensusConstants, db_version: int) -> T
 
     coin_store = await CoinStore.create(wrapper)
     store = await BlockStore.create(wrapper)
-    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2)
+    bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2, single_threaded=True)
     assert bc1.get_peak() is None
     return bc1, wrapper
 
@@ -32,12 +32,14 @@ def persistent_blocks(
     bt: BlockTools,
     seed: bytes = b"",
     empty_sub_slots: int = 0,
+    *,
     normalized_to_identity_cc_eos: bool = False,
     normalized_to_identity_icc_eos: bool = False,
     normalized_to_identity_cc_sp: bool = False,
     normalized_to_identity_cc_ip: bool = False,
     block_list_input: Optional[List[FullBlock]] = None,
     time_per_block: Optional[float] = None,
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     # try loading from disc, if not create new blocks.db file
     # TODO hash fixtures.py and blocktool.py, add to path, delete if the files changed
@@ -77,10 +79,11 @@ def persistent_blocks(
         bt,
         block_list_input,
         time_per_block,
-        normalized_to_identity_cc_eos,
-        normalized_to_identity_icc_eos,
-        normalized_to_identity_cc_sp,
-        normalized_to_identity_cc_ip,
+        normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
+        normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
+        normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
+        normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
 
 
@@ -92,10 +95,12 @@ def new_test_db(
     bt: BlockTools,
     block_list_input: List[FullBlock],
     time_per_block: Optional[float],
+    *,
     normalized_to_identity_cc_eos: bool = False,  # CC_EOS,
     normalized_to_identity_icc_eos: bool = False,  # ICC_EOS
     normalized_to_identity_cc_sp: bool = False,  # CC_SP,
     normalized_to_identity_cc_ip: bool = False,  # CC_IP
+    dummy_block_references: bool = False,
 ) -> List[FullBlock]:
     print(f"create {path} with {num_of_blocks} blocks with ")
     blocks: List[FullBlock] = bt.get_consecutive_blocks(
@@ -108,6 +113,7 @@ def new_test_db(
         normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
         normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
     )
     block_bytes_list: List[bytes] = []
     for block in blocks:


### PR DESCRIPTION
This PR should be reviewed one commit at a time.

### Purpose:

The node is currently having a hard time with deep reorgs. The issue can be split in 2 parts:

1. Some parts of block validation require some previous blocks to be loaded in the block record cache in the blockchain object. When performing a reorg deeper than the cache size, those block records may not be in the cache and fail.

2. When validating coin spends on the forked chain, we re-run blocks in order to compute the additions and removals for the fork of the chain. This is done very inefficiently, causing the same blocks to be run many times.

When validating blocks on the fork of the chain (before accepting it and updating our peak) we need to be able to pick up block records (and generators) from blocks that are not in the main chain. This requires looking them up from the database. One case of interest, that has previously not been covered by a test, is when a block reference points into the forked chain (i.e. a block not in the main chain).

### Current Behavior:

In a long/deep reorg, the node may fail with `KeyError` while looking up block records that are not in the cache.

### New Behavior:

Long/deep reorgs work as expected.

# Changes

These are all the commits in this PR.

## test block chains, BlockTools updates

Update `BlockTools` to make reorg test blockchains use block references and transactions. These updated test chains have been put in the `test-cache` repo and released as `0.38.0`.

* add feature to BlockTools to allow including block references to previous generators in test chains. Use a longer chain, with block generators, in the long_reorg test add new test block chain fixture for reorgs with lighter weight blocks, this covers reorgs to greater block heights than the current peak

* add feature to BlockTools to include transactions in every transaction block, to exercise more parts of our validation logic in simulations

## fall back to pulling block records from DB

Allow block validation to pull blocks from the database, that currently *only* pull from the cache.

* update block validation to pull block dependencies from the database
* transition find_fork_point_in_chain() to be async and pull blocks from the database

## Preserve fork state across blocks, when validating

Preserve the state of the fork across block validations. This is done in `ForkInfo`, by preserving all additions and removals of the fork. The "fix reorg performance" commit is the big one that passes around information about the fork that's currently being validated (if any).

* introduce new function, lookup_fork_chain(), similar to find_fork_point_in_chain(), but return the whole sequence of block hashes
* optimize find_fork_point_in_chain() to just look up prev_hash from the database, avoiding parsing and constructing a whole BlockRecord object for block traversed
* fix reorg performance issue by preserving additions and removals across block validations (instead of re-computing them from scratch for every block)
* update get_block_generator() to use new lookup_fork_chain()

## Update and add new tests

Extend the existing long reorg test to be even longer (to be deeper than the block cache size).
Also add tests on the `FullNode` object including one with two nodes syncing via the network protocol.

* update test_long_reorg to use the new, longer, test chains with block generators and block references
* add new test_long_reorg operating on full node
* update test with two nodes with a deep fork, where one syncs to the other
* ~~make the timeout for collecting 3 peaks configurable. Set it to 1 seconds in the simulation tests to avoid waiting on CI~~ (already addressed by https://github.com/Chia-Network/chia-blockchain/pull/16698 and https://github.com/Chia-Network/chia-blockchain/pull/16771 )
* bump test chains used on CI

# Benchmark

I profiled the new reorg logic via `test_long_reorg_nodes()` and the `Blockchain.py` `test_long_reorg()` tests.

## test_long_reorg_nodes()

![full-node-test-long-reorg](https://github.com/Chia-Network/chia-blockchain/assets/661450/5c84b0e6-41dc-4f48-9c36-62dc5b99ca6c)

## test_long_reorg()

![blockchain-test-long-reorg](https://github.com/Chia-Network/chia-blockchain/assets/661450/66f2e4dd-eb52-47f2-9c2e-5c4983323a22)

# future improvements

## get_block_generator()

There are still some significant performance improvements to be made to the `get_block_generator()` function. If the fork chain's height-to-hash map would be recorded in the `ForkInfo` object, it could avoid the (expensive) call to `lookup_fork_chain()` entirely.

## _reconsider_peak()

This function pulls in *all* full blocks of the fork chain in order to apply them one at a time. At this point we have access to the `ForkInfo` object, so we could already know the block hashes to apply. Then we could load them one at a time from the database, and apply them one at a time.

It appears we mainly build the `blocks_to_add` up front to be able to reverse the order of blocks. However, since we also have all the additions and removals, we don't technically need to re-run the blocks either at this point. But we would need to record the height for removals in that case.

The loop to fetch the full blocks and block records from the DB is bottlenecked on the parsing, and DB access.

![reorg-fetch-blocks-to-add](https://github.com/Chia-Network/chia-blockchain/assets/661450/6c8ed5e0-471a-4a70-892b-843f31ddfb0a)

There's some work started to address this:
https://github.com/Chia-Network/chia-blockchain/pull/16787
https://github.com/Chia-Network/chia-blockchain/pull/16793

## protocol error when syncing

This test: `tests/core/full_node/test_full_node.py::test_long_reorg_nodes` exposes an issue where a node attempts to fetch a block at a height that doesn't exist. This happens when a node is exposed to a heavier chain with a lower peak height. It seems like we try to request blocks at *our* peak height, rather than the peer's peak height.

This is visible in the log as:

```
22:22:05 chia.full_node.full_node: INFO 🌱 Updated peak to height 1499, weight 1957496, hh 132e925cd2b6a639e67c1afefedb307a796bcb67fed780a294e2e2ab8ba5feeb, forked at 1498, rh: 7440aff5006463202dbebaa0f6a07710b8601717ba6cb7983532c38fae99a6fb, total iters: 232005, overflow: True, deficit: 12, difficulty: 2400, sub slot iters: 8000, Generator size: 1287, Generator ref list size: 3
...
22:22:05 chia.full_node.full_node: INFO Starting batch short sync from 1593 to height 1499
22:22:05 chia.full_node.full_node: ERROR Error short batch syncing, could not fetch block at height 1593
```

This is addressed by: https://github.com/Chia-Network/chia-blockchain/pull/16779

## overlapping block requests

When syncing, it appears we make requests for overlapping block ranges. When this is printed to the log:

```
22:22:07 chia.full_node.full_node: INFO Added blocks 0 to 32
22:22:07 chia.full_node.full_node: INFO Added blocks 32 to 64
22:22:07 chia.full_node.full_node: INFO Added blocks 64 to 96
22:22:07 chia.full_node.full_node: INFO Added blocks 96 to 128
```

Blocks 32, 64, 96 are requested and added twice from the peer. This seems to be a mistake.

This is addressed by: https://github.com/Chia-Network/chia-blockchain/pull/16792

## throwing `get_peak()`

In the test we wait for all nodes to have the same peak, indicating they're synced. Sometimes `get_peak()` throws:

```
Traceback (most recent call last):
  File "/home/arvid/dev/3/chia-blockchain/tests/core/full_node/test_full_node.py", line 2195, in check_nodes_in_sync
    p2 = full_node_1.full_node.blockchain.get_peak()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arvid/dev/3/chia-blockchain/chia/consensus/blockchain.py", line 191, in get_peak
    return self.height_to_block_record(self._peak_height)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arvid/dev/3/chia-blockchain/chia/consensus/blockchain.py", line 697, in height_to_block_record
    if header_hash is None:
        ^^^^^^^^^^^^^^^^^^^^
ValueError: Height is not in blockchain: 1599
```

This is addressed by: https://github.com/Chia-Network/chia-blockchain/pull/16776

## ~~invalid weight proof in test~~

~~When enabling the shorter chains in `tests/core/full_node/test_full_node.py::test_long_reorg_nodes`, some combinations fail with the following error log:~~

```
22:41:49 chia.types.blockchain_format.proof_of_space: ERROR Calculated pos challenge doesn't match the provided one
22:41:49 chia.full_node.weight_proof: ERROR could not verify proof of space
22:41:49 chia.full_node.weight_proof: ERROR failed to validate sub_epoch 2 segment 0 slots
22:41:49 full_node_server: WARNING Trying to ban localhost for 600, but will not ban
```

~~followed by:~~

```
22:41:49 chia.full_node.full_node: ERROR Error with syncing: <class 'ValueError'>Traceback (most recent call last):
  File "/Users/arvid/Documents/dev/2/chia-blockchain/chia/full_node/full_node.py", line 975, in _sync
    fork_point, summaries = await self.request_validate_wp(
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/arvid/Documents/dev/2/chia-blockchain/chia/full_node/full_node.py", line 1040, in request_validate_wp
    raise ValueError("Weight proof validation failed")
ValueError: Weight proof validation failed
```

~~It would be good to understand why.~~