### PR TITLE
Add unregister subscription messages to full node

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -313,7 +313,7 @@ class Farmer:
             value=ErrorResponse(uint16(PoolErrorCode.REQUEST_FAILED.value), error_message).to_json_dict(),
         )
 
-    def on_disconnect(self, connection: WSChiaConnection) -> None:
+    async def on_disconnect(self, connection: WSChiaConnection) -> None:
         self.log.info(f"peer disconnected {connection.get_peer_logging()}")
         self.state_changed("close_connection", {})
         if connection.connection_type is NodeType.HARVESTER:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -145,7 +145,7 @@ class FullNode:
     #       config would end up on stdout if handled here.
     multiprocessing_context: Optional[BaseContext] = None
     _ui_tasks: Set[asyncio.Task[None]] = dataclasses.field(default_factory=set)
-    subscriptions: PeerSubscriptions = dataclasses.field(default_factory=PeerSubscriptions)
+    _subscriptions: Optional[PeerSubscriptions] = None
     _transaction_queue_task: Optional[asyncio.Task[None]] = None
     simulator_transaction_callback: Optional[Callable[[bytes32], Awaitable[None]]] = None
     _sync_task: Optional[asyncio.Task[None]] = None
@@ -259,6 +259,7 @@ class FullNode:
             self._block_store = await BlockStore.create(self.db_wrapper)
             self._hint_store = await HintStore.create(self.db_wrapper)
             self._coin_store = await CoinStore.create(self.db_wrapper)
+            self._subscriptions = await PeerSubscriptions.create()
             self.log.info("Initializing blockchain from disk")
             start_time = time.time()
             reserved_cores = self.config.get("reserved_cores", 0)
@@ -416,6 +417,11 @@ class FullNode:
     def hint_store(self) -> HintStore:
         assert self._hint_store is not None
         return self._hint_store
+
+    @property
+    def subscriptions(self) -> PeerSubscriptions:
+        assert self._subscriptions is not None
+        return self._subscriptions
 
     @property
     def new_peak_sem(self) -> LimitedSemaphore:
@@ -895,14 +901,14 @@ class FullNode:
             elif connection.connection_type is NodeType.TIMELORD:
                 await self.send_peak_to_timelords()
 
-    def on_disconnect(self, connection: WSChiaConnection) -> None:
+    async def on_disconnect(self, connection: WSChiaConnection) -> None:
         self.log.info(f"peer disconnected {connection.get_peer_logging()}")
         self._state_changed("close_connection")
         self._state_changed("sync_mode")
         if self.sync_store is not None:
             self.sync_store.peer_disconnected(connection.peer_node_id)
         # Remove all ph | coin id subscription for this peer
