### PR TITLE
Change -h to -k for --key flag for datalayer get_value cli command

### DIFF
--- a/chia/cmds/data.py
+++ b/chia/cmds/data.py
@@ -53,7 +53,7 @@ def create_changelist_option() -> Callable[[FC], FC]:
 
 def create_key_option() -> Callable[[FC], FC]:
     return click.option(
-        "-h",
+        "-k",
         "--key",
         "key_string",
         help="str representing the key",


### PR DESCRIPTION
### Purpose:
The `-h` flag is used everywhere in the Chia CLI to access the "help" and provide documentation.  In one place, the `chia data get_value` command, the `-h` flag is used for `--key` instead.  I could find no good reason for this to use `-h` instead of something else, so this pull request changes it to `-k`, which is more intuitive (to me at least) and restores the expected functionality of `-h` as the "help" flag. 

This is a breaking change for this one datalayer CLI command.  This is the only command in the Chia CLI that uses `create_key_option` so this only impacts `get_value`.  I did a basic search of Github for projects or scripts using `chia data get_value` and all of the returned projects use the `--key` flag instead of `-h`, so none of these should be impacted by the change.  With datalayer adoption still in the early days and usage beginning to ramp up, now is an opportune time to fix this poor user experience.  

### Current Behavior:
```
$ chia data get_value
Usage: chia data get_value [OPTIONS]
Try 'chia data get_value -h' for help.
```

```
$ chia data get_value -h
Error: Option '-h' requires an argument.
```

😡

```
chia data get_value --id xxxxxxxxx -h xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

### New Behavior:
```
$ chia data get_value -h
Usage: chia data get_value [OPTIONS]

  Get the value for a given key and store

Options:
  -store, --id TEXT             The hexadecimal store id.  [required]
  -k, --key TEXT                str representing the key  [required]
  -r, --root_hash TEXT          The hexadecimal root hash
  -dp, --data-rpc-port INTEGER  Set the port where the data layer is hosting
                                the RPC interface. See rpc_port under wallet
                                in config.yaml
  -f, --fingerprint INTEGER     Fingerprint of the wallet to use
  --help                        Show this message and exit.
```
  
  
  
```
chia data get_value --id xxxxxxxxx -k xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```


### Testing Notes:
No additional tests written
