### PR TITLE
fixup pylint confusion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 *	@Chia-Network/required-reviewers
 /.github/* @Chia-Network/actions-reviewers
 /PRETTY_GOOD_PRACTICES.md	@altendky @Chia-Network/required-reviewers
+/pylintrc	@altendky @Chia-Network/required-reviewers

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -372,7 +372,7 @@ class WebSocketServer:
                                     show_traceback=False,
                                 ):
                                     await connection.ping()
-                            except:  # noqa E722 pylint: disable=bare-except
+                            except:  # noqa E722
                                 self.remove_connection(connection)
                                 await connection.close()
 

--- a/pylintrc
+++ b/pylintrc
@@ -2,7 +2,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=
+extension-pkg-allow-list=lxml,zstd
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -65,10 +65,10 @@ disable=raw-checker-failed,
         arguments-differ,
         arguments-renamed,
         attribute-defined-outside-init,
+        bare-except,
         broad-exception-caught,
         broad-exception-raised,
         cell-var-from-loop,
-        c-extension-no-member,
         chained-comparison,
         comparison-with-callable,
         consider-iterating-dictionary,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

so i had a pr changing the pylint config.  it crossed with my own other pr that, after the pylint config change, was missing a pylint ignore.  thing is, this bare except check is already being done by flake8 so we probably don't need pylint warning us against it as well.  so, i'm proposing reverting amine's change and instead disabling the `bare-except` pylint message.  additionally, there's a situation around zstd.  my pylint config change resulted in 1) warnings being enabled from pylint and 2) a conflicting configuration with `c-extension-no-member` being both enabled (previously) and disabled by my change.  it is informational and we had error only configured so before it didn't matter that it was enabled.  why did it fail?  sometimes?  maybe there's some non-determinism around the enable/disable conflict, i don't know.  but regardless, before it was just a pointless config.  so, we could go ahead and just remove the enable.  but...  we could also `extension-pkg-allow-list=zstd` instead and allow pylint to inspect the zstd extension (and lxml) by loading it.  then also remove my disable of the `c-extension-no-member` and allow the previously pointless enable of it to do something now.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
