### PR TITLE
avoid redundant list->set and set->list conversions

### DIFF
--- a/benchmarks/coin_store.py
+++ b/benchmarks/coin_store.py
@@ -74,7 +74,7 @@ async def run_new_block_benchmark(version: int) -> None:
             await coin_store.new_block(
                 uint32(height),
                 uint64(timestamp),
-                {pool_coin, farmer_coin},
+                [pool_coin, farmer_coin],
                 additions,
                 removals,
             )
@@ -114,7 +114,7 @@ async def run_new_block_benchmark(version: int) -> None:
             await coin_store.new_block(
                 uint32(height),
                 uint64(timestamp),
-                {pool_coin, farmer_coin},
+                [pool_coin, farmer_coin],
                 additions,
                 removals,
             )
@@ -164,7 +164,7 @@ async def run_new_block_benchmark(version: int) -> None:
             await coin_store.new_block(
                 uint32(height),
                 uint64(timestamp),
-                {pool_coin, farmer_coin},
+                [pool_coin, farmer_coin],
                 additions,
                 removals,
             )
@@ -212,7 +212,7 @@ async def run_new_block_benchmark(version: int) -> None:
             await coin_store.new_block(
                 uint32(height),
                 uint64(timestamp),
-                {pool_coin, farmer_coin},
+                [pool_coin, farmer_coin],
                 additions,
                 removals,
             )

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -542,7 +542,7 @@ class Blockchain(BlockchainInterface):
                 await self.block_store.set_in_chain([(block_record.header_hash,)])
                 await self.block_store.set_peak(block_record.header_hash)
                 return [block_record], StateChangeSummary(
-                    block_record, uint32(0), [], [], [], list(block.get_included_reward_coins())
+                    block_record, uint32(0), [], [], [], block.get_included_reward_coins()
                 )
             return [], None
 

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import sqlite3
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Collection, Dict, List, Optional, Set, Tuple
 
 import typing_extensions
 from aiosqlite import Cursor
@@ -81,8 +81,8 @@ class CoinStore:
         self,
         height: uint32,
         timestamp: uint64,
