### PR TITLE
Return TX records from offer creation endpoints

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -1155,7 +1155,7 @@ class DataLayerWallet:
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
-    ) -> Offer:
+    ) -> Tuple[Offer, List[TransactionRecord]]:
         dl_wallet = None
         for wallet in wallet_state_manager.wallets.values():
             if wallet.type() == WalletType.DATA_LAYER.value:
@@ -1167,6 +1167,7 @@ class DataLayerWallet:
         offered_launchers: List[bytes32] = [k for k, v in offer_dict.items() if v < 0 and k is not None]
         fee_left_to_pay: uint64 = fee
         all_bundles: List[SpendBundle] = []
+        all_transactions: List[TransactionRecord] = []
         for launcher in offered_launchers:
             try:
                 this_solver: Solver = solver[launcher.hex()]
@@ -1212,7 +1213,16 @@ class DataLayerWallet:
                 txs[0].spend_bundle,
                 coin_spends=all_other_spends,
             )
-            all_bundles.append(SpendBundle.aggregate([signed_bundle, new_bundle]))
+            agg_bundle: SpendBundle = SpendBundle.aggregate([signed_bundle, new_bundle])
+            all_bundles.append(agg_bundle)
+            all_transactions.append(
+                dataclasses.replace(
+                    txs[0],
+                    spend_bundle=agg_bundle,
+                    name=agg_bundle.name(),
+                )
+            )
+            all_transactions.extend(txs[1:])
 
         # create some dummy requested payments
         requested_payments = {
@@ -1220,7 +1230,7 @@ class DataLayerWallet:
             for k, v in offer_dict.items()
             if v > 0
         }
-        return Offer(requested_payments, SpendBundle.aggregate(all_bundles), driver_dict)
+        return Offer(requested_payments, SpendBundle.aggregate(all_bundles), driver_dict), all_transactions
 
     @staticmethod
     async def finish_graftroot_solutions(offer: Offer, solver: Solver) -> Offer:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1843,10 +1843,11 @@ class WalletRpcApi:
                 extra_conditions=extra_conditions,
             )
         if result[0]:
-            success, trade_record, error = result
+            success, trade_record, tx_records, error = result
             return {
                 "offer": Offer.from_bytes(trade_record.offer).to_bech32(),
                 "trade_record": trade_record.to_json_dict_convenience(),
+                "transactions": [tx.to_json_dict_convenience(self.service.config) for tx in tx_records],
             }
         raise ValueError(result[2])
 

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -796,7 +796,7 @@ class NFTWallet:
         tx_config: TXConfig,
         fee: uint64,
         extra_conditions: Tuple[Condition, ...],
-    ) -> Offer:
+    ) -> Tuple[Offer, List[TransactionRecord]]:
         # First, let's take note of all the royalty enabled NFTs
         royalty_nft_asset_dict: Dict[bytes32, int] = {}
         for asset, amount in offer_dict.items():
@@ -1089,7 +1089,7 @@ class NFTWallet:
         txs_bundle = SpendBundle.aggregate([tx.spend_bundle for tx in all_transactions if tx.spend_bundle is not None])
         aggregate_bundle = SpendBundle.aggregate([txs_bundle, *additional_bundles])
         offer = Offer(notarized_payments, aggregate_bundle, driver_dict)
-        return offer
+        return offer, all_transactions
 
     async def set_bulk_nft_did(
         self,

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -442,7 +442,7 @@ async def test_cat_trades(
     taker_unused_index = taker_unused_dr.index
     # Execute all of the trades
     # chia_for_cat
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         chia_for_cat, wallet_environments.tx_config, fee=uint64(1)
     )
     assert error is None
@@ -650,7 +650,7 @@ async def test_cat_trades(
     )
 
     # cat_for_chia
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         cat_for_chia, wallet_environments.tx_config
     )
     assert error is None
@@ -768,7 +768,7 @@ async def test_cat_trades(
     )
     assert taker_unused_dr is not None
     taker_unused_index = taker_unused_dr.index
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         cat_for_cat, wallet_environments.tx_config
     )
     assert error is None
@@ -954,7 +954,7 @@ async def test_cat_trades(
         assert taker_unused_index < taker_unused_dr.index
 
     # chia_for_multiple_cat
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         chia_for_multiple_cat,
         wallet_environments.tx_config,
         driver_dict=driver_dict,
@@ -1196,7 +1196,7 @@ async def test_cat_trades(
         )
 
     # multiple_cat_for_chia
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         multiple_cat_for_chia,
         wallet_environments.tx_config,
     )
@@ -1321,7 +1321,7 @@ async def test_cat_trades(
     await time_out_assert(15, get_trade_and_status, TradeStatus.CONFIRMED, trade_manager_taker, trade_take)
 
     # chia_and_cat_for_cat
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         chia_and_cat_for_cat,
         wallet_environments.tx_config,
     )
@@ -1563,7 +1563,7 @@ class TestCATTrades:
             trade_rec = await trade_manager.get_trade_by_id(trade.trade_id)
             return TradeStatus(trade_rec.status)
 