-        self.subscriptions.remove_peer(connection.peer_node_id)
+        await self.subscriptions.remove_peer(connection.peer_node_id)
 
     async def _sync(self) -> None:
         """
@@ -1150,10 +1156,10 @@ class FullNode:
                 if state_change_summary is not None:
                     assert peak is not None
                     # Hints must be added to the DB. The other post-processing tasks are not required when syncing
-                    hints_to_add, _ = get_hints_and_subscription_coin_ids(
+                    hints_to_add, _ = await get_hints_and_subscription_coin_ids(
                         state_change_summary,
-                        self.subscriptions.has_coin_subscription,
-                        self.subscriptions.has_ph_subscription,
+                        self.subscriptions.is_coin_subscribed,
+                        self.subscriptions.is_puzzle_subscribed,
                     )
                     await self.hint_store.add_hints(hints_to_add)
                 # Note that end_height is not necessarily the peak at this
@@ -1198,11 +1204,13 @@ class FullNode:
         changes_for_peer: Dict[bytes32, Set[CoinState]] = {}
         for coin_record in wallet_update.coin_records:
             coin_id = coin_record.name
-            subscribed_peers = self.subscriptions.peers_for_coin_id(coin_id)
-            subscribed_peers.update(self.subscriptions.peers_for_puzzle_hash(coin_record.coin.puzzle_hash))
+            subscribed_peers = await self.subscriptions.peers_for_coin_id(coin_id)
+            puzzle_peers = await self.subscriptions.peers_for_puzzle_hash(coin_record.coin.puzzle_hash)
+            subscribed_peers.update(puzzle_peers)
             hint = wallet_update.hints.get(coin_id)
             if hint is not None:
-                subscribed_peers.update(self.subscriptions.peers_for_puzzle_hash(hint))
+                hint_peers = await self.subscriptions.peers_for_puzzle_hash(hint)
+                subscribed_peers.update(hint_peers)
             for peer in subscribed_peers:
                 changes_for_peer.setdefault(peer, set()).add(coin_record.coin_state)
 
@@ -1480,10 +1488,10 @@ class FullNode:
         ):
             self.full_node_store.previous_generator = None
 
-        hints_to_add, lookup_coin_ids = get_hints_and_subscription_coin_ids(
+        hints_to_add, lookup_coin_ids = await get_hints_and_subscription_coin_ids(
             state_change_summary,
-            self.subscriptions.has_coin_subscription,
-            self.subscriptions.has_ph_subscription,
+            self.subscriptions.is_coin_subscribed,
+            self.subscriptions.is_puzzle_subscribed,
         )
         await self.hint_store.add_hints(hints_to_add)
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1505,7 +1505,7 @@ class FullNodeAPI:
         # the returned puzzle hashes are the ones we ended up subscribing to.
         # It will have filtered duplicates and ones exceeding the subscription
         # limit.
-        puzzle_hashes = self.full_node.subscriptions.add_ph_subscriptions(
+        puzzle_hashes = await self.full_node.subscriptions.add_puzzle_subscriptions(
             peer.peer_node_id, request.puzzle_hashes, max_subscriptions
         )
 
@@ -1576,7 +1576,9 @@ class FullNodeAPI:
         # TODO: apparently we have tests that expect to receive a
         # RespondToCoinUpdates even when subscribing to the same coin multiple
         # times, so we can't optimize away such DB lookups (yet)
-        self.full_node.subscriptions.add_coin_subscriptions(peer.peer_node_id, request.coin_ids, max_subscriptions)
+        await self.full_node.subscriptions.add_coin_subscriptions(
+            peer.peer_node_id, request.coin_ids, max_subscriptions
+        )
 
         states: List[CoinState] = await self.full_node.coin_store.get_coin_states_by_ids(
             include_spent_coins=True, coin_ids=set(request.coin_ids), min_height=request.min_height, max_items=max_items
@@ -1590,13 +1592,13 @@ class FullNodeAPI:
     async def unregister_interest_in_puzzle_hash(
         self, request: wallet_protocol.UnregisterPhUpdates, peer: WSChiaConnection
     ) -> None:
-        self.full_node.subscriptions.remove_ph_subscriptions(peer.peer_node_id, request.puzzle_hashes)
+        await self.full_node.subscriptions.remove_puzzle_subscriptions(peer.peer_node_id, request.puzzle_hashes)
 
     @api_request(peer_required=True)
     async def unregister_interest_in_coin(
         self, request: wallet_protocol.UnregisterCoinUpdates, peer: WSChiaConnection
     ) -> None:
-        self.full_node.subscriptions.remove_coin_subscriptions(peer.peer_node_id, request.coin_ids)
+        await self.full_node.subscriptions.remove_coin_subscriptions(peer.peer_node_id, request.coin_ids)
 
     @api_request()
     async def request_children(self, request: wallet_protocol.RequestChildren) -> Optional[Message]:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1586,6 +1586,18 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_to_coin_update, response)
         return msg
 
+    @api_request(peer_required=True)
+    async def unregister_interest_in_puzzle_hash(
+        self, request: wallet_protocol.UnregisterPhUpdates, peer: WSChiaConnection
+    ) -> None:
+        self.full_node.subscriptions.remove_ph_subscriptions(peer.peer_node_id, request.puzzle_hashes)
+
+    @api_request(peer_required=True)
+    async def unregister_interest_in_coin(
+        self, request: wallet_protocol.UnregisterCoinUpdates, peer: WSChiaConnection
+    ) -> None:
+        self.full_node.subscriptions.remove_coin_subscriptions(peer.peer_node_id, request.coin_ids)
+
     @api_request()
     async def request_children(self, request: wallet_protocol.RequestChildren) -> Optional[Message]:
         coin_records: List[CoinRecord] = await self.full_node.coin_store.get_coin_records_by_parent_ids(

--- a/chia/full_node/hint_management.py
+++ b/chia/full_node/hint_management.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, List, Optional, Set, Tuple
+from typing import Awaitable, Callable, List, Optional, Set, Tuple
 
 from chia.consensus.blockchain import StateChangeSummary
 from chia.types.blockchain_format.sized_bytes import bytes32
 
 
-def get_hints_and_subscription_coin_ids(
+async def get_hints_and_subscription_coin_ids(
     state_change_summary: StateChangeSummary,
-    has_coin_subscription: Callable[[bytes32], bool],
-    has_ph_subscription: Callable[[bytes32], bool],
+    has_coin_subscription: Callable[[bytes32], Awaitable[bool]],
+    has_ph_subscription: Callable[[bytes32], Awaitable[bool]],
 ) -> Tuple[List[Tuple[bytes32, bytes]], List[bytes32]]:
     # Precondition: all hints passed in are max 32 bytes long
     # Returns the hints that we need to add to the DB, and the coin ids that need to be looked up
@@ -21,27 +21,27 @@ def get_hints_and_subscription_coin_ids(
     # Goes through additions and removals for each block and flattens to a map and a set
     lookup_coin_ids: Set[bytes32] = set()
 
-    def add_if_coin_subscription(coin_id: bytes32) -> None:
-        if has_coin_subscription(coin_id):
+    async def add_if_coin_subscription(coin_id: bytes32) -> None:
+        if await has_coin_subscription(coin_id):
             lookup_coin_ids.add(coin_id)
 
-    def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
-        if has_ph_subscription(puzzle_hash):
+    async def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
+        if await has_ph_subscription(puzzle_hash):
             lookup_coin_ids.add(coin_id)
 
     for spend_id, puzzle_hash in state_change_summary.removals:
         # Record all coin_ids that we are interested in, that had changes
-        add_if_coin_subscription(spend_id)
-        add_if_ph_subscription(puzzle_hash, spend_id)
+        await add_if_coin_subscription(spend_id)
+        await add_if_ph_subscription(puzzle_hash, spend_id)
 
     for addition_coin, hint in state_change_summary.additions:
         addition_coin_name = addition_coin.name()
-        add_if_coin_subscription(addition_coin_name)
-        add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
+        await add_if_coin_subscription(addition_coin_name)
+        await add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
         if hint is None:
             continue
         if len(hint) == 32:
-            add_if_ph_subscription(bytes32(hint), addition_coin_name)
+            await add_if_ph_subscription(bytes32(hint), addition_coin_name)
 
         if len(hint) > 0:
             assert len(hint) <= 32
@@ -50,7 +50,7 @@ def get_hints_and_subscription_coin_ids(
     # Goes through all new reward coins
     for reward_coin in state_change_summary.new_rewards:
         reward_coin_name: bytes32 = reward_coin.name()
-        add_if_coin_subscription(reward_coin_name)
-        add_if_ph_subscription(reward_coin.puzzle_hash, reward_coin_name)
+        await add_if_coin_subscription(reward_coin_name)
+        await add_if_ph_subscription(reward_coin.puzzle_hash, reward_coin_name)
 
     return hints_to_add, list(lookup_coin_ids)

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 from dataclasses import dataclass
 from typing import List, Set, final
 
@@ -17,7 +18,10 @@ class PeerSubscriptions:
 
     @classmethod
     async def create(cls) -> PeerSubscriptions:
-        db_wrapper = await DBWrapper2.create(database=":memory:")
+        unique_database_uri = (
+            f"file:db_{cls.__module__}.{cls.__qualname__}_{random.randint(0, 99999999)}?mode=memory&cache=shared"
+        )
+        db_wrapper = await DBWrapper2.create(database=unique_database_uri)
         self = PeerSubscriptions(db_wrapper)
 
         async with self.db_wrapper.writer() as conn:

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -111,6 +111,54 @@ class PeerSubscriptions:
                 )
                 break
 
+    def remove_ph_subscriptions(self, peer_id: bytes32, phs: List[bytes32]) -> None:
+        puzzle_hash_peers = self._peer_puzzle_hash.get(peer_id)
+
+        # there are no subscriptions to remove
+        if puzzle_hash_peers is None:
+            return
+
+        for ph in phs:
+            if ph not in puzzle_hash_peers:
+                continue
+
+            ph_subs = self._ph_subscriptions[ph]
+            ph_subs.remove(peer_id)
+
+            if len(ph_subs) == 0:
+                del self._ph_subscriptions[ph]
+
+            puzzle_hash_peers.remove(ph)
+            self._peer_sub_counter[peer_id] -= 1
+
+        # if the peer is no longer subscribed to anything, it's safe to remove it
+        if len(puzzle_hash_peers) == 0:
+            del self._peer_puzzle_hash[peer_id]
+
+    def remove_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32]) -> None:
+        peer_coin_ids = self._peer_coin_ids.get(peer_id)
+
+        # there are no subscriptions to remove
+        if peer_coin_ids is None:
+            return
+
+        for coin_id in coin_ids:
+            if coin_id not in peer_coin_ids:
+                continue
+
+            coin_subs = self._coin_subscriptions[coin_id]
+            coin_subs.remove(peer_id)
+
+            if len(coin_subs) == 0:
+                del self._coin_subscriptions[coin_id]
+
+            peer_coin_ids.remove(coin_id)
+            self._peer_sub_counter[peer_id] -= 1
+
+        # if the peer is no longer subscribed to anything, it's safe to remove it
+        if len(peer_coin_ids) == 0:
+            del self._peer_coin_ids[peer_id]
+
     def remove_peer(self, peer_id: bytes32) -> None:
         counter = 0
         puzzle_hashes = self._peer_puzzle_hash.get(peer_id)

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -1,37 +1,73 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from typing import Dict, List, Set
+from dataclasses import dataclass
+from typing import List, Set, final
 
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.db_wrapper import DBWrapper2
 
 log = logging.getLogger(__name__)
 
 
-# The PeerSubscriptions class is essentially a multi-index container. It can be
-# indexed by peer_id, coin_id and puzzle_hash.
-@dataclass(frozen=True)
+@final
+@dataclass
 class PeerSubscriptions:
-    # TODO: use NewType all over to describe these various uses of the same types
-    # Puzzle Hash : Set[Peer ID]
-    _coin_subscriptions: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
-    # Puzzle Hash : Set[Peer ID]
-    _ph_subscriptions: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
-    # Peer ID: Set[Coin ids]
-    _peer_coin_ids: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
-    # Peer ID: Set[puzzle_hash]
-    _peer_puzzle_hash: Dict[bytes32, Set[bytes32]] = field(default_factory=dict, init=False)
-    # Peer ID: subscription count
-    _peer_sub_counter: Dict[bytes32, int] = field(default_factory=dict, init=False)
+    db_wrapper: DBWrapper2
 
-    def has_ph_subscription(self, ph: bytes32) -> bool:
-        return ph in self._ph_subscriptions
+    @classmethod
+    async def create(cls) -> PeerSubscriptions:
+        db_wrapper = await DBWrapper2.create(database=":memory:")
+        self = PeerSubscriptions(db_wrapper)
 
-    def has_coin_subscription(self, coin_id: bytes32) -> bool:
-        return coin_id in self._coin_subscriptions
+        async with self.db_wrapper.writer() as conn:
+            log.info("DB: Creating peer subscription tables")
+            await conn.execute(
+                """
+                CREATE TABLE puzzle_subscriptions (
+                    id INT PRIMARY KEY,
+                    peer_id BLOB,
+                    puzzle_hash BLOB,
+                    UNIQUE (peer_id, puzzle_hash)
+                )
+                """
+            )
+            await conn.execute(
+                """
+                CREATE TABLE coin_subscriptions (
+                    id INT PRIMARY KEY,
+                    peer_id BLOB,
+                    coin_id BLOB,
+                    UNIQUE (peer_id, coin_id)
+                )
+                """
+            )
 
-    def add_ph_subscriptions(self, peer_id: bytes32, phs: List[bytes32], max_items: int) -> Set[bytes32]:
+        return self
+
+    async def is_puzzle_subscribed(self, puzzle_hash: bytes32) -> bool:
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute(
+                "SELECT COUNT(*) FROM puzzle_subscriptions WHERE puzzle_hash=?", (puzzle_hash,)
+            ) as cursor:
+                row = await cursor.fetchone()
+
+        assert row is not None
+
+        return int(row[0]) > 0
+
+    async def is_coin_subscribed(self, coin_id: bytes32) -> bool:
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute("SELECT COUNT(*) FROM coin_subscriptions WHERE coin_id=?", (coin_id,)) as cursor:
+                row = await cursor.fetchone()
+
+        assert row is not None
+
+        return int(row[0]) > 0
+
+    async def add_puzzle_subscriptions(
+        self, peer_id: bytes32, puzzle_hashes: List[bytes32], max_items: int
+    ) -> Set[bytes32]:
         """
         returns the puzzle hashes that were actually subscribed to. These may be
         fewer than requested in case:
