### PR TITLE
Fix invalid sync request

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -703,7 +703,10 @@ class FullNode:
                             False,
                         )
         else:
-            if request.height <= curr_peak_height + self.config["short_sync_blocks_behind_threshold"]:
+            if (
+                curr_peak_height <= request.height
+                and request.height <= curr_peak_height + self.config["short_sync_blocks_behind_threshold"]
+            ):
                 # This is the normal case of receiving the next block
                 if await self.short_sync_backtrack(
                     peer, curr_peak_height, request.height, request.unfinished_reward_block_hash
@@ -716,11 +719,10 @@ class FullNode:
                 await self.short_sync_batch(peer, uint32(0), request.height)
                 return None
 
-            if request.height < curr_peak_height + self.config["sync_blocks_behind_threshold"]:
-                # TODO: We get here if we encountered a heavier peak with a
-                # lower height than ours. We don't seem to handle this case
-                # right now. This ends up requesting the block at *our* peak
-                # height.
+            if (
+                curr_peak_height <= request.height
+                and request.height < curr_peak_height + self.config["sync_blocks_behind_threshold"]
+            ):
                 # This case of being behind but not by so much
                 if await self.short_sync_batch(peer, uint32(max(curr_peak_height - 6, 0)), request.height):
                     return None


### PR DESCRIPTION
### Purpose:

When exposed to a heavier peak with a *lower* height than our current peak, we currently fall into the short-sync (catch-up) case because the current logic (mistakenly) assumes the heavier peak has a greater height. This results in us sending an invalid block request to the peer, which in turn responds with a `None` message.

The log looks like this:

```
11:52:23 chia.full_node.full_node: INFO Starting batch short sync from 1593 to height 1077
11:52:23 chia.full_node.full_node: ERROR Error short batch syncing, could not fetch block at height 1593
```

In the above test our (lighter) peak height is 1593 and the other (heavier) peak height is 1077. We end up requesting block 1593 from the peer.

This patch adds the additional condition that the heavier peak also has a greater or equal height, as it appears was the intention to begin with. This avoids sending an invalid block request to the peer and we immediately fall back to a long sync.

### Current Behavior:

We send an invalid request, handle the resulting error and then initiate the long sync.

### New Behavior:

We initiate the long sync right away.