### PR TITLE
Rewrite peer subscription manager with an in-memory SQLite db

### DIFF
--- a/benchmarks/subscriptions.py
+++ b/benchmarks/subscriptions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from time import monotonic
+from typing import List
+
+from chia.full_node.subscriptions import PeerSubscriptions
+from chia.types.blockchain_format.sized_bytes import bytes32
+
+
+def generate_ids(amount: int) -> List[bytes32]:
+    next = bytes32(b"\0" * 32)
+    ids = []
+    for _ in range(0, amount):
+        ids.append(next)
+        for i in range(0, 32):
+            if next[i] != 255:
+                next = bytes32(next[:i] + bytes([next[i] + 1]) + next[i + 1 :])
+                break
+            else:
+                next = bytes32(next[:i] + bytes([0]) + next[i + 1 :])
+    return ids
+
+
+def run_subscriptions_benchmark() -> None:
+    subs = PeerSubscriptions()
+
+    peer_id = bytes32(b"\0" * 32)
+    puzzle_hashes = generate_ids(1000000)
+    coin_ids = generate_ids(1000000)
+
+    start = monotonic()
+
+    subs.add_puzzle_subscriptions(peer_id, puzzle_hashes, len(puzzle_hashes))
+    subs.add_coin_subscriptions(peer_id, coin_ids, len(coin_ids) * 2)
+
+    stop = monotonic()
+
+    print(f"  time: {stop - start:0.4f}s")
+
+
+if __name__ == "__main__":
+    import logging
+
+    logger = logging.getLogger()
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.WARNING)
+    run_subscriptions_benchmark()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -238,7 +238,7 @@ class FullNode:
             reader_count=4,
             log_path=sql_log_path,
             synchronous=db_sync,
