### PR TITLE
Fixed an issue where plot filter reduction was not applied on testnet10

### DIFF
--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Dict
+
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint8, uint32, uint64, uint128
 
@@ -69,3 +71,24 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     # June 2033
     PLOT_FILTER_32_HEIGHT=uint32(20643000),
 )
+
+
+def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None:
+    if network_id != "testnet10":
+        return
+    # activate softforks immediately on testnet
+    # these numbers are supposed to match initial-config.yaml
+    if "SOFT_FORK2_HEIGHT" not in overrides:
+        overrides["SOFT_FORK2_HEIGHT"] = 3000000
+    if "SOFT_FORK3_HEIGHT" not in overrides:
+        overrides["SOFT_FORK3_HEIGHT"] = 2997292
+    if "HARD_FORK_HEIGHT" not in overrides:
+        overrides["HARD_FORK_HEIGHT"] = 2997292
+    if "HARD_FORK_FIX_HEIGHT" not in overrides:
+        overrides["HARD_FORK_FIX_HEIGHT"] = 3426000
+    if "PLOT_FILTER_128_HEIGHT" not in overrides:
+        overrides["PLOT_FILTER_128_HEIGHT"] = 3061804
+    if "PLOT_FILTER_64_HEIGHT" not in overrides:
+        overrides["PLOT_FILTER_64_HEIGHT"] = 8010796
+    if "PLOT_FILTER_32_HEIGHT" not in overrides:
+        overrides["PLOT_FILTER_32_HEIGHT"] = 13056556

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Dict, Optional
 
 from chia.consensus.constants import ConsensusConstants
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.default_constants import DEFAULT_CONSTANTS, update_testnet_overrides
 from chia.farmer.farmer import Farmer
 from chia.farmer.farmer_api import FarmerAPI
 from chia.rpc.farmer_rpc_api import FarmerRpcApi
@@ -37,14 +37,15 @@ def create_farmer_service(
     fnp = service_config.get("full_node_peer")
     connect_peers = set() if fnp is None else {UnresolvedPeerInfo(fnp["host"], fnp["port"])}
 
-    overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
+    network_id = service_config["selected_network"]
+    overrides = service_config["network_overrides"]["constants"][network_id]
+    update_testnet_overrides(network_id, overrides)
     updated_constants = consensus_constants.replace_str_to_bytes(**overrides)
 
     farmer = Farmer(
         root_path, service_config, config_pool, consensus_constants=updated_constants, local_keychain=keychain
     )
     peer_api = FarmerAPI(farmer)
-    network_id = service_config["selected_network"]
     rpc_info: Optional[RpcInfo] = None
     if service_config["start_rpc_server"]:
         rpc_info = (FarmerRpcApi, service_config["rpc_port"])

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -8,7 +8,7 @@ from multiprocessing import freeze_support
 from typing import Any, Dict, List, Optional, Tuple
 
 from chia.consensus.constants import ConsensusConstants
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.default_constants import DEFAULT_CONSTANTS, update_testnet_overrides
 from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.rpc.full_node_rpc_api import FullNodeRpcApi
@@ -66,27 +66,6 @@ async def create_full_node_service(
         connect_to_daemon=connect_to_daemon,
         override_capabilities=override_capabilities,
     )
-
-
-def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None:
-    if network_id != "testnet10":
-        return
-    # activate softforks immediately on testnet
-    # these numbers are supposed to match initial-config.yaml
-    if "SOFT_FORK2_HEIGHT" not in overrides:
-        overrides["SOFT_FORK2_HEIGHT"] = 3000000
-    if "SOFT_FORK3_HEIGHT" not in overrides:
-        overrides["SOFT_FORK3_HEIGHT"] = 2997292
-    if "HARD_FORK_HEIGHT" not in overrides:
-        overrides["HARD_FORK_HEIGHT"] = 2997292
-    if "HARD_FORK_FIX_HEIGHT" not in overrides:
-        overrides["HARD_FORK_FIX_HEIGHT"] = 3426000
-    if "PLOT_FILTER_128_HEIGHT" not in overrides:
-        overrides["PLOT_FILTER_128_HEIGHT"] = 3061804
-    if "PLOT_FILTER_64_HEIGHT" not in overrides:
-        overrides["PLOT_FILTER_64_HEIGHT"] = 8010796
-    if "PLOT_FILTER_32_HEIGHT" not in overrides:
-        overrides["PLOT_FILTER_32_HEIGHT"] = 13056556
 
 
 async def async_main(service_config: Dict[str, Any]) -> int:

--- a/tests/util/test_testnet_overrides.py
+++ b/tests/util/test_testnet_overrides.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from chia.server.start_full_node import update_testnet_overrides
+from chia.consensus.default_constants import update_testnet_overrides
 
 
 def test_testnet10() -> None:


### PR DESCRIPTION
There are testnet10 config adjustment function for full_node as attached below.
Since farmer does not have such kind of testnet10 config adjustment, if testnet10 user does not update `config.yaml` to set `PLOT_FILTER_XXX_HEIGHT` to appropriate value, farmer misses a lot of sps for farming.

I expect that many testnet users don't update their `config.yaml` for plot filter reduction height.
In this case, while FullNode is aware of plot filter reduction on testnet10, Farmer isn't.

![image](https://github.com/Chia-Network/chia-blockchain/assets/84098616/211e42be-780d-46f0-a2d3-86dc41be8145)
