### PR TITLE
`SerializedProgram` updates

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -491,7 +491,7 @@ class DataLayerWallet:
             second_coin_spend = CoinSpend(
                 second_coin,
                 SerializedProgram.from_program(second_full_puz),
-                Program.to(
+                SerializedProgram.to(
                     [
                         LineageProof(
                             current_coin.parent_coin_info,
@@ -796,7 +796,7 @@ class DataLayerWallet:
         mirror_spend = CoinSpend(
             mirror_coin,
             SerializedProgram.from_program(create_mirror_puzzle()),
-            Program.to(
+            SerializedProgram.to(
                 [
                     parent_coin.parent_coin_info,
                     parent_inner_puzzle,

--- a/chia/full_node/generator.py
+++ b/chia/full_node/generator.py
@@ -51,4 +51,6 @@ def create_compressed_generator(
     program = DECOMPRESS_BLOCK.curry(
         DECOMPRESS_PUZZLE, DECOMPRESS_CSE_WITH_PREFIX, Program.to(start), Program.to(end), compressed_cse_list
     )
-    return BlockGenerator(program, [original_generator.generator], [original_generator.block_height])
+    return BlockGenerator(
+        SerializedProgram.from_program(program), [original_generator.generator], [original_generator.block_height]
+    )

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -27,7 +27,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.types.coin_spend import CoinSpend, CoinSpendWithConditions, SpendInfo
+from chia.types.coin_spend import CoinSpend, CoinSpendWithConditions, SpendInfo, make_spend
 from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.condition_tools import conditions_for_solution
@@ -158,7 +158,7 @@ def get_spends_for_block(generator: BlockGenerator, height: int, constants: Cons
         parent, puzzle, amount, solution = spend.as_iter()
         puzzle_hash = puzzle.get_tree_hash()
         coin = Coin(parent.as_atom(), puzzle_hash, amount.as_int())
-        spends.append(CoinSpend(coin, puzzle, solution))
+        spends.append(make_spend(coin, puzzle, solution))
 
     return spends
 
@@ -187,8 +187,12 @@ def get_spends_for_block_with_conditions(
         parent, puzzle, amount, solution = spend.as_iter()
         puzzle_hash = puzzle.get_tree_hash()
         coin = Coin(parent.as_atom(), puzzle_hash, amount.as_int())
-        coin_spend = CoinSpend(coin, puzzle, solution)
-        conditions = conditions_for_solution(puzzle, solution, DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM)
+        coin_spend = make_spend(coin, puzzle, solution)
+        conditions = conditions_for_solution(
+            SerializedProgram.from_program(puzzle),
+            SerializedProgram.from_program(solution),
+            DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+        )
         spends.append(CoinSpendWithConditions(coin_spend, conditions))
 
     return spends

--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import Tuple, Type
+from typing import Tuple
 
 from chia_rs import MEMPOOL_MODE, run_chia_program, serialized_length, tree_hash
 from clvm import SExp
@@ -34,38 +34,36 @@ class SerializedProgram:
     An opaque representation of a clvm program. It has a more limited interface than a full SExp
     """
 
-    _buf: bytes = b""
+    _buf: bytes
 
-    @classmethod
-    def parse(cls: Type[SerializedProgram], f: io.BytesIO) -> SerializedProgram:
+    def __init__(self, buf: bytes) -> None:
+        assert isinstance(buf, bytes)
+        self._buf = buf
+
+    @staticmethod
+    def parse(f: io.BytesIO) -> SerializedProgram:
         length = serialized_length(f.getvalue()[f.tell() :])
         return SerializedProgram.from_bytes(f.read(length))
 
     def stream(self, f: io.BytesIO) -> None:
         f.write(self._buf)
 
-    @classmethod
-    def from_bytes(cls: Type[SerializedProgram], blob: bytes) -> SerializedProgram:
-        ret = SerializedProgram()
+    @staticmethod
+    def from_bytes(blob: bytes) -> SerializedProgram:
         assert serialized_length(blob) == len(blob)
-        ret._buf = bytes(blob)
-        return ret
+        return SerializedProgram(bytes(blob))
 
-    @classmethod
-    def fromhex(cls: Type[SerializedProgram], hexstr: str) -> SerializedProgram:
-        return cls.from_bytes(hexstr_to_bytes(hexstr))
+    @staticmethod
+    def fromhex(hexstr: str) -> SerializedProgram:
+        return SerializedProgram.from_bytes(hexstr_to_bytes(hexstr))
 
-    @classmethod
-    def from_program(cls: Type[SerializedProgram], p: Program) -> SerializedProgram:
-        ret = SerializedProgram()
-        ret._buf = bytes(p)
-        return ret
+    @staticmethod
+    def from_program(p: Program) -> SerializedProgram:
+        return SerializedProgram(bytes(p))
 
     @staticmethod
     def to(o: CastableType) -> SerializedProgram:
-        ret = SerializedProgram()
-        ret._buf = Program.to(o).as_bin()
-        return ret
+        return SerializedProgram(Program.to(o).as_bin())
 
     def to_program(self) -> Program:
         return Program.from_bytes(self._buf)

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -26,6 +26,26 @@ class CoinSpend(Streamable):
     coin: Coin
     puzzle_reveal: SerializedProgram
     solution: SerializedProgram
+
+
+def make_spend(
+    coin: Coin,
+    puzzle_reveal: Union[Program, SerializedProgram],
+    solution: Union[Program, SerializedProgram],
+) -> CoinSpend:
+    pr: SerializedProgram
+    sol: SerializedProgram
+    if isinstance(puzzle_reveal, SerializedProgram):
+        pr = puzzle_reveal
+    elif isinstance(puzzle_reveal, Program):
+        pr = SerializedProgram.from_program(puzzle_reveal)
+
+    if isinstance(solution, SerializedProgram):
+        sol = solution
+    elif isinstance(solution, Program):
+        sol = SerializedProgram.from_program(solution)
+
+    return CoinSpend(coin, pr, sol)
 
 
 def compute_additions_with_cost(

--- a/chia/wallet/cat_wallet/cat_utils.py
+++ b/chia/wallet/cat_wallet/cat_utils.py
@@ -8,7 +8,7 @@ from chia_rs import G2Element
 from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution
@@ -155,7 +155,7 @@ def unsigned_spend_bundle_for_spendable_cats(mod_code: Program, spendable_cat_li
             subtotals[index],
             spend_info.extra_delta,
         ]
-        coin_spend = CoinSpend(spend_info.coin, puzzle_reveal, Program.to(solution))
+        coin_spend = make_spend(spend_info.coin, puzzle_reveal, Program.to(solution))
         coin_spends.append(coin_spend)
 
     return SpendBundle(coin_spends, NULL_SIGNATURE)

--- a/chia/wallet/dao_wallet/dao_wallet.py
+++ b/chia/wallet/dao_wallet/dao_wallet.py
@@ -19,7 +19,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64, uint128
@@ -746,7 +746,7 @@ class DAOWallet:
 
         genesis_launcher_solution = Program.to([full_treasury_puzzle_hash, 1, bytes(0x80)])
 
-        launcher_cs = CoinSpend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
+        launcher_cs = make_spend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
         launcher_sb = SpendBundle([launcher_cs], AugSchemeMPL.aggregate([]))
 
         launcher_proof = LineageProof(
@@ -830,7 +830,7 @@ class DAOWallet:
                 inner_sol,
             ]
         )
-        eve_coin_spend = CoinSpend(eve_coin, full_treasury_puzzle, fullsol)
+        eve_coin_spend = make_spend(eve_coin, full_treasury_puzzle, fullsol)
         eve_spend_bundle = SpendBundle([eve_coin_spend], G2Element())
 
         next_proof = LineageProof(
@@ -910,7 +910,7 @@ class DAOWallet:
             [full_proposal_puzzle_hash, dao_rules.proposal_minimum_amount, bytes(0x80)]
         )
 
-        launcher_cs = CoinSpend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
+        launcher_cs = make_spend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
         launcher_sb = SpendBundle([launcher_cs], AugSchemeMPL.aggregate([]))
         eve_coin = Coin(launcher_coin.name(), full_proposal_puzzle_hash, dao_rules.proposal_minimum_amount)
 
@@ -1023,7 +1023,7 @@ class DAOWallet:
                 inner_sol,
             ]
         )
-        list_of_coinspends = [CoinSpend(eve_coin, full_proposal_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(eve_coin, full_proposal_puzzle, fullsol)]
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
         return unsigned_spend_bundle.aggregate([unsigned_spend_bundle, dao_cat_spend])
 
@@ -1112,7 +1112,7 @@ class DAOWallet:
             ]
         )
         full_proposal_puzzle = curry_singleton(proposal_id, proposal_info.current_innerpuz)
-        list_of_coinspends = [CoinSpend(proposal_info.current_coin, full_proposal_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(proposal_info.current_coin, full_proposal_puzzle, fullsol)]
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
         if fee > 0:
             chia_tx = await self.standard_wallet.create_tandem_xch_tx(
@@ -1213,7 +1213,7 @@ class DAOWallet:
                 solution,
             ]
         )
-        proposal_cs = CoinSpend(proposal_info.current_coin, full_proposal_puzzle, fullsol)
+        proposal_cs = make_spend(proposal_info.current_coin, full_proposal_puzzle, fullsol)
         if not self_destruct:
             timer_puzzle = get_proposal_timer_puzzle(
                 self.get_cat_tail_hash(),
@@ -1241,7 +1241,7 @@ class DAOWallet:
                     proposal_info.current_coin.amount,
                 ]
             )
-            timer_cs = CoinSpend(proposal_info.timer_coin, timer_puzzle, timer_solution)
+            timer_cs = make_spend(proposal_info.timer_coin, timer_puzzle, timer_solution)
 
         full_treasury_puz = curry_singleton(self.dao_info.treasury_id, self.dao_info.current_treasury_innerpuz)
         assert isinstance(self.dao_info.current_treasury_coin, Coin)
@@ -1308,7 +1308,7 @@ class DAOWallet:
                                     mint_amount,
                                 ]
                             )
-                            coin_spends.append(CoinSpend(cat_launcher_coin, cat_launcher, solution))
+                            coin_spends.append(make_spend(cat_launcher_coin, cat_launcher, solution))
                             eve_coin = Coin(cat_launcher_coin.name(), full_puz.get_tree_hash(), mint_amount)
                             tail_solution = Program.to([cat_launcher_coin.parent_coin_info, cat_launcher_coin.amount])
                             solution = Program.to([mint_amount, tail_reconstruction, tail_solution])
@@ -1346,7 +1346,7 @@ class DAOWallet:
                                 xch_coin.name(),
                             ]
                         )
-                        coin_spends.append(CoinSpend(xch_coin, p2_singleton_puzzle, solution))
+                        coin_spends.append(make_spend(xch_coin, p2_singleton_puzzle, solution))
                     delegated_puzzle_sb = SpendBundle(coin_spends, AugSchemeMPL.aggregate([]))
                 for tail_hash_conditions_pair in LIST_OF_TAILHASH_CONDITIONS.as_iter():
                     tail_hash: bytes32 = tail_hash_conditions_pair.first().as_atom()
@@ -1467,7 +1467,7 @@ class DAOWallet:
             ]
         )
 
-        treasury_cs = CoinSpend(self.dao_info.current_treasury_coin, full_treasury_puz, full_treasury_solution)
+        treasury_cs = make_spend(self.dao_info.current_treasury_coin, full_treasury_puz, full_treasury_solution)
 
         if self_destruct:
             spend_bundle = SpendBundle([proposal_cs, treasury_cs], AugSchemeMPL.aggregate([]))
@@ -1614,7 +1614,7 @@ class DAOWallet:
                 lineage_proof: LineageProof = await self.fetch_singleton_lineage_proof(proposal_info.current_coin)
                 solution = Program.to([lineage_proof.to_program(), proposal_info.current_coin.amount, inner_solution])
                 finished_puz = get_finished_state_puzzle(proposal_info.proposal_id)
-                cs = CoinSpend(proposal_info.current_coin, finished_puz, solution)
+                cs = make_spend(proposal_info.current_coin, finished_puz, solution)
                 prop_sb = SpendBundle([cs], AugSchemeMPL.aggregate([]))
                 spends.append(prop_sb)
 

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -15,7 +15,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
@@ -603,7 +603,10 @@ class DIDWallet:
             ]
         )
         new_coin = Coin(coin.name(), new_full_puzzle.get_tree_hash(), coin.amount)
-        list_of_coinspends = [CoinSpend(coin, full_puzzle, fullsol), CoinSpend(new_coin, new_full_puzzle, new_full_sol)]
+        list_of_coinspends = [
+            make_spend(coin, full_puzzle, fullsol),
+            make_spend(new_coin, new_full_puzzle, new_full_sol),
+        ]
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
         spend_bundle = await self.sign(unsigned_spend_bundle)
         if fee > 0:
@@ -701,7 +704,7 @@ class DIDWallet:
                 innersol,
             ]
         )
-        list_of_coinspends = [CoinSpend(coin, full_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(coin, full_puzzle, fullsol)]
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
         spend_bundle = await self.sign(unsigned_spend_bundle)
         if fee > 0:
@@ -799,7 +802,7 @@ class DIDWallet:
                 innersol,
             ]
         )
-        list_of_coinspends = [CoinSpend(coin, full_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(coin, full_puzzle, fullsol)]
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
         signed_spend_bundle: SpendBundle = await self.sign(unsigned_spend_bundle)
         return TransactionRecord(
@@ -851,7 +854,7 @@ class DIDWallet:
                 innersol,
             ]
         )
-        list_of_coinspends = [CoinSpend(coin, full_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(coin, full_puzzle, fullsol)]
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
         spend_bundle = await self.sign(unsigned_spend_bundle)
 
@@ -932,7 +935,7 @@ class DIDWallet:
                 innersol,
             ]
         )
-        list_of_coinspends = [CoinSpend(coin, full_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(coin, full_puzzle, fullsol)]
         message_spend = did_wallet_puzzles.create_spend_for_message(coin.name(), recovering_coin_name, newpuz, pubkey)
         message_spend_bundle = SpendBundle([message_spend], AugSchemeMPL.aggregate([]))
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
@@ -1046,7 +1049,7 @@ class DIDWallet:
                 innersol,
             ]
         )
-        list_of_coinspends = [CoinSpend(coin, full_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(coin, full_puzzle, fullsol)]
 
         index = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pubkey)
         if index is None:
@@ -1271,7 +1274,7 @@ class DIDWallet:
 
         genesis_launcher_solution = Program.to([did_puzzle_hash, amount, bytes(0x80)])
 
-        launcher_cs = CoinSpend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
+        launcher_cs = make_spend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
         launcher_sb = SpendBundle([launcher_cs], AugSchemeMPL.aggregate([]))
         eve_coin = Coin(launcher_coin.name(), did_puzzle_hash, amount)
         future_parent = LineageProof(
@@ -1358,7 +1361,7 @@ class DIDWallet:
                 innersol,
             ]
         )
-        list_of_coinspends = [CoinSpend(coin, full_puzzle, fullsol)]
+        list_of_coinspends = [make_spend(coin, full_puzzle, fullsol)]
         unsigned_spend_bundle = SpendBundle(list_of_coinspends, G2Element())
         return await self.sign(unsigned_spend_bundle)
 

--- a/chia/wallet/did_wallet/did_wallet_puzzles.py
+++ b/chia/wallet/did_wallet/did_wallet_puzzles.py
@@ -7,7 +7,7 @@ from chia_rs import G1Element
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.ints import uint64
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
@@ -144,7 +144,7 @@ def create_spend_for_message(
     puzzle = create_recovery_message_puzzle(recovering_coin, newpuz, pubkey)
     coin = Coin(parent_of_message, puzzle.get_tree_hash(), uint64(0))
     solution = Program.to([])
-    coinsol = CoinSpend(coin, puzzle, solution)
+    coinsol = make_spend(coin, puzzle, solution)
     return coinsol
 
 

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -18,7 +18,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend, compute_additions
+from chia.types.coin_spend import CoinSpend, compute_additions, make_spend
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
@@ -398,7 +398,7 @@ class NFTWallet:
         genesis_launcher_solution = Program.to([eve_fullpuz_hash, amount, []])
 
         # launcher spend to generate the singleton
-        launcher_cs = CoinSpend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
+        launcher_cs = make_spend(launcher_coin, genesis_launcher_puz, genesis_launcher_solution)
         launcher_sb = SpendBundle([launcher_cs], AugSchemeMPL.aggregate([]))
 
         eve_coin = Coin(launcher_coin.name(), eve_fullpuz_hash, uint64(amount))
@@ -780,7 +780,7 @@ class NFTWallet:
         nft_layer_solution = Program.to([innersol])
         assert isinstance(nft_coin.lineage_proof, LineageProof)
         singleton_solution = Program.to([nft_coin.lineage_proof.to_program(), nft_coin.coin.amount, nft_layer_solution])
-        coin_spend = CoinSpend(nft_coin.coin, nft_coin.full_puzzle, singleton_solution)
+        coin_spend = make_spend(nft_coin.coin, nft_coin.full_puzzle, singleton_solution)
 
         nft_spend_bundle = SpendBundle([coin_spend], G2Element())
 
@@ -1088,7 +1088,7 @@ class NFTWallet:
                             )
                             royalty_sol = solve_puzzle(driver_dict[asset], solver, OFFER_MOD, inner_royalty_sol)
 
-                        new_coin_spend = CoinSpend(royalty_coin, offer_puzzle, royalty_sol)
+                        new_coin_spend = make_spend(royalty_coin, offer_puzzle, royalty_sol)
                         additional_bundles.append(SpendBundle([new_coin_spend], G2Element()))
 
                         if duplicate_payments != []:
@@ -1360,7 +1360,7 @@ class NFTWallet:
             primaries.append(Payment(intermediate_launcher_ph, uint64(0), [intermediate_launcher_ph]))
             intermediate_launcher_sol = Program.to([])
             intermediate_launcher_coin = Coin(did_coin.name(), intermediate_launcher_ph, uint64(0))
-            intermediate_launcher_coin_spend = CoinSpend(
+            intermediate_launcher_coin_spend = make_spend(
                 intermediate_launcher_coin, intermediate_launcher_puz, intermediate_launcher_sol
             )
             intermediate_coin_spends.append(intermediate_launcher_coin_spend)
@@ -1399,7 +1399,7 @@ class NFTWallet:
 
             genesis_launcher_solution = Program.to([eve_fullpuz.get_tree_hash(), amount, []])
 
-            launcher_cs = CoinSpend(
+            launcher_cs = make_spend(
                 launcher_coin, chia.wallet.singleton.SINGLETON_LAUNCHER_PUZZLE, genesis_launcher_solution
             )
             launcher_spends.append(launcher_cs)
@@ -1482,7 +1482,7 @@ class NFTWallet:
                 solution = self.standard_wallet.make_solution(
                     primaries=[], coin_announcements_to_assert={primary_announcement_hash}
                 )
-            xch_spends.append(CoinSpend(xch_coin, puzzle, solution))
+            xch_spends.append(make_spend(xch_coin, puzzle, solution))
         xch_spend = await self.wallet_state_manager.sign_transaction(xch_spends)
 
         # Create the DID spend using the announcements collected when making the intermediate launcher coins
@@ -1520,7 +1520,7 @@ class NFTWallet:
                 did_inner_sol,
             ]
         )
-        did_spend = CoinSpend(did_coin, did_full_puzzle, did_full_sol)
+        did_spend = make_spend(did_coin, did_full_puzzle, did_full_sol)
 
         # Collect up all the coin spends and sign them
         list_of_coinspends = [did_spend] + intermediate_coin_spends + launcher_spends
@@ -1606,7 +1606,7 @@ class NFTWallet:
             primaries.append(Payment(intermediate_launcher_ph, uint64(1), [intermediate_launcher_ph]))
             intermediate_launcher_sol = Program.to([])
             intermediate_launcher_coin = Coin(funding_coin.name(), intermediate_launcher_ph, uint64(1))
-            intermediate_launcher_coin_spend = CoinSpend(
+            intermediate_launcher_coin_spend = make_spend(
                 intermediate_launcher_coin, intermediate_launcher_puz, intermediate_launcher_sol
             )
             intermediate_coin_spends.append(intermediate_launcher_coin_spend)
@@ -1644,7 +1644,7 @@ class NFTWallet:
 
             genesis_launcher_solution = Program.to([eve_fullpuz.get_tree_hash(), amount, []])
 
-            launcher_cs = CoinSpend(launcher_coin, nft_puzzles.LAUNCHER_PUZZLE, genesis_launcher_solution)
+            launcher_cs = make_spend(launcher_coin, nft_puzzles.LAUNCHER_PUZZLE, genesis_launcher_solution)
             launcher_spends.append(launcher_cs)
 
             eve_coin = Coin(launcher_coin.name(), eve_fullpuz.get_tree_hash(), uint64(amount))
@@ -1723,7 +1723,7 @@ class NFTWallet:
                 solution = self.standard_wallet.make_solution(
                     primaries=[], coin_announcements_to_assert={primary_announcement_hash}
                 )
-            xch_spends.append(CoinSpend(xch_coin, puzzle, solution))
+            xch_spends.append(make_spend(xch_coin, puzzle, solution))
         xch_spend = await self.wallet_state_manager.sign_transaction(xch_spends)
 
         # Collect up all the coin spends and sign them

--- a/chia/wallet/notification_manager.py
+++ b/chia/wallet/notification_manager.py
@@ -11,7 +11,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
@@ -99,7 +99,7 @@ class NotificationManager:
         notification_puzzle: Program = construct_notification(target, amount)
         notification_hash: bytes32 = notification_puzzle.get_tree_hash()
         notification_coin: Coin = Coin(origin_coin, notification_hash, amount)
-        notification_spend = CoinSpend(
+        notification_spend = make_spend(
             notification_coin,
             notification_puzzle,
             Program.to(None),

--- a/chia/wallet/puzzles/clawback/drivers.py
+++ b/chia/wallet/puzzles/clawback/drivers.py
@@ -7,7 +7,7 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.condition_tools import conditions_for_solution
 from chia.util.ints import uint64
@@ -178,4 +178,4 @@ def generate_clawback_spend_bundle(
     solution: Program = create_merkle_solution(
         time_lock, metadata.sender_puzzle_hash, metadata.recipient_puzzle_hash, inner_puzzle, inner_solution
     )
-    return CoinSpend(coin, puzzle, solution)
+    return make_spend(coin, puzzle, solution)

--- a/chia/wallet/puzzles/singleton_top_layer.py
+++ b/chia/wallet/puzzles/singleton_top_layer.py
@@ -5,7 +5,7 @@ from typing import Iterator, List, Optional, Tuple
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.hash import std_hash
 from chia.util.ints import uint64
@@ -227,7 +227,7 @@ def launch_conditions_and_coinsol(
 
     conditions = [create_launcher, assert_launcher_announcement]
 
-    launcher_coin_spend = CoinSpend(
+    launcher_coin_spend = make_spend(
         launcher_coin,
         SINGLETON_LAUNCHER,
         launcher_solution,
@@ -333,7 +333,7 @@ def claim_p2_singleton(
             delay_time,
             delay_ph,
         )
-    claim_coinsol = CoinSpend(
+    claim_coinsol = make_spend(
         p2_singleton_coin,
         puzzle,
         solution_for_p2_singleton(p2_singleton_coin, singleton_inner_puzhash),
@@ -349,7 +349,7 @@ def spend_to_delayed_puzzle(
     delay_time: uint64,
     delay_ph: bytes32,
 ) -> CoinSpend:
-    claim_coinsol = CoinSpend(
+    claim_coinsol = make_spend(
         p2_singleton_coin,
         pay_to_singleton_or_delay_puzzle(launcher_id, delay_time, delay_ph),
         solution_for_p2_delayed_puzzle(output_amount),

--- a/chia/wallet/puzzles/singleton_top_layer_v1_1.py
+++ b/chia/wallet/puzzles/singleton_top_layer_v1_1.py
@@ -5,7 +5,7 @@ from typing import Iterator, List, Optional, Tuple
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.hash import std_hash
 from chia.util.ints import uint64
@@ -216,7 +216,7 @@ def launch_conditions_and_coinsol(
 
     conditions = [create_launcher, assert_launcher_announcement]
 
-    launcher_coin_spend = CoinSpend(
+    launcher_coin_spend = make_spend(
         launcher_coin,
         SINGLETON_LAUNCHER,
         launcher_solution,
@@ -325,7 +325,7 @@ def claim_p2_singleton(
             delay_time,
             delay_ph,
         )
-    claim_coinsol = CoinSpend(
+    claim_coinsol = make_spend(
         p2_singleton_coin,
         puzzle,
         solution_for_p2_singleton(p2_singleton_coin, singleton_inner_puzhash),
@@ -341,7 +341,7 @@ def spend_to_delayed_puzzle(
     delay_time: uint64,
     delay_ph: bytes32,
 ) -> CoinSpend:
-    claim_coinsol = CoinSpend(
+    claim_coinsol = make_spend(
         p2_singleton_coin,
         pay_to_singleton_or_delay_puzzle(launcher_id, delay_time, delay_ph),
         solution_for_p2_delayed_puzzle(output_amount),

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -11,7 +11,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import bech32_decode, bech32_encode, convertbits
 from chia.util.errors import Err, ValidationError
@@ -555,7 +555,7 @@ class Offer:
                     solution = Program.to(coin_to_solution_dict[coin])
 
                 completion_spends.append(
-                    CoinSpend(
+                    make_spend(
                         coin,
                         construct_puzzle(self.driver_dict[asset_id], OFFER_MOD) if asset_id else OFFER_MOD,
                         solution,
@@ -581,7 +581,7 @@ class Offer:
                 inner_solutions.append((nonce, [np.as_condition_args() for np in nonce_payments]))
 
             additional_coin_spends.append(
-                CoinSpend(
+                make_spend(
                     Coin(
                         ZERO_32,
                         puzzle_reveal.get_tree_hash(),

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -33,7 +33,7 @@ from chia.protocols.wallet_protocol import (
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.header_block import HeaderBlock
 from chia.util.ints import uint32
 from chia.util.merkle_set import MerkleSet, confirm_included_already_hashed, confirm_not_included_already_hashed
@@ -341,7 +341,7 @@ async def fetch_coin_spend(height: uint32, coin: Coin, peer: WSChiaConnection) -
     assert solution_response.response.puzzle.get_tree_hash() == coin.puzzle_hash
     assert solution_response.response.coin_name == coin.name()
 
-    return CoinSpend(
+    return make_spend(
         coin,
         solution_response.response.puzzle,
         solution_response.response.solution,

--- a/chia/wallet/vc_wallet/cr_cat_drivers.py
+++ b/chia/wallet/vc_wallet/cr_cat_drivers.py
@@ -11,7 +11,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint64
 from chia.util.streamable import Streamable, streamable
@@ -250,7 +250,7 @@ class CRCAT:
 
         return (
             dpuz,
-            CoinSpend(
+            make_spend(
                 eve_coin,
                 eve_cat_puzzle,
                 Program.to(  # solve_cat
@@ -462,7 +462,7 @@ class CRCAT:
 
         return (
             announcements,
-            CoinSpend(
+            make_spend(
                 self.coin,
                 self.construct_puzzle(inner_puzzle),
                 Program.to(  # solve_cat

--- a/chia/wallet/vc_wallet/vc_drivers.py
+++ b/chia/wallet/vc_wallet/vc_drivers.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple, Type, TypeVar
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend, compute_additions
+from chia.types.coin_spend import CoinSpend, compute_additions, make_spend
 from chia.util.hash import std_hash
 from chia.util.ints import uint64
 from chia.util.streamable import Streamable, streamable
@@ -420,12 +420,12 @@ class VerifiedCredential(Streamable):
         return (
             dpuz,
             [
-                CoinSpend(
+                make_spend(
                     launcher_coin,
                     SINGLETON_LAUNCHER,
                     launcher_solution,
                 ),
-                CoinSpend(
+                make_spend(
                     second_launcher_coin,
                     curried_eve_singleton,
                     solution_for_singleton(
@@ -747,7 +747,7 @@ class VerifiedCredential(Streamable):
 
         return (
             expected_announcement,
-            CoinSpend(
+            make_spend(
                 self.coin,
                 self.construct_puzzle(),
                 vc_solution,
@@ -799,7 +799,7 @@ class VerifiedCredential(Streamable):
 
         return (
             expected_announcement,
-            CoinSpend(self.coin, self.construct_puzzle(), vc_solution),
+            make_spend(self.coin, self.construct_puzzle(), vc_solution),
         )
 
     ####################################################################################################################

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -12,7 +12,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
@@ -378,7 +378,7 @@ class Wallet:
                 primary_announcement_hash = Announcement(coin.name(), message).name()
 
                 spends.append(
-                    CoinSpend(
+                    make_spend(
                         coin, SerializedProgram.from_bytes(bytes(puzzle)), SerializedProgram.from_bytes(bytes(solution))
                     )
                 )
@@ -394,7 +394,7 @@ class Wallet:
             solution = self.make_solution(primaries=[], coin_announcements_to_assert={primary_announcement_hash})
             solution = decorator_manager.solve(puzzle, [], solution)
             spends.append(
-                CoinSpend(
+                make_spend(
                     coin, SerializedProgram.from_bytes(bytes(puzzle)), SerializedProgram.from_bytes(bytes(solution))
                 )
             )

--- a/tests/clvm/test_puzzle_compression.py
+++ b/tests/clvm/test_puzzle_compression.py
@@ -10,7 +10,7 @@ from chia_rs import G1Element, G2Element
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD, construct_cat_puzzle
@@ -49,7 +49,7 @@ def report_compression_fixture(record_property):
 
 
 def test_standard_puzzle(report_compression):
-    coin_spend = CoinSpend(
+    coin_spend = make_spend(
         COIN,
         puzzle_for_pk(G1Element()),
         SOLUTION,
@@ -71,7 +71,7 @@ def test_decompress_limit():
 
 
 def test_cat_puzzle(report_compression):
-    coin_spend = CoinSpend(
+    coin_spend = make_spend(
         COIN,
         construct_cat_puzzle(CAT_MOD, Program.to([]).get_tree_hash(), Program.to(1)),
         SOLUTION,
@@ -84,7 +84,7 @@ def test_cat_puzzle(report_compression):
 
 
 def test_offer_puzzle(report_compression):
-    coin_spend = CoinSpend(
+    coin_spend = make_spend(
         COIN,
         OFFER_MOD,
         SOLUTION,
@@ -97,7 +97,7 @@ def test_offer_puzzle(report_compression):
 
 
 def test_nesting_puzzles(report_compression):
-    coin_spend = CoinSpend(
+    coin_spend = make_spend(
         COIN,
         construct_cat_puzzle(CAT_MOD, Program.to([]).get_tree_hash(), puzzle_for_pk(G1Element())),
         SOLUTION,
@@ -111,7 +111,7 @@ def test_nesting_puzzles(report_compression):
 
 def test_unknown_wrapper(report_compression):
     unknown = Program.to([2, 2, []])  # (a 2 ())
-    coin_spend = CoinSpend(
+    coin_spend = make_spend(
         COIN,
         unknown.curry(puzzle_for_pk(G1Element())),
         SOLUTION,
@@ -130,7 +130,7 @@ def test_lowest_best_version():
 
 
 def test_version_override():
-    coin_spend = CoinSpend(
+    coin_spend = make_spend(
         COIN,
         OFFER_MOD,
         SOLUTION,

--- a/tests/clvm/test_puzzles.py
+++ b/tests/clvm/test_puzzles.py
@@ -7,7 +7,7 @@ from chia_rs import AugSchemeMPL, G1Element, G2Element
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64
@@ -72,7 +72,7 @@ def do_test_spend(
     coin = coin_db.farm_coin(puzzle_hash, farm_time)
 
     # spend it
-    coin_spend = CoinSpend(coin, puzzle_reveal, solution)
+    coin_spend = make_spend(coin, puzzle_reveal, solution)
 
     spend_bundle = SpendBundle([coin_spend], G2Element())
     coin_db.update_coin_store_for_spend_bundle(spend_bundle, spend_time, MAX_BLOCK_COST_CLVM)

--- a/tests/clvm/test_singletons.py
+++ b/tests/clvm/test_singletons.py
@@ -10,7 +10,7 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
@@ -124,7 +124,7 @@ async def test_singleton_top_layer(version, cost_logger):
         delegated_puzzle: Program = p2_conditions.puzzle_for_conditions(conditions)  # noqa
         full_solution: Program = p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)  # noqa
 
-        starting_coinsol = CoinSpend(
+        starting_coinsol = make_spend(
             starting_coin,
             starting_puzzle,
             full_solution,
@@ -173,7 +173,7 @@ async def test_singleton_top_layer(version, cost_logger):
             inner_solution,
         )
 
-        singleton_eve_coinsol = CoinSpend(
+        singleton_eve_coinsol = make_spend(
             singleton_eve,
             puzzle_reveal,
             full_solution,
@@ -200,7 +200,7 @@ async def test_singleton_top_layer(version, cost_logger):
             inner_solution,
         )
 
-        singleton_coinsol = CoinSpend(
+        singleton_coinsol = make_spend(
             singleton,
             puzzle_reveal,
             full_solution,
@@ -249,7 +249,7 @@ async def test_singleton_top_layer(version, cost_logger):
             singleton_eve.amount,
             inner_solution,
         )
-        singleton_claim_coinsol = CoinSpend(
+        singleton_claim_coinsol = make_spend(
             singleton_child,
             puzzle_reveal,
             full_solution,
@@ -307,7 +307,7 @@ async def test_singleton_top_layer(version, cost_logger):
             singleton_eve.amount,
             inner_solution,
         )
-        delay_claim_coinsol = CoinSpend(
+        delay_claim_coinsol = make_spend(
             singleton_child,
             puzzle_reveal,
             full_solution,
@@ -364,7 +364,7 @@ async def test_singleton_top_layer(version, cost_logger):
             lineage_proof, singleton_child.amount, inner_solution
         )
 
-        multi_odd_coinsol = CoinSpend(
+        multi_odd_coinsol = make_spend(
             singleton_child,
             puzzle_reveal,
             full_solution,
@@ -400,7 +400,7 @@ async def test_singleton_top_layer(version, cost_logger):
             lineage_proof, singleton_child.amount, inner_solution
         )
 
-        no_odd_coinsol = CoinSpend(
+        no_odd_coinsol = make_spend(
             singleton_child,
             puzzle_reveal,
             full_solution,
@@ -442,7 +442,7 @@ async def test_singleton_top_layer(version, cost_logger):
             lineage_proof, singleton_child.amount, inner_solution
         )
 
-        singleton_even_coinsol = CoinSpend(
+        singleton_even_coinsol = make_spend(
             singleton_child,
             puzzle_reveal,
             full_solution,
@@ -482,7 +482,7 @@ async def test_singleton_top_layer(version, cost_logger):
             inner_solution,
         )
 
-        evil_coinsol = CoinSpend(
+        evil_coinsol = make_spend(
             evil_coin,
             puzzle_reveal,
             full_solution,
@@ -520,7 +520,7 @@ async def test_singleton_top_layer(version, cost_logger):
             lineage_proof, singleton_child.amount, inner_solution
         )
 
-        melt_coinsol = CoinSpend(
+        melt_coinsol = make_spend(
             singleton_child,
             puzzle_reveal,
             full_solution,

--- a/tests/clvm/test_spend_sim.py
+++ b/tests/clvm/test_spend_sim.py
@@ -6,7 +6,7 @@ from chia_rs import G2Element
 from chia.clvm.spend_sim import sim_and_client
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.spend_bundle import SpendBundle
 
 
@@ -93,7 +93,7 @@ async def test_all_endpoints():
         spendable_coin = spendable_coin[0].coin
         bundle = SpendBundle(
             [
-                CoinSpend(
+                make_spend(
                     spendable_coin,
                     Program.to(1),
                     Program.to([[51, puzzle_hash, 1]]),

--- a/tests/core/custom_types/test_spend_bundle.py
+++ b/tests/core/custom_types/test_spend_bundle.py
@@ -11,7 +11,7 @@ from chia_rs import G2Element
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import ValidationError
@@ -107,7 +107,7 @@ def create_spends(num: int) -> Tuple[List[CoinSpend], List[Coin]]:
         coin = Coin(rand_hash(rng), puzzle_hash, 1000)
         new_coin = Coin(coin.name(), target_ph, 1)
         create_coin.append(new_coin)
-        spends.append(CoinSpend(coin, puzzle, Program.to(conditions)))
+        spends.append(make_spend(coin, puzzle, Program.to(conditions)))
 
     return spends, create_coin
 

--- a/tests/core/full_node/test_conditions.py
+++ b/tests/core/full_node/test_conditions.py
@@ -18,7 +18,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.coin_record import CoinRecord
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
@@ -103,7 +103,7 @@ async def check_conditions(
     blocks = await initial_blocks(bt)
     coin = blocks[spend_reward_index].get_included_reward_coins()[0]
 
-    coin_spend = CoinSpend(coin, EASY_PUZZLE, SerializedProgram.from_program(condition_solution))
+    coin_spend = make_spend(coin, EASY_PUZZLE, SerializedProgram.from_program(condition_solution))
     spend_bundle = SpendBundle([coin_spend], G2Element())
 
     # now let's try to create a block with the spend bundle and ensure that it doesn't validate

--- a/tests/core/full_node/test_full_node.py
+++ b/tests/core/full_node/test_full_node.py
@@ -42,7 +42,7 @@ from chia.types.blockchain_format.reward_chain_block import RewardChainBlockUnfi
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFProof
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.full_block import FullBlock
@@ -341,7 +341,7 @@ class TestFullNodeBlockCompression:
         )
         extra_spend = SpendBundle(
             [
-                CoinSpend(
+                make_spend(
                     next(coin for coin in tr.additions if coin.puzzle_hash == Program.to(1).get_tree_hash()),
                     Program.to(1),
                     Program.to([[51, ph, 30000]]),
@@ -387,7 +387,7 @@ class TestFullNodeBlockCompression:
         )
         extra_spend = SpendBundle(
             [
-                CoinSpend(
+                make_spend(
                     next(coin for coin in tr.additions if coin.puzzle_hash == Program.to(1).get_tree_hash()),
                     Program.to(1),
                     Program.to([[51, ph, 30000]]),

--- a/tests/core/make_block_generator.py
+++ b/tests/core/make_block_generator.py
@@ -9,7 +9,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle import SpendBundle
@@ -60,7 +60,7 @@ def make_spend_bundle(count: int) -> SpendBundle:
         puzzle_reveal = puzzle_hash_db[coin.puzzle_hash]
         conditions = conditions_for_payment(coin)
         solution = SerializedProgram.from_program(solution_for_conditions(conditions))
-        coin_spend = CoinSpend(coin, puzzle_reveal, solution)
+        coin_spend = make_spend(coin, puzzle_reveal, solution)
         coin_spends.append(coin_spend)
 
     spend_bundle = SpendBundle(coin_spends, G2Element())

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -32,7 +32,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.clvm_cost import CLVMCost
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.eligible_coin_spends import run_for_cost
@@ -2652,7 +2652,7 @@ class TestMaliciousGenerators:
         cs = spend_bundle.coin_spends[0]
         c = cs.coin
         coin_0 = Coin(c.parent_coin_info, bytes32([1] * 32), c.amount)
-        coin_spend_0 = CoinSpend(coin_0, cs.puzzle_reveal, cs.solution)
+        coin_spend_0 = make_spend(coin_0, cs.puzzle_reveal, cs.solution)
         new_bundle = recursive_replace(spend_bundle, "coin_spends", [coin_spend_0] + spend_bundle.coin_spends[1:])
         assert spend_bundle is not None
         res = await full_node_1.full_node.add_transaction(new_bundle, new_bundle.name(), test=True)

--- a/tests/fee_estimation/test_mempoolitem_height_added.py
+++ b/tests/fee_estimation/test_mempoolitem_height_added.py
@@ -13,7 +13,7 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bitcoin_fee_estimator import BitcoinFeeEstimator
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.spend_bundle import SpendBundle
 
 log = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ async def farm(
 
 
 def make_tx_sb(from_coin: Coin) -> SpendBundle:
-    coin_spend = CoinSpend(
+    coin_spend = make_spend(
         from_coin,
         Program.to(1),
         Program.to([[51, from_coin.puzzle_hash, from_coin.amount]]),

--- a/tests/pools/test_pool_puzzles_lifecycle.py
+++ b/tests/pools/test_pool_puzzles_lifecycle.py
@@ -27,7 +27,7 @@ from chia.pools.pool_wallet_info import PoolState
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
 from chia.wallet.puzzles import singleton_top_layer
@@ -145,7 +145,7 @@ class TestPoolPuzzles(TestCase):
         # Creating solution for standard transaction
         delegated_puzzle: Program = puzzle_for_conditions(conditions)
         full_solution: Program = solution_for_conditions(conditions)
-        starting_coinsol = CoinSpend(
+        starting_coinsol = make_spend(
             starting_coin,
             starting_puzzle,
             full_solution,
@@ -252,7 +252,7 @@ class TestPoolPuzzles(TestCase):
         )
         coin_db._add_coin_entry(non_reward_p2_singleton, time)
         # construct coin solution for the p2_singleton coin
-        bad_coinsol = CoinSpend(
+        bad_coinsol = make_spend(
             non_reward_p2_singleton,
             p2_singleton_puz,
             Program.to(

--- a/tests/pools/test_wallet_pool_store.py
+++ b/tests/pools/test_wallet_pool_store.py
@@ -11,7 +11,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend, compute_additions
+from chia.types.coin_spend import CoinSpend, compute_additions, make_spend
 from chia.util.ints import uint32, uint64
 from chia.wallet.wallet_pool_store import WalletPoolStore
 from tests.util.db_connection import DBConnection
@@ -28,7 +28,7 @@ def make_child_solution(
     if new_coin is None:
         assert coin_spend is not None
         new_coin = compute_additions(coin_spend)[0]
-    sol: CoinSpend = CoinSpend(
+    sol: CoinSpend = make_spend(
         new_coin,
         SerializedProgram.from_program(puzzle_prog),
         SerializedProgram.from_program(solution_prog),

--- a/tests/wallet/cat_wallet/test_cat_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_cat_lifecycle.py
@@ -10,7 +10,7 @@ from chia.clvm.spend_sim import CostLogger, SimClient, SpendSim, sim_and_client
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
@@ -232,7 +232,7 @@ class TestCATLifecycle:
             ].coin
             acs_bundle = SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         acs_coin,
                         temp_p,
                         Program.to([]),
@@ -373,7 +373,7 @@ class TestCATLifecycle:
 
             await sim_client.push_tx(
                 SpendBundle(
-                    [CoinSpend(starting_coin, standard_acs, Program.to([[51, cat_ph, starting_coin.amount]]))],
+                    [make_spend(starting_coin, standard_acs, Program.to([[51, cat_ph, starting_coin.amount]]))],
                     G2Element(),
                 )
             )
@@ -415,7 +415,7 @@ class TestCATLifecycle:
 
             await sim_client.push_tx(
                 SpendBundle(
-                    [CoinSpend(starting_coin, standard_acs, Program.to([[51, cat_ph, starting_coin.amount]]))],
+                    [make_spend(starting_coin, standard_acs, Program.to([[51, cat_ph, starting_coin.amount]]))],
                     G2Element(),
                 )
             )
@@ -521,7 +521,7 @@ class TestCATLifecycle:
             ].coin
             acs_bundle = SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         acs_coin,
                         temp_p,
                         Program.to([]),
@@ -569,7 +569,7 @@ class TestCATLifecycle:
 
             await sim_client.push_tx(
                 SpendBundle(
-                    [CoinSpend(starting_coin, standard_acs, Program.to([[51, cat_ph, starting_coin.amount]]))],
+                    [make_spend(starting_coin, standard_acs, Program.to([[51, cat_ph, starting_coin.amount]]))],
                     G2Element(),
                 )
             )

--- a/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
+++ b/tests/wallet/cat_wallet/test_cat_outer_puzzle.py
@@ -9,7 +9,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.util.ints import uint64
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD, construct_cat_puzzle
 from chia.wallet.outer_puzzles import construct_puzzle, get_inner_puzzle, get_inner_solution, match_puzzle, solve_puzzle
@@ -38,7 +38,7 @@ def test_cat_outer_puzzle() -> None:
     # Set up for solve
     parent_coin = Coin(tail, double_cat_puzzle.get_tree_hash(), uint64(100))
     child_coin = Coin(parent_coin.name(), double_cat_puzzle.get_tree_hash(), uint64(100))
-    parent_spend = CoinSpend(parent_coin, SerializedProgram.from_program(double_cat_puzzle), Program.to([]))
+    parent_spend = make_spend(parent_coin, SerializedProgram.from_program(double_cat_puzzle), Program.to([]))
     child_coin_as_hex: str = (
         "0x"
         + child_coin.parent_coin_info.hex()

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -16,7 +16,7 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtoco
 from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.db_wrapper import DBWrapper2
@@ -990,7 +990,7 @@ class TestCATWallet:
         )
         eve_spend = await wallet_node_0.wallet_state_manager.sign_transaction(
             [
-                CoinSpend(
+                make_spend(
                     cat_coin,
                     cat_puzzle,
                     Program.to(
@@ -1015,7 +1015,7 @@ class TestCATWallet:
                         ]
                     ),
                 ),
-                CoinSpend(
+                make_spend(
                     next_coin,
                     construct_cat_puzzle(
                         CAT_MOD,

--- a/tests/wallet/clawback/test_clawback_lifecycle.py
+++ b/tests/wallet/clawback/test_clawback_lifecycle.py
@@ -9,7 +9,7 @@ from chia.clvm.spend_sim import CostLogger, SimClient, SpendSim, sim_and_client
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
@@ -127,7 +127,7 @@ class TestClawbackLifecycle:
                     ],
                 ]
             )
-            coin_spend = CoinSpend(starting_coin, sender_puz, sender_sol)
+            coin_spend = make_spend(starting_coin, sender_puz, sender_sol)
             sig = self.sign_coin_spend(coin_spend, sender_index)
             spend_bundle = SpendBundle([coin_spend], sig)
 
@@ -154,7 +154,7 @@ class TestClawbackLifecycle:
             # Fail an early claim spend
             recipient_sol = solution_for_conditions([[ConditionOpcode.CREATE_COIN, recipient_ph, amount]])
             claim_sol = create_merkle_solution(timelock, sender_ph, recipient_ph, recipient_puz, recipient_sol)
-            coin_spend = CoinSpend(clawback_coin, cb_puzzle, claim_sol)
+            coin_spend = make_spend(clawback_coin, cb_puzzle, claim_sol)
             sig = self.sign_coin_spend(coin_spend, recipient_index)
             spend_bundle = SpendBundle([coin_spend], sig)
 
@@ -186,7 +186,7 @@ class TestClawbackLifecycle:
             # create another clawback coin and claw it back to a "cold wallet"
             cold_ph = bytes32([1] * 32)
             new_coin = (await sim_client.get_coin_records_by_puzzle_hash(sender_ph, include_spent_coins=False))[0].coin
-            coin_spend = CoinSpend(new_coin, sender_puz, sender_sol)
+            coin_spend = make_spend(new_coin, sender_puz, sender_sol)
             sig = self.sign_coin_spend(coin_spend, sender_index)
             spend_bundle = SpendBundle([coin_spend], sig)
 
@@ -205,7 +205,7 @@ class TestClawbackLifecycle:
 
             sender_claw_sol = solution_for_conditions([[ConditionOpcode.CREATE_COIN, cold_ph, amount]])
             claw_sol = create_merkle_solution(timelock, sender_ph, recipient_ph, sender_puz, sender_claw_sol)
-            coin_spend = CoinSpend(new_cb_coin, cb_puzzle, claw_sol)
+            coin_spend = make_spend(new_cb_coin, cb_puzzle, claw_sol)
             sig = self.sign_coin_spend(coin_spend, sender_index)
             spend_bundle = SpendBundle([coin_spend], sig)
 

--- a/tests/wallet/dao_wallet/test_dao_clvm.py
+++ b/tests/wallet/dao_wallet/test_dao_clvm.py
@@ -10,7 +10,7 @@ from chia.clvm.spend_sim import SimClient, SpendSim, sim_and_client
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
@@ -1229,7 +1229,7 @@ async def do_spend(
 ) -> Tuple[MempoolInclusionStatus, Optional[Err]]:
     spends = []
     for coin, puzzle, solution in zip(coins, puzzles, solutions):
-        spends.append(CoinSpend(coin, puzzle, solution))
+        spends.append(make_spend(coin, puzzle, solution))
     spend_bundle = SpendBundle(spends, AugSchemeMPL.aggregate([]))
     result = await sim_client.push_tx(spend_bundle)
     await sim.farm_block()

--- a/tests/wallet/db_wallet/test_db_graftroot.py
+++ b/tests/wallet/db_wallet/test_db_graftroot.py
@@ -9,7 +9,7 @@ from chia.clvm.spend_sim import CostLogger, sim_and_client
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
@@ -84,7 +84,7 @@ async def test_graftroot(cost_logger: CostLogger) -> None:
             fake_coin: Coin = (await sim_client.get_coin_records_by_puzzle_hash(fake_puzzle.get_tree_hash()))[0].coin
 
             # Create the spend
-            fake_spend = CoinSpend(
+            fake_spend = make_spend(
                 fake_coin,
                 fake_puzzle,
                 Program.to([[[62, "$"]]]),
@@ -97,7 +97,7 @@ async def test_graftroot(cost_logger: CostLogger) -> None:
                 else:
                     proofs_of_inclusion.append((0, []))
 
-            graftroot_spend = CoinSpend(
+            graftroot_spend = make_spend(
                 graftroot_coin,
                 graftroot_puzzle,
                 Program.to(
@@ -129,7 +129,7 @@ async def test_graftroot(cost_logger: CostLogger) -> None:
                 await sim.rewind(same_height)
 
                 # try with a bad merkle root announcement
-                new_fake_spend = CoinSpend(
+                new_fake_spend = make_spend(
                     fake_coin,
                     ACS.curry(fake_struct, ACS.curry(ACS_PH, (bytes32([0] * 32), None), None, None)),
                     Program.to([[[62, "$"]]]),

--- a/tests/wallet/nft_wallet/test_nft_lifecycle.py
+++ b/tests/wallet/nft_wallet/test_nft_lifecycle.py
@@ -10,7 +10,7 @@ from chia.clvm.spend_sim import CostLogger, sim_and_client
 from chia.types.announcement import Announcement
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
@@ -54,7 +54,7 @@ async def test_state_layer(cost_logger: CostLogger, metadata_updater: str) -> No
             await sim_client.get_coin_records_by_puzzle_hash(state_layer_ph, include_spent_coins=False)
         )[0].coin
 
-        generic_spend = CoinSpend(
+        generic_spend = make_spend(
             state_layer_coin,
             state_layer_puzzle,
             Program.to([[[51, ACS_PH, 1]]]),
@@ -115,7 +115,7 @@ async def test_state_layer(cost_logger: CostLogger, metadata_updater: str) -> No
             state_layer_coin = (
                 await sim_client.get_coin_records_by_parent_ids([state_layer_coin.name()], include_spent_coins=False)
             )[0].coin
-            update_spend = CoinSpend(
+            update_spend = make_spend(
                 state_layer_coin,
                 state_layer_puzzle,
                 Program.to(
@@ -156,7 +156,7 @@ async def test_ownership_layer(cost_logger: CostLogger) -> None:
             0
         ].coin
 
-        generic_spend = CoinSpend(
+        generic_spend = make_spend(
             ownership_coin,
             ownership_puzzle,
             Program.to([[[51, ACS_PH, 1], [-10, [], []]]]),
@@ -171,7 +171,7 @@ async def test_ownership_layer(cost_logger: CostLogger) -> None:
             0
         ].coin
 
-        skip_tp_spend = CoinSpend(
+        skip_tp_spend = make_spend(
             ownership_coin,
             ownership_puzzle,
             Program.to([[[51, ACS_PH, 1]]]),
@@ -183,7 +183,7 @@ async def test_ownership_layer(cost_logger: CostLogger) -> None:
         with pytest.raises(ValueError, match="clvm raise"):
             skip_tp_spend.puzzle_reveal.to_program().run(skip_tp_spend.solution.to_program())
 
-        make_bad_announcement_spend = CoinSpend(
+        make_bad_announcement_spend = make_spend(
             ownership_coin,
             ownership_puzzle,
             Program.to(
@@ -213,7 +213,7 @@ async def test_ownership_layer(cost_logger: CostLogger) -> None:
             ownership_puzzle.get_tree_hash(),
             b"oy",
         )
-        update_everything_spend = CoinSpend(
+        update_everything_spend = make_spend(
             ownership_coin,
             ownership_puzzle,
             Program.to(
@@ -277,7 +277,7 @@ async def test_default_transfer_program(cost_logger: CostLogger) -> None:
         BLOCK_HEIGHT = sim.block_height
 
         # Try a spend, no royalties, no owner update
-        generic_spend = CoinSpend(
+        generic_spend = make_spend(
             ownership_coin,
             ownership_puzzle,
             Program.to([[[51, ACS_PH, 1]]]),
@@ -303,7 +303,7 @@ async def test_default_transfer_program(cost_logger: CostLogger) -> None:
         )[0].coin
         xch_coin = (await sim_client.get_coin_records_by_puzzle_hash(ACS_PH, include_spent_coins=False))[0].coin
 
-        ownership_spend = CoinSpend(
+        ownership_spend = make_spend(
             ownership_coin,
             ownership_puzzle,
             Program.to(
@@ -311,7 +311,7 @@ async def test_default_transfer_program(cost_logger: CostLogger) -> None:
             ),
         )
 
-        did_announcement_spend = CoinSpend(
+        did_announcement_spend = make_spend(
             singleton_coin,
             FAKE_SINGLETON,
             Program.to([[[62, FAKE_LAUNCHER_ID]]]),
@@ -320,13 +320,13 @@ async def test_default_transfer_program(cost_logger: CostLogger) -> None:
         expected_announcement_data = Program.to(
             (FAKE_LAUNCHER_ID, [[ROYALTY_ADDRESS, 50, [ROYALTY_ADDRESS]]])
         ).get_tree_hash()
-        xch_announcement_spend = CoinSpend(
+        xch_announcement_spend = make_spend(
             xch_coin,
             ACS,
             Program.to([[62, expected_announcement_data]]),
         )
 
-        cat_announcement_spend = CoinSpend(cat_coin, FAKE_CAT, Program.to([[[62, expected_announcement_data]]]))
+        cat_announcement_spend = make_spend(cat_coin, FAKE_CAT, Program.to([[[62, expected_announcement_data]]]))
 
         # Make sure every combo except all of them fail
         for i in range(1, 3):
@@ -358,7 +358,7 @@ async def test_default_transfer_program(cost_logger: CostLogger) -> None:
             await sim_client.get_coin_records_by_puzzle_hash(new_ownership_ph, include_spent_coins=False)
         )[0].coin
 
-        empty_spend = CoinSpend(
+        empty_spend = make_spend(
             new_ownership_coin,
             new_ownership_puzzle,
             Program.to([[[51, ACS_PH, 1], [-10, [], [], []]]]),

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -27,7 +27,7 @@ from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.peer_info import PeerInfo
 from chia.types.signing_mode import SigningMode
 from chia.types.spend_bundle import SpendBundle
@@ -2440,7 +2440,7 @@ async def test_cat_spend_run_tail(wallet_rpc_environment: WalletRpcTestEnvironme
     cat_coin = next(c for c in spend_bundle.additions() if c.amount == tx_amount)
     eve_spend = SpendBundle(
         [
-            CoinSpend(
+            make_spend(
                 cat_coin,
                 cat_puzzle,
                 Program.to(

--- a/tests/wallet/test_debug_spend_bundle.py
+++ b/tests/wallet/test_debug_spend_bundle.py
@@ -8,7 +8,7 @@ from chia_rs import AugSchemeMPL, PrivateKey
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
@@ -49,17 +49,17 @@ def test_debug_spend_bundle() -> None:
     debug_spend_bundle(
         SpendBundle(
             [
-                CoinSpend(
+                make_spend(
                     coin_bad_reveal,
                     ACS,
                     Program.to(None),
                 ),
-                CoinSpend(
+                make_spend(
                     coin,
                     ACS,
                     solution,
                 ),
-                CoinSpend(
+                make_spend(
                     child_coin,
                     ACS,
                     Program.to(None),

--- a/tests/wallet/test_sign_coin_spends.py
+++ b/tests/wallet/test_sign_coin_spends.py
@@ -10,7 +10,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.db_wrapper import DBWrapper2, manage_connection
 from chia.util.ints import uint32
@@ -52,12 +52,12 @@ solution_h = SerializedProgram.from_program(
 solution_u = SerializedProgram.from_program(
     Program.to([[ConditionOpcode.AGG_SIG_UNSAFE, pk1_u, msg1], [ConditionOpcode.AGG_SIG_ME, pk2_u, msg2]])
 )
-spend_h: CoinSpend = CoinSpend(
+spend_h: CoinSpend = make_spend(
     coin,
     puzzle,
     solution_h,
 )
-spend_u: CoinSpend = CoinSpend(
+spend_u: CoinSpend = make_spend(
     coin,
     puzzle,
     solution_u,

--- a/tests/wallet/test_singleton_lifecycle.py
+++ b/tests/wallet/test_singleton_lifecycle.py
@@ -10,7 +10,7 @@ from chia.types.announcement import Announcement
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
@@ -68,7 +68,7 @@ def launcher_conditions_and_spend_bundle(
         )
     )
     launcher_solution = Program.to([singleton_full_puzzle_hash, launcher_amount, metadata])
-    coin_spend = CoinSpend(launcher_coin, launcher_puzzle, launcher_solution)
+    coin_spend = make_spend(launcher_coin, launcher_puzzle, launcher_solution)
     spend_bundle = SpendBundle([coin_spend], G2Element())
     lineage_proof = Program.to([parent_coin_id, launcher_amount])
     return lineage_proof, launcher_coin.name(), expected_conditions, spend_bundle
@@ -110,7 +110,7 @@ async def test_only_odd_coins_0(bt):
     )
 
     conditions = Program.to(condition_list)
-    coin_spend = CoinSpend(farmed_coin, ANYONE_CAN_SPEND_PUZZLE, conditions)
+    coin_spend = make_spend(farmed_coin, ANYONE_CAN_SPEND_PUZZLE, conditions)
     spend_bundle = SpendBundle.aggregate([launcher_spend_bundle, SpendBundle([coin_spend], G2Element())])
     coins_added, coins_removed, _ = await check_spend_bundle_validity(bt, blocks, spend_bundle)
 

--- a/tests/wallet/test_singleton_lifecycle_fast.py
+++ b/tests/wallet/test_singleton_lifecycle_fast.py
@@ -12,7 +12,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend, compute_additions
+from chia.types.coin_spend import CoinSpend, compute_additions, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
@@ -223,7 +223,7 @@ class SingletonWallet:
         solution = solve_puzzle(
             puzzle_db, puzzle_reveal, lineage_proof=self.lineage_proof, coin_amount=coin.amount, **kwargs
         )
-        return CoinSpend(coin, puzzle_reveal, solution)
+        return make_spend(coin, puzzle_reveal, solution)
 
     def update_state(self, puzzle_db: PuzzleDB, removals: List[CoinSpend]) -> int:
         state_change_count = 0
@@ -295,7 +295,7 @@ def launcher_conditions_and_spend_bundle(
         launcher_amount=launcher_amount,
         metadata=metadata,
     )
-    coin_spend = CoinSpend(launcher_coin, SerializedProgram.from_program(launcher_puzzle), solution)
+    coin_spend = make_spend(launcher_coin, SerializedProgram.from_program(launcher_puzzle), solution)
     spend_bundle = SpendBundle([coin_spend], G2Element())
     return launcher_coin.name(), expected_conditions, spend_bundle
 
@@ -354,7 +354,7 @@ def claim_p2_singleton(
         singleton_inner_puzzle_hash=inner_puzzle_hash,
         p2_singleton_coin_name=p2_singleton_coin_name,
     )
-    p2_singleton_coin_spend = CoinSpend(
+    p2_singleton_coin_spend = make_spend(
         p2_singleton_coin,
         SerializedProgram.from_program(p2_singleton_puzzle),
         p2_singleton_solution,
@@ -416,7 +416,7 @@ def spend_coin_to_singleton(
     )
 
     conditions = Program.to(condition_list)
-    coin_spend = CoinSpend(farmed_coin, ANYONE_CAN_SPEND_PUZZLE, conditions)
+    coin_spend = make_spend(farmed_coin, ANYONE_CAN_SPEND_PUZZLE, conditions)
     spend_bundle = SpendBundle.aggregate([launcher_spend_bundle, SpendBundle([coin_spend], G2Element())])
 
     additions, removals = coin_store.update_coin_store_for_spend_bundle(spend_bundle, now, MAX_BLOCK_COST_CLVM)

--- a/tests/wallet/test_singleton_store.py
+++ b/tests/wallet/test_singleton_store.py
@@ -8,7 +8,7 @@ import pytest
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.util.ints import uint32, uint64
 
 # from chia.wallet.dao_wallet.dao_wallet import DAOInfo, DAOWallet
@@ -29,7 +29,7 @@ def get_record(wallet_id: uint32 = uint32(2)) -> SingletonRecord:
     inner_sol = Program.to([[51, inner_puz_hash, 1]])
     lineage_proof = LineageProof(launcher_id, inner_puz.get_tree_hash(), uint64(1))
     parent_sol = Program.to([lineage_proof.to_program(), 1, inner_sol])
-    parent_coinspend = CoinSpend(parent_coin, parent_puz, parent_sol)
+    parent_coinspend = make_spend(parent_coin, parent_puz, parent_sol)
     pending = True
     removed_height = 0
     custom_data = "{'key': 'value'}"
@@ -84,7 +84,7 @@ class TestSingletonStore:
             inner_puz_hash = inner_puz.get_tree_hash()
             bad_coin = Coin(record.singleton_id, inner_puz_hash, 1)
             inner_sol = Program.to([[51, inner_puz_hash, 1]])
-            bad_coinspend = CoinSpend(bad_coin, inner_puz, inner_sol)
+            bad_coinspend = make_spend(bad_coin, inner_puz, inner_sol)
             with pytest.raises(RuntimeError) as e_info:
                 await db.add_spend(uint32(2), bad_coinspend, uint32(10))
             assert e_info.value.args[0] == "Coin to add is not a valid singleton"

--- a/tests/wallet/vc_wallet/test_vc_lifecycle.py
+++ b/tests/wallet/vc_wallet/test_vc_lifecycle.py
@@ -10,7 +10,7 @@ from chia.clvm.spend_sim import CostLogger, sim_and_client
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
@@ -79,12 +79,12 @@ async def test_covenant_layer(cost_logger: CostLogger) -> None:
                 "2x ACS spends - create one coin",
                 SpendBundle(
                     [
-                        CoinSpend(
+                        make_spend(
                             fake_acs_coin,
                             FAKE_ACS,
                             Program.to([[51, covenant_puzzle_hash, fake_acs_coin.amount]]),
                         ),
-                        CoinSpend(
+                        make_spend(
                             acs_coin,
                             ACS,
                             Program.to([[51, covenant_puzzle_hash, acs_coin.amount]]),
@@ -108,7 +108,7 @@ async def test_covenant_layer(cost_logger: CostLogger) -> None:
         result: Tuple[MempoolInclusionStatus, Optional[Err]] = await client.push_tx(
             SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         acs_cov,
                         covenant_puzzle,
                         solve_covenant_layer(
@@ -134,7 +134,7 @@ async def test_covenant_layer(cost_logger: CostLogger) -> None:
                     "Covenant layer eve spend - one create coin",
                     SpendBundle(
                         [
-                            CoinSpend(
+                            make_spend(
                                 cov,
                                 covenant_puzzle,
                                 solve_covenant_layer(
@@ -164,7 +164,7 @@ async def test_covenant_layer(cost_logger: CostLogger) -> None:
                 "Covenant layer non-eve spend - one create coin",
                 SpendBundle(
                     [
-                        CoinSpend(
+                        make_spend(
                             new_acs_cov,
                             covenant_puzzle,
                             solve_covenant_layer(
@@ -216,7 +216,7 @@ async def test_did_tp(cost_logger: CostLogger) -> None:
         result: Tuple[MempoolInclusionStatus, Optional[Err]] = await client.push_tx(
             SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         eml_coin,
                         eml_puzzle,
                         Program.to(
@@ -241,7 +241,7 @@ async def test_did_tp(cost_logger: CostLogger) -> None:
         did_coin: Coin = (
             await client.get_coin_records_by_puzzle_hashes([MOCK_SINGLETON.get_tree_hash()], include_spent_coins=False)
         )[0].coin
-        did_authorization_spend: CoinSpend = CoinSpend(
+        did_authorization_spend: CoinSpend = make_spend(
             did_coin,
             MOCK_SINGLETON,
             Program.to([[[62, std_hash(my_coin_id + new_metadata.get_tree_hash() + new_tp_hash)]]]),
@@ -251,7 +251,7 @@ async def test_did_tp(cost_logger: CostLogger) -> None:
         result = await client.push_tx(
             SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         eml_coin,
                         eml_puzzle,
                         Program.to(
@@ -277,7 +277,7 @@ async def test_did_tp(cost_logger: CostLogger) -> None:
             "Fake Ownership Layer - NFT DID TP",
             SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         eml_coin,
                         eml_puzzle,
                         Program.to(
@@ -330,7 +330,7 @@ async def test_viral_backdoor(cost_logger: CostLogger) -> None:
         result: Tuple[MempoolInclusionStatus, Optional[Err]] = await client.push_tx(
             SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         p2_either_coin,
                         p2_either_puzzle,
                         solve_viral_backdoor(
@@ -349,7 +349,7 @@ async def test_viral_backdoor(cost_logger: CostLogger) -> None:
         result = await client.push_tx(
             SpendBundle(
                 [
-                    CoinSpend(
+                    make_spend(
                         p2_either_coin,
                         p2_either_puzzle,
                         solve_viral_backdoor(
@@ -375,7 +375,7 @@ async def test_viral_backdoor(cost_logger: CostLogger) -> None:
                 "Viral backdoor spend - one create coin",
                 SpendBundle(
                     [
-                        CoinSpend(
+                        make_spend(
                             p2_either_coin,
                             p2_either_puzzle,
                             solve_viral_backdoor(
@@ -420,7 +420,7 @@ async def test_proofs_checker(cost_logger: CostLogger, num_proofs: int) -> None:
                     f"Proofs Checker only - num_proofs: {num_proofs} - permutation: {i}",
                     SpendBundle(
                         [
-                            CoinSpend(
+                            make_spend(
                                 proof_checker_coin,
                                 proofs_checker_runner,
                                 Program.to([[Program.to((flag, "1")) for flag in proof_list]]),
@@ -470,7 +470,7 @@ async def test_vc_lifecycle(test_syncing: bool, cost_logger: CostLogger) -> None
             await client.push_tx(
                 SpendBundle(
                     [
-                        CoinSpend(
+                        make_spend(
                             fund_coin,
                             RUN_PUZ_PUZ,
                             Program.to((1, conditions)),
@@ -511,7 +511,7 @@ async def test_vc_lifecycle(test_syncing: bool, cost_logger: CostLogger) -> None
                 "Launch VC",
                 SpendBundle(
                     [
-                        CoinSpend(
+                        make_spend(
                             vc_fund_coin,
                             RUN_PUZ_PUZ,
                             dpuz,
@@ -547,7 +547,7 @@ async def test_vc_lifecycle(test_syncing: bool, cost_logger: CostLogger) -> None
                         [
                             *(
                                 [
-                                    CoinSpend(
+                                    make_spend(
                                         did if correct_did else other_did,
                                         puzzle_for_singleton(
                                             launcher_id if correct_did else other_launcher_id,
@@ -631,12 +631,12 @@ async def test_vc_lifecycle(test_syncing: bool, cost_logger: CostLogger) -> None
             result = await client.push_tx(
                 SpendBundle(
                     [
-                        CoinSpend(
+                        make_spend(
                             cr_coin_1,
                             RUN_PUZ_PUZ,
                             dpuz_1,
                         ),
-                        CoinSpend(
+                        make_spend(
                             cr_coin_2,
                             RUN_PUZ_PUZ,
                             dpuz_2,
@@ -771,7 +771,7 @@ async def test_vc_lifecycle(test_syncing: bool, cost_logger: CostLogger) -> None
                     "VC yoink by DID provider",
                     SpendBundle(
                         [
-                            CoinSpend(
+                            make_spend(
                                 new_did,
                                 puzzle_for_singleton(
                                     launcher_id if correct_did else other_launcher_id,

--- a/tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/tests/wallet/vc_wallet/test_vc_wallet.py
@@ -12,7 +12,7 @@ from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.types.blockchain_format.coin import coin_as_list
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.coin_spend import CoinSpend
+from chia.types.coin_spend import make_spend
 from chia.types.peer_info import PeerInfo
 from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
@@ -69,7 +69,7 @@ async def mint_cr_cat(
     cat_coin = next(c for c in spend_bundle.additions() if c.amount == CAT_AMOUNT_0)
     eve_spend = SpendBundle(
         [
-            CoinSpend(
+            make_spend(
                 cat_coin,
                 cat_puzzle,
                 Program.to(


### PR DESCRIPTION
### Purpose:

Makes `SerializedProgram` not default constructible. When constructing a `Streamable` type, we ensure all the members have the correct type in `__post_init__`, by calling each member's constructor with whatever value was passed in to the constructor of the aggregate type. Since `Program` is considered `Any`, mypy will not complain when constructing a `SerializedProgram` with a `Program`. adding an explicit `__init__` function that ensures it's only constructed by `bytes`, these kinds of type mismatches are caught.

The main causes of these mismatches are constructing `CoinSpend`, which has two `SerializedProgram` members, but are often constructed by `Program`. To address these cases, a new function, `make_spend()` is introduced which converts whatever arguments were passed in to `SerializedProgram`.

This is a step towards addressing all type mismatches involving `Program` and `SerializedProgram`.

### Current Behavior:

Some places construct an invalid `SerializedProgram` with a `Program` instead of a buffer.

### New Behavior:

These places now construct a `SerializedProgram` with a buffer, as is expected.