### PR TITLE
Distinguish `insufficient_partials` from `invalid_partials`

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -529,6 +529,8 @@ class Farmer:
                         "valid_partials_24h": [],
                         "invalid_partials_since_start": 0,
                         "invalid_partials_24h": [],
+                        "insufficient_partials_since_start": 0,
+                        "insufficient_partials_24h": [],
                         "stale_partials_since_start": 0,
                         "stale_partials_24h": [],
                         "missing_partials_since_start": 0,

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -194,7 +194,7 @@ class FarmerAPI:
                     increment_pool_stats(
                         self.farmer.pool_state,
                         p2_singleton_puzzle_hash,
-                        "invalid_partials",
+                        "insufficient_partials",
                         time.time(),
                     )
                     self.farmer.state_changed(

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -317,69 +317,77 @@ class FarmerAPI:
                             ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.farmer.log),
                             headers={"User-Agent": f"Chia Blockchain v.{__version__}"},
                         ) as resp:
-                            if resp.ok:
-                                pool_response: Dict[str, Any] = json.loads(await resp.text())
-                                self.farmer.log.info(f"Pool response: {pool_response}")
-                                if "error_code" in pool_response:
-                                    self.farmer.log.error(
-                                        f"Error in pooling: "
-                                        f"{pool_response['error_code'], pool_response['error_message']}"
-                                    )
+                            if not resp.ok:
+                                self.farmer.log.error(f"Error sending partial to {pool_url}, {resp.status}")
+                                increment_pool_stats(
+                                    self.farmer.pool_state,
+                                    p2_singleton_puzzle_hash,
+                                    "invalid_partials",
+                                    time.time(),
+                                )
+                                return
 
+                            pool_response: Dict[str, Any] = json.loads(await resp.text())
+                            self.farmer.log.info(f"Pool response: {pool_response}")
+                            if "error_code" in pool_response:
+                                self.farmer.log.error(
+                                    f"Error in pooling: "
+                                    f"{pool_response['error_code'], pool_response['error_message']}"
+                                )
+
+                                increment_pool_stats(
+                                    self.farmer.pool_state,
+                                    p2_singleton_puzzle_hash,
+                                    "pool_errors",
+                                    time.time(),
+                                    value=pool_response,
+                                )
+
+                                if pool_response["error_code"] == PoolErrorCode.TOO_LATE.value:
                                     increment_pool_stats(
                                         self.farmer.pool_state,
                                         p2_singleton_puzzle_hash,
-                                        "pool_errors",
+                                        "stale_partials",
                                         time.time(),
-                                        value=pool_response,
                                     )
-
-                                    if pool_response["error_code"] == PoolErrorCode.TOO_LATE.value:
-                                        increment_pool_stats(
-                                            self.farmer.pool_state,
-                                            p2_singleton_puzzle_hash,
-                                            "stale_partials",
-                                            time.time(),
-                                        )
-                                    elif pool_response["error_code"] == PoolErrorCode.PROOF_NOT_GOOD_ENOUGH.value:
-                                        self.farmer.log.error(
-                                            "Partial not good enough, forcing pool farmer update to "
-                                            "get our current difficulty."
-                                        )
-                                        increment_pool_stats(
-                                            self.farmer.pool_state,
-                                            p2_singleton_puzzle_hash,
-                                            "insufficient_partials",
-                                            time.time(),
-                                        )
-                                        pool_state_dict["next_farmer_update"] = 0
-                                        await self.farmer.update_pool_state()
-                                    else:
-                                        increment_pool_stats(
-                                            self.farmer.pool_state,
-                                            p2_singleton_puzzle_hash,
-                                            "invalid_partials",
-                                            time.time(),
-                                        )
+                                elif pool_response["error_code"] == PoolErrorCode.PROOF_NOT_GOOD_ENOUGH.value:
+                                    self.farmer.log.error(
+                                        "Partial not good enough, forcing pool farmer update to "
+                                        "get our current difficulty."
+                                    )
+                                    increment_pool_stats(
+                                        self.farmer.pool_state,
+                                        p2_singleton_puzzle_hash,
+                                        "insufficient_partials",
+                                        time.time(),
+                                    )
+                                    pool_state_dict["next_farmer_update"] = 0
+                                    await self.farmer.update_pool_state()
                                 else:
                                     increment_pool_stats(
                                         self.farmer.pool_state,
                                         p2_singleton_puzzle_hash,
-                                        "valid_partials",
+                                        "invalid_partials",
                                         time.time(),
                                     )