-        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(cat_for_chia, DEFAULT_TX_CONFIG)
+        success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(cat_for_chia, DEFAULT_TX_CONFIG)
         assert error is None
         assert success is True
         assert trade_make is not None
@@ -1623,7 +1623,7 @@ class TestCATTrades:
             await trade_manager_taker.respond_to_offer(Offer.from_bytes(trade_make.offer), peer, DEFAULT_TX_CONFIG)
 
         # Now we're going to create the other way around for test coverage sake
-        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
+        success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
         assert error is None
         assert success is True
         assert trade_make is not None
@@ -1684,7 +1684,7 @@ class TestCATTrades:
             trade_rec = await trade_manager.get_trade_by_id(trade.trade_id)
             return TradeStatus(trade_rec.status)
 
-        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
+        success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
         await time_out_assert(10, get_trade_and_status, TradeStatus.PENDING_ACCEPT, trade_manager_maker, trade_make)
         assert error is None
         assert success is True
@@ -1743,7 +1743,7 @@ class TestCATTrades:
                 return TradeStatus(trade_rec.status)
             raise ValueError("Couldn't find the trade record")
 
-        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
+        success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
         await time_out_assert(10, get_trade_and_status, TradeStatus.PENDING_ACCEPT, trade_manager_maker, trade_make)
         assert error is None
         assert success is True
@@ -1806,7 +1806,7 @@ class TestCATTrades:
                 return TradeStatus(trade_rec.status)
             raise ValueError("Couldn't find the trade record")
 
-        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
+        success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
         await time_out_assert(30, get_trade_and_status, TradeStatus.PENDING_ACCEPT, trade_manager_maker, trade_make)
         assert error is None
         assert success is True
@@ -1871,7 +1871,7 @@ class TestCATTrades:
                 return TradeStatus(trade_rec.status)
             raise ValueError("Couldn't find the trade record")
 
-        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
+        success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
         await time_out_assert(10, get_trade_and_status, TradeStatus.PENDING_ACCEPT, trade_manager_maker, trade_make)
         assert error is None
         assert success is True

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -1931,12 +1931,16 @@ class TestCATTrades:
                 return TradeStatus(trade_rec.status)
             raise ValueError("Couldn't find the trade record")  # pragma: no cover
 
-        success, trade_make_1, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, DEFAULT_TX_CONFIG)
+        success, trade_make_1, _, error = await trade_manager_maker.create_offer_for_ids(
+            chia_for_cat, DEFAULT_TX_CONFIG
+        )
         await time_out_assert(10, get_trade_and_status, TradeStatus.PENDING_ACCEPT, trade_manager_maker, trade_make_1)
         assert error is None
         assert success is True
         assert trade_make_1 is not None
-        success, trade_make_2, error = await trade_manager_maker.create_offer_for_ids(cat_for_chia, DEFAULT_TX_CONFIG)
+        success, trade_make_2, _, error = await trade_manager_maker.create_offer_for_ids(
+            cat_for_chia, DEFAULT_TX_CONFIG
+        )
         await time_out_assert(10, get_trade_and_status, TradeStatus.PENDING_ACCEPT, trade_manager_maker, trade_make_2)
         assert error is None
         assert success is True

--- a/tests/wallet/db_wallet/test_dl_offers.py
+++ b/tests/wallet/db_wallet/test_dl_offers.py
@@ -104,7 +104,7 @@ async def test_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
 
     fee = uint64(2_000_000_000_000)
 