-        ) as self._db_wrapper:
+        ) as self._db_wrapper, PeerSubscriptions.managed() as self._subscriptions:
             if self.db_wrapper.db_version != 2:
                 async with self.db_wrapper.reader_no_transaction() as conn:
                     async with conn.execute(
@@ -259,7 +259,6 @@ class FullNode:
             self._block_store = await BlockStore.create(self.db_wrapper)
             self._hint_store = await HintStore.create(self.db_wrapper)
             self._coin_store = await CoinStore.create(self.db_wrapper)
-            self._subscriptions = await PeerSubscriptions.create()
             self.log.info("Initializing blockchain from disk")
             start_time = time.time()
             reserved_cores = self.config.get("reserved_cores", 0)

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1505,7 +1505,7 @@ class FullNodeAPI:
         # the returned puzzle hashes are the ones we ended up subscribing to.
         # It will have filtered duplicates and ones exceeding the subscription
         # limit.
-        puzzle_hashes = self.full_node.subscriptions.add_ph_subscriptions(
+        puzzle_hashes = await self.full_node.subscriptions.add_puzzle_subscriptions(
             peer.peer_node_id, request.puzzle_hashes, max_subscriptions
         )
 
@@ -1576,7 +1576,9 @@ class FullNodeAPI:
         # TODO: apparently we have tests that expect to receive a
         # RespondToCoinUpdates even when subscribing to the same coin multiple
         # times, so we can't optimize away such DB lookups (yet)
-        self.full_node.subscriptions.add_coin_subscriptions(peer.peer_node_id, request.coin_ids, max_subscriptions)
+        await self.full_node.subscriptions.add_coin_subscriptions(
+            peer.peer_node_id, request.coin_ids, max_subscriptions
+        )
 
         states: List[CoinState] = await self.full_node.coin_store.get_coin_states_by_ids(
             include_spent_coins=True, coin_ids=set(request.coin_ids), min_height=request.min_height, max_items=max_items

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1505,7 +1505,7 @@ class FullNodeAPI:
         # the returned puzzle hashes are the ones we ended up subscribing to.
         # It will have filtered duplicates and ones exceeding the subscription
         # limit.
-        puzzle_hashes = await self.full_node.subscriptions.add_puzzle_subscriptions(
+        puzzle_hashes = self.full_node.subscriptions.add_puzzle_subscriptions(
             peer.peer_node_id, request.puzzle_hashes, max_subscriptions
         )
 
@@ -1576,9 +1576,7 @@ class FullNodeAPI:
         # TODO: apparently we have tests that expect to receive a
         # RespondToCoinUpdates even when subscribing to the same coin multiple
         # times, so we can't optimize away such DB lookups (yet)
-        await self.full_node.subscriptions.add_coin_subscriptions(
-            peer.peer_node_id, request.coin_ids, max_subscriptions
-        )
+        self.full_node.subscriptions.add_coin_subscriptions(peer.peer_node_id, request.coin_ids, max_subscriptions)
 
         states: List[CoinState] = await self.full_node.coin_store.get_coin_states_by_ids(
             include_spent_coins=True, coin_ids=set(request.coin_ids), min_height=request.min_height, max_items=max_items

--- a/chia/full_node/hint_management.py
+++ b/chia/full_node/hint_management.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from typing import Awaitable, Callable, List, Optional, Set, Tuple
+from typing import Callable, List, Optional, Set, Tuple
 
 from chia.consensus.blockchain import StateChangeSummary
 from chia.types.blockchain_format.sized_bytes import bytes32
 
 
-async def get_hints_and_subscription_coin_ids(
+def get_hints_and_subscription_coin_ids(
     state_change_summary: StateChangeSummary,
-    has_coin_subscription: Callable[[bytes32], Awaitable[bool]],
-    has_ph_subscription: Callable[[bytes32], Awaitable[bool]],
+    has_coin_subscription: Callable[[bytes32], bool],
+    has_ph_subscription: Callable[[bytes32], bool],
 ) -> Tuple[List[Tuple[bytes32, bytes]], List[bytes32]]:
     # Precondition: all hints passed in are max 32 bytes long
     # Returns the hints that we need to add to the DB, and the coin ids that need to be looked up
@@ -21,27 +21,27 @@ async def get_hints_and_subscription_coin_ids(
     # Goes through additions and removals for each block and flattens to a map and a set
     lookup_coin_ids: Set[bytes32] = set()
 
-    async def add_if_coin_subscription(coin_id: bytes32) -> None:
-        if await has_coin_subscription(coin_id):
+    def add_if_coin_subscription(coin_id: bytes32) -> None:
+        if has_coin_subscription(coin_id):
             lookup_coin_ids.add(coin_id)
 
-    async def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
-        if await has_ph_subscription(puzzle_hash):
+    def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
+        if has_ph_subscription(puzzle_hash):
             lookup_coin_ids.add(coin_id)
 
     for spend_id, puzzle_hash in state_change_summary.removals:
         # Record all coin_ids that we are interested in, that had changes
-        await add_if_coin_subscription(spend_id)
-        await add_if_ph_subscription(puzzle_hash, spend_id)
+        add_if_coin_subscription(spend_id)
+        add_if_ph_subscription(puzzle_hash, spend_id)
 
     for addition_coin, hint in state_change_summary.additions:
         addition_coin_name = addition_coin.name()
-        await add_if_coin_subscription(addition_coin_name)
-        await add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
+        add_if_coin_subscription(addition_coin_name)
+        add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
         if hint is None:
             continue
         if len(hint) == 32:
-            await add_if_ph_subscription(bytes32(hint), addition_coin_name)
+            add_if_ph_subscription(bytes32(hint), addition_coin_name)
 
         if len(hint) > 0:
             assert len(hint) <= 32
@@ -50,7 +50,7 @@ async def get_hints_and_subscription_coin_ids(
     # Goes through all new reward coins
     for reward_coin in state_change_summary.new_rewards:
         reward_coin_name: bytes32 = reward_coin.name()
-        await add_if_coin_subscription(reward_coin_name)
-        await add_if_ph_subscription(reward_coin.puzzle_hash, reward_coin_name)
+        add_if_coin_subscription(reward_coin_name)
+        add_if_ph_subscription(reward_coin.puzzle_hash, reward_coin_name)
 
     return hints_to_add, list(lookup_coin_ids)

--- a/chia/full_node/hint_management.py
+++ b/chia/full_node/hint_management.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, List, Optional, Set, Tuple
+from typing import Awaitable, Callable, List, Optional, Set, Tuple
 
 from chia.consensus.blockchain import StateChangeSummary
 from chia.types.blockchain_format.sized_bytes import bytes32
 
 
-def get_hints_and_subscription_coin_ids(
+async def get_hints_and_subscription_coin_ids(
     state_change_summary: StateChangeSummary,
-    has_coin_subscription: Callable[[bytes32], bool],
-    has_ph_subscription: Callable[[bytes32], bool],
+    has_coin_subscription: Callable[[bytes32], Awaitable[bool]],
+    has_ph_subscription: Callable[[bytes32], Awaitable[bool]],
 ) -> Tuple[List[Tuple[bytes32, bytes]], List[bytes32]]:
     # Precondition: all hints passed in are max 32 bytes long
     # Returns the hints that we need to add to the DB, and the coin ids that need to be looked up
@@ -21,27 +21,27 @@ def get_hints_and_subscription_coin_ids(
     # Goes through additions and removals for each block and flattens to a map and a set
     lookup_coin_ids: Set[bytes32] = set()
 
-    def add_if_coin_subscription(coin_id: bytes32) -> None:
-        if has_coin_subscription(coin_id):
+    async def add_if_coin_subscription(coin_id: bytes32) -> None:
+        if await has_coin_subscription(coin_id):
             lookup_coin_ids.add(coin_id)
 
-    def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
-        if has_ph_subscription(puzzle_hash):
+    async def add_if_ph_subscription(puzzle_hash: bytes32, coin_id: bytes32) -> None:
+        if await has_ph_subscription(puzzle_hash):
             lookup_coin_ids.add(coin_id)
 
     for spend_id, puzzle_hash in state_change_summary.removals:
         # Record all coin_ids that we are interested in, that had changes
-        add_if_coin_subscription(spend_id)
-        add_if_ph_subscription(puzzle_hash, spend_id)
+        await add_if_coin_subscription(spend_id)
+        await add_if_ph_subscription(puzzle_hash, spend_id)
 
     for addition_coin, hint in state_change_summary.additions:
         addition_coin_name = addition_coin.name()
-        add_if_coin_subscription(addition_coin_name)
-        add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
+        await add_if_coin_subscription(addition_coin_name)
+        await add_if_ph_subscription(addition_coin.puzzle_hash, addition_coin_name)
         if hint is None:
             continue
         if len(hint) == 32:
-            add_if_ph_subscription(bytes32(hint), addition_coin_name)
+            await add_if_ph_subscription(bytes32(hint), addition_coin_name)
 
         if len(hint) > 0:
             assert len(hint) <= 32
@@ -50,7 +50,7 @@ def get_hints_and_subscription_coin_ids(
     # Goes through all new reward coins
     for reward_coin in state_change_summary.new_rewards:
         reward_coin_name: bytes32 = reward_coin.name()
-        add_if_coin_subscription(reward_coin_name)
-        add_if_ph_subscription(reward_coin.puzzle_hash, reward_coin_name)
+        await add_if_coin_subscription(reward_coin_name)
+        await add_if_ph_subscription(reward_coin.puzzle_hash, reward_coin_name)
 
     return hints_to_add, list(lookup_coin_ids)

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -1,81 +1,68 @@
 from __future__ import annotations
 
-import contextlib
 import logging
-import random
-from dataclasses import dataclass
-from typing import AsyncIterator, List, Set, final
+import sqlite3
+from typing import List, Set
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.db_wrapper import DBWrapper2
 
 log = logging.getLogger(__name__)
 
 
-@final
-@dataclass
 class PeerSubscriptions:
-    db_wrapper: DBWrapper2
+    _db_conn: sqlite3.Connection
 
-    @classmethod
-    @contextlib.asynccontextmanager
-    async def managed(cls) -> AsyncIterator[PeerSubscriptions]:
-        unique_database_uri = (
-            f"file:db_{cls.__module__}_{cls.__qualname__}_{random.randint(0, 99999999)}?mode=memory&cache=shared"
-        )
+    def __init__(self) -> None:
+        self._db_conn = sqlite3.connect(":memory:")
 
-        async with DBWrapper2.managed(database=unique_database_uri) as db_wrapper:
-            self = PeerSubscriptions(db_wrapper)
-
-            async with self.db_wrapper.writer() as conn:
-                log.info("DB: Creating peer subscription tables")
-                await conn.execute(
-                    """
-                    CREATE TABLE puzzle_subscriptions (
-                        id INT PRIMARY KEY,
-                        peer_id BLOB,
-                        puzzle_hash BLOB,
-                        UNIQUE (peer_id, puzzle_hash)
-                    )
-                    """
+        with self._db_conn as conn:
+            log.info("DB: Creating peer subscription tables")
+            conn.execute(
+                """
+                CREATE TABLE puzzle_subscriptions (
+                    id INT PRIMARY KEY,
+                    peer_id BLOB,
+                    puzzle_hash BLOB,
+                    UNIQUE (peer_id, puzzle_hash)
                 )
-                await conn.execute(
-                    """
-                    CREATE TABLE coin_subscriptions (
-                        id INT PRIMARY KEY,
-                        peer_id BLOB,
-                        coin_id BLOB,
-                        UNIQUE (peer_id, coin_id)
-                    )
-                    """
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE coin_subscriptions (
+                    id INT PRIMARY KEY,
+                    peer_id BLOB,
+                    coin_id BLOB,
+                    UNIQUE (peer_id, coin_id)
                 )
+                """
+            )
 
-            yield self
+    def __del__(self) -> None:
+        self._db_conn.close()
 
-    async def is_puzzle_subscribed(self, puzzle_hash: bytes32) -> bool:
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute(
+    def is_puzzle_subscribed(self, puzzle_hash: bytes32) -> bool:
+        with self._db_conn as conn:
+            row = conn.execute(
                 "SELECT COUNT(*) FROM puzzle_subscriptions WHERE puzzle_hash=?", (puzzle_hash,)
-            ) as cursor:
-                row = await cursor.fetchone()
+            ).fetchone()
 
         assert row is not None
 
         return int(row[0]) > 0
 
-    async def is_coin_subscribed(self, coin_id: bytes32) -> bool:
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute("SELECT COUNT(*) FROM coin_subscriptions WHERE coin_id=?", (coin_id,)) as cursor:
-                row = await cursor.fetchone()
+    def is_coin_subscribed(self, coin_id: bytes32) -> bool:
+        with self._db_conn as conn:
+            row = conn.execute("SELECT COUNT(*) FROM coin_subscriptions WHERE coin_id=?", (coin_id,)).fetchone()
 
         assert row is not None
 
         return int(row[0]) > 0
 
-    async def _add_subscriptions(
+    def _add_subscriptions(
         self, peer_id: bytes32, table_name: str, item_name: str, items: List[bytes32], max_items: int
     ) -> Set[bytes32]:
-        existing_sub_count = await self.peer_subscription_count(peer_id)
+        existing_sub_count = self.peer_subscription_count(peer_id)
         inserted: Set[bytes32] = set()
 
         # If we've reached the subscription limit, just bail.
@@ -86,23 +73,22 @@ class PeerSubscriptions:
             )
             return inserted
 
-        async with self.db_wrapper.writer() as conn:
+        with self._db_conn as conn:
             # Decrement this counter as we go, to know if we've hit the subscription limit.
             subscriptions_left = max_items - existing_sub_count
 
             for item in items:
-                async with conn.execute(
+                row = conn.execute(
                     f"SELECT COUNT(*) FROM {table_name} WHERE peer_id=? AND {item_name}=?",
                     (peer_id, item),
-                ) as cursor:
-                    row = await cursor.fetchone()
+                ).fetchone()
 
                 assert row is not None
 
                 if int(row[0]) > 0:
                     continue
 
-                await conn.execute(f"INSERT INTO {table_name} (peer_id, {item_name}) VALUES (?, ?)", (peer_id, item))
+                conn.execute(f"INSERT INTO {table_name} (peer_id, {item_name}) VALUES (?, ?)", (peer_id, item))
                 inserted.add(item)
                 subscriptions_left -= 1
 
@@ -115,16 +101,14 @@ class PeerSubscriptions:
 
             return inserted
 
-    async def add_puzzle_subscriptions(
-        self, peer_id: bytes32, puzzle_hashes: List[bytes32], max_items: int
-    ) -> Set[bytes32]:
+    def add_puzzle_subscriptions(self, peer_id: bytes32, puzzle_hashes: List[bytes32], max_items: int) -> Set[bytes32]:
         """
         Returns the items that were actually subscribed to, which is fewer in these cases:
         * There are duplicate items.
         * Some items are already subscribed to.
         * The `max_items` limit is exceeded.
         """
-        return await self._add_subscriptions(
+        return self._add_subscriptions(
             peer_id=peer_id,
             table_name="puzzle_subscriptions",
             item_name="puzzle_hash",
@@ -132,14 +116,14 @@ class PeerSubscriptions:
             max_items=max_items,
         )
 
-    async def add_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32], max_items: int) -> Set[bytes32]:
+    def add_coin_subscriptions(self, peer_id: bytes32, coin_ids: List[bytes32], max_items: int) -> Set[bytes32]:
         """
         Returns the items that were actually subscribed to, which is fewer in these cases:
         * There are duplicate items.
         * Some items are already subscribed to.
         * The `max_items` limit is exceeded.
         """
-        return await self._add_subscriptions(
+        return self._add_subscriptions(
             peer_id=peer_id,
             table_name="coin_subscriptions",
             item_name="coin_id",
@@ -147,37 +131,33 @@ class PeerSubscriptions:
             max_items=max_items,
         )
 
-    async def peer_subscription_count(self, peer_id: bytes32) -> int:
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute("SELECT COUNT(*) FROM puzzle_subscriptions WHERE peer_id=?", (peer_id,)) as cursor:
-                row = await cursor.fetchone()
-                assert row is not None
-                puzzle_subscription_count = int(row[0])
+    def peer_subscription_count(self, peer_id: bytes32) -> int:
+        with self._db_conn as conn:
+            row = conn.execute("SELECT COUNT(*) FROM puzzle_subscriptions WHERE peer_id=?", (peer_id,)).fetchone()
+            assert row is not None
+            puzzle_subscription_count = int(row[0])
 
-            async with conn.execute("SELECT COUNT(*) FROM coin_subscriptions WHERE peer_id=?", (peer_id,)) as cursor:
-                row = await cursor.fetchone()
-                assert row is not None
-                coin_subscription_count = int(row[0])
+            row = conn.execute("SELECT COUNT(*) FROM coin_subscriptions WHERE peer_id=?", (peer_id,)).fetchone()
+            assert row is not None
+            coin_subscription_count = int(row[0])
 
         return puzzle_subscription_count + coin_subscription_count
 
-    async def remove_peer(self, peer_id: bytes32) -> None:
-        async with self.db_wrapper.writer() as conn:
-            await conn.execute("DELETE FROM puzzle_subscriptions WHERE peer_id=?", (peer_id,))
-            await conn.execute("DELETE FROM coin_subscriptions WHERE peer_id=?", (peer_id,))
+    def remove_peer(self, peer_id: bytes32) -> None:
+        with self._db_conn as conn:
+            conn.execute("DELETE FROM puzzle_subscriptions WHERE peer_id=?", (peer_id,))
+            conn.execute("DELETE FROM coin_subscriptions WHERE peer_id=?", (peer_id,))
 
-    async def peers_for_coin_id(self, coin_id: bytes32) -> Set[bytes32]:
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute("SELECT peer_id FROM coin_subscriptions WHERE coin_id=?", (coin_id,)) as cursor:
-                rows = await cursor.fetchall()
+    def peers_for_coin_id(self, coin_id: bytes32) -> Set[bytes32]:
+        with self._db_conn as conn:
+            rows = conn.execute("SELECT peer_id FROM coin_subscriptions WHERE coin_id=?", (coin_id,)).fetchall()
 
         return {bytes32(row[0]) for row in rows}
 
-    async def peers_for_puzzle_hash(self, puzzle_hash: bytes32) -> Set[bytes32]:
-        async with self.db_wrapper.reader_no_transaction() as conn:
-            async with conn.execute(
+    def peers_for_puzzle_hash(self, puzzle_hash: bytes32) -> Set[bytes32]:
+        with self._db_conn as conn:
+            rows = conn.execute(
                 "SELECT peer_id FROM puzzle_subscriptions WHERE puzzle_hash=?", (puzzle_hash,)
-            ) as cursor:
-                rows = await cursor.fetchall()
+            ).fetchall()
 
         return {bytes32(row[0]) for row in rows}

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -76,7 +76,13 @@ class PeerSubscriptions:
             subscriptions_left = max_items - existing_sub_count
 
             for item in items:
-                cursor = conn.execute(f"INSERT INTO {table_name} (peer_id, {item_name}) VALUES (?, ?)", (peer_id, item))
+                try:
+                    cursor = conn.execute(
+                        f"INSERT INTO {table_name} (peer_id, {item_name}) VALUES (?, ?)", (peer_id, item)
+                    )
+                except sqlite3.Error:
+                    continue
+
                 if cursor.rowcount == 0:
                     continue
 

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -143,6 +143,22 @@ class PeerSubscriptions:
 
         return puzzle_subscription_count + coin_subscription_count
 
+    def total_puzzle_subscriptions(self) -> int:
+        with self._db_conn as conn:
+            row = conn.execute("SELECT COUNT(*) FROM puzzle_subscriptions").fetchone()
+            assert row is not None
+            puzzle_subscription_count = int(row[0])
+
+        return puzzle_subscription_count
+
+    def total_coin_subscriptions(self) -> int:
+        with self._db_conn as conn:
+            row = conn.execute("SELECT COUNT(*) FROM coin_subscriptions").fetchone()
+            assert row is not None
+            coin_subscription_count = int(row[0])
+
+        return coin_subscription_count
+
     def remove_peer(self, peer_id: bytes32) -> None:
         with self._db_conn as conn:
             conn.execute("DELETE FROM puzzle_subscriptions WHERE peer_id=?", (peer_id,))

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -78,17 +78,10 @@ class PeerSubscriptions:
             subscriptions_left = max_items - existing_sub_count
 
             for item in items:
-                row = conn.execute(
-                    f"SELECT COUNT(*) FROM {table_name} WHERE peer_id=? AND {item_name}=?",
-                    (peer_id, item),
-                ).fetchone()
-
-                assert row is not None
-
-                if int(row[0]) > 0:
+                cursor = conn.execute(f"INSERT INTO {table_name} (peer_id, {item_name}) VALUES (?, ?)", (peer_id, item))
+                if cursor.rowcount == 0:
                     continue
 
-                conn.execute(f"INSERT INTO {table_name} (peer_id, {item_name}) VALUES (?, ?)", (peer_id, item))
                 inserted.add(item)
                 subscriptions_left -= 1
 

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -20,7 +20,6 @@ class PeerSubscriptions:
             conn.execute(
                 """
                 CREATE TABLE puzzle_subscriptions (
-                    id INT PRIMARY KEY,
                     peer_id BLOB,
                     puzzle_hash BLOB,
                     UNIQUE (peer_id, puzzle_hash)
@@ -30,7 +29,6 @@ class PeerSubscriptions:
             conn.execute(
                 """
                 CREATE TABLE coin_subscriptions (
-                    id INT PRIMARY KEY,
                     peer_id BLOB,
                     coin_id BLOB,
                     UNIQUE (peer_id, coin_id)

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -21,7 +21,7 @@ class PeerSubscriptions:
     @contextlib.asynccontextmanager
     async def managed(cls) -> AsyncIterator[PeerSubscriptions]:
         unique_database_uri = (
-            f"file:db_{cls.__module__}.{cls.__qualname__}_{random.randint(0, 99999999)}?mode=memory&cache=shared"
+            f"file:db_{cls.__module__}_{cls.__qualname__}_{random.randint(0, 99999999)}?mode=memory&cache=shared"
         )
 
         async with DBWrapper2.managed(database=unique_database_uri) as db_wrapper:

--- a/tests/core/full_node/test_hint_management.py
+++ b/tests/core/full_node/test_hint_management.py
@@ -29,7 +29,7 @@ additions = [
 ]
 
 
-async def no_sub(c: bytes32) -> bool:
+def no_sub(c: bytes32) -> bool:
     return False
 
 
@@ -42,7 +42,7 @@ async def test_hints_to_add(bt: BlockTools, empty_blockchain: Blockchain) -> Non
     assert br is not None
 
     scs = StateChangeSummary(br, uint32(0), [], removals, additions, [])
-    hints_to_add, lookup_coin_ids = await get_hints_and_subscription_coin_ids(scs, no_sub, no_sub)
+    hints_to_add, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, no_sub, no_sub)
     assert len(lookup_coin_ids) == 0
 
     first_coin_id: bytes32 = Coin(bytes32(coin_ids[0]), bytes32(phs[4]), uint64(3)).name()
@@ -101,12 +101,12 @@ async def test_lookup_coin_ids(
 
     scs = StateChangeSummary(br, uint32(0), [], removals, additions, rewards)
 
-    async def has_coin_sub(c: bytes32) -> bool:
+    def has_coin_sub(c: bytes32) -> bool:
         return c == coin_check
 
-    async def has_ph_sub(ph: bytes32) -> bool:
+    def has_ph_sub(ph: bytes32) -> bool:
         return ph == ph_check
 
-    _, lookup_coin_ids = await get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
+    _, lookup_coin_ids = get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
 
     assert set(lookup_coin_ids) == results

--- a/tests/core/full_node/test_hint_management.py
+++ b/tests/core/full_node/test_hint_management.py
@@ -80,10 +80,10 @@ async def test_lookup_coin_ids(bt: BlockTools, empty_blockchain: Blockchain) -> 
     assert set(lookup_coin_ids) == {coin_ids[1], first_coin_id, second_coin_id}
 
     # Removal PH and addition ID
-    async def has_coin_sub(c: bytes32) -> bool:  # type: ignore[no-redef]
+    async def has_coin_sub(c: bytes32) -> bool:  # type: ignore[no-redef] # noqa: E0102
         return c == first_coin_id
 
-    async def has_ph_sub(ph: bytes32) -> bool:  # type: ignore[no-redef]
+    async def has_ph_sub(ph: bytes32) -> bool:  # type: ignore[no-redef] # noqa: E0102
         return ph == phs[0]
 
     _, lookup_coin_ids = await get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)
@@ -92,21 +92,21 @@ async def test_lookup_coin_ids(bt: BlockTools, empty_blockchain: Blockchain) -> 
     # Subscribe to hint
     third_coin_id: bytes32 = Coin(bytes32(coin_ids[2]), phs[9], uint64(123)).name()
 
-    async def has_ph_sub(ph: bytes32) -> bool:  # type: ignore[no-redef]
+    async def has_ph_sub(ph: bytes32) -> bool:  # type: ignore[no-redef] # noqa: E0102
         return ph == bytes32(b"1" * 32)
 
     _, lookup_coin_ids = await get_hints_and_subscription_coin_ids(scs, no_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {first_coin_id, third_coin_id}
 
     # Reward PH
-    async def has_ph_sub(ph: bytes32) -> bool:  # type: ignore[no-redef]
+    async def has_ph_sub(ph: bytes32) -> bool:  # type: ignore[no-redef] # noqa: E0102
         return ph == rewards[0].puzzle_hash
 
     _, lookup_coin_ids = await get_hints_and_subscription_coin_ids(scs, no_sub, has_ph_sub)
     assert set(lookup_coin_ids) == {rewards[0].name(), rewards[2].name()}
 
     # Reward coin id + reward ph
-    async def has_coin_sub(c: bytes32) -> bool:  # type: ignore[no-redef]
+    async def has_coin_sub(c: bytes32) -> bool:  # type: ignore[no-redef] # noqa: E0102
         return c == rewards[1].name()
 
     _, lookup_coin_ids = await get_hints_and_subscription_coin_ids(scs, has_coin_sub, has_ph_sub)

--- a/tests/core/full_node/test_subscriptions.py
+++ b/tests/core/full_node/test_subscriptions.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from chia.full_node.subscriptions import PeerSubscriptions
 from chia.types.blockchain_format.sized_bytes import bytes32
 
@@ -19,341 +17,341 @@ ph3 = bytes32(b"g" * 32)
 ph4 = bytes32(b"h" * 32)
 
 
-@pytest.mark.anyio
-async def test_has_ph_sub() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
+def test_has_ph_sub() -> None:
+    sub = PeerSubscriptions()
 
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
-        assert ret == {ph1}
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is False
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1], 100)
+    assert ret == {ph1}
 
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2], 100)
-        # we have already subscribed to ph1, it's filtered in the returned list
-        assert ret == {ph2}
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is False
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is True
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1, ph2], 100)
+    # we have already subscribed to ph1, it's filtered in the returned list
+    assert ret == {ph2}
 
-        # note that this is technically a type error as well.
-        # we can remove these asserts once we have type checking
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.is_coin_subscribed(coin2) is False
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is True
 
-        await sub.remove_peer(peer1)
+    # note that this is technically a type error as well.
+    # we can remove these asserts once we have type checking
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.is_coin_subscribed(coin2) is False
 
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
+    sub.remove_peer(peer1)
 
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
 
-@pytest.mark.anyio
-async def test_has_coin_sub() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.is_coin_subscribed(coin2) is False
 
-        await sub.add_coin_subscriptions(peer1, [coin1], 100)
+def test_has_coin_sub() -> None:
+    sub = PeerSubscriptions()
 
-        assert await sub.is_coin_subscribed(coin1) is True
-        assert await sub.is_coin_subscribed(coin2) is False
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.is_coin_subscribed(coin2) is False
 
-        await sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
+    sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-        assert await sub.is_coin_subscribed(coin1) is True
-        assert await sub.is_coin_subscribed(coin2) is True
+    assert sub.is_coin_subscribed(coin1) is True
+    assert sub.is_coin_subscribed(coin2) is False
 
-        # note that this is technically a type error as well.
-        # we can remove these asserts once we have type checking
-        assert await sub.is_puzzle_subscribed(coin1) is False
-        assert await sub.is_puzzle_subscribed(coin2) is False
+    sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
 
-        await sub.remove_peer(peer1)
+    assert sub.is_coin_subscribed(coin1) is True
+    assert sub.is_coin_subscribed(coin2) is True
 
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.is_coin_subscribed(coin2) is False
+    # note that this is technically a type error as well.
+    # we can remove these asserts once we have type checking
+    assert sub.is_puzzle_subscribed(coin1) is False
+    assert sub.is_puzzle_subscribed(coin2) is False
 
+    sub.remove_peer(peer1)
 
-@pytest.mark.anyio
-async def test_overlapping_coin_subscriptions() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.is_coin_subscribed(coin2) is False
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.is_coin_subscribed(coin2) is False
 
-        assert await sub.peers_for_coin_id(coin1) == set()
-        assert await sub.peers_for_coin_id(coin2) == set()
 
-        # subscribed to different coins
-        await sub.add_coin_subscriptions(peer1, [coin1], 100)
+def test_overlapping_coin_subscriptions() -> None:
+    sub = PeerSubscriptions()
 
-        assert await sub.peers_for_coin_id(coin1) == {peer1}
-        assert await sub.peers_for_coin_id(coin2) == set()
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.is_coin_subscribed(coin2) is False
 
-        await sub.add_coin_subscriptions(peer2, [coin2], 100)
+    assert sub.peers_for_coin_id(coin1) == set()
+    assert sub.peers_for_coin_id(coin2) == set()
 
-        assert await sub.is_coin_subscribed(coin1) is True
-        assert await sub.is_coin_subscribed(coin2) is True
+    # subscribed to different coins
+    sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-        assert await sub.peers_for_coin_id(coin1) == {peer1}
-        assert await sub.peers_for_coin_id(coin2) == {peer2}
+    assert sub.peers_for_coin_id(coin1) == {peer1}
+    assert sub.peers_for_coin_id(coin2) == set()
 
-        # peer1 is now subscribing to both coins
-        await sub.add_coin_subscriptions(peer1, [coin2], 100)
+    sub.add_coin_subscriptions(peer2, [coin2], 100)
 
-        assert await sub.is_coin_subscribed(coin1) is True
-        assert await sub.is_coin_subscribed(coin2) is True
+    assert sub.is_coin_subscribed(coin1) is True
+    assert sub.is_coin_subscribed(coin2) is True
 
-        assert await sub.peers_for_coin_id(coin1) == {peer1}
-        assert await sub.peers_for_coin_id(coin2) == {peer1, peer2}
+    assert sub.peers_for_coin_id(coin1) == {peer1}
+    assert sub.peers_for_coin_id(coin2) == {peer2}
 
-        # removing peer1 still leaves the subscription to coin2
-        await sub.remove_peer(peer1)
+    # peer1 is now subscribing to both coins
+    sub.add_coin_subscriptions(peer1, [coin2], 100)
 
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.is_coin_subscribed(coin2) is True
+    assert sub.is_coin_subscribed(coin1) is True
+    assert sub.is_coin_subscribed(coin2) is True
 
-        assert await sub.peers_for_coin_id(coin1) == set()
-        assert await sub.peers_for_coin_id(coin2) == {peer2}
+    assert sub.peers_for_coin_id(coin1) == {peer1}
+    assert sub.peers_for_coin_id(coin2) == {peer1, peer2}
 
+    # removing peer1 still leaves the subscription to coin2
+    sub.remove_peer(peer1)
 
-@pytest.mark.anyio
-async def test_overlapping_ph_subscriptions() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.is_coin_subscribed(coin2) is True
 
-        assert await sub.peers_for_puzzle_hash(ph1) == set()
-        assert await sub.peers_for_puzzle_hash(ph2) == set()
+    assert sub.peers_for_coin_id(coin1) == set()
+    assert sub.peers_for_coin_id(coin2) == {peer2}
 
-        # subscribed to different phs
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
-        assert ret == {ph1}
 
-        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph2) == set()
+def test_overlapping_ph_subscriptions() -> None:
+    sub = PeerSubscriptions()
 
-        ret = await sub.add_puzzle_subscriptions(peer2, [ph2], 100)
-        assert ret == {ph2}
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is True
+    assert sub.peers_for_puzzle_hash(ph1) == set()
+    assert sub.peers_for_puzzle_hash(ph2) == set()
 
-        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
+    # subscribed to different phs
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1], 100)
+    assert ret == {ph1}
 
-        # peer1 is now subscribing to both phs
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph2], 100)
-        assert ret == {ph2}
+    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph2) == set()
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is True
+    ret = sub.add_puzzle_subscriptions(peer2, [ph2], 100)
+    assert ret == {ph2}
 
-        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is True
 
-        # removing peer1 still leaves the subscription to ph2
-        await sub.remove_peer(peer1)
+    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph2) == {peer2}
 
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is True
+    # peer1 is now subscribing to both phs
+    ret = sub.add_puzzle_subscriptions(peer1, [ph2], 100)
+    assert ret == {ph2}
 
-        assert await sub.peers_for_puzzle_hash(ph1) == set()
-        assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is True
 
+    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
 
-@pytest.mark.anyio
-async def test_ph_sub_limit() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
-        assert await sub.is_puzzle_subscribed(ph3) is False
+    # removing peer1 still leaves the subscription to ph2
+    sub.remove_peer(peer1)
 
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
-        # we only ended up subscribing to 3 puzzle hashes because of the limit
-        assert ret == {ph1, ph2, ph3}
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is True
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is True
-        assert await sub.is_puzzle_subscribed(ph3) is True
-        assert await sub.is_puzzle_subscribed(ph4) is False
+    assert sub.peers_for_puzzle_hash(ph1) == set()
+    assert sub.peers_for_puzzle_hash(ph2) == {peer2}
 
-        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph3) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph4) == set()
 
