### PR TITLE
remove special case logic for soft-fork 3 activation

### DIFF
--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -68,7 +68,7 @@ class CostLogger:
             program,
             INFINITE_COST,
             mempool_mode=True,
-            height=DEFAULT_CONSTANTS.SOFT_FORK3_HEIGHT,
+            height=DEFAULT_CONSTANTS.HARD_FORK_HEIGHT,
             constants=DEFAULT_CONSTANTS,
         )
         self.cost_dict[descriptor] = npc_result.cost

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -65,9 +65,6 @@ class ConsensusConstants:
     # soft fork initiated in 1.8.0 release
     SOFT_FORK2_HEIGHT: uint32
 
-    # soft fork initiated in 2.0 release
-    SOFT_FORK3_HEIGHT: uint32
-
     # the hard fork planned with the 2.0 release
     # this is the block with the first plot filter adjustment
     HARD_FORK_HEIGHT: uint32

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -63,8 +63,6 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     MAX_GENERATOR_REF_LIST_SIZE=uint32(512),  # Number of references allowed in the block generator ref list
     POOL_SUB_SLOT_ITERS=uint64(37600000000),  # iters limit * NUM_SPS
     SOFT_FORK2_HEIGHT=uint32(0),
-    # November 14, 2023
-    SOFT_FORK3_HEIGHT=uint32(4510000),
     # June 2024
     HARD_FORK_HEIGHT=uint32(5496000),
     HARD_FORK_FIX_HEIGHT=uint32(5496000),
@@ -84,8 +82,6 @@ def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None
     # these numbers are supposed to match initial-config.yaml
     if "SOFT_FORK2_HEIGHT" not in overrides:
         overrides["SOFT_FORK2_HEIGHT"] = 3000000
-    if "SOFT_FORK3_HEIGHT" not in overrides:
-        overrides["SOFT_FORK3_HEIGHT"] = 2997292
     if "HARD_FORK_HEIGHT" not in overrides:
         overrides["HARD_FORK_HEIGHT"] = 2997292
     if "HARD_FORK_FIX_HEIGHT" not in overrides:

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -49,14 +49,13 @@ def get_flags_for_height_and_constants(height: int, constants: ConsensusConstant
     if height >= constants.SOFT_FORK2_HEIGHT:
         flags = flags | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 
-    if height >= constants.SOFT_FORK3_HEIGHT:
-        # the soft-fork initiated with 2.0. To activate end of October 2023
-        # * the number of announces created and asserted are limited per spend
-        # * the total number of CLVM objects (atoms or pairs) are limited
-        # * BLS operators enabled, behind the softfork op. This set of operators
-        #   also includes coinid, % and modpow
-        # * secp operators enabled
-        flags = flags | LIMIT_ANNOUNCES | LIMIT_OBJECTS | ENABLE_BLS_OPS | ENABLE_SECP_OPS
+    # the soft-fork initiated with 2.0 and activated in November 2023
+    # * the number of announces created and asserted are limited per spend
+    # * the total number of CLVM objects (atoms or pairs) are limited
+    # * BLS operators enabled, behind the softfork op. This set of operators
+    #   also includes coinid, % and modpow
+    # * secp operators enabled
+    flags = flags | LIMIT_ANNOUNCES | LIMIT_OBJECTS | ENABLE_BLS_OPS | ENABLE_SECP_OPS
 
     if height >= constants.HARD_FORK_HEIGHT:
         # the hard-fork initiated with 2.0. To activate June 2024

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -74,7 +74,6 @@ network_overrides: &network_overrides
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
       SOFT_FORK2_HEIGHT: 3000000
-      SOFT_FORK3_HEIGHT: 2997292
       # planned 2.0 release is July 26, height 2965036 on testnet
       # 1 week later
       HARD_FORK_HEIGHT: 2997292

--- a/tests/clvm/benchmark_costs.py
+++ b/tests/clvm/benchmark_costs.py
@@ -16,7 +16,7 @@ def cost_of_spend_bundle(spend_bundle: SpendBundle) -> int:
         program,
         INFINITE_COST,
         mempool_mode=True,
-        height=DEFAULT_CONSTANTS.SOFT_FORK3_HEIGHT,
+        height=DEFAULT_CONSTANTS.HARD_FORK_HEIGHT,
         constants=DEFAULT_CONSTANTS,
     )
     return npc_result.cost

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,12 +153,11 @@ def get_keychain():
 class ConsensusMode(Enum):
     PLAIN = 0
     HARD_FORK_2_0 = 1
