### PR TITLE
get_block_generator() fork detection

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -1100,11 +1100,8 @@ class Blockchain(BlockchainInterface):
             return BlockGenerator(block.transactions_generator, [], [])
 
         result: List[SerializedProgram] = []
-        previous_block_hash = block.prev_header_hash
-        if (
-            self.try_block_record(previous_block_hash)
-            and self.height_to_hash(self.block_record(previous_block_hash).height) == previous_block_hash
-        ):
+        previous_br = await self.get_block_record_from_db(block.prev_header_hash)
+        if previous_br is not None and self.height_to_hash(previous_br.height) == block.prev_header_hash:
             # We are not in a reorg, no need to look up alternate header hashes
             # (we can get them from height_to_hash)
             # in the v2 database, we can look up blocks by height directly


### PR DESCRIPTION
### Purpose:

fix logic in get_block_generator() that determines whether we're looking up a block from a fork or the main chain.

### Current Behavior:

We only consider a block lookup to be in the main chain if its previous block is in *the cache*.

### New Behavior:

We consider block lookups part of the main chain if the previous block is in the database and its hash is the same as the height-to-hash map for that height.

### testing

This change was tested by issuing the following RPC command:

```
chia rpc full_node get_puzzle_and_solution '{"coin_id": "0xdc43c91390490b8bbec628bf3c0c2388578548c1889f0ea40c6cfc8fac409947", "height": 280858}'
```

in `main` this freezes with this patch it returns the result quickly.