### PR TITLE
bump chia_rs to version 0.2.13

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 from chia_rs import (
     AGG_SIG_ARGS,
     ALLOW_BACKREFS,
-    ENABLE_ASSERT_BEFORE,
     ENABLE_BLS_OPS,
     ENABLE_BLS_OPS_OUTSIDE_GUARD,
     ENABLE_FIXED_DIV,
@@ -45,7 +44,7 @@ log = logging.getLogger(__name__)
 
 
 def get_flags_for_height_and_constants(height: int, constants: ConsensusConstants) -> int:
-    flags = ENABLE_ASSERT_BEFORE
+    flags = 0
 
     if height >= constants.SOFT_FORK2_HEIGHT:
         flags = flags | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ dependencies = [
     "chiapos==2.0.3",  # proof of space
     "clvm==0.9.8",
     "clvm_tools==0.4.6",  # Currying, Program.to, other conveniences
-    "chia_rs==0.2.11",
+    "chia_rs==0.2.13",
     "clvm-tools-rs==0.1.38",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.8.5",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/generator/test_rom.py
+++ b/tests/generator/test_rom.py
@@ -12,7 +12,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.generator_types import BlockGenerator
-from chia.types.spend_bundle_conditions import ELIGIBLE_FOR_DEDUP, Spend
+from chia.types.spend_bundle_conditions import Spend
 from chia.util.ints import uint32
 from chia.wallet.puzzles.load_clvm import load_clvm, load_serialized_clvm_maybe_recompile
 
@@ -155,7 +155,7 @@ class TestROM:
             agg_sig_puzzle_amount=[],
             agg_sig_parent_amount=[],
             agg_sig_parent_puzzle=[],
-            flags=ELIGIBLE_FOR_DEDUP,
+            flags=0,
         )
 
         assert npc_result.conds.spends == [spend]


### PR DESCRIPTION
### Purpose:
The new version of chia_rs includes:
* adds `fast_forward_singleton()`
* `blspy` compatible wrappers on top of BLST
* remove `ENABLE_ASSERT_BEFORE` flag as it's enabled by default now
* improved compatibility of rust protocol types with the python counterparts

Full changelogs here:
https://github.com/Chia-Network/chia_rs/releases/tag/0.2.12
https://github.com/Chia-Network/chia_rs/releases/tag/0.2.13