### PR TITLE
Convert KeyTool to a dataclass and annotate it

### DIFF
--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -107,7 +107,6 @@ tests.simulation.test_simulation
 tests.tools.test_run_block
 tests.util.benchmark_cost
 tests.util.generator_tools_testing
-tests.util.key_tool
 tests.util.test_full_block_utils
 tests.util.test_misc
 tests.util.test_network

--- a/tests/clvm/test_puzzles.py
+++ b/tests/clvm/test_puzzles.py
@@ -233,7 +233,7 @@ def do_test_spend_p2_delegated_puzzle_or_hidden_puzzle_with_delegated_puzzle(hid
 
     assert synthetic_public_key == int_to_public_key(synthetic_offset) + hidden_pub_key_point
 
-    secret_exponent = key_lookup.get(hidden_public_key)
+    secret_exponent = key_lookup.dict.get(hidden_public_key)
     assert int_to_public_key(secret_exponent) == hidden_pub_key_point
 
     synthetic_secret_exponent = secret_exponent + synthetic_offset

--- a/tests/util/key_tool.py
+++ b/tests/util/key_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import List
+from dataclasses import dataclass, field
+from typing import Dict, List
 
 from blspy import AugSchemeMPL, G2Element, PrivateKey
 
@@ -10,17 +11,16 @@ from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_fo
 from tests.core.make_block_generator import GROUP_ORDER, int_to_public_key
 
 
-class KeyTool(dict):
-    @classmethod
-    def __new__(cls, *args):
-        return dict.__new__(*args)
+@dataclass
+class KeyTool:
+    dict: Dict[bytes, int] = field(default_factory=dict)
 
     def add_secret_exponents(self, secret_exponents: List[int]) -> None:
         for _ in secret_exponents:
-            self[bytes(int_to_public_key(_))] = _ % GROUP_ORDER
+            self.dict[bytes(int_to_public_key(_))] = _ % GROUP_ORDER
 
     def sign(self, public_key: bytes, message: bytes) -> G2Element:
-        secret_exponent = self.get(public_key)
+        secret_exponent = self.dict.get(public_key)
         if not secret_exponent:
             raise ValueError("unknown pubkey %s" % public_key.hex())
         bls_private_key = PrivateKey.from_bytes(secret_exponent.to_bytes(32, "big"))

--- a/tests/wallet/clawback/test_clawback_lifecycle.py
+++ b/tests/wallet/clawback/test_clawback_lifecycle.py
@@ -87,7 +87,7 @@ class TestClawbackLifecycle:
     @pytest.mark.asyncio()
     async def test_clawback_spends(self, cost_logger: CostLogger) -> None:
         async with sim_and_client() as (sim, sim_client):
-            key_lookup = KeyTool()  # type: ignore[no-untyped-call]
+            key_lookup = KeyTool()
             sender_index = 1
             sender_pk = G1Element.from_bytes(public_key_for_index(sender_index, key_lookup))
             sender_puz = puzzle_for_pk(sender_pk)


### PR DESCRIPTION
This allows us to remove `tests/util/key_tool.py` from the mypy exclusions list.