-        # peer1 should still be limited
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph4], 3)
-        assert ret == set()
+def test_ph_sub_limit() -> None:
+    sub = PeerSubscriptions()
 
-        assert await sub.is_puzzle_subscribed(ph4) is False
-        assert await sub.peers_for_puzzle_hash(ph4) == set()
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_puzzle_subscribed(ph3) is False
 
-        # peer1 is also limied on coin subscriptions
-        await sub.add_coin_subscriptions(peer1, [coin1], 3)
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
+    # we only ended up subscribing to 3 puzzle hashes because of the limit
+    assert ret == {ph1, ph2, ph3}
 
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.peers_for_coin_id(coin1) == set()
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is True
+    assert sub.is_puzzle_subscribed(ph3) is True
+    assert sub.is_puzzle_subscribed(ph4) is False
 
-        # peer2 is has its own limit
-        ret = await sub.add_puzzle_subscriptions(peer2, [ph4], 3)
-        assert ret == {ph4}
+    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph2) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph3) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph4) == set()
 
-        assert await sub.is_puzzle_subscribed(ph4) is True
-        assert await sub.peers_for_puzzle_hash(ph4) == {peer2}
+    # peer1 should still be limited
+    ret = sub.add_puzzle_subscriptions(peer1, [ph4], 3)
+    assert ret == set()
 
