### PR TITLE
add `DBWrapper2.managed()`

### DIFF
--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -30,7 +30,6 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.full_block import FullBlock
-from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint8, uint32, uint64, uint128
 
 # to run this benchmark:
@@ -44,7 +43,6 @@ random.seed(123456789)
 
 async def run_add_block_benchmark(version: int) -> None:
     verbose: bool = "--verbose" in sys.argv
-    db_wrapper: DBWrapper2 = await setup_db("block-store-benchmark.db", version)
 
     # keep track of benchmark total time
     all_test_time = 0.0
@@ -54,7 +52,7 @@ async def run_add_block_benchmark(version: int) -> None:
 
     header_hashes = []
 
-    try:
+    async with setup_db("block-store-benchmark.db", version) as db_wrapper:
         block_store = await BlockStore.create(db_wrapper)
 
         block_height = 1
@@ -494,9 +492,6 @@ async def run_add_block_benchmark(version: int) -> None:
 
         db_size = os.path.getsize(Path("block-store-benchmark.db"))
         print(f"database size: {db_size/1000000:.3f} MB")
-
-    finally:
-        await db_wrapper.close()
 
 
 if __name__ == "__main__":

--- a/benchmarks/coin_store.py
+++ b/benchmarks/coin_store.py
@@ -12,7 +12,6 @@ from benchmarks.utils import rand_hash, rewards, setup_db
 from chia.full_node.coin_store import CoinStore
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
 
 # to run this benchmark:
@@ -41,12 +40,11 @@ def make_coins(num: int) -> Tuple[List[Coin], List[bytes32]]:
 
 async def run_new_block_benchmark(version: int) -> None:
     verbose: bool = "--verbose" in sys.argv
-    db_wrapper: DBWrapper2 = await setup_db("coin-store-benchmark.db", version)
 
     # keep track of benchmark total time
     all_test_time = 0.0
 
-    try:
+    async with setup_db("coin-store-benchmark.db", version) as db_wrapper:
         coin_store = await CoinStore.create(db_wrapper)
 
         all_unspent: List[bytes32] = []
@@ -300,9 +298,6 @@ async def run_new_block_benchmark(version: int) -> None:
         )
         all_test_time += total_time
         print(f"all tests completed in {all_test_time:0.4f}s")
-
-    finally:
-        await db_wrapper.close()
 
     db_size = os.path.getsize(Path("coin-store-benchmark.db"))
     print(f"database size: {db_size/1000000:.3f} MB")

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -9,7 +9,6 @@ import sys
 from pathlib import Path
 from typing import Any, AsyncIterator, Generic, Optional, Tuple, Type, TypeVar, Union
 
-import aiosqlite
 import click
 from chia_rs import AugSchemeMPL, G1Element, G2Element
 
@@ -197,10 +196,10 @@ async def setup_db(name: Union[str, os.PathLike[str]], db_version: int) -> Async
         database=db_filename,
         log_path=log_path,
         db_version=db_version,
+        reader_count=1,
         journal_mode="wal",
         synchronous="full",
     ) as db_wrapper:
-        await db_wrapper.add_connection(await aiosqlite.connect(db_filename))
         yield db_wrapper
 
 

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import contextlib
 import enum
 import os
 import random
 import subprocess
 import sys
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, AsyncIterator, Generic, Optional, Tuple, Type, TypeVar, Union
 
 import aiosqlite
 import click
@@ -179,30 +179,29 @@ def rand_full_block() -> FullBlock:
     return full_block
 
 
-async def setup_db(name: Union[str, os.PathLike[str]], db_version: int) -> DBWrapper2:
+@contextlib.asynccontextmanager
+async def setup_db(name: Union[str, os.PathLike[str]], db_version: int) -> AsyncIterator[DBWrapper2]:
     db_filename = Path(name)
     try:
         os.unlink(db_filename)
     except FileNotFoundError:
         pass
-    connection = await aiosqlite.connect(db_filename)
 
-    def sql_trace_callback(req: str) -> None:
-        sql_log_path = "sql.log"
-        timestamp = datetime.now().strftime("%H:%M:%S.%f")
-        log = open(sql_log_path, "a")
-        log.write(timestamp + " " + req + "\n")
-        log.close()
-
+    log_path: Optional[Path]
     if "--sql-logging" in sys.argv:
-        await connection.set_trace_callback(sql_trace_callback)
+        log_path = Path("sql.log")
+    else:
+        log_path = None
 
-    await connection.execute("pragma journal_mode=wal")
-    await connection.execute("pragma synchronous=full")
-
-    ret = DBWrapper2(connection, db_version)
-    await ret.add_connection(await aiosqlite.connect(db_filename))
-    return ret
+    async with DBWrapper2.managed(
+        database=db_filename,
+        log_path=log_path,
+        db_version=db_version,
+        journal_mode="wal",
+        synchronous="full",
+    ) as db_wrapper:
+        await db_wrapper.add_connection(await aiosqlite.connect(db_filename))
+        yield db_wrapper
 
 
 def get_commit_hash() -> str:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -214,6 +214,7 @@ class FullNode:
         # These many respond_transaction tasks can be active at any point in time
         self._add_transaction_semaphore = asyncio.Semaphore(200)
 