-        included_reward_coins: List[Coin],
-        tx_additions: List[Coin],
+        included_reward_coins: Collection[Coin],
+        tx_additions: Collection[Coin],
         tx_removals: List[bytes32],
     ) -> List[CoinRecord]:
         """

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -81,7 +81,7 @@ class CoinStore:
         self,
         height: uint32,
         timestamp: uint64,
-        included_reward_coins: Set[Coin],
+        included_reward_coins: List[Coin],
         tx_additions: List[Coin],
         tx_removals: List[bytes32],
     ) -> List[CoinRecord]:

--- a/chia/types/full_block.py
+++ b/chia/types/full_block.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Set
+from typing import List, Optional
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.foliage import Foliage, FoliageTransactionBlock, TransactionsInfo
@@ -56,11 +56,11 @@ class FullBlock(Streamable):
     def is_transaction_block(self) -> bool:
         return self.foliage_transaction_block is not None
 
-    def get_included_reward_coins(self) -> Set[Coin]:
+    def get_included_reward_coins(self) -> List[Coin]:
         if not self.is_transaction_block():
-            return set()
+            return []
         assert self.transactions_info is not None
-        return set(self.transactions_info.reward_claims_incorporated)
+        return self.transactions_info.reward_claims_incorporated
 
     def is_fully_compactified(self) -> bool:
         for sub_slot in self.finished_sub_slots:

--- a/chia/util/generator_tools.py
+++ b/chia/util/generator_tools.py
@@ -16,7 +16,7 @@ from chia.util.ints import uint64
 def get_block_header(block: FullBlock, tx_addition_coins: List[Coin], removals_names: List[bytes32]) -> HeaderBlock:
     # Create filter
     byte_array_tx: List[bytearray] = []
-    addition_coins = tx_addition_coins + list(block.get_included_reward_coins())
+    addition_coins = tx_addition_coins + block.get_included_reward_coins()
     if block.is_transaction_block():
         for coin in addition_coins:
             byte_array_tx.append(bytearray(coin.puzzle_hash))

--- a/chia/util/generator_tools.py
+++ b/chia/util/generator_tools.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import Collection, List, Optional, Tuple
 
 from chiabip158 import PyBIP158
 
@@ -13,12 +13,15 @@ from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.ints import uint64
 
 
-def get_block_header(block: FullBlock, tx_addition_coins: List[Coin], removals_names: List[bytes32]) -> HeaderBlock:
+def get_block_header(
+    block: FullBlock, tx_addition_coins: Collection[Coin], removals_names: Collection[bytes32]
+) -> HeaderBlock:
     # Create filter
     byte_array_tx: List[bytearray] = []
-    addition_coins = tx_addition_coins + block.get_included_reward_coins()
     if block.is_transaction_block():
-        for coin in addition_coins:
+        for coin in tx_addition_coins:
+            byte_array_tx.append(bytearray(coin.puzzle_hash))
+        for coin in block.get_included_reward_coins():
             byte_array_tx.append(bytearray(coin.puzzle_hash))
         for name in removals_names:
             byte_array_tx.append(bytearray(name))

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -1816,7 +1816,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx1: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         coin1: Coin = tx1.additions()[0]
 
@@ -1951,7 +1951,7 @@ class TestBodyValidation:
 
             conditions = {opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)])]}
 
-            coin = list(blocks[-1].get_included_reward_coins())[0]
+            coin = blocks[-1].get_included_reward_coins()[0]
             tx: SpendBundle = wt.generate_signed_transaction(
                 10, wt.get_new_puzzlehash(), coin, condition_dic=conditions
             )
@@ -2035,7 +2035,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx1: SpendBundle = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         coin1: Coin = tx1.additions()[0]
         secret_key = wt.get_private_key_for_puzzle_hash(coin1.puzzle_hash)
@@ -2156,7 +2156,7 @@ class TestBodyValidation:
             }
 
             tx1: SpendBundle = wt.generate_signed_transaction(
-                10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+                10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
             )
             coin1: Coin = tx1.additions()[0]
             tx2: SpendBundle = wt.generate_signed_transaction(
@@ -2382,7 +2382,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -2442,7 +2442,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, blocks[-1])
         wt: WalletTool = bt.get_pool_wallet_tool()
         tx: SpendBundle = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, guarantee_transaction_block=False)
         for block in blocks[-5:]:
@@ -2537,7 +2537,7 @@ class TestBodyValidation:
             condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0], condition_dic=condition_dict
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0], condition_dic=condition_dict
         )
 
         blocks = bt.get_consecutive_blocks(
@@ -2583,7 +2583,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
         blocks = bt.get_consecutive_blocks(
@@ -2709,7 +2709,7 @@ class TestBodyValidation:
         #     tx: SpendBundle = wt.generate_signed_transaction_multiple_coins(
         #         10,
         #         wt.get_new_puzzlehash(),
-        #         list(blocks[1].get_included_reward_coins()),
+        #         blocks[1].get_included_reward_coins(),
         #         condition_dic=condition_dict,
         #     )
         #     with pytest.raises(Exception):
@@ -2735,7 +2735,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
         blocks = bt.get_consecutive_blocks(
@@ -2784,7 +2784,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
         blocks = bt.get_consecutive_blocks(
@@ -2823,7 +2823,7 @@ class TestBodyValidation:
             condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0], condition_dic=condition_dict
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0], condition_dic=condition_dict
         )
 
         blocks = bt.get_consecutive_blocks(
@@ -2848,10 +2848,10 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         tx_2: SpendBundle = wt.generate_signed_transaction(
-            11, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            11, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         agg = SpendBundle.aggregate([tx, tx_2])
 
@@ -2877,7 +2877,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
         blocks = bt.get_consecutive_blocks(
@@ -2886,7 +2886,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, blocks[-1])
 
         tx_2: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-2].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-2].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx_2
@@ -2911,7 +2911,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -3002,7 +3002,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        spend = list(blocks[-1].get_included_reward_coins())[0]
+        spend = blocks[-1].get_included_reward_coins()[0]
         print("spend=", spend)
         # this create coin will spend all of the coin, so the 10 mojos below
         # will be "minted".
@@ -3041,7 +3041,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
         blocks = bt.get_consecutive_blocks(
@@ -3082,7 +3082,7 @@ class TestBodyValidation:
         wt: WalletTool = bt.get_pool_wallet_tool()
 
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -3326,7 +3326,7 @@ class TestReorgs:
 
         spend_block = blocks[10]
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
         spend_bundle = wallet_a.generate_signed_transaction(1000, receiver_puzzlehash, spend_coin)
@@ -3370,7 +3370,7 @@ class TestReorgs:
         await _validate_and_add_block(b, blocks[2])
         wt: WalletTool = bt.get_pool_wallet_tool()
         tx: SpendBundle = wt.generate_signed_transaction(
-            10, wt.get_new_puzzlehash(), list(blocks[2].get_included_reward_coins())[0]
+            10, wt.get_new_puzzlehash(), blocks[2].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
             1,
@@ -3420,7 +3420,7 @@ async def test_reorg_new_ref(empty_blockchain, bt):
 
     all_coins = []
     for spend_block in blocks[:5]:
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 all_coins.append(coin)
     spend_bundle_0 = wallet_a.generate_signed_transaction(1000, receiver_puzzlehash, all_coins.pop())
@@ -3500,7 +3500,7 @@ async def test_reorg_stale_fork_height(empty_blockchain, bt):
 
     all_coins = []
     for spend_block in blocks:
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 all_coins.append(coin)
 
@@ -3555,7 +3555,7 @@ async def test_chain_failed_rollback(empty_blockchain, bt):
 
     all_coins = []
     for spend_block in blocks[:10]:
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 all_coins.append(coin)
 
@@ -3604,7 +3604,7 @@ async def test_reorg_flip_flop(empty_blockchain, bt):
 
     all_coins = []
     for spend_block in chain_a:
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 all_coins.append(coin)
 

--- a/tests/blockchain/test_blockchain_transactions.py
+++ b/tests/blockchain/test_blockchain_transactions.py
@@ -49,7 +49,7 @@ class TestBlockchainTransactions:
 
         spend_block = blocks[2]
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
 
@@ -113,7 +113,7 @@ class TestBlockchainTransactions:
 
         spend_block = blocks[2]
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
         assert spend_coin is not None
@@ -154,7 +154,7 @@ class TestBlockchainTransactions:
         spend_block = blocks[2]
 
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
         assert spend_coin is not None
@@ -193,7 +193,7 @@ class TestBlockchainTransactions:
         spend_block = blocks[2]
 
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
         assert spend_coin is not None
@@ -304,7 +304,7 @@ class TestBlockchainTransactions:
         spend_block = blocks[2]
 
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
 
@@ -399,7 +399,7 @@ class TestBlockchainTransactions:
 
         spend_block = new_blocks[-1]
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
         assert spend_coin is not None
@@ -434,7 +434,7 @@ class TestBlockchainTransactions:
 
         spend_block = blocks[-1]
         spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
         assert spend_coin is not None
@@ -491,11 +491,11 @@ class TestBlockchainTransactions:
         bad_block = blocks[3]
         spend_coin = None
         bad_spend_coin = None
-        for coin in list(spend_block.get_included_reward_coins()):
+        for coin in spend_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin = coin
         assert spend_coin is not None
-        for coin in list(bad_block.get_included_reward_coins()):
+        for coin in bad_block.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 bad_spend_coin = coin
         assert bad_spend_coin is not None
@@ -563,11 +563,11 @@ class TestBlockchainTransactions:
 
         spend_coin_block_1 = None
         spend_coin_block_2 = None
-        for coin in list(block1.get_included_reward_coins()):
+        for coin in block1.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_1 = coin
         assert spend_coin_block_1 is not None
-        for coin in list(block2.get_included_reward_coins()):
+        for coin in block2.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_2 = coin
         assert spend_coin_block_2 is not None
@@ -647,11 +647,11 @@ class TestBlockchainTransactions:
 
         spend_coin_block_1 = None
         spend_coin_block_2 = None
-        for coin in list(block1.get_included_reward_coins()):
+        for coin in block1.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_1 = coin
         assert spend_coin_block_1 is not None
-        for coin in list(block2.get_included_reward_coins()):
+        for coin in block2.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_2 = coin
         assert spend_coin_block_2 is not None
@@ -728,7 +728,7 @@ class TestBlockchainTransactions:
         # Coinbase that gets spent
         block1 = blocks[2]
         spend_coin_block_1 = None
-        for coin in list(block1.get_included_reward_coins()):
+        for coin in block1.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_1 = coin
         assert spend_coin_block_1 is not None
@@ -794,7 +794,7 @@ class TestBlockchainTransactions:
         # Coinbase that gets spent
         block1 = blocks[2]
         spend_coin_block_1 = None
-        for coin in list(block1.get_included_reward_coins()):
+        for coin in block1.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_1 = coin
         assert spend_coin_block_1 is not None
@@ -862,7 +862,7 @@ class TestBlockchainTransactions:
         # Coinbase that gets spent
         block1 = blocks[2]
         spend_coin_block_1 = None
-        for coin in list(block1.get_included_reward_coins()):
+        for coin in block1.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_1 = coin
         assert spend_coin_block_1 is not None
@@ -934,7 +934,7 @@ class TestBlockchainTransactions:
         # Coinbase that gets spent
         block1 = blocks[2]
         spend_coin_block_1 = None
-        for coin in list(block1.get_included_reward_coins()):
+        for coin in block1.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_1 = coin
         assert spend_coin_block_1 is not None
@@ -1008,7 +1008,7 @@ class TestBlockchainTransactions:
         # Coinbase that gets spent
         block1 = blocks[2]
         spend_coin_block_1 = None
-        for coin in list(block1.get_included_reward_coins()):
+        for coin in block1.get_included_reward_coins():
             if coin.puzzle_hash == coinbase_puzzlehash:
                 spend_coin_block_1 = coin
         assert spend_coin_block_1 is not None

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -105,7 +105,7 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
                 else:
                     tx_removals, tx_additions = [], []
 
-                assert block.get_included_reward_coins() == should_be_included_prev
+                assert set(block.get_included_reward_coins()) == should_be_included_prev
 
                 if block.is_transaction_block():
                     assert block.foliage_transaction_block is not None

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -109,7 +109,7 @@ async def check_conditions(
     spend_reward_index: int = -2,
 ) -> Tuple[List[CoinRecord], List[CoinRecord], FullBlock]:
     blocks = await initial_blocks(bt)
-    coin = list(blocks[spend_reward_index].get_included_reward_coins())[0]
+    coin = blocks[spend_reward_index].get_included_reward_coins()[0]
 
     coin_spend = CoinSpend(coin, EASY_PUZZLE, SerializedProgram.from_program(condition_solution))
     spend_bundle = SpendBundle([coin_spend], G2Element())
@@ -281,7 +281,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_invalid_my_id(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = list(blocks[-2].get_included_reward_coins())[0]
+        coin = blocks[-2].get_included_reward_coins()[0]
         wrong_name = bytearray(coin.name())
         wrong_name[-1] ^= 1
         conditions = Program.to(
@@ -294,7 +294,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_valid_my_id(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = list(blocks[-2].get_included_reward_coins())[0]
+        coin = blocks[-2].get_included_reward_coins()[0]
         conditions = Program.to(
             assemble(
                 f"(({ConditionOpcode.ASSERT_MY_COIN_ID[0]} 0x{coin.name().hex()}))"
@@ -305,7 +305,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_invalid_coin_announcement(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = list(blocks[-2].get_included_reward_coins())[0]
+        coin = blocks[-2].get_included_reward_coins()[0]
         announce = Announcement(coin.name(), b"test_bad")
         conditions = Program.to(
             assemble(
@@ -318,7 +318,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_valid_coin_announcement(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = list(blocks[-2].get_included_reward_coins())[0]
+        coin = blocks[-2].get_included_reward_coins()[0]
         announce = Announcement(coin.name(), b"test")
         conditions = Program.to(
             assemble(
@@ -389,7 +389,7 @@ class TestConditions:
         """
 
         blocks = await initial_blocks(bt)