-        await sub.remove_peer(peer1)
-        await sub.remove_peer(peer2)
+    assert sub.is_puzzle_subscribed(ph4) is False
+    assert sub.peers_for_puzzle_hash(ph4) == set()
 
+    # peer1 is also limied on coin subscriptions
+    sub.add_coin_subscriptions(peer1, [coin1], 3)
 
-@pytest.mark.anyio
-async def test_ph_sub_limit_incremental() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
-        assert await sub.is_puzzle_subscribed(ph3) is False
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.peers_for_coin_id(coin1) == set()
 
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 2)
-        assert ret == {ph1}
+    # peer2 is has its own limit
+    ret = sub.add_puzzle_subscriptions(peer2, [ph4], 3)
+    assert ret == {ph4}
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is False
-        assert await sub.is_puzzle_subscribed(ph3) is False
-        assert await sub.is_puzzle_subscribed(ph4) is False
+    assert sub.is_puzzle_subscribed(ph4) is True
+    assert sub.peers_for_puzzle_hash(ph4) == {peer2}
 
-        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph2) == set()
-        assert await sub.peers_for_puzzle_hash(ph3) == set()
-        assert await sub.peers_for_puzzle_hash(ph4) == set()
+    sub.remove_peer(peer1)
+    sub.remove_peer(peer2)
 
-        # this will cross the limit. Only ph2 will be added
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph2, ph3], 2)
-        assert ret == {ph2}
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is True
-        assert await sub.is_puzzle_subscribed(ph3) is False
-        assert await sub.is_puzzle_subscribed(ph4) is False
+def test_ph_sub_limit_incremental() -> None:
+    sub = PeerSubscriptions()
 
-        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
-        assert await sub.peers_for_puzzle_hash(ph3) == set()
-        assert await sub.peers_for_puzzle_hash(ph4) == set()
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_puzzle_subscribed(ph3) is False
 
-        await sub.remove_peer(peer1)
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1], 2)
+    assert ret == {ph1}
 
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_puzzle_subscribed(ph3) is False
+    assert sub.is_puzzle_subscribed(ph4) is False
 
-@pytest.mark.anyio
-async def test_coin_sub_limit() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.is_coin_subscribed(coin2) is False
-        assert await sub.is_coin_subscribed(coin2) is False
-        assert await sub.is_coin_subscribed(coin3) is False
+    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph2) == set()
+    assert sub.peers_for_puzzle_hash(ph3) == set()
+    assert sub.peers_for_puzzle_hash(ph4) == set()
 
-        await sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
+    # this will cross the limit. Only ph2 will be added
+    ret = sub.add_puzzle_subscriptions(peer1, [ph2, ph3], 2)
+    assert ret == {ph2}
 
-        assert await sub.is_coin_subscribed(coin1) is True
-        assert await sub.is_coin_subscribed(coin2) is True
-        assert await sub.is_coin_subscribed(coin3) is True
-        assert await sub.is_coin_subscribed(coin4) is False
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is True
+    assert sub.is_puzzle_subscribed(ph3) is False
+    assert sub.is_puzzle_subscribed(ph4) is False
 
-        assert await sub.peers_for_coin_id(coin1) == {peer1}
-        assert await sub.peers_for_coin_id(coin2) == {peer1}
-        assert await sub.peers_for_coin_id(coin3) == {peer1}
-        assert await sub.peers_for_coin_id(coin4) == set()
+    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph2) == {peer1}
+    assert sub.peers_for_puzzle_hash(ph3) == set()
+    assert sub.peers_for_puzzle_hash(ph4) == set()
 
-        # peer1 should still be limited
-        await sub.add_coin_subscriptions(peer1, [coin4], 3)
+    sub.remove_peer(peer1)
 
-        assert await sub.is_coin_subscribed(coin4) is False
-        assert await sub.peers_for_coin_id(coin4) == set()
 
-        # peer1 is also limied on ph subscriptions
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 3)
-        assert ret == set()
+def test_coin_sub_limit() -> None:
+    sub = PeerSubscriptions()
 
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.peers_for_puzzle_hash(ph1) == set()
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.is_coin_subscribed(coin2) is False
+    assert sub.is_coin_subscribed(coin2) is False
+    assert sub.is_coin_subscribed(coin3) is False
 
-        # peer2 is has its own limit
-        await sub.add_coin_subscriptions(peer2, [coin4], 3)
+    sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
 