+        sql_log_path: Optional[Path] = None
         with contextlib.ExitStack() as exit_stack:
             sql_log_file: Optional[TextIO] = None
             if self.config.get("log_sqlite_cmds", False):

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -22,6 +22,7 @@ from typing import (
     List,
     Optional,
     Set,
+    TextIO,
     Tuple,
     Union,
     cast,
@@ -213,161 +214,162 @@ class FullNode:
         # These many respond_transaction tasks can be active at any point in time
         self._add_transaction_semaphore = asyncio.Semaphore(200)
 
-        sql_log_path: Optional[Path] = None
-        if self.config.get("log_sqlite_cmds", False):
-            sql_log_path = path_from_root(self.root_path, "log/sql.log")
-            self.log.info(f"logging SQL commands to {sql_log_path}")
+        with contextlib.ExitStack() as exit_stack:
+            sql_log_file: Optional[TextIO] = None
+            if self.config.get("log_sqlite_cmds", False):
+                sql_log_path = path_from_root(self.root_path, "log/sql.log")
+                self.log.info(f"logging SQL commands to {sql_log_path}")
+                sql_log_file = exit_stack.enter_context(sql_log_path.open("a", encoding="utf-8"))
 
-        # create the store (db) and full node instance
-        # TODO: is this standardized and thus able to be handled by DBWrapper2?
-        async with manage_connection(self.db_path, log_path=sql_log_path, name="version_check") as db_connection:
-            db_version = await lookup_db_version(db_connection)
+            # create the store (db) and full node instance
+            # TODO: is this standardized and thus able to be handled by DBWrapper2?
+            async with manage_connection(self.db_path, log_file=sql_log_file, name="version_check") as db_connection:
+                db_version = await lookup_db_version(db_connection)
+
         self.log.info(f"using blockchain database {self.db_path}, which is version {db_version}")
 
         db_sync = db_synchronous_on(self.config.get("db_sync", "auto"))
         self.log.info(f"opening blockchain DB: synchronous={db_sync}")
 
-        self._db_wrapper = await DBWrapper2.create(
+        async with DBWrapper2.managed(
             self.db_path,
             db_version=db_version,
             reader_count=4,
             log_path=sql_log_path,
             synchronous=db_sync,
-        )
+        ) as self._db_wrapper:
+            if self.db_wrapper.db_version != 2:
+                async with self.db_wrapper.reader_no_transaction() as conn:
+                    async with conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='full_blocks'"
+                    ) as cur:
+                        if len(list(await cur.fetchall())) == 0:
+                            try:
+                                # this is a new DB file. Make it v2
+                                async with self.db_wrapper.writer_maybe_transaction() as w_conn:
+                                    await set_db_version_async(w_conn, 2)
+                                    self.db_wrapper.db_version = 2
+                                    self.log.info("blockchain database is empty, configuring as v2")
+                            except sqlite3.OperationalError:
+                                # it could be a database created with "chia init", which is
+                                # empty except it has the database_version table
+                                pass
 
-        if self.db_wrapper.db_version != 2:
-            async with self.db_wrapper.reader_no_transaction() as conn:
-                async with conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='full_blocks'"
-                ) as cur:
-                    if len(list(await cur.fetchall())) == 0:
-                        try:
-                            # this is a new DB file. Make it v2
-                            async with self.db_wrapper.writer_maybe_transaction() as w_conn:
-                                await set_db_version_async(w_conn, 2)
-                                self.db_wrapper.db_version = 2
-                                self.log.info("blockchain database is empty, configuring as v2")
-                        except sqlite3.OperationalError:
-                            # it could be a database created with "chia init", which is
-                            # empty except it has the database_version table
-                            pass
+            self._block_store = await BlockStore.create(self.db_wrapper)
+            self._hint_store = await HintStore.create(self.db_wrapper)
+            self._coin_store = await CoinStore.create(self.db_wrapper)
+            self.log.info("Initializing blockchain from disk")
+            start_time = time.time()
+            reserved_cores = self.config.get("reserved_cores", 0)
+            single_threaded = self.config.get("single_threaded", False)
+            multiprocessing_start_method = process_config_start_method(config=self.config, log=self.log)
+            self.multiprocessing_context = multiprocessing.get_context(method=multiprocessing_start_method)
+            self._blockchain = await Blockchain.create(
+                coin_store=self.coin_store,
+                block_store=self.block_store,
+                consensus_constants=self.constants,
+                blockchain_dir=self.db_path.parent,
+                reserved_cores=reserved_cores,
+                multiprocessing_context=self.multiprocessing_context,
+                single_threaded=single_threaded,
+            )
 
-        self._block_store = await BlockStore.create(self.db_wrapper)
-        self._hint_store = await HintStore.create(self.db_wrapper)
-        self._coin_store = await CoinStore.create(self.db_wrapper)
-        self.log.info("Initializing blockchain from disk")
-        start_time = time.time()
-        reserved_cores = self.config.get("reserved_cores", 0)
-        single_threaded = self.config.get("single_threaded", False)
-        multiprocessing_start_method = process_config_start_method(config=self.config, log=self.log)
-        self.multiprocessing_context = multiprocessing.get_context(method=multiprocessing_start_method)
-        self._blockchain = await Blockchain.create(
-            coin_store=self.coin_store,
-            block_store=self.block_store,
-            consensus_constants=self.constants,
-            blockchain_dir=self.db_path.parent,
-            reserved_cores=reserved_cores,
-            multiprocessing_context=self.multiprocessing_context,
-            single_threaded=single_threaded,
-        )
+            self._mempool_manager = MempoolManager(
+                get_coin_record=self.coin_store.get_coin_record,
+                consensus_constants=self.constants,
+                multiprocessing_context=self.multiprocessing_context,
+                single_threaded=single_threaded,
+            )
 
-        self._mempool_manager = MempoolManager(
-            get_coin_record=self.coin_store.get_coin_record,
-            consensus_constants=self.constants,
-            multiprocessing_context=self.multiprocessing_context,
-            single_threaded=single_threaded,
-        )
+            # Transactions go into this queue from the server, and get sent to respond_transaction
+            self._transaction_queue = TransactionQueue(1000, self.log)
+            self._transaction_queue_task: asyncio.Task[None] = asyncio.create_task(self._handle_transactions())
+            self.transaction_responses = []
 