-        coin = list(blocks[-2].get_included_reward_coins())[0]
+        coin = blocks[-2].get_included_reward_coins()[0]
         coin_announcement = Announcement(coin.name(), b"test")
         puzzle_announcement = Announcement(EASY_PUZZLE_HASH, b"test")
 

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -771,7 +771,7 @@ class TestFullNodeProtocol:
         )
         await full_node_1.full_node.add_block(blocks[-2])
         await full_node_1.full_node.add_block(blocks[-1])
-        coin_to_spend = list(blocks[-1].get_included_reward_coins())[0]
+        coin_to_spend = blocks[-1].get_included_reward_coins()[0]
 
         spend_bundle = wallet_a.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend)
 
@@ -1085,7 +1085,7 @@ class TestFullNodeProtocol:
         receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
 
         spend_bundle = wallet_a.generate_signed_transaction(
-            100, receiver_puzzlehash, list(blocks[-1].get_included_reward_coins())[0]
+            100, receiver_puzzlehash, blocks[-1].get_included_reward_coins()[0]
         )
         assert spend_bundle is not None
         respond_transaction = fnp.RespondTransaction(spend_bundle)
@@ -1136,7 +1136,7 @@ class TestFullNodeProtocol:
         spend_bundle = wallet_a.generate_signed_transaction(
             100000000000000,
             receiver_puzzlehash,
-            list(blocks_new[-1].get_included_reward_coins())[0],
+            blocks_new[-1].get_included_reward_coins()[0],
         )
 
         assert spend_bundle is not None