-        assert await sub.is_coin_subscribed(coin4) is True
-        assert await sub.peers_for_coin_id(coin4) == {peer2}
+    assert sub.is_coin_subscribed(coin1) is True
+    assert sub.is_coin_subscribed(coin2) is True
+    assert sub.is_coin_subscribed(coin3) is True
+    assert sub.is_coin_subscribed(coin4) is False
 
-        await sub.remove_peer(peer1)
-        await sub.remove_peer(peer2)
+    assert sub.peers_for_coin_id(coin1) == {peer1}
+    assert sub.peers_for_coin_id(coin2) == {peer1}
+    assert sub.peers_for_coin_id(coin3) == {peer1}
+    assert sub.peers_for_coin_id(coin4) == set()
 
+    # peer1 should still be limited
+    sub.add_coin_subscriptions(peer1, [coin4], 3)
 
-@pytest.mark.anyio
-async def test_coin_sub_limit_incremental() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_coin_subscribed(coin1) is False
-        assert await sub.is_coin_subscribed(coin2) is False
-        assert await sub.is_coin_subscribed(coin2) is False
-        assert await sub.is_coin_subscribed(coin3) is False
+    assert sub.is_coin_subscribed(coin4) is False
+    assert sub.peers_for_coin_id(coin4) == set()
 
-        await sub.add_coin_subscriptions(peer1, [coin1], 2)
+    # peer1 is also limied on ph subscriptions
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1], 3)
+    assert ret == set()
 
-        assert await sub.is_coin_subscribed(coin1) is True
-        assert await sub.is_coin_subscribed(coin2) is False
-        assert await sub.is_coin_subscribed(coin3) is False
-        assert await sub.is_coin_subscribed(coin4) is False
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.peers_for_puzzle_hash(ph1) == set()
 
-        assert await sub.peers_for_coin_id(coin1) == {peer1}
-        assert await sub.peers_for_coin_id(coin2) == set()
-        assert await sub.peers_for_coin_id(coin3) == set()
-        assert await sub.peers_for_coin_id(coin4) == set()
+    # peer2 is has its own limit
+    sub.add_coin_subscriptions(peer2, [coin4], 3)
 
-        # this will cross the limit. Only coin2 will be added
-        await sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
+    assert sub.is_coin_subscribed(coin4) is True
+    assert sub.peers_for_coin_id(coin4) == {peer2}
 
-        assert await sub.is_coin_subscribed(coin1) is True
-        assert await sub.is_coin_subscribed(coin2) is True
-        assert await sub.is_coin_subscribed(coin3) is False
-        assert await sub.is_coin_subscribed(coin4) is False
+    sub.remove_peer(peer1)
+    sub.remove_peer(peer2)
 
-        assert await sub.peers_for_coin_id(coin1) == {peer1}
-        assert await sub.peers_for_coin_id(coin2) == {peer1}
-        assert await sub.peers_for_coin_id(coin3) == set()
-        assert await sub.peers_for_coin_id(coin4) == set()
 
-        await sub.remove_peer(peer1)
+def test_coin_sub_limit_incremental() -> None:
+    sub = PeerSubscriptions()
 
+    assert sub.is_coin_subscribed(coin1) is False
+    assert sub.is_coin_subscribed(coin2) is False
+    assert sub.is_coin_subscribed(coin2) is False
+    assert sub.is_coin_subscribed(coin3) is False
 
-@pytest.mark.anyio
-async def test_ph_subscription_duplicates() -> None:
-    async with PeerSubscriptions.managed() as sub:
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
-        assert await sub.is_puzzle_subscribed(ph3) is False
-        assert await sub.is_puzzle_subscribed(ph4) is False
+    sub.add_coin_subscriptions(peer1, [coin1], 2)
 
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3], 100)
-        assert ret == {ph1, ph2, ph3}
+    assert sub.is_coin_subscribed(coin1) is True
+    assert sub.is_coin_subscribed(coin2) is False
+    assert sub.is_coin_subscribed(coin3) is False
+    assert sub.is_coin_subscribed(coin4) is False
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is True
-        assert await sub.is_puzzle_subscribed(ph3) is True
-        assert await sub.is_puzzle_subscribed(ph4) is False
+    assert sub.peers_for_coin_id(coin1) == {peer1}
+    assert sub.peers_for_coin_id(coin2) == set()
+    assert sub.peers_for_coin_id(coin3) == set()
+    assert sub.peers_for_coin_id(coin4) == set()
 
-        # only ph4 is new, the others are duplicates and ignored
-        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
-        assert ret == {ph4}
+    # this will cross the limit. Only coin2 will be added
+    sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
 
-        assert await sub.is_puzzle_subscribed(ph1) is True
-        assert await sub.is_puzzle_subscribed(ph2) is True
-        assert await sub.is_puzzle_subscribed(ph3) is True
-        assert await sub.is_puzzle_subscribed(ph4) is True
+    assert sub.is_coin_subscribed(coin1) is True
+    assert sub.is_coin_subscribed(coin2) is True
+    assert sub.is_coin_subscribed(coin3) is False
+    assert sub.is_coin_subscribed(coin4) is False
 
-        await sub.remove_peer(peer1)
+    assert sub.peers_for_coin_id(coin1) == {peer1}
+    assert sub.peers_for_coin_id(coin2) == {peer1}
+    assert sub.peers_for_coin_id(coin3) == set()
+    assert sub.peers_for_coin_id(coin4) == set()
 
-        assert await sub.is_puzzle_subscribed(ph1) is False
-        assert await sub.is_puzzle_subscribed(ph2) is False
-        assert await sub.is_puzzle_subscribed(ph3) is False
-        assert await sub.is_puzzle_subscribed(ph4) is False
+    sub.remove_peer(peer1)
+
+
+def test_ph_subscription_duplicates() -> None:
+    sub = PeerSubscriptions()
+
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_puzzle_subscribed(ph3) is False
+    assert sub.is_puzzle_subscribed(ph4) is False
+
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3], 100)
+    assert ret == {ph1, ph2, ph3}
+
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is True
+    assert sub.is_puzzle_subscribed(ph3) is True
+    assert sub.is_puzzle_subscribed(ph4) is False
+
+    # only ph4 is new, the others are duplicates and ignored
+    ret = sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
+    assert ret == {ph4}
+
+    assert sub.is_puzzle_subscribed(ph1) is True
+    assert sub.is_puzzle_subscribed(ph2) is True
+    assert sub.is_puzzle_subscribed(ph3) is True
+    assert sub.is_puzzle_subscribed(ph4) is True
+
+    sub.remove_peer(peer1)
+
+    assert sub.is_puzzle_subscribed(ph1) is False
+    assert sub.is_puzzle_subscribed(ph2) is False
+    assert sub.is_puzzle_subscribed(ph3) is False
+    assert sub.is_puzzle_subscribed(ph4) is False

--- a/tests/core/full_node/test_subscriptions.py
+++ b/tests/core/full_node/test_subscriptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from chia.full_node.subscriptions import PeerSubscriptions
 from chia.types.blockchain_format.sized_bytes import bytes32
 
@@ -17,341 +19,350 @@ ph3 = bytes32(b"g" * 32)
 ph4 = bytes32(b"h" * 32)
 
 
-def test_has_ph_sub() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_has_ph_sub() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
     assert ret == {ph1}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2], 100)
     # we have already subscribed to ph1, it's filtered in the returned list
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
     # note that this is technically a type error as well.
     # we can remove these asserts once we have type checking
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
 
-def test_has_coin_sub() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_has_coin_sub() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1], 100)
+    await sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
+    await sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
 
     # note that this is technically a type error as well.
     # we can remove these asserts once we have type checking
-    assert sub.has_ph_subscription(coin1) is False
-    assert sub.has_ph_subscription(coin2) is False
+    assert await sub.is_puzzle_subscribed(coin1) is False
+    assert await sub.is_puzzle_subscribed(coin2) is False
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
 
-def test_overlapping_coin_subscriptions() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_overlapping_coin_subscriptions() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
 
-    assert sub.peers_for_coin_id(coin1) == set()
-    assert sub.peers_for_coin_id(coin2) == set()
+    assert await sub.peers_for_coin_id(coin1) == set()
+    assert await sub.peers_for_coin_id(coin2) == set()
 
     # subscribed to different coins
-    sub.add_coin_subscriptions(peer1, [coin1], 100)
+    await sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == set()
 
-    sub.add_coin_subscriptions(peer2, [coin2], 100)
+    await sub.add_coin_subscriptions(peer2, [coin2], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer2}
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer2}
 
     # peer1 is now subscribing to both coins
-    sub.add_coin_subscriptions(peer1, [coin2], 100)
+    await sub.add_coin_subscriptions(peer1, [coin2], 100)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer1, peer2}
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer1, peer2}
 
     # removing peer1 still leaves the subscription to coin2
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is True
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is True
 
-    assert sub.peers_for_coin_id(coin1) == set()
-    assert sub.peers_for_coin_id(coin2) == {peer2}
+    assert await sub.peers_for_coin_id(coin1) == set()
+    assert await sub.peers_for_coin_id(coin2) == {peer2}
 
 
-def test_overlapping_ph_subscriptions() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_overlapping_ph_subscriptions() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == set()
-    assert sub.peers_for_puzzle_hash(ph2) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == set()
+    assert await sub.peers_for_puzzle_hash(ph2) == set()
 
     # subscribed to different phs
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
     assert ret == {ph1}
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == set()
 
-    ret = sub.add_ph_subscriptions(peer2, [ph2], 100)
+    ret = await sub.add_puzzle_subscriptions(peer2, [ph2], 100)
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer2}
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
 
     # peer1 is now subscribing to both phs
-    ret = sub.add_ph_subscriptions(peer1, [ph2], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph2], 100)
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
 
     # removing peer1 still leaves the subscription to ph2
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert sub.peers_for_puzzle_hash(ph1) == set()
-    assert sub.peers_for_puzzle_hash(ph2) == {peer2}
+    assert await sub.peers_for_puzzle_hash(ph1) == set()
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
 
 
-def test_ph_sub_limit() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_ph_sub_limit() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
     # we only ended up subscribing to 3 puzzle hashes because of the limit
     assert ret == {ph1, ph2, ph3}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is True
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is True
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph3) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph3) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
     # peer1 should still be limited
-    ret = sub.add_ph_subscriptions(peer1, [ph4], 3)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph4], 3)
     assert ret == set()
 
-    assert sub.has_ph_subscription(ph4) is False
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.is_puzzle_subscribed(ph4) is False
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
     # peer1 is also limied on coin subscriptions
