### PR TITLE
fix full node hangs and timeouts

### DIFF
--- a/tests/core/full_node/config.py
+++ b/tests/core/full_node/config.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
 
 job_timeout = 50
-check_resource_usage = True
 checkout_blocks_and_plots = True

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -140,7 +140,7 @@ async def test_sync_no_farmer(
         p2 = full_node_1.full_node.blockchain.get_peak()
         return p1 == p2
 
-    await time_out_assert(40, check_nodes_in_sync)
+    await time_out_assert(120, check_nodes_in_sync)
 
     assert full_node_1.full_node.blockchain.get_peak() == target_peak
     assert full_node_2.full_node.blockchain.get_peak() == target_peak


### PR DESCRIPTION
- disable pytest-monitor for `tests.core.full_node`
- increase `test_sync_no_farmer()` time out assert from 40s to 120s

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