@@ -1162,7 +1162,7 @@ class TestFullNodeProtocol:
         spend_bundle = wallet_a.generate_signed_transaction(
             1123,
             wallet_receiver.get_new_puzzlehash(),
-            list(blocks[-1].get_included_reward_coins())[0],
+            blocks[-1].get_included_reward_coins()[0],
         )
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=spend_bundle
@@ -1206,7 +1206,7 @@ class TestFullNodeProtocol:
         spend_bundle = wallet_a.generate_signed_transaction(
             1123,
             wallet_receiver.get_new_puzzlehash(),
-            list(blocks[-1].get_included_reward_coins())[0],
+            blocks[-1].get_included_reward_coins()[0],
         )
         blocks_t = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=spend_bundle
@@ -1447,7 +1447,7 @@ class TestFullNodeProtocol:
             await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(ph))
         blocks: List[FullBlock] = await full_node_1.get_all_full_blocks()
 
-        coin = list(blocks[-1].get_included_reward_coins())[0]
+        coin = blocks[-1].get_included_reward_coins()[0]
         tx: SpendBundle = wallet_a.generate_signed_transaction(10000, wallet_receiver.get_new_puzzlehash(), coin)
 
         blocks = bt.get_consecutive_blocks(

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -359,7 +359,7 @@ async def next_block(full_node_1, wallet_a, bt) -> Coin:
         await full_node_1.full_node.add_block(block)
 
     await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 1)
