### PR TITLE
Add systemd init files to CLI-only Linux packages

### DIFF
--- a/build_scripts/assets/systemd/chia-crawler@.service
+++ b/build_scripts/assets/systemd/chia-crawler@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Crawler Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_crawler
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-daemon@.service
+++ b/build_scripts/assets/systemd/chia-daemon@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Daemon Service for %i
+StopWhenUnneeded=true
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/daemon
+ExecStartPost=/bin/bash -c '(while ! nc -z -v -w1 localhost 55400 2>/dev/null; do echo "Waiting for the daemon to listen on port 55400..."; sleep 1; done); sleep 1'
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-data-layer-http@.service
+++ b/build_scripts/assets/systemd/chia-data-layer-http@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Chia Data Layer HTTP Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_data_layer_http
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-data-layer@.service
+++ b/build_scripts/assets/systemd/chia-data-layer@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Chia Data Layer Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_data_layer
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-farmer@.service
+++ b/build_scripts/assets/systemd/chia-farmer@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Farmer Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_farmer
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-full-node@.service
+++ b/build_scripts/assets/systemd/chia-full-node@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Full Node Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_full_node
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-harvester@.service
+++ b/build_scripts/assets/systemd/chia-harvester@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Harvester Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_harvester
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-introducer@.service
+++ b/build_scripts/assets/systemd/chia-introducer@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Introducer Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_introducer
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-seeder@.service
+++ b/build_scripts/assets/systemd/chia-seeder@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Seeder Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_seeder
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-timelord@.service
+++ b/build_scripts/assets/systemd/chia-timelord@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Chia Timelord Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_timelord
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-wallet@.service
+++ b/build_scripts/assets/systemd/chia-wallet@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Chia Wallet Service for %i
+Requires=chia-daemon@%i.service
+After=chia-daemon@%i.service
+
+[Service]
+Type=simple
+Environment=CHIA_ROOT=/home/%i/.chia/mainnet
+ExecStart=/opt/chia/start_wallet
+ExecStartPost=/bin/bash -c '(while ! nc -z -v -w1 localhost {{ chia_wallet_rpc_port }} 2>/dev/null; do echo "Waiting for the wallet to listen on port {{ chia_wallet_rpc_port }}..."; sleep 1; done); sleep 1'
+User=%i
+Group=%i
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/build_scripts/assets/systemd/chia-wallet@.service
+++ b/build_scripts/assets/systemd/chia-wallet@.service
@@ -7,7 +7,7 @@ After=chia-daemon@%i.service
 Type=simple
 Environment=CHIA_ROOT=/home/%i/.chia/mainnet
 ExecStart=/opt/chia/start_wallet
-ExecStartPost=/bin/bash -c '(while ! nc -z -v -w1 localhost {{ chia_wallet_rpc_port }} 2>/dev/null; do echo "Waiting for the wallet to listen on port {{ chia_wallet_rpc_port }}..."; sleep 1; done); sleep 1'
+ExecStartPost=/bin/bash -c '(while ! nc -z -v -w1 localhost 9256 2>/dev/null; do echo "Waiting for the wallet to listen on port 9256..."; sleep 1; done); sleep 1'
 User=%i
 Group=%i
 LimitNOFILE=1048576

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -57,6 +57,7 @@ mkdir -p "dist/$CLI_DEB_BASE/opt/chia"
 mkdir -p "dist/$CLI_DEB_BASE/usr/bin"
 mkdir -p "dist/$CLI_DEB_BASE/DEBIAN"
 j2 -o "dist/$CLI_DEB_BASE/DEBIAN/control" assets/deb/control.j2
