### PR TITLE
factor out repeated logic and fix types in `Program.__eq__()` call

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -598,22 +598,21 @@ class PoolWallet:
                 pool_reward_prefix,
                 escape_puzzle_hash,
             ) = uncurry_pool_member_inner_puzzle(inner_puzzle)
-            pk_bytes: bytes = bytes(pubkey_as_program.as_atom())
-            assert len(pk_bytes) == 48
-            owner_pubkey = G1Element.from_bytes(pk_bytes)
-            assert owner_pubkey == pool_wallet_info.current.owner_pubkey
         elif is_pool_waitingroom_inner_puzzle(inner_puzzle):
             (
                 target_puzzle_hash,  # payout_puzzle_hash
                 relative_lock_height,
-                owner_pubkey,
+                pubkey_as_program,
                 p2_singleton_hash,
             ) = uncurry_pool_waitingroom_inner_puzzle(inner_puzzle)
-            pk_bytes = bytes(owner_pubkey.as_atom())
-            assert len(pk_bytes) == 48
-            assert owner_pubkey == pool_wallet_info.current.owner_pubkey
         else:
             raise RuntimeError("Invalid state")
+
+        pk_bytes = pubkey_as_program.as_atom()
+        assert pk_bytes is not None
+        assert len(pk_bytes) == 48
+        owner_pubkey = G1Element.from_bytes(pk_bytes)
+        assert owner_pubkey == pool_wallet_info.current.owner_pubkey
 
         signed_spend_bundle = await self.sign(outgoing_coin_spend)
         assert signed_spend_bundle.removals()[0].puzzle_hash == singleton.puzzle_hash


### PR DESCRIPTION
### Purpose:

The underlying fix is the types used in a comparison, where we currently compare `G1Element` to a `Program`. We do the same thing (but correctly) right next to this code, so I fixed it by factoring out the repeated code.

Techincally, it's not a problem to compare `G1Element` to `Program`, we'll just serialize the G1Element into an atom and then compare. However, as we're working on improving type safety, and the scope of mypy checks, comparing unrelated types like this is best avoided.

### Current Behavior:

We compare a `G1Element` to a `Program` and have a block of code repeated.

### New Behavior:

The block of code is not repeated and we properly convert the `Program` into a `G1Element` before comparing it.