### PR TITLE
Add check to github jwt step in publish rpm job

### DIFF
--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -319,6 +319,7 @@ jobs:
           build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm
 
     - uses: Chia-Network/actions/github/jwt@main
+      if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
     - name: Mark pre-release installer complete
       if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This fixes an issue in the RPM publish job that runs an unnecessary step on workflows ran from a fork. The step doesn't actually do anything from fork workflows because it doesn't have the necessary Actions permissions.

The JWT in question is used to authenticate to the github-glue service, but those job steps also get skipped if it fails this same secrets access check.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
This step fails on fork workflows.


### New Behavior:
This step is skipped on fork workflows.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
