### PR TITLE
Return TX records from CATWallet creation

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -691,7 +691,7 @@ class WalletRpcApi:
                     if not push:
                         raise ValueError("Test CAT minting must be pushed automatically")  # pragma: no cover
                     async with self.service.wallet_state_manager.lock:
-                        cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+                        cat_wallet, txs = await CATWallet.create_new_cat_wallet(
                             wallet_state_manager,
                             main_wallet,
                             {"identifier": "genesis_by_id"},
@@ -702,7 +702,12 @@ class WalletRpcApi:
                         )
                         asset_id = cat_wallet.get_asset_id()
                     self.service.wallet_state_manager.state_changed("wallet_created")
-                    return {"type": cat_wallet.type(), "asset_id": asset_id, "wallet_id": cat_wallet.id()}
+                    return {
+                        "type": cat_wallet.type(),
+                        "asset_id": asset_id,
+                        "wallet_id": cat_wallet.id(),
+                        "transactions": [tx.to_json_dict_convenience(self.service.config) for tx in txs],
+                    }
                 else:
                     raise ValueError(
                         "Support for this RPC mode has been dropped."

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -95,7 +95,7 @@ class CATWallet:
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
         name: Optional[str] = None,
-    ) -> CATWallet:
+    ) -> Tuple[CATWallet, List[TransactionRecord]]:
         self = CATWallet()
         self.standard_wallet = wallet
         self.log = logging.getLogger(__name__)
@@ -180,7 +180,7 @@ class CATWallet:
         )
         chia_tx = dataclasses.replace(chia_tx, spend_bundle=spend_bundle, name=spend_bundle.name())
         await self.wallet_state_manager.add_pending_transactions([chia_tx, cat_record])
-        return self
+        return self, [chia_tx, cat_record]
 
     @staticmethod
     async def get_or_create_wallet_for_cat(

--- a/chia/wallet/dao_wallet/dao_wallet.py
+++ b/chia/wallet/dao_wallet/dao_wallet.py
@@ -687,7 +687,7 @@ class DAOWallet:
                 "treasury_id": launcher_coin.name(),
                 "coins": different_coins,
             }
-            new_cat_wallet = await CATWallet.create_new_cat_wallet(
+            new_cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 self.wallet_state_manager,
                 self.standard_wallet,
                 cat_tail_info,

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -88,7 +88,7 @@ class CRCATWallet(CATWallet):
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
         name: Optional[str] = None,
-    ) -> CATWallet:  # pragma: no cover
+    ) -> Tuple[CATWallet, List[TransactionRecord]]:  # pragma: no cover
         raise NotImplementedError("create_new_cat_wallet is a legacy method and is not available on CR-CAT wallets")
 
     @staticmethod

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -75,7 +75,7 @@ class TestCATWallet:
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
@@ -145,14 +145,14 @@ class TestCATWallet:
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet_1: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_1, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
                 uint64(100),
                 DEFAULT_TX_CONFIG,
             )
-            cat_wallet_2: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_2, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
@@ -206,7 +206,7 @@ class TestCATWallet:
         await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
@@ -318,7 +318,7 @@ class TestCATWallet:
         await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
@@ -420,7 +420,7 @@ class TestCATWallet:
         await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
@@ -482,7 +482,7 @@ class TestCATWallet:
         await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
@@ -579,7 +579,7 @@ class TestCATWallet:
         await time_out_assert(20, wallet_0.get_confirmed_balance, funds)
 
         async with wallet_node_0.wallet_state_manager.lock:
-            cat_wallet_0: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_0, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_0.wallet_state_manager,
                 wallet_0,
                 {"identifier": "genesis_by_id"},
@@ -700,7 +700,7 @@ class TestCATWallet:
         await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},
@@ -815,7 +815,7 @@ class TestCATWallet:
         await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
         async with wallet_node.wallet_state_manager.lock:
