### PR TITLE
increase `tests.core.full_node` timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate matrix configuration
         id: configure
         run: |
-          python tests/build-job-matrix.py --per directory --verbose > matrix.json
+          python tests/build-job-matrix.py --per directory --verbose --only core/full_node --duplicates 50 > matrix.json
           cat matrix.json
           echo configuration=$(cat matrix.json) >> "$GITHUB_OUTPUT"
           echo matrix_mode=${{ ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate matrix configuration
         id: configure
         run: |
-          python tests/build-job-matrix.py --per directory --verbose --only core/full_node --duplicates 50 > matrix.json
+          python tests/build-job-matrix.py --per directory --verbose > matrix.json
           cat matrix.json
           echo configuration=$(cat matrix.json) >> "$GITHUB_OUTPUT"
           echo matrix_mode=${{ ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> "$GITHUB_OUTPUT"

--- a/tests/core/full_node/config.py
+++ b/tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 50
+job_timeout = 70
 checkout_blocks_and_plots = True

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2222,7 +2222,7 @@ async def test_long_reorg_nodes(
         p3 = full_node_3.full_node.blockchain.get_peak()
         return p1 == p3
 
-    await time_out_assert(1500, check_nodes_in_sync2)
+    await time_out_assert(2000, check_nodes_in_sync2)
 
     p1 = full_node_1.full_node.blockchain.get_peak()
     # p2 = full_node_2.full_node.blockchain.get_peak()

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2222,7 +2222,7 @@ async def test_long_reorg_nodes(
         p3 = full_node_3.full_node.blockchain.get_peak()
         return p1 == p3
 
-    await time_out_assert(1000, check_nodes_in_sync2)
+    await time_out_assert(1500, check_nodes_in_sync2)
 
     p1 = full_node_1.full_node.blockchain.get_peak()
     # p2 = full_node_2.full_node.blockchain.get_peak()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Avoid assert and job timeouts.  Work to actually improve the performance is being done in https://github.com/Chia-Network/chia-blockchain/pull/16594.  I am also, separately, working on instrumenting timeout asserts so we can readily view the runtimes on non-failed time out asserts and set this, and others, back to 'good' values.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

https://github.com/Chia-Network/chia-blockchain/actions/runs/6858144175/job/18648436913?pr=16824

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