-                                    new_difficulty = pool_response["new_difficulty"]
-                                    increment_pool_stats(
-                                        self.farmer.pool_state,
-                                        p2_singleton_puzzle_hash,
-                                        "points_acknowledged",
-                                        time.time(),
-                                        new_difficulty,
-                                        new_difficulty,
-                                    )
-                                    pool_state_dict["current_difficulty"] = new_difficulty
-                            else:
-                                self.farmer.log.error(f"Error sending partial to {pool_url}, {resp.status}")
+                                return
+
+                            increment_pool_stats(
+                                self.farmer.pool_state,
+                                p2_singleton_puzzle_hash,
+                                "valid_partials",
+                                time.time(),
+                            )
+                            new_difficulty = pool_response["new_difficulty"]
+                            increment_pool_stats(
+                                self.farmer.pool_state,
+                                p2_singleton_puzzle_hash,
+                                "points_acknowledged",
+                                time.time(),
+                                new_difficulty,
+                                new_difficulty,
+                            )
+                            pool_state_dict["current_difficulty"] = new_difficulty
                 except Exception as e:
                     self.farmer.log.error(f"Error connecting to pool: {e}")
 

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -341,6 +341,19 @@ class FarmerAPI:
                                             "stale_partials",
                                             time.time(),
                                         )
+                                    elif pool_response["error_code"] == PoolErrorCode.PROOF_NOT_GOOD_ENOUGH.value:
+                                        self.farmer.log.error(
+                                            "Partial not good enough, forcing pool farmer update to "
+                                            "get our current difficulty."
+                                        )
+                                        increment_pool_stats(
+                                            self.farmer.pool_state,
+                                            p2_singleton_puzzle_hash,
+                                            "insufficient_partials",
+                                            time.time(),
+                                        )
+                                        pool_state_dict["next_farmer_update"] = 0
+                                        await self.farmer.update_pool_state()
                                     else:
                                         increment_pool_stats(
                                             self.farmer.pool_state,
@@ -348,14 +361,6 @@ class FarmerAPI:
                                             "invalid_partials",
                                             time.time(),
                                         )
