### PR TITLE
aiohttp 3.9.1 to fix a WebSocket bug introduced in 3.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dependencies = [
     "clvm_tools==0.4.7",  # Currying, Program.to, other conveniences
     "chia_rs==0.2.13",
     "clvm-tools-rs==0.1.39",  # Rust implementation of clvm_tools' compiler
-    "aiohttp==3.9.0",  # HTTP server for full node rpc
+    "aiohttp==3.9.1",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks
     "bitstring==4.1.2",  # Binary data management library
     "colorama==0.4.6",  # Colorizes terminal output


### PR DESCRIPTION
### Purpose:
aiohttp 3.9.0 introduced new compression support that was enabled by default. This compression support had a bug that could cause WebSocket frames to get mixed up, causing problems for the GUI. The observed behavior was that multiple responses from the Chia daemon could appear in a single message, breaking message parsing in the GUI.

This bug has been fixed in aiohttp 3.9.1.

Commit that fixes the issue in aiohttp:
https://github.com/aio-libs/aiohttp/issues/7859

Bug reported against aiohttp:
https://github.com/aio-libs/aiohttp/issues/7859

### Testing Notes:
Manually tested going back and forth between 3.8.6, 3.9.0, and 3.9.1 and testing against the GUI.