-        # Transactions go into this queue from the server, and get sent to respond_transaction
-        self._transaction_queue = TransactionQueue(1000, self.log)
-        self._transaction_queue_task: asyncio.Task[None] = asyncio.create_task(self._handle_transactions())
-        self.transaction_responses = []
+            self._init_weight_proof = asyncio.create_task(self.initialize_weight_proof())
 
-        self._init_weight_proof = asyncio.create_task(self.initialize_weight_proof())
+            if self.config.get("enable_profiler", False):
+                asyncio.create_task(profile_task(self.root_path, "node", self.log))
 
-        if self.config.get("enable_profiler", False):
-            asyncio.create_task(profile_task(self.root_path, "node", self.log))
+            if self.config.get("enable_memory_profiler", False):
+                asyncio.create_task(mem_profile_task(self.root_path, "node", self.log))
 
-        if self.config.get("enable_memory_profiler", False):
-            asyncio.create_task(mem_profile_task(self.root_path, "node", self.log))
-
-        time_taken = time.time() - start_time
-        peak: Optional[BlockRecord] = self.blockchain.get_peak()
-        if peak is None:
-            self.log.info(f"Initialized with empty blockchain time taken: {int(time_taken)}s")
-            num_unspent = await self.coin_store.num_unspent()
-            if num_unspent > 0:
-                self.log.error(
-                    f"Inconsistent blockchain DB file! Could not find peak block but found {num_unspent} coins! "
-                    "This is a fatal error. The blockchain database may be corrupt"
+            time_taken = time.time() - start_time
+            peak: Optional[BlockRecord] = self.blockchain.get_peak()
+            if peak is None:
+                self.log.info(f"Initialized with empty blockchain time taken: {int(time_taken)}s")
+                num_unspent = await self.coin_store.num_unspent()
+                if num_unspent > 0:
+                    self.log.error(
+                        f"Inconsistent blockchain DB file! Could not find peak block but found {num_unspent} coins! "
+                        "This is a fatal error. The blockchain database may be corrupt"
+                    )
+                    raise RuntimeError("corrupt blockchain DB")
+            else:
+                self.log.info(
+                    f"Blockchain initialized to peak {peak.header_hash} height"
+                    f" {peak.height}, "
+                    f"time taken: {int(time_taken)}s"
                 )
-                raise RuntimeError("corrupt blockchain DB")
-        else:
-            self.log.info(
-                f"Blockchain initialized to peak {peak.header_hash} height"
-                f" {peak.height}, "
-                f"time taken: {int(time_taken)}s"
-            )
-            async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
-                pending_tx = await self.mempool_manager.new_peak(peak, None)
-            assert len(pending_tx) == 0  # no pending transactions when starting up
+                async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
+                    pending_tx = await self.mempool_manager.new_peak(peak, None)
+                assert len(pending_tx) == 0  # no pending transactions when starting up
 
-            full_peak: Optional[FullBlock] = await self.blockchain.get_full_peak()
-            assert full_peak is not None
-            state_change_summary = StateChangeSummary(peak, uint32(max(peak.height - 1, 0)), [], [], [], [])
-            ppp_result: PeakPostProcessingResult = await self.peak_post_processing(
-                full_peak, state_change_summary, None
-            )
-            await self.peak_post_processing_2(full_peak, None, state_change_summary, ppp_result)
-        if self.config["send_uncompact_interval"] != 0:
-            sanitize_weight_proof_only = False
-            if "sanitize_weight_proof_only" in self.config:
-                sanitize_weight_proof_only = self.config["sanitize_weight_proof_only"]
-            assert self.config["target_uncompact_proofs"] != 0
-            self.uncompact_task = asyncio.create_task(
-                self.broadcast_uncompact_blocks(
-                    self.config["send_uncompact_interval"],
-                    self.config["target_uncompact_proofs"],
-                    sanitize_weight_proof_only,
+                full_peak: Optional[FullBlock] = await self.blockchain.get_full_peak()
+                assert full_peak is not None
+                state_change_summary = StateChangeSummary(peak, uint32(max(peak.height - 1, 0)), [], [], [], [])
+                ppp_result: PeakPostProcessingResult = await self.peak_post_processing(
+                    full_peak, state_change_summary, None
                 )
-            )
-        if self.wallet_sync_task is None or self.wallet_sync_task.done():
-            self.wallet_sync_task = asyncio.create_task(self._wallets_sync_task_handler())
+                await self.peak_post_processing_2(full_peak, None, state_change_summary, ppp_result)
+            if self.config["send_uncompact_interval"] != 0:
+                sanitize_weight_proof_only = False
+                if "sanitize_weight_proof_only" in self.config:
+                    sanitize_weight_proof_only = self.config["sanitize_weight_proof_only"]
+                assert self.config["target_uncompact_proofs"] != 0
+                self.uncompact_task = asyncio.create_task(
+                    self.broadcast_uncompact_blocks(
+                        self.config["send_uncompact_interval"],
+                        self.config["target_uncompact_proofs"],
+                        sanitize_weight_proof_only,
+                    )
+                )
+            if self.wallet_sync_task is None or self.wallet_sync_task.done():
+                self.wallet_sync_task = asyncio.create_task(self._wallets_sync_task_handler())
 
-        self.initialized = True
-        if self.full_node_peers is not None:
-            asyncio.create_task(self.full_node_peers.start())
-        try:
-            yield
-        finally:
-            self._shut_down = True
-            if self._init_weight_proof is not None:
-                self._init_weight_proof.cancel()
-
-            # blockchain is created in _start and in certain cases it may not exist here during _close
-            if self._blockchain is not None:
-                self.blockchain.shut_down()
-            # same for mempool_manager
-            if self._mempool_manager is not None:
-                self.mempool_manager.shut_down()
-
+            self.initialized = True
             if self.full_node_peers is not None:
-                asyncio.create_task(self.full_node_peers.close())
-            if self.uncompact_task is not None:
-                self.uncompact_task.cancel()
-            if self._transaction_queue_task is not None:
-                self._transaction_queue_task.cancel()
-            cancel_task_safe(task=self.wallet_sync_task, log=self.log)
-            cancel_task_safe(task=self._sync_task, log=self.log)
+                asyncio.create_task(self.full_node_peers.start())
+            try:
+                yield
+            finally:
+                self._shut_down = True
+                if self._init_weight_proof is not None:
+                    self._init_weight_proof.cancel()
 
-            for task_id, task in list(self.full_node_store.tx_fetch_tasks.items()):
-                cancel_task_safe(task, self.log)
-            await self.db_wrapper.close()
-            if self._init_weight_proof is not None:
-                await asyncio.wait([self._init_weight_proof])
-            if self._sync_task is not None:
-                with contextlib.suppress(asyncio.CancelledError):
-                    await self._sync_task
+                # blockchain is created in _start and in certain cases it may not exist here during _close
+                if self._blockchain is not None:
+                    self.blockchain.shut_down()
+                # same for mempool_manager
+                if self._mempool_manager is not None:
+                    self.mempool_manager.shut_down()
+
+                if self.full_node_peers is not None:
+                    asyncio.create_task(self.full_node_peers.close())
+                if self.uncompact_task is not None:
+                    self.uncompact_task.cancel()
+                if self._transaction_queue_task is not None:
+                    self._transaction_queue_task.cancel()
+                cancel_task_safe(task=self.wallet_sync_task, log=self.log)
+                cancel_task_safe(task=self._sync_task, log=self.log)
+
+                for task_id, task in list(self.full_node_store.tx_fetch_tasks.items()):
+                    cancel_task_safe(task, self.log)
+                if self._init_weight_proof is not None:
+                    await asyncio.wait([self._init_weight_proof])
+                if self._sync_task is not None:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await self._sync_task
 
     @property
     def block_store(self) -> BlockStore:

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -65,7 +65,8 @@ async def manage_connection(
     try:
         yield connection
     finally:
-        await connection.close()
+        with anyio.CancelScope(shield=True):
+            await connection.close()
 
 
 def sql_trace_callback(req: str, file: TextIO, name: Optional[str] = None) -> None:

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -194,7 +194,7 @@ class DBWrapper2:
         foreign_keys: bool = False,
         row_factory: Optional[Type[aiosqlite.Row]] = None,
     ) -> DBWrapper2:
-        # TODO: please use .managed() instead
+        # WARNING: please use .managed() instead
         if log_path is None:
             log_file = None
         else:
@@ -224,7 +224,7 @@ class DBWrapper2:
         return self
 
     async def close(self) -> None:
-        # TODO: please use .managed() instead
+        # WARNING: please use .managed() instead
         try:
             while self._num_read_connections > 0:
                 await (await self._read_connections.get()).close()

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -6,11 +6,13 @@ import functools
 import random
 import sqlite3
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, Iterable, Optional, TextIO, Type, Union
 
 import aiosqlite
+import anyio
 from typing_extensions import final
 
 if aiosqlite.sqlite_version_info < (3, 32, 0):
@@ -102,17 +104,18 @@ def get_host_parameter_limit() -> int:
 
 
 @final
+@dataclass
 class DBWrapper2:
-    db_version: int
-    host_parameter_limit: int
-    _lock: asyncio.Lock
-    _read_connections: asyncio.Queue[aiosqlite.Connection]
     _write_connection: aiosqlite.Connection
-    _num_read_connections: int
-    _in_use: Dict[asyncio.Task[object], aiosqlite.Connection]
-    _current_writer: Optional[asyncio.Task[object]]
-    _savepoint_name: int
-    _log_file: Optional[TextIO]
+    db_version: int = 1
+    _log_file: Optional[TextIO] = None
+    host_parameter_limit: int = get_host_parameter_limit()
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _read_connections: asyncio.Queue[aiosqlite.Connection] = field(default_factory=asyncio.Queue)
+    _num_read_connections: int = 0
+    _in_use: Dict[asyncio.Task[object], aiosqlite.Connection] = field(default_factory=dict)
+    _current_writer: Optional[asyncio.Task[object]] = None
+    _savepoint_name: int = 0
 
     async def add_connection(self, c: aiosqlite.Connection) -> None:
         # this guarantees that reader connections can only be used for reading
@@ -121,22 +124,61 @@ class DBWrapper2:
         self._read_connections.put_nowait(c)
         self._num_read_connections += 1
 
-    def __init__(
-        self,
-        connection: aiosqlite.Connection,
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def managed(
+        cls,
+        database: Union[str, Path],
+        *,
         db_version: int = 1,
-        log_file: Optional[TextIO] = None,
-    ) -> None:
-        self._read_connections = asyncio.Queue()
-        self._write_connection = connection
-        self._lock = asyncio.Lock()
-        self.db_version = db_version
-        self._num_read_connections = 0
-        self._in_use = {}
-        self._current_writer = None
-        self._savepoint_name = 0
-        self._log_file = log_file
-        self.host_parameter_limit = get_host_parameter_limit()
+        uri: bool = False,
+        reader_count: int = 4,
+        log_path: Optional[Path] = None,
+        journal_mode: str = "WAL",
+        synchronous: Optional[str] = None,
+        foreign_keys: bool = False,
+        row_factory: Optional[Type[aiosqlite.Row]] = None,
+    ) -> AsyncIterator[DBWrapper2]:
+        if log_path is None:
+            log_file = None
+        else:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_file = log_path.open("a", encoding="utf-8")
+
+        # TODO: better handle shutting down all these other things
+        write_connection = await _create_connection(database=database, uri=uri, log_file=log_file, name="writer")
+        await (await write_connection.execute(f"pragma journal_mode={journal_mode}")).close()
+        if synchronous is not None:
+            await (await write_connection.execute(f"pragma synchronous={synchronous}")).close()
+
+        await (await write_connection.execute(f"pragma foreign_keys={'ON' if foreign_keys else 'OFF'}")).close()
+
+        write_connection.row_factory = row_factory
+
+        self = cls(_write_connection=write_connection, db_version=db_version, _log_file=log_file)
+
+        for index in range(reader_count):
+            read_connection = await _create_connection(
+                database=database,
+                uri=uri,
+                log_file=log_file,
+                name=f"reader-{index}",
+            )
+            read_connection.row_factory = row_factory
+            await self.add_connection(c=read_connection)
+
+        try:
+            yield self
+        finally:
+            with anyio.CancelScope(shield=True):
+                try:
+                    while self._num_read_connections > 0:
+                        await (await self._read_connections.get()).close()
+                        self._num_read_connections -= 1
+                    await self._write_connection.close()
+                finally:
+                    if self._log_file is not None:
+                        self._log_file.close()
 
     @classmethod
     async def create(
@@ -152,6 +194,7 @@ class DBWrapper2:
         foreign_keys: bool = False,
         row_factory: Optional[Type[aiosqlite.Row]] = None,
     ) -> DBWrapper2:
+        # TODO: please use .managed() instead
         if log_path is None:
             log_file = None
         else:
@@ -166,7 +209,7 @@ class DBWrapper2:
 
         write_connection.row_factory = row_factory
 
-        self = cls(connection=write_connection, db_version=db_version, log_file=log_file)
+        self = cls(_write_connection=write_connection, db_version=db_version, _log_file=log_file)
 
         for index in range(reader_count):
             read_connection = await _create_connection(
@@ -181,6 +224,7 @@ class DBWrapper2:
         return self
 
     async def close(self) -> None:
+        # TODO: please use .managed() instead
         try:
             while self._num_read_connections > 0:
                 await (await self._read_connections.get()).close()

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -177,13 +177,9 @@ class DBWrapper2:
                 yield self
             finally:
                 with anyio.CancelScope(shield=True):
-                    try:
-                        while self._num_read_connections > 0:
-                            await self._read_connections.get()
-                            self._num_read_connections -= 1
-                    finally:
-                        if self._log_file is not None:
-                            self._log_file.close()
+                    while self._num_read_connections > 0:
+                        await self._read_connections.get()
+                        self._num_read_connections -= 1
 
     @classmethod
     async def create(

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -56,7 +56,6 @@ async def _create_connection(
 async def manage_connection(
     database: Union[str, Path],
     uri: bool = False,
-    # TODO: switch to log_file
     log_file: Optional[TextIO] = None,
     name: Optional[str] = None,
 ) -> AsyncIterator[aiosqlite.Connection]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,11 +212,8 @@ async def empty_blockchain(latest_db_version, blockchain_constants):
     """
     from tests.util.blockchain import create_blockchain
 
-    bc1, db_wrapper = await create_blockchain(blockchain_constants, latest_db_version)
-    yield bc1
-
-    await db_wrapper.close()
-    bc1.shut_down()
+    async with create_blockchain(blockchain_constants, latest_db_version) as (bc1, db_wrapper):
+        yield bc1
 
 
 @pytest.fixture(scope="function")

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -82,8 +82,7 @@ async def test_create_creates_tables_and_columns(
     # allow you to parametrize the query.
     query = f"pragma table_info({table_name});"
 
-    db_wrapper = await DBWrapper2.create(database=database_uri, uri=True, reader_count=1)
-    try:
+    async with DBWrapper2.managed(database=database_uri, uri=True, reader_count=1) as db_wrapper:
         async with db_wrapper.reader() as reader:
             cursor = await reader.execute(query)
             columns = await cursor.fetchall()
@@ -97,8 +96,6 @@ async def test_create_creates_tables_and_columns(
                 assert [column[1] for column in columns] == expected_columns
         finally:
             await store.close()
-    finally:
-        await db_wrapper.close()
 
 
 @pytest.mark.anyio

--- a/tests/core/full_node/ram_db.py
+++ b/tests/core/full_node/ram_db.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import random
 from pathlib import Path
-from typing import Tuple
+from typing import AsyncIterator, Tuple
 
 from chia.consensus.blockchain import Blockchain
 from chia.consensus.constants import ConsensusConstants
@@ -11,10 +12,16 @@ from chia.full_node.coin_store import CoinStore
 from chia.util.db_wrapper import DBWrapper2
 
 
-async def create_ram_blockchain(consensus_constants: ConsensusConstants) -> Tuple[DBWrapper2, Blockchain]:
+@contextlib.asynccontextmanager
+async def create_ram_blockchain(
+    consensus_constants: ConsensusConstants,
+) -> AsyncIterator[Tuple[DBWrapper2, Blockchain]]:
     uri = f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
-    db_wrapper = await DBWrapper2.create(database=uri, uri=True, reader_count=1, db_version=2)
-    block_store = await BlockStore.create(db_wrapper)
-    coin_store = await CoinStore.create(db_wrapper)
-    blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, Path("."), 2)
-    return db_wrapper, blockchain
+    async with DBWrapper2.managed(database=uri, uri=True, reader_count=1, db_version=2) as db_wrapper:
+        block_store = await BlockStore.create(db_wrapper)
+        coin_store = await CoinStore.create(db_wrapper)
+        blockchain = await Blockchain.create(coin_store, block_store, consensus_constants, Path("."), 2)
+        try:
+            yield db_wrapper, blockchain
+        finally:
+            blockchain.shut_down()

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -49,20 +49,16 @@ async def empty_blockchain(db_version: int, blockchain_constants: ConsensusConst
         DISCRIMINANT_SIZE_BITS=32,
         SUB_SLOT_ITERS_STARTING=uint64(2**12),
     )
-    bc1, db_wrapper = await create_blockchain(patched_constants, db_version)
-    yield bc1
-    await db_wrapper.close()
-    bc1.shut_down()
+    async with create_blockchain(patched_constants, db_version) as (bc1, db_wrapper):
+        yield bc1
 
 
 @pytest.fixture(scope="function")
 async def empty_blockchain_with_original_constants(
     db_version: int, blockchain_constants: ConsensusConstants
 ) -> AsyncIterator[Blockchain]:
-    bc1, db_wrapper = await create_blockchain(blockchain_constants, db_version)
-    yield bc1
-    await db_wrapper.close()
-    bc1.shut_down()
+    async with create_blockchain(blockchain_constants, db_version) as (bc1, db_wrapper):
+        yield bc1
 
 
 @pytest.mark.limit_consensus_modes(reason="save time")

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -68,8 +68,7 @@ async def check_spend_bundle_validity(
     or fails with the correct error code.
     """
 
-    db_wrapper, blockchain = await create_ram_blockchain(bt.constants)
-    try:
+    async with create_ram_blockchain(bt.constants) as (db_wrapper, blockchain):
         for block in blocks:
             await _validate_and_add_block(blockchain, block)
 
@@ -93,13 +92,6 @@ async def check_spend_bundle_validity(
             coins_removed = []
 
         return coins_added, coins_removed, newest_block
-
-    finally:
-        # if we don't close the db_wrapper, the test process doesn't exit cleanly
-        await db_wrapper.close()
-
-        # we must call `shut_down` or the executor in `Blockchain` doesn't stop
-        blockchain.shut_down()
 
 
 async def check_conditions(

--- a/tests/core/test_db_validation.py
+++ b/tests/core/test_db_validation.py
@@ -129,8 +129,7 @@ def test_db_validate_in_main_chain(invalid_in_chain: bool) -> None:
 
 
 async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
-    db_wrapper = await DBWrapper2.create(database=db_file, reader_count=1, db_version=2)
-    try:
+    async with DBWrapper2.managed(database=db_file, reader_count=1, db_version=2) as db_wrapper:
         async with db_wrapper.writer_maybe_transaction() as conn:
             # this is done by chia init normally
             await conn.execute("CREATE TABLE database_version(version int)")
@@ -145,8 +144,6 @@ async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
             results = PreValidationResult(None, uint64(1), None, False)
             result, err, _ = await bc.add_block(block, results)
             assert err is None
-    finally:
-        await db_wrapper.close()
 
 
 @pytest.mark.anyio

--- a/tests/timelord/test_new_peak.py
+++ b/tests/timelord/test_new_peak.py
@@ -26,117 +26,104 @@ class TestNewPeak:
     async def test_timelord_new_peak_basic(
         self, bt: BlockTools, timelord: Tuple[TimelordAPI, ChiaServer], default_1000_blocks: List[FullBlock]
     ) -> None:
-        b1, db_wrapper1 = await create_blockchain(bt.constants, 2)
-        b2, db_wrapper2 = await create_blockchain(bt.constants, 2)
+        async with create_blockchain(bt.constants, 2) as (b1, db_wrapper1):
+            async with create_blockchain(bt.constants, 2) as (b2, db_wrapper2):
+                timelord_api, _ = timelord
+                for block in default_1000_blocks:
+                    await _validate_and_add_block(b1, block)
+                    await _validate_and_add_block(b2, block)
 
-        timelord_api, _ = timelord
-        for block in default_1000_blocks:
-            await _validate_and_add_block(b1, block)
-            await _validate_and_add_block(b2, block)
+                peak = timelord_peak_from_block(default_1000_blocks[-1], b1, bt.constants)
+                assert peak is not None
+                assert timelord_api.timelord.new_peak is None
+                await timelord_api.new_peak_timelord(peak)
+                assert timelord_api.timelord.new_peak is not None
+                assert timelord_api.timelord.new_peak.reward_chain_block.height == peak.reward_chain_block.height
+                blocks = bt.get_consecutive_blocks(1, default_1000_blocks)
+                await _validate_and_add_block(b1, blocks[-1])
+                await _validate_and_add_block(b2, blocks[-1])
 
-        peak = timelord_peak_from_block(default_1000_blocks[-1], b1, bt.constants)
-        assert peak is not None
-        assert timelord_api.timelord.new_peak is None
-        await timelord_api.new_peak_timelord(peak)
-        assert timelord_api.timelord.new_peak is not None
-        assert timelord_api.timelord.new_peak.reward_chain_block.height == peak.reward_chain_block.height
-        blocks = bt.get_consecutive_blocks(1, default_1000_blocks)
-        await _validate_and_add_block(b1, blocks[-1])
-        await _validate_and_add_block(b2, blocks[-1])
+                await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks[-1], b1, bt.constants))
+                assert timelord_api.timelord.new_peak.reward_chain_block.height == blocks[-1].height
 
-        await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks[-1], b1, bt.constants))
-        assert timelord_api.timelord.new_peak.reward_chain_block.height == blocks[-1].height
+                blocks_1 = bt.get_consecutive_blocks(2, blocks)
+                await _validate_and_add_block(b1, blocks_1[-2])
+                await _validate_and_add_block(b1, blocks_1[-1])
+                await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_1[-2], b1, bt.constants))
+                await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_1[-1], b1, bt.constants))
+                assert timelord_api.timelord.new_peak.reward_chain_block.height == blocks_1[-1].height
 
