### PR TITLE
Add check to github jwt step in other workflows that call github-glue

### DIFF
--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -331,6 +331,7 @@ jobs:
           build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_${{ matrix.os.arch }}.deb
 
     - uses: Chia-Network/actions/github/jwt@main
+      if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
     - name: Mark pre-release installer complete
       if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -381,6 +381,7 @@ jobs:
             build_scripts/final_installer/*.dmg
 
       - uses: Chia-Network/actions/github/jwt@main
+        if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
       - name: Mark pre-release installer complete
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -397,6 +397,7 @@ jobs:
         gh release upload $env:RELEASE_TAG "${GITHUB_WORKSPACE}"/chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${{ env.CHIA_INSTALLER_VERSION }}.exe
 
     - uses: Chia-Network/actions/github/jwt@main
+      if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
     - name: Mark pre-release installer complete
       if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'

--- a/.github/workflows/trigger-docker-dev.yml
+++ b/.github/workflows/trigger-docker-dev.yml
@@ -37,6 +37,7 @@ jobs:
           GLUE_API_URL: "${{ secrets.GLUE_API_URL }}"
 
       - uses: Chia-Network/actions/github/jwt@main
+        if: steps.check_secrets.outputs.HAS_SECRET
 
       - name: Trigger docker dev workflow via github-glue
         if: steps.check_secrets.outputs.HAS_SECRET


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This fixes an issue in various jobs that call github-glue that run an unnecessary step on workflows ran from a fork. The step doesn't actually do anything from fork workflows because it doesn't have the necessary Actions permissions.

The JWT in question is used to authenticate to the github-glue service, but those job steps also get skipped if it fails this same secrets access check.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
This step fails on fork workflows.


### New Behavior:
This step is skipped on fork workflows.



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
