### PR TITLE
[ADDED] Allow the daemon to use TLS v1.2 via config flag 

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -178,8 +178,8 @@ class WebSocketServer:
 
         # Note: the minimum_version has been already set to TLSv1_2
         # in ssl_context_for_server()
-        # Daemon is internal connections, so override to TLSv1_3 only
-        if ssl.HAS_TLSv1_3:
+        # Daemon is internal connections, so override to TLSv1_3 only unless specified in the config
+        if ssl.HAS_TLSv1_3 and not self.net_config.get("daemon_allow_tls_1_2", False):
             try:
                 self.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_3
             except ValueError:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -8,6 +8,7 @@ rpc_timeout: 300
 daemon_port: 55400
 daemon_max_message_size: 50000000 # maximum size of RPC message in bytes
 daemon_heartbeat: 300 # sets the heartbeat for ping/ping interval and timeouts
+daemon_allow_tls_1_2: False # if True, allow TLS 1.2 for daemon connections
 inbound_rate_limit_percent: 100
 outbound_rate_limit_percent: 30
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

(see https://github.com/Chia-Network/chia-blockchain/pull/16731)

.NET, as of version 6.0, does not support TLS v1.3 on macOS or Windows 10. .NET apps on those OSes are not be able to connect to the daemon.

This change creates a config option `daemon_allow_tls_1_2` which allows incoming wss connections that use TLS 1.2. 

(for context please see https://github.com/dkackman/chia-dotnet/issues/62)

<!-- Does this PR introduce a breaking change? -->
This is *not* a breaking change

### Current Behavior:
The daemon server enforces TLS 1.3 as the minimum version. 


### New Behavior:
The daemon server enforces TLS 1.2 as the minimum version. 


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
I'm not sure exactly how this could be tested within the chia unit test framework. I have done bench testing on a windows 10 VM and @greimela has tested on macOS. Am happy to add some demonstrating unit tests in chia.dotnet.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
