### PR TITLE
reduce redundant calls to compute the header hash

### DIFF
--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -201,6 +201,7 @@ async def pre_validate_blocks_multiprocessing(
             return [PreValidationResult(uint16(Err.INVALID_PREV_BLOCK_HASH.value), None, None, False)]
         curr = block_records.block_record(blocks[0].prev_header_hash)
         num_sub_slots_to_look_for = 3 if curr.overflow else 2
+        header_hash = curr.header_hash
         while (
             curr.sub_epoch_summary_included is None
             or num_blocks_seen < constants.NUMBER_OF_TIMESTAMPS
@@ -209,14 +210,19 @@ async def pre_validate_blocks_multiprocessing(
             if curr.first_in_sub_slot:
                 assert curr.finished_challenge_slot_hashes is not None
                 num_sub_slots_found += len(curr.finished_challenge_slot_hashes)
-            recent_blocks[curr.header_hash] = curr
+            recent_blocks[header_hash] = curr
             if curr.is_transaction_block:
                 num_blocks_seen += 1
-            curr = block_records.block_record(curr.prev_hash)
-        recent_blocks[curr.header_hash] = curr
+            header_hash = curr.prev_hash
+            curr = block_records.block_record(header_hash)
+        recent_blocks[header_hash] = curr
     block_record_was_present = []
+
+    block_hashes: List[bytes32] = []
     for block in blocks:
-        block_record_was_present.append(block_records.contains_block(block.header_hash))
+        header_hash = block.header_hash
+        block_hashes.append(header_hash)
+        block_record_was_present.append(block_records.contains_block(header_hash))
 
     diff_ssis: List[Tuple[uint64, uint64]] = []
     for block in blocks:
@@ -240,8 +246,8 @@ async def pre_validate_blocks_multiprocessing(
         )
         if q_str is None:
             for i, block_i in enumerate(blocks):
-                if not block_record_was_present[i] and block_records.contains_block(block_i.header_hash):
-                    block_records.remove_block_record(block_i.header_hash)
+                if not block_record_was_present[i] and block_records.contains_block(block_hashes[i]):
+                    block_records.remove_block_record(block_hashes[i])
             return [PreValidationResult(uint16(Err.INVALID_POSPACE.value), None, None, False)]
 
         required_iters: uint64 = calculate_iterations_quality(
@@ -280,9 +286,9 @@ async def pre_validate_blocks_multiprocessing(
 
     block_dict: Dict[bytes32, FullBlock] = {}
     for i, block in enumerate(blocks):
-        block_dict[block.header_hash] = block
+        block_dict[block_hashes[i]] = block
         if not block_record_was_present[i]:
-            block_records.remove_block_record(block.header_hash)
+            block_records.remove_block_record(block_hashes[i])
 
     npc_results_pickled = {}
     for k, v in npc_results.items():
@@ -304,8 +310,9 @@ async def pre_validate_blocks_multiprocessing(
             curr_b: FullBlock = block
 
             while curr_b.prev_header_hash in block_dict:
+                header_hash = curr_b.prev_header_hash
                 curr_b = block_dict[curr_b.prev_header_hash]
-                prev_blocks_dict[curr_b.header_hash] = curr_b
+                prev_blocks_dict[header_hash] = curr_b
 
             if isinstance(block, FullBlock):
                 assert get_block_generator is not None

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2222,7 +2222,7 @@ async def test_long_reorg_nodes(
         p3 = full_node_3.full_node.blockchain.get_peak()
         return p1 == p3
 
-    await time_out_assert(950, check_nodes_in_sync2)
+    await time_out_assert(1000, check_nodes_in_sync2)
 
     p1 = full_node_1.full_node.blockchain.get_peak()
     # p2 = full_node_2.full_node.blockchain.get_peak()


### PR DESCRIPTION
### Purpose:

In `multiprocess_validation`, we compute the header hash of `FullBlock`s multiple times. This is a quite expensive operation. This patch reduces the redundant calls to speed things up.

In profiling the setup in `test_long_reorg_nodes`, the time spent calling `header_hash` goes from 11.13% (163876 calls) to 3.47% (30379 calls).

### Current Behavior:

![test-setup-2](https://github.com/Chia-Network/chia-blockchain/assets/661450/56940e4b-abb6-43da-b5ff-7c8f7744cde6)

### New Behavior:

![test-setup-2](https://github.com/Chia-Network/chia-blockchain/assets/661450/4980c1ca-1b95-4d55-9ae1-d2e688a5c654)