-    sub.add_coin_subscriptions(peer1, [coin1], 3)
+    await sub.add_coin_subscriptions(peer1, [coin1], 3)
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.peers_for_coin_id(coin1) == set()
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.peers_for_coin_id(coin1) == set()
 
     # peer2 is has its own limit
-    ret = sub.add_ph_subscriptions(peer2, [ph4], 3)
+    ret = await sub.add_puzzle_subscriptions(peer2, [ph4], 3)
     assert ret == {ph4}
 
-    assert sub.has_ph_subscription(ph4) is True
-    assert sub.peers_for_puzzle_hash(ph4) == {peer2}
+    assert await sub.is_puzzle_subscribed(ph4) is True
+    assert await sub.peers_for_puzzle_hash(ph4) == {peer2}
 
-    sub.remove_peer(peer1)
-    sub.remove_peer(peer2)
+    await sub.remove_peer(peer1)
+    await sub.remove_peer(peer2)
 
 
-def test_ph_sub_limit_incremental() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_ph_sub_limit_incremental() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 2)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 2)
     assert ret == {ph1}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == set()
-    assert sub.peers_for_puzzle_hash(ph3) == set()
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == set()
+    assert await sub.peers_for_puzzle_hash(ph3) == set()
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
     # this will cross the limit. Only ph2 will be added
-    ret = sub.add_ph_subscriptions(peer1, [ph2, ph3], 2)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph2, ph3], 2)
     assert ret == {ph2}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph2) == {peer1}
-    assert sub.peers_for_puzzle_hash(ph3) == set()
-    assert sub.peers_for_puzzle_hash(ph4) == set()
+    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
+    assert await sub.peers_for_puzzle_hash(ph3) == set()
+    assert await sub.peers_for_puzzle_hash(ph4) == set()
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
 
-def test_coin_sub_limit() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_coin_sub_limit() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin3) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin3) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
+    await sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
-    assert sub.has_coin_subscription(coin3) is True
-    assert sub.has_coin_subscription(coin4) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
+    assert await sub.is_coin_subscribed(coin3) is True
+    assert await sub.is_coin_subscribed(coin4) is False
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer1}
-    assert sub.peers_for_coin_id(coin3) == {peer1}
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer1}
+    assert await sub.peers_for_coin_id(coin3) == {peer1}
+    assert await sub.peers_for_coin_id(coin4) == set()
 
     # peer1 should still be limited
-    sub.add_coin_subscriptions(peer1, [coin4], 3)
+    await sub.add_coin_subscriptions(peer1, [coin4], 3)
 
-    assert sub.has_coin_subscription(coin4) is False
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.is_coin_subscribed(coin4) is False
+    assert await sub.peers_for_coin_id(coin4) == set()
 
     # peer1 is also limied on ph subscriptions
-    ret = sub.add_ph_subscriptions(peer1, [ph1], 3)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 3)
     assert ret == set()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.peers_for_puzzle_hash(ph1) == set()
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.peers_for_puzzle_hash(ph1) == set()
 
     # peer2 is has its own limit
-    sub.add_coin_subscriptions(peer2, [coin4], 3)
+    await sub.add_coin_subscriptions(peer2, [coin4], 3)
 
-    assert sub.has_coin_subscription(coin4) is True
-    assert sub.peers_for_coin_id(coin4) == {peer2}
+    assert await sub.is_coin_subscribed(coin4) is True
+    assert await sub.peers_for_coin_id(coin4) == {peer2}
 
-    sub.remove_peer(peer1)
-    sub.remove_peer(peer2)
+    await sub.remove_peer(peer1)
+    await sub.remove_peer(peer2)
 
 
-def test_coin_sub_limit_incremental() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_coin_sub_limit_incremental() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_coin_subscription(coin1) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin3) is False
+    assert await sub.is_coin_subscribed(coin1) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin3) is False
 
-    sub.add_coin_subscriptions(peer1, [coin1], 2)
+    await sub.add_coin_subscriptions(peer1, [coin1], 2)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is False
-    assert sub.has_coin_subscription(coin3) is False
-    assert sub.has_coin_subscription(coin4) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is False
+    assert await sub.is_coin_subscribed(coin3) is False
+    assert await sub.is_coin_subscribed(coin4) is False
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == set()
-    assert sub.peers_for_coin_id(coin3) == set()
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == set()
+    assert await sub.peers_for_coin_id(coin3) == set()
+    assert await sub.peers_for_coin_id(coin4) == set()
 
     # this will cross the limit. Only coin2 will be added
-    sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
+    await sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
 
-    assert sub.has_coin_subscription(coin1) is True
-    assert sub.has_coin_subscription(coin2) is True
-    assert sub.has_coin_subscription(coin3) is False
-    assert sub.has_coin_subscription(coin4) is False
+    assert await sub.is_coin_subscribed(coin1) is True
+    assert await sub.is_coin_subscribed(coin2) is True
+    assert await sub.is_coin_subscribed(coin3) is False
+    assert await sub.is_coin_subscribed(coin4) is False
 
-    assert sub.peers_for_coin_id(coin1) == {peer1}
-    assert sub.peers_for_coin_id(coin2) == {peer1}
-    assert sub.peers_for_coin_id(coin3) == set()
-    assert sub.peers_for_coin_id(coin4) == set()
+    assert await sub.peers_for_coin_id(coin1) == {peer1}
+    assert await sub.peers_for_coin_id(coin2) == {peer1}
+    assert await sub.peers_for_coin_id(coin3) == set()
+    assert await sub.peers_for_coin_id(coin4) == set()
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
 
-def test_ph_subscription_duplicates() -> None:
-    sub = PeerSubscriptions()
+@pytest.mark.anyio
+async def test_ph_subscription_duplicates() -> None:
+    sub = await PeerSubscriptions.create()
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3], 100)
     assert ret == {ph1, ph2, ph3}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is True
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is True
+    assert await sub.is_puzzle_subscribed(ph4) is False
 
     # only ph4 is new, the others are duplicates and ignored
-    ret = sub.add_ph_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
+    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
     assert ret == {ph4}
 
-    assert sub.has_ph_subscription(ph1) is True
-    assert sub.has_ph_subscription(ph2) is True
-    assert sub.has_ph_subscription(ph3) is True
-    assert sub.has_ph_subscription(ph4) is True
+    assert await sub.is_puzzle_subscribed(ph1) is True
+    assert await sub.is_puzzle_subscribed(ph2) is True
+    assert await sub.is_puzzle_subscribed(ph3) is True
+    assert await sub.is_puzzle_subscribed(ph4) is True
 
-    sub.remove_peer(peer1)
+    await sub.remove_peer(peer1)
 
-    assert sub.has_ph_subscription(ph1) is False
-    assert sub.has_ph_subscription(ph2) is False
-    assert sub.has_ph_subscription(ph3) is False
-    assert sub.has_ph_subscription(ph4) is False
+    assert await sub.is_puzzle_subscribed(ph1) is False
+    assert await sub.is_puzzle_subscribed(ph2) is False
+    assert await sub.is_puzzle_subscribed(ph3) is False
+    assert await sub.is_puzzle_subscribed(ph4) is False

--- a/tests/core/full_node/test_subscriptions.py
+++ b/tests/core/full_node/test_subscriptions.py
@@ -21,348 +21,339 @@ ph4 = bytes32(b"h" * 32)
 
 @pytest.mark.anyio
 async def test_has_ph_sub() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
+        assert ret == {ph1}
 
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
-    assert ret == {ph1}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is False
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2], 100)
+        # we have already subscribed to ph1, it's filtered in the returned list
+        assert ret == {ph2}
 
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2], 100)
-    # we have already subscribed to ph1, it's filtered in the returned list
-    assert ret == {ph2}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is True
+        # note that this is technically a type error as well.
+        # we can remove these asserts once we have type checking
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.is_coin_subscribed(coin2) is False
 
-    # note that this is technically a type error as well.
-    # we can remove these asserts once we have type checking
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.is_coin_subscribed(coin2) is False
+        await sub.remove_peer(peer1)
 
-    await sub.remove_peer(peer1)
-
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
 
 
 @pytest.mark.anyio
 async def test_has_coin_sub() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.is_coin_subscribed(coin2) is False
 
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.is_coin_subscribed(coin2) is False
+        await sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-    await sub.add_coin_subscriptions(peer1, [coin1], 100)
+        assert await sub.is_coin_subscribed(coin1) is True
+        assert await sub.is_coin_subscribed(coin2) is False
 
-    assert await sub.is_coin_subscribed(coin1) is True
-    assert await sub.is_coin_subscribed(coin2) is False
+        await sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
 
-    await sub.add_coin_subscriptions(peer1, [coin1, coin2], 100)
+        assert await sub.is_coin_subscribed(coin1) is True
+        assert await sub.is_coin_subscribed(coin2) is True
 
-    assert await sub.is_coin_subscribed(coin1) is True
-    assert await sub.is_coin_subscribed(coin2) is True
+        # note that this is technically a type error as well.
+        # we can remove these asserts once we have type checking
+        assert await sub.is_puzzle_subscribed(coin1) is False
+        assert await sub.is_puzzle_subscribed(coin2) is False
 
-    # note that this is technically a type error as well.
-    # we can remove these asserts once we have type checking
-    assert await sub.is_puzzle_subscribed(coin1) is False
-    assert await sub.is_puzzle_subscribed(coin2) is False
+        await sub.remove_peer(peer1)
 
-    await sub.remove_peer(peer1)
-
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.is_coin_subscribed(coin2) is False
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.is_coin_subscribed(coin2) is False
 
 
 @pytest.mark.anyio
 async def test_overlapping_coin_subscriptions() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.is_coin_subscribed(coin2) is False
 
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.is_coin_subscribed(coin2) is False
+        assert await sub.peers_for_coin_id(coin1) == set()
+        assert await sub.peers_for_coin_id(coin2) == set()
 
-    assert await sub.peers_for_coin_id(coin1) == set()
-    assert await sub.peers_for_coin_id(coin2) == set()
+        # subscribed to different coins
+        await sub.add_coin_subscriptions(peer1, [coin1], 100)
 
-    # subscribed to different coins
-    await sub.add_coin_subscriptions(peer1, [coin1], 100)
+        assert await sub.peers_for_coin_id(coin1) == {peer1}
+        assert await sub.peers_for_coin_id(coin2) == set()
 
-    assert await sub.peers_for_coin_id(coin1) == {peer1}
-    assert await sub.peers_for_coin_id(coin2) == set()
+        await sub.add_coin_subscriptions(peer2, [coin2], 100)
 
