### PR TITLE
add measured sizes for plot check

### DIFF
--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -138,6 +138,7 @@ class Cache:
                 cache_data: CacheDataV1 = CacheDataV1.from_bytes(stored_cache.blob)
                 self._data = {}
                 estimated_c2_sizes: Dict[int, int] = {}
+                measured_sizes: Dict[int, int] = {32: 738, 33: 1083, 34: 1771, 35: 3147, 36: 5899, 37: 11395, 38: 22395}
                 for path, cache_entry in cache_data.entries:
                     new_entry = CacheEntry(
                         DiskProver.from_bytes(cache_entry.prover_data),
@@ -160,7 +161,14 @@ class Cache:
                     # static data: version(2) + table pointers (<=96) + id(32) + k(1) => ~130
                     # path: up to ~1870, all above will lead to false positive.
                     # See https://github.com/Chia-Network/chiapos/blob/3ee062b86315823dd775453ad320b8be892c7df3/src/prover_disk.hpp#L282-L287  # noqa: E501
-                    if prover_size > (estimated_c2_sizes[k] + memo_size + 2000):
+
+                    # Use experimental measurements if more than estimates
+                    # https://github.com/Chia-Network/chia-blockchain/issues/16063 
+                    check_size = estimated_c2_sizes[k] + memo_size + 2000
+                    if k in measured_sizes:
+                        check_size = max(check_size, measured_sizes[k])
+
+                    if prover_size > check_size:
                         log.warning(
                             "Suspicious cache entry dropped. Recommended: stop the harvester, remove "
                             f"{self._path}, restart. Entry: size {prover_size}, path {path}"

--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -163,7 +163,7 @@ class Cache:
                     # See https://github.com/Chia-Network/chiapos/blob/3ee062b86315823dd775453ad320b8be892c7df3/src/prover_disk.hpp#L282-L287  # noqa: E501
 
                     # Use experimental measurements if more than estimates
-                    # https://github.com/Chia-Network/chia-blockchain/issues/16063 
+                    # https://github.com/Chia-Network/chia-blockchain/issues/16063
                     check_size = estimated_c2_sizes[k] + memo_size + 2000
                     if k in measured_sizes:
                         check_size = max(check_size, measured_sizes[k])


### PR DESCRIPTION
### Purpose:

Avoid flagging plots for bad file sizes

### Current Behavior:

Code uses estimates which are sometimes too low for large plots

### New Behavior:

Use measures sizes if larger than estimate

### Testing Notes:

Need to test with farm of varying plot k sizes. Should reduce the number of false positives but not flag additional plots
