### PR TITLE
harmonize `SerializedProgram` with `Program`

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1819,7 +1819,7 @@ def compute_cost_test(generator: BlockGenerator, constants: ConsensusConstants, 
 
     if height >= constants.HARD_FORK_FIX_HEIGHT:
         blocks = [bytes(g) for g in generator.generator_refs]
-        cost, result = generator.program._run(INFINITE_COST, MEMPOOL_MODE | ALLOW_BACKREFS, DESERIALIZE_MOD, blocks)
+        cost, result = generator.program._run(INFINITE_COST, MEMPOOL_MODE | ALLOW_BACKREFS, [DESERIALIZE_MOD, blocks])
         clvm_cost += cost
 
         for spend in result.first().as_iter():
@@ -1834,7 +1834,7 @@ def compute_cost_test(generator: BlockGenerator, constants: ConsensusConstants, 
 
     else:
         block_program_args = Program.to([[bytes(g) for g in generator.generator_refs]])
-        clvm_cost, result = GENERATOR_MOD._run(INFINITE_COST, MEMPOOL_MODE, generator.program, block_program_args)
+        clvm_cost, result = GENERATOR_MOD._run(INFINITE_COST, MEMPOOL_MODE, [generator.program, block_program_args])
 
         for res in result.first().as_iter():
             # each condition item is:

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -108,15 +108,15 @@ class Program(SExp):
     def get_tree_hash(self) -> bytes32:
         return bytes32(tree_hash(bytes(self)))
 
-    def _run(self, max_cost: int, flags: int, args) -> Tuple[int, Program]:
+    def _run(self, max_cost: int, flags: int, args: object) -> Tuple[int, Program]:
         prog_args = Program.to(args)
         cost, r = run_chia_program(self.as_bin(), prog_args.as_bin(), max_cost, flags)
         return cost, Program.to(r)
 
-    def run_with_cost(self, max_cost: int, args) -> Tuple[int, Program]:
+    def run_with_cost(self, max_cost: int, args: object) -> Tuple[int, Program]:
         return self._run(max_cost, 0, args)
 
-    def run(self, args) -> Program:
+    def run(self, args: object) -> Program:
         cost, r = self.run_with_cost(INFINITE_COST, args)
         return r
 

--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -12,6 +12,13 @@ from chia.util.byte_types import hexstr_to_bytes
 
 
 def _serialize(node: object) -> bytes:
+    if isinstance(node, list):
+        serialized_list = bytearray()
+        for a in node:
+            serialized_list += b"\xff"
+            serialized_list += _serialize(a)
+        serialized_list += b"\x80"
+        return bytes(serialized_list)
     if type(node) is SerializedProgram:
         return bytes(node)
     if type(node) is Program:
@@ -81,26 +88,18 @@ class SerializedProgram:
     def get_tree_hash(self) -> bytes32:
         return bytes32(tree_hash(self._buf))
 
-    def run_mempool_with_cost(self, max_cost: int, *args: object) -> Tuple[int, Program]:
-        return self._run(max_cost, MEMPOOL_MODE, *args)
+    def run_mempool_with_cost(self, max_cost: int, arg: object) -> Tuple[int, Program]:
+        return self._run(max_cost, MEMPOOL_MODE, arg)
 
-    def run_with_cost(self, max_cost: int, *args: object) -> Tuple[int, Program]:
-        return self._run(max_cost, 0, *args)
+    def run_with_cost(self, max_cost: int, arg: object) -> Tuple[int, Program]:
+        return self._run(max_cost, 0, arg)
 
-    def _run(self, max_cost: int, flags: int, *args: object) -> Tuple[int, Program]:
+    def _run(self, max_cost: int, flags: int, arg: object) -> Tuple[int, Program]:
         # when multiple arguments are passed, concatenate them into a serialized
         # buffer. Some arguments may already be in serialized form (e.g.
         # SerializedProgram) so we don't want to de-serialize those just to
         # serialize them back again. This is handled by _serialize()
-        serialized_args = bytearray()
-        if len(args) > 1:
-            # when we have more than one argument, serialize them into a list
-            for a in args:
-                serialized_args += b"\xff"
-                serialized_args += _serialize(a)
-            serialized_args += b"\x80"
-        else:
-            serialized_args += _serialize(args[0])
+        serialized_args = _serialize(arg)
 
         cost, ret = run_chia_program(
             self._buf,

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -290,7 +290,7 @@ async def test_get_puzzle_and_solution_for_coin_performance(benchmark_runner: Be
     assert LARGE_BLOCK.transactions_generator is not None
     # first, list all spent coins in the block
     cost, result = LARGE_BLOCK.transactions_generator.run_with_cost(
-        DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM, DESERIALIZE_MOD, []
+        DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM, [DESERIALIZE_MOD, []]
     )
 
     coin_spends = result.first()

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -81,7 +81,7 @@ EXPECTED_OUTPUT = (
 def run_generator(self: BlockGenerator) -> Tuple[int, Program]:
     """This mode is meant for accepting possibly soft-forked transactions into the mempool"""
     args = Program.to([[bytes(g) for g in self.generator_refs]])
-    return GENERATOR_MOD.run_with_cost(MAX_COST, self.program, args)
+    return GENERATOR_MOD.run_with_cost(MAX_COST, [self.program, args])
 
 
 def as_atom_list(prg: Program) -> List[bytes]:

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -104,7 +104,7 @@ def npc_to_dict(npc: NPC):
 
 def run_generator(block_generator: BlockGenerator, constants: ConsensusConstants, max_cost: int) -> List[CAT]:
     block_args = [bytes(a) for a in block_generator.generator_refs]
-    cost, block_result = block_generator.program.run_with_cost(max_cost, DESERIALIZE_MOD, block_args)
+    cost, block_result = block_generator.program.run_with_cost(max_cost, [DESERIALIZE_MOD, block_args])
 
     coin_spends = block_result.first()
 


### PR DESCRIPTION
### Purpose:

`SerializedProgram` takes a vararg arguments passed to the CLVM program to run, whereas `Program` takes a single argument. In order to pass multiple arguments, they have to be placed in a list (just like CLVM itself).

This patch makes `SerializedProgram` have the same interface, and it fixes up a few call sites.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

```
cost, result = generator.program._run(
    INFINITE_COST,
    MEMPOOL_MODE | ALLOW_BACKREFS,
    DESERIALIZE_MOD, blocks)
```

### New Behavior:

```
cost, result = generator.program._run(
    INFINITE_COST,
    MEMPOOL_MODE | ALLOW_BACKREFS,
    [DESERIALIZE_MOD, blocks])
```