### PR TITLE
adapt `conditions_dict_for_solution()` to how it's used

### DIFF
--- a/chia/simulator/wallet_tools.py
+++ b/chia/simulator/wallet_tools.py
@@ -191,7 +191,9 @@ class WalletTool:
             secret_key = self.get_private_key_for_puzzle_hash(coin_spend.coin.puzzle_hash)
             synthetic_secret_key = calculate_synthetic_secret_key(secret_key, DEFAULT_HIDDEN_PUZZLE_HASH)
             conditions_dict = conditions_dict_for_solution(
-                coin_spend.puzzle_reveal, coin_spend.solution, self.constants.MAX_BLOCK_COST_CLVM
+                coin_spend.puzzle_reveal.to_program(),
+                coin_spend.solution.to_program(),
+                self.constants.MAX_BLOCK_COST_CLVM,
             )
 
             for cwa in conditions_dict.get(ConditionOpcode.AGG_SIG_UNSAFE, []):

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -184,12 +184,14 @@ def created_outputs_for_conditions_dict(
 
 
 def conditions_dict_for_solution(
-    puzzle_reveal: SerializedProgram,
-    solution: SerializedProgram,
+    puzzle_reveal: Program,
+    solution: Program,
     max_cost: int,
 ) -> Dict[ConditionOpcode, List[ConditionWithArgs]]:
     conditions_dict: Dict[ConditionOpcode, List[ConditionWithArgs]] = {}
-    for cvp in conditions_for_solution(puzzle_reveal, solution, max_cost):
+    puzz = SerializedProgram.from_program(puzzle_reveal)
+    sol = SerializedProgram.from_program(solution)
+    for cvp in conditions_for_solution(puzz, sol, max_cost):
         conditions_dict.setdefault(cvp.opcode, list()).append(cvp)
     return conditions_dict
 

--- a/chia/wallet/sign_coin_spends.py
+++ b/chia/wallet/sign_coin_spends.py
@@ -41,7 +41,9 @@ async def sign_coin_spends(
     msg_list: List[bytes] = []
     for coin_spend in coin_spends:
         # Get AGG_SIG conditions
-        conditions_dict = conditions_dict_for_solution(coin_spend.puzzle_reveal, coin_spend.solution, max_cost)
+        conditions_dict = conditions_dict_for_solution(
+            coin_spend.puzzle_reveal.to_program(), coin_spend.solution.to_program(), max_cost
+        )
         # Create signature
         for pk_bytes, msg in pkm_pairs_for_conditions_dict(conditions_dict, coin_spend.coin, additional_data):
             pk = G1Element.from_bytes(pk_bytes)

--- a/tests/util/key_tool.py
+++ b/tests/util/key_tool.py
@@ -29,7 +29,7 @@ class KeyTool:
     def signature_for_solution(self, coin_spend: CoinSpend, additional_data: bytes) -> G2Element:
         signatures = []
         conditions_dict = conditions_dict_for_solution(
-            coin_spend.puzzle_reveal, coin_spend.solution, test_constants.MAX_BLOCK_COST_CLVM
+            coin_spend.puzzle_reveal.to_program(), coin_spend.solution.to_program(), test_constants.MAX_BLOCK_COST_CLVM
         )
         for public_key, message in pkm_pairs_for_conditions_dict(conditions_dict, coin_spend.coin, additional_data):
             signature = self.sign(public_key, message)

--- a/tests/wallet/clawback/test_clawback_lifecycle.py
+++ b/tests/wallet/clawback/test_clawback_lifecycle.py
@@ -73,7 +73,9 @@ class TestClawbackLifecycle:
             DEFAULT_HIDDEN_PUZZLE_HASH,
         )
 
-        conditions_dict = conditions_dict_for_solution(coin_spend.puzzle_reveal, coin_spend.solution, INFINITE_COST)
+        conditions_dict = conditions_dict_for_solution(
+            coin_spend.puzzle_reveal.to_program(), coin_spend.solution.to_program(), INFINITE_COST
+        )
         signatures = []
         for pk_bytes, msg in pkm_pairs_for_conditions_dict(
             conditions_dict, coin_spend.coin, DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA


### PR DESCRIPTION
### Purpose:

Most call-sites of `conditions_dict_for_solution()` pass it `Program` instead of `SerializedProgram`. This patch makes it take `Program` instead. Once we have type checking for `Program`, these errors would be detected.

### Current Behavior:

We pass `Program` instead of `SerializedProgram` to `conditions_dict_for_solution()`.

### New Behavior:

`conditions_dict_for_solution()` accepts `Program`, so there's no type error.

### Testing

The fact that both cases have test coverage is evidence of call sites exists for both types.