### PR TITLE
request blocks in batches of 32 instead of 33

### DIFF
--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -54,7 +54,11 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     WEIGHT_PROOF_THRESHOLD=uint8(2),
     BLOCKS_CACHE_SIZE=uint32(4608 + (128 * 4)),
     WEIGHT_PROOF_RECENT_BLOCKS=uint32(1000),
-    MAX_BLOCK_COUNT_PER_REQUESTS=uint32(32),  # Allow up to 32 blocks per request
+    # Allow up to 33 blocks per request. This defines the max allowed difference
+    # between start and end in the block request message. But the range is
+    # inclusive, so the max allowed range of 32 is a request for 33 blocks
+    # (which is allowed)
+    MAX_BLOCK_COUNT_PER_REQUESTS=uint32(32),
     MAX_GENERATOR_SIZE=uint32(1000000),
     MAX_GENERATOR_REF_LIST_SIZE=uint32(512),  # Number of references allowed in the block generator ref list
     POOL_SUB_SLOT_ITERS=uint64(37600000000),  # iters limit * NUM_SPS

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1055,8 +1055,11 @@ class FullNode:
             start_height, end_height = 0, 0
             new_peers_with_peak: List[WSChiaConnection] = peers_with_peak[:]
             try:
-                for start_height in range(fork_point_height, target_peak_sb_height, batch_size):
-                    end_height = min(target_peak_sb_height, start_height + batch_size)
+                # block request ranges are *inclusive*, this requires some
+                # gymnastics of this range (+1 to make it exclusive, like normal
+                # ranges) and then -1 when forming the request message
+                for start_height in range(fork_point_height, target_peak_sb_height + 1, batch_size):
+                    end_height = min(target_peak_sb_height, start_height + batch_size - 1)
                     request = RequestBlocks(uint32(start_height), uint32(end_height), True)
                     fetched = False
                     for peer in random.sample(new_peers_with_peak, len(new_peers_with_peak)):

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -328,6 +328,9 @@ class FullNodeAPI:
 
     @api_request(reply_types=[ProtocolMessageTypes.respond_blocks, ProtocolMessageTypes.reject_blocks])
     async def request_blocks(self, request: full_node_protocol.RequestBlocks) -> Optional[Message]:
+        # note that we treat the request range as *inclusive*, but we check the
+        # size before we bump end_height. So MAX_BLOCK_COUNT_PER_REQUESTS is off
+        # by one
         if (
             request.end_height < request.start_height
             or request.end_height - request.start_height > self.full_node.constants.MAX_BLOCK_COUNT_PER_REQUESTS


### PR DESCRIPTION
Currently, the last block overlaps with the next request.
Add comments to document a quirk in how we interpret the block range in the block request message.

This was uncovered while working on addressing performance issues in deep reorgs, where we ended up adding every 33rd block twice during sync.

This fix will save about 3% bandwidth during long sync.