-        blocks_1 = bt.get_consecutive_blocks(2, blocks)
-        await _validate_and_add_block(b1, blocks_1[-2])
-        await _validate_and_add_block(b1, blocks_1[-1])
-        await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_1[-2], b1, bt.constants))
-        await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_1[-1], b1, bt.constants))
-        assert timelord_api.timelord.new_peak.reward_chain_block.height == blocks_1[-1].height
-
-        # # new unknown peak, weight less then curr peak
-        # blocks_2 = bt.get_consecutive_blocks(1, blocks)
-        # await _validate_and_add_block(b2, blocks_2[-1])
-        # await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_2[-1], b2, bt.constants))
-        # assert timelord_api.timelord.new_peak.reward_chain_block.height == blocks_1[-1].height
-
-        await db_wrapper1.close()
-        await db_wrapper2.close()
-        b1.shut_down()
-        b2.shut_down()
-
-        return None
+                # # new unknown peak, weight less then curr peak
+                # blocks_2 = bt.get_consecutive_blocks(1, blocks)
+                # await _validate_and_add_block(b2, blocks_2[-1])
+                # await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_2[-1], b2, bt.constants))
+                # assert timelord_api.timelord.new_peak.reward_chain_block.height == blocks_1[-1].height
 
     @pytest.mark.anyio
     async def test_timelord_new_peak_heavier_unfinished(
         self, bt: BlockTools, timelord: Tuple[TimelordAPI, ChiaServer], default_1000_blocks: List[FullBlock]
     ) -> None:
