### PR TITLE
return List[TransactionRecord] from nft bulk mint functions

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -3556,7 +3556,7 @@ class WalletRpcApi:
         fee = uint64(request.get("fee", 0))
 
         if mint_from_did:
-            sb = await nft_wallet.mint_from_did(
+            txs = await nft_wallet.mint_from_did(
                 metadata_list,
                 mint_number_start=mint_number_start,
                 mint_total=mint_total,
@@ -3572,7 +3572,7 @@ class WalletRpcApi:
                 extra_conditions=extra_conditions,
             )
         else:
-            sb = await nft_wallet.mint_from_xch(
+            txs = await nft_wallet.mint_from_xch(
                 metadata_list,
                 mint_number_start=mint_number_start,
                 mint_total=mint_total,
@@ -3583,6 +3583,8 @@ class WalletRpcApi:
                 tx_config=tx_config,
                 extra_conditions=extra_conditions,
             )
+        sb = txs[0].spend_bundle
+        assert sb is not None
         nft_id_list = []
         for cs in sb.coin_spends:
             if cs.coin.puzzle_hash == nft_puzzles.LAUNCHER_PUZZLE_HASH:

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -1259,7 +1259,7 @@ class NFTWallet:
         did_lineage_parent: Optional[bytes32] = None,
         fee: Optional[uint64] = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
-    ) -> SpendBundle:
+    ) -> List[TransactionRecord]:
         """
         Minting NFTs from the DID linked wallet, also used for bulk minting NFTs.
         - The DID is spent along with an intermediate launcher puzzle which
@@ -1529,7 +1529,9 @@ class NFTWallet:
 
         # Aggregate everything into a single spend bundle
         total_spend = SpendBundle.aggregate([signed_spend_bundle, xch_spend, *eve_spends])
-        return total_spend
+
+        tx_record: TransactionRecord = dataclasses.replace(eve_txs[0], spend_bundle=total_spend)
+        return [tx_record]
 
     async def mint_from_xch(
         self,
@@ -1542,7 +1544,7 @@ class NFTWallet:
         xch_change_ph: Optional[bytes32] = None,
         fee: Optional[uint64] = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
-    ) -> SpendBundle:
+    ) -> List[TransactionRecord]:
         """
         Minting NFTs from a single XCH spend using intermediate launcher puzzle
         :param metadata_list: A list of dicts containing the metadata for each NFT to be minted
@@ -1731,7 +1733,8 @@ class NFTWallet:
 
         # Aggregate everything into a single spend bundle
         total_spend = SpendBundle.aggregate([signed_spend_bundle, xch_spend, *eve_spends])
-        return total_spend
+        tx_record: TransactionRecord = dataclasses.replace(eve_txs[0], spend_bundle=total_spend)
+        return [tx_record]
 
     async def select_coins(
         self,

--- a/tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -112,9 +112,11 @@ async def test_nft_mint_from_did(
 
     target_list = [(await wallet_1.get_new_puzzlehash()) for x in range(mint_total)]
 
-    sb = await nft_wallet_maker.mint_from_did(
+    tx_records = await nft_wallet_maker.mint_from_did(
         metadata_list, DEFAULT_TX_CONFIG, target_list=target_list, mint_number_start=1, mint_total=mint_total, fee=fee
     )
+    sb = tx_records[0].spend_bundle
+    assert sb is not None
 
     await api_0.push_tx({"spend_bundle": bytes(sb).hex()})
 
@@ -603,7 +605,7 @@ async def test_nft_mint_from_did_multiple_xch(
 
     target_list = [ph_taker for x in range(mint_total)]
 
-    sb = await nft_wallet_maker.mint_from_did(
+    tx_records = await nft_wallet_maker.mint_from_did(
         metadata_list,
         DEFAULT_TX_CONFIG,
         target_list=target_list,
@@ -612,6 +614,8 @@ async def test_nft_mint_from_did_multiple_xch(
         xch_coins=xch_coins,
         fee=fee,
     )
+    sb = tx_records[0].spend_bundle
+    assert sb is not None
 
     await api_0.push_tx({"spend_bundle": bytes(sb).hex()})
 
@@ -708,9 +712,11 @@ async def test_nft_mint_from_xch(
 
     target_list = [(await wallet_1.get_new_puzzlehash()) for x in range(mint_total)]
 
-    sb = await nft_wallet_maker.mint_from_xch(
+    tx_records = await nft_wallet_maker.mint_from_xch(
         metadata_list, DEFAULT_TX_CONFIG, target_list=target_list, mint_number_start=1, mint_total=mint_total, fee=fee
     )
+    sb = tx_records[0].spend_bundle
+    assert sb is not None
 
     await api_0.push_tx({"spend_bundle": bytes(sb).hex()})
 
@@ -1015,7 +1021,7 @@ async def test_nft_mint_from_xch_multiple_xch(
 
     target_list = [ph_taker for x in range(mint_total)]
 
-    sb = await nft_wallet_maker.mint_from_xch(
+    tx_records = await nft_wallet_maker.mint_from_xch(
         metadata_list,
         DEFAULT_TX_CONFIG,
         target_list=target_list,
@@ -1024,6 +1030,8 @@ async def test_nft_mint_from_xch_multiple_xch(
         xch_coins=xch_coins,
         fee=fee,
     )
+    sb = tx_records[0].spend_bundle
+    assert sb is not None
 
     await api_0.push_tx({"spend_bundle": bytes(sb).hex()})
 


### PR DESCRIPTION
Bringing the `mint_from_did` and `mint_from_xch` functions in line with the standard practice of returning TransactionRecords instead of SpendBundles