### PR TITLE
sync caches to db after rollback

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -450,10 +450,6 @@ class Blockchain(BlockchainInterface):
             None,
         )
 
-        # in case we fail and need to restore the blockchain state, remember the
-        # peak height
-        previous_peak_height = self._peak_height
-
         try:
             # Always add the block to the database
             async with self.block_store.db_wrapper.writer():

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -486,7 +486,10 @@ class Blockchain(BlockchainInterface):
 
         except BaseException as e:
             # Find peak as reported by the on disk DB
-            rollback_peak_hash, rollback_peak_height = await self.block_store.get_peak()
+            peak_ret = await self.block_store.get_peak()
+
+            assert peak_ret is not None
+            rollback_peak_hash, rollback_peak_height = peak_ret
 
             # Now remove any blocks higher than that in the caches so they are synced after rollback
             height = rollback_peak_height + 1


### PR DESCRIPTION
## Purpose:

If we rollback due to disk I/O errors, caches may not be in sync with the on disk db state

## Current Behavior:

Caches still have records of rolled back blocks which causes problems later on

## New Behavior:

Make sure caches don't have blocks that are newer than the peak on disk