### PR TITLE
Sync no farmer

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -897,8 +897,9 @@ class FullNode:
             self.log.info("Waiting to receive peaks from peers.")
 
             # Wait until we have 3 peaks or up to a max of 30 seconds
+            max_iterations = int(self.config.get("max_sync_wait", 30)) * 10
             peaks = []
-            for i in range(300):
+            for i in range(max_iterations):
                 peaks = [peak.header_hash for peak in self.sync_store.get_peak_of_each_peer().values()]
                 if len(self.sync_store.get_peers_that_have_peak(peaks)) < 3:
                     if self._shut_down:

--- a/chia/simulator/setup_nodes.py
+++ b/chia/simulator/setup_nodes.py
@@ -143,6 +143,10 @@ async def setup_simulators_and_wallets(
     disable_capabilities: Optional[List[Capability]] = None,
 ) -> AsyncIterator[Tuple[List[FullNodeSimulator], List[Tuple[WalletNode, ChiaServer]], BlockTools]]:
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
+        if config_overrides is None:
+            config_overrides = {}
+        if "full_node.max_sync_wait" not in config_overrides:
+            config_overrides["full_node.max_sync_wait"] = 1
         async with setup_simulators_and_wallets_inner(
             db_version,
             consensus_constants,

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -411,6 +411,10 @@ full_node:
   # timeout for weight proof request
   weight_proof_timeout: &weight_proof_timeout 360
 
+  # when the full node enters sync-mode, we wait until we have collected peaks
+  # from at least 3 peers, or until we've waitied this many seconds
+  max_sync_wait: 30
+
   # when enabled, the full node will print a pstats profile to the root_dir/profile every second
   # analyze with chia/utils/profiler.py
   enable_profiler: False

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -65,7 +65,6 @@ from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.make_block_generator import make_spend_bundle
 from tests.core.mempool.test_mempool_performance import wallet_height_at_least
 from tests.core.node_height import node_height_at_least
-from tests.plot_sync.util import get_dummy_connection
 
 
 async def new_transaction_not_requested(incoming, new_spend):
@@ -125,17 +124,13 @@ async def test_sync_no_farmer(
 
     # full node 1 has the complete chain
     for block_batch in to_batches(blocks, 64):
-        await full_node_1.full_node.add_block_batch(
-            block_batch.entries, get_dummy_connection(NodeType.FULL_NODE, bytes32.random(seeded_random)), None
-        )
+        await full_node_1.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
 
     target_peak = full_node_1.full_node.blockchain.get_peak()
 
     # full node 2 is behind by 800 blocks
     for block_batch in to_batches(blocks[:-800], 64):
-        await full_node_2.full_node.add_block_batch(
-            block_batch.entries, get_dummy_connection(NodeType.FULL_NODE, bytes32.random(seeded_random)), None
-        )
+        await full_node_2.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
 
     # connect the nodes and wait for node 2 to sync up to node 1
     await connect_and_get_peer(server_1, server_2, self_hostname)

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -54,6 +54,7 @@ from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
 from chia.util.limited_semaphore import LimitedSemaphore
+from chia.util.misc import to_batches
 from chia.util.recursive_replace import recursive_replace
 from chia.util.vdf_prover import get_vdf_info_and_proof
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
@@ -64,6 +65,7 @@ from tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from tests.core.make_block_generator import make_spend_bundle
 from tests.core.mempool.test_mempool_performance import wallet_height_at_least
 from tests.core.node_height import node_height_at_least
+from tests.plot_sync.util import get_dummy_connection
 
 
 async def new_transaction_not_requested(incoming, new_spend):
@@ -104,6 +106,49 @@ async def get_block_path(full_node: FullNodeAPI):
         assert b is not None
         blocks_list.insert(0, b)
     return blocks_list
+
+
+@pytest.mark.asyncio
+async def test_sync_no_farmer(
+    setup_two_nodes_and_wallet,
+    default_1000_blocks: List[FullBlock],
+    self_hostname: str,
+    seeded_random: random.Random,
+):
+    nodes, wallets, bt = setup_two_nodes_and_wallet
+    server_1 = nodes[0].full_node.server
+    server_2 = nodes[1].full_node.server
+    full_node_1 = nodes[0]
+    full_node_2 = nodes[1]
+
+    blocks = default_1000_blocks
+
+    # full node 1 has the complete chain
+    for block_batch in to_batches(blocks, 64):
+        await full_node_1.full_node.add_block_batch(
+            block_batch.entries, get_dummy_connection(NodeType.FULL_NODE, bytes32.random(seeded_random)), None
+        )
+
+    target_peak = full_node_1.full_node.blockchain.get_peak()
+
+    # full node 2 is behind by 800 blocks
+    for block_batch in to_batches(blocks[:-800], 64):
+        await full_node_2.full_node.add_block_batch(
+            block_batch.entries, get_dummy_connection(NodeType.FULL_NODE, bytes32.random(seeded_random)), None
+        )
+
+    # connect the nodes and wait for node 2 to sync up to node 1
+    await connect_and_get_peer(server_1, server_2, self_hostname)
+
+    def check_nodes_in_sync():
+        p1 = full_node_2.full_node.blockchain.get_peak()
+        p2 = full_node_1.full_node.blockchain.get_peak()
+        return p1 == p2
+
+    await time_out_assert(40, check_nodes_in_sync)
+
+    assert full_node_1.full_node.blockchain.get_peak() == target_peak
+    assert full_node_2.full_node.blockchain.get_peak() == target_peak
 
 
 class TestFullNodeBlockCompression:


### PR DESCRIPTION
### Purpose:

As part of the patch to fix deep-reorgs, it was discovered that one of the tests would not trigger a reorg sync unless a new block was farmed. That's not the intention, so I added this test to ensure a normal, catch-up, sync can be triggered without a new farm being farmed.

In order to make the tests not take too long, I cherry-picked one of the commits from the deep-reorg PR to make the delay configurable, of how long to wait to receive 3 peers with the same peak. This is set to 1 seconds in the tests now.

There is no change in behavior, except the delay is configurable, still defaults to 30 seconds.