-        b1, db_wrapper1 = await create_blockchain(bt.constants, 2)
-        b2, db_wrapper2 = await create_blockchain(bt.constants, 2)
+        async with create_blockchain(bt.constants, 2) as (b1, db_wrapper1):
+            async with create_blockchain(bt.constants, 2) as (b2, db_wrapper2):
+                timelord_api, _ = timelord
+                for block in default_1000_blocks:
+                    await _validate_and_add_block(b1, block)
+                    await _validate_and_add_block(b2, block)
 
-        timelord_api, _ = timelord
-        for block in default_1000_blocks:
-            await _validate_and_add_block(b1, block)
-            await _validate_and_add_block(b2, block)
+                peak = timelord_peak_from_block(default_1000_blocks[-1], b1, bt.constants)
+                assert peak is not None
+                assert timelord_api.timelord.new_peak is None
+                await timelord_api.new_peak_timelord(peak)
+                assert timelord_api.timelord.new_peak is not None
+                assert timelord_api.timelord.new_peak.reward_chain_block.height == peak.reward_chain_block.height
 
-        peak = timelord_peak_from_block(default_1000_blocks[-1], b1, bt.constants)
-        assert peak is not None
-        assert timelord_api.timelord.new_peak is None
-        await timelord_api.new_peak_timelord(peak)
-        assert timelord_api.timelord.new_peak is not None
-        assert timelord_api.timelord.new_peak.reward_chain_block.height == peak.reward_chain_block.height
+                # make two new blocks on tip
+                blocks_1 = bt.get_consecutive_blocks(2, default_1000_blocks)
+                await _validate_and_add_block(b1, blocks_1[-2])
+                await _validate_and_add_block(b1, blocks_1[-1])
+                blocks_2 = bt.get_consecutive_blocks(1, default_1000_blocks)
+                await _validate_and_add_block(b2, blocks_2[-1])
+                block_record = b1.block_record(blocks_1[-1].header_hash)
+                block = blocks_1[-1]
 
