### PR TITLE
DL: Remove unused data from node table.

### DIFF
--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1203,6 +1203,9 @@ class DataStore:
                 if node.hash not in known_hashes:
                     await self._insert_ancestor_table(node.left_hash, node.right_hash, tree_id, root.generation)
 
+            # Clean up intermediary hashes that are no longer needed, since every hash we need should be in ancestors.
+            await writer.execute("DELETE FROM node WHERE hash NOT IN (SELECT hash FROM ancestors)")
+
     async def insert_root_with_ancestor_table(
         self, tree_id: bytes32, node_hash: Optional[bytes32], status: Status = Status.PENDING
     ) -> None:

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1176,7 +1176,7 @@ class DataStore:
             return InternalNode.from_row(row=row)
 
     async def build_ancestor_table_for_latest_root(self, tree_id: bytes32) -> None:
-        async with self.db_wrapper.writer():
+        async with self.db_wrapper.writer() as writer:
             root = await self.get_tree_root(tree_id=tree_id)
             if root.node_hash is None:
                 return


### PR DESCRIPTION
During batch insert, lots of intermediary hashes are being stored that we no longer need. Once the data makes it in the ancestor table it is final, so we can delete all node hashes that don't appear there.