-    await sub.add_coin_subscriptions(peer2, [coin2], 100)
+        assert await sub.is_coin_subscribed(coin1) is True
+        assert await sub.is_coin_subscribed(coin2) is True
 
-    assert await sub.is_coin_subscribed(coin1) is True
-    assert await sub.is_coin_subscribed(coin2) is True
+        assert await sub.peers_for_coin_id(coin1) == {peer1}
+        assert await sub.peers_for_coin_id(coin2) == {peer2}
 
-    assert await sub.peers_for_coin_id(coin1) == {peer1}
-    assert await sub.peers_for_coin_id(coin2) == {peer2}
+        # peer1 is now subscribing to both coins
+        await sub.add_coin_subscriptions(peer1, [coin2], 100)
 
-    # peer1 is now subscribing to both coins
-    await sub.add_coin_subscriptions(peer1, [coin2], 100)
+        assert await sub.is_coin_subscribed(coin1) is True
+        assert await sub.is_coin_subscribed(coin2) is True
 
-    assert await sub.is_coin_subscribed(coin1) is True
-    assert await sub.is_coin_subscribed(coin2) is True
+        assert await sub.peers_for_coin_id(coin1) == {peer1}
+        assert await sub.peers_for_coin_id(coin2) == {peer1, peer2}
 
-    assert await sub.peers_for_coin_id(coin1) == {peer1}
-    assert await sub.peers_for_coin_id(coin2) == {peer1, peer2}
+        # removing peer1 still leaves the subscription to coin2
+        await sub.remove_peer(peer1)
 
-    # removing peer1 still leaves the subscription to coin2
-    await sub.remove_peer(peer1)
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.is_coin_subscribed(coin2) is True
 
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.is_coin_subscribed(coin2) is True
-
-    assert await sub.peers_for_coin_id(coin1) == set()
-    assert await sub.peers_for_coin_id(coin2) == {peer2}
+        assert await sub.peers_for_coin_id(coin1) == set()
+        assert await sub.peers_for_coin_id(coin2) == {peer2}
 
 
 @pytest.mark.anyio
 async def test_overlapping_ph_subscriptions() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.peers_for_puzzle_hash(ph1) == set()
+        assert await sub.peers_for_puzzle_hash(ph2) == set()
 
-    assert await sub.peers_for_puzzle_hash(ph1) == set()
-    assert await sub.peers_for_puzzle_hash(ph2) == set()
+        # subscribed to different phs
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
+        assert ret == {ph1}
 
-    # subscribed to different phs
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 100)
-    assert ret == {ph1}
+        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph2) == set()
 
-    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph2) == set()
+        ret = await sub.add_puzzle_subscriptions(peer2, [ph2], 100)
+        assert ret == {ph2}
 
-    ret = await sub.add_puzzle_subscriptions(peer2, [ph2], 100)
-    assert ret == {ph2}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is True
+        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
 
-    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
+        # peer1 is now subscribing to both phs
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph2], 100)
+        assert ret == {ph2}
 
-    # peer1 is now subscribing to both phs
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph2], 100)
-    assert ret == {ph2}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is True
+        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
 
-    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph2) == {peer1, peer2}
+        # removing peer1 still leaves the subscription to ph2
+        await sub.remove_peer(peer1)
 
-    # removing peer1 still leaves the subscription to ph2
-    await sub.remove_peer(peer1)
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is True
 
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is True
-
-    assert await sub.peers_for_puzzle_hash(ph1) == set()
-    assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
+        assert await sub.peers_for_puzzle_hash(ph1) == set()
+        assert await sub.peers_for_puzzle_hash(ph2) == {peer2}
 
 
 @pytest.mark.anyio
 async def test_ph_sub_limit() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph3) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
-    assert await sub.is_puzzle_subscribed(ph3) is False
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
+        # we only ended up subscribing to 3 puzzle hashes because of the limit
+        assert ret == {ph1, ph2, ph3}
 
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 3)
-    # we only ended up subscribing to 3 puzzle hashes because of the limit
-    assert ret == {ph1, ph2, ph3}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is True
+        assert await sub.is_puzzle_subscribed(ph3) is True
+        assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is True
-    assert await sub.is_puzzle_subscribed(ph3) is True
-    assert await sub.is_puzzle_subscribed(ph4) is False
+        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph3) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph4) == set()
 
-    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph3) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph4) == set()
+        # peer1 should still be limited
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph4], 3)
+        assert ret == set()
 
-    # peer1 should still be limited
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph4], 3)
-    assert ret == set()
+        assert await sub.is_puzzle_subscribed(ph4) is False
+        assert await sub.peers_for_puzzle_hash(ph4) == set()
 
-    assert await sub.is_puzzle_subscribed(ph4) is False
-    assert await sub.peers_for_puzzle_hash(ph4) == set()
+        # peer1 is also limied on coin subscriptions
+        await sub.add_coin_subscriptions(peer1, [coin1], 3)
 
-    # peer1 is also limied on coin subscriptions
-    await sub.add_coin_subscriptions(peer1, [coin1], 3)
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.peers_for_coin_id(coin1) == set()
 
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.peers_for_coin_id(coin1) == set()
+        # peer2 is has its own limit
+        ret = await sub.add_puzzle_subscriptions(peer2, [ph4], 3)
+        assert ret == {ph4}
 
-    # peer2 is has its own limit
-    ret = await sub.add_puzzle_subscriptions(peer2, [ph4], 3)
-    assert ret == {ph4}
+        assert await sub.is_puzzle_subscribed(ph4) is True
+        assert await sub.peers_for_puzzle_hash(ph4) == {peer2}
 
-    assert await sub.is_puzzle_subscribed(ph4) is True
-    assert await sub.peers_for_puzzle_hash(ph4) == {peer2}
-
-    await sub.remove_peer(peer1)
-    await sub.remove_peer(peer2)
+        await sub.remove_peer(peer1)
+        await sub.remove_peer(peer2)
 
 
 @pytest.mark.anyio
 async def test_ph_sub_limit_incremental() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph3) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
-    assert await sub.is_puzzle_subscribed(ph3) is False
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 2)
+        assert ret == {ph1}
 
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 2)
-    assert ret == {ph1}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph3) is False
+        assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is False
-    assert await sub.is_puzzle_subscribed(ph3) is False
-    assert await sub.is_puzzle_subscribed(ph4) is False
+        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph2) == set()
+        assert await sub.peers_for_puzzle_hash(ph3) == set()
+        assert await sub.peers_for_puzzle_hash(ph4) == set()
 
-    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph2) == set()
-    assert await sub.peers_for_puzzle_hash(ph3) == set()
-    assert await sub.peers_for_puzzle_hash(ph4) == set()
+        # this will cross the limit. Only ph2 will be added
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph2, ph3], 2)
+        assert ret == {ph2}
 
-    # this will cross the limit. Only ph2 will be added
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph2, ph3], 2)
-    assert ret == {ph2}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is True
+        assert await sub.is_puzzle_subscribed(ph3) is False
+        assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is True
-    assert await sub.is_puzzle_subscribed(ph3) is False
-    assert await sub.is_puzzle_subscribed(ph4) is False
+        assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
+        assert await sub.peers_for_puzzle_hash(ph3) == set()
+        assert await sub.peers_for_puzzle_hash(ph4) == set()
 
-    assert await sub.peers_for_puzzle_hash(ph1) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph2) == {peer1}
-    assert await sub.peers_for_puzzle_hash(ph3) == set()
-    assert await sub.peers_for_puzzle_hash(ph4) == set()
-
-    await sub.remove_peer(peer1)
+        await sub.remove_peer(peer1)
 
 
 @pytest.mark.anyio
 async def test_coin_sub_limit() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.is_coin_subscribed(coin2) is False
+        assert await sub.is_coin_subscribed(coin2) is False
+        assert await sub.is_coin_subscribed(coin3) is False
 
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.is_coin_subscribed(coin2) is False
-    assert await sub.is_coin_subscribed(coin2) is False
-    assert await sub.is_coin_subscribed(coin3) is False
+        await sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
 
-    await sub.add_coin_subscriptions(peer1, [coin1, coin2, coin3, coin4], 3)
+        assert await sub.is_coin_subscribed(coin1) is True
+        assert await sub.is_coin_subscribed(coin2) is True
+        assert await sub.is_coin_subscribed(coin3) is True
+        assert await sub.is_coin_subscribed(coin4) is False
 
-    assert await sub.is_coin_subscribed(coin1) is True
-    assert await sub.is_coin_subscribed(coin2) is True
-    assert await sub.is_coin_subscribed(coin3) is True
-    assert await sub.is_coin_subscribed(coin4) is False
+        assert await sub.peers_for_coin_id(coin1) == {peer1}
+        assert await sub.peers_for_coin_id(coin2) == {peer1}
+        assert await sub.peers_for_coin_id(coin3) == {peer1}
+        assert await sub.peers_for_coin_id(coin4) == set()
 
-    assert await sub.peers_for_coin_id(coin1) == {peer1}
-    assert await sub.peers_for_coin_id(coin2) == {peer1}
-    assert await sub.peers_for_coin_id(coin3) == {peer1}
-    assert await sub.peers_for_coin_id(coin4) == set()
+        # peer1 should still be limited
+        await sub.add_coin_subscriptions(peer1, [coin4], 3)
 
-    # peer1 should still be limited
-    await sub.add_coin_subscriptions(peer1, [coin4], 3)
+        assert await sub.is_coin_subscribed(coin4) is False
+        assert await sub.peers_for_coin_id(coin4) == set()
 
-    assert await sub.is_coin_subscribed(coin4) is False
-    assert await sub.peers_for_coin_id(coin4) == set()
+        # peer1 is also limied on ph subscriptions
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 3)
+        assert ret == set()
 
-    # peer1 is also limied on ph subscriptions
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1], 3)
-    assert ret == set()
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.peers_for_puzzle_hash(ph1) == set()
 
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.peers_for_puzzle_hash(ph1) == set()
+        # peer2 is has its own limit
+        await sub.add_coin_subscriptions(peer2, [coin4], 3)
 
-    # peer2 is has its own limit
-    await sub.add_coin_subscriptions(peer2, [coin4], 3)
+        assert await sub.is_coin_subscribed(coin4) is True
+        assert await sub.peers_for_coin_id(coin4) == {peer2}
 