-
-                                    if pool_response["error_code"] == PoolErrorCode.PROOF_NOT_GOOD_ENOUGH.value:
-                                        self.farmer.log.error(
-                                            "Partial not good enough, forcing pool farmer update to "
-                                            "get our current difficulty."
-                                        )
-                                        pool_state_dict["next_farmer_update"] = 0
-                                        await self.farmer.update_pool_state()
                                 else:
                                     increment_pool_stats(
                                         self.farmer.pool_state,

--- a/tests/farmer_harvester/test_farmer.py
+++ b/tests/farmer_harvester/test_farmer.py
@@ -341,6 +341,8 @@ def test_increment_pool_stats(case: IncrementPoolStatsCase) -> None:
                     "valid_partials_24h": [],
                     "invalid_partials_since_start": 0,
                     "invalid_partials_24h": [],
+                    "insufficient_partials_since_start": 0,
+                    "insufficient_partials_24h": [],
                     "stale_partials_since_start": 0,
                     "stale_partials_24h": [],
                     "missing_partials_since_start": 1,
@@ -370,6 +372,8 @@ def test_increment_pool_stats(case: IncrementPoolStatsCase) -> None:
                     "valid_partials_24h": [],
                     "invalid_partials_since_start": 0,
                     "invalid_partials_24h": [],
+                    "insufficient_partials_since_start": 0,
+                    "insufficient_partials_24h": [],
                     "stale_partials_since_start": 0,
                     "stale_partials_24h": [],
                     "missing_partials_since_start": 1,
@@ -397,8 +401,10 @@ def test_increment_pool_stats(case: IncrementPoolStatsCase) -> None:
                     "pool_errors_24h": [],
                     "valid_partials_since_start": 0,
                     "valid_partials_24h": [],
-                    "invalid_partials_since_start": 1,
-                    "invalid_partials_24h": [1],
+                    "invalid_partials_since_start": 0,
+                    "invalid_partials_24h": [],
+                    "insufficient_partials_since_start": 1,
+                    "insufficient_partials_24h": [1],
                     "stale_partials_since_start": 0,
                     "stale_partials_24h": [],
                     "missing_partials_since_start": 0,
@@ -428,6 +434,8 @@ def test_increment_pool_stats(case: IncrementPoolStatsCase) -> None:
                     "valid_partials_24h": [],
                     "invalid_partials_since_start": 0,
                     "invalid_partials_24h": [],
+                    "insufficient_partials_since_start": 0,
+                    "insufficient_partials_24h": [],
                     "stale_partials_since_start": 0,
                     "stale_partials_24h": [],
                     "missing_partials_since_start": 1,
@@ -457,6 +465,8 @@ def test_increment_pool_stats(case: IncrementPoolStatsCase) -> None:
                     "valid_partials_24h": [],
                     "invalid_partials_since_start": 1,
                     "invalid_partials_24h": [1],
+                    "insufficient_partials_since_start": 0,
+                    "insufficient_partials_24h": [],
                     "stale_partials_since_start": 0,
                     "stale_partials_24h": [],
                     "missing_partials_since_start": 0,
@@ -486,6 +496,8 @@ def test_increment_pool_stats(case: IncrementPoolStatsCase) -> None:
                     "valid_partials_24h": [],
                     "invalid_partials_since_start": 0,
                     "invalid_partials_24h": [],
+                    "insufficient_partials_since_start": 0,
+                    "insufficient_partials_24h": [],
                     "stale_partials_since_start": 0,
                     "stale_partials_24h": [],
                     "missing_partials_since_start": 1,
@@ -515,6 +527,8 @@ def test_increment_pool_stats(case: IncrementPoolStatsCase) -> None:
                     "valid_partials_24h": [],
                     "invalid_partials_since_start": 1,
                     "invalid_partials_24h": [1],
+                    "insufficient_partials_since_start": 0,
+                    "insufficient_partials_24h": [],
                     "stale_partials_since_start": 0,
                     "stale_partials_24h": [],
                     "missing_partials_since_start": 0,
@@ -578,6 +592,8 @@ async def test_farmer_new_proof_of_space_for_pool_stats(
         "valid_partials_24h": [],
         "invalid_partials_since_start": 0,
         "invalid_partials_24h": [],
+        "insufficient_partials_since_start": 0,
+        "insufficient_partials_24h": [],
         "stale_partials_since_start": 0,
         "stale_partials_24h": [],
         "missing_partials_since_start": 0,
@@ -619,6 +635,8 @@ async def test_farmer_new_proof_of_space_for_pool_stats(
     assert_stats_24h("valid_partials_24h")
     assert_stats_since_start("invalid_partials_since_start")
     assert_stats_24h("invalid_partials_24h")
+    assert_stats_since_start("insufficient_partials_since_start")
+    assert_stats_24h("insufficient_partials_24h")
     assert_stats_since_start("stale_partials_since_start")
     assert_stats_24h("stale_partials_24h")
     assert_stats_since_start("missing_partials_since_start")


### PR DESCRIPTION
Fixing issue: https://github.com/Chia-Network/chia-blockchain/issues/16073

### Summary
When a proof of space is not sufficient enough to pass difficulty check for a pool, currently it is recorded as an `invalid_partials` on pool stats dict.
As claimed in the above issue, the term "Invalid Partials" tends to cause unnecessary concern among individuals, as it may imply issues with one's configuration.

I hereby distinguish `insufficient_partials` from `invalid_partials` to resolve the above issue.

### Note
This PR should be merged before updating the GUI to show this new `insufficient_partials` stat on Farmer page.
https://github.com/Chia-Network/chia-blockchain-gui/pull/2211