-        # make two new blocks on tip
-        blocks_1 = bt.get_consecutive_blocks(2, default_1000_blocks)
-        await _validate_and_add_block(b1, blocks_1[-2])
-        await _validate_and_add_block(b1, blocks_1[-1])
-        blocks_2 = bt.get_consecutive_blocks(1, default_1000_blocks)
-        await _validate_and_add_block(b2, blocks_2[-1])
-        block_record = b1.block_record(blocks_1[-1].header_hash)
-        block = blocks_1[-1]
+                ses: Optional[SubEpochSummary] = next_sub_epoch_summary(
+                    bt.constants, b1, block_record.required_iters, block, True
+                )
 
-        ses: Optional[SubEpochSummary] = next_sub_epoch_summary(
-            bt.constants, b1, block_record.required_iters, block, True
-        )
+                sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
+                    bt.constants, len(block.finished_sub_slots) > 0, b1.block_record(blocks_1[-1].prev_header_hash), b1
+                )
 
-        sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
-            bt.constants, len(block.finished_sub_slots) > 0, b1.block_record(blocks_1[-1].prev_header_hash), b1
-        )
+                if block.reward_chain_block.signage_point_index == 0:
+                    # find first in slot and find slot challenge
+                    blk = b1.block_record(blocks_1[-1].header_hash)
+                    while blk.first_in_sub_slot is False:
+                        blk = b1.block_record(blocks_1[-1].prev_header_hash)
+                    full_blk = await b1.get_full_block(blk.header_hash)
+                    sub_slot = None
+                    for s in full_blk.finished_sub_slots:
+                        if (
+                            s is not None
+                            and s.challenge_chain.get_hash() == block.reward_chain_block.pos_ss_cc_challenge_hash
+                        ):
+                            sub_slot = s
+                    if sub_slot is None:
+                        assert block.reward_chain_block.pos_ss_cc_challenge_hash == bt.constants.GENESIS_CHALLENGE
+                        rc_prev = bt.constants.GENESIS_CHALLENGE
+                    else:
+                        rc_prev = sub_slot.reward_chain.get_hash()
+                else:
+                    assert block.reward_chain_block.reward_chain_sp_vdf is not None
+                    rc_prev = block.reward_chain_block.reward_chain_sp_vdf.challenge
 