+cp systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
 cp -r dist/daemon/* "dist/$CLI_DEB_BASE/opt/chia/"
 
 ln -s ../../opt/chia/chia "dist/$CLI_DEB_BASE/usr/bin/chia"

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -57,7 +57,7 @@ mkdir -p "dist/$CLI_DEB_BASE/opt/chia"
 mkdir -p "dist/$CLI_DEB_BASE/usr/bin"
 mkdir -p "dist/$CLI_DEB_BASE/DEBIAN"
 j2 -o "dist/$CLI_DEB_BASE/DEBIAN/control" assets/deb/control.j2
-cp systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
+cp assets/systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
 cp -r dist/daemon/* "dist/$CLI_DEB_BASE/opt/chia/"
 
 ln -s ../../opt/chia/chia "dist/$CLI_DEB_BASE/usr/bin/chia"

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -56,6 +56,7 @@ CLI_DEB_BASE="chia-blockchain-cli_$CHIA_INSTALLER_VERSION-1_$PLATFORM"
 mkdir -p "dist/$CLI_DEB_BASE/opt/chia"
 mkdir -p "dist/$CLI_DEB_BASE/usr/bin"
 mkdir -p "dist/$CLI_DEB_BASE/DEBIAN"
+mkdir -p "dist/$CLI_DEB_BASE/etc/systemd/system"
 j2 -o "dist/$CLI_DEB_BASE/DEBIAN/control" assets/deb/control.j2
 cp assets/systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
 cp -r dist/daemon/* "dist/$CLI_DEB_BASE/opt/chia/"

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -50,6 +50,7 @@ bash ./build_license_directory.sh
 CLI_RPM_BASE="chia-blockchain-cli-$CHIA_INSTALLER_VERSION-1.$REDHAT_PLATFORM"
 mkdir -p "dist/$CLI_RPM_BASE/opt/chia"
 mkdir -p "dist/$CLI_RPM_BASE/usr/bin"
+mkdir -p "dist/$CLI_RPM_BASE/etc/systemd/system"
 cp -r dist/daemon/* "dist/$CLI_RPM_BASE/opt/chia/"
 cp assets/systemd/*.service "dist/$CLI_RPM_BASE/etc/systemd/system/"
 

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -51,6 +51,7 @@ CLI_RPM_BASE="chia-blockchain-cli-$CHIA_INSTALLER_VERSION-1.$REDHAT_PLATFORM"
 mkdir -p "dist/$CLI_RPM_BASE/opt/chia"
 mkdir -p "dist/$CLI_RPM_BASE/usr/bin"
 cp -r dist/daemon/* "dist/$CLI_RPM_BASE/opt/chia/"
+cp systemd/*.service "dist/$CLI_RPM_BASE/etc/systemd/system/"
 
 ln -s ../../opt/chia/chia "dist/$CLI_RPM_BASE/usr/bin/chia"
 # This is built into the base build image

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -51,7 +51,7 @@ CLI_RPM_BASE="chia-blockchain-cli-$CHIA_INSTALLER_VERSION-1.$REDHAT_PLATFORM"
 mkdir -p "dist/$CLI_RPM_BASE/opt/chia"
 mkdir -p "dist/$CLI_RPM_BASE/usr/bin"
 cp -r dist/daemon/* "dist/$CLI_RPM_BASE/opt/chia/"
-cp systemd/*.service "dist/$CLI_RPM_BASE/etc/systemd/system/"
+cp assets/systemd/*.service "dist/$CLI_RPM_BASE/etc/systemd/system/"
 
 ln -s ../../opt/chia/chia "dist/$CLI_RPM_BASE/usr/bin/chia"
 # This is built into the base build image


### PR DESCRIPTION
### Purpose:
Add Systemd initialization files to the .deb and .rpm CLI-only installers for more friendly process management.  This specifically helps hobby and enterprise users running Chia on a headless Linux server, which a big improvement being the ability to easily start Chia services at boot.  This is currently a pain-point for the Carbon users attempting to install Chia and the carbon applications in their infrastructure.  

These bundled systemd files allow the user to pass in the Linux user that Chia should run as and assumes default ports and locations for the CHIA_ROOT directory.  This likely covers a very large percentage of users and those who need customization can modify their own systemd files.  By passing in the user to the systemd script, multiple versions of Chia could be run on a single system using different Linux user accounts for the CHIA_ROOT.  

### Current Behavior:
No bundled init files.


### New Behavior:
If installed with the CLI .rpm or .deb file, Linux admins will be able to start Chia services with

```
systemctl start chia-full-node@username
systemctl start chia-wallet@username
systemctl start chia-data-layer@username
```

These services will start at boot with the following commands:

```
systemctl enable chia-full-node@username
systemctl enable chia-wallet@username
systemctl enable chia-data-layer@username
```

