### PR TITLE
Adjust ban times for DL dat files

### DIFF
--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1583,7 +1583,8 @@ class DataStore:
         await self.update_server_info(tree_id, new_server_info)
 
     async def server_misses_file(self, tree_id: bytes32, server_info: ServerInfo, timestamp: int) -> None:
-        BAN_TIME_BY_MISSING_COUNT = [5 * 60] * 3 + [15 * 60] * 3 + [60 * 60] * 2 + [240 * 60]
+        # Max banned time is 1 hour.
+        BAN_TIME_BY_MISSING_COUNT = [5 * 60] * 3 + [15 * 60] * 3 + [30 * 60] * 2 + [60 * 60]
         index = min(server_info.num_consecutive_failures, len(BAN_TIME_BY_MISSING_COUNT) - 1)
         new_server_info = replace(
             server_info,

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -196,7 +196,11 @@ async def insert_from_delta_file(
         except Exception:
             target_filename = client_foldername.joinpath(filename)
             os.remove(target_filename)
-            await data_store.received_incorrect_file(tree_id, server_info, timestamp)
+            # await data_store.received_incorrect_file(tree_id, server_info, timestamp)
+            # incorrect file bans for 7 days which in practical usage
+            # is too long given this file might be incorrect for various reasons
+            # therefore, use the misses file logic instead
+            await data_store.server_misses_file(tree_id, server_info, timestamp)
             await data_store.rollback_to_generation(tree_id, existing_generation - 1)
             raise
 

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -1243,7 +1243,7 @@ async def test_server_selection(data_store: DataStore, tree_id: bytes32) -> None
     assert servers_info[0].url == "http://127.0.0.1/8000"
     await data_store.received_correct_file(tree_id=tree_id, server_info=servers_info[0])
 
-    ban_times = [5 * 60] * 3 + [15 * 60] * 3 + [60 * 60] * 2 + [240 * 60] * 10
+    ban_times = [5 * 60] * 3 + [15 * 60] * 3 + [30 * 60] * 2 + [60 * 60] * 10
     for ban_time in ban_times:
         servers_info = await data_store.get_available_servers_for_store(tree_id=tree_id, timestamp=current_timestamp)
         assert len(servers_info) == 1


### PR DESCRIPTION
Currently, if a file is downloaded, but fails to insert properly, we ban that server for 7 days. In this case, the files can fail to insert for a variety of reasons, such as a truncated download, or disk problem that is likely not a result of a malicious actor.

This ban is overly long and has caused some problems with both CADT and Labrador.

This PR uses the logic for missing files to set a progressive ban per attempt with a maximum of one hour. This is using an existing function for this and so has very little risk. We would like to get into 2.1.2 so we can update CADT with this change

Change made in agreement with Zach and Ken. 