-        if block.reward_chain_block.signage_point_index == 0:
-            # find first in slot and find slot challenge
-            blk = b1.block_record(blocks_1[-1].header_hash)
-            while blk.first_in_sub_slot is False:
-                blk = b1.block_record(blocks_1[-1].prev_header_hash)
-            full_blk = await b1.get_full_block(blk.header_hash)
-            sub_slot = None
-            for s in full_blk.finished_sub_slots:
-                if s is not None and s.challenge_chain.get_hash() == block.reward_chain_block.pos_ss_cc_challenge_hash:
-                    sub_slot = s
-            if sub_slot is None:
-                assert block.reward_chain_block.pos_ss_cc_challenge_hash == bt.constants.GENESIS_CHALLENGE
-                rc_prev = bt.constants.GENESIS_CHALLENGE
-            else:
-                rc_prev = sub_slot.reward_chain.get_hash()
-        else:
-            assert block.reward_chain_block.reward_chain_sp_vdf is not None
-            rc_prev = block.reward_chain_block.reward_chain_sp_vdf.challenge
+                timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
+                    block.reward_chain_block.get_unfinished(), difficulty, sub_slot_iters, block.foliage, ses, rc_prev
+                )
 
-        timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
-            block.reward_chain_block.get_unfinished(), difficulty, sub_slot_iters, block.foliage, ses, rc_prev
-        )
+                timelord_api.new_unfinished_block_timelord(timelord_unf_block)
 