-            cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node.wallet_state_manager,
                 wallet,
                 {"identifier": "genesis_by_id"},

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -295,7 +295,7 @@ async def test_cat_trades(
 
         # Mint some standard CATs
         async with wallet_node_maker.wallet_state_manager.lock:
-            cat_wallet_maker = await CATWallet.create_new_cat_wallet(
+            cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_maker.wallet_state_manager,
                 wallet_maker,
                 {"identifier": "genesis_by_id"},
@@ -304,7 +304,7 @@ async def test_cat_trades(
             )
 
         async with wallet_node_taker.wallet_state_manager.lock:
-            new_cat_wallet_taker = await CATWallet.create_new_cat_wallet(
+            new_cat_wallet_taker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_taker.wallet_state_manager,
                 wallet_taker,
                 {"identifier": "genesis_by_id"},
@@ -1529,7 +1529,7 @@ class TestCATTrades:
         xch_to_cat_amount = uint64(100)
 
         async with wallet_node_maker.wallet_state_manager.lock:
-            cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_maker.wallet_state_manager,
                 wallet_maker,
                 {"identifier": "genesis_by_id"},
@@ -1656,7 +1656,7 @@ class TestCATTrades:
         xch_to_cat_amount = uint64(100)
 
         async with wallet_node_maker.wallet_state_manager.lock:
-            cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_maker.wallet_state_manager,
                 wallet_maker,
                 {"identifier": "genesis_by_id"},
@@ -1711,7 +1711,7 @@ class TestCATTrades:
         xch_to_cat_amount = uint64(100)
 
         async with wallet_node_maker.wallet_state_manager.lock:
-            cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_maker.wallet_state_manager,
                 wallet_maker,
                 {"identifier": "genesis_by_id"},
@@ -1775,7 +1775,7 @@ class TestCATTrades:
         xch_to_cat_amount = uint64(100)
 
         async with wallet_node_maker.wallet_state_manager.lock:
-            cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_maker.wallet_state_manager,
                 wallet_maker,
                 {"identifier": "genesis_by_id"},
@@ -1840,7 +1840,7 @@ class TestCATTrades:
         xch_to_cat_amount = uint64(100)
 
         async with wallet_node_maker.wallet_state_manager.lock:
-            cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_maker.wallet_state_manager,
                 wallet_maker,
                 {"identifier": "genesis_by_id"},

--- a/tests/wallet/cat_wallet/test_trades.py
+++ b/tests/wallet/cat_wallet/test_trades.py
@@ -1896,7 +1896,7 @@ class TestCATTrades:
         xch_to_cat_amount = uint64(100)
 
         async with wallet_node_maker.wallet_state_manager.lock:
-            cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+            cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
                 wallet_node_maker.wallet_state_manager,
                 wallet_maker,
                 {"identifier": "genesis_by_id"},

--- a/tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -607,7 +607,7 @@ async def test_nft_offer_sell_nft_for_cat(
     cats_to_trade = uint64(10000)
     async with wallet_node_maker.wallet_state_manager.lock:
         full_node_api.full_node.log.warning(f"Mempool size: {full_node_api.full_node.mempool_manager.mempool.size()}")
-        cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+        cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
             wallet_node_maker.wallet_state_manager,
             wallet_maker,
             {"identifier": "genesis_by_id"},
@@ -788,7 +788,7 @@ async def test_nft_offer_request_nft_for_cat(
     cats_to_mint = 100000
     cats_to_trade = uint64(20000)
     async with wallet_node_maker.wallet_state_manager.lock:
-        cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+        cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
             wallet_node_maker.wallet_state_manager,
             wallet_maker,
             {"identifier": "genesis_by_id"},
@@ -1173,11 +1173,11 @@ async def test_complex_nft_offer(
 
     CAT_AMOUNT = uint64(100000000)
     async with wsm_maker.lock:
-        cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+        cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
             wsm_maker, wallet_maker, {"identifier": "genesis_by_id"}, CAT_AMOUNT, DEFAULT_TX_CONFIG
         )
     async with wsm_maker.lock:
-        cat_wallet_taker: CATWallet = await CATWallet.create_new_cat_wallet(
+        cat_wallet_taker, _ = await CATWallet.create_new_cat_wallet(
             wsm_taker, wallet_taker, {"identifier": "genesis_by_id"}, CAT_AMOUNT, DEFAULT_TX_CONFIG
         )
     cat_spend_bundle_maker = (

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -585,7 +585,7 @@ async def test_nft_offer_nft_for_cat(
     # Create two new CATs and wallets for maker and taker
     cats_to_mint = 10000
     async with wallet_node_0.wallet_state_manager.lock:
-        cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+        cat_wallet_maker, _ = await CATWallet.create_new_cat_wallet(
             wallet_node_0.wallet_state_manager,
             wallet_maker,
             {"identifier": "genesis_by_id"},
@@ -597,7 +597,7 @@ async def test_nft_offer_nft_for_cat(
     await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
 
     async with wallet_node_1.wallet_state_manager.lock:
-        cat_wallet_taker: CATWallet = await CATWallet.create_new_cat_wallet(
+        cat_wallet_taker, _ = await CATWallet.create_new_cat_wallet(
             wallet_node_1.wallet_state_manager,
             wallet_taker,
             {"identifier": "genesis_by_id"},

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -376,7 +376,7 @@ async def test_get_balance(wallet_rpc_environment: WalletRpcTestEnvironment):
     wallet_rpc_client = env.wallet_1.rpc_client
     await full_node_api.farm_blocks_to_wallet(2, wallet)
     async with wallet_node.wallet_state_manager.lock:
-        cat_wallet: CATWallet = await CATWallet.create_new_cat_wallet(
+        cat_wallet, _ = await CATWallet.create_new_cat_wallet(
             wallet_node.wallet_state_manager, wallet, {"identifier": "genesis_by_id"}, uint64(100), DEFAULT_TX_CONFIG
         )
     await assert_get_balance(wallet_rpc_client, wallet_node, wallet)


### PR DESCRIPTION
This function is primarily a testing function but it's helpful to have the transaction records it creates available to levels higher up.