-    assert await sub.is_coin_subscribed(coin4) is True
-    assert await sub.peers_for_coin_id(coin4) == {peer2}
-
-    await sub.remove_peer(peer1)
-    await sub.remove_peer(peer2)
+        await sub.remove_peer(peer1)
+        await sub.remove_peer(peer2)
 
 
 @pytest.mark.anyio
 async def test_coin_sub_limit_incremental() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_coin_subscribed(coin1) is False
+        assert await sub.is_coin_subscribed(coin2) is False
+        assert await sub.is_coin_subscribed(coin2) is False
+        assert await sub.is_coin_subscribed(coin3) is False
 
-    assert await sub.is_coin_subscribed(coin1) is False
-    assert await sub.is_coin_subscribed(coin2) is False
-    assert await sub.is_coin_subscribed(coin2) is False
-    assert await sub.is_coin_subscribed(coin3) is False
+        await sub.add_coin_subscriptions(peer1, [coin1], 2)
 
-    await sub.add_coin_subscriptions(peer1, [coin1], 2)
+        assert await sub.is_coin_subscribed(coin1) is True
+        assert await sub.is_coin_subscribed(coin2) is False
+        assert await sub.is_coin_subscribed(coin3) is False
+        assert await sub.is_coin_subscribed(coin4) is False
 
-    assert await sub.is_coin_subscribed(coin1) is True
-    assert await sub.is_coin_subscribed(coin2) is False
-    assert await sub.is_coin_subscribed(coin3) is False
-    assert await sub.is_coin_subscribed(coin4) is False
+        assert await sub.peers_for_coin_id(coin1) == {peer1}
+        assert await sub.peers_for_coin_id(coin2) == set()
+        assert await sub.peers_for_coin_id(coin3) == set()
+        assert await sub.peers_for_coin_id(coin4) == set()
 
-    assert await sub.peers_for_coin_id(coin1) == {peer1}
-    assert await sub.peers_for_coin_id(coin2) == set()
-    assert await sub.peers_for_coin_id(coin3) == set()
-    assert await sub.peers_for_coin_id(coin4) == set()
+        # this will cross the limit. Only coin2 will be added
+        await sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
 
-    # this will cross the limit. Only coin2 will be added
-    await sub.add_coin_subscriptions(peer1, [coin2, coin3], 2)
+        assert await sub.is_coin_subscribed(coin1) is True
+        assert await sub.is_coin_subscribed(coin2) is True
+        assert await sub.is_coin_subscribed(coin3) is False
+        assert await sub.is_coin_subscribed(coin4) is False
 
-    assert await sub.is_coin_subscribed(coin1) is True
-    assert await sub.is_coin_subscribed(coin2) is True
-    assert await sub.is_coin_subscribed(coin3) is False
-    assert await sub.is_coin_subscribed(coin4) is False
+        assert await sub.peers_for_coin_id(coin1) == {peer1}
+        assert await sub.peers_for_coin_id(coin2) == {peer1}
+        assert await sub.peers_for_coin_id(coin3) == set()
+        assert await sub.peers_for_coin_id(coin4) == set()
 
-    assert await sub.peers_for_coin_id(coin1) == {peer1}
-    assert await sub.peers_for_coin_id(coin2) == {peer1}
-    assert await sub.peers_for_coin_id(coin3) == set()
-    assert await sub.peers_for_coin_id(coin4) == set()
-
-    await sub.remove_peer(peer1)
+        await sub.remove_peer(peer1)
 
 
 @pytest.mark.anyio
 async def test_ph_subscription_duplicates() -> None:
-    sub = await PeerSubscriptions.create()
+    async with PeerSubscriptions.managed() as sub:
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph3) is False
+        assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
-    assert await sub.is_puzzle_subscribed(ph3) is False
-    assert await sub.is_puzzle_subscribed(ph4) is False
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3], 100)
+        assert ret == {ph1, ph2, ph3}
 
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3], 100)
-    assert ret == {ph1, ph2, ph3}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is True
+        assert await sub.is_puzzle_subscribed(ph3) is True
+        assert await sub.is_puzzle_subscribed(ph4) is False
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is True
-    assert await sub.is_puzzle_subscribed(ph3) is True
-    assert await sub.is_puzzle_subscribed(ph4) is False
+        # only ph4 is new, the others are duplicates and ignored
+        ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
+        assert ret == {ph4}
 
-    # only ph4 is new, the others are duplicates and ignored
-    ret = await sub.add_puzzle_subscriptions(peer1, [ph1, ph2, ph3, ph4], 100)
-    assert ret == {ph4}
+        assert await sub.is_puzzle_subscribed(ph1) is True
+        assert await sub.is_puzzle_subscribed(ph2) is True
+        assert await sub.is_puzzle_subscribed(ph3) is True
+        assert await sub.is_puzzle_subscribed(ph4) is True
 
-    assert await sub.is_puzzle_subscribed(ph1) is True
-    assert await sub.is_puzzle_subscribed(ph2) is True
-    assert await sub.is_puzzle_subscribed(ph3) is True
-    assert await sub.is_puzzle_subscribed(ph4) is True
+        await sub.remove_peer(peer1)
 
-    await sub.remove_peer(peer1)
-
-    assert await sub.is_puzzle_subscribed(ph1) is False
-    assert await sub.is_puzzle_subscribed(ph2) is False
-    assert await sub.is_puzzle_subscribed(ph3) is False
-    assert await sub.is_puzzle_subscribed(ph4) is False
+        assert await sub.is_puzzle_subscribed(ph1) is False
+        assert await sub.is_puzzle_subscribed(ph2) is False
+        assert await sub.is_puzzle_subscribed(ph3) is False
+        assert await sub.is_puzzle_subscribed(ph4) is False

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1059,7 +1059,7 @@ class TestCATWallet:
         await time_out_assert(20, check_wallets, 2, wallet_node_0)
         cat_wallet = wallet_node_0.wallet_state_manager.wallets[uint32(2)]
         await time_out_assert(20, cat_wallet.get_confirmed_balance, cat_amount_1)
-        assert not full_node_api.full_node.subscriptions.has_ph_subscription(puzzlehash_unhardened)
+        assert not full_node_api.full_node.subscriptions.is_puzzle_subscribed(puzzlehash_unhardened)
 
 
 @pytest.mark.anyio

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -685,23 +685,23 @@ class TestSimpleSyncProtocol:
         msg_response = await full_node_api.register_interest_in_puzzle_hash(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_ph_update.value
         s = full_node_api.full_node.subscriptions
-        assert len(s._ph_subscriptions) == 2
-        assert s.has_ph_subscription(phs[0])
-        assert s.has_ph_subscription(phs[1])
-        assert not s.has_ph_subscription(phs[2])
-        assert not s.has_ph_subscription(phs[3])
+        assert s.total_puzzle_subscriptions() == 2
+        assert s.is_puzzle_subscribed(phs[0])
+        assert s.is_puzzle_subscribed(phs[1])
+        assert not s.is_puzzle_subscribed(phs[2])
+        assert not s.is_puzzle_subscribed(phs[3])
         full_node_api.full_node.config["trusted_max_subscribe_items"] = 4
         full_node_api.full_node.config["trusted_peers"] = {server_2.node_id.hex(): server_2.node_id.hex()}
         assert full_node_api.is_trusted(con) is True
         msg_response = await full_node_api.register_interest_in_puzzle_hash(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_ph_update.value
-        assert len(s._ph_subscriptions) == 4
-        assert s.has_ph_subscription(phs[0])
-        assert s.has_ph_subscription(phs[1])
-        assert s.has_ph_subscription(phs[2])
-        assert s.has_ph_subscription(phs[3])
-        assert not s.has_ph_subscription(phs[4])
-        assert not s.has_ph_subscription(phs[5])
+        assert s.total_puzzle_subscriptions() == 4
+        assert s.is_puzzle_subscribed(phs[0])
+        assert s.is_puzzle_subscribed(phs[1])
+        assert s.is_puzzle_subscribed(phs[2])
+        assert s.is_puzzle_subscribed(phs[3])
+        assert not s.is_puzzle_subscribed(phs[4])
+        assert not s.is_puzzle_subscribed(phs[5])
 
     @pytest.mark.anyio
     async def test_coin_subscribe_limits(self, simulator_and_wallet, self_hostname):
@@ -725,20 +725,20 @@ class TestSimpleSyncProtocol:
         msg_response = await full_node_api.register_interest_in_coin(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_coin_update.value
         s = full_node_api.full_node.subscriptions
-        assert len(s._coin_subscriptions) == 2
-        assert s.has_coin_subscription(coins[0])
-        assert s.has_coin_subscription(coins[1])
-        assert not s.has_coin_subscription(coins[2])
-        assert not s.has_coin_subscription(coins[3])
+        assert s.total_coin_subscriptions() == 2
+        assert s.is_coin_subscribed(coins[0])
+        assert s.is_coin_subscribed(coins[1])
+        assert not s.is_coin_subscribed(coins[2])
+        assert not s.is_coin_subscribed(coins[3])
         full_node_api.full_node.config["trusted_max_subscribe_items"] = 4
         full_node_api.full_node.config["trusted_peers"] = {server_2.node_id.hex(): server_2.node_id.hex()}
         assert full_node_api.is_trusted(con) is True
         msg_response = await full_node_api.register_interest_in_coin(msg, con)
         assert msg_response.type == ProtocolMessageTypes.respond_to_coin_update.value
-        assert len(s._coin_subscriptions) == 4
-        assert s.has_coin_subscription(coins[0])
-        assert s.has_coin_subscription(coins[1])
-        assert s.has_coin_subscription(coins[2])
-        assert s.has_coin_subscription(coins[3])
-        assert not s.has_coin_subscription(coins[4])
-        assert not s.has_coin_subscription(coins[5])
+        assert s.total_coin_subscriptions() == 4
+        assert s.is_coin_subscribed(coins[0])
+        assert s.is_coin_subscribed(coins[1])
+        assert s.is_coin_subscribed(coins[2])
+        assert s.is_coin_subscribed(coins[3])
+        assert not s.is_coin_subscribed(coins[4])
+        assert not s.is_coin_subscribed(coins[5])


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Switching from dictionaries to SQLite for PeerSubscriptions reduces the amount of duplicated logic and enables addition of new fields or functionality in the future without exponentially increasing the complexity.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

PeerSubscriptions is implemented as a set of dictionaries containing peer ids and subscription ids.

### New Behavior:

It uses an in-memory managed SQLite database to store and query the subscription data.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

All of the tests have been updated to use this new async PeerSubscription implementation.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
