### PR TITLE
add NFT, DID, DAO_CAT to wallets denominated in mojos

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -100,6 +100,8 @@ def get_mojo_per_unit(wallet_type: WalletType) -> int:  # pragma: no cover
         mojo_per_unit = units["chia"]
     elif wallet_type in {WalletType.CAT, WalletType.CRCAT}:
         mojo_per_unit = units["cat"]
+    elif wallet_type in {WalletType.NFT, WalletType.DECENTRALIZED_ID, WalletType.DAO_CAT}:
+        mojo_per_unit = units["mojo"]
     else:
         raise LookupError(f"Operation is not supported for Wallet type {wallet_type.name}")
 


### PR DESCRIPTION
running `chia wallet coins list` does not work for NFT or DID wallets because the `get_mojo_per_unit` function does not handle those wallet types.

Adding them in means `coins list` will now return the coins in NFT, DID, DAO_CAT wallets.
