### PR TITLE
reorg optimization

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -63,6 +63,13 @@ class ForkInfo:
     # coin-id
     removals_since_fork: Set[bytes32] = field(default_factory=set)
 
+    def reset(self, fork_height: int, header_hash: bytes32) -> None:
+        self.fork_height = fork_height
+        self.peak_height = fork_height
+        self.peak_hash = header_hash
+        self.additions_since_fork = {}
+        self.removals_since_fork = set()
+
     def include_spends(self, npc_result: Optional[NPCResult], block: FullBlock) -> None:
         height = block.height
         if npc_result is not None:

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -70,8 +70,13 @@ class ForkInfo:
         self.additions_since_fork = {}
         self.removals_since_fork = set()
 
-    def include_spends(self, npc_result: Optional[NPCResult], block: FullBlock) -> None:
+    def include_spends(self, npc_result: Optional[NPCResult], block: FullBlock, header_hash: bytes32) -> None:
         height = block.height
+        assert self.peak_height == height - 1
+
+        self.peak_height = int(block.height)
+        self.peak_hash = header_hash
+
         if npc_result is not None:
             assert npc_result.conds is not None
             assert block.foliage_transaction_block is not None

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -44,6 +44,15 @@ log = logging.getLogger(__name__)
 #           :
 
 
+@dataclass(frozen=True)
+class ForkAdd:
+    coin: Coin
+    confirmed_height: uint32
+    timestamp: uint64
+    hint: Optional[bytes]
+    is_coinbase: bool
+
+
 @dataclass
 class ForkInfo:
     # defines the last block shared by the fork and the main chain. additions
@@ -58,8 +67,7 @@ class ForkInfo:
     # the header hash of the peak block of this fork
     peak_hash: bytes32
     # The additions include coinbase additions
-    # coin, creation-height, timestamp
-    additions_since_fork: Dict[bytes32, Tuple[Coin, uint32, uint64]] = field(default_factory=dict)
+    additions_since_fork: Dict[bytes32, ForkAdd] = field(default_factory=dict)
     # coin-id
     removals_since_fork: Set[bytes32] = field(default_factory=set)
 
@@ -83,14 +91,14 @@ class ForkInfo:
             timestamp = block.foliage_transaction_block.timestamp
             for spend in npc_result.conds.spends:
                 self.removals_since_fork.add(bytes32(spend.coin_id))
-                for puzzle_hash, amount, _ in spend.create_coin:
+                for puzzle_hash, amount, hint in spend.create_coin:
                     coin = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
-                    self.additions_since_fork[coin.name()] = (coin, height, timestamp)
+                    self.additions_since_fork[coin.name()] = ForkAdd(coin, height, timestamp, hint, False)
         for coin in block.get_included_reward_coins():
             assert block.foliage_transaction_block is not None
             timestamp = block.foliage_transaction_block.timestamp
             assert coin.name() not in self.additions_since_fork
