### PR TITLE
generalize JSON serializer

### DIFF
--- a/chia/util/json_util.py
+++ b/chia/util/json_util.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import json
 from typing import Any
 
@@ -15,7 +14,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
     """
 
     def default(self, o: Any) -> Any:
-        if dataclasses.is_dataclass(o):
+        if hasattr(type(o), "to_json_dict"):
             return o.to_json_dict()
         elif isinstance(o, WalletType):
             return o.name


### PR DESCRIPTION
### Purpose:

This makes it work with any type that has a `to_json_dict()` member, not just dataclasses.

Not making this change was an oversight when introducing the first rust native types among our protocol message types. (here: https://github.com/Chia-Network/chia-blockchain/pull/11503 ). That PR updates `recurse_jsonify()` (here: https://github.com/Chia-Network/chia-blockchain/pull/11503/files#diff-dd6f0c93f94df70ed7b9693a16d72d4d79e9f2338eb65b13bebad03b28d9593cR145-R147 ).

This highlights that we currently have two functions to convert a structure to json, `recurse_jsonify()` as well as the `EnhancedJSONEncoder`. That seems a bit risky.