-    return list(blocks[-1].get_included_reward_coins())[0]
+    return blocks[-1].get_included_reward_coins()[0]
 
 
 co = ConditionOpcode
@@ -522,7 +522,7 @@ class TestMempoolManager:
             await full_node_1.full_node.add_block(block)
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
-        spend_bundle1 = generate_test_spend_bundle(wallet_a, list(blocks[-1].get_included_reward_coins())[0])
+        spend_bundle1 = generate_test_spend_bundle(wallet_a, blocks[-1].get_included_reward_coins()[0])
 
         assert spend_bundle1 is not None
         tx1: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle1)
@@ -532,7 +532,7 @@ class TestMempoolManager:
 
         spend_bundle2 = generate_test_spend_bundle(
             wallet_a,
-            list(blocks[-1].get_included_reward_coins())[0],
+            blocks[-1].get_included_reward_coins()[0],
             new_puzzle_hash=BURN_PUZZLE_HASH_2,
         )
         assert spend_bundle2 is not None
@@ -741,8 +741,8 @@ class TestMempoolManager:
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
-        coin_1 = list(blocks[-2].get_included_reward_coins())[0]
-        coin_2 = list(blocks[-1].get_included_reward_coins())[0]
+        coin_1 = blocks[-2].get_included_reward_coins()[0]
+        coin_2 = blocks[-1].get_included_reward_coins()[0]
 
         bundle = test_fun(coin_1, coin_2)
 
