### PR TITLE
remove unnecessary parameter to ClassgroupElement.get_size()

### DIFF
--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -1026,7 +1026,7 @@ class Timelord:
                 proof_bytes: bytes = stdout_bytes_io.read()
 
                 # Verifies our own proof just in case
-                form_size = ClassgroupElement.get_size(self.constants)
+                form_size = ClassgroupElement.get_size()
                 output = ClassgroupElement.from_bytes(y_bytes[:form_size])
                 # default value so that it's always set for state_changed later
                 ips: float = 0

--- a/chia/types/blockchain_format/classgroup.py
+++ b/chia/types/blockchain_format/classgroup.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from chia.consensus.constants import ConsensusConstants
 from chia.types.blockchain_format.sized_bytes import bytes100
 from chia.util.streamable import Streamable, streamable
 
@@ -31,5 +30,5 @@ class ClassgroupElement(Streamable):
         return ClassgroupElement.from_bytes(b"\x08")
 
     @staticmethod
-    def get_size(constants: ConsensusConstants) -> int:
+    def get_size() -> int:
         return 100

--- a/chia/util/vdf_prover.py
+++ b/chia/util/vdf_prover.py
@@ -18,7 +18,7 @@ def get_vdf_info_and_proof(
     number_iters: uint64,
     normalized_to_identity: bool = False,
 ) -> Tuple[VDFInfo, VDFProof]:
-    form_size = ClassgroupElement.get_size(constants)
+    form_size = ClassgroupElement.get_size()
     result: bytes = prove(
         bytes(challenge_hash),
         vdf_input.data,


### PR DESCRIPTION
### Purpose:

Simplify the code