### PR TITLE
Add cache to wallet node preventing resend of processing TX

### DIFF
--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -97,6 +97,12 @@ class WalletNodeAPI:
         async with self.wallet_node.wallet_state_manager.lock:
             assert peer.peer_node_id is not None
             name = peer.peer_node_id.hex()
+            if peer.peer_node_id in self.wallet_node._tx_messages_in_progress:
+                self.wallet_node._tx_messages_in_progress[peer.peer_node_id] = [
+                    txid for txid in self.wallet_node._tx_messages_in_progress[peer.peer_node_id] if txid != ack.txid
+                ]
+                if self.wallet_node._tx_messages_in_progress[peer.peer_node_id] == []:
+                    del self.wallet_node._tx_messages_in_progress[peer.peer_node_id]
             status = MempoolInclusionStatus(ack.status)
             try:
                 wallet_state_manager = self.wallet_node.wallet_state_manager


### PR DESCRIPTION
This is a subtle bugfix that affects almost nothing currently but could potentially in the future.  Here's the breakdown:

The method in the full node that receives wallet transactions (https://github.com/Chia-Network/chia-blockchain/blob/3707aa4ae79c9b34c6663244337443a4d494663e/chia/full_node/full_node_api.py#L1262) first adds the transaction it receives to a processing queue (https://github.com/Chia-Network/chia-blockchain/blob/3707aa4ae79c9b34c6663244337443a4d494663e/chia/full_node/full_node_api.py#L1271) then repeatedly checks a local cache to see if it has been processed before notifying the wallet (https://github.com/Chia-Network/chia-blockchain/blob/3707aa4ae79c9b34c6663244337443a4d494663e/chia/full_node/full_node_api.py#L1277-L1287)

The problem here is that this API is called asynchronously yet shares a single cache of the requests it is processing which is indexed by the id of the transaction it is processing.  So, if the wallet sends the same transaction multiple times (as it often does), the first one to resolve will satisfy the condition that _all of the calls are waiting on_.  The most common result of this is that 1) the first transaction is received and validation begins 2) another copy is received 3) the second copy notices it is currently validating the previous one and adds the response of ALREADY_INCLUDING_TRANSACTION to the shared cache 4) the first transaction notices a response has been added to the shared cache and _also_ returns ALREADY_INCLUDING_TRANSACTION 5) Both calls resolve and the validation result of the first transaction is never returned to the wallet.

A more complete fix here would be to rework the transaction processing on the full node side but given the delicate nature of the full node and the complexity of such a fix, I've decided to instead fix this on the wallet side by adding a cache of the transactions it has already sent so it doesn't send them again until it has received a response from the first call.  This is a good idea anyways because it will result in less network calls, the wallet has no need to send the transaction again before it receives a response.