-    success, offer_maker, error = await trade_manager_maker.create_offer_for_ids(
+    success, offer_maker, _, error = await trade_manager_maker.create_offer_for_ids(
         {launcher_id_maker: -1, launcher_id_taker: 1},
         DEFAULT_TX_CONFIG,
         solver=Solver(
@@ -266,7 +266,7 @@ async def test_dl_offer_cancellation(wallets_prefarm: Any, trusted: bool) -> Non
     ROWS.append(addition)
     root, proofs = build_merkle_tree(ROWS)
 
-    success, offer, error = await trade_manager.create_offer_for_ids(
+    success, offer, _, error = await trade_manager.create_offer_for_ids(
         {launcher_id: -1, launcher_id_2: 1},
         DEFAULT_TX_CONFIG,
         solver=Solver(
@@ -386,7 +386,7 @@ async def test_multiple_dl_offers(wallets_prefarm: Any, trusted: bool) -> None:
 
     fee = uint64(2_000_000_000_000)
 
-    success, offer_maker, error = await trade_manager_maker.create_offer_for_ids(
+    success, offer_maker, _, error = await trade_manager_maker.create_offer_for_ids(
         {launcher_id_maker_1: -1, launcher_id_taker_1: 1, launcher_id_maker_2: -1, launcher_id_taker_2: 1},
         DEFAULT_TX_CONFIG,
         solver=Solver(

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -169,7 +169,7 @@ async def test_nft_offer_sell_nft(
 
     offer_did_nft_for_xch = {nft_to_offer_asset_id: -1, wallet_maker.id(): xch_requested}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_did_nft_for_xch, DEFAULT_TX_CONFIG, {}, fee=maker_fee
     )
     assert success is True
@@ -312,7 +312,7 @@ async def test_nft_offer_request_nft(
 
     offer_dict = {nft_to_request_asset_id: 1, wallet_maker.id(): -xch_offered}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_dict, DEFAULT_TX_CONFIG, driver_dict, fee=maker_fee
     )
     assert success is True
@@ -466,7 +466,7 @@ async def test_nft_offer_sell_did_to_did(
 
     offer_did_nft_for_xch = {nft_to_offer_asset_id: -1, wallet_maker.id(): xch_requested}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_did_nft_for_xch, DEFAULT_TX_CONFIG, {}, fee=maker_fee
     )
     assert success is True
@@ -650,7 +650,7 @@ async def test_nft_offer_sell_nft_for_cat(
 
     offer_did_nft_for_xch = {nft_to_offer_asset_id: -1, cat_wallet_maker.id(): cats_requested}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_did_nft_for_xch, DEFAULT_TX_CONFIG, {}, fee=maker_fee
     )
 
@@ -842,7 +842,7 @@ async def test_nft_offer_request_nft_for_cat(
 
     offer_dict = {nft_to_request_asset_id: 1, cat_wallet_maker.id(): -cats_requested}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_dict, DEFAULT_TX_CONFIG, driver_dict, fee=maker_fee
     )
     assert success is True
@@ -976,7 +976,7 @@ async def test_nft_offer_sell_cancel(
 
     offer_did_nft_for_xch = {nft_to_offer_asset_id: -1, wallet_maker.id(): xch_requested}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_did_nft_for_xch, DEFAULT_TX_CONFIG, {}, fee=maker_fee
     )
 
@@ -1097,7 +1097,7 @@ async def test_nft_offer_sell_cancel_in_batch(
 
     offer_did_nft_for_xch = {nft_to_offer_asset_id: -1, wallet_maker.id(): xch_requested}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_did_nft_for_xch, DEFAULT_TX_CONFIG, {}, fee=maker_fee
     )
 
@@ -1362,7 +1362,7 @@ async def test_complex_nft_offer(
         ),
     }
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         complex_nft_offer, DEFAULT_TX_CONFIG, driver_dict=driver_dict, fee=FEE
     )
     assert error is None
@@ -1475,7 +1475,7 @@ async def test_complex_nft_offer(
         ),
     }
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         complex_nft_offer, DEFAULT_TX_CONFIG, driver_dict=driver_dict, fee=uint64(0)
     )
     assert error is None

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -135,7 +135,7 @@ async def test_nft_offer_with_fee(
         await wallet_taker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
     ).index
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_nft_for_xch, tx_config, driver_dict, fee=maker_fee
     )
     assert success is True
@@ -207,7 +207,7 @@ async def test_nft_offer_with_fee(
     maker_fee = uint64(10)
     offer_xch_for_nft = {wallet_maker.id(): -xch_offered, nft_to_buy_asset_id: 1}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_xch_for_nft, tx_config, driver_dict_to_buy, fee=maker_fee
     )
     assert success is True
@@ -325,7 +325,7 @@ async def test_nft_offer_cancellations(
     maker_fee = uint64(10)
     offer_nft_for_xch = {wallet_maker.id(): xch_request, nft_asset_id: -1}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_nft_for_xch, DEFAULT_TX_CONFIG, driver_dict, fee=maker_fee
     )
     assert success is True
@@ -469,7 +469,7 @@ async def test_nft_offer_with_metadata_update(
     maker_fee = uint64(10)
     offer_nft_for_xch = {wallet_maker.id(): xch_request, nft_asset_id: -1}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_nft_for_xch, DEFAULT_TX_CONFIG, driver_dict, fee=maker_fee
     )
     assert success is True
@@ -644,7 +644,7 @@ async def test_nft_offer_nft_for_cat(
         await wallet_taker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
     ).index
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_nft_for_cat, tx_config, driver_dict, fee=maker_fee
     )
     assert success is True
@@ -728,7 +728,7 @@ async def test_nft_offer_nft_for_cat(
         cat_wallet_maker.id(): -maker_cat_amount,
     }
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_multi_cats_for_nft, tx_config, driver_dict_to_buy, fee=maker_fee
     )
     assert success is True
@@ -878,7 +878,7 @@ async def test_nft_offer_nft_for_nft(
     maker_fee = uint64(10)
     offer_nft_for_nft = {nft_to_take_asset_id: 1, nft_to_offer_asset_id: -1}
 
-    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+    success, trade_make, _, error = await trade_manager_maker.create_offer_for_ids(
         offer_nft_for_nft, DEFAULT_TX_CONFIG, driver_dict, fee=maker_fee
     )
     assert success is True


### PR DESCRIPTION
Even though the tx records that an offer generates can't be pushed to the network, it's worth including all of the information about their creation to endpoints that might need it.