@@ -40,153 +76,82 @@ class PeerSubscriptions:
         * the max_items limit is exceeded
         """
 
-        puzzle_hash_peers = self._peer_puzzle_hash.setdefault(peer_id, set())
-        existing_sub_count = self._peer_sub_counter.setdefault(peer_id, 0)
+        async with self.db_wrapper.writer() as conn:
+            async with conn.execute("SELECT COUNT(*) FROM puzzle_subscriptions WHERE peer_id=?", (peer_id,)) as cursor:
+                row = await cursor.fetchone()
 
-        ret: Set[bytes32] = set()
+            assert row is not None
 
-        # if we've reached the limit on number of subscriptions, just bail
-        if existing_sub_count >= max_items:
-            log.info(
-                "peer_id: %s reached max number of puzzle-hash subscriptions. "
-                "Not all its coin states will be reported",
-                peer_id,
-            )
-            return ret
+            existing_sub_count = int(row[0])
+            inserted: Set[bytes32] = set()
 
-        # decrement this counter as we go, to know if we've hit the limit of
-        # number of subscriptions
-        subscriptions_left = max_items - existing_sub_count
-
-        for ph in phs:
-            ph_sub = self._ph_subscriptions.setdefault(ph, set())
-            if peer_id in ph_sub:
-                continue
-
-            ret.add(ph)
-            ph_sub.add(peer_id)
-            puzzle_hash_peers.add(ph)
-            self._peer_sub_counter[peer_id] += 1
-            subscriptions_left -= 1
-
-            if subscriptions_left == 0:
+            # if we've reached the limit on number of subscriptions, just bail
+            if existing_sub_count >= max_items:
                 log.info(
                     "peer_id: %s reached max number of puzzle-hash subscriptions. "
                     "Not all its coin states will be reported",
                     peer_id,
                 )
-                break
-        return ret
+                return inserted
 
-    def add_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32], max_items: int) -> None:
-        coin_id_peers = self._peer_coin_ids.setdefault(peer_id, set())
-        existing_sub_count = self._peer_sub_counter.setdefault(peer_id, 0)
+            # decrement this counter as we go, to know if we've hit the limit of
+            # number of subscriptions
+            subscriptions_left = max_items - existing_sub_count
 
-        # if we've reached the limit on number of subscriptions, just bail
-        if existing_sub_count >= max_items:
-            log.info(
-                "peer_id: %s reached max number of coin subscriptions. Not all its coin states will be reported",
-                peer_id,
-            )
-            return
+            for puzzle_hash in puzzle_hashes:
+                async with conn.execute(
+                    "SELECT COUNT(*) FROM puzzle_subscriptions WHERE peer_id=? AND puzzle_hash=?",
+                    (peer_id, puzzle_hash),
+                ) as cursor:
+                    row = await cursor.fetchone()
 
-        # decrement this counter as we go, to know if we've hit the limit of
-        # number of subscriptions
-        subscriptions_left = max_items - existing_sub_count
+                assert row is not None
 
-        for coin_id in coin_ids:
-            coin_sub = self._coin_subscriptions.setdefault(coin_id, set())
-            if peer_id in coin_sub:
-                continue
+                if int(row[0]) > 0:
+                    continue
 
-            coin_sub.add(peer_id)
-            coin_id_peers.add(coin_id)
-            self._peer_sub_counter[peer_id] += 1
-            subscriptions_left -= 1
-
-            if subscriptions_left == 0:
-                log.info(
-                    "peer_id: %s reached max number of coin subscriptions. Not all its coin states will be reported",
-                    peer_id,
+                await conn.execute(
+                    "INSERT INTO puzzle_subscriptions (peer_id, puzzle_hash) VALUES (?, ?)", (peer_id, puzzle_hash)
                 )
-                break
+                inserted.add(puzzle_hash)
+                subscriptions_left -= 1
 
-    def remove_ph_subscriptions(self, peer_id: bytes32, phs: List[bytes32]) -> None:
-        puzzle_hash_peers = self._peer_puzzle_hash.get(peer_id)
+                if subscriptions_left == 0:
+                    log.info(
+                        "peer_id: %s reached max number of puzzle-hash subscriptions. "
+                        "Not all its coin states will be reported",
+                        peer_id,
+                    )
+                    break
 
-        # there are no subscriptions to remove
-        if puzzle_hash_peers is None:
-            return
+            return inserted
 
-        for ph in phs:
-            if ph not in puzzle_hash_peers:
-                continue
+    async def add_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32], max_items: int) -> None:
+        return None
 
-            ph_subs = self._ph_subscriptions[ph]
-            ph_subs.remove(peer_id)
+    async def remove_puzzle_subscriptions(self, peer_id: bytes32, puzzle_hashes: List[bytes32]) -> None:
+        return None
 
-            if len(ph_subs) == 0:
-                del self._ph_subscriptions[ph]
+    async def remove_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32]) -> None:
+        return None
 
-            puzzle_hash_peers.remove(ph)
-            self._peer_sub_counter[peer_id] -= 1
+    async def remove_peer(self, peer_id: bytes32) -> None:
+        async with self.db_wrapper.writer() as conn:
+            await conn.execute("DELETE FROM puzzle_subscriptions WHERE peer_id=?", (peer_id,))
+            await conn.execute("DELETE FROM coin_subscriptions WHERE peer_id=?", (peer_id,))
 
-        # if the peer is no longer subscribed to anything, it's safe to remove it
-        if len(puzzle_hash_peers) == 0:
-            del self._peer_puzzle_hash[peer_id]
+    async def peers_for_coin_id(self, coin_id: bytes32) -> Set[bytes32]:
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute("SELECT peer_id FROM coin_subscriptions WHERE coin_id=?", (coin_id,)) as cursor:
+                rows = await cursor.fetchall()
 
-    def remove_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32]) -> None:
-        peer_coin_ids = self._peer_coin_ids.get(peer_id)
+        return {bytes32(row[0]) for row in rows}
 
-        # there are no subscriptions to remove
-        if peer_coin_ids is None:
-            return
+    async def peers_for_puzzle_hash(self, puzzle_hash: bytes32) -> Set[bytes32]:
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            async with conn.execute(
+                "SELECT peer_id FROM puzzle_subscriptions WHERE puzzle_hash=?", (puzzle_hash,)
+            ) as cursor:
+                rows = await cursor.fetchall()
 
-        for coin_id in coin_ids:
-            if coin_id not in peer_coin_ids:
-                continue
-
-            coin_subs = self._coin_subscriptions[coin_id]
-            coin_subs.remove(peer_id)
-
-            if len(coin_subs) == 0:
-                del self._coin_subscriptions[coin_id]
-
-            peer_coin_ids.remove(coin_id)
-            self._peer_sub_counter[peer_id] -= 1
-
-        # if the peer is no longer subscribed to anything, it's safe to remove it
-        if len(peer_coin_ids) == 0:
-            del self._peer_coin_ids[peer_id]
-
-    def remove_peer(self, peer_id: bytes32) -> None:
-        counter = 0
-        puzzle_hashes = self._peer_puzzle_hash.get(peer_id)
-        if puzzle_hashes is not None:
-            for ph in puzzle_hashes:
-                subs = self._ph_subscriptions[ph]
-                subs.remove(peer_id)
-                counter += 1
-                if subs == set():
-                    self._ph_subscriptions.pop(ph)
-            self._peer_puzzle_hash.pop(peer_id)
-
-        coin_ids = self._peer_coin_ids.get(peer_id)
-        if coin_ids is not None:
-            for coin_id in coin_ids:
-                subs = self._coin_subscriptions[coin_id]
-                subs.remove(peer_id)
-                counter += 1
-                if subs == set():
-                    self._coin_subscriptions.pop(coin_id)
-            self._peer_coin_ids.pop(peer_id)
-
-        if peer_id in self._peer_sub_counter:
-            num_subs = self._peer_sub_counter.pop(peer_id)
-            assert num_subs == counter
-
-    def peers_for_coin_id(self, coin_id: bytes32) -> Set[bytes32]:
-        return self._coin_subscriptions.get(coin_id, set())
-
-    def peers_for_puzzle_hash(self, puzzle_hash: bytes32) -> Set[bytes32]:
-        return self._ph_subscriptions.get(puzzle_hash, set())
+        return {bytes32(row[0]) for row in rows}

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -173,7 +173,7 @@ class Harvester:
         if event == PlotRefreshEvents.done:
             self.plot_sync_sender.sync_done(update_result.removed, update_result.duration)
 
-    def on_disconnect(self, connection: WSChiaConnection) -> None:
+    async def on_disconnect(self, connection: WSChiaConnection) -> None:
         self.log.info(f"peer disconnected {connection.get_peer_logging()}")
         self.state_changed("close_connection")
         self.plot_sync_sender.stop()

--- a/chia/protocols/protocol_message_types.py
+++ b/chia/protocols/protocol_message_types.py
@@ -114,4 +114,8 @@ class ProtocolMessageTypes(Enum):
     request_fee_estimates = 89
     respond_fee_estimates = 90
 
+    # Extended wallet protocol
+    unregister_interest_in_puzzle_hash = 92
+    unregister_interest_in_coin = 93
+
     error = 255

--- a/chia/protocols/wallet_protocol.py
+++ b/chia/protocols/wallet_protocol.py
@@ -229,6 +229,18 @@ class RespondToCoinUpdates(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class UnregisterPhUpdates(Streamable):
+    puzzle_hashes: List[bytes32]
+
+
+@streamable
+@dataclass(frozen=True)
+class UnregisterCoinUpdates(Streamable):
+    coin_ids: List[bytes32]
+
+
+@streamable
+@dataclass(frozen=True)
 class CoinStateUpdate(Streamable):
     height: uint32
     fork_height: uint32

--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -146,6 +146,8 @@ rate_limits = {
             ProtocolMessageTypes.respond_to_ph_update: RLSettings(1000, 100 * 1024 * 1024),
             ProtocolMessageTypes.register_interest_in_coin: RLSettings(1000, 100 * 1024 * 1024),
             ProtocolMessageTypes.respond_to_coin_update: RLSettings(1000, 100 * 1024 * 1024),
+            ProtocolMessageTypes.unregister_interest_in_puzzle_hash: RLSettings(1000, 100 * 1024 * 1024),
+            ProtocolMessageTypes.unregister_interest_in_coin: RLSettings(1000, 100 * 1024 * 1024),
             ProtocolMessageTypes.request_ses_hashes: RLSettings(2000, 1 * 1024 * 1024),
             ProtocolMessageTypes.respond_ses_hashes: RLSettings(2000, 1 * 1024 * 1024),
             ProtocolMessageTypes.request_children: RLSettings(2000, 1024 * 1024),

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -522,7 +522,9 @@ class ChiaServer:
 
         return False
 
-    def connection_closed(self, connection: WSChiaConnection, ban_time: int, closed_connection: bool = False) -> None:
+    async def connection_closed(
+        self, connection: WSChiaConnection, ban_time: int, closed_connection: bool = False
+    ) -> None:
         # closed_connection is true if the callback is being called with a connection that was previously closed
         # in this case we still want to do the banning logic and remove the conection from the list
         # but the other cleanup should already have been done so we skip that
@@ -555,7 +557,7 @@ class ChiaServer:
             connection.cancel_tasks()
             on_disconnect = getattr(self.node, "on_disconnect", None)
             if on_disconnect is not None:
-                on_disconnect(connection)
+                await on_disconnect(connection)
 
     async def validate_broadcast_message_type(self, messages: List[Message], node_type: NodeType) -> None:
         for message in messages:

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -52,7 +52,7 @@ def create_default_last_message_time_dict() -> Dict[ProtocolMessageTypes, float]
 
 
 class ConnectionClosedCallbackProtocol(Protocol):
-    def __call__(
+    async def __call__(
         self,
         connection: WSChiaConnection,
         ban_time: int,
@@ -277,7 +277,7 @@ class WSChiaConnection:
             with log_exceptions(self.log, consume=True):
                 self.log.debug(f"Closing already closed connection for {self.peer_info.host}")
                 if self.close_callback is not None:
-                    self.close_callback(self, ban_time, closed_connection=True)
+                    await self.close_callback(self, ban_time, closed_connection=True)
             self._close_event.set()
             return None
         self.closed = True
@@ -307,7 +307,7 @@ class WSChiaConnection:
         finally:
             with log_exceptions(self.log, consume=True):
                 if self.close_callback is not None:
-                    self.close_callback(self, ban_time, closed_connection=False)
+                    await self.close_callback(self, ban_time, closed_connection=False)
             self._close_event.set()
 
     async def wait_until_closed(self) -> None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -691,7 +691,7 @@ class WalletNode:
             )
             asyncio.create_task(self.wallet_peers.start())
 
-    def on_disconnect(self, peer: WSChiaConnection) -> None:
+    async def on_disconnect(self, peer: WSChiaConnection) -> None:
         if self.is_trusted(peer):
             self.local_node_synced = False
             self.initialize_wallet_peers()

--- a/tests/core/full_node/test_subscriptions.py
+++ b/tests/core/full_node/test_subscriptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from chia.full_node.subscriptions import PeerSubscriptions
 from chia.types.blockchain_format.sized_bytes import bytes32
 
@@ -17,341 +19,350 @@ ph3 = bytes32(b"g" * 32)
 ph4 = bytes32(b"h" * 32)
 
 
-def test_has_ph_sub() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_has_ph_sub() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
     assert ret == {ph1}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2], 100)
     # we have already subscribed to ph1, it's filtered in the returned list
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
     # note that this is technically a type error as well.
     # we can remove these asserts once we have type checking
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
 
-def test_has_coin_sub() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_has_coin_sub() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1], 100)
+    await sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
+    await sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
 
     # note that this is technically a type error as well.
     # we can remove these asserts once we have type checking
-    assert sub.has_ph_subscription(coin1) is False
-    assert sub.has_ph_subscription(coin2) is False
+    assert await sub.is_puzzle_subscribed(coin1) is False
+    assert await sub.is_puzzle_subscribed(coin2) is False
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
 
-def test_overlapping_coin_subscriptions() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_overlapping_coin_subscriptions() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    assert sub.peers_for_coin_id(coin1) == set()
-    assert sub.peers_for_coin_id(coin2) == set()
+    assert await sub.peers_for_coin_id(coin1) == set()
+    assert await sub.peers_for_coin_id(coin2) == set()
 
     # subscribed to different coins
-    sub.add_coin_subscriptions(peer1, [coin1], 100)
+    await sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == set()
 
-    sub.add_coin_subscriptions(peer2, [coin2], 100)
+    await sub.add_coin_subscriptions(peer2, [coin2], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer2}
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer2}
 
     # peer1 is now subscribing to both coins
-    sub.add_coin_subscriptions(peer1, [coin2], 100)
+    await sub.add_coin_subscriptions(peer1, [coin2], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer1, peer2}
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer1, peer2}
 
     # removing peer1 still leaves the subscription to coin2
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is True
 
-    assert sub.peers_for_coin_id(coin1) == set()
-    assert sub.peers_for_coin_id(coin2) == {peer2}
+    assert await sub.peers_for_coin_id(coin1) == set()
+    assert await sub.peers_for_coin_id(coin2) == {peer2}
 
 
-def test_overlapping_ph_subscriptions() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_overlapping_ph_subscriptions() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == set()
-    assert sub.peers_for_puzzle_hash(ph2) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == set()
+    assert await sub.peers_for_puzzle_hash(ph2) == set()
 
     # subscribed to different phs
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
     assert ret == {ph1}
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == set()
 
-    ret = sub.add_ph_subscriptions(peer2, [ph2], 100)
+    ret = await sub.add_puzzle_subscriptions(peer2, [ph2], 100)
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer2}
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
 
     # peer1 is now subscribing to both phs
-    ret = sub.add_ph_subscriptions(peer1, [ph2], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph2], 100)
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
 
     # removing peer1 still leaves the subscription to ph2
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert sub.peers_for_puzzle_hash(ph1) == set()
-    assert sub.peers_for_puzzle_hash(ph2) == {peer2}
+    assert await sub.peers_for_puzzle_hash(ph1) == set()
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
 
 
-def test_ph_sub_limit() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_ph_sub_limit() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
     # we only ended up subscribing to 3 puzzle hashes because of the limit
     assert ret == {ph1, ph2, ph3}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is True
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is True
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph3) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph3) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
     # peer1 should still be limited
-    ret = sub.add_ph_subscriptions(peer1, [ph4], 3)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph4], 3)
     assert ret == set()
 
-    assert sub.has_ph_subscription(ph4) is False
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.is_puzzle_subscribed(ph4) is False
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
     # peer1 is also limied on coin subscriptions
-    sub.add_coin_subscriptions(peer1, [coin1], 3)
+    await sub.add_coin_subscriptions(peer1, [coin1], 3)
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.peers_for_coin_id(coin1) == set()
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.peers_for_coin_id(coin1) == set()
 
     # peer2 is has its own limit
-    ret = sub.add_ph_subscriptions(peer2, [ph4], 3)
+    ret = await sub.add_puzzle_subscriptions(peer2, [ph4], 3)
     assert ret == {ph4}
 
-    assert sub.has_ph_subscription(ph4) is True
-    assert sub.peers_for_puzzle_hash(ph4) == {peer2}
+    assert await sub.is_puzzle_subscribed(ph4) is True
+    assert await sub.peers_for_puzzle_hash(ph4) == {peer2}
 
-    sub.remove_peer(peer1)
-    sub.remove_peer(peer2)
+    await sub.remove_peer(peer1)
+    await sub.remove_peer(peer2)
 
 
-def test_ph_sub_limit_incremental() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_ph_sub_limit_incremental() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 2)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 2)
     assert ret == {ph1}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == set()
-    assert sub.peers_for_puzzle_hash(ph3) == set()
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == set()
+    assert await sub.peers_for_puzzle_hash(ph3) == set()
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
     # this will cross the limit. Only ph2 will be added
-    ret = sub.add_ph_subscriptions(peer1, [ph2, ph3], 2)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph2, ph3], 2)
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph3) == set()
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph3) == set()
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
 
-def test_coin_sub_limit() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_coin_sub_limit() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin3) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin3) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
+    await sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
-    assert sub.has_coin_subscription(coin3) is True
-    assert sub.has_coin_subscription(coin4) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
+    assert await sub.is_coin_subscribed(coin3) is True
+    assert await sub.is_coin_subscribed(coin4) is False
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer1}
-    assert sub.peers_for_coin_id(coin3) == {peer1}
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer1}
+    assert await sub.peers_for_coin_id(coin3) == {peer1}
+    assert await sub.peers_for_coin_id(coin4) == set()
 
     # peer1 should still be limited
-    sub.add_coin_subscriptions(peer1, [coin4], 3)
+    await sub.add_coin_subscriptions(peer1, [coin4], 3)
 
-    assert sub.has_coin_subscription(coin4) is False
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.is_coin_subscribed(coin4) is False
+    assert await sub.peers_for_coin_id(coin4) == set()
 
     # peer1 is also limied on ph subscriptions
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 3)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 3)
     assert ret == set()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.peers_for_puzzle_hash(ph1) == set()
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.peers_for_puzzle_hash(ph1) == set()
 
     # peer2 is has its own limit
-    sub.add_coin_subscriptions(peer2, [coin4], 3)
+    await sub.add_coin_subscriptions(peer2, [coin4], 3)
 
-    assert sub.has_coin_subscription(coin4) is True
-    assert sub.peers_for_coin_id(coin4) == {peer2}
+    assert await sub.is_coin_subscribed(coin4) is True
+    assert await sub.peers_for_coin_id(coin4) == {peer2}
 
-    sub.remove_peer(peer1)
-    sub.remove_peer(peer2)
+    await sub.remove_peer(peer1)
+    await sub.remove_peer(peer2)
 
 
-def test_coin_sub_limit_incremental() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_coin_sub_limit_incremental() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin3) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin3) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1], 2)
+    await sub.add_coin_subscriptions(peer1, [coin1], 2)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin3) is False
-    assert sub.has_coin_subscription(coin4) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin3) is False
+    assert await sub.is_coin_subscribed(coin4) is False
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == set()
-    assert sub.peers_for_coin_id(coin3) == set()
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == set()
+    assert await sub.peers_for_coin_id(coin3) == set()
+    assert await sub.peers_for_coin_id(coin4) == set()
 
     # this will cross the limit. Only coin2 will be added
-    sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
+    await sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
-    assert sub.has_coin_subscription(coin3) is False
-    assert sub.has_coin_subscription(coin4) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
+    assert await sub.is_coin_subscribed(coin3) is False
+    assert await sub.is_coin_subscribed(coin4) is False
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer1}
-    assert sub.peers_for_coin_id(coin3) == set()
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer1}
+    assert await sub.peers_for_coin_id(coin3) == set()
+    assert await sub.peers_for_coin_id(coin4) == set()
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
 
-def test_ph_subscription_duplicates() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_ph_subscription_duplicates() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3], 100)
     assert ret == {ph1, ph2, ph3}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is True
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is True
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
     # only ph4 is new, the others are duplicates and ignored
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
     assert ret == {ph4}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is True
-    assert sub.has_ph_subscription(ph4) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is True
+    assert await sub.is_puzzle_subscribed(ph4) is True
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1059,7 +1059,7 @@ class TestCATWallet:
         await time_out_assert(20, check_wallets, 2, wallet_node_0)
         cat_wallet = wallet_node_0.wallet_state_manager.wallets[uint32(2)]
         await time_out_assert(20, cat_wallet.get_confirmed_balance, cat_amount_1)
-        assert not full_node_api.full_node.subscriptions.has_ph_subscription(puzzlehash_unhardened)
+        assert not full_node_api.full_node.subscriptions.is_puzzle_subscribed(puzzlehash_unhardened)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This is a work in progress PR for updating the wallet protocol.

Introduces the following changes to the wallet protocol:

- `UnregisterPhUpdates`, which removes subscriptions added with `RegisterForPhUpdates`.
- `UnregisterCoinUpdates`, which removes subscriptions added with `RegisterForCoinUpdates`.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Doesn't support these new messages and changes to the wallet protocol.

### New Behavior:

Adds the new wallet protocol changes with backward compatibility with previous protocol versions.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Not yet fully tested.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