-    SOFT_FORK3 = 2
 
 
 @pytest.fixture(
     scope="session",
-    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK3],
+    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0],
 )
 def consensus_mode(request):
     return request.param
@@ -168,8 +167,6 @@ def consensus_mode(request):
 def blockchain_constants(consensus_mode) -> ConsensusConstants:
     if consensus_mode == ConsensusMode.PLAIN:
         return test_constants
-    if consensus_mode == ConsensusMode.SOFT_FORK3:
-        return dataclasses.replace(test_constants, SOFT_FORK3_HEIGHT=uint32(3))
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         return dataclasses.replace(
             test_constants,
@@ -229,7 +226,7 @@ def db_version(request) -> int:
     return request.param
 
 
-SOFTFORK_HEIGHTS = [1000000, 4510000, 5496000, 5496100]
+SOFTFORK_HEIGHTS = [1000000, 5496000, 5496100]
 
 
 @pytest.fixture(scope="function", params=SOFTFORK_HEIGHTS)

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -377,11 +377,6 @@ class TestConditions:
         pre-v2-softfork, and rejects more than the announcement limit afterward.
         """
 
-        if consensus_mode.value < ConsensusMode.SOFT_FORK3.value:
-            # before softfork 3, there was no limit on the number of
-            # announcements
-            expect_err = None
-
         blocks = await initial_blocks(bt)
         coin = list(blocks[-2].get_included_reward_coins())[0]
         coin_announcement = Announcement(coin.name(), b"test")

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2589,12 +2589,8 @@ class TestMaliciousGenerators:
         "opcode", [ConditionOpcode.CREATE_COIN_ANNOUNCEMENT, ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT]
     )
     def test_duplicate_coin_announces(self, opcode, softfork_height, benchmark_runner: BenchmarkRunner):
-        # with soft-fork3, we only allow 1024 create- or assert announcements
-        # per spend
-        if softfork_height >= test_constants.SOFT_FORK3_HEIGHT:
-            condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=1024)
-        else:
-            condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=5950000)
+        # we only allow 1024 create- or assert announcements per spend
+        condition = CREATE_ANNOUNCE_COND.format(opcode=opcode.value[0], num=1024)
 
         with benchmark_runner.assert_runtime(seconds=14):
             npc_result = generator_condition_tester(condition, quote=False, height=softfork_height)

--- a/tests/util/test_testnet_overrides.py
+++ b/tests/util/test_testnet_overrides.py
@@ -10,7 +10,6 @@ def test_testnet10() -> None:
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
         "SOFT_FORK2_HEIGHT": 3000000,
-        "SOFT_FORK3_HEIGHT": 2997292,
         "HARD_FORK_HEIGHT": 2997292,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 3061804,
@@ -21,7 +20,6 @@ def test_testnet10() -> None:
 
 def test_testnet10_existing() -> None:
     overrides: Dict[str, Any] = {
-        "SOFT_FORK3_HEIGHT": 42,
         "HARD_FORK_HEIGHT": 42,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 42,
@@ -31,7 +29,6 @@ def test_testnet10_existing() -> None:
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
         "SOFT_FORK2_HEIGHT": 3000000,
-        "SOFT_FORK3_HEIGHT": 42,
         "HARD_FORK_HEIGHT": 42,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 42,


### PR DESCRIPTION
### Purpose:

Apply the new rules to the entire chain, to simplify our code.

### Current Behavior:

Softfork-3 activates at height 4510000

### New Behavior:

Softfork-3 activates at height 0

### Test

[here](https://grafana.chiatechlab.com/d/oBgwkDI7z/blockchain-sync-tests?orgId=1&var-ref=enable-softfork3-unconditionally&var-repo=All&var-network=mainnet&var-network=testnet10&from=now-4d&to=now)

Main currently runs 6391 tests, with this patch we run 5227 tests (saving 1164 tests)