@@ -1604,9 +1604,9 @@ class TestMempoolManager:
 
         fee = 9
 
-        coin_1 = list(blocks[-2].get_included_reward_coins())[0]
+        coin_1 = blocks[-2].get_included_reward_coins()[0]
         coin_2 = None
-        for coin in list(blocks[-1].get_included_reward_coins()):
+        for coin in blocks[-1].get_included_reward_coins():
             if coin.amount == coin_1.amount:
                 coin_2 = coin
         spend_bundle1 = generate_test_spend_bundle(wallet_a, coin_1, dic, uint64(fee))
@@ -1650,7 +1650,7 @@ class TestMempoolManager:
             await full_node_1.full_node.add_block(block)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
-        # coin = list(blocks[-1].get_included_reward_coins())[0]
+        # coin = blocks[-1].get_included_reward_coins()[0]
         # spend_bundle1 = generate_test_spend_bundle(wallet_a, coin)
         coin = await next_block(full_node_1, wallet_a, bt)
         spend_bundle1 = generate_test_spend_bundle(wallet_a, coin)
@@ -1697,7 +1697,7 @@ class TestMempoolManager:
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         coin = await next_block(full_node_1, wallet_a, bt)
-        # coin = list(blocks[-1].get_included_reward_coins())[0]
+        # coin = blocks[-1].get_included_reward_coins()[0]
         spend_bundle_0 = generate_test_spend_bundle(wallet_a, coin)
         unsigned: List[CoinSpend] = spend_bundle_0.coin_spends
 
@@ -2648,7 +2648,7 @@ class TestMaliciousGenerators:
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
 
-        spend_bundle = generate_test_spend_bundle(wallet_a, list(blocks[-1].get_included_reward_coins())[0])
+        spend_bundle = generate_test_spend_bundle(wallet_a, blocks[-1].get_included_reward_coins()[0])
         cs = spend_bundle.coin_spends[0]
         c = cs.coin
         coin_0 = Coin(c.parent_coin_info, bytes32([1] * 32), c.amount)

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -23,7 +23,7 @@ async def test_basic_filter_test(simulator_and_wallet):
     for i in range(1, num_blocks):
         byte_array_tx: List[bytes] = []
         block = blocks[i]
-        coins = list(block.get_included_reward_coins())
+        coins = block.get_included_reward_coins()
         coin_0 = bytearray(coins[0].puzzle_hash)
         coin_1 = bytearray(coins[1].puzzle_hash)
         byte_array_tx.append(coin_0)

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -97,6 +97,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
 
         assert (await client.get_block_record_by_height(100)) is None
 
+        # TODO: Understand why the list(set()) is required to make this work and address it.  This shouldn't be needed.
         ph = list(set(blocks[-1].get_included_reward_coins()))[0].puzzle_hash
         coins = await client.get_coin_records_by_puzzle_hash(ph)
         print(coins)

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -97,19 +97,19 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
 
         assert (await client.get_block_record_by_height(100)) is None
 
