### PR TITLE
fix issue with syncing testnet, introduced in: Get block spends (#16451)

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -44,10 +44,10 @@ log = logging.getLogger(__name__)
 
 
 def get_flags_for_height_and_constants(height: int, constants: ConsensusConstants) -> int:
-    flags = ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+    flags = ENABLE_ASSERT_BEFORE
 
     if height >= constants.SOFT_FORK2_HEIGHT:
-        flags = flags | ENABLE_ASSERT_BEFORE | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+        flags = flags | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 
     if height >= constants.SOFT_FORK3_HEIGHT:
         # the soft-fork initiated with 2.0. To activate end of October 2023


### PR DESCRIPTION
### Purpose:

When soft fork 2 activated on mainnet, most of the pre-softfork special cases were removed from the code. However, testnet still violated some of the new soft-fork rules prior to activation, so some soft fork 2 special cases need to remain in order to support testnet.

Specifically, the `NO_RELATIVE_CONDITIONS_ON_EPHEMERAL` need to be disabled on lower block heights. On mainnet, this is always active now.

There was a bug in #16451 which enabled `NO_RELATIVE_CONDITIONS_ON_EPHEMERAL` unconditionally, which is fine on mainnet, but not on testnet. This restores the previous behavior.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

testnet10 can not sync from scratch

### New Behavior:

testnet10 *can* sync from scratch (although, I have not tested this)

### Testing Notes:

I'm hoping @cmmarslender can test the sync-from-scratch on testnet10.