### PR TITLE
use separate protocol versions for the different services

### DIFF
--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -4,10 +4,19 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import List, Optional, Tuple
 
+from chia.server.outbound_message import NodeType
 from chia.util.ints import int16, uint8, uint16
 from chia.util.streamable import Streamable, streamable
 
-protocol_version = "0.0.35"
+protocol_version = {
+    NodeType.FULL_NODE: "0.0.35",
+    NodeType.HARVESTER: "0.0.35",
+    NodeType.FARMER: "0.0.35",
+    NodeType.TIMELORD: "0.0.35",
+    NodeType.INTRODUCER: "0.0.35",
+    NodeType.WALLET: "0.0.35",
+    NodeType.DATA_LAYER: "0.0.35",
+}
 
 
 """

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -334,7 +334,9 @@ class ChiaServer:
                 outbound_rate_limit_percent=self._outbound_rate_limit_percent,
                 local_capabilities_for_handshake=self._local_capabilities_for_handshake,
             )
-            await connection.perform_handshake(self._network_id, protocol_version, self.get_port(), self._local_type)
+            await connection.perform_handshake(
+                self._network_id, protocol_version[self._local_type], self.get_port(), self._local_type
+            )
             assert connection.connection_type is not None, "handshake failed to set connection type, still None"
 
             # Limit inbound connections to config's specifications.
@@ -485,7 +487,9 @@ class ChiaServer:
                 local_capabilities_for_handshake=self._local_capabilities_for_handshake,
                 session=session,
             )
-            await connection.perform_handshake(self._network_id, protocol_version, server_port, self._local_type)
+            await connection.perform_handshake(
+                self._network_id, protocol_version[self._local_type], server_port, self._local_type
+            )
             await self.connection_added(connection, on_connect)
             # the session has been adopted by the connection, don't close it at
             # the end of the function

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -223,6 +223,9 @@ class WSChiaConnection:
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
 
+            if inbound_handshake.protocol_version != protocol_version:
+                raise ProtocolError(Err.INCOMPATIBLE_PROTOCOL_VERSION)
+
             self.version = inbound_handshake.software_version
             self.protocol_version = Version(inbound_handshake.protocol_version)
             self.peer_server_port = inbound_handshake.server_port
@@ -250,6 +253,10 @@ class WSChiaConnection:
             inbound_handshake = Handshake.from_bytes(message.data)
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
+
+            if inbound_handshake.protocol_version != protocol_version:
+                raise ProtocolError(Err.INCOMPATIBLE_PROTOCOL_VERSION)
+
             await self._send_message(outbound_handshake)
             self.version = inbound_handshake.software_version
             self.protocol_version = Version(inbound_handshake.protocol_version)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -223,13 +223,14 @@ class WSChiaConnection:
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
 
-            if inbound_handshake.protocol_version != protocol_version:
+            inbound_node_type = NodeType(inbound_handshake.node_type)
+            if inbound_handshake.protocol_version != protocol_version[inbound_node_type]:
                 raise ProtocolError(Err.INCOMPATIBLE_PROTOCOL_VERSION)
 
             self.version = inbound_handshake.software_version
             self.protocol_version = Version(inbound_handshake.protocol_version)
             self.peer_server_port = inbound_handshake.server_port
-            self.connection_type = NodeType(inbound_handshake.node_type)
+            self.connection_type = inbound_node_type
             # "1" means capability is enabled
             self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
         else:
@@ -254,14 +255,15 @@ class WSChiaConnection:
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
 
-            if inbound_handshake.protocol_version != protocol_version:
+            inbound_node_type = NodeType(inbound_handshake.node_type)
+            if inbound_handshake.protocol_version != protocol_version[inbound_node_type]:
                 raise ProtocolError(Err.INCOMPATIBLE_PROTOCOL_VERSION)
 
             await self._send_message(outbound_handshake)
             self.version = inbound_handshake.software_version
             self.protocol_version = Version(inbound_handshake.protocol_version)
             self.peer_server_port = inbound_handshake.server_port
-            self.connection_type = NodeType(inbound_handshake.node_type)
+            self.connection_type = inbound_node_type
             # "1" means capability is enabled
             self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
 

--- a/tests/connection_utils.py
+++ b/tests/connection_utils.py
@@ -87,7 +87,7 @@ async def add_dummy_connection_wsc(
         30,
         local_capabilities_for_handshake=capabilities,
     )
-    await wsc.perform_handshake(server._network_id, protocol_version, dummy_port, type)
+    await wsc.perform_handshake(server._network_id, protocol_version[type], dummy_port, type)
     if wsc.incoming_message_task is not None:
         wsc.incoming_message_task.cancel()
     return wsc, peer_id

--- a/tests/core/server/test_server.py
+++ b/tests/core/server/test_server.py
@@ -13,7 +13,7 @@ from chia.protocols.full_node_protocol import RejectBlock, RequestBlock, Request
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.shared_protocol import Error, protocol_version
 from chia.protocols.wallet_protocol import RejectHeaderRequest
-from chia.server.outbound_message import make_msg
+from chia.server.outbound_message import NodeType, make_msg
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection, error_response_version
 from chia.simulator.block_tools import BlockTools
@@ -78,7 +78,7 @@ async def test_connection_versions(
     outgoing_connection = wallet_node.server.all_connections[full_node.server.node_id]
     incoming_connection = full_node.server.all_connections[wallet_node.server.node_id]
     for connection in [outgoing_connection, incoming_connection]:
-        assert connection.protocol_version == Version(protocol_version)
+        assert connection.protocol_version == Version(protocol_version[NodeType.FULL_NODE])
         assert connection.version == chia_full_version_str()
         assert connection.get_version() == chia_full_version_str()
 

--- a/tests/core/ssl/test_ssl.py
+++ b/tests/core/ssl/test_ssl.py
@@ -33,7 +33,9 @@ async def establish_connection(server: ChiaServer, self_hostname: str, ssl_conte
             30,
             local_capabilities_for_handshake=capabilities,
         )
-        await wsc.perform_handshake(server._network_id, protocol_version, dummy_port, NodeType.FULL_NODE)
+        await wsc.perform_handshake(
+            server._network_id, protocol_version[NodeType.FULL_NODE], dummy_port, NodeType.FULL_NODE
+        )
         await wsc.close()
 
 


### PR DESCRIPTION
### Purpose:

When updating the harvester protocol, we should bump its version number. Currently all our protocols use a single protocol version constant, which means we would also have to bump the version number of the full node- and wallet protocol as well (even though they haven't changed).

This patch separates the constant into one version number per protocol.