### PR TITLE
remove singleton_store

### DIFF
--- a/chia/wallet/dao_wallet/dao_wallet.py
+++ b/chia/wallet/dao_wallet/dao_wallet.py
@@ -69,7 +69,6 @@ from chia.wallet.singleton import (
     get_singleton_id_from_puzzle,
     get_singleton_struct_for_id,
 )
-from chia.wallet.singleton_record import SingletonRecord
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.transaction_type import TransactionType
@@ -423,11 +422,6 @@ class DAOWallet:
             cs = (await wallet_node.get_coin_state([coin.parent_coin_info], peer, height))[0]
             parent_spend = await fetch_coin_spend(cs.spent_height, cs.coin, peer)
 
-            # check if it's a singleton and add to singleton_store
-            singleton_id = get_singleton_id_from_puzzle(parent_spend.puzzle_reveal)
-
-            if singleton_id:
-                await self.wallet_state_manager.singleton_store.add_spend(self.id(), parent_spend, height)
             puzzle = Program.from_bytes(bytes(parent_spend.puzzle_reveal))
             solution = Program.from_bytes(bytes(parent_spend.solution))
             uncurried = uncurry_puzzle(puzzle)
@@ -843,7 +837,6 @@ class DAOWallet:
 
         dao_info = dataclasses.replace(self.dao_info, current_treasury_coin=next_coin)
         await self.save_info(dao_info)
-        await self.wallet_state_manager.singleton_store.add_spend(self.id(), eve_coin_spend)
         return eve_spend_bundle
 
     async def generate_new_proposal(
@@ -1775,23 +1768,6 @@ class DAOWallet:
         # If we return a value, it is a coin that we are also interested in (to support two transitions per block)
         return get_most_recent_singleton_coin_from_coin_spend(spend)
 
-    async def get_tip(self, singleton_id: bytes32) -> Optional[Tuple[uint32, SingletonRecord]]:
-        ret: List[
-            Tuple[uint32, SingletonRecord]
-        ] = await self.wallet_state_manager.singleton_store.get_records_by_singleton_id(singleton_id)
-        if len(ret) == 0:  # pragma: no cover
-            return None
-        return ret[-1]
-
-    async def get_tip_created_height(self, singleton_id: bytes32) -> Optional[int]:  # pragma: no cover
-        ret: List[
-            Tuple[uint32, SingletonRecord]
-        ] = await self.wallet_state_manager.singleton_store.get_records_by_singleton_id(singleton_id)
-        if len(ret) < 1:
-            return None
-        assert isinstance(ret[-2], SingletonRecord)
-        return ret[-2].removed_height
-
     async def add_or_update_proposal_info(
         self,
         new_state: CoinSpend,
@@ -2103,14 +2079,6 @@ class DAOWallet:
         await self.add_parent(new_state.coin.name(), future_parent)
         return
 
-    async def get_spend_history(self, singleton_id: bytes32) -> List[Tuple[uint32, CoinSpend]]:  # pragma: no cover
-        ret: List[
-            Tuple[uint32, CoinSpend]
-        ] = await self.wallet_state_manager.singleton_store.get_records_by_singleton_id(singleton_id)
-        if len(ret) == 0:
-            raise ValueError(f"No records found in singleton store for singleton id {singleton_id}")
-        return ret
-
     async def apply_state_transition(self, new_state: CoinSpend, block_height: uint32) -> bool:
         """
         We are being notified of a singleton state transition. A Singleton has been spent.
@@ -2123,20 +2091,6 @@ class DAOWallet:
         singleton_id = get_singleton_id_from_puzzle(new_state.puzzle_reveal)
         if not singleton_id:  # pragma: no cover
             raise ValueError("Received a non singleton coin for dao wallet")
-        tip: Optional[Tuple[uint32, SingletonRecord]] = await self.get_tip(singleton_id)
-        if tip is None:  # pragma: no cover
-            # this is our first time, just store it
-            await self.wallet_state_manager.singleton_store.add_spend(self.wallet_id, new_state, block_height)
-        else:
-            assert isinstance(tip, SingletonRecord)
-            tip_spend = tip.parent_coinspend
-
-            tip_coin: Optional[Coin] = get_most_recent_singleton_coin_from_coin_spend(tip_spend)
-            assert tip_coin is not None
-            # TODO: Add check for pending transaction on our behalf in here
-            # if we have pending transaction that is now invalidated, then:
-            # check if we should auto re-create spend or flash error to use (should we have a failed tx db?)
-            await self.wallet_state_manager.singleton_store.add_spend(self.id(), new_state, block_height)
 
         # Consume new DAOBlockchainInfo
         # Determine if this is a treasury spend or a proposal spend

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -300,7 +300,6 @@ class WalletNode:
             "trade_record_times",
             "tx_times",
             "pool_state_transitions",
-            "singletons",
             "singleton_records",
             "mirrors",
             "launchers",

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -138,7 +138,6 @@ from chia.wallet.wallet_pool_store import WalletPoolStore
 from chia.wallet.wallet_protocol import WalletProtocol
 from chia.wallet.wallet_puzzle_store import WalletPuzzleStore
 from chia.wallet.wallet_retry_store import WalletRetryStore
-from chia.wallet.wallet_singleton_store import WalletSingletonStore
 from chia.wallet.wallet_transaction_store import WalletTransactionStore
 from chia.wallet.wallet_user_store import WalletUserStore
 
@@ -192,7 +191,6 @@ class WalletStateManager:
     wallet_node: WalletNode
     pool_store: WalletPoolStore
     dl_store: DataLayerStore
-    singleton_store: WalletSingletonStore
     default_cats: Dict[str, Any]
     asset_to_wallet_map: Dict[AssetType, Any]
     initial_num_public_keys: int
@@ -248,7 +246,6 @@ class WalletStateManager:
         self.dl_store = await DataLayerStore.create(self.db_wrapper)
         self.interested_store = await WalletInterestedStore.create(self.db_wrapper)
         self.retry_store = await WalletRetryStore.create(self.db_wrapper)
-        self.singleton_store = await WalletSingletonStore.create(self.db_wrapper)
         self.default_cats = DEFAULT_CATS
 
         self.wallet_node = wallet_node


### PR DESCRIPTION
There's a backwards compatibility issue with adding the singletons table to `required_tables` in `wallet_node.reset_sync_db`. The singletons table exists in the DB, but when users revert to an older release of chia-blockchain reset_sync_db raises an error since the singletons table doesn't exist in earlier releases.

This PR provides a temporary fix by removing the use of singleton_store in the DAO wallet and WSM. Once there's a fix for the required_tables issue we can revert these changes.