### PR TITLE
rename ClassgroupElement.from_bytes()

### DIFF
--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1618,7 +1618,7 @@ def _validate_vdf_batch(
 ) -> bool:
     for vdf_proof_bytes, class_group_bytes, info in vdf_list:
         vdf = VDFProof.from_bytes(vdf_proof_bytes)
-        class_group = ClassgroupElement.from_bytes(class_group_bytes)
+        class_group = ClassgroupElement.create(class_group_bytes)
         vdf_info = VDFInfo.from_bytes(info)
         if not vdf.is_valid(constants, class_group, vdf_info):
             return False

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -1026,8 +1026,9 @@ class Timelord:
                 proof_bytes: bytes = stdout_bytes_io.read()
 
                 # Verifies our own proof just in case
+
                 form_size = ClassgroupElement.get_size()
-                output = ClassgroupElement.from_bytes(y_bytes[:form_size])
+                output = ClassgroupElement.create(y_bytes[:form_size])
                 # default value so that it's always set for state_changed later
                 ips: float = 0
                 if not self.bluebox_mode:
@@ -1180,7 +1181,7 @@ class Timelord:
                     log.info(f"Finished compact proof: {picked_info.height}. Time: {delta}s. IPS: {ips}.")
                     output = proof[:100]
                     proof_part = proof[100:200]
-                    if ClassgroupElement.from_bytes(output) != picked_info.new_proof_of_time.output:
+                    if ClassgroupElement.create(output) != picked_info.new_proof_of_time.output:
                         log.error("Expected vdf output different than produced one. Stopping.")
                         return
                     vdf_proof = VDFProof(uint8(0), proof_part, True)

--- a/chia/types/blockchain_format/classgroup.py
+++ b/chia/types/blockchain_format/classgroup.py
@@ -18,7 +18,7 @@ class ClassgroupElement(Streamable):
     data: bytes100
 
     @staticmethod
-    def from_bytes(data: bytes) -> ClassgroupElement:
+    def create(data: bytes) -> ClassgroupElement:
         if len(data) < 100:
             data += b"\x00" * (100 - len(data))
         return ClassgroupElement(bytes100(data))
@@ -27,7 +27,7 @@ class ClassgroupElement(Streamable):
     def get_default_element() -> "ClassgroupElement":
         # Bit 3 in the first byte of serialized compressed form indicates if
         # it's the default generator element.
-        return ClassgroupElement.from_bytes(b"\x08")
+        return ClassgroupElement.create(b"\x08")
 
     @staticmethod
     def get_size() -> int:

--- a/chia/util/vdf_prover.py
+++ b/chia/util/vdf_prover.py
@@ -26,6 +26,6 @@ def get_vdf_info_and_proof(
         number_iters,
     )
 
-    output = ClassgroupElement.from_bytes(result[:form_size])
+    output = ClassgroupElement.create(result[:form_size])
     proof_bytes = result[form_size : 2 * form_size]
     return VDFInfo(challenge_hash, number_iters, output), VDFProof(uint8(0), proof_bytes, normalized_to_identity)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -60,7 +60,7 @@ from tests.conftest import ConsensusMode
 from tests.util.blockchain import create_blockchain
 
 log = logging.getLogger(__name__)
-bad_element = ClassgroupElement.from_bytes(b"\x00")
+bad_element = ClassgroupElement.create(b"\x00")
 
 
 @asynccontextmanager


### PR DESCRIPTION
to not clash with the Streamable class. It's confusing to shadow the `from_bytes()` function used by the Streamable interface with a function that behaves *almost*, but not quite, the same.

This renames the `from_bytes()` function to reveal the underlying `from_bytes()` function inherited from `Streamable`, which behaves predictably.

All occurrences of `ClassgroupElement.from_bytes` were changed in this patch.

### Purpose:

Reduce potential confusion in reading the code.

### Current Behavior:

`from_bytes()` has special behavior for `ClassgroupElement`

### New Behavior:

`from_bytes()` behaves the same for `ClassgroupElement` as any other streamable class, the special behavior is available as `ClassgroupElement.create()`