### PR TITLE
require SerializedProgram.from_bytes() is passed a valid clvm structure

### DIFF
--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -39,6 +39,7 @@ class SerializedProgram:
     @classmethod
     def from_bytes(cls: Type[SerializedProgram], blob: bytes) -> SerializedProgram:
         ret = SerializedProgram()
+        assert serialized_length(blob) == len(blob)
         ret._buf = bytes(blob)
         return ret
 

--- a/tests/core/full_node/stores/test_block_store.py
+++ b/tests/core/full_node/stores/test_block_store.py
@@ -300,7 +300,7 @@ async def test_get_generator(bt: BlockTools, db_version: int, use_cache: bool) -
     blocks = bt.get_consecutive_blocks(10)
 
     def generator(i: int) -> SerializedProgram:
-        return SerializedProgram.from_bytes(int_to_bytes(i))
+        return SerializedProgram.from_bytes(int_to_bytes(i + 1))
 
     async with DBConnection(db_version) as db_wrapper:
         store = await BlockStore.create(db_wrapper, use_cache=use_cache)

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -1204,7 +1204,7 @@ def test_run_for_cost(amount: int) -> None:
 def test_run_for_cost_max_cost() -> None:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
     solution = Program.to(conditions)
-    with pytest.raises(ValueError, match="('cost exceeded', '2b')"):
+    with pytest.raises(ValueError, match="cost exceeded"):
         run_for_cost(IDENTITY_PUZZLE, solution, additions_count=1, max_cost=uint64(43))
 
 

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -261,14 +261,14 @@ async def test_standard_tx(benchmark_runner: BenchmarkRunner):
         "af949b78fa6a957602c3593a3d6cb7711e08720415dad831ab18adacaa9b27ec3dda508ee32e24bc811c0abc5781ae21"
     )
     puzzle_program = SerializedProgram.from_bytes(
-        p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(G1Element.from_bytes(public_key))
+        bytes(p2_delegated_puzzle_or_hidden_puzzle.puzzle_for_pk(G1Element.from_bytes(public_key)))
     )
     conditions = binutils.assemble(
         "((51 0x699eca24f2b6f4b25b16f7a418d0dc4fc5fce3b9145aecdda184158927738e3e 10)"
         " (51 0x847bb2385534070c39a39cc5dfdc7b35e2db472dc0ab10ab4dec157a2178adbf 0x00cbba106df6))"
     )
     solution_program = SerializedProgram.from_bytes(
-        p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)
+        bytes(p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions))
     )
 
     with benchmark_runner.assert_runtime(seconds=0.1):

--- a/tests/generator/test_compression.py
+++ b/tests/generator/test_compression.py
@@ -51,10 +51,16 @@ original_generator = hexstr_to_bytes(
     "ff01ffffffa00000000000000000000000000000000000000000000000000000000000000000ff830186a080ffffff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b081963921826355dcb6c355ccf9c2637c18adf7d38ee44d803ea9ca41587e48c913d8d46896eb830aeadfc13144a8eac3ff018080ffff80ffff01ffff33ffa06b7a83babea1eec790c947db4464ab657dbe9b887fe9acc247062847b8c2a8a9ff830186a08080ff8080808080"
 )  # noqa
 
-gen1 = b"aaaaaaaaaa" + original_generator
-gen2 = b"bb" + original_generator
+gen1 = b"\xff\x01" + original_generator
+gen2 = b"\xff\x01\xff\x01" + original_generator
 FAKE_BLOCK_HEIGHT1 = uint32(100)
 FAKE_BLOCK_HEIGHT2 = uint32(200)
+
+from chia_rs import serialized_length
+
+assert serialized_length(original_generator) == len(original_generator)
+assert serialized_length(gen1) == len(gen1)
+assert serialized_length(gen2) == len(gen2)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

The *Streamable* protocol (normally) requires input passed to `parse()` and `from_bytes()` be equally valid input. The distinction is that `parse()` consumes input from a stream, whereas `from_bytes()` expects the complete byte buffer to represent the complete value to be consumed for the streamable type.

`SerializedProgram` is currently an exception to this, where there is no validation at all of the input passed to `from_bytes()`, whereas `parse()` *does* validate the input. In most normal production use, `parse()` is how `SerializedProgram`s are initialized (such as parsing a `FullBlock` from the network or database).

There are however a few tests where we initialize `SerializedProgram` with invalid input. This is a small tweak to correct this quirk, and fix the tests.

### Current Behavior:

`SerializedProgram.from_bytes(b"aaa")` is valid.

### New Behavior:

`SerializedProgram.from_bytes(b"aaa")` is *not* valid.