### PR TITLE
Fixed handling for max coin amount when it is set to zero & updated unit tests

### DIFF
--- a/chia/wallet/util/tx_config.py
+++ b/chia/wallet/util/tx_config.py
@@ -84,7 +84,9 @@ class CoinSelectionConfigLoader(Streamable):
         constants: ConsensusConstants = kwargs["constants"]
         return CoinSelectionConfig(
             min_coin_amount=uint64(0) if self.min_coin_amount is None else self.min_coin_amount,
-            max_coin_amount=uint64(constants.MAX_COIN_AMOUNT) if self.max_coin_amount is None else self.max_coin_amount,
+            max_coin_amount=uint64(constants.MAX_COIN_AMOUNT)
+            if (self.max_coin_amount is None or self.max_coin_amount == 0)
+            else self.max_coin_amount,
             excluded_coin_amounts=[] if self.excluded_coin_amounts is None else self.excluded_coin_amounts,
             excluded_coin_ids=[] if self.excluded_coin_ids is None else self.excluded_coin_ids,
         )

--- a/tests/cmds/test_tx_config_args.py
+++ b/tests/cmds/test_tx_config_args.py
@@ -48,8 +48,8 @@ def test_coin_selection_args() -> None:
     )
 
     assert (
-        r"{'min_coin_amount': 0, 'max_coin_amount': 0, 'excluded_coin_amounts': [0], 'excluded_coin_ids': "
-        r"['0x0000000000000000000000000000000000000000000000000000000000000000']}" in result.output
+        r"{'min_coin_amount': 0, 'max_coin_amount': 18446744073709551615, 'excluded_coin_amounts': [0], "
+        r"'excluded_coin_ids': ['0x0000000000000000000000000000000000000000000000000000000000000000']}" in result.output
     )
 
     result = runner.invoke(

--- a/tests/cmds/wallet/test_coins.py
+++ b/tests/cmds/wallet/test_coins.py
@@ -38,7 +38,10 @@ def test_coins_get_info(capsys: object, get_test_cli_clients: Tuple[TestRpcClien
             (
                 1,
                 CoinSelectionConfig(
-                    min_coin_amount=uint64(0), max_coin_amount=uint64(0), excluded_coin_amounts=[], excluded_coin_ids=[]
+                    min_coin_amount=uint64(0),
+                    max_coin_amount=uint64(18446744073709551615),
+                    excluded_coin_amounts=[],
+                    excluded_coin_ids=[],
                 ),
             )
         ],


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Allows transactions to go through when the max coin amount is set to zero, this is commonly used as a default by most cli commands.
Fixes `chia wallet coins combine` when used with fee
Resolves #16802 


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
when no max coin value is set with some rpc / cli calls, max coin ammt is set to zero so no fees coins can be found.


### New Behavior:
max coin amount set to max coin constant, fee coin searching succeeds. 


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Updated Unit tests


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
