### PR TITLE
fix typo introduced in the deep-reorg performance fix

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -389,8 +389,8 @@ class Blockchain(BlockchainInterface):
                 fork_info.fork_height = block.height - 1
                 fork_info.peak_height = block.height - 1
                 fork_info.peak_hash = block.prev_header_hash
-                fork_info.additions_since_fork == {}
-                fork_info.removals_since_fork == set()
+                fork_info.additions_since_fork = {}
+                fork_info.removals_since_fork = set()
 
             if await self.contains_block_from_db(header_hash):
                 # We have already validated the block, but if it's not part of the

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1268,8 +1268,8 @@ class FullNode:
                 fork_info.fork_height = block.height
                 fork_info.peak_height = block.height
                 fork_info.peak_hash = header_hash
-                fork_info.additions_since_fork == {}
-                fork_info.removals_since_fork == set()
+                fork_info.additions_since_fork = {}
+                fork_info.removals_since_fork = set()
             else:
                 # We have already validated the block, but if it's not part of the
                 # main chain, we still need to re-run it to update the additions and


### PR DESCRIPTION
### Purpose:

This was a typo introduced in the deep-reorg performance fix patch. `additions_since_fork` and `removals_since_fork` are supposed to be reset.