### PR TITLE
move vdf validation to a free free function

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -52,7 +52,7 @@ from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.pool_target import PoolTarget
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
-from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof
+from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof, validate_vdf
 from chia.types.coin_record import CoinRecord
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
@@ -2291,7 +2291,7 @@ class FullNode:
         if vdf_proof.witness_type > 0 or not vdf_proof.normalized_to_identity:
             self.log.error(f"Received vdf proof is not compact: {vdf_proof}.")
             return False
-        if not vdf_proof.is_valid(self.constants, ClassgroupElement.get_default_element(), vdf_info):
+        if not validate_vdf(vdf_proof, self.constants, ClassgroupElement.get_default_element(), vdf_info):
             self.log.error(f"Received compact vdf proof is not valid: {vdf_proof}.")
             return False
         header_block = await self.blockchain.get_header_block_by_height(height, header_hash, tx_filter=False)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -29,7 +29,7 @@ from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_s
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import ChallengeChainSubSlot, RewardChainSubSlot
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
-from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
+from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.header_block import HeaderBlock
 from chia.types.weight_proof import (
@@ -1076,7 +1076,7 @@ def _validate_sub_slot_data(
         if (not prev_ssd.is_end_of_slot()) and (not sub_slot_data.cc_slot_end.normalized_to_identity):
             assert prev_ssd.cc_ip_vdf_info
             input = prev_ssd.cc_ip_vdf_info.output
-        if not sub_slot_data.cc_slot_end.is_valid(constants, input, sub_slot_data.cc_slot_end_info):
+        if not validate_vdf(sub_slot_data.cc_slot_end, constants, input, sub_slot_data.cc_slot_end_info):
             log.error(f"failed cc slot end validation  {sub_slot_data.cc_slot_end_info}")
             return False, []
     else:
@@ -1620,7 +1620,7 @@ def _validate_vdf_batch(
         vdf = VDFProof.from_bytes(vdf_proof_bytes)
         class_group = ClassgroupElement.create(class_group_bytes)
         vdf_info = VDFInfo.from_bytes(info)
-        if not vdf.is_valid(constants, class_group, vdf_info):
+        if not validate_vdf(vdf, constants, class_group, vdf_info):
             return False
 
         if shutdown_file_path is not None and not shutdown_file_path.is_file():

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -36,7 +36,7 @@ from chia.types.blockchain_format.slots import (
     SubSlotProofs,
 )
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
-from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
+from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.util.config import process_config_start_method
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
@@ -1051,7 +1051,7 @@ class Timelord:
                     self.bluebox_mode,
                 )
 
-                if not vdf_proof.is_valid(self.constants, initial_form, vdf_info):
+                if not validate_vdf(vdf_proof, self.constants, initial_form, vdf_info):
                     log.error("Invalid proof of time!")
                 if not self.bluebox_mode:
                     async with self.lock:
@@ -1186,7 +1186,7 @@ class Timelord:
                         return
                     vdf_proof = VDFProof(uint8(0), proof_part, True)
                     initial_form = ClassgroupElement.get_default_element()
-                    if not vdf_proof.is_valid(self.constants, initial_form, picked_info.new_proof_of_time):
+                    if not validate_vdf(vdf_proof, self.constants, initial_form, picked_info.new_proof_of_time):
                         log.error("Invalid compact proof of time!")
                         return
                     response = timelord_protocol.RespondCompactProofOfTime(

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -31,7 +31,7 @@ from chia.types.blockchain_format.foliage import TransactionsInfo
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import InfusedChallengeChainSubSlot
-from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
+from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
@@ -86,7 +86,7 @@ class TestGenesisBlock:
             blockchain_constants.GENESIS_CHALLENGE,
             uint64(231),
         )
-        if proof.is_valid(blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
+        if validate_vdf(proof, blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
             raise Exception("invalid proof")
 
     @pytest.mark.asyncio
@@ -97,7 +97,7 @@ class TestGenesisBlock:
             blockchain_constants.GENESIS_CHALLENGE,
             uint64(231),
         )
-        if proof.is_valid(blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
+        if validate_vdf(proof, blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
             raise Exception("invalid proof")
 
     @pytest.mark.asyncio
@@ -108,7 +108,7 @@ class TestGenesisBlock:
             blockchain_constants.GENESIS_CHALLENGE,
             uint64(231),
         )
-        if proof.is_valid(blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
+        if validate_vdf(proof, blockchain_constants, ClassgroupElement.get_default_element(), vdf) is False:
             raise Exception("invalid proof")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Purpose:

This loosens the coupling between the `VDFInfo` type and the chiavdf module (which is a native implementation). Specifically, it opens up the possibility for the `VDFInfo` type to be implemented in `chia_rs`.

That's currently not possible without also make `chia_rs` depend on `chiavdf`, which would be messy.

### Current Behavior:

`VDFInfo` depends on `chiavdf`

### New Behavior:

`VDFInfo` does not depend on `chiavdf`