-        timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-
-        await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_2[-1], b2, bt.constants))
-        assert timelord_api.timelord.last_state.get_height() == peak.reward_chain_block.height
-
-        await db_wrapper1.close()
-        await db_wrapper2.close()
-        b1.shut_down()
-        b2.shut_down()
-
-        return None
+                await timelord_api.new_peak_timelord(timelord_peak_from_block(blocks_2[-1], b2, bt.constants))
+                assert timelord_api.timelord.last_state.get_height() == peak.reward_chain_block.height
 
 
 def get_recent_reward_challenges(

--- a/tests/util/db_connection.py
+++ b/tests/util/db_connection.py
@@ -11,19 +11,13 @@ from chia.util.db_wrapper import DBWrapper2, generate_in_memory_db_uri
 @asynccontextmanager
 async def DBConnection(db_version: int) -> AsyncIterator[DBWrapper2]:
     db_uri = generate_in_memory_db_uri()
-    _db_wrapper = await DBWrapper2.create(database=db_uri, uri=True, reader_count=4, db_version=db_version)
-    try:
+    async with DBWrapper2.managed(database=db_uri, uri=True, reader_count=4, db_version=db_version) as _db_wrapper:
         yield _db_wrapper
-    finally:
-        await _db_wrapper.close()
 
 
 @asynccontextmanager
 async def PathDBConnection(db_version: int) -> AsyncIterator[DBWrapper2]:
     with tempfile.TemporaryDirectory() as directory:
         db_path = Path(directory).joinpath("db.sqlite")
-        _db_wrapper = await DBWrapper2.create(database=db_path, reader_count=4, db_version=db_version)
-        try:
+        async with DBWrapper2.managed(database=db_path, reader_count=4, db_version=db_version) as _db_wrapper:
             yield _db_wrapper
-        finally:
-            await _db_wrapper.close()

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1066,10 +1066,9 @@ class TestCATWallet:
 async def test_unacknowledged_cat_table() -> None:
     db_name = Path(tempfile.TemporaryDirectory().name).joinpath("test.sqlite")
     db_name.parent.mkdir(parents=True, exist_ok=True)
-    db_wrapper = await DBWrapper2.create(
+    async with DBWrapper2.managed(
         database=db_name,
-    )
-    try:
+    ) as db_wrapper:
         interested_store = await WalletInterestedStore.create(db_wrapper)
 
         def asset_id(i: int) -> bytes32:
@@ -1103,5 +1102,3 @@ async def test_unacknowledged_cat_table() -> None:
         assert await interested_store.get_unacknowledged_states_for_asset_id(asset_id(0)) == [(coin_state(0), 0)]
         await interested_store.delete_unacknowledged_states_for_asset_id(asset_id(0))
         assert await interested_store.get_unacknowledged_states_for_asset_id(asset_id(0)) == []
-    finally:
-        await db_wrapper.close()

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -25,10 +25,9 @@ async def test_notification_store_backwards_compat() -> None:
     # First create the DB the way it would have otheriwse been created
     db_name = Path(tempfile.TemporaryDirectory().name).joinpath("test.sqlite")
     db_name.parent.mkdir(parents=True, exist_ok=True)
-    db_wrapper = await DBWrapper2.create(
+    async with DBWrapper2.managed(
         database=db_name,
-    )
-    try:
+    ) as db_wrapper:
         async with db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(
                 "CREATE TABLE IF NOT EXISTS notifications(coin_id blob PRIMARY KEY,msg blob,amount blob)"
@@ -45,8 +44,6 @@ async def test_notification_store_backwards_compat() -> None:
 
         await NotificationStore.create(db_wrapper)
         await NotificationStore.create(db_wrapper)
-    finally:
-        await db_wrapper.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Just adding a `DBWrapper2.managed()` class method to the db wrapper so it can easily be created directly for use with a context manager.  This means it can provide it's own cleanup code instead of needing the close call duplicated at every use.

There are a few remaining uses of the create/stop pattern that will need to be updated as well.

- https://github.com/Chia-Network/chia-blockchain/pull/16890
- https://github.com/Chia-Network/chia-blockchain/pull/16889
- and i think the wallet state manager which probably plays into https://github.com/Chia-Network/chia-blockchain/pull/16760

The anyio cancel scopes and shielding will be introduced to the team soon.  I am going ahead and including them myself both to get a start at filling them in and get some time thinking about them in actual code changes.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
### Draft For:
- [x] [`# TODO: switch to log_file`](https://github.com/Chia-Network/chia-blockchain/pull/16880/files#diff-70ec43bc92826e3bab2e1ae6a4c59a21d96a369430ea600f94c903568d47841dR59) after https://github.com/Chia-Network/chia-blockchain/pull/16753