-        ph = list(blocks[-1].get_included_reward_coins())[0].puzzle_hash
+        ph = list(set(blocks[-1].get_included_reward_coins()))[0].puzzle_hash
         coins = await client.get_coin_records_by_puzzle_hash(ph)
         print(coins)
         assert len(coins) >= 1
 
-        pid = list(blocks[-1].get_included_reward_coins())[0].parent_coin_info
-        pid_2 = list(blocks[-1].get_included_reward_coins())[1].parent_coin_info
+        pid = list(set(blocks[-1].get_included_reward_coins()))[0].parent_coin_info
+        pid_2 = list(set(blocks[-1].get_included_reward_coins()))[1].parent_coin_info
         coins = await client.get_coin_records_by_parent_ids([pid, pid_2])
         print(coins)
         assert len(coins) == 2
 
-        name = list(blocks[-1].get_included_reward_coins())[0].name()
-        name_2 = list(blocks[-1].get_included_reward_coins())[1].name()
+        name = list(set(blocks[-1].get_included_reward_coins()))[0].name()
+        name_2 = list(set(blocks[-1].get_included_reward_coins()))[1].name()
         coins = await client.get_coin_records_by_names([name, name_2])
         print(coins)
         assert len(coins) == 2
@@ -137,7 +137,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
         assert len(await client.get_coin_records_by_puzzle_hash(ph)) == 2
         assert len(await client.get_coin_records_by_puzzle_hash(ph_receiver)) == 0
 
-        coin_to_spend = list(blocks[-1].get_included_reward_coins())[0]
+        coin_to_spend = list(set(blocks[-1].get_included_reward_coins()))[0]
 
         spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend)
 
@@ -163,7 +163,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
         assert (await client.get_coin_record_by_name(coin.name())) is None
 
         # Verify that the include_pending arg to get_mempool_item_by_tx_id works
-        coin_to_spend_pending = list(blocks[-1].get_included_reward_coins())[1]
+        coin_to_spend_pending = list(set(blocks[-1].get_included_reward_coins()))[1]
         ahr = ConditionOpcode.ASSERT_HEIGHT_RELATIVE  # to force pending/potential
         condition_dic = {ahr: [ConditionWithArgs(ahr, [int_to_bytes(100)])]}
         spend_bundle_pending = wallet.generate_signed_transaction(
@@ -358,7 +358,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
             state = await client.get_blockchain_state()
             block = await client.get_block(state["peak"].header_hash)
 
-            coin_to_spend = list(block.get_included_reward_coins())[0]
+            coin_to_spend = list(set(block.get_included_reward_coins()))[0]
 
             spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_2, coin_to_spend, memo=memo)
             await client.push_tx(spend_bundle)
@@ -727,7 +727,7 @@ async def test_coin_name_found_in_mempool(one_node, self_hostname):
         # empty mempool
         assert len(await client.get_all_mempool_items()) == 0
 
-        coin_to_spend = list(blocks[-1].get_included_reward_coins())[0]
+        coin_to_spend = list(set(blocks[-1].get_included_reward_coins()))[0]
         spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend)
         await client.push_tx(spend_bundle)
 


### PR DESCRIPTION
### Purpose:

`get_included_reward_coins()` constructs a `set` to return. Most call sites then convert it back to a list (at least in tests). But even in the consensus code, we never take advantage of this being a set. We just iterate over it.

This patch makes `get_included_reward_coins()` just return the list of reward coins (which is a member of `FullBlock`), and removes conversions to `list` which are now redundant.

It also changes the parameter type of `CoinStore.new_block()` to take a list instead of a set.

### Current Behavior:

we create a (redundant) set every time we call `get_included_reward_coins()` and we mostly convert it back into a list immediately.

### New Behavior:

We avoid constructing a temporary set + list when we call `get_included_reward_coins()`
