### PR TITLE
blind bump `test_benchmark_batch_insert_speed()` runtime limits

### DIFF
--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -1386,7 +1386,7 @@ class BatchInsertBenchmarkCase:
     BatchInsertBenchmarkCase(
         pre=1_000,
         count=100,
-        limit=2.2,
+        limit=3,
     ),
     BatchInsertBenchmarkCase(
         pre=0,
@@ -1396,7 +1396,7 @@ class BatchInsertBenchmarkCase:
     BatchInsertBenchmarkCase(
         pre=1_000,
         count=1_000,
-        limit=24,
+        limit=28,
     ),
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

https://github.com/Chia-Network/chia-blockchain/actions/runs/6561756183/job/17824413112?pr=16653#step:13:4138
```
FAILED tests/core/data_layer/test_data_store.py::test_benchmark_batch_insert_speed[pre=1000,count=100] - AssertionError: 2.561575168819995 seconds not less than 2.2 seconds ( 116 % )
FAILED tests/core/data_layer/test_data_store.py::test_benchmark_batch_insert_speed[pre=1000,count=1000] - AssertionError: 24.83443241782002 seconds not less than 24 seconds ( 103 % )
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
