### PR TITLE
clean up `SpendBundle` class

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -22,7 +22,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.conditions import Condition, UnknownCondition, parse_timelock_info
@@ -1009,7 +1009,8 @@ class DataLayerWallet:
                     for tx in relevant_dl_txs:
                         if any(c.name() == singleton.coin_id for c in tx.additions):
                             if tx.spend_bundle is not None:
-                                fee = uint64(tx.spend_bundle.fees())
+                                # This executes the puzzles
+                                fee = uint64(estimate_fees(tx.spend_bundle))
                             else:
                                 fee = uint64(0)
 

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -43,7 +43,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
-from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.conditions import Condition, ConditionValidTimes, parse_timelock_info
 from chia.wallet.derive_keys import find_owner_sk
@@ -902,7 +902,7 @@ class PoolWallet:
             assert fee_tx.spend_bundle is not None
             full_spend = SpendBundle.aggregate([fee_tx.spend_bundle, claim_spend])
 
-        assert full_spend.fees() == fee
+        assert estimate_fees(full_spend) == fee
         current_time = uint64(int(time.time()))
         # The claim spend, minus the fee amount from the main wallet
         absorb_transaction: TransactionRecord = TransactionRecord(

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -71,19 +71,6 @@ class SpendBundle(Streamable):
     def debug(self, agg_sig_additional_data: bytes = DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA) -> None:
         debug_spend_bundle(self, agg_sig_additional_data)
 
-    # TODO: this should be removed
-    def not_ephemeral_additions(self) -> List[Coin]:
-        all_removals = self.removals()
-        all_additions = self.additions()
-        result: List[Coin] = []
-
-        for add in all_additions:
-            if add in all_removals:
-                continue
-            result.append(add)
-
-        return result
-
     # Note that `coin_spends` used to have the bad name `coin_solutions`.
     # Some API still expects this name. For now, we accept both names.
     #

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -29,10 +29,6 @@ class SpendBundle(Streamable):
     coin_spends: List[CoinSpend]
     aggregated_signature: G2Element
 
-    @property
-    def coin_solutions(self) -> List[CoinSpend]:
-        return self.coin_spends
-
     @classmethod
     def aggregate(cls, spend_bundles: List[SpendBundle]) -> SpendBundle:
         coin_spends: List[CoinSpend] = []
@@ -63,7 +59,8 @@ class SpendBundle(Streamable):
     def debug(self, agg_sig_additional_data: bytes = DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA) -> None:
         debug_spend_bundle(self, agg_sig_additional_data)
 
-    # Note that `coin_spends` used to have the bad name `coin_solutions`.
+    # Note that `coin_spends` used to have the bad name `coin_solutions`, prior
+    # to Jul 12, 2021
     # Some API still expects this name. For now, we accept both names.
     #
     # TODO: continue this deprecation. Eventually, all code below here should be removed.

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -57,14 +57,6 @@ class SpendBundle(Streamable):
     def removals(self) -> List[Coin]:
         return [_.coin for _ in self.coin_spends]
 
-    # TODO: this should be removed
-    def fees(self) -> int:
-        """Unsafe to use for fees validation!!!"""
-        amount_in = sum(coin.amount for coin in self.removals())
-        amount_out = sum(coin.amount for coin in self.additions())
-
-        return amount_in - amount_out
-
     def name(self) -> bytes32:
         return self.get_hash()
 
@@ -101,3 +93,21 @@ class SpendBundle(Streamable):
         if exclude_modern_keys:
             del d["coin_spends"]
         return cast(Dict[str, Any], recurse_jsonify(d))
+
+
+# This function executes all the puzzles to compute the difference between
+# additions and removals
+def estimate_fees(spend_bundle: SpendBundle) -> int:
+    """Unsafe to use for fees validation!!!"""
+    removed_amount = 0
+    added_amount = 0
+    max_cost = DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM
+    for cs in spend_bundle.coin_spends:
+        removed_amount += cs.coin.amount
+        coins, cost = compute_additions_with_cost(cs, max_cost=max_cost)
+        max_cost -= cost
+        if max_cost < 0:
+            raise ValidationError(Err.BLOCK_COST_EXCEEDS_MAX, "estimate_fees() for SpendBundle")
+        for c in coins:
+            added_amount += c.amount
+    return removed_amount - added_amount

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -13,7 +13,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
@@ -647,7 +647,8 @@ class TradeManager:
                 for condition in spend.puzzle_reveal.to_program().run(spend.solution.to_program()).as_iter()
             )
         )
-        all_fees = uint64(final_spend_bundle.fees())
+        # this executes the puzzles again
+        all_fees = uint64(estimate_fees(final_spend_bundle))
 
         txs = []
 

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -15,7 +15,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
-from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.util.errors import ConsensusError, Err
 from chia.util.ints import uint32, uint64
 from tests.blockchain.blockchain_test_utils import _validate_and_add_block
