### PR TITLE
BUG create_data_layer_service does not respect wallet_peer config

### DIFF
--- a/chia/server/start_data_layer.py
+++ b/chia/server/start_data_layer.py
@@ -42,7 +42,7 @@ def create_data_layer_service(
     if downloaders is None:
         downloaders = []
     service_config = config[SERVICE_NAME]
-    self_hostname = config["self_hostname"]
+    wallet_hostname = service_config["wallet_peer"]["host"]
     wallet_rpc_port = service_config["wallet_peer"]["port"]
     if wallet_service is None:
         wallet_root_path = root_path
@@ -50,7 +50,7 @@ def create_data_layer_service(
     else:
         wallet_root_path = wallet_service.root_path
         wallet_config = wallet_service.config
-    wallet_rpc_init = WalletRpcClient.create(self_hostname, uint16(wallet_rpc_port), wallet_root_path, wallet_config)
+    wallet_rpc_init = WalletRpcClient.create(wallet_hostname, uint16(wallet_rpc_port), wallet_root_path, wallet_config)
 
     data_layer = DataLayer.create(
         config=service_config,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Allow data_layer service to use a remote wallet. I don't think this is the only step as I haven't had success making it connect yet but this is an obvious oversight and a necessary first step. 


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The `start_data_layer` function uses the `self_hostname` config when configuring its wallet rpc client. 

### New Behavior:

The `start_data_layer.create_data_layer_service` function uses the `[data_layer][wallet_peer][host]` config when configuring its wallet rpc client. By default this is `localhost` so won't change anything in practice for current usage. The very next line uses [data_layer][wallet_peer][port] so it must be the intent and safe.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
- Works fine when `[data_layer][wallet_peer][host]` is `localhost` (the default)
- I am unable to connect to a remote wallet so there may be more to look at.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