-            self.additions_since_fork[coin.name()] = (coin, block.height, timestamp)
+            self.additions_since_fork[coin.name()] = ForkAdd(coin, block.height, timestamp, None, True)
 
 
 async def validate_block_body(
@@ -409,13 +417,13 @@ async def validate_block_body(
             # Check for spending a coin that does not exist in this fork
             log.error(f"Err.UNKNOWN_UNSPENT: COIN ID: {rem} NPC RESULT: {npc_result}")
             return Err.UNKNOWN_UNSPENT, None
-        new_coin, confirmed_height, confirmed_timestamp = fork_info.additions_since_fork[rem]
+        addition: ForkAdd = fork_info.additions_since_fork[rem]
         new_coin_record: CoinRecord = CoinRecord(
-            new_coin,
-            confirmed_height,
+            addition.coin,
+            addition.confirmed_height,
             uint32(0),
             False,
-            confirmed_timestamp,
+            addition.timestamp,
         )
         removal_coin_records[new_coin_record.name] = new_coin_record
 

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -265,10 +265,7 @@ class Blockchain(BlockchainInterface):
             )
             assert npc.error is None
 
-        fork_info.include_spends(npc, block)
-
-        fork_info.peak_height = block.height
-        fork_info.peak_hash = block.header_hash
+        fork_info.include_spends(npc, block, block.header_hash)
 
     async def add_block(
         self,
@@ -393,9 +390,7 @@ class Blockchain(BlockchainInterface):
                 # main chain, we still need to re-run it to update the additions and
                 # removals in fork_info.
                 await self.advance_fork_info(block, fork_info, {})
-                fork_info.include_spends(npc_result, block)
-                fork_info.peak_height = int(block.height)
-                fork_info.peak_hash = header_hash
+                fork_info.include_spends(npc_result, block, header_hash)
 
                 return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
 
@@ -430,9 +425,7 @@ class Blockchain(BlockchainInterface):
         # need to know of these additions and removals
         if not temporary_fork_info:
             assert fork_info.peak_height == block.height - 1
-            fork_info.include_spends(npc_result, block)
-            fork_info.peak_height = int(block.height)
-            fork_info.peak_hash = header_hash
+            fork_info.include_spends(npc_result, block, header_hash)
 
         # block_to_block_record() require the previous block in the cache
         if not genesis and prev_block is not None:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -386,11 +386,7 @@ class Blockchain(BlockchainInterface):
         else:
             temporary_fork_info = False
             if extending_main_chain:
-                fork_info.fork_height = block.height - 1
-                fork_info.peak_height = block.height - 1
-                fork_info.peak_hash = block.prev_header_hash
-                fork_info.additions_since_fork == {}
-                fork_info.removals_since_fork == set()
+                fork_info.reset(block.height - 1, block.prev_header_hash)
 
             if await self.contains_block_from_db(header_hash):
                 # We have already validated the block, but if it's not part of the

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -47,7 +47,7 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
 from chia.types.weight_proof import SubEpochChallengeSegment
 from chia.util.errors import ConsensusError, Err
-from chia.util.generator_tools import get_block_header, tx_removals_and_additions
+from chia.util.generator_tools import get_block_header
 from chia.util.hash import std_hash
 from chia.util.inline_executor import InlineExecutor
 from chia.util.ints import uint16, uint32, uint64, uint128
@@ -441,9 +441,7 @@ class Blockchain(BlockchainInterface):
             async with self.block_store.db_wrapper.writer():
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
-                records, state_change_summary = await self._reconsider_peak(
-                    block_record, genesis, fork_info, npc_result
-                )
+                records, state_change_summary = await self._reconsider_peak(block_record, genesis, fork_info)
 
                 # Then update the memory cache. It is important that this is not cancelled and does not throw
                 # This is done after all async/DB operations, so there is a decreased chance of failure.
@@ -491,7 +489,6 @@ class Blockchain(BlockchainInterface):
         block_record: BlockRecord,
         genesis: bool,
         fork_info: ForkInfo,
-        npc_result: Optional[NPCResult],
     ) -> Tuple[List[BlockRecord], Optional[StateChangeSummary]]:
         """
         When a new block is added, this is called, to check if the new block is the new peak of the chain.
@@ -503,93 +500,59 @@ class Blockchain(BlockchainInterface):
         peak = self.get_peak()
         rolled_back_state: Dict[bytes32, CoinRecord] = {}
 
-        if genesis:
-            if peak is None:
-                block: Optional[FullBlock] = await self.block_store.get_full_block(block_record.header_hash)
-                assert block is not None
-
-                if npc_result is not None:
-                    tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
-                else:
-                    tx_removals, tx_additions = [], []
-                if block.is_transaction_block():
-                    assert block.foliage_transaction_block is not None
-                    await self.coin_store.new_block(
-                        block.height,
-                        block.foliage_transaction_block.timestamp,
-                        block.get_included_reward_coins(),
-                        tx_additions,
-                        tx_removals,
-                    )
-                await self.block_store.set_in_chain([(block_record.header_hash,)])
-                await self.block_store.set_peak(block_record.header_hash)
-                return [block_record], StateChangeSummary(
-                    block_record, uint32(0), [], [], [], block.get_included_reward_coins()
-                )
+        if genesis and peak is not None:
             return [], None
 
-        assert peak is not None
-        if block_record.weight <= peak.weight:
-            # This is not a heavier block than the heaviest we have seen, so we don't change the coin set
-            return [], None
+        if peak is not None:
+            if block_record.weight <= peak.weight:
+                # This is not a heavier block than the heaviest we have seen, so we don't change the coin set
+                return [], None
 
-        if block_record.prev_hash != peak.header_hash:
-            for coin_record in await self.coin_store.rollback_to_block(fork_info.fork_height):
-                rolled_back_state[coin_record.name] = coin_record
+            if block_record.prev_hash != peak.header_hash:
+                for coin_record in await self.coin_store.rollback_to_block(fork_info.fork_height):
+                    rolled_back_state[coin_record.name] = coin_record
 
         # Collects all blocks from fork point to new peak
-        blocks_to_add: List[Tuple[FullBlock, BlockRecord]] = []
-        curr = block_record.header_hash
-
-        # Backtracks up to the fork point, pulling all the required blocks from DB (that will soon be in the chain)
-        while fork_info.fork_height < 0 or curr != self.height_to_hash(uint32(fork_info.fork_height)):
-            fetched_full_block: Optional[FullBlock] = await self.block_store.get_full_block(curr)
-            fetched_block_record: Optional[BlockRecord] = await self.block_store.get_block_record(curr)
-            assert fetched_full_block is not None
-            assert fetched_block_record is not None
-            blocks_to_add.append((fetched_full_block, fetched_block_record))
-            if fetched_full_block.height == 0:
-                # Doing a full reorg, starting at height 0
-                break
-            curr = fetched_block_record.prev_hash
-
         records_to_add: List[BlockRecord] = []
-        # coin-id, puzzle-hash
-        removals: List[Tuple[bytes32, bytes32]] = []
-        additions: List[Tuple[Coin, Optional[bytes]]] = []
-        reward_coins: List[Coin] = []
-        for fetched_full_block, fetched_block_record in reversed(blocks_to_add):
-            records_to_add.append(fetched_block_record)
-            if not fetched_full_block.is_transaction_block():
+
+        if genesis:
+            records_to_add = [block_record]
+        else:
+            records_to_add = await self.block_store.get_block_records_by_hash(fork_info.block_hashes)
+
+        for fetched_block_record in records_to_add:
+            if not fetched_block_record.is_transaction_block:
                 # Coins are only created in TX blocks so there are no state updates for this block
                 continue
 
-            # We need to recompute the additions and removals, since they are not stored on DB (only generator is).
-            if fetched_block_record.header_hash == block_record.header_hash:
-                tx_removals, tx_additions, npc_res = await self.get_tx_removals_and_additions(
-                    fetched_full_block, npc_result
-                )
-            else:
-                tx_removals, tx_additions, npc_res = await self.get_tx_removals_and_additions(fetched_full_block, None)
-
-            # Collect the NPC results for later post-processing
-            if npc_res is not None and npc_res.conds is not None:
-                for spend in npc_res.conds.spends:
-                    removals.append((bytes32(spend.coin_id), bytes32(spend.puzzle_hash)))
-                    for ph, amount, hint in spend.create_coin:
-                        additions.append((Coin(spend.coin_id, ph, amount), hint))
+            height = fetched_block_record.height
+            # We need to recompute the additions and removals, since they are
+            # not stored on DB. We have all the additions and removals in the
+            # fork_info object, we just need to pick the ones belonging to each
+            # individual block height
 
             # Apply the coin store changes for each block that is now in the blockchain
-            assert fetched_full_block.foliage_transaction_block is not None
+            included_reward_coins = [
+                fork_add.coin
+                for fork_add in fork_info.additions_since_fork.values()
+                if fork_add.confirmed_height == height and fork_add.is_coinbase
+            ]
+            tx_additions = [
+                fork_add.coin
+                for fork_add in fork_info.additions_since_fork.values()
+                if fork_add.confirmed_height == height and not fork_add.is_coinbase
+            ]
+            tx_removals = [
+                coin_id for coin_id, fork_rem in fork_info.removals_since_fork.items() if fork_rem.height == height
+            ]
+            assert fetched_block_record.timestamp is not None
             await self.coin_store.new_block(
-                fetched_full_block.height,
-                fetched_full_block.foliage_transaction_block.timestamp,
-                fetched_full_block.get_included_reward_coins(),
+                height,
+                fetched_block_record.timestamp,
+                included_reward_coins,
                 tx_additions,
                 tx_removals,
             )
-            # Collect the new reward coins for later post-processing
-            reward_coins.extend(fetched_full_block.get_included_reward_coins())
 
         # we made it to the end successfully
         # Rollback sub_epoch_summaries
@@ -603,32 +566,14 @@ class Blockchain(BlockchainInterface):
             block_record,
             uint32(max(fork_info.fork_height, 0)),
             list(rolled_back_state.values()),
-            removals,
-            additions,
-            reward_coins,
+            [(coin_id, fork_rem.puzzle_hash) for coin_id, fork_rem in fork_info.removals_since_fork.items()],
+            [
+                (fork_add.coin, fork_add.hint)
+                for fork_add in fork_info.additions_since_fork.values()
+                if not fork_add.is_coinbase
+            ],
+            [fork_add.coin for fork_add in fork_info.additions_since_fork.values() if fork_add.is_coinbase],
         )
-
-    async def get_tx_removals_and_additions(
-        self, block: FullBlock, npc_result: Optional[NPCResult] = None
-    ) -> Tuple[List[bytes32], List[Coin], Optional[NPCResult]]:
-        if not block.is_transaction_block():
-            return [], [], None
-
-        if block.transactions_generator is None:
-            return [], [], None
-
-        if npc_result is None:
-            block_generator: Optional[BlockGenerator] = await self.get_block_generator(block)
-            assert block_generator is not None
-            npc_result = get_name_puzzle_conditions(
-                block_generator,
-                self.constants.MAX_BLOCK_COST_CLVM,
-                mempool_mode=False,
-                height=block.height,
-                constants=self.constants,
-            )
-        tx_removals, tx_additions = tx_removals_and_additions(npc_result.conds)
-        return tx_removals, tx_additions, npc_result
 
     def get_next_difficulty(self, header_hash: bytes32, new_slot: bool) -> uint64:
         assert self.contains_block(header_hash)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1265,11 +1265,7 @@ class FullNode:
             # update the fork context with its additions and removals
             if self.blockchain.height_to_hash(block.height) == header_hash:
                 # we're on the main chain, just fast-forward the fork height
-                fork_info.fork_height = block.height
-                fork_info.peak_height = block.height
-                fork_info.peak_hash = header_hash
-                fork_info.additions_since_fork == {}
-                fork_info.removals_since_fork == set()
+                fork_info.reset(block.height, header_hash)
             else:
                 # We have already validated the block, but if it's not part of the
                 # main chain, we still need to re-run it to update the additions and
@@ -1309,6 +1305,10 @@ class FullNode:
             )
 
             if result == AddBlockResult.NEW_PEAK:
+                # since this block just added a new peak, we've don't need any
+                # fork history from fork_info anymore
+                if fork_info is not None:
+                    fork_info.reset(block.height, block.header_hash)
                 assert state_change_summary is not None
                 # Since all blocks are contiguous, we can simply append the rollback changes and npc results
                 if agg_state_change_summary is None:

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -2285,6 +2285,8 @@ async def test_long_reorg_nodes(
     # heavier chain.
     await full_node_2.full_node.add_block(reorg_blocks[-1])
 
+    start = time.monotonic()
+
     def check_nodes_in_sync():
         p1 = full_node_2.full_node.blockchain.get_peak()
         p2 = full_node_1.full_node.blockchain.get_peak()
@@ -2293,6 +2295,8 @@ async def test_long_reorg_nodes(
     await time_out_assert(100, check_nodes_in_sync)
     peak = full_node_2.full_node.blockchain.get_peak()
     print(f"peak: {str(peak.header_hash)[:6]}")
+
+    reorg1_timing = time.monotonic() - start
 
     p1 = full_node_1.full_node.blockchain.get_peak()
     p2 = full_node_2.full_node.blockchain.get_peak()
@@ -2313,6 +2317,8 @@ async def test_long_reorg_nodes(
     await connect_and_get_peer(full_node_3.full_node.server, full_node_1.full_node.server, self_hostname)
     await connect_and_get_peer(full_node_3.full_node.server, full_node_2.full_node.server, self_hostname)
 
+    start = time.monotonic()
+
     def check_nodes_in_sync2():
         p1 = full_node_1.full_node.blockchain.get_peak()
         p2 = full_node_2.full_node.blockchain.get_peak()
@@ -2321,6 +2327,8 @@ async def test_long_reorg_nodes(
 
     await time_out_assert(900, check_nodes_in_sync2)
 
+    reorg2_timing = time.monotonic() - start
+
     p1 = full_node_1.full_node.blockchain.get_peak()
     p2 = full_node_2.full_node.blockchain.get_peak()
     p3 = full_node_3.full_node.blockchain.get_peak()
@@ -2328,3 +2336,6 @@ async def test_long_reorg_nodes(
     assert p1.header_hash == blocks[-1].header_hash
     assert p2.header_hash == blocks[-1].header_hash
     assert p3.header_hash == blocks[-1].header_hash
+
+    print(f"reorg1 timing: {reorg1_timing:0.2f}s")
+    print(f"reorg2 timing: {reorg2_timing:0.2f}s")


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

The main change is in the last commit.

### Purpose:

In `_reconsider_peak()` we check if the new fork is heavier and if so, decide to switch our peak to this new chain. We also return a `StateChangeSummary` indicating to the caller what (if anything) has changed. e.g. any coin spends that were reorged-out and any new additions and removals (to update the mempool) and hints (to update the hint store).

In order to compute the additions and removals, we fetch all the full blocks and block records (again) along the fork and execute all the block generators (again) (`get_tx_removals_and_additions()`). This is wasteful, and especially risky with expensive block generators.

This patch updates the `ForkInfo` object to keep a little bit more state, in order to be able to produce the `StateChangeSummary` without having to re-run the block generators. This saves looking up `FullBlock`s from the database in addition to the CPU of executing blocks.

### Current Behavior:

When switching to a new fork of the chain, we re-run all the block generators along the fork in order to compute additions and removals, even though we already have most of that information now (in `ForkInfo`).

### New Behavior:

While validating blocks on the fork, store confirmation height of additions and removals as well as whether additions are coinbase rewards or not. This lets us build the `StateChangeSummary` object without re-running block generators, and without fetching `FullBlock`s from the database. We still need to fetch the `BlockRecord`s though.

### Testing Notes:

There's a sync-from-scratch test [here](https://grafana.chiatechlab.com/d/oBgwkDI7z/blockchain-sync-tests?orgId=1&var-ref=reorg-optimization&var-repo=All&var-network=mainnet&var-network=testnet10&var-network=testneta&refresh=1h).

Profiling this on an M1 did not give the speed-up I was expecting. It saves about 9% (time) in `test_long_reorg_nodes` test.

### timing M1

| test | before | after | after / before |
| --- | --- | --- | --- |
| reorg1 | 6.47s | 6.02s | 93% |
| reorg2 | 27.13s | 24.77s | 91.3% |

### timing RPi

| test | before | after | after / before |
| --- | --- | --- | --- |
| reorg1 | 61.84s | 58.27s  | 94.38% |
| reorg2 | 274.26s | 251.79s | 91.80% |

### profile (RPi)

It appears a large part of the time is spent waiting for database I/O (i.e. time spent in `kqueue`). Pay attention to the `kqueue` and `_reconsider_peak` timings of the following profiles:

| test | function | before | after |
| --- | --- | --- | --- |
| reorg 1 | _reconsider_peak | 6.51% | 1.72% |
| reorg 1 | add_block | 14.02% | 9.81% |
| reorg 2 | _reconsider_peak | 9.18% | 3.32% |
| reorg 2 | add_block | 17.31% | 12.26% |

### main

![test-reorg-1](https://github.com/Chia-Network/chia-blockchain/assets/661450/0697b411-58af-4399-8768-c4cf198820be)

![test-reorg-2](https://github.com/Chia-Network/chia-blockchain/assets/661450/4b9c6863-02a3-47f5-9406-842d99f4d127)

### with this patch

![test-reorg-1](https://github.com/Chia-Network/chia-blockchain/assets/661450/e7a1bf2d-598b-4b3a-8045-a42b8d112250)

![test-reorg-2](https://github.com/Chia-Network/chia-blockchain/assets/661450/30385c88-754e-4239-860c-9f0e99415e8a)
