### PR TITLE
Fix peak height race

### DIFF
--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -6,7 +6,6 @@ import dataclasses
 import logging
 import random
 import time
-import traceback
 from typing import Coroutine, Dict, List, Optional, Tuple
 
 import pytest
@@ -2190,16 +2189,9 @@ async def test_long_reorg_nodes(
     await full_node_2.full_node.add_block(reorg_blocks[-1])
 
     def check_nodes_in_sync():
-        try:
-            p1 = full_node_2.full_node.blockchain.get_peak()
-            p2 = full_node_1.full_node.blockchain.get_peak()
-            return p1 == p2
-        except Exception as e:
-            # TODO: understand why we get an exception here sometimes. Fix it or
-            # add comment explaining why we need to catch here
-            traceback.print_exc()
-            print(f"e: {e}")
-            return False
+        p1 = full_node_2.full_node.blockchain.get_peak()
+        p2 = full_node_1.full_node.blockchain.get_peak()
+        return p1 == p2
 
     await time_out_assert(120, check_nodes_in_sync)
     peak = full_node_2.full_node.blockchain.get_peak()


### PR DESCRIPTION
### Purpose:

When we add a block, there's a subtle co-routine suspension point in between updating the height-to-hash map and the peak height. There's a comment in the code to highlight this now.

This creates a window where a call to `get_peak()` fails because the peak height doesn't exist in height-to-hash map.

This is demonstrated in https://github.com/Chia-Network/chia-blockchain/pull/16774 .

```
Traceback (most recent call last):
  File "/home/arvid/dev/3/chia-blockchain/tests/core/full_node/test_full_node.py", line 2195, in check_nodes_in_sync
    p2 = full_node_1.full_node.blockchain.get_peak()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arvid/dev/3/chia-blockchain/chia/consensus/blockchain.py", line 191, in get_peak
    return self.height_to_block_record(self._peak_height)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arvid/dev/3/chia-blockchain/chia/consensus/blockchain.py", line 697, in height_to_block_record
    if header_hash is None:
        ^^^^^^^^^^^^^^^^^^^^
ValueError: Height is not in blockchain: 1599
```

This patch moves the suspension point to make these updates to the height-to-hash map and `peak_height` atomic.
Then it's possible to remove the try-catch handler in the test.

### Current Behavior:

`get_peak()` may throw an exception if called at an unfortunate time.

### New Behavior:

`get_peak()` always work