### PR TITLE
make spend_prefarm.py checked by mypy

### DIFF
--- a/chia/wallet/puzzles/prefarm/spend_prefarm.py
+++ b/chia/wallet/puzzles/prefarm/spend_prefarm.py
@@ -8,6 +8,7 @@ from clvm_tools import binutils
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
@@ -18,7 +19,7 @@ from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint16, uint32
 
 
-def print_conditions(spend_bundle: SpendBundle):
+def print_conditions(spend_bundle: SpendBundle) -> None:
     print("\nConditions:")
     for coin_spend in spend_bundle.coin_spends:
         result = Program.from_bytes(bytes(coin_spend.puzzle_reveal)).run(Program.from_bytes(bytes(coin_spend.solution)))
@@ -51,11 +52,15 @@ async def main() -> None:
         ph1 = decode_puzzle_hash(address1)
         ph2 = decode_puzzle_hash(address2)
 
-        p_farmer_2 = Program.to(
-            binutils.assemble(f"(q . ((51 0x{ph1.hex()} {farmer_amounts}) (51 0x{ph2.hex()} {farmer_amounts})))")
+        p_farmer_2 = SerializedProgram.to(
+            binutils.assemble(
+                f"(q . ((51 0x{ph1.hex()} {farmer_amounts}) " f"(51 0x{ph2.hex()} {farmer_amounts})))"
+            )  # type: ignore[no-untyped-call]
         )
-        p_pool_2 = Program.to(
-            binutils.assemble(f"(q . ((51 0x{ph1.hex()} {pool_amounts}) (51 0x{ph2.hex()} {pool_amounts})))")
+        p_pool_2 = SerializedProgram.to(
+            binutils.assemble(
+                f"(q . ((51 0x{ph1.hex()} {pool_amounts}) " f"(51 0x{ph2.hex()} {pool_amounts})))"
+            )  # type: ignore[no-untyped-call]
         )
 
         print(f"Ph1: {ph1.hex()}")
@@ -63,7 +68,7 @@ async def main() -> None:
         assert ph1.hex() == "1b7ab2079fa635554ad9bd4812c622e46ee3b1875a7813afba127bb0cc9794f9"
         assert ph2.hex() == "6f184a7074c925ef8688ce56941eb8929be320265f824ec7e351356cc745d38a"
 
-        p_solution = Program.to(binutils.assemble("()"))
+        p_solution = SerializedProgram.to(binutils.assemble("()"))  # type: ignore[no-untyped-call]
 
         sb_farmer = SpendBundle([CoinSpend(farmer_prefarm, p_farmer_2, p_solution)], G2Element())
         sb_pool = SpendBundle([CoinSpend(pool_prefarm, p_pool_2, p_solution)], G2Element())

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -34,7 +34,6 @@ chia.wallet.puzzles.p2_delegated_puzzle
 chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle
 chia.wallet.puzzles.p2_m_of_n_delegate_direct
 chia.wallet.puzzles.p2_puzzle_hash
-chia.wallet.puzzles.prefarm.spend_prefarm
 chia.wallet.puzzles.singleton_top_layer
 chia.wallet.puzzles.tails
 chia.wallet.trading.trade_store


### PR DESCRIPTION
### Purpose:

remove `spend_prefarm.py` from mypy exclusions.
All of `clvm` is untyped (currently), that's why we need the type ignore comments.

### Current Behavior:

spend_prefarm.py is not fully checked by mypy

### New Behavior:

spend_prefarm.py is checked by mypy

### Testing Notes:

There seem to not be any tests for `spend_prefarm.py`