### PR TITLE
add `-force` to `hdiutil detach`

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -453,4 +453,4 @@ jobs:
     - name: Detach .dmg
       if: always()
       run: |
-        hdiutil detach "/Volumes/Chia "*
+        hdiutil detach -force "/Volumes/Chia "*


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Hopefully reduce flaky failures.

https://github.com/Chia-Network/chia-blockchain/actions/runs/6632243250/job/18019093752?pr=16686
```
hdiutil: couldn't unmount "disk2" - Resource busy
Error: Process completed with exit code 16.
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
