### PR TITLE
undo BlockRecord cache insert, when DB fails

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -118,6 +118,13 @@ class ForkInfo:
             assert coin.name() not in self.additions_since_fork
             self.additions_since_fork[coin.name()] = ForkAdd(coin, uint32(block.height), uint64(timestamp), None, True)
 
+    def rollback(self, header_hash: bytes32, height: int) -> None:
+        assert height <= self.peak_height
+        self.peak_height = height
+        self.peak_hash = header_hash
+        self.additions_since_fork = {k: v for k, v in self.additions_since_fork.items() if v.confirmed_height <= height}
+        self.removals_since_fork = {k: v for k, v in self.removals_since_fork.items() if v.height <= height}
+
 
 async def validate_block_body(
     constants: ConsensusConstants,

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -408,6 +408,7 @@ async def validate_block_body(
             # and coins created after fork (additions_since_fork)
             if rem in fork_info.removals_since_fork:
                 # This coin was spent in the fork
+                log.error(f"Err.DOUBLE_SPEND_IN_FORK {fork_info.removals_since_fork[rem]}")
                 return Err.DOUBLE_SPEND_IN_FORK, None
             removals_from_db.append(rem)
 
@@ -440,7 +441,7 @@ async def validate_block_body(
         # This coin is not in the current heaviest chain, so it must be in the fork
         if rem not in fork_info.additions_since_fork:
             # Check for spending a coin that does not exist in this fork
-            log.error(f"Err.UNKNOWN_UNSPENT: COIN ID: {rem} NPC RESULT: {npc_result}")
+            log.error(f"Err.UNKNOWN_UNSPENT: COIN ID: {rem} fork_info: {fork_info}")
             return Err.UNKNOWN_UNSPENT, None
         addition: ForkAdd = fork_info.additions_since_fork[rem]
         new_coin_record: CoinRecord = CoinRecord(

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -471,6 +471,7 @@ class Blockchain(BlockchainInterface):
                 self.remove_block_record(header_hash)
             except KeyError:
                 pass
+            fork_info.rollback(header_hash, -1 if previous_peak_height is None else previous_peak_height)
             self.block_store.rollback_cache_block(header_hash)
             self._peak_height = previous_peak_height
             log.error(

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -465,6 +465,12 @@ class Blockchain(BlockchainInterface):
                 self._peak_height = block_record.height
 
         except BaseException as e:
+            # depending on exactly when the failure of adding the block
+            # happened, we may not have added it to the block record cache
+            try:
+                self.remove_block_record(header_hash)
+            except KeyError:
+                pass
             self.block_store.rollback_cache_block(header_hash)
             self._peak_height = previous_peak_height
             log.error(


### PR DESCRIPTION
We currently have two caches on top of the block store database.

1. The `BlockStore` itself keeps an LRU of recently requested `FullBlock` objects.
2. The `Blockchain` class keeps *recent* `BlockRecords` in a cache (recent, as in close to the peak)

When we fail to insert a block in the DB, we undo the insertion into the block cache in `BlockStore`, but we currently don't undo the insertion of the block record into the block-record cache in Blockchain.

This PR fixes that.

Additionally, this PR rolls back any additions and removals from `ForkInfo`, if they have been added while validating the block.