@@ -1025,7 +1025,7 @@ class TestBlockchainTransactions:
             uint64(1000), receiver_puzzlehash, spend_coin_block_1, block1_dic_good, fee=10
         )
         log.warning(block1_spend_bundle_good.additions())
-        log.warning(f"Spend bundle fees: {block1_spend_bundle_good.fees()}")
+        log.warning(f"Spend bundle fees: {estimate_fees(block1_spend_bundle_good)}")
         invalid_new_blocks = bt.get_consecutive_blocks(
             1,
             blocks,

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -50,7 +50,7 @@ from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.full_block import FullBlock
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo, TimestampedPeerInfo
-from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
@@ -965,7 +965,7 @@ class TestFullNodeProtocol:
                 )
             ]
             spend_bundle = SpendBundle.aggregate(spend_bundles)
-            assert spend_bundle.fees() == fee
+            assert estimate_fees(spend_bundle) == fee
             respond_transaction = wallet_protocol.SendTransaction(spend_bundle)
 
             await full_node_1.send_transaction(respond_transaction)

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -41,7 +41,7 @@ from chia.types.fee_rate import FeeRate
 from chia.types.generator_types import BlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import MempoolItem
-from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.api_decorators import api_request
 from chia.util.errors import Err
@@ -1620,7 +1620,7 @@ class TestMempoolManager:
 
         combined = SpendBundle.aggregate([spend_bundle1, steal_fee_spendbundle])
 
-        assert combined.fees() == 4
+        assert estimate_fees(combined) == 4
 
         tx1: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle1)
 

--- a/tests/wallet/test_singleton_lifecycle_fast.py
+++ b/tests/wallet/test_singleton_lifecycle_fast.py
@@ -17,6 +17,7 @@ from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
 from chia.wallet.puzzles.load_clvm import load_clvm
+from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 from tests.clvm.coin_store import BadSpendBundleError, CoinStore, CoinTimestamp
 
 SINGLETON_MOD = load_clvm("singleton_top_layer.clsp")
@@ -633,7 +634,7 @@ def test_lifecycle_with_coinstore_as_wallet():
             pool_reward_height=now.height - 1,
         )
         spend_bundle = SpendBundle([coin_spend, p2_singleton_coin_spend], G2Element())
-        spend_bundle.debug()
+        debug_spend_bundle(spend_bundle)
 
         _, removals = coin_store.update_coin_store_for_spend_bundle(spend_bundle, now, MAX_BLOCK_COST_CLVM)
         now.seconds += 500
@@ -737,7 +738,7 @@ def test_lifecycle_with_coinstore_as_wallet():
         PUZZLE_DB, conditions=[[ConditionOpcode.CREATE_COIN, 0, -113]]
     )
     spend_bundle = SpendBundle([coin_spend], G2Element())
-    spend_bundle.debug()
+    debug_spend_bundle(spend_bundle)
 
     _, removals = coin_store.update_coin_store_for_spend_bundle(spend_bundle, now, MAX_BLOCK_COST_CLVM)
     update_count = SINGLETON_WALLET.update_state(PUZZLE_DB, removals)

--- a/tests/wallet/test_wallet.py
+++ b/tests/wallet/test_wallet.py
@@ -21,6 +21,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import compute_additions
 from chia.types.peer_info import PeerInfo
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX
+from chia.types.spend_bundle import estimate_fees
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes
@@ -1182,7 +1183,7 @@ class TestWalletSimulator:
         )
         assert tx.spend_bundle is not None
 
-        fees = tx.spend_bundle.fees()
+        fees = estimate_fees(tx.spend_bundle)
         assert fees == tx_fee
 
         await wallet.push_transaction(tx)
@@ -1249,7 +1250,7 @@ class TestWalletSimulator:
         tx_id = tx.name.hex()
         assert tx.spend_bundle is not None
 
-        fees = tx.spend_bundle.fees()
+        fees = estimate_fees(tx.spend_bundle)
         assert fees == tx_fee
 
         await wallet.push_transaction(tx)


### PR DESCRIPTION
These changes are best reviewed one commit at a time.

This PR moves some member functions of `SpendBundle` to free functions and removes others.

`non_ephemeral_additions()` is only used by the wallet, and it's not generally safe to run on untrusted spend bundles. In fact, it's only used in one place, so this moves this function into the file where it's used.

~~`debug()` is removed. It's only used in one place, and we already have a free function version of it.~~

`fees()` is turned into a free function, renamed to `estimate_fees()` and some call sites are update to clarify that we run the puzzles in that call. It's also made independent of the `additions()` and `removals()` member functions.

The `coin_solutions` property is removed as it's not used anywhere in our code base anymore. I added a comment of when this field was renamed (Jul 12, 2021) to help guide us when we should complete the deprecation.

### Purpose:

Clean up the `SpendBundle` class.
This is also part of an effort to move away from having functions executing the puzzles on the spend bundle class. These are not safe to use in the full node, but may be safe in the wallet. Since they are potentially expensive, it should